### PR TITLE
APIv2: Add ProductType endpoint

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -152,6 +152,12 @@ class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
         return obj.findings_count
 
 
+class ProductTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product_Type
+        fields = '__all__'
+
+
 class EngagementSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets, mixins
 from rest_framework.permissions import DjangoModelPermissions
 from django_filters.rest_framework import DjangoFilterBackend
 
-from dojo.models import Product, Engagement, Test, Finding, \
+from dojo.models import Product, Product_Type, Engagement, Test, Finding, \
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Endpoint, JIRA_PKey, JIRA_Conf
@@ -127,6 +127,15 @@ class ProductViewSet(mixins.ListModelMixin,
                 authorized_users__in=[self.request.user])
         else:
             return Product.objects.all()
+
+
+class ProductTypeViewSet(mixins.ListModelMixin,
+                         mixins.RetrieveModelMixin,
+                         viewsets.GenericViewSet):
+    serializer_class = serializers.ProductTypeSerializer
+    queryset = Product_Type.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'name', 'critical_product', 'key_product', 'created', 'updated')
 
 
 class ScanSettingsViewSet(mixins.ListModelMixin,

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -21,7 +21,7 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView, ReImportScanView
+    UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -89,6 +89,7 @@ v2_api.register(r'jira_configurations', JiraConfigurationsViewSet)
 v2_api.register(r'jira_finding_mappings', JiraIssuesViewSet)
 v2_api.register(r'jira_product_configurations', JiraViewSet)
 v2_api.register(r'products', ProductViewSet)
+v2_api.register(r'product_types', ProductTypeViewSet)
 v2_api.register(r'scan_settings', ScanSettingsViewSet)
 v2_api.register(r'scans', ScansViewSet)
 v2_api.register(r'stub_findings', StubFindingsViewSet)


### PR DESCRIPTION
This PR adds an APIv2 endpoint for `Product_Type`s.

This also resolves one of the inconsistencies mentioned in #682.