### PR TITLE
Add a `Has JIRA issue` filter option to the findings view

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -8,7 +8,8 @@ from django.contrib.auth.models import User
 from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 from django_filters import FilterSet, CharFilter, OrderingFilter, \
-    ModelMultipleChoiceFilter, ModelChoiceFilter, MultipleChoiceFilter
+    ModelMultipleChoiceFilter, ModelChoiceFilter, MultipleChoiceFilter, \
+    BooleanFilter
 from django_filters.filters import ChoiceFilter, _truncate, DateTimeFilter
 from pytz import timezone
 
@@ -336,6 +337,11 @@ class OpenFindingFilter(DojoFilter):
     test__engagement__product = ModelMultipleChoiceFilter(
         queryset=Product.objects.all(),
         label="Product")
+    if get_system_setting('enable_jira'):
+        jira_issue = BooleanFilter(name='jira_issue',
+                                   lookup_expr='isnull',
+                                   exclude=True,
+                                   label='JIRA issue')
 
     o = OrderingFilter(
         # tuple-mapping retains order


### PR DESCRIPTION
Hey there,

this PR adds a new filter option for the findings view so that findings can be filtered by 'having an attached JIRA issue'.  This filter is quite useful for our workflows.  Looks like this:

![2018-10-12-110207_2560x1394_scrot](https://user-images.githubusercontent.com/1176393/46947534-63e05080-d07b-11e8-9775-acbc3e7bd9f5.png)
