### PR TITLE
Adapt Celery config

### DIFF
--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -11,7 +11,7 @@ app = Celery('dojo')
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings')
+app.config_from_object('django.conf:settings', namespace='CELERY')
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -191,17 +191,16 @@ PORT_SCAN_SOURCE_IP = '127.0.0.1'
 TEAM_NAME = 'Security Engineering'
 
 # Celery settings
-BROKER_URL = 'sqla+sqlite:///dojo.celerydb.sqlite'
-CELERY_SEND_TASK_ERROR_EMAILS = True
-CELERY_IGNORE_RESULT = True
+CELERY_BROKER_URL = 'sqla+sqlite:///dojo.celerydb.sqlite'
+CELERY_TASK_IGNORE_RESULT = True
 CELERY_TIMEZONE = TIME_ZONE
-CELERY_TASK_RESULT_EXPIRES = 86400
-CELERYBEAT_SCHEDULE_FILENAME = DOJO_ROOT + '/dojo.celery.beat.db'
+CELERY_RESULT_EXPIRES = 86400
+CELERY_BEAT_SCHEDULE_FILENAME = DOJO_ROOT + '/dojo.celery.beat.db'
 CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = "pickle"
 
 # Celery beat scheduled tasks
-CELERYBEAT_SCHEDULE = {
+CELERY_BEAT_SCHEDULE = {
     'add-alerts': {
         'task':'dojo.tasks.add_alerts',
         'schedule': timedelta(hours=1),


### PR DESCRIPTION
Adapt settings to new settings names introduced by Celery 4.0 and documented at http://docs.celeryproject.org/en/latest/userguide/configuration.html

Note that Celery 4.1 has a known bug, ignoring the TIMEZONE setting described in https://github.com/celery/celery/issues/4717.

The change in ``dojo/celery.py`` may be breaking for users having copy&pasted their own settings file (having taken over the default settings). Manual adaption of their settings file is necessary. 


Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is pep8 compliant (Dojo's code isn't currently pep8 compliant, but we're trying to correct that)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder
