### PR TITLE
Centospostgresfix

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -140,7 +140,7 @@ if [[ ! -z "$YUM_CMD" ]]; then
 
         if [ "$DBTYPE" == $MYSQL ]; then
            echo "Installing MySQL client"
-           sudo yum install libmysqlclient-dev mysql-server mysql-devel MySQL-py2thon
+           sudo yum install mysql mysql-devel mysql-lib MySQL-python
         elif [ "$DBTYPE" == $POSTGRES ]; then
            echo "Installing Postgres client"
            sudo yum install postgresql-libs postgresql postgresql-contrib

--- a/setup.bash
+++ b/setup.bash
@@ -17,10 +17,10 @@ POSTGRES=2
 function prompt_db_type() {
     read -p "Select database type: 1.) MySQL or 2.) Postgres: " DBTYPE
     if [ "$DBTYPE" == '1' ] || [ "$DBTYPE" == '2' ] ; then
-    	echo "Setting up database"
+      echo "Setting up database"
     else
-	echo "Please enter 1 or 2"
-	prompt_db_type
+  echo "Please enter 1 or 2"
+  prompt_db_type
     fi
 }
 
@@ -135,15 +135,15 @@ BREW_CMD=$(which brew)
 
 if [[ ! -z "$YUM_CMD" ]]; then
     curl -sL https://rpm.nodesource.com/setup | sudo bash -
-    wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
-	sudo yum install gcc python-devel python-setuptools python-pip nodejs yarn wkhtmltopdf npm
+    sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
+  sudo yum install gcc python-devel python-setuptools python-pip nodejs yarn wkhtmltopdf npm
 
         if [ "$DBTYPE" == $MYSQL ]; then
            echo "Installing MySQL client"
-           sudo yum install libmysqlclient-dev mysql-server mysql-devel MySQL-python
+           sudo yum install libmysqlclient-dev mysql-server mysql-devel MySQL-py2thon
         elif [ "$DBTYPE" == $POSTGRES ]; then
            echo "Installing Postgres client"
-           sudo yum install libpq-dev postgresql postgresql-contrib libmysqlclient-dev
+           sudo yum install postgresql-libs postgresql postgresql-contrib
         fi
         sudo yum groupinstall 'Development Tools'
 elif [[ ! -z "$APT_GET_CMD" ]]; then
@@ -151,7 +151,7 @@ elif [[ ! -z "$APT_GET_CMD" ]]; then
         echo "Installing MySQL client"
         sudo apt-get -y install libmysqlclient-dev mysql-server
      elif [ "$DBTYPE" == $POSTGRES ]; then
-	echo "Installing Postgres client"
+  echo "Installing Postgres client"
         sudo apt-get -y install libpq-dev postgresql postgresql-contrib libmysqlclient-dev
      fi
      sudo apt-get install -y curl apt-transport-https
@@ -171,8 +171,8 @@ elif [[ ! -z "$BREW_CMD" ]]; then
         brew install postgresql
     fi
 else
-	echo "ERROR! OS not supported. Try the Vagrant option."
-	exit 1;
+  echo "ERROR! OS not supported. Try the Vagrant option."
+  exit 1;
 fi
 
 echo
@@ -187,7 +187,7 @@ fi
 unset HISTFILE
 
 if [[ ! -z "$BREW_CMD" ]]; then
-	LC_CTYPE=C
+  LC_CTYPE=C
 fi
 
 SECRET=`cat /dev/urandom | LC_CTYPE=C tr -dc "a-zA-Z0-9" | head -c 128`
@@ -246,7 +246,11 @@ fi
 
 # Detect if we're in a a virtualenv
 if python -c 'import sys; print sys.real_prefix' 2>/dev/null; then
-    pip install .
+    if [ "$DBTYPE" == $MYSQL ]; then
+      pip install .[mysql]
+    else
+      pip install .
+    fi
     python manage.py makemigrations dojo
     python manage.py makemigrations --merge --noinput
     python manage.py migrate
@@ -260,7 +264,11 @@ if python -c 'import sys; print sys.real_prefix' 2>/dev/null; then
     python manage.py installwatson
     python manage.py buildwatson
 else
-    pip install .
+    if [ "$DBTYPE" == $MYSQL ]; then
+      pip install .[mysql]
+    else
+      pip install .
+    fi
     python manage.py makemigrations dojo
     python manage.py makemigrations --merge --noinput
     python manage.py migrate

--- a/setup.bash
+++ b/setup.bash
@@ -140,7 +140,7 @@ if [[ ! -z "$YUM_CMD" ]]; then
 
         if [ "$DBTYPE" == $MYSQL ]; then
            echo "Installing MySQL client"
-           sudo yum install mysql mysql-devel mysql-lib MySQL-python
+           sudo yum install mysql mysql-devel mysql-libs MySQL-python
         elif [ "$DBTYPE" == $POSTGRES ]; then
            echo "Installing Postgres client"
            sudo yum install postgresql-libs postgresql postgresql-contrib

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='DefectDojo',
-    version='1.2.0',
+    version='1.2.1',
     author='Greg Anderson',
     description="Tool for managing vulnerability engagements",
     install_requires=[
@@ -28,7 +28,6 @@ setup(
         'humanize',
         'jira',
         'lxml',
-        'mysqlclient==1.3.12',
         'pdfkit==0.6.1',
         'Pillow',
         'psycopg2',
@@ -57,8 +56,9 @@ setup(
         'psycopg2',
         'django-multiselectfield',
         'pbr',
-	'django-slack',
+    'django-slack',
     ],
+    extra_requires={'mysql': ['mysqlclient==1.3.12']},
 
     dependency_links=[
         "https://github.com/grendel513/python-pdfkit/tarball/master#egg=pdfkit-0.5.0",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'pbr',
     'django-slack',
     ],
-    extra_requires={'mysql': ['mysqlclient==1.3.12']},
+    extras_require={'mysql': ['mysqlclient==1.3.12']},
 
     dependency_links=[
         "https://github.com/grendel513/python-pdfkit/tarball/master#egg=pdfkit-0.5.0",


### PR DESCRIPTION
When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is pep8 compliant (Dojo's code isn't currently pep8 compliant, but we're trying to correct that)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder

Relates to BUG https://github.com/DefectDojo/django-DefectDojo/issues/516

Fixes Centos package naming issues for both mysql and postgres, creates a extras-require feature to unblock postgres install (previous behavior with pip failure with mysql libraries).  


Passed all but zap test (didn't have it running on linux host)