### PR TITLE
APIv2:  Use IDs instead of URLs as identifier for objects

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -130,18 +130,14 @@ class TaggitSerializer(serializers.Serializer):
         return (to_be_tagged, validated_data)
 
 
-class UserSerializer(serializers.HyperlinkedModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('url', 'username', 'first_name', 'last_name', 'last_login')
+        fields = ('id', 'username', 'first_name', 'last_name', 'last_login')
 
 
-class ProductSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
+class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
     findings_count = serializers.SerializerMethodField()
-    prod_type = serializers.PrimaryKeyRelatedField(
-        queryset=Product_Type.objects.all())
-    regulations = serializers.PrimaryKeyRelatedField(
-        queryset=Regulation.objects.all(), many=True, required=False)
     tags = TagListSerializerField(required=False)
 
     class Meta:
@@ -149,9 +145,6 @@ class ProductSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer
         exclude = ('tid', 'manager', 'prod_manager', 'tech_contact',
                    'updated')
         extra_kwargs = {
-            'product_manager': {'view_name': 'user-detail'},
-            'technical_contact': {'view_name': 'user-detail'},
-            'team_manager': {'view_name': 'user-detail'},
             'authorized_users': {'queryset': User.objects.exclude(is_staff=True).exclude(is_active=False)}
         }
 
@@ -159,11 +152,7 @@ class ProductSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer
         return obj.findings_count
 
 
-class EngagementSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
-    eng_type = serializers.PrimaryKeyRelatedField(
-        queryset=Engagement_Type.objects.all(), required=False)
-    report_type = serializers.PrimaryKeyRelatedField(
-        queryset=Report_Type.objects.all(), required=False)
+class EngagementSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
 
     class Meta:
@@ -178,33 +167,29 @@ class EngagementSerializer(TaggitSerializer, serializers.HyperlinkedModelSeriali
         return data
 
 
-class ToolTypeSerializer(serializers.HyperlinkedModelSerializer):
+class ToolTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tool_Type
         fields = '__all__'
 
 
-class ToolConfigurationSerializer(serializers.HyperlinkedModelSerializer):
+class ToolConfigurationSerializer(serializers.ModelSerializer):
     configuration_url = serializers.CharField(source='url')
-    url = serializers.HyperlinkedIdentityField(
-        view_name='tool_configuration-detail')
 
     class Meta:
         model = Tool_Configuration
         fields = '__all__'
 
 
-class ToolProductSettingsSerializer(serializers.HyperlinkedModelSerializer):
+class ToolProductSettingsSerializer(serializers.ModelSerializer):
     setting_url = serializers.CharField(source='url')
-    url = serializers.HyperlinkedIdentityField(
-        view_name='tool_product_settings-detail')
 
     class Meta:
         model = Tool_Product_Settings
         fields = '__all__'
 
 
-class EndpointSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
+class EndpointSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
 
     class Meta:
@@ -290,38 +275,25 @@ class EndpointSerializer(TaggitSerializer, serializers.HyperlinkedModelSerialize
         return data
 
 
-class JIRAIssueSerializer(serializers.HyperlinkedModelSerializer):
+class JIRAIssueSerializer(serializers.ModelSerializer):
     class Meta:
         model = JIRA_Issue
         fields = '__all__'
 
 
-class JIRAConfSerializer(serializers.HyperlinkedModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='jira_conf-detail')
-    jira_url = serializers.CharField(
-        source='url')
-
+class JIRAConfSerializer(serializers.ModelSerializer):
     class Meta:
         model = JIRA_Conf
         fields = '__all__'
 
 
-class JIRASerializer(serializers.HyperlinkedModelSerializer):
-
+class JIRASerializer(serializers.ModelSerializer):
     class Meta:
         model = JIRA_PKey
         fields = '__all__'
 
 
-class TestSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
-    test_type = serializers.PrimaryKeyRelatedField(
-        queryset=Test_Type.objects.all())
-    environment = serializers.PrimaryKeyRelatedField(
-        queryset=Development_Environment.objects.all())
-    notes = serializers.PrimaryKeyRelatedField(
-        queryset=Notes.objects.all(),
-        many=True)
+class TestSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
 
     class Meta:
@@ -329,15 +301,9 @@ class TestSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
         fields = '__all__'
 
 
-class TestCreateSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
-    test_type = serializers.PrimaryKeyRelatedField(
-        queryset=Test_Type.objects.all())
-    environment = serializers.PrimaryKeyRelatedField(
-        queryset=Development_Environment.objects.all())
-    engagement = serializers.HyperlinkedRelatedField(
-        queryset=Engagement.objects.all(),
-        view_name='engagement-detail',
-        format='html')
+class TestCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
+    engagement = serializers.PrimaryKeyRelatedField(
+        queryset=Engagement.objects.all())
     notes = serializers.PrimaryKeyRelatedField(
         allow_null=True,
         default=[],
@@ -350,35 +316,18 @@ class TestCreateSerializer(TaggitSerializer, serializers.HyperlinkedModelSeriali
         fields = '__all__'
 
 
-class RiskAcceptanceSerializer(serializers.HyperlinkedModelSerializer):
+class RiskAcceptanceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Risk_Acceptance
         fields = '__all__'
 
 
-class FindingSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
-    notes = serializers.SlugRelatedField(
-        read_only=True,
-        slug_field='entry',
-        many=True)
-    found_by = serializers.PrimaryKeyRelatedField(
-        read_only=True,
-        many=True)
-    finding_url = serializers.CharField(
-        source='url',
-        read_only=True)
-    url = serializers.HyperlinkedIdentityField(view_name='finding-detail')
+class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Finding
         fields = '__all__'
-        extra_kwargs = {
-            'review_requested_by': {'view_name': 'user-detail'},
-            'reviewers': {'view_name': 'user-detail'},
-            'reporter': {'view_name': 'user-detail'},
-            'defect_review_requested_by': {'view_name': 'user-detail'},
-        }
 
     def validate(self, data):
         if self.context['request'].method == 'PATCH':
@@ -400,17 +349,14 @@ class FindingSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer
         return data
 
 
-class FindingCreateSerializer(TaggitSerializer, serializers.HyperlinkedModelSerializer):
-    notes = serializers.SlugRelatedField(
+class FindingCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
+    notes = serializers.PrimaryKeyRelatedField(
         read_only=True,
-        slug_field='entry',
         allow_null=True,
         default=[],
         many=True)
-    test = serializers.HyperlinkedRelatedField(
-        queryset=Test.objects.all(),
-        view_name='test-detail',
-        format='html')
+    test = serializers.PrimaryKeyRelatedField(
+        queryset=Test.objects.all())
     thread_id = serializers.IntegerField(default=0)
     found_by = serializers.PrimaryKeyRelatedField(
         queryset=Test_Type.objects.all(),
@@ -424,11 +370,7 @@ class FindingCreateSerializer(TaggitSerializer, serializers.HyperlinkedModelSeri
         model = Finding
         fields = '__all__'
         extra_kwargs = {
-            'review_requested_by': {'view_name': 'user-detail'},
-            'reporter': {
-                'default': serializers.CurrentUserDefault()
-            },
-            'defect_review_requested_by': {'view_name': 'user-detail'},
+            'reporter': {'default': serializers.CurrentUserDefault()},
         }
 
     def validate(self, data):
@@ -441,22 +383,21 @@ class FindingCreateSerializer(TaggitSerializer, serializers.HyperlinkedModelSeri
         return data
 
 
-class FindingTemplateSerializer(serializers.HyperlinkedModelSerializer):
+class FindingTemplateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Finding_Template
         fields = '__all__'
 
 
-class StubFindingSerializer(serializers.HyperlinkedModelSerializer):
+class StubFindingSerializer(serializers.ModelSerializer):
     class Meta:
         model = Stub_Finding
         fields = '__all__'
 
 
-class StubFindingCreateSerializer(serializers.HyperlinkedModelSerializer):
-    test = serializers.HyperlinkedRelatedField(
-        queryset=Test.objects.all(),
-        view_name='test-detail')
+class StubFindingCreateSerializer(serializers.ModelSerializer):
+    test = serializers.PrimaryKeyRelatedField(
+        queryset=Test.objects.all())
 
     class Meta:
         model = Stub_Finding
@@ -466,19 +407,17 @@ class StubFindingCreateSerializer(serializers.HyperlinkedModelSerializer):
         }
 
 
-class ScanSettingsSerializer(serializers.HyperlinkedModelSerializer):
+class ScanSettingsSerializer(serializers.ModelSerializer):
     class Meta:
         model = ScanSettings
         fields = '__all__'
 
 
-class ScanSettingsCreateSerializer(serializers.HyperlinkedModelSerializer):
-    user = serializers.HyperlinkedRelatedField(
-        queryset=User.objects.all(),
-        view_name='user-detail')
-    product = serializers.HyperlinkedRelatedField(
-        queryset=Product.objects.all(),
-        view_name='product-detail')
+class ScanSettingsCreateSerializer(serializers.ModelSerializer):
+    user = serializers.PrimaryKeyRelatedField(
+        queryset=User.objects.all())
+    product = serializers.PrimaryKeyRelatedField(
+        queryset=Product.objects.all())
     data = serializers.DateTimeField(required=False)
 
     class Meta:
@@ -486,28 +425,24 @@ class ScanSettingsCreateSerializer(serializers.HyperlinkedModelSerializer):
         fields = '__all__'
 
 
-class IPScanSerializer(serializers.HyperlinkedModelSerializer):
+class IPScanSerializer(serializers.ModelSerializer):
     class Meta:
         model = IPScan
         fields = '__all__'
 
 
-class ScanSerializer(serializers.HyperlinkedModelSerializer):
-    # scan_settings_link = serializers.HyperlinkedRelatedField(
+class ScanSerializer(serializers.ModelSerializer):
+    # scan_settings_link = serializers.PrimaryKeyRelatedField(
     #     read_only=True,
-    #     source='scan_settings',
-    #     view_name='scan_settings-detail',
-    #     format='html')
+    #     source='scan_settings')
     # scan_settings = serializers.PrimaryKeyRelatedField(
     #     queryset=ScanSettings.objects.all(),
     #     write_only=True,
     #     )
-    # ipscan_links = serializers.HyperlinkedRelatedField(
+    # ipscan_links = serializers.PrimaryKeyRelatedField(
     #     read_only=True,
     #     many=True,
-    #     source='ipscan_set',
-    #     view_name='ipscan-detail',
-    #     format='html')
+    #     source='ipscan_set')
 
     class Meta:
         model = Scan
@@ -524,11 +459,9 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
     file = serializers.FileField()
-    engagement = serializers.HyperlinkedRelatedField(
-        view_name='engagement-detail',
+    engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all())
-    lead = serializers.HyperlinkedRelatedField(
-        view_name='user-detail',
+    lead = serializers.PrimaryKeyRelatedField(
         allow_null=True,
         default=None,
         queryset=User.objects.all())
@@ -637,8 +570,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
     tags = TagListSerializerField(required=False)
     file = serializers.FileField()
-    test = serializers.HyperlinkedRelatedField(
-        view_name='test-detail',
+    test = serializers.PrimaryKeyRelatedField(
         queryset=Test.objects.all())
 
     def save(self):

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -39,43 +39,38 @@ class BaseClass():
             token = Token.objects.get(user=testuser)
             self.client = APIClient()
             self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+            self.url = reverse(self.viewname + '-list')
 
         @skipIfNotSubclass('ListModelMixin')
         def test_list(self):
-            response = self.client.get(
-                reverse(self.viewname + '-list'), format='json')
+            response = self.client.get(self.url, format='json')
             self.assertEqual(200, response.status_code)
 
         @skipIfNotSubclass('CreateModelMixin')
         def test_create(self):
             length = self.endpoint_model.objects.count()
-            response = self.client.post(
-                reverse(self.viewname + '-list'),
-                self.payload)
-            self.assertEqual(201, response.status_code)
+            response = self.client.post(self.url, self.payload)
+            self.assertEqual(201, response.status_code, response.data)
             self.assertEqual(self.endpoint_model.objects.count(), length + 1)
 
         @skipIfNotSubclass('RetrieveModelMixin')
         def test_detail(self):
-            current_objects = self.client.get(
-                reverse(self.viewname + '-list'), format='json').data
-            relative_url = urlparse(current_objects['results'][0]['url']).path
+            current_objects = self.client.get(self.url, format='json').data
+            relative_url = self.url + '%s/' % current_objects['results'][0]['id']
             response = self.client.get(relative_url)
             self.assertEqual(200, response.status_code)
 
         @skipIfNotSubclass('DestroyModelMixin')
         def test_delete(self):
-            current_objects = self.client.get(
-                reverse(self.viewname + '-list'), format='json').data
-            relative_url = urlparse(current_objects['results'][0]['url']).path
+            current_objects = self.client.get(self.url, format='json').data
+            relative_url = self.url + '%s/' % current_objects['results'][0]['id']
             response = self.client.delete(relative_url)
             self.assertEqual(204, response.status_code)
 
         @skipIfNotSubclass('UpdateModelMixin')
         def test_update(self):
-            current_objects = self.client.get(
-                reverse(self.viewname + '-list'), format='json').data
-            relative_url = urlparse(current_objects['results'][0]['url']).path
+            current_objects = self.client.get(self.url, format='json').data
+            relative_url = self.url + '%s/' % current_objects['results'][0]['id']
             response = self.client.patch(
                 relative_url, self.update_fields)
             for key, value in self.update_fields.iteritems():
@@ -98,7 +93,7 @@ class EndpointTest(BaseClass.RESTEndpointTest):
             'path': '/',
             'query': 'test=true',
             'fragment': 'test-1',
-            'product': 'http://testserver/api/v2/products/1/'
+            'product': 1,
         }
         self.update_fields = {'protocol': 'ftp'}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -121,7 +116,7 @@ class EngagementTest(BaseClass.RESTEndpointTest):
             "target_end": '1937-01-01',
             "reason": "",
             "test_strategy": "",
-            "product": "http://testserver/api/v2/products/1/",
+            "product": "1",
             "tags": ["mytag"]
         }
         self.update_fields = {'version': 'latest'}
@@ -136,12 +131,10 @@ class FindingsTest(BaseClass.RESTEndpointTest):
         self.viewname = 'finding'
         self.viewset = FindingViewSet
         self.payload = {
-            "review_requested_by": "http://testserver/api/v2/users/2/",
-            "reviewers": [
-                "http://testserver/api/v2/users/2/",
-                "http://testserver/api/v2/users/3/"],
-            "defect_review_requested_by": "http://testserver/api/v2/users/2/",
-            "test": "http://testserver/api/v2/tests/3/",
+            "review_requested_by": 2,
+            "reviewers": [2, 3],
+            "defect_review_requested_by": 2,
+            "test": 3,
             "url": "http://www.example.com",
             "thread_id": 1,
             "found_by": [],
@@ -166,9 +159,7 @@ class FindingsTest(BaseClass.RESTEndpointTest):
             "file_path": "",
             "static_finding": False,
             "dynamic_finding": False,
-            "endpoints": [
-                "http://testserver/api/v2/endpoints/1/",
-                "http://testserver/api/v2/endpoints/2/"],
+            "endpoints": [1, 2],
             "images": []}
         self.update_fields = {'active': True}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -202,7 +193,7 @@ class JiraConfigurationsTest(BaseClass.RESTEndpointTest):
         self.viewname = 'jira_conf'
         self.viewset = JiraConfigurationsViewSet
         self.payload = {
-            "jira_url": "http://www.example.com",
+            "url": "http://www.example.com",
             "username": "testuser",
             "password": "testuser",
             "default_issue_type": "Story",
@@ -229,11 +220,10 @@ class JiraIssuesTest(BaseClass.RESTEndpointTest):
         self.payload = {
             "jira_id": "JIRA 1",
             "jira_key": "SOME KEY",
-            "finding": "http://testserver/api/v2/findings/2/",
-            "engagement": 'http://testserver/api/v2/engagements/2/'
+            "finding": 2,
+            "engagement": 2,
         }
-        self.update_fields = {
-            'finding': 'http://testserver/api/v2/findings/2/'}
+        self.update_fields = {'finding': 2}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -250,11 +240,10 @@ class JiraTest(BaseClass.RESTEndpointTest):
             "push_all_issues": False,
             "enable_engagement_epic_mapping": False,
             "push_notes": False,
-            "product": 'http://testserver/api/v2/products/1/',
-            "conf": "http://testserver/api/v2/jira_configurations/2/"
+            "product": 1,
+            "conf": 2,
         }
-        self.update_fields = {
-            'conf': "http://testserver/api/v2/jira_configurations/3/"}
+        self.update_fields = {'conf': 3}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -266,12 +255,10 @@ class ProductTest(BaseClass.RESTEndpointTest):
         self.viewname = 'product'
         self.viewset = ProductViewSet
         self.payload = {
-            "product_manager": "http://testserver/api/v2/users/2/",
-            "technical_contact": "http://testserver/api/v2/users/3/",
-            "team_manager": "http://testserver/api/v2/users/2/",
-            "authorized_users": [
-                "http://testserver/api/v2/users/2/",
-                "http://testserver/api/v2/users/3/"],
+            "product_manager": 2,
+            "technical_contact": 3,
+            "team_manager": 2,
+            "authorized_users": [2, 3],
             "prod_type": 1,
             "name": "Test Product",
             "description": "test product",
@@ -293,8 +280,8 @@ class ScanSettingsTest(BaseClass.RESTEndpointTest):
             "frequency": "Weekly",
             "email": "test@dojo.com",
             "protocol": "TCP",
-            "product": "http://testserver/api/v2/products/1/",
-            "user": "http://testserver/api/v2/users/3/"
+            "product": 1,
+            "user": 3,
         }
         self.update_fields = {'protocol': 'ftp'}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -322,8 +309,8 @@ class StubFindingsTest(BaseClass.RESTEndpointTest):
             "date": "2017-12-31",
             "severity": "HIGH",
             "description": "test stub finding",
-            "reporter": "http://testserver/api/v2/users/3/",
-            "test": "http://testserver/api/v2/tests/3/"
+            "reporter": 3,
+            "test": 3,
         }
         self.update_fields = {'severity': 'LOW'}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -339,14 +326,14 @@ class TestsTest(BaseClass.RESTEndpointTest):
         self.payload = {
             "test_type": 1,
             "environment": 1,
-            "engagement": "http://testserver/api/v2/engagements/2/",
+            "engagement": 2,
             "estimated_time": "0:30:20",
             "actual_time": "0:20:30",
             "notes": [],
             "target_start": "2017-01-12T00:00",
             "target_end": "2017-01-12T00:00",
             "percent_complete": 0,
-            "lead": "http://testserver/api/v2/users/2/"
+            "lead": 2,
         }
         self.update_fields = {'percent_complete': 100}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -369,7 +356,7 @@ class ToolConfigurationsTest(BaseClass.RESTEndpointTest):
             "auth_title": "",
             "ssh": "",
             "api_key": "test key",
-            "tool_type": 'http://127.0.0.1:8000/api/v2/tool_types/1/'
+            "tool_type": 1,
         }
         self.update_fields = {'ssh': 'test string'}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -387,8 +374,7 @@ class ToolProductSettingsTest(BaseClass.RESTEndpointTest):
             "name": "Tool Product Setting",
             "description": "test tool product setting",
             "tool_project_id": "1",
-            "tool_configuration":
-                "http://127.0.0.1:8000/api/v2/tool_configurations/3/"
+            "tool_configuration": 3,
         }
         self.update_fields = {'tool_project_id': '2'}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -432,9 +418,7 @@ class ProductPermissionTest(APITestCase):
         response = self.client.get(
             reverse('product-list'), format='json')
         for obj in response.data['results']:
-            self.assertNotEqual(
-                obj['url'],
-                'http://testserver/api/v2/products/3/')
+            self.assertNotEqual(obj['id'], 3)
 
     def test_user_should_not_have_access_to_product_3_in_detail(self):
         response = self.client.get('http://testserver/api/v2/products/3/')
@@ -454,9 +438,7 @@ class ScanSettingsPermissionTest(APITestCase):
         response = self.client.get(
             reverse('scansettings-list'), format='json')
         for obj in response.data['results']:
-            self.assertNotEqual(
-                obj['url'],
-                'http://testserver/api/v2/scan_settings/3/')
+            self.assertNotEqual(obj['id'], 3)
 
     def test_user_should_not_have_access_to_setting_3_in_detail(self):
         response = self.client.get('http://testserver/api/v2/scan_settings/3/')
@@ -476,9 +458,7 @@ class ScansPermissionTest(APITestCase):
         response = self.client.get(
             reverse('scan-list'), format='json')
         for obj in response.data['results']:
-            self.assertNotEqual(
-                obj['url'],
-                'http://testserver/api/v2/scans/3/')
+            self.assertNotEqual(obj['id'], 3)
 
     def test_user_should_not_have_access_to_scan_3_in_detail(self):
         response = self.client.get('http://testserver/api/v2/scans/3/')
@@ -499,8 +479,8 @@ class ImportScanTest(BaseClass.RESTEndpointTest):
             "verified": True,
             "scan_type": 'ZAP Scan',
             "file": open('tests/zap_sample.xml'),
-            "engagement": 'http://testserver/api/v2/engagements/1/',
-            "lead": 'http://testserver/api/v2/users/2/'
+            "engagement": 1,
+            "lead": 2,
         }
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
@@ -524,6 +504,7 @@ class ReimportScanTest(APITestCase):
                 "verified": True,
                 "scan_type": 'ZAP Scan',
                 "file": open('tests/zap_sample.xml'),
-                "test": 'http://testserver/api/v2/tests/3/'})
+                "test": 3,
+            })
         self.assertEqual(length, Test.objects.all().count())
         self.assertEqual(201, response.status_code)


### PR DESCRIPTION
This PR modifies the APIv2 so that the IDs of an object are used as identifier instead of the object's URL.

Additionally, this PR removes a lot of serializer field definitions as the generated default fields can be used now.