### PR TITLE
Apply Template: Add buttons for applying the same option to all fields

### DIFF
--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -110,5 +110,13 @@
             return isFormValid;
         });
     </script>
-
+    <script>
+        $("#template_set_all_options button").click(function () {
+            $("#template_set_all_options button").removeClass("btn-primary");
+            $(this).addClass("btn-primary");
+            var option = $(this).data('option');
+            $("#add_finding select option[value='" + option + "']").prop("selected", true).change();
+            return false;
+        });
+    </script>
 {% endblock %}

--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -7,6 +7,11 @@
         {{ form.non_field_errors }}
     </div>
 {% endif %}
+<div id="template_set_all_options" class="form-group"><div class="col-sm-offset-2 col-sm-10">
+        <button data-option="Keep" class="btn">Keep all</button>
+        <button data-option="Replace" class="btn">Replace all</button>
+        <button data-option="Combine" class="btn">Combine all</button>
+</div></div>
 {% for field in form.hidden_fields %}
     {{ field }}
 {% endfor %}


### PR DESCRIPTION
This patch adds three buttons to the 'apply template to finding' view for applying the same option (Keep, Replace, Combine) to all fields.

I'm not that familiar with JavaScript, but it works for me :smile: 

#### Example when clicking on 'Replace all':
Before:
![screenshot-2018-9-25 finding template options defectdojo](https://user-images.githubusercontent.com/1176393/46015467-a93fdc80-c0d2-11e8-9549-11f6d0a7741c.png)

After:
![screenshot-2018-9-25 finding template options defectdojo 1](https://user-images.githubusercontent.com/1176393/46015481-ac3acd00-c0d2-11e8-8ee0-238ca6054bee.png)
