### PR TITLE
Disabled autocomplete for date fields

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1262,10 +1262,10 @@ class DateRangeMetrics(forms.Form):
 class MetricsFilterForm(forms.Form):
     start_date = forms.DateField(required=False,
                                  label="To",
-                                 widget=forms.TextInput(attrs={'class':'datepicker', 'autocomplete': 'off'}))
+                                 widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     end_date = forms.DateField(required=False,
                                label="From",
-                               widget=forms.TextInput(attrs={'class':'datepicker', 'autocomplete': 'off'}))
+                               widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     finding_status = forms.MultipleChoiceField(
         required=False,
         widget=forms.CheckboxSelectMultiple,

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -520,9 +520,9 @@ class EngForm(forms.ModelForm):
                            help_text="Add tags that help describe this engagement.  "
                                      "Choose from the list or add new tags.  Press TAB key to add.")
     target_start = forms.DateField(widget=forms.TextInput(
-        attrs={'class': 'datepicker'}))
+        attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     target_end = forms.DateField(widget=forms.TextInput(
-        attrs={'class': 'datepicker'}))
+        attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     lead = forms.ModelChoiceField(
         queryset=User.objects.exclude(is_staff=False),
         required=True, label="Testing Lead")
@@ -589,9 +589,9 @@ class EngForm2(forms.ModelForm):
                                      "Choose from the list or add new tags.  Press TAB key to add.")
     product = forms.ModelChoiceField(queryset=Product.objects.all())
     target_start = forms.DateField(widget=forms.TextInput(
-        attrs={'class': 'datepicker'}))
+        attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     target_end = forms.DateField(widget=forms.TextInput(
-        attrs={'class': 'datepicker'}))
+        attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     test_options = (('API', 'API Test'), ('Static', 'Static Check'),
                     ('Pen', 'Pen Test'), ('Web App', 'Web Application Test'))
     lead = forms.ModelChoiceField(
@@ -643,9 +643,9 @@ class TestForm(forms.ModelForm):
         queryset=Development_Environment.objects.all().order_by('name'))
     # credential = forms.ModelChoiceField(Cred_User.objects.all(), required=False)
     target_start = forms.DateTimeField(widget=forms.TextInput(
-        attrs={'class': 'datepicker'}))
+        attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     target_end = forms.DateTimeField(widget=forms.TextInput(
-        attrs={'class': 'datepicker'}))
+        attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     tags = forms.CharField(widget=forms.SelectMultiple(choices=[]),
                            required=False,
                            help_text="Add tags that help describe this test.  "
@@ -683,8 +683,7 @@ class DeleteTestForm(forms.ModelForm):
 class AddFindingForm(forms.ModelForm):
     title = forms.CharField(max_length=1000)
     date = forms.DateField(required=True,
-                           widget=forms.TextInput(attrs={'class':
-                                                             'datepicker'}))
+                           widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     cwe = forms.IntegerField(required=False)
     description = forms.CharField(widget=forms.Textarea)
     severity = forms.ChoiceField(
@@ -721,8 +720,7 @@ class AddFindingForm(forms.ModelForm):
 class AdHocFindingForm(forms.ModelForm):
     title = forms.CharField(max_length=1000)
     date = forms.DateField(required=True,
-                           widget=forms.TextInput(attrs={'class':
-                                                             'datepicker'}))
+                           widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     cwe = forms.IntegerField(required=False)
     description = forms.CharField(widget=forms.Textarea)
     severity = forms.ChoiceField(
@@ -759,8 +757,7 @@ class AdHocFindingForm(forms.ModelForm):
 class PromoteFindingForm(forms.ModelForm):
     title = forms.CharField(max_length=1000)
     date = forms.DateField(required=True,
-                           widget=forms.TextInput(attrs={'class':
-                                                             'datepicker'}))
+                           widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     cwe = forms.IntegerField(required=False)
     description = forms.CharField(widget=forms.Textarea)
     severity = forms.ChoiceField(
@@ -784,8 +781,7 @@ class PromoteFindingForm(forms.ModelForm):
 class FindingForm(forms.ModelForm):
     title = forms.CharField(max_length=1000)
     date = forms.DateField(required=True,
-                           widget=forms.TextInput(attrs={'class':
-                                                             'datepicker'}))
+                           widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     cwe = forms.IntegerField(required=False)
     description = forms.CharField(widget=forms.Textarea)
     severity = forms.ChoiceField(
@@ -1257,23 +1253,19 @@ class SimpleSearchForm(forms.Form):
 
 class DateRangeMetrics(forms.Form):
     start_date = forms.DateField(required=True, label="To",
-                                 widget=forms.TextInput(attrs={'class':
-                                                                   'datepicker'}))
+                                 widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
     end_date = forms.DateField(required=True,
                                label="From",
-                               widget=forms.TextInput(attrs={'class':
-                                                                 'datepicker'}))
+                               widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
 
 
 class MetricsFilterForm(forms.Form):
     start_date = forms.DateField(required=False,
                                  label="To",
-                                 widget=forms.TextInput(attrs={'class':
-                                                                   'datepicker'}))
+                                 widget=forms.TextInput(attrs={'class':'datepicker', 'autocomplete': 'off'}))
     end_date = forms.DateField(required=False,
                                label="From",
-                               widget=forms.TextInput(attrs={'class':
-                                                                 'datepicker'}))
+                               widget=forms.TextInput(attrs={'class':'datepicker', 'autocomplete': 'off'}))
     finding_status = forms.MultipleChoiceField(
         required=False,
         widget=forms.CheckboxSelectMultiple,

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -231,7 +231,7 @@ def add_issue_task(find, push_to_jira):
 
 @task(name='update_issue_task')
 def update_issue_task(find, old_status, push_to_jira):
-    logger.info("add issue task")
+    logger.info("update issue task")
     update_issue(find, old_status, push_to_jira)
 
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -982,7 +982,7 @@ def add_issue(find, push_to_jira):
                             ],
                             description=jira_long_description(
                                 find.long_desc(), find.id,
-                                jira_conf.finding_ftext),
+                                jira_conf.finding_text),
                             issuetype={'name': jira_conf.default_issue_type},
                             priority={
                                 'name': jira_conf.get_priority(find.severity)

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -982,7 +982,7 @@ def add_issue(find, push_to_jira):
                             ],
                             description=jira_long_description(
                                 find.long_desc(), find.id,
-                                jira_conf.finding_text),
+                                jira_conf.finding_ftext),
                             issuetype={'name': jira_conf.default_issue_type},
                             priority={
                                 'name': jira_conf.get_priority(find.severity)


### PR DESCRIPTION
Disabled autocomplete for DateFields with datepicker class as the autocomplete dialog overlaps with the calendar if its large enough:
![screen shot 2018-08-16 at 6 22 50 pm](https://user-images.githubusercontent.com/27908745/44203785-dff50f80-a182-11e8-90d4-c169356ac7ec.png)

Also fixed the logs for update_issue_task, which was logging "add issue task" instead of "update issue task". 