### PR TITLE
Add flake8 for achieveing pep8, the devops way

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,15 @@
+[flake8]
+# Documentation for flake8 http://flake8.pycqa.org/en/3.1.1/user/index.html
+ignore =
+    # Suppress - line too long (> 79 characters)
+    E501,
+    # Suppress - Continuation line missing indentation or outdented
+    E127
+exclude =
+    # No need to traverse our git directory
+    .git,
+    # There's no value in checking cache directories
+    __pycache__,
+    # This contains of branch that we don't want to check
+    # dev
+max-complexity = 10

--- a/.flake8
+++ b/.flake8
@@ -5,6 +5,8 @@ ignore =
     E501,
     # Suppress - Continuation line missing indentation or outdented
     E127
+    # Suppress - Function is too complex
+    C901
 exclude =
     # No need to traverse our git directory
     .git,

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
   allow_failures:
     - env: TEST=bandit
     - env: TEST=sourceclear
+    - env: TEST=pep8
 
 services:
   - docker
@@ -66,12 +67,16 @@ script:
         true
         ;;
       pep8)
-        pip install pep8 flake8 flake8-diff
+        pip install pep8
         pep8 .
+        ;;
       flake8)
-        if [ "$TRAVIS_BRANCH" != "dev" ]
+        echo "$TRAVIS_BRANCH"
+        if [ "$TRAVIS_BRANCH" == "dev" ]
         then 
             echo "Running Flake8 tests on dev branch aka pull requests"
+            # We need to checkout dev for flake8-diff to work properly
+            git checkout dev
             pip install pep8 flake8 flake8-diff
             flake8-diff
         else

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
   - TEST=docker-bench-security
   - TEST=ansible
   - TEST=pep8
+  - TEST=flake8
 
 matrix:
   allow_failures:
     - env: TEST=bandit
     - env: TEST=sourceclear
-    - env: TEST=pep8
 
 services:
   - docker
@@ -66,8 +66,17 @@ script:
         true
         ;;
       pep8)
-        pip install pep8
+        pip install pep8 flake8 flake8-diff
         pep8 .
+      flake8)
+        if [ "$TRAVIS_BRANCH" != "dev" ]
+        then 
+            echo "Running Flake8 tests on dev branch aka pull requests"
+            pip install pep8 flake8 flake8-diff
+            flake8-diff
+        else
+            echo "true"
+        fi
     esac
 
 after_success:


### PR DESCRIPTION
This PR adds support for flake8 tests for code quality on Dev Branch. Whenever someone pushes code to dev branch, this code will run and only lint the files which have been changed in that PR request against master branch. 

So Instead of achieving pep8 in one go, we will only check PRs and little by little, we will achieve pep8 :) 

Also this PR ignores the following checks using .flake8 file. Once all the pep8 issues are taken care, we can work on enable those checks. 
 
E501: line too long (> 79 characters)
E127: Continuation line missing indentation or outdented
Scan complexity is set to 10 so it won't go deeper. 

- [x] Your code is pep8 compliant (Dojo's code isn't currently pep8 compliant, but we're trying to correct that)

- [] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder
