### PR TITLE
External db build args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,23 @@ MAINTAINER Matt Tesauro <matt.tesauro@owasp.org>
 
 # # # Create a single Docker image running DefectDojo and all dependencies
 
+# Setup database environment variables. Used to setup an external
+# database, and is optional.
+# Set a variable using build args.
+#   i.e. `docker build --build-arg DBNAME="db.foopy.com" ...`
+
+ARG SQLHOST=""
+ARG SQLPORT=""
+ARG SQLUSER=""
+ARG SQLPWD=""
+ARG DBNAME=""
+
+ENV SQLHOST=$SQLHOST
+ENV SQLPORT=$SQLPORT
+ENV SQLUSER=$SQLUSER
+ENV SQLPWD=$SQLPWD
+ENV DBNAME=$DBNAME
+
 # Update and install basic requirements;
 # Install mysql-server already at this place, since we want to avoid
 # interactivity when creating a Docker image;


### PR DESCRIPTION
Small `Dockerfile` change to allow devs to set env variables for an external db in the `docker build` command instead of modifying the `Dockerfile` using build args.

This makes it easier to use an external database, while keeping repos in sync with the upstream repository by avoiding merges.

The current build doesn't change because defaults are set (blank strings) so no errors get thrown if someone does not choose to use a build arg.


[dockerfile ARG reference](https://docs.docker.com/engine/reference/builder/#arg)
[docker build command build arg reference](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)