### PR TITLE
Added support for JSON import of NPM Audit scans

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -146,6 +146,7 @@
     "model": "dojo.test_type",
     "pk": 20
   },
+
   {
     "fields": {
       "name": "Qualys Scan"
@@ -201,13 +202,19 @@
     },
     "model": "dojo.test_type",
     "pk": 29
+  },
+  {
+    "fields": {
+      "name": "Gosec Scanner"
+    },
+    "model": "dojo.test_type",
+    "pk": 30
+  },
+  {
+    "fields": {
+      "name": "NPM Audit Scan"
+    },
+    "model": "dojo.test_type",
+    "pk": 31
   }
-    {
-      "fields": {
-	"name": "Gosec Scanner"
-      },
-      "model": "dojo.test_type",
-      "pk":28
-}
-
 ]

--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -146,7 +146,6 @@
     "model": "dojo.test_type",
     "pk": 20
   },
-
   {
     "fields": {
       "name": "Qualys Scan"

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -239,6 +239,7 @@ class ImportScanForm(forms.Form):
                          ("Dependency Check Scan", "Dependency Check Scan"),
                          ("Retire.js Scan", "Retire.js Scan"),
                          ("Node Security Platform Scan", "Node Security Platform Scan"),
+                         ("NPM Audit Scan", "NPM Audit Scan"),
                          ("Qualys Scan", "Qualys Scan"),
                          ("Qualys Webapp Scan", "Qualys Webapp Scan"),
                          ("OpenVAS CSV", "OpenVAS CSV"),

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -41,6 +41,7 @@
 	<li><b>Nikto</b> - XML output</li>
 	<li><b>Nmap</b> - XML output (use -oX)</li>
 	<li><b>Node Security Platform</b> - Node Security Platform (NSP) output file can be imported in JSON format.</li>
+	<li><b>NPM Audit</b> - NPM Audit Scan output file can be imported in JSON format.</li>
 	<li><b>OpenVAS CSV</b> - Import OpenVAS Scan in CSV format. Export as CSV Results on OpenVAS.</li>
 	<li><b>Qualys</b> - Qualys output files can be imported in XML format.</li>
 	<li><b>Qualys WebScan</b> - Qualys WebScan output files can be imported in XML format.</li>

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -13,6 +13,7 @@ from dojo.tools.vcg.parser import VCGParser
 from dojo.tools.dependencycheck.parser import DependencyCheckParser
 from dojo.tools.retirejs.parser import RetireJsParser
 from dojo.tools.nsp.parser import NspParser
+from dojo.tools.npmaudit.parser import NpmAuditParser
 from dojo.tools.generic.parser import GenericFindingUploadCsvParser
 from dojo.tools.qualys.parser import QualysParser
 from dojo.tools.qualyswebapp.parser import QualysWebAppParser
@@ -69,6 +70,8 @@ def import_parser_factory(file, test, scan_type=None):
         parser = RetireJsParser(file, test)
     elif scan_type == 'Node Security Platform Scan':
         parser = NspParser(file, test)
+    elif scan_type == 'NPM Audit Scan':
+        parser = NpmAuditParser(file, test)
     elif scan_type == 'Generic Findings Import':
         parser = GenericFindingUploadCsvParser(file, test)
     elif scan_type == 'Qualys Scan':

--- a/dojo/tools/npmaudit/parser.py
+++ b/dojo/tools/npmaudit/parser.py
@@ -1,0 +1,69 @@
+import json
+
+from dojo.models import Finding
+
+
+class NpmAuditParser(object):
+    def __init__(self, json_output, test):
+
+        tree = self.parse_json(json_output)
+
+        if tree:
+            self.items = [data for data in self.get_items(tree, test)]
+        else:
+            self.items = []
+
+    def parse_json(self, json_output):
+        try:
+            tree = json.load(json_output)
+            subtree = tree.get('advisories')
+        except:
+            raise Exception("Invalid format")
+
+        return subtree
+
+    def get_items(self, tree, test):
+        items = {}
+
+        for key, node in tree.iteritems():
+            item = get_item(node, test)
+            unique_key = str(node['id']) + str(node['module_name'])
+            items[unique_key] = item
+
+        return items.values()
+
+
+def get_item(item_node, test):
+
+    if item_node['severity'] == 'low':
+        severity = 'Low'
+    elif item_node['severity'] == 'moderate':
+        severity = 'Medium'
+    elif item_node['severity'] == 'high':
+        severity = 'High'
+    elif item_node['severity'] == 'critical':
+        severity = 'Critical'
+    else:
+        severity = 'Info'
+
+    finding = Finding(title=item_node['title'] + " - " + "(" + item_node['module_name'] + ", " + item_node['vulnerable_versions'] + ")",
+                      test=test,
+                      severity=severity,
+                      description=item_node['overview'] + "\n Vulnerable Module: " +
+                      item_node['module_name'] + "\n Vulnerable Versions: " +
+                      str(item_node['vulnerable_versions']) + "\n Patched Version: " +
+                      str(item_node['patched_versions']) + "\n Vulnerable Path: " + str(item_node['findings'][0]['paths']) + "\n CWE: " +
+                      str(item_node['cwe']) + "\n Access: " +
+                      str(item_node['access']),
+                      cwe=item_node['cwe'][4:],
+                      mitigation=item_node['recommendation'],
+                      references=item_node['url'],
+                      active=False,
+                      verified=False,
+                      false_p=False,
+                      duplicate=False,
+                      out_of_scope=False,
+                      mitigated=None,
+                      impact="No impact provided")
+
+    return finding


### PR DESCRIPTION
The Node Package Manager has an 'Audit' package which checks npm dependencies.

Commits add support for the '--json' output of 'npm audit'.