### PR TITLE
Avoid integration test failures due to timeouts

### DIFF
--- a/scripts/travis-integration-test.sh
+++ b/scripts/travis-integration-test.sh
@@ -31,7 +31,7 @@ echo "Checking to see if dojo is running"
 set +e
 STATE="inactive"
 for i in $(seq 1 5); do
-    curl -s http://127.0.0.1:8000/login?next=/
+    curl -o /dev/null http://127.0.0.1:8000/login?next=/
     if [ "$?" == "0" ]; then
         STATE="running"
         break

--- a/scripts/travis-integration-test.sh
+++ b/scripts/travis-integration-test.sh
@@ -31,7 +31,7 @@ echo "Checking to see if dojo is running"
 set +e
 STATE="inactive"
 for i in $(seq 1 5); do
-    curl -o /dev/null http://127.0.0.1:8000/login?next=/
+    curl -s -o /dev/null http://127.0.0.1:8000/login?next=/
     if [ "$?" == "0" ]; then
         STATE="running"
         break

--- a/scripts/travis-integration-test.sh
+++ b/scripts/travis-integration-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ev
+set -e
 
 # Docker Build
 export DOJO_ADMIN_USER='admin'
@@ -26,7 +26,7 @@ sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
 docker ps -a
 docker logs $CONTAINER_NAME
 echo "Checking to see if dojo is running"
-curl http://127.0.0.1:8000/login?next=/
+curl http://127.0.0.1:8000/login?next=/ || docker exec $CONTAINER_NAME bash -c "cat /opt/django-DefectDojo/dojo.log" && exit 1
 
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start
@@ -35,4 +35,4 @@ whereis chromedriver
 export PATH=$PATH:/usr/local/bin/
 python tests/check_status.py -v && python tests/smoke_test.py #&& python tests/zap.py
 
-set +ev 
+set +e

--- a/scripts/travis-integration-test.sh
+++ b/scripts/travis-integration-test.sh
@@ -26,7 +26,7 @@ sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
 docker ps -a
 docker logs $CONTAINER_NAME
 echo "Checking to see if dojo is running"
-curl http://127.0.0.1:8000/login?next=/ || docker exec $CONTAINER_NAME bash -c "cat /opt/django-DefectDojo/dojo.log" && exit 1
+curl -s http://127.0.0.1:8000/login?next=/ || docker exec $CONTAINER_NAME bash -c "cat /opt/django-DefectDojo/dojo.log" && exit 1
 
 export DISPLAY=:99.0
 sh -e /etc/init.d/xvfb start

--- a/scripts/travis-integration-test.sh
+++ b/scripts/travis-integration-test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 # Docker Build
 export DOJO_ADMIN_USER='admin'
@@ -35,4 +35,4 @@ whereis chromedriver
 export PATH=$PATH:/usr/local/bin/
 python tests/check_status.py -v && python tests/smoke_test.py #&& python tests/zap.py
 
-set +e
+set +ex


### PR DESCRIPTION
This PR mainly adds a loop that gives the container used for integration tests a bit more time to come up. It waits at most 5 x 10secs for the container to spin up. 

The motivation for this PR were recent test failures on TravisCI, due to containers not being ready for a curl request yet. 