### PR TITLE
Fix endpoint add view

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -307,7 +307,7 @@ def add_product_endpoint(request):
                                  messages.SUCCESS,
                                  'Endpoint added successfully.',
                                  extra_tags='alert-success')
-            return HttpResponseRedirect(reverse('view_endpoint'))
+            return HttpResponseRedirect(reverse('endpoints') + "?product=%s" % form.product.id)
     add_breadcrumb(title="Add Endpoint", top_level=False, request=request)
     return render(request,
                   'dojo/add_endpoint.html',


### PR DESCRIPTION
Currently, adding an endpoint for a product fails with the following error:

```
NoReverseMatch at /endpoints/add

Reverse for 'view_endpoint' with no arguments not found. 1 pattern(s) tried: [u'endpoint/(?P<eid>\\d+)$']
```

Fix this by redirecting to the endpoint overview for the specific product.