### PR TITLE
APIv2: Change APIv2 key URL to fix missing authentication

### DIFF
--- a/dojo/user/urls.py
+++ b/dojo/user/urls.py
@@ -21,5 +21,5 @@ urlpatterns = [
     url(r'^user/(?P<uid>\d+)/delete', views.delete_user,
         name='delete_user'),
     url(r'^api/key$', views.api_key, name='api_key'),
-    url(r'^api/v2/key$', views.api_v2_key, name='api_v2_key'),
+    url(r'^api/key-v2$', views.api_v2_key, name='api_v2_key'),
 ]


### PR DESCRIPTION
The previous APIv2 key URL matches the `settings.LOGIN_EXEMPT_URLS` so that no
authentication has been enforced. Fortunately, an unauthorized access from an anonymous user results in an error page. I propose to change the APIv2 key URL to match the schema of the APIv1 key URL.