### PR TITLE
An automated closed finding should be marked as mitigated

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -590,6 +590,10 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
                                        test__engagement__product=test.engagement.product,
                                        active=True):
                 old_finding.active = False
+                old_finding.mitigated = datetime.datetime.combine(
+                    test.target_start,
+                    timezone.now().time())
+                old_finding.mitigated_by = self.context['request'].user
                 old_finding.notes.create(author=self.context['request'].user,
                                          entry="This finding has been automatically closed"
                                          " as it is not present anymore in recent scans.")


### PR DESCRIPTION
A finding needs to be mitigated to not show up under Metrics.
See also https://github.com/DefectDojo/django-DefectDojo/pull/748
