### PR TITLE
Remove yarn raphael dependency

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -28,7 +28,6 @@
     "@yarn_components/mocha": "mochajs/mocha#~1.17.1",
     "@yarn_components/moment": "moment/moment#^2.9.0",
     "@yarn_components/morrisjs": "morrisjs/morris.js#~0.5.1",
-    "@yarn_components/raphael": "DmitryBaranovskiy/raphael#~2.1.4",
     "@yarn_components/startbootstrap-sb-admin-2": "BlackrockDigital/startbootstrap-sb-admin-2#*"
   },
   "engines": {


### PR DESCRIPTION
As elaborated in issue #482, I think the raphael dependency is not required, since it comes with "justgage" already and only causes problems during installation, due to a ssh connection to github. 

``justgage/raphael-2.1.4.min.js`` is loaded in ``metrics.html``. No other inclusions of raphael scripts have been found. Therefore, it is assumed to be safe to remove this dependency.
