### PR TITLE
Fix unicode handling in Dependency Check parser

### DIFF
--- a/dojo/tools/dependencycheck/parser.py
+++ b/dojo/tools/dependencycheck/parser.py
@@ -12,30 +12,34 @@ logger = logging.getLogger(__name__)
 class DependencyCheckParser(object):
     def get_field_value(self, parent_node, field_name):
         field_node = parent_node.find(self.namespace + field_name)
-        field_value = '' if field_node is None else field_node.text
+        field_value = u'' if field_node is None else field_node.text
         return field_value
 
     def get_filename_from_dependency(self, dependency):
         return self.get_field_value(dependency, 'fileName')
 
     def get_finding_from_vulnerability(self, vulnerability, filename, test):
-        title = '{0} | {1}'.format(filename,
-                                   self.get_field_value(vulnerability, 'name'))
+        name = self.get_field_value(vulnerability, 'name')
         severity = self.get_field_value(vulnerability, 'severity')
-        finding_detail = '{0}\n\n{1}'.format(
-            self.get_field_value(vulnerability, 'cwe'),
-            self.get_field_value(vulnerability, 'description'))
-        reference_detail = None
+        cwe = self.get_field_value(vulnerability, 'cwe')
+        description = self.get_field_value(vulnerability, 'description')
 
+        title = u'{0} | {1}'.format(filename, name)
+        finding_detail = u'{0}\n\n{1}'.format(cwe, description)
+
+        reference_detail = None
         references_node = vulnerability.find(self.namespace + 'references')
 
         if references_node is not None:
             reference_detail = ''
             for reference_node in references_node.findall(self.namespace +
                                                           'reference'):
-                reference_detail += 'name: {0}\n' \
-                                    'source: {1}\n' \
-                                    'url: {2}\n\n'.format(self.get_field_value(reference_node, 'name'), self.get_field_value(reference_node, 'source'), self.get_field_value(reference_node, 'url'))
+                name = self.get_field_value(reference_node, 'name')
+                source = self.get_field_value(reference_node, 'source')
+                url = self.get_field_value(reference_node, 'url')
+                reference_detail += u'name: {0}\n' \
+                                     'source: {1}\n' \
+                                     'url: {2}\n\n'.format(name, source, url)
 
         return Finding(
             title=title,
@@ -83,9 +87,10 @@ class DependencyCheckParser(object):
                             vulnerability, dependency_filename, test)
 
                         if finding is not None:
-                            key = hashlib.md5(finding.severity + '|' +
-                                              finding.title + '|' +
-                                              finding.description).hexdigest()
+                            key_str = u'{}|{}|{}'.format(finding.severity,
+                                                         finding.title,
+                                                         finding.description)
+                            key = hashlib.md5(key_str.encode('utf-8')).hexdigest()
 
                             if key not in self.dupes:
                                 self.dupes[key] = finding


### PR DESCRIPTION
We had a `dependency-check-report.xml` where a reporter had a German umlaut in their name which broke the parser :)

The fix is to just replace all byte format strings with unicode format strings.