### PR TITLE
Let tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ script:
     case "$TEST" in
       unit-test)
         travis_fold start "unit-test"
-        bash ./scripts/travis-unit-test.sh
+        bash ./scripts/travis-unit-test.sh || exit 1
         travis_fold end "unit-test"
         ;;
       integration-test)
         travis_fold start "integration-test"
-        bash ./scripts/travis-integration-test.sh
+        bash ./scripts/travis-integration-test.sh || exit 1
         travis_fold end "integration-test"
         ;;
       sourceclear)


### PR DESCRIPTION
Add an exit statement triggered in case of failing tests, also letting travis know tests have failed.
Otherwise, tests may seem "green", even if problems have occurred during test execution. 