### PR TITLE
Fix several issues and documentation errors related to install/configuration

### DIFF
--- a/docs/dojo-production.rst
+++ b/docs/dojo-production.rst
@@ -1,7 +1,7 @@
 Running in Production
 =====================
 
-This guide will walk you through how to setup DefectDojo for running in production using Ubuntu 16.04, nginx, and uwsgi.
+This guide will walk you through how to setup DefectDojo for running in production using Ubuntu 16.04, MySQL, nginx, and uwsgi.
 
 **Install Required Packages**
 

--- a/docs/dojo-production.rst
+++ b/docs/dojo-production.rst
@@ -3,6 +3,28 @@ Running in Production
 
 This guide will walk you through how to setup DefectDojo for running in production using Ubuntu 16.04, nginx, and uwsgi.
 
+**Install Required Packages**
+
+.. code-block:: console
+
+  sudo apt-get install python-pip nginx mysql-server
+
+**Create MySQL Database and User**
+
+.. code-block:: console
+
+  mysql -u root -p
+
+  mysql> create user 'dojo'@'localhost' identified by '<password>';
+
+  mysql> create database defectdojo;
+
+  mysql> grant all privileges on defectdojo.* to 'dojo'@'localhost';
+
+  mysql> flush privileges;
+
+  mysql> quit
+
 *Install, Setup, and Activate Virtualenv*
 
 .. code-block:: console
@@ -11,7 +33,7 @@ This guide will walk you through how to setup DefectDojo for running in producti
 
   virtualenv dojo
 
-  source my_project/bin/activate
+  source dojo/bin/activate
 
 **Install Dojo**
 
@@ -19,7 +41,7 @@ This guide will walk you through how to setup DefectDojo for running in producti
 
   cd django-DefectDojo
 
-  ./install.bash
+  ./setup.bash
 
 **Install Uwsgi**
 
@@ -82,27 +104,28 @@ It is recommended that you use an Upstart job or a @restart cron job to launch u
 
 *NGINX Configuration*
 
-Everyone feels a little differently about nginx settings, so here are the barebones to add your to your nginx configuration to proxy uwsgi:
+Everyone feels a little differently about nginx settings, so here are the barebones to add your to your nginx configuration to proxy uwsgi. Make sure to modify the filesystem paths if needed:
 
 .. code-block:: json
 
   upstream django {
-   
     server 127.0.0.1:8001; 
   }
 
-  location /dojo/static/ {
-      alias   /data/prod_dojo/django-DefectDojo/static/;
-  }
+  server {
+    listen 80;
+    location /static/ {
+        alias   /data/prod_dojo/django-DefectDojo/static/;
+    }
 
-  location /dojo/media/ {
-      alias   /data/prod_dojo/django-DefectDojo/media/;
-  }
+    location /media/ {
+        alias   /data/prod_dojo/django-DefectDojo/media/;
+    }
 
-
-  location /dojo {
-      uwsgi_pass django;
-      include     /data/prod_dojo/django-DefectDojo/wsgi_params;
+    location / {
+        uwsgi_pass django;
+        include     /data/prod_dojo/django-DefectDojo/wsgi_params;
+    }
   }
 
 *That's it!*

--- a/docs/dojo-production.rst
+++ b/docs/dojo-production.rst
@@ -63,19 +63,19 @@ Using the text-editor of your choice, change ``DEBUG`` in django-DefectDojo/dojo
 
 .. code-block:: console
 
-  `DEBUG = False` 
+  DEBUG = False
 
 Modify `ALLOWED_HOSTS` with valid hostnames for the site:
 
 .. code-block:: console
 
-  `ALLOWED_HOSTS = ['localhost','127.0.0.1']`
+  ALLOWED_HOSTS = ['localhost','127.0.0.1']
 
 Modify the path to `wkhtmltopdf` if you ran the reports.bash script:
 
 .. code-block:: console
 
-  `WKHTMLTOPDF_PATH = '/usr/bin/wkhtmltopdf'`
+  WKHTMLTOPDF_PATH = '/usr/bin/wkhtmltopdf'
 
 **Configure Nginx**
 
@@ -146,7 +146,7 @@ However, for a quick setup you can use the following to run both in the backgrou
 
   celery beat -A dojo -l info &
 
-*Start Uwsgi*
+**Start Uwsgi**
 
 From inside the django-DefectDojo/ directory execute:
 


### PR DESCRIPTION
This PR fixes several issues in both the install scripts and documentation and should make the install process a lot more robust. 

First, setup.bash would fail to set up the database properly because it did not grant itself permissions after creating it. It felt awkward to me to have the admin create a user but NOT a database, so I've modified the script to require the empty database to already have been created. This way, the admin creates the database the same time he creates the user, and then assigns privileges to the database, similar to the process involved in installing something like WordPress. Note that we could also solve this problem by modifying the script to assign itself necessary permissions after creating the database--feel free to discuss. I've also modified the script so that it will terminate with an error if it cannot access the database with the supplied information. Previously, it just continued to run and would throw a bunch of Python MySQL errors.

I've also updated the relevant documentation to reflect these changes and provided a walkthrough for running the MySQL commands.

Second, I've rearranged and revised several parts of the dojo-production.rst documentation, since there were errors, missing steps, etc. I've also fixed formatting issues to make it consistent throughout.