### PR TITLE
Replace `eval` with `ast.literal_eval`

### DIFF
--- a/dojo/management/commands/run_scan.py
+++ b/dojo/management/commands/run_scan.py
@@ -2,6 +2,7 @@ import Queue
 from datetime import datetime
 import sys
 import threading
+from ast import literal_eval
 
 from django.core.mail import send_mail
 from django.core.management import call_command
@@ -152,10 +153,10 @@ class Command(BaseCommand):
 
             scan_results = set()
             try:
-                scan_results = eval('set(' + IPScan.objects.get(
+                scan_results = set(literal_eval(IPScan.objects.get(
                     address=host,
                     scan=Scan.objects.get(
-                        id=service_dict['scan_id'])).services+')')
+                        id=service_dict['scan_id'])).services))
                 scan_results = map(
                     lambda x: str(x[0]) + '/' + str(x[1]) + ': ' + str(x[3]),
                     scan_results)
@@ -271,7 +272,7 @@ class Command(BaseCommand):
                         most_recent_ports = map(
                             lambda x: str(x[0]) + '/' + str(x[1]) + ': ' +
                             str(x[3]),
-                            eval(most_recent_ipscans.get(
+                            literal_eval(most_recent_ipscans.get(
                                 address=addr).services))
                     except:
                         most_recent_ports = []

--- a/dojo/scan/views.py
+++ b/dojo/scan/views.py
@@ -2,6 +2,7 @@
 
 import logging
 from threading import Thread
+from ast import literal_eval
 
 from django.conf import settings
 from django.contrib import messages
@@ -50,7 +51,7 @@ def view_scan(request, sid):
     ipScans = []
     ipScan_objects = IPScan.objects.filter(scan=scan)
     for i in ipScan_objects:
-        service_list = eval(i.services)
+        service_list = literal_eval(i.services)
         row = [i.address]
         for (port, protocol, status, service) in service_list:
             row.append(port)

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -16,6 +16,7 @@ from django.utils import timezone
 from markdown.extensions import Extension
 import dateutil.relativedelta
 import datetime
+from ast import literal_eval
 
 register = template.Library()
 
@@ -36,7 +37,7 @@ def markdown_render(value):
 def ports_open(value):
     count = 0
     for ipscan in value.ipscan_set.all():
-        count += len(eval(ipscan.services))
+        count += len(literal_eval(ipscan.services))
     return count
 
 


### PR DESCRIPTION
`eval` is used for parsing Python literals in the model field `IPscan.services`.  As `eval`
executes the given string as Python code, this is dangerous and should
be avoided.  For literal parsing, `ast.literal_eval` can be used instead.

See:  https://docs.python.org/2/library/ast.html#ast.literal_eval