### PR TITLE
add markdown to finding creation view

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -28,7 +28,8 @@
     "@yarn_components/mocha": "mochajs/mocha#~1.17.1",
     "@yarn_components/moment": "moment/moment#^2.9.0",
     "@yarn_components/morrisjs": "morrisjs/morris.js#~0.5.1",
-    "@yarn_components/startbootstrap-sb-admin-2": "BlackrockDigital/startbootstrap-sb-admin-2#*"
+    "@yarn_components/startbootstrap-sb-admin-2": "BlackrockDigital/startbootstrap-sb-admin-2#*",
+    "@yarn_components/simplemde": "sparksuite/simplemde-markdown-editor#1.11.2"
   },
   "engines": {
     "yarn": ">= 1.0.0"

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -1,48 +1,57 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load static from staticfiles %}
+{% block add_css %}
+    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+{% endblock %}
+{% block add_styles %}
+    .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
+    width: 70% !important;
+    }
+{% endblock %}
 {% block content %}
     <div>
         <h3> Add findings to a test</h3>
     </div>
     <div>
-    {% if temp %}
-        <form class="form-horizontal" action="{% url 'add_temp_finding' tid fid %}" method="post">
-            {% csrf_token %}
-            {% include "dojo/form_fields.html" with form=form %}
-            {%  if jform %}
-                <h4> JIRA </h4>
-                <h4>
-                {% include "dojo/form_fields.html" with form=jform %}
-            {% endif %}
-            <div class="form-group">
-                <div class="col-sm-offset-2 col-sm-10">
-                    <input class="btn btn-primary" type="submit" value="Add Another Finding"/>
-                    <input class="btn btn-primary" type="submit" value="Finished"/>
+        {% if temp %}
+            <form class="form-horizontal" action="{% url 'add_temp_finding' tid fid %}" method="post">
+                {% csrf_token %}
+                {% include "dojo/form_fields.html" with form=form %}
+                {% if jform %}
+                    <h4> JIRA </h4>
+                    <h4>
+                    {% include "dojo/form_fields.html" with form=jform %}
+                {% endif %}
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10">
+                        <input class="btn btn-primary" type="submit" value="Add Another Finding"/>
+                        <input class="btn btn-primary" type="submit" value="Finished"/>
+                    </div>
                 </div>
-            </div>
-        </form>
-    {% else %}
-        <form class="form-horizontal" action="{% url 'add_findings' tid %}" method="post">
-            {% csrf_token %}
-            {% include "dojo/form_fields.html" with form=form %}
-            {%  if jform %}
-                <h4> JIRA </h4>
-                <hr>
-                {% include "dojo/form_fields.html" with form=jform %}
-            {% endif %}
-            <div class="form-group">
-                <div class="col-sm-offset-2 col-sm-10">
-                    <input class="btn btn-primary" type="submit" value="Add Another Finding"/>
-                    <input class="btn btn-primary" name="_Finished" type="submit" value="Finished"/>
+            </form>
+        {% else %}
+            <form class="form-horizontal" action="{% url 'add_findings' tid %}" method="post">
+                {% csrf_token %}
+                {% include "dojo/form_fields.html" with form=form %}
+                {% if jform %}
+                    <h4> JIRA </h4>
+                    <hr>
+                    {% include "dojo/form_fields.html" with form=jform %}
+                {% endif %}
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10">
+                        <input class="btn btn-primary" type="submit" value="Add Another Finding"/>
+                        <input class="btn btn-primary" name="_Finished" type="submit" value="Finished"/>
+                    </div>
                 </div>
-            </div>
-        </form>
-    {% endif %}
+            </form>
+        {% endif %}
     </div>
 {% endblock %}
 {% block postscript %}
-    <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
+    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
     <script type="application/javascript">
         $ = django.jQuery;
@@ -50,7 +59,15 @@
         {% if not form_error %}
             $('#id_endpoints').find('option').remove();
         {% endif %}
+        $(function () {
+            $("textarea").each(function (index, elem) {
+                var mde = new SimpleMDE({
+                    element: elem,
+                    autofocus: false,
+                    hideIcons: ["side-by-side", "fullscreen"]
+                });
+                mde.render();
+            });
+        });
     </script>
-
-
 {% endblock %}

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -15,7 +15,7 @@
     </div>
     <div>
         {% if temp %}
-            <form class="form-horizontal" action="{% url 'add_temp_finding' tid fid %}" method="post">
+            <form id="add_finding" class="form-horizontal" action="{% url 'add_temp_finding' tid fid %}" method="post">
                 {% csrf_token %}
                 {% include "dojo/form_fields.html" with form=form %}
                 {% if jform %}
@@ -31,7 +31,7 @@
                 </div>
             </form>
         {% else %}
-            <form class="form-horizontal" action="{% url 'add_findings' tid %}" method="post">
+            <form id="add_finding" class="form-horizontal" action="{% url 'add_findings' tid %}" method="post">
                 {% csrf_token %}
                 {% include "dojo/form_fields.html" with form=form %}
                 {% if jform %}
@@ -59,15 +59,41 @@
         {% if not form_error %}
             $('#id_endpoints').find('option').remove();
         {% endif %}
+
         $(function () {
             $("textarea").each(function (index, elem) {
+
+                if (elem.hasAttribute("required")) {
+                    elem.removeAttribute("required");
+                    elem.id = "req"
+                }
+
                 var mde = new SimpleMDE({
                     element: elem,
                     autofocus: false,
+                    forceSync: true,
                     hideIcons: ["side-by-side", "fullscreen"]
                 });
                 mde.render();
             });
+        });
+
+        $("#add_finding").submit(function () {
+            var isFormValid = true;
+
+            $("textarea#req").each(function () {
+                if ($.trim($(this).val()).length == 0) {
+                    $(this).addClass("highlight");
+                    isFormValid = false;
+                }
+                else {
+                    $(this).removeClass("highlight");
+                }
+            });
+
+            if (!isFormValid) alert("Please fill in all the required fields (indicated by *)");
+
+            return isFormValid;
         });
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -2,11 +2,15 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
-.chosen-container {
+    .chosen-container {
     width: 70% !important;
-}
+    }
+    .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
+    width: 70% !important;
+    }
 {% endblock %}
 {% block content %}
     <h3> {{ name }} {{ template }}</h3>
@@ -16,7 +20,6 @@
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <input class="btn btn-primary" type="submit" name="add_template" value="Save Template"/>
-                &nbsp;&nbsp;
             </div>
         </div>
     </form>
@@ -25,7 +28,6 @@
             <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">
                     <input class="btn btn-danger" type="submit" name="delete_template" value="Delete Template"/>
-                    &nbsp;&nbsp;
                     <input type="hidden" name="id" value="{{ template.id }}"/>
                 </div>
             </div>
@@ -34,6 +36,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({
@@ -50,6 +53,15 @@
                     $('#id_tags').focus();
                     return false;
                 }
+            });
+
+            $("textarea").each(function (index, elem) {
+                var mde = new SimpleMDE({
+                    element: elem,
+                    autofocus: false,
+                    hideIcons: ["side-by-side", "fullscreen"]
+                });
+                mde.render();
             });
         });
     </script>

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -15,7 +15,7 @@
 {% block content %}
     <h3> {{ name }} {{ template }}</h3>
 
-    <form class="form-horizontal" method="post">{% csrf_token %}
+    <form id="add_finding" class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
@@ -24,7 +24,8 @@
         </div>
     </form>
     {% if template %}
-        <form class="form-horizontal" method="post" action="{% url 'delete_template' template.id %}">{% csrf_token %}
+        <form id="add_finding" class="form-horizontal" method="post"
+              action="{% url 'delete_template' template.id %}">{% csrf_token %}
             <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">
                     <input class="btn btn-danger" type="submit" name="delete_template" value="Delete Template"/>
@@ -56,13 +57,39 @@
             });
 
             $("textarea").each(function (index, elem) {
+
+                if (elem.hasAttribute("required")) {
+                    elem.removeAttribute("required");
+                    elem.id = "req"
+                }
+
                 var mde = new SimpleMDE({
                     element: elem,
                     autofocus: false,
+                    forceSync: true,
                     hideIcons: ["side-by-side", "fullscreen"]
                 });
                 mde.render();
             });
+        });
+
+        $("#add_finding").submit(function () {
+
+            var isFormValid = true;
+
+            $("textarea#req").each(function () {
+                if ($.trim($(this).val()).length == 0) {
+                    $(this).addClass("highlight");
+                    isFormValid = false;
+                }
+                else {
+                    $(this).removeClass("highlight");
+                }
+            });
+
+            if (!isFormValid) alert("Please fill in all the required fields (indicated by *)");
+
+            return isFormValid;
         });
     </script>
 

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -3,9 +3,13 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {
+    width: 70% !important;
+    }
+    .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
 {% endblock %}
@@ -28,6 +32,7 @@
     <script type="application/javascript">
         $('#add_id_endpoints').attr('href', '/endpoints/{{ finding.test.engagement.product.id }}/add?_popup');
     </script>
+    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
@@ -46,6 +51,15 @@
                     $('#id_tags').focus();
                     return false;
                 }
+            });
+
+            $("textarea").each(function (index, elem) {
+                var mde = new SimpleMDE({
+                    element: elem,
+                    autofocus: false,
+                    hideIcons: ["side-by-side", "fullscreen"]
+                });
+                mde.render();
             });
         });
     </script>

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -15,7 +15,7 @@
 {% endblock %}
 {% block content %}
     <h3> Apply template to a Finding</h3>
-    <form class="form-horizontal" name="apply_template" action="{% url 'apply_template_to_finding' finding.id template.id %}" method="post">
+    <form id="add_finding" class="form-horizontal" name="apply_template" action="{% url 'apply_template_to_finding' finding.id template.id %}" method="post">
         {% csrf_token %}
         {% include "dojo/apply_finding_template_form_fields.html" with form=form template=template %}
         {%  if jform %}
@@ -54,13 +54,38 @@
             });
 
             $("textarea").each(function (index, elem) {
+
+                 if (elem.hasAttribute("required")) {
+                    elem.removeAttribute("required");
+                    elem.id = "req"
+                }
+
                 var mde = new SimpleMDE({
                     element: elem,
                     autofocus: false,
+                    forceSync: true,
                     hideIcons: ["side-by-side", "fullscreen"]
                 });
                 mde.render();
             });
+        });
+
+        $("#add_finding").submit(function () {
+            var isFormValid = true;
+
+            $("textarea#req").each(function () {
+                if ($.trim($(this).val()).length == 0) {
+                    $(this).addClass("highlight");
+                    isFormValid = false;
+                }
+                else {
+                    $(this).removeClass("highlight");
+                }
+            });
+
+            if (!isFormValid) alert("Please fill in all the required fields (indicated by *)");
+
+            return isFormValid;
         });
     </script>
 

--- a/dojo/templates/dojo/edit_findings.html
+++ b/dojo/templates/dojo/edit_findings.html
@@ -17,7 +17,7 @@
     <h3> Edit a Finding</h3>
     {% if temp %}
 
-        <form class="form-horizontal" action="{% url 'edit_finding' finding.id %}" method="post">
+        <form id="add_finding" class="form-horizontal" action="{% url 'edit_finding' finding.id %}" method="post">
             {% csrf_token %}
             {% include "dojo/form_fields.html" with form=form %}
             {% if jform %}
@@ -33,7 +33,7 @@
             </div>
         </form>
     {% else %}
-        <form class="form-horizontal" action="{% url 'edit_finding' finding.id %}" method="post">
+        <form id="add_finding" class="form-horizontal" action="{% url 'edit_finding' finding.id %}" method="post">
             {% csrf_token %}
             {% include "dojo/form_fields.html" with form=form %}
             {% if jform %}
@@ -76,13 +76,38 @@
             });
 
             $("textarea").each(function (index, elem) {
+
+                if (elem.hasAttribute("required")) {
+                    elem.removeAttribute("required");
+                    elem.id = "req"
+                }
+
                 var mde = new SimpleMDE({
                     element: elem,
                     autofocus: false,
+                    forceSync: true,
                     hideIcons: ["side-by-side", "fullscreen"]
                 });
                 mde.render();
             });
+        });
+
+        $("#add_finding").submit(function () {
+            var isFormValid = true;
+
+            $("textarea#req").each(function () {
+                if ($.trim($(this).val()).length == 0) {
+                    $(this).addClass("highlight");
+                    isFormValid = false;
+                }
+                else {
+                    $(this).removeClass("highlight");
+                }
+            });
+
+            if (!isFormValid) alert("Please fill in all the required fields (indicated by *)");
+
+            return isFormValid;
         });
     </script>
 

--- a/dojo/templates/dojo/edit_findings.html
+++ b/dojo/templates/dojo/edit_findings.html
@@ -3,11 +3,15 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
-.chosen-container {
+    .chosen-container {
     width: 70% !important;
-}
+    }
+    .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
+    width: 70% !important;
+    }
 {% endblock %}
 {% block content %}
     <h3> Edit a Finding</h3>
@@ -16,7 +20,7 @@
         <form class="form-horizontal" action="{% url 'edit_finding' finding.id %}" method="post">
             {% csrf_token %}
             {% include "dojo/form_fields.html" with form=form %}
-            {%  if jform %}
+            {% if jform %}
                 <h3> JIRA </h3>
                 <hr>
                 {% include "dojo/form_fields.html" with form=jform %}
@@ -32,7 +36,7 @@
         <form class="form-horizontal" action="{% url 'edit_finding' finding.id %}" method="post">
             {% csrf_token %}
             {% include "dojo/form_fields.html" with form=form %}
-            {%  if jform %}
+            {% if jform %}
                 {% include "dojo/form_fields.html" with form=jform %}
             {% endif %}
             <div class="form-group">
@@ -46,8 +50,9 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
 
-    <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
+    <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 
     <script type="application/javascript">
@@ -68,6 +73,15 @@
                     $('#id_tags').focus();
                     return false;
                 }
+            });
+
+            $("textarea").each(function (index, elem) {
+                var mde = new SimpleMDE({
+                    element: elem,
+                    autofocus: false,
+                    hideIcons: ["side-by-side", "fullscreen"]
+                });
+                mde.render();
             });
         });
     </script>

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -1,6 +1,14 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load static from staticfiles %}
+{% block add_css %}
+    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+{% endblock %}
+{% block add_styles %}
+    .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
+    width: 70% !important;
+    }
+{% endblock %}
 {% block content %}
     <div>
         <h3>Promote Potential Finding</h3>
@@ -9,12 +17,13 @@
         In order to promote a Potential Finding to a Verified Finding you must provide the following information.
     </div>
 
-    <form class="form-horizontal" action="{% url 'promote_to_finding' stub_finding.id %}" method="post">
+    <form id="add_finding" class="form-horizontal" action="{% url 'promote_to_finding' stub_finding.id %}"
+          method="post">
         {% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
-        {%  if jform %}
-                {% include "dojo/form_fields.html" with form=jform %}
-            {% endif %}
+        {% if jform %}
+            {% include "dojo/form_fields.html" with form=jform %}
+        {% endif %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <input class="btn btn-primary" type="submit" value="Promote Finding"/>&nbsp;&nbsp;
@@ -23,7 +32,8 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
+    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
     <script type="application/javascript">
         $ = django.jQuery;
@@ -31,5 +41,42 @@
         {% if not form_error %}
             $('#id_endpoints').find('option').remove();
         {% endif %}
+
+        $(function () {
+            $("textarea").each(function (index, elem) {
+
+                if (elem.hasAttribute("required")) {
+                    elem.removeAttribute("required");
+                    elem.id = "req"
+                }
+
+                var mde = new SimpleMDE({
+                    element: elem,
+                    autofocus: false,
+                    forceSync: true,
+                    hideIcons: ["side-by-side", "fullscreen"]
+                });
+                mde.render();
+            });
+        });
+
+        $("#add_finding").submit(function () {
+
+            var isFormValid = true;
+
+            $("textarea#req").each(function () {
+                if ($.trim($(this).val()).length == 0) {
+                    $(this).addClass("highlight");
+                    isFormValid = false;
+                }
+                else {
+                    $(this).removeClass("highlight");
+                }
+            });
+
+            if (!isFormValid) alert("Please fill in all the required fields (indicated by *)");
+
+            return isFormValid;
+        });
     </script>
 {% endblock %}


### PR DESCRIPTION
When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is pep8 compliant (Dojo's code isn't currently pep8 compliant, but we're trying to correct that)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder

Defect Dojo supports the markdown in the finding view but not in the creation/editing of findings. This PR adds the SimpleMDE-Markdown-Editor [link](https://github.com/sparksuite/simplemde-markdown-editor) to each textarea fields in (hopefully) all finding creation/editing views. However, the required attribute will not working anymore as the original textarea will be disabled by simpleMDE. Thus, a simple JS validation checks for empty, required field.