### PR TITLE
DELETE API endpoints for engagements, tests and findings and support for JSON import of Brakeman scans

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -25,6 +25,7 @@ class EndPointViewSet(mixins.ListModelMixin,
 class EngagementViewSet(mixins.ListModelMixin,
                         mixins.RetrieveModelMixin,
                         mixins.UpdateModelMixin,
+                        mixins.DestroyModelMixin,
                         mixins.CreateModelMixin,
                         viewsets.GenericViewSet):
     serializer_class = serializers.EngagementSerializer
@@ -51,6 +52,7 @@ class FindingTemplatesViewSet(mixins.ListModelMixin,
 class FindingViewSet(mixins.ListModelMixin,
                      mixins.RetrieveModelMixin,
                      mixins.UpdateModelMixin,
+                     mixins.DestroyModelMixin,
                      mixins.CreateModelMixin,
                      viewsets.GenericViewSet):
     serializer_class = serializers.FindingSerializer
@@ -215,6 +217,7 @@ class StubFindingsViewSet(mixins.ListModelMixin,
 class TestsViewSet(mixins.ListModelMixin,
                    mixins.RetrieveModelMixin,
                    mixins.UpdateModelMixin,
+                   mixins.DestroyModelMixin,
                    mixins.CreateModelMixin,
                    viewsets.GenericViewSet):
     serializer_class = serializers.TestSerializer

--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -222,5 +222,12 @@
     },
     "model": "dojo.test_type",
     "pk": 32
+  },
+  {
+    "fields": {
+      "name": "Brakeman Scan"
+    },
+    "model": "dojo.test_type",
+    "pk": 33
   }
 ]

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -254,7 +254,8 @@ class ImportScanForm(forms.Form):
                          ("MobSF Scan", "MobSF Scan"),
                          ("Trufflehog Scan", "Trufflehog Scan"),
                          ("Nikto Scan", "Nikto Scan"),
-                         ("Clair Scan", "Clair Scan"))
+                         ("Clair Scan", "Clair Scan"),
+                         ("Brakeman Scan", "Brakeman Scan"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
 

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -31,6 +31,7 @@
 	<li><b>Bandit</b> - JSON report format</li>
 	<li><b>Burp XML</b> - When the Burp report is generated, the recommended option is Base64 encoding both the request and
 	    response fields. These fields will be processed and made available in the 'Finding View' page.</li>
+        <li><b>Brakeman Scan</b> - Import Brakeman Scanner findings in JSON format.</li>
 	<li><b>Clair Scan</b> - Import JSON reports of Docker image vulnerabilities.</li>
 	<li><b>Contrast Scanner</b> - CSV Report</b></li>
 	<li><b>Checkmarx Detailed XML Report</b></li>

--- a/dojo/tools/brakeman/__init__.py
+++ b/dojo/tools/brakeman/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'feeltheajf'

--- a/dojo/tools/brakeman/parser.py
+++ b/dojo/tools/brakeman/parser.py
@@ -1,0 +1,66 @@
+__author__ = 'feeltheajf'
+
+from datetime import datetime
+from dateutil import parser
+import json
+from dojo.models import Finding
+
+
+class BrakemanScanParser(object):
+    def __init__(self, filename, test):
+        data = json.load(filename)
+        dupes = dict()
+        find_date = parser.parse(data['scan_info']['end_time'])
+
+        for item in data['warnings']:
+            categories = ''
+            language = ''
+            mitigation = ''
+            impact = ''
+            references = ''
+            findingdetail = ''
+            title = ''
+            group = ''
+            status = ''
+
+            title = item['warning_type'] + '. ' + item['message']
+
+            ###### Finding details information ######
+            findingdetail += 'Filename: ' + item['file'] + '\n'
+            findingdetail += 'Line number: ' + str(item['line'] or '') + '\n'
+            findingdetail += 'Issue Confidence: ' + item['confidence'] + '\n\n'
+            findingdetail += 'Code:\n'
+            findingdetail += item['code'] or '' + '\n'
+
+            sev = 'Medium'
+            mitigation = 'coming soon'
+            references = item['link']
+
+            dupe_key = item['fingerprint']
+
+            if dupe_key in dupes:
+                find = dupes[dupe_key]
+            else:
+                dupes[dupe_key] = True
+
+                find = Finding(
+                    title=title,
+                    test=test,
+                    active=False,
+                    verified=False,
+                    description=findingdetail,
+                    severity=sev,
+                    numerical_severity=Finding.get_numerical_severity(sev),
+                    mitigation=mitigation,
+                    impact=impact,
+                    references=references,
+                    file_path=item['file'],
+                    line=item['line'],
+                    url='N/A',
+                    date=find_date,
+                    static_finding=True)
+
+                dupes[dupe_key] = find
+
+        self.items = dupes.values()
+

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -28,6 +28,7 @@ from dojo.tools.trufflehog.parser import TruffleHogJSONParser
 from dojo.tools.sonarqube.parser import SonarQubeHtmlParser
 from dojo.tools.clair.parser import ClairParser
 from dojo.tools.mobsf.parser import MobSFParser
+from dojo.tools.brakeman.parser import BrakemanScanParser
 
 __author__ = 'Jay Paz'
 
@@ -98,6 +99,8 @@ def import_parser_factory(file, test, scan_type=None):
         parser = SonarQubeHtmlParser(file, test)
     elif scan_type == 'MobSF Scan':
         parser = MobSFParser(file, test)
+    elif scan_type == 'Brakeman Scan':
+        parser = BrakemanScanParser(file, test)
     else:
         raise ValueError('Unknown Test Type')
 


### PR DESCRIPTION
- [Brakeman](https://github.com/presidentbeef/brakeman) is a well-known scanner for RoR projects
- We use DELETE API endpoints for automatic deletion of stale/closed engagements and findings, and bulk remove of tests, for instance, basing on their tags