### PR TITLE
Fix JIRA integration

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -145,16 +145,14 @@ def edit_engagement(request, eid):
 
         if (form.is_valid() and jform is None) or (form.is_valid() and jform and jform.is_valid()):
             if 'jiraform-push_to_jira' in request.POST:
-                try:
-                    # jissue = JIRA_Issue.objects.get(engagement=eng)
+                if JIRA_Issue.objects.filter(engagement=eng).exists():
                     update_epic_task.delay(
                         eng, jform.cleaned_data.get('push_to_jira'))
                     enabled = True
-                except:
+                else:
                     enabled = False
                     add_epic_task.delay(eng,
                                         jform.cleaned_data.get('push_to_jira'))
-                    pass
             temp_form = form.save(commit=False)
             if (temp_form.status == "Cancelled" or temp_form.status == "Completed"):
                 temp_form.active = False

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -518,16 +518,14 @@ def edit_finding(request, fid):
                 jform = JIRAFindingForm(
                     request.POST, prefix='jiraform', enabled=enabled)
                 if jform.is_valid():
-                    try:
-                        # jissue = JIRA_Issue.objects.get(finding=new_finding)
+                    if JIRA_Issue.objects.filter(finding=new_finding).exists():
                         update_issue_task.delay(
                             new_finding, old_status,
                             jform.cleaned_data.get('push_to_jira'))
-                    except:
+                    else:
                         add_issue_task.delay(
                             new_finding,
                             jform.cleaned_data.get('push_to_jira'))
-                        pass
             tags = request.POST.getlist('tags')
             t = ", ".join(tags)
             new_finding.tags = t


### PR DESCRIPTION
Currently, pushing to JIRA fails the following exception in the Celery
worker.  Fix this by re-adding the check whether a `JIRA_Issue` object
exists for the `Finding` or `Engagement`.

```
DoesNotExist('JIRA_Issue matching query does not exist.',)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 382, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/trace.py", line 641, in __protected_call__
    return self.run(*args, **kwargs)
  File "/home/defectdojo/django-DefectDojo/dojo/tasks.py", line 235, in update_issue_task
    update_issue(find, old_status, push_to_jira)
  File "/home/defectdojo/django-DefectDojo/dojo/utils.py", line 1064, in update_issue
    j_issue = JIRA_Issue.objects.get(finding=find)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/django/db/models/query.py", line 380, in get
    self.model._meta.object_name
Exception: JIRA_Issue matching query does not exist.
```