### PR TITLE
Added back SQLAlchemy requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,7 @@ python-dateutil==2.6.1
 python-nmap==0.6.1
 pytz==2017.3
 requests==2.18.4
+sqlalchemy  # Required by Celery broker transport
 supervisor==3.3.3
 urllib3==1.22
 vobject==0.9.5

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'python-nmap>=0.3.4',
         'pytz>=2013.9',
         'requests>=2.2.1',
+        'sqlalchemy',  # Required by Celery broker transport
         'supervisor',
         'vobject',
     ],


### PR DESCRIPTION
Added back SQLAlchemy requirement, since the Celery broker URL transport part explicitely requires it to be installed (the 'sqla' part of sqla+sqlite://... in the [CELERY_]BROKER_URL).
