### PR TITLE
Add unique constraints for some model fields

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -276,7 +276,7 @@ class Contact(models.Model):
 
 
 class Product_Type(models.Model):
-    name = models.CharField(max_length=300)
+    name = models.CharField(max_length=300, unique=True)
     critical_product = models.BooleanField(default=False)
     key_product = models.BooleanField(default=False)
     updated = models.DateTimeField(auto_now=True, null=True)
@@ -349,7 +349,7 @@ class Report_Type(models.Model):
 
 
 class Test_Type(models.Model):
-    name = models.CharField(max_length=200)
+    name = models.CharField(max_length=200, unique=True)
     static_tool = models.BooleanField(default=False)
     dynamic_tool = models.BooleanField(default=False)
 
@@ -418,7 +418,7 @@ class Product(models.Model):
         (NONE_CRITICALITY, _('None')),
     )
 
-    name = models.CharField(max_length=255)
+    name = models.CharField(max_length=255, unique=True)
     description = models.CharField(max_length=4000)
 
     '''
@@ -758,6 +758,7 @@ class Engagement(models.Model):
 
     class Meta:
         ordering = ['-target_start']
+        unique_together = ('name', 'target_start', 'product')
 
     def __unicode__(self):
         return "Engagement: %s (%s)" % (self.name if self.name else '',
@@ -797,7 +798,7 @@ class Endpoint(models.Model):
     path = models.CharField(null=True, blank=True, max_length=500,
                             help_text="The location of the resource, it should start with a '/'. For example"
                                       "/endpoint/420/edit")
-    query = models.CharField(null=True, blank=True, max_length=5000,
+    query = models.CharField(null=True, blank=True, max_length=1000,
                              help_text="The query string, the question mark should be omitted."
                                        "For example 'group=4&team=8'")
     fragment = models.CharField(null=True, blank=True, max_length=500,
@@ -809,6 +810,7 @@ class Endpoint(models.Model):
 
     class Meta:
         ordering = ['product', 'protocol', 'host', 'path', 'query', 'fragment']
+        unique_together = ('protocol', 'host', 'path', 'query', 'fragment', 'product')
 
     def __unicode__(self):
         from urlparse import uses_netloc
@@ -1543,7 +1545,7 @@ class JIRA_Conf(models.Model):
 
 
 class JIRA_Issue(models.Model):
-    jira_id = models.CharField(max_length=200)
+    jira_id = models.CharField(max_length=200, unique=True)
     jira_key = models.CharField(max_length=200)
     finding = models.OneToOneField(Finding, null=True, blank=True)
     engagement = models.OneToOneField(Engagement, null=True, blank=True)

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -310,3 +310,7 @@ LOGGING = {
         }
     }
 }
+
+# As we require `innodb_large_prefix = ON` for MySQL, we can silence the
+# warning about large varchar with unique indices.
+SILENCED_SYSTEM_CHECKS = ['mysql.E001']


### PR DESCRIPTION
Add unique constraints on the following fields:
- `Product.name`
- `Product_Type.name`
- `Tool_Type.name`
- `JIRA_Issue.jira_id`
- `Engagement.(name,target_start,product)`
- `Endpoint.(protocol,host,path,query,fragment,product)`

Now, all these objects can be uniquely identified by their names which is handy for synchronizing DefectDojo's state with external sources.

Some parts of the code already relied on the unique constraints, for example by using `Model.objects.get(name=<...>)`. (There are probably even more cases)

In turn, this requires `max_length <= 1024` for the corresponding char fields
and `innodb_large_prefix` must be ON which is the default for MySQL >= 5.7.7.

See also: https://stackoverflow.com/questions/45233362/django-says-that-mysql-does-not-allow-unique-charfields-to-have-a-max-length-2
