### PR TITLE
Removed null argument for ManyToMany field creation

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -627,7 +627,7 @@ class Finding(models.Model):
     false_p = models.BooleanField(default=False, verbose_name="False Positive")
     duplicate = models.BooleanField(default=False)
     duplicate_finding = models.ForeignKey('self', editable=False, null=True, related_name='original_finding', blank=True)
-    duplicate_list = models.ManyToManyField("self",editable=False, null=True, blank=True)
+    duplicate_list = models.ManyToManyField("self",editable=False, blank=True)
     out_of_scope = models.BooleanField(default=False)
     under_review = models.BooleanField(default=False)
     review_requested_by = models.ForeignKey(Dojo_User, null=True, blank=True, related_name='review_requested_by')


### PR DESCRIPTION
The null argument in the model definition threw a warning during migration application.
