### PR TITLE
APIv2: Clean up redundant serializer fields

### DIFF
--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -144,7 +144,6 @@ class FindingsTest(BaseClass.RESTEndpointTest):
             "test": "http://testserver/api/v2/tests/3/",
             "url": "http://www.example.com",
             "thread_id": 1,
-            "reporter": "http://testserver/api/v2/users/2/",
             "found_by": [],
             "title": "DUMMY FINDING",
             "date": "2017-12-31",


### PR DESCRIPTION
This PR removes some redundant serializer fields in APIv2 as they match the default settings.

For `(Stub)Finding`, this PR sets the `reporter` field to the current user of the API so that the APIv2 behaves the same as DefectDojo's UI. (Do you actually want this? :) )