### PR TITLE
If the server does not have FQDN, create the endpoint with the IP

### DIFF
--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -85,8 +85,12 @@ def issue_r(raw_row, vuln):
 
     # FQDN
     issue_row['fqdn'] =raw_row.findtext('DNS')
-    fqdn_parts = urlparse(issue_row['fqdn'])
-    ep = Endpoint(host=fqdn_parts.netloc, path=fqdn_parts.path, query=fqdn_parts.query, fragment=fqdn_parts.fragment)
+
+    # Create Endpoint
+    if issue_row['fqdn']:
+        ep = Endpoint(host=issue_row['fqdn'])
+    else:
+        ep = Endpoint(host=issue_row['ip_address'])
 
     # OS NAME
     issue_row['os'] = raw_row.findtext('OPERATING_SYSTEM')


### PR DESCRIPTION
Hello,

I tried to upload a Qualys scan and I got an error. The error was produced because the parser looks for the DNS tag and this tag is not always in the XML.

With this change if DNS is not in the XML, the endpoint is going to be created using the IP.

Also, I changed the way of creating the endpoint when the FQDN is available because currently it creates only one endpoint without name.

Regards,