### PR TITLE
add test_type_name to test API

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -317,6 +317,7 @@ class JIRASerializer(serializers.ModelSerializer):
 
 class TestSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
+    test_type_name = serializers.ReadOnlyField()
 
     class Meta:
         model = Test

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -962,6 +962,9 @@ class Test(models.Model):
     updated = models.DateTimeField(auto_now=True, null=True)
     created = models.DateTimeField(auto_now_add=True, null=True)
 
+    def test_type_name(self):
+        return self.test_type.name
+
     def __unicode__(self):
         return "%s (%s)" % (self.test_type,
                             self.target_start.strftime("%b %d, %Y"))


### PR DESCRIPTION
This allows to retrive the test type name for each test when requesting the test API.
