### PR TITLE
bugfix for templated findings and empty component handling

### DIFF
--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -320,7 +320,8 @@ def add_temp_finding(request, tid, fid):
             new_finding.save()
             if 'jiraform-push_to_jira' in request.POST:
                     jform = JIRAFindingForm(request.POST, prefix='jiraform', enabled=True)
-                    add_issue_task.delay(new_finding, jform.cleaned_data.get('push_to_jira'))
+                    if jform.is_valid():
+                        add_issue_task.delay(new_finding, jform.cleaned_data.get('push_to_jira'))
             messages.add_message(request,
                                  messages.SUCCESS,
                                  'Finding from template added successfully.',

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1077,7 +1077,7 @@ def update_issue(find, old_status, push_to_jira):
                 log_jira_alert(
                     "Component not updated, exists in Jira already. Update from Jira instead.",
                     find)
-            else:
+            elif jpkey.component:
                 # Add component to the Jira issue
                 component = [
                     {


### PR DESCRIPTION
This pull request is to fix two bugs which I found while using DefectDojo. 

The first fix is for adding findings from template - findings added from templates cannot be pushed to JIRA successfully as the `cleaned_data` attribute of the `jform` in `add_temp_findings` is accessed before calling `jform.is_valid` when calling `add_issue_task.delay`, which would fail.

The second fix is for handling empty component names when updating JIRA issues. Unlike in the `add_issue` function, there isn't a check for empty component names in the `update_issue` function, which causes a JIRA error to occur when findings with no components are edited. 