### PR TITLE
Add test types in api v2

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -339,6 +339,14 @@ class TestCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
         fields = '__all__'
 
 
+class TestTypeSerializer(TaggitSerializer, serializers.ModelSerializer):
+    tags = TagListSerializerField(required=False)
+
+    class Meta:
+        model = Test_Type
+        fields = '__all__'
+
+
 class RiskAcceptanceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Risk_Acceptance

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets, mixins
 from rest_framework.permissions import DjangoModelPermissions
 from django_filters.rest_framework import DjangoFilterBackend
 
-from dojo.models import Product, Product_Type, Engagement, Test, Finding, \
+from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta
@@ -231,6 +231,13 @@ class TestsViewSet(mixins.ListModelMixin,
             return serializers.TestCreateSerializer
         else:
             return serializers.TestSerializer
+
+
+class TestTypesViewSet(mixins.ListModelMixin,
+                       viewsets.GenericViewSet):
+    serializer_class = serializers.TestTypeSerializer
+    queryset = Test_Type.objects.all()
+    filter_backends = (DjangoFilterBackend,)
 
 
 class ToolConfigurationsViewSet(mixins.ListModelMixin,

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -20,7 +20,7 @@ from dojo.api import UserResource, ProductResource, EngagementResource, \
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
-    ScansViewSet, StubFindingsViewSet, TestsViewSet, \
+    ScansViewSet, StubFindingsViewSet, TestsViewSet, TestTypesViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
     UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet
 
@@ -96,6 +96,7 @@ v2_api.register(r'scan_settings', ScanSettingsViewSet)
 v2_api.register(r'scans', ScansViewSet)
 v2_api.register(r'stub_findings', StubFindingsViewSet)
 v2_api.register(r'tests', TestsViewSet)
+v2_api.register(r'test_types', TestTypesViewSet)
 v2_api.register(r'tool_configurations', ToolConfigurationsViewSet)
 v2_api.register(r'tool_product_settings', ToolProductSettingsViewSet)
 v2_api.register(r'tool_types', ToolTypesViewSet)


### PR DESCRIPTION
You can make a get request on /api/v2/test_types to get the test types list.