### PR TITLE
Added new setup.bash installer, moved old one to legacy-setup.bash

### DIFF
--- a/entrypoint_scripts/README.MD
+++ b/entrypoint_scripts/README.MD
@@ -1,0 +1,115 @@
+## Documentation on setup.bash 
+
+The bash script setup.bash was created to automate installation of Defect Dojo and allow for the following install situations to be automated:
+
+### Supported Installs
+
+* Single Server - simplest DefectDojo install where DefectDojo, Dojo dependencies and 3rd party services are installed on a single server. [default install]
+* Dev Install - install for local development where a Single Server install is run with credentials and other passwords set to known values.  
+* Stand-alone Server - install DefectDojo & Dojo dependencies only where 3rd party services (database) is running on other infrastructure.
+* ? Docker Single Server - a Single Server install where DefectDojo, Dojo dependencies and 3rd party services are installed in a single container
+* ? Docker Stand-alone - a Stand-alone Server install DefectDojo & Dojo dependencies only are installed in a single container.  
+
+Note: Cloning the DefectDojo repo and running ./setup.bash does a single server interactive install.  Doing other install methods requires setting configuration values and/or using command-line options.  
+
+### TDB install situations
+
+* Docker Dev Install - a dev install that uses docker + a mounted local directory structure to isolate dojo code from the rest of the run-time.
+* Fronted Dojo Installs - a install of DefectDojo where a separate HTTP server answers the initial requests for DefectDojo such as using Nginx upstream of DefectDojo
+
+### Assumptions
+
+All installs make these assumption:
+
+* DefectDojo will be run in a virtualenv
+* All installs support an interactive and non-interactive install methods
+* All installation configuration lives in ./dojo/settings/template-env
+* * Running setup.bash without editing template-env assumes a single-server install.
+* * Running setup.bash without editing template-env non-interactively assumes a single-server install with MySQL
+* Any install configuration variable can be overridden by setting an environmental variable
+* One of the following OSes is used as the base for the install
+* * Ubuntu Linux - officially supported versions: 16.04 LTS, 18.04 LTS
+* * CentOS - officially supported versions: ?
+* * Mac OS X - officially supported versions: ?
+
+### Definitions
+
+* DefectDojo - the source code and supporting files for DefectDojo contained in the Github repo at https://github.com/DefectDojo/django-DefectDojo
+* Dojo dependencies - any additional software, libraries or services needed to install and run the software in the DefectDojo repo.  This includes Django and other pip packages, celery workers, and any binaries required to run DefectDojo such as wkhtmltopdf
+* 3rd party services - additional services not maintained by DefectDojo but needed to run DefectDojo - currently a database
+
+### Command-line options
+
+```
+ ./setup.bash --help
+Usage: ./setup.bash [OPTION]...
+
+Install DefectDojo in an interactive (default) or non-interactive method
+
+Options:
+  -h or --help             Display this help message and exit with a status code of 0
+  -n or --non-interactive  Run install non-interactivity e.g. for Dockerfiles or automation
+
+Note: No options are required, all are optional
+```
+
+### Installer details
+
+setup.bash relies on the following files and directory structure:
+
+```
+setup.bash => the main install program
+├── entrypoint_scripts
+    ├── common
+        ├── config-vars.sh
+        ├── cmd-args.sh
+        ├── prompt.sh
+```
+
+Install configuration is in config-vars.sh contains the following install options and default values:
+
+**Format for this list:** *install option* [default value] - *definition*
+
+* PROMPT [true] - Run the install in interactive mode aka prompt the user for config values
+* DB_TYPE [MySQL] - The database type to be used by DefectDojo
+* DB_LOCAL [true] - Boolean for if the database is installed locally aka on the same OS as DefectDojo
+* DB_EXISTS [false] - Boolean for if the database already exists for DefectDojo to use aka doesn't need to be installed
+* DB_NAME [dojodb] - Name of the database created to store DefectDojo data
+* DB_USER [dojodbusr] - Database username used to access the DefectDojo database
+* DB_PASS [vee0Thoanae1daePooz0ieka] - Default password used only for Dev installs, otherwise a random 24 character password is created at install time
+* DB_HOST [localhost] - Database hostname where the DefectDojo database is located
+* DB_PORT [3306] - Port database is listening on, default port is for the default database MySQL
+* DB_DROP_EXISTING [true] - If the database name already exists in database server for DefectDojo, drop that database if this is true.  If false and a database name match occurs, throw an error and exit the installer.
+OS_USER=${OS_USER:-"dojo-srv"}
+OS_PASS=${OS_PASS:-"wahlieboojoKa8aitheibai3"}
+OS_GROUP=${OS_GROUP:-"dojo-srv"}
+INSTALL_ROOT=${INSTALL_ROOT:-"/opt/dojo"}
+DOJO_SOURCE=${DOJO_SOURCE:-"$INSTALL_ROOT/django-DefectDojo"}
+DOJO_FILES=${DOJO_FILES:-"$INSTALL_ROOT/local"}
+MEDIA_ROOT=${MEDIA_ROOT:-"$DOJO_FILES/media"}
+STATIC_ROOT=${STATIC_ROOT:-"$DOJO_FILES/static"}
+ADMIN_USER=${ADMIN_USER:-"admin"}
+ADMIN_PASS=${ADMIN_PASS:-"admin"}
+ADMIN_EMAIL=${ADMIN_EMAIL:-"ed@example.com"}
+
+Configuration items for setup.py are in template-env in ./dojo/settings/ and contain
+
+* 
+
+### Installers workflow
+
+1. Check for command-line arguments, if none, do an interactive single server install
+2. Check for install OS
+3. Bootstrap any software needed by the install process
+4. Install Dojo dependencies
+5. Install 3rd party services
+
+
+### Installer Bash variables
+
+* REPO_BASE : The full path to where the DefectDojo source was cloned usually /opt/dojo
+* LIB_PATH : The full path to where the configuration values and libraries are for the DefectDojo installer which is REPO_BASE + /entrypoint_scripts/common/
+* DB_TYPPE : The database type DefectDojo will use - currently either SQLite, MySQL or PostgreSQL
+* 
+
+

--- a/entrypoint_scripts/common/cmd-args.sh
+++ b/entrypoint_scripts/common/cmd-args.sh
@@ -1,0 +1,44 @@
+# DefectDojo install 'library' to handle command-line arguments
+#  
+
+function help() {
+    echo "Usage: $0 [OPTION]..."
+    echo ""
+    echo "Install DefectDojo in an interactive (default) or non-interactive method"
+    echo ""
+    echo "Options:"
+    echo "  -h or --help             Display this help message and exit with a status code of 0"
+    echo "  -n or --non-interactive  Run install non-interactivity e.g. for Dockerfiles or automation"
+    echo ""
+    echo "Note: No options are required, all are optional"
+}
+
+function welcome_msg() {
+    echo ""
+	echo "Welcome to DefectDojo! This is a quick script to get you up and running."
+	echo "For more info on how $0 does an install, see:"
+	echo " https://github.com/DefectDojo/django-DefectDojo/tree/master/entrypoint_scripts"
+	echo ""
+}
+
+function read_cmd_args() {
+    # Double check that we're in the DefectDojo source root - why not, the function was already written
+    verify_cwd
+    
+    # Check the arguments sent to setup.bash
+    # from: https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash Method #1
+    for i in ${BASH_ARGV[*]}
+	do
+	case $i in
+	    -h|--help)
+	    help
+	    exit 0
+	    ;;
+	    -n|--non-interactive)
+	    PROMPT=false
+	    ;;
+	esac
+	done
+    
+    welcome_msg
+}

--- a/entrypoint_scripts/common/common-os.sh
+++ b/entrypoint_scripts/common/common-os.sh
@@ -1,0 +1,137 @@
+# DefectDojo install 'library' to handle determining which OS the installer is being run on
+#  
+
+find_linux_distro() {
+	# Determine Linux Distro
+	# Based on https://unix.stackexchange.com/questions/6345/how-can-i-get-distribution-name-and-version-number-in-a-simple-shell-script
+	if [ -f /etc/os-release ]; then
+	    # freedesktop.org and systemd
+	    . /etc/os-release
+	    OS=$NAME
+	    VER=$VERSION_ID
+	elif type lsb_release >/dev/null 2>&1; then
+	    # linuxbase.org
+	    OS=$(lsb_release -si)
+	    VER=$(lsb_release -sr)
+	elif [ -f /etc/lsb-release ]; then
+	    # For some versions of Debian/Ubuntu without lsb_release command
+	    . /etc/lsb-release
+	    OS=$DISTRIB_ID
+	    VER=$DISTRIB_RELEASE
+	elif [ -f /etc/debian_version ]; then
+	    # Older Debian/Ubuntu/etc.
+	    OS=Debian
+	    VER=$(cat /etc/debian_version)
+	elif [ -f /etc/SuSe-release ]; then
+	    # Older SuSE/etc.
+	    echo "  ERROR: Unsupported Linux distro - exiting."
+	    exit 1
+	elif [ -f /etc/redhat-release ]; then
+	    # Older Red Hat, CentOS, etc.
+	    echo "  ERROR: Unsupported Linux distro - exiting."
+	    exit 1
+	else
+	    # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
+	    OS=$(uname -s)
+	    VER=$(uname -r)
+	    echo "  ERROR: Unsupported Linux distro - exiting."
+	    exit 1
+	fi
+	
+	INSTALL_DISTRO=$OS
+	INSTALL_OS_VER=$VER
+}
+
+check_install_os() {
+	#  Determine OS
+	# based on https://stackoverflow.com/questions/394230/how-to-detect-the-os-from-a-bash-script
+	echo "Inside check install os"
+	if [[ "$OSTYPE" == "linux-gnu" ]]; then
+	    # Liux
+	    echo "Install on Linux"
+	    INSTALL_OS="linux-gnu"
+	    find_linux_distro
+	elif [[ "$OSTYPE" == "darwin"* ]]; then
+	    # Mac OSX
+	    echo "Install on Mac OSX"
+	    INSTALL_OS="darwin"
+	    # From https://www.cyberciti.biz/faq/mac-osx-find-tell-operating-system-version-from-bash-prompt/
+	    INSTALL_DISTRO=`sw_vers -productName`
+	    INSTALL_OS_VER=`sw_vers -productVersion`
+	elif [[ "$OSTYPE" == "cygwin" ]]; then
+	    # POSIX compatibility layer and Linux environment emulation for Windows
+	    echo "  ERROR: Windows isn't currently supported"
+	    exit 1
+	elif [[ "$OSTYPE" == "msys" ]]; then
+	    # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+	    echo "  ERROR: MinGW isn't currently supported"
+	    exit 1
+	elif [[ "$OSTYPE" == "win32" ]]; then
+	    # I'm not sure this can happen.
+	    echo "  ERROR: Windows isn't currently supported"
+	    exit 1
+	elif [[ "$OSTYPE" == "freebsd"* ]]; then
+	    # FreeBSD
+	    echo "  ERROR: FreeBSD isn't currently supported"
+	    exit 1
+	else
+	    # Unable to determine OS, exit with error
+	    echo "  ERROR: Unable to determine OS type, exiting."
+	    exit 1
+	fi
+}
+
+bootstrap_install() {
+	echo "Inside bootstrap install"
+	
+	# Check for proper permissions - either root or sudo access
+	if [[ $EUID -ne 0 ]]; then
+	   # Install user isn't root,  check for sudo privileges
+	   echo "  Checking for sudo access, you may be prompted for your password"
+       sudo -v 2>/dev/null
+       SUDO_CHECK=`sudo -v | wc -l`
+       if [ "$SUDO_CHECK" = 0 ] ; then
+         echo "  Install user has sudo access"
+       else
+         echo "  ERROR: Install user needs sudo access or to be root, quitting"
+         exit 1
+       fi
+	else
+	  echo "  Install user is root, sudo not required"
+	fi
+	
+	# Install any programs needed by the installer
+	case $INSTALL_DISTRO in
+	    "Ubuntu")
+	    echo "  Bootstapping Ubuntu"
+	    echo "  Updating package list"
+	    DEBIAN_FRONTEND=noninteractive apt update
+	    echo "  Updating $INSTALL_DISTRO packages"
+	    DEBIAN_FRONTEND=noninteractive apt -y upgrade
+	    echo "  Installing packages needed for the installer"
+	    DEBIAN_FRONTEND=noninteractive apt -y install curl sudo python expect wget git gnupg2
+	    ;;
+	    "centos")
+	    echo "Bootstapping CentOS"
+	    echo "  TBD: Pre-reqs for CentOS"
+	    ;;
+	    *)
+	    echo "    Error: Unsupported OS"
+	    exit 1
+	    ;;
+	esac
+}
+
+check_python_version() {
+	# 
+	echo "Inside check python version"
+	# Detect Python version
+    PYV=`python -c "import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)";`
+    if [[ "$PYV"<"2.7" ]]; then
+        echo "ERROR: DefectDojo requires Python 2.7+"
+        exit 1;
+    else
+        echo "Python version 2.7+ found, installation can continue"
+    fi
+}
+

--- a/entrypoint_scripts/common/config-vars.sh
+++ b/entrypoint_scripts/common/config-vars.sh
@@ -1,0 +1,113 @@
+# Configuration variables for DefectDojo installs
+
+# Format for setting install config values
+# [name of config variable]=${[name of config variable]:-"[default value]"}
+# So if you wanted a variable called DD_FOO to default to "BAR" the syntax
+# would be:
+#    DD_FOO=${DD_FOO:-"BAR"}
+# And without an environmental variable called DD_FOO being set before 
+# running the install, the value of DD_FOO would be "BAR"
+# If you set an environmental variable such as
+#    export DD_FOO="BAZ"
+# and ran setup.bash, DD_FOO would be "BAZ" instead of the default "BAR"
+# 
+# This can be used as a template for adding new config variables in future
+# D=${D:-"z"}
+
+# Install variables that can be overridden 
+
+########################################################################
+# Global vars                                                          #
+########################################################################
+PROMPT=${PROMPT:-"true"}
+INSTALL_TYPE=${INSTALL_TYPE:-"Single Server"}
+
+########################################################################
+# DB vars
+########################################################################
+DB_TYPE=${DB_TYPE:-"MySQL"}  # Valid options: SQLite, MySQL, PostgreSQL
+DB_LOCAL=${DB_LOCAL:-"true"}
+DB_EXISTS=${DB_EXISTS:-"false"}
+DB_ROOT=${DB_ROOT:-"vee0Thoanae1daePooz0ieka"}
+DB_NAME=${DB_NAME:-"dojodb"}
+DB_USER=${DB_USER:-"dojodbusr"}
+DB_PASS=${DB_PASS:-"vee0Thoanae1daePooz0ieka"}
+DEV_DB_PASS="vee0Thoanae1daePooz0ieka"
+#DEV_DB_PASS="vee0T%oanae1daeP%oz0ieka"
+DB_HOST=${DB_HOST:-"localhost"}
+DB_PORT=${DB_PORT:-"3306"}
+# Drop an existing DB with the same name as above?  true = drop db, false = keep db and exit installer
+DB_DROP_EXISTING=${DB_DROP_EXISTING:-"false"} 
+
+########################################################################
+# OS vars
+########################################################################
+OS_USER=${OS_USER:-"dojo-srv"}
+OS_PASS=${OS_PASS:-"wahlieboojoKa8aitheibai3"}
+DEV_OS_PASS="wahlieboojoKa8aitheibai3"
+OS_GROUP=${OS_GROUP:-"dojo-srv"}
+INSTALL_ROOT=${INSTALL_ROOT:-"/opt/dojo"}
+DOJO_SOURCE=${DOJO_SOURCE:-"$INSTALL_ROOT/django-DefectDojo"}
+DOJO_FILES=${DOJO_FILES:-"$INSTALL_ROOT/local"}
+MEDIA_ROOT=${MEDIA_ROOT:-"$DOJO_FILES/media"}
+STATIC_ROOT=${STATIC_ROOT:-"$DOJO_FILES/static"}
+DOJO_ROOT=${DOJO_ROOT:-"$DOJO_SOURCE/dojo"}
+#appPath: /opt/dojo/django-DefectDojo/app 
+
+########################################################################
+# DefectDojo settings and app vars                                     #
+########################################################################
+
+# Meta vars used by installer 
+SOURCE_SETTINGS_FILE=${SOURCE_SETTINGS_FILE:-"dojo/settings/settings.dist.py"}
+TARGET_SETTINGS_FILE=${TARGET_SETTINGS_FILE:-"dojo/settings/settings.py"}
+LOAD_SAMPLE_DATA=${LOAD_SAMPLE_DATA:-"false"}
+ENV_SETTINGS_FILE=${ENV_SETTINGS_FILE:-"$REPO_BASE/entrypoint_scripts/common/install-env"} 
+ENV_TARGET_FILE=${ENV_TARGET_FILE:-"$REPO_BASE/dojo/settings/.env.prod"}
+
+# Default Dojo Admin user:
+ADMIN_USER=${ADMIN_USER:-"admin"}
+ADMIN_PASS=${ADMIN_PASS:-"admin"}
+DEV_ADMIN_PASS="admin"
+ADMIN_EMAIL=${ADMIN_EMAIL:-"ed@example.com"}
+
+# Django settings.py vars
+DD_DEBUG=${DD_DEBUG:="off"}                              # Django Debug, defaults to off and should be for production. Can be off or on
+DD_DJANGO_ADMIN_ENABLED=${DD_DJANGO_ADMIN_ENABLED:-"on"} # Enables Django Admin, defaults to on - either off or on
+DD_SECRET_KEY="GENERATED-DYNAMICALLY-AT-INSTALL-TIME"    # A secret key for a particular Django installation.
+DD_CREDENTIAL_AES_256_KEY="GENERATED-DYNAMICALLY-AT-INSTALL-TIME" # Key for encrypting credentials in the manager
+DD_DATABASE_URL=${DD_DATABASE_URL:-"mysql://dojodbusr:vee0Thoanae1daePooz0ieka@localhost:3306/dojodb"} # Database URL, options: postgres://, mysql://, sqlite://, to use unsafe characters encode with urllib.parse.encode
+DD_ALLOWED_HOSTS=${DD_ALLOWED_HOSTS:-"*"}                # Hosts/domain names that are valid for this site - Separate accepted hosts with a comma for 2+ hostnames
+# WhiteNoise allows your web app to serve its own static files,
+# making it a self-contained unit that can be deployed anywhere without relying on nginx,
+# if using nginx then disable Whitenoise
+DD_WHITENOISE=${DD_WHITENOISE:-"on"}   # Valid options: on, off 
+# Additional Settings / Override defaults in settings.py
+DD_TIME_ZONE=${DD_TIME_ZONE:-"America/New_York"}         # Timezone - default America/New_York
+DD_TRACK_MIGRATIONS=${DD_TRACK_MIGRATIONS:-"on"}         # Track migrations through source control rather than making migrations locally
+DD_SESSION_COOKIE_HTTPONLY=${DD_SESSION_COOKIE_HTTPONLY:-"on"} # Whether to use HTTPOnly flag on the session cookie - either on or off
+DD_CSRF_COOKIE_HTTPONLY=${DD_CSRF_COOKIE_HTTPONLY:-"on"} # Whether to use HttpOnly flag on the CSRF cookie - either on or off
+DD_SECURE_SSL_REDIRECT=${DD_SECURE_SSL_REDIRECT:-"off"}  # If True, the SecurityMiddleware redirects all non-HTTPS requests to HTTPS - either on or off
+DD_CSRF_COOKIE_SECURE=${DD_CSRF_COOKIE_SECURE:-"off"}    # Whether to use a secure cookie for the CSRF cookie - either on or off
+DD_SECURE_BROWSER_XSS_FILTER=${DD_SECURE_BROWSER_XSS_FILTER:-"on"} # If on, the SecurityMiddleware sets the X-XSS-Protection: 1; - either on or off
+DD_LANG=${DD_LANG:-"en-us"}                              # Change the default language set
+DD_WKHTMLTOPDF=${DD_WKHTMLTOPDF:-"/usr/local/bin/wkhtmltopdf"} # Path to PDF library
+DD_TEAM_NAME=${DD_TEAM_NAME:-"Security"}                 # Security team name, used for outgoing emails
+DD_ADMINS=${DD_ADMINS:-"dojo-srv@localhost"}             # Admins for log emails, separate with comma for 2+ addresses
+DD_PORT_SCAN_CONTACT_EMAIL=${DD_PORT_SCAN_CONTACT_EMAIL:-"dojo-srv@localhost"} # Port scan contact email
+DD_PORT_SCAN_RESULT_EMAIL_FROM=${DD_PORT_SCAN_RESULT_EMAIL_FROM:-"dojo-srv@localhost"} # Port scan from email
+DD_PORT_SCAN_EXTERNAL_UNIT_EMAIL_LIST=${DD_PORT_SCAN_EXTERNAL_UNIT_EMAIL_LIST:-"dojo-srv@localhost"} # Port scan email list
+DD_PORT_SCAN_SOURCE_IP=${DD_PORT_SCAN_SOURCE_IP:-"127.0.0.1"} # Port scan source
+
+#D=${D:-"z"}
+
+########################################################################
+# Install variables used internally which can't be overridden          #
+########################################################################
+SUPPORTED_DBS="SQLite MySQL PostgreSQL"  
+INSTALL_OS="linux-gnu"
+INSTALL_DISTRO="Ubuntu"
+INSTALL_OS_VER="18.04"
+YARN_GPG="https://dl.yarnpkg.com/debian/pubkey.gpg"
+YARN_REPO="deb https://dl.yarnpkg.com/debian/ stable main"
+NODE_URL="https://deb.nodesource.com/setup_6.x"

--- a/entrypoint_scripts/common/install-dojo.sh
+++ b/entrypoint_scripts/common/install-dojo.sh
@@ -1,0 +1,23 @@
+# DefectDojo install 'library' to handle installing DefectDojo across multiple install targets
+# 
+
+# Case statement on OS - move OS specific install code into separate included files
+install_dojo() {
+	OS_LIBS="$REPO_BASE/entrypoint_scripts/os"
+	echo "Starting install-dojo"
+	case $INSTALL_OS in
+	    "linux-gnu")
+	    echo "  Linux install target"
+	    . "$OS_LIBS/linux.sh"
+	    install_linux
+	    ;;
+	    "darwin")
+	    echo "Mac OS X install target"
+	    echo "  TBD: Install for Mac OS X"
+	    ;;
+	    *)
+	    echo "    Error: Unsupported OS"
+	    exit 1
+	    ;;
+	esac
+}

--- a/entrypoint_scripts/common/install-env
+++ b/entrypoint_scripts/common/install-env
@@ -1,0 +1,71 @@
+# Django Debug, don't enable on production! - default is off
+DD_DEBUG=#DD_DEBUG#
+
+# Enables Django Admin - default is on
+DD_DJANGO_ADMIN_ENABLED=#DD_DJANGO_ADMIN_ENABLED#
+
+# A secret key for a particular Django installation.
+DD_SECRET_KEY=#DD_SECRET_KEY#
+
+# Key for encrypting credentials in the manager
+DD_CREDENTIAL_AES_256_KEY=#DD_CREDENTIAL_AES_256_KEY#
+
+# Database URL, options: postgres://, mysql://, sqlite://, to use unsafe characters encode with urllib.parse.encode
+DD_DATABASE_URL=#DD_DATABASE_URL#
+
+# Hosts/domain names that are valid for this site;
+DD_ALLOWED_HOSTS=#DD_ALLOWED_HOSTS#
+
+# WhiteNoise allows your web app to serve its own static files,
+# making it a self-contained unit that can be deployed anywhere without relying on nginx,
+# if using nginx then disable Whitenoise
+DD_WHITENOISE=on
+
+# -------------------------------------------------------
+# Additional Settings / Override defaults in settings.py
+# -------------------------------------------------------
+
+# Timezone - default is America/New_York
+DD_TIME_ZONE=#DD_TIME_ZONE#
+
+# Track migrations through source control rather than making migrations locally - default is on
+DD_TRACK_MIGRATIONS=#DD_TRACK_MIGRATIONS#
+
+# Whether to use HTTPOnly flag on the session cookie - default is on
+DD_SESSION_COOKIE_HTTPONLY=#DD_SESSION_COOKIE_HTTPONLY#
+
+# Whether to use HttpOnly flag on the CSRF cookie - default is on
+DD_CSRF_COOKIE_HTTPONLY=#DD_CSRF_COOKIE_HTTPONLY#
+
+# If True, the SecurityMiddleware redirects all non-HTTPS requests to HTTPS - default is off
+DD_SECURE_SSL_REDIRECT=#DD_SECURE_SSL_REDIRECT#
+
+# Whether to use a secure cookie for the CSRF cookie - default is off
+DD_CSRF_COOKIE_SECURE=#DD_CSRF_COOKIE_SECURE#
+
+# If on, the SecurityMiddleware sets the X-XSS-Protection: 1; - default is on
+DD_SECURE_BROWSER_XSS_FILTER=#DD_SECURE_BROWSER_XSS_FILTER#
+
+# Change the default language set - default is en-us
+DD_LANG=#DD_LANG#
+
+# Path to PDF library - default is /usr/local/bin/wkhtmltopdf
+DD_WKHTMLTOPDF=#DD_WKHTMLTOPDF#
+
+# Security team name, used for outgoing emails - default is Security
+DD_TEAM_NAME=#DD_TEAM_NAME#
+
+# Admins for log emails - default is dojo-srv@localhost
+DD_ADMINS=#DD_ADMINS#
+
+# Port scan contact email - default is dojo-srv@localhost
+DD_PORT_SCAN_CONTACT_EMAIL=email@localhost
+
+# Port scan from email - default is dojo-srv@localhost
+DD_PORT_SCAN_RESULT_EMAIL_FROM=#DD_PORT_SCAN_RESULT_EMAIL_FROM#
+
+# Port scan email list - default is dojo-srv@localhost
+DD_PORT_SCAN_EXTERNAL_UNIT_EMAIL_LIST=#DD_PORT_SCAN_EXTERNAL_UNIT_EMAIL_LIST#
+
+# Port scan source - default is 127.0.0.1
+DD_PORT_SCAN_SOURCE_IP=#DD_PORT_SCAN_SOURCE_IP#

--- a/entrypoint_scripts/common/prompt.sh
+++ b/entrypoint_scripts/common/prompt.sh
@@ -1,0 +1,425 @@
+# DefectDojo install 'library' to handle command-line arguments
+#  
+
+# Function to randomly generate all passwords for credential pairs used by the installer
+init_install_creds() {
+	# Set creds to random values or hard-code them only for Dev installs
+	if [ "$INSTALL_TYPE" = "Dev Install" ]; then
+	    # Hardcode passwords for Dev installs so they are consistent
+	    echo ""
+	    echo "  WARNNING: Dev install has hard coded credentials - you have been warned."
+	    echo ""
+	    DB_PASS="$DEV_DB_PASS"
+	    DB_ROOT="$DEV_DB_PASS"
+	    OS_PASS="$DEV_OS_PASS"
+	    ADMIN_PASS="$DEV_ADMIN_PASS"
+	else
+	    # Generate a unique password for this install for the database user
+	    DB_PASS=`LC_CTYPE=C tr -dc A-Za-z0-9_\!\@\#\$\%\^\&\*\(\)-+ < /dev/urandom | head -c 24`
+	    # Generate a unique password for this install for the database root user
+	    DB_ROOT=`LC_CTYPE=C tr -dc A-Za-z0-9_\!\@\#\$\%\^\&\*\(\)-+ < /dev/urandom | head -c 24`
+	    # Generate a unique password for this install for the OS user
+	    OS_PASS=`LC_CTYPE=C tr -dc A-Za-z0-9_\!\@\#\$\%\^\&\*\(\)-+ < /dev/urandom | head -c 24`
+	    # Generate a unique password for this install for the dojo admin user
+	    ADMIN_PASS=`LC_CTYPE=C tr -dc A-Za-z0-9_\!\@\#\$\%\^\&\*\(\)-+ < /dev/urandom | head -c 24`
+	fi
+	
+	# Always generate unique values for any install type
+	
+	# Generate a unique secret to use in the Django settings.py file per install
+	DD_SECRET_KEY=`cat /dev/urandom | LC_CTYPE=C tr -dc "a-zA-Z0-9" | head -c 128`
+	# Generate a unique AES key to use in the Django settings.py file per install
+	DD_CREDENTIAL_AES_256_KEY=`cat /dev/urandom | LC_CTYPE=C tr -dc "a-zA-Z0-9" | head -c 128`
+}
+
+# Function to handle changing database install config options
+change_db_config() {
+	# Prompt for the various DB options
+	ANS="invalid"
+	echo ""
+	while [ $ANS = "invalid" ]
+    do
+	    read -p "  Change DB name from $DB_NAME? (1) Yes, (2) No, keep the default: " DB_Q
+	    case $DB_Q in
+		    1)
+		    echo ""
+		    read -p "    Enter a new DB name: " DB_NAME
+		    ANS="valid"
+		    ;;
+		    2)
+		    echo ""
+		    echo "  Keeping DB name of $DB_NAME"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1, or 2"
+		    ;;
+		esac
+    done
+    
+    ANS="invalid"
+    echo ""
+	while [ $ANS = "invalid" ]
+    do
+	    read -p "  Change DB user from $DB_USER (1) Yes, (2) No, keep the default: " DB_Q
+	    case $DB_Q in
+		    1)
+		    echo ""
+		    read -p "    Enter a new DB user: " DB_USER
+		    ANS="valid"
+		    ;;
+		    2)
+		    echo ""
+		    echo "  Keeping DB user of $DB_USER"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1, or 2"
+		    ;;
+		esac
+    done
+	
+	ANS="invalid"
+	echo ""
+	while [ $ANS = "invalid" ]
+    do
+	    read -p "  Change DB password from $DB_PASS (1) Yes, (2) No, keep this password: " DB_Q
+	    case $DB_Q in
+		    1)
+		    echo ""
+		    read -p "    Enter a new DB password: " DB_PASS
+		    ANS="valid"
+		    ;;
+		    2)
+		    echo ""
+		    echo "  Keeping generated DB password of $DB_PASS"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1, or 2"
+		    ;;
+		esac
+    done
+    
+    # Only ask for host when the DB is remote and exists 
+    #  otherwise it's going to be localhost (aka local install)
+    #  or the remote db doesn't exist and this installed doesn't handle remove DB installs
+    if [ "$DB_LOCAL" = false ] && [ "$DB_EXISTS" = true ]; then
+	    ANS="invalid"
+		echo ""
+		while [ $ANS = "invalid" ]
+	    do
+		    read -p "  Change DB host from $DB_HOST (1) Yes, (2) No, keep the default: " DB_Q
+		    case $DB_Q in
+			    1)
+			    echo ""
+			    read -p "    Enter a new DB host: " DB_HOST
+			    ANS="valid"
+			    ;;
+			    2)
+			    echo ""
+			    echo "  Keeping DB host of $DB_HOST"
+			    ANS="valid"
+			    ;;
+			    *)
+			    echo "    Error: Please enter 1, or 2"
+			    ;;
+			esac
+	    done
+	fi
+    
+	ANS="invalid"
+	echo ""
+	while [ $ANS = "invalid" ]
+    do
+	    read -p "  Change DB port from $DB_PORT (1) Yes, (2) No, keep this port number: " DB_Q
+	    case $DB_Q in
+		    1)
+		    echo ""
+		    read -p "    Enter a new DB port: " DB_PORT
+		    ANS="valid"
+		    ;;
+		    2)
+		    echo ""
+		    echo "  Keeping DB port of $DB_PORT"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1, or 2"
+		    ;;
+		esac
+    done
+}
+
+# Function to handle interactive changes to OS config values
+change_os_config() {
+	echo ""
+	echo "Prompts for OS configs HERE"
+}
+
+# Function to handle interactive changes to DefectDojo's admin login
+change_admin_login() {
+	echo ""
+	echo "Prompts for DefectDojo's admin login HERE"
+}
+
+# Prompt user for config options needed for interactive install
+prompt_for_config_vals() {
+	echo ""
+	echo "Starting interactive DefectDojo installation"
+	echo ""
+	
+	# Prompt install type
+	ANS="invalid"
+	echo "  Choose install type - setup.bash supports the following install types:"
+	echo "    (1) Single Server - Everything on one OS/server/container"
+	echo "    (2) Dev Install - Single Server install with all default install options & passwords"
+	echo "    (3) Stand-alone Server - DefectDojo installed on a separate OS/server/container then the database"
+	echo ""
+	while [ $ANS = "invalid" ]
+    do
+	    read -p "  Select install type: (1) Single-Server, (2) Dev Install or (3) Stand-alone: " IN_Q
+	    case $IN_Q in
+		    1)
+		    INSTALL_TYPE="Single Server"
+		    ANS="valid"
+		    ;;
+		    2)
+		    INSTALL_TYPE="Dev Install"
+		    init_install_creds
+		    # Return accepting all default install config values
+		    return
+		    ;;
+		    3)
+		    INSTALL_TYPE="Stand-alone Server"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1, 2 or 3"
+		    ;;
+		esac
+    done
+    init_install_creds
+    echo ""
+	
+	# Prompt user for DB type to use
+	ANS="invalid"
+	while [ $ANS = "invalid" ]
+    do
+	    read -p "  Select database type: (1) SQLite, (2) MySQL or (3) PostgreSQL: " DB_Q
+	    case $DB_Q in
+		    1)
+		    DB_TYPE="SQLite"
+		    ANS="valid"
+		    ;;
+		    2)
+		    DB_TYPE="MySQL"
+		    DB_PORT=${DB_PORT:-"3306"}
+		    ANS="valid"
+		    ;;
+		    3)
+		    DB_TYPE="PostgreSQL"
+		    DB_PORT=${DB_PORT:-"5432"}
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1, 2 or 3"
+		    ;;
+		esac
+    done
+    
+    # Prompt for local or remote database
+    echo ""
+    ANS="invalid"
+    while [ $ANS = "invalid" ]
+    do
+        echo "  Will the $DB_TYPE database be local (on the same OS) or remote for this install?"
+        read -p "  Select (1) Remote, (2) Local: " DB_Q
+        case $DB_Q in
+		    1)
+		    DB_LOCAL="false"
+		    ANS="valid"
+		    ;;
+		    2)
+		    DB_LOCAL="true"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1 or 2"
+		    ;;
+		esac
+    done
+    
+    # Prompt for existing or new database
+    echo ""
+    ANS="invalid"
+    while [ $ANS = "invalid" ]
+    do
+        echo "  Will the $DB_TYPE database be installed during setup or does it already exist?"
+        read -p "  Select (1) Install of $DB_TYPE required, (2) $DB_TYPE server already exists/is running: " DB_Q
+        case $DB_Q in
+		    1)
+		    DB_EXISTS="false"
+		    ANS="valid"
+		    ;;
+		    2)
+		    DB_EXISTS="true"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1 or 2"
+		    ;;
+		esac
+    done
+    
+    # Prompt for dropping any existing Dojo DB
+    echo ""
+    ANS="invalid"
+    while [ $ANS = "invalid" ]
+    do
+        echo "  If the installer finds an existing DefectDojo database, should it be dropped?"
+        read -p "  Select (1) Drop existing database, (2) Keep existing database & exit: " DB_Q
+        case $DB_Q in
+		    1)
+		    DB_DROP_EXISTING="true"
+		    ANS="valid"
+		    ;;
+		    2)
+		    DB_DROP_EXISTING="false"
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1 or 2"
+		    ;;
+		esac
+    done
+	
+	# Sanity check answers, and exit if DB is remote and doesn't exists aka beyond the scope of this installer
+	# Case 1: Remote database + database doesn't exist
+	if [ "$DB_LOCAL" = false ] && [ "$DB_EXISTS" = false ]; then
+	    echo ""
+	    echo "  ERROR:"
+	    echo "  You answered that the $DB_TYPE is remote and doesn't already exist"
+	    echo "  This installer cannot do remote installs.  Please install $DB_TYPE"
+	    echo "  on the remote system of your choosing then re-run this installer"
+	    echo "  Exiting..."
+	    echo ""
+	    exit 1
+	fi
+	
+	# Ask if DB defaults are OK for a new, local DB install
+	# Case 2: Local database + database doesn't exist
+	if [ "$DB_LOCAL" = true ] && [ "$DB_EXISTS" = false ]; then
+	    echo ""
+	    echo "  Current $DB_TYPE database install config includes:"
+	    echo "    Name of database:          $DB_NAME"
+	    echo "    User for the database:     $DB_USER"
+	    echo "    Password for DB user:      $DB_ROOT"
+	    echo "    Password for DB root user: $DB_PASS"
+	    echo "    Host:                      $DB_HOST"
+	    echo "    Port:                      $DB_PORT"
+	    echo ""
+	    ANS="invalid"
+	    while [ $ANS = "invalid" ]
+	    do
+	        echo "  Do you want to change any of these values?"
+	        read -p "  Select (1) Yes, (2) No: " DB_Q
+	        case $DB_Q in
+			    1)
+			    change_db_config
+			    ANS="valid"
+			    ;;
+			    2)
+			    echo ""
+			    echo "  OK. Keeping default $DB_TYPE configuration values for this install"
+			    echo ""
+			    ANS="valid"
+			    ;;
+			    *)
+			    echo "    Error: Please enter 1 or 2"
+			    ;;
+			esac
+	    done
+	fi
+	
+	# Case 3: Local database + database exists
+	if [ "$DB_LOCAL" = true ] && [ "$DB_EXISTS" = true ]; then
+	    # Should only need to get config values
+	    echo ""
+	    echo "  Please update database config to reflect the existing local database"
+	    change_db_config
+	fi
+	
+	# Case 4: Remote database + database exists
+	if [ "$DB_LOCAL" = false ] && [ "$DB_EXISTS" = true ]; then
+	    # Should only need to get config values
+	    echo ""
+	    echo "  Please update database config to reflect the existing remote database"
+	    change_db_config
+	fi
+
+	# Ask if OS defaults are OK for this install
+	echo ""
+    echo "  Current OS install config includes:"
+    echo "    OS user to run Dojo as:             $OS_USER"
+    echo "    Password for OS user:               $OS_PASS"
+    echo "    Group for the OS user:              $OS_GROUP"
+    echo "    Install root directory:             $INSTALL_ROOT"
+    echo "    DefectDojo source directory:        $DOJO_SOURCE"
+    echo "    Directory of files created by Dojo: $DOJO_FILES"
+    echo "    Directory of uploads/media of Dojo: $MEDIA_ROOT"
+    echo "    Directory of static files for Dojo: $STATIC_ROOT"
+    echo ""
+    ANS="invalid"
+    while [ $ANS = "invalid" ]
+    do
+        echo "  Do you want to change any of these values?"
+        read -p "  Select (1) Yes, (2) No: " OS_Q
+        case $OS_Q in
+		    1)
+		    change_os_config
+		    ANS="valid"
+		    ;;
+		    2)
+		    echo ""
+		    echo "  OK. Keeping default OS configuration values for this install"
+		    echo ""
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1 or 2"
+		    ;;
+		esac
+    done
+	
+	# Ask if Dojo admin user defaults are OK for this install
+	echo ""
+    echo "  Current admin user config for DefectDojo:"
+    echo "    Admin user to log into Dojo:  $ADMIN_USER"
+    echo "    Password for the admin user:  $ADMIN_PASS"
+    echo "    Email for the admin user:     $ADMIN_EMAIL"
+    echo ""
+    ANS="invalid"
+    while [ $ANS = "invalid" ]
+    do
+        echo "  Do you want to change any of these values?"
+        read -p "  Select (1) Yes, (2) No: " AD_Q
+        case $AD_Q in
+		    1)
+		    change_admin_login
+		    ANS="valid"
+		    ;;
+		    2)
+		    echo ""
+		    echo "  OK. Keeping default admin user config values for this install"
+		    echo ""
+		    ANS="valid"
+		    ;;
+		    *)
+		    echo "    Error: Please enter 1 or 2"
+		    ;;
+		esac
+    done
+	
+	echo "END prompt_for_config"
+}

--- a/entrypoint_scripts/os/linux.sh
+++ b/entrypoint_scripts/os/linux.sh
@@ -1,0 +1,330 @@
+# DefectDojo install 'library' to handle installing DefectDojo on Linux
+# 
+
+function ubuntu_db_install() {
+	# Install the database type for this install - SQLite, MySQL, PostgreSQL
+	case $DB_TYPE in
+	  "SQLite")
+	  echo "  Installing SQLite"
+	  DEBIAN_FRONTEND=noninteractive sudo apt install -y sqlite3
+	  ;;
+	  "MySQL")
+	  echo "  Installing MySQL"
+	  DEBIAN_FRONTEND=noninteractive sudo apt install -y mysql-server libmysqlclient-dev
+	  ;;
+	  "PostgreSQL")
+	  echo "  Installing PostgreSQL"
+	  DEBIAN_FRONTEND=noninteractive sudo apt install -y libpq-dev postgresql postgresql-contrib
+	  ;;
+	  *)
+	  echo "    Error: Unsupported DB Type"
+	  exit 1
+	  ;;
+	esac
+}
+
+function ubuntu_db_config() {
+	## Add a case statement for the DB types
+	
+	# Start up DB
+	if [ "$DB_LOCAL" = true ]; then
+	    sudo usermod -d /var/lib/mysql/ mysql
+	    sudo mkdir /var/run/mysqld
+	    sudo chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
+	    sudo service mysql start
+	fi
+	
+	# Check if MySQL DB exists already
+	if mysql -fs --protocol=TCP -h "$DB_HOST" -P "$DB_PORT" -u"$DB_USER" -p"$DB_PASS" "$DB_NAME" >/dev/null 2>&1 </dev/null; then
+	    # DB exists already
+	    echo "  Database $DB_NAME already exists!"
+	    if [ "$DB_DROP_EXISTING"  = true ]; then
+	        # Drop existing DB
+	        MYSQL_PWD="$DB_PASS" mysqladmin -f --host="$DB_HOST" --port="$DB_PORT" --user="$DB_USER" drop "$DB_NAME"
+	    else
+	        echo "  ERROR: DefectDojo DB exists but DB_DROP_EXISTING is set to $DB_DROP_EXISTING"
+	        echo "         Exiting"
+	        exit 1
+	    fi
+	else 
+	   # DB does not exist already, set the password for the root user
+	   echo "  Setting up root user for new DB install"
+	   mysql -u "root" -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost'"
+	   mysql -u "root" -e "SET PASSWORD = PASSWORD('${DB_ROOT}');"
+	fi
+	
+	# Create the database for DefectDojo
+	echo "  Creating database for DefectDojo"
+	# CREATE DATABASE <dbname> CHARACTER SET utf8;
+	#if MYSQL_PWD="" mysqladmin --host="$DB_HOST" --port="$DB_PORT" --user="root" create "$DB_NAME"; then
+	if MYSQL_PWD="$DB_ROOT" mysql -u root --host="$DB_HOST" --port="$DB_PORT" -e "CREATE DATABASE $DB_NAME CHARACTER SET UTF8;"; then
+        # Setup DB user for DefectDojo to use
+        echo "  Adding $DB_USER to the DefectDojo database."
+        MYSQL_PWD="$DB_ROOT" mysql -u "root" -e "DROP USER '$DB_USER'@'localhost'" >/dev/null 2>&1
+        MYSQL_PWD="$DB_ROOT" mysql -u "root" -e "CREATE USER '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASS';"
+        MYSQL_PWD="$DB_ROOT" mysql -u "root" -e "GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'localhost';"
+        MYSQL_PWD="$DB_ROOT" mysql -u "root" -e "FLUSH PRIVILEGES;"
+    else
+        echo "  ERROR: Failed to create database $DB_NAME. Exiting."
+        exit 1
+   fi
+}
+
+function ubuntu_os_packages() {
+	# Install Yarn repo
+    curl -sS "$YARN_GPG" | sudo apt-key add -
+    echo "$YARN_REPO" | sudo tee /etc/apt/sources.list.d/yarn.list
+    
+    # Install Node
+    curl -sL "$NODE_URL" | sudo -E bash
+    
+    # Install OS packages needed by Defect Dojo
+    sudo apt update
+    sudo apt install -y apt-transport-https libjpeg-dev gcc libssl-dev python-dev python-pip nodejs yarn build-essential
+}
+
+function ubuntu_wkhtml_install() {
+	# Install wkhtmltopdf for report generation
+	cd /tmp
+	
+	# case statement on Ubuntu version built against 18.04 or 16.04
+	case $INSTALL_OS_VER in
+	    "18.04")
+        wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.bionic_amd64.deb 
+        apt install -y ./wkhtmltox_0.12.5-1.bionic_amd64.deb 
+	    ;;
+	    "16.04")
+	    wget https://downloads.wkhtmltopdf.org/0.12/0.12.5/wkhtmltox_0.12.5-1.xenial_amd64.deb
+	    dpkg -i wkhtmltox_0.12.5-1.xenial_amd64.deb 
+	    ;;
+	    *)
+		echo "    Error: Unsupported OS version - $INSTALL_OS_VER"
+		exit 1
+		;;
+	esac
+	
+	# Clean up
+	cd "$DOJO_SOURCE"
+    rm /tmp/wkhtmlto*
+}
+
+function urlenc() {
+	local STRING="${1}"
+	echo `python -c "import sys, urllib as ul; print ul.quote_plus('$STRING')"`
+	#NEW=`python -c "import sys, urllib as ul; print ul.quote_plus('$STRING')"`
+	#echo `echo "$NEW" | sed -e 's/%/^/g'`
+}
+
+function create_dojo_settings() {
+	# From Aaron's prepare_settings_file()
+	echo "=============================================================================="
+    echo "Creating dojo/settings/settings.py and .env file"
+    echo "=============================================================================="
+    echo ""
+    
+    # Copy settings file & env files to final location
+    cp "$SOURCE_SETTINGS_FILE" "$TARGET_SETTINGS_FILE"
+    cp "$ENV_SETTINGS_FILE" "$ENV_TARGET_FILE"
+    
+    # Construct DD_DATABASE_URL based on DB type - see https://github.com/kennethreitz/dj-database-url
+    case $DB_TYPE in
+        "SQLite") 
+        # sqlite:///PATH
+        DD_DATABASE_URL="sqlite:///defectdojo.db"
+        ;;
+        "MySQL")
+        # mysql://USER:PASSWORD@HOST:PORT/NAME
+        #SAFE_URL=$(urlenc "$DB_USER")":$DB_PASS@"$(urlenc "$DB_HOST")":"$(urlenc "$DB_PORT")"/"$(urlenc "$DB_NAME")
+        SAFE_URL=$(urlenc "$DB_USER")":"$(urlenc "$DB_PASS")"@"$(urlenc "$DB_HOST")":"$(urlenc "$DB_PORT")"/"$(urlenc "$DB_NAME")
+        DD_DATABASE_URL="mysql://$SAFE_URL"
+        ;;
+        "PostgreSQL")
+        # postgres://USER:PASSWORD@HOST:PORT/NAME
+        SAFE_URL=$(urlenc "$DB_USER")":"$(urlenc "$DB_PASS")"@"$(urlenc "$DB_HOST")":"$(urlenc "$DB_PORT")"/"$(urlenc "$DB_NAME")
+        DD_DATABASE_URL="postgres://$SAFE_URL"
+        ;;
+        *)
+        echo "    Error: Unsupported DB type - $DB_TYPE"
+		exit 1
+		;;
+	esac
+    
+    echo "DB URL is:"
+    echo "$DD_DATABASE_URL"
+    
+    # Questions:
+    # (1) OK to remove the env stuff from settings.py if setup.bash handles them natively?
+    #     Idea is to use env vars at install time to create settings.py
+    #     Using SOURCE_SETTINGS_FILE=${SOURCE_SETTINGS_FILE:-"dojo/settings/settings.matt.py"} in my POC
+    # (2) What default do we want for Whitenoise?  on or off???
+    # (3) Why was DB config changed to a URL?  I think I'm getting breakage on the URL string with sed
+    #     if the generated password has problematic characters
+    # (4) I don't see an env variable for DD_EMAIL_URL - is this on purpose?
+    #     Also line 302 in settings.matt.py - is that needed?
+    # (5) Always do VENV, make it optional or what?
+    #
+    # Questions round #2
+    # (1) Default allowed hosts - empty or ['*']??
+    #       https://docs.djangoproject.com/en/2.1/ref/settings/#allowed-hosts
+    
+    # Substitute install vars for settings.py values
+    echo "1"
+    sed -i -e 's%#DD_DEBUG#%'$DD_DEBUG'%' "$ENV_TARGET_FILE"
+    echo "2"
+    sed -i -e 's%#DD_DJANGO_ADMIN_ENABLED#%'$DD_DJANGO_ADMIN_ENABLED'%' "$ENV_TARGET_FILE"
+    echo "3"
+    sed -i -e 's%#DD_SECRET_KEY#%'$DD_SECRET_KEY'%' "$ENV_TARGET_FILE"
+    echo "4"
+    sed -i -e 's%#DD_CREDENTIAL_AES_256_KEY#%'$DD_CREDENTIAL_AES_256_KEY'%' "$ENV_TARGET_FILE"
+    echo "5"
+    sed -i -e "s^#DD_DATABASE_URL#^$DD_DATABASE_URL^" "$ENV_TARGET_FILE"
+    echo "6"
+    sed -i -e "s%#DD_ALLOWED_HOSTS#%$DD_ALLOWED_HOSTS%" "$ENV_TARGET_FILE" 
+    echo "7"
+    sed -i -e 's%#DD_WHITENOISE#%'$DD_WHITENOISE'%' "$ENV_TARGET_FILE"
+    # Additional Settings / Override defaults in settings.py
+    echo "8"
+    sed -i -e 's%#DD_TIME_ZONE#%'$DD_TIME_ZONE'%' "$ENV_TARGET_FILE"
+    echo "9"
+    sed -i -e "s%#DD_TRACK_MIGRATIONS#%$DD_TRACK_MIGRATIONS%" "$ENV_TARGET_FILE"
+    echo "10"
+    sed -i -e 's%#DD_SESSION_COOKIE_HTTPONLY#%'$DD_SESSION_COOKIE_HTTPONLY'%' "$ENV_TARGET_FILE"
+    echo "11"
+    sed -i -e 's%#DD_CSRF_COOKIE_HTTPONLY#%'$DD_CSRF_COOKIE_HTTPONLY'%' "$ENV_TARGET_FILE"
+    echo "12"
+    sed -i -e 's%#DD_SECURE_SSL_REDIRECT#%'$DD_SECURE_SSL_REDIRECT'%' "$ENV_TARGET_FILE"
+    echo "13"
+    sed -i -e 's%#DD_CSRF_COOKIE_SECURE#%'$DD_CSRF_COOKIE_SECURE'%' "$ENV_TARGET_FILE"
+    echo "14"
+    sed -i -e 's%#DD_SECURE_BROWSER_XSS_FILTER#%'$DD_SECURE_BROWSER_XSS_FILTER'%' "$ENV_TARGET_FILE"
+    echo "15"
+    sed -i -e 's%#DD_LANG#%'$DD_LANG'%' "$ENV_TARGET_FILE"
+    echo "16"
+    sed -i -e 's%#DD_WKHTMLTOPDF#%'$DD_WKHTMLTOPDF'%' "$ENV_TARGET_FILE"
+    echo "17"
+    sed -i -e 's%#DD_TEAM_NAME#%'$DD_TEAM_NAME'%' "$ENV_TARGET_FILE"
+    echo "18"
+    sed -i -e 's%#DD_ADMINS#%'$DD_ADMINS'%' "$ENV_TARGET_FILE"
+    echo "19"
+    sed -i -e 's%#DD_PORT_SCAN_CONTACT_EMAIL#%'$DD_PORT_SCAN_CONTACT_EMAIL'%' "$ENV_TARGET_FILE"
+    echo "20"
+    sed -i -e 's%#DD_PORT_SCAN_RESULT_EMAIL_FROM#%'$DD_PORT_SCAN_RESULT_EMAIL_FROM'%' "$ENV_TARGET_FILE"
+    echo "21"
+    sed -i -e 's%#DD_PORT_SCAN_EXTERNAL_UNIT_EMAIL_LIST#%'$DD_PORT_SCAN_EXTERNAL_UNIT_EMAIL_LIST'%' "$ENV_TARGET_FILE"
+    echo "22"
+    sed -i -e 's%#DD_PORT_SCAN_SOURCE_IP#%'$DD_PORT_SCAN_SOURCE_IP'%' "$ENV_TARGET_FILE"
+    # File paths for settings.py
+    #sed -i -e 's%#DOJO_ROOT#%'$DOJO_ROOT'%' "$TARGET_SETTINGS_FILE"
+    #sed -i -e 's%#MEDIA_ROOT#%'$MEDIA_ROOT'%' "$TARGET_SETTINGS_FILE"
+    #sed -i -e 's%#STATIC_ROOT#%'$STATIC_ROOT'%' "$TARGET_SETTINGS_FILE"
+    ## NEED TO CHECK HOW THESE END UP !!
+}
+
+function ubuntu_dojo_install() {
+	echo "=============================================================================="
+    echo "Installing DefectDojo Django application "
+    echo "=============================================================================="
+    echo ""
+    
+	# Detect if we're in a a virtualenv
+    python -c 'import sys; print sys.real_prefix' 2>/dev/null
+    VENV_ACTIVE=$?
+
+    # Decide if we always want to install in a VENV
+    if [ "$VENV_ACTIVE" = "0" ]; then
+        pip install --upgrade pip
+        pip install -U pip
+        if [ "$DB_TYPE" = MySQL ]; then
+            pip install .[mysql]
+        else
+            pip install .
+        fi
+
+    else
+        sudo pip install --upgrade pip
+        if [ "$DB_TYPE" = MySQL ]; then
+            sudo -H pip install .[mysql]
+        else
+            sudo -H pip install .
+        fi
+    fi
+    
+    python manage.py makemigrations dojo
+    python manage.py makemigrations --merge --noinput
+    python manage.py migrate
+
+    python manage.py createsuperuser --noinput --username="$ADMIN_USER" --email="$ADMIN_EMAIL"
+    entrypoint_scripts/common/setup-superuser.expect "$ADMIN_USER" "$ADMIN_PASS"
+    
+
+    if [ "$LOAD_SAMPLE_DATA" = true ]; then
+      python manage.py loaddata dojo/fixtures/defect_dojo_sample_data.json
+    fi
+    
+    python manage.py loaddata product_type
+    python manage.py loaddata test_type
+    python manage.py loaddata development_environment
+    python manage.py loaddata system_settings
+    python manage.py loaddata benchmark_type
+    python manage.py loaddata benchmark_category
+    python manage.py loaddata benchmark_requirement
+    python manage.py loaddata language_type
+    python manage.py loaddata objects_review
+    python manage.py loaddata regulation
+    
+    python manage.py installwatson
+    python manage.py buildwatson
+
+    # Install yarn packages
+    cd components && yarn && cd ..
+
+    python manage.py collectstatic --noinput
+}
+
+function install_linux() {
+	echo "Inside install_linux"
+	
+	# Install DB if required
+	if [ "$DB_LOCAL" = true ] && [ "$DB_EXISTS" = false ]; then
+        # DB is local and needs to be installed	
+		case $INSTALL_DISTRO in
+		    "Ubuntu")
+		    echo "  Installing database on Ubuntu"
+		    ubuntu_db_install 
+		    ubuntu_db_config
+		    ;;
+		    "centos")
+		    echo "  Installing database on CentOS"
+		    echo "  TBD: DB install for CentOS"
+		    ;;
+		    *)
+		    echo "    Error: Unsupported OS"
+		    exit 1
+		    ;;
+		esac
+	
+	fi
+	
+	# Install OS packages and DefectDojo app
+	echo "Install OS packages on $INSTALL_DISTRO"
+	case $INSTALL_DISTRO in
+	    "Ubuntu")
+	    # OS Packages needed by DefectDojo
+	    ubuntu_os_packages
+	    ubuntu_wkhtml_install
+	    # Install DefectDojo
+	    create_dojo_settings
+	    ubuntu_dojo_install
+	    ;;
+        "centos")
+        echo "  Installing database on CentOS"
+		echo "  TBD: DB install for CentOS"
+		;;
+		*)
+		echo "    Error: Unsupported OS"
+		exit 1
+		;;
+  	esac
+	
+	## Final message on the install
+}

--- a/legacy-setup.bash
+++ b/legacy-setup.bash
@@ -1,0 +1,73 @@
+#!/bin/bash
+# setup.bash helps you installing DefectDojo in your current environment
+#
+# setup.bash covers the following cases (and types of environments):
+# - Fresh installs on non-transient environments (physical or virtual OS)
+# - Fresh installs on transient environment blueprints (containerized environments)
+# - Updates on non-transient environments
+#
+# Not (yet) addressed:
+# - Updates for transient environments
+#
+
+echo
+echo "Welcome to DefectDojo! This is a quick script to get you up and running."
+echo
+
+# Initialize variables and functions
+source entrypoint_scripts/common/dojo-shared-resources.sh
+
+# This function invocation ensures we're running the script at the right place
+verify_cwd
+
+if [ "$BATCH_MODE" == "yes" ]; then
+    setup_batch_mode
+else
+    prompt_db_type
+fi
+
+echo
+echo "NEED SUDO PRIVILEGES FOR NEXT STEPS!"
+echo
+echo "Installing required packages..."
+echo
+
+# Install OS dependencies like DB client, further package managers, etc.
+install_os_dependencies
+
+# Install database-related packages
+install_db
+
+# Create the application DB or recreate it, if it's already present
+ensure_application_db
+
+if [ -z "$BATCH_MODE" ]; then
+  # Adjust the settings.py file
+  prepare_settings_file
+fi
+
+# Ensure, we're running on a supported python version
+verify_python_version
+
+# Install the actual application
+install_app
+
+echo "=============================================================================="
+echo
+echo "SUCCESS! Now edit your settings.py file in the 'dojo/settings/' directory to complete the installation."
+echo
+echo "We suggest you consider changing the following defaults:"
+echo
+echo "    DEBUG = True  # you should set this to False when you are ready for production."
+echo "    Uncomment the following lines if you enabled SSL/TLS on your server:"
+echo "        SESSION_COOKIE_SECURE = True"
+echo "        CSRF_COOKIE_SECURE = True"
+echo "        SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')"
+echo "        SECURE_SSL_REDIRECT = True"
+echo "        SECURE_BROWSER_XSS_FILTER = True"
+echo "        django.middleware.security.SecurityMiddleware"
+echo
+echo "When you're ready to start the DefectDojo server, type in this directory:"
+echo
+echo "    python manage.py runserver"
+echo


### PR DESCRIPTION
Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [X] Your code is flake8 compliant (Dojo's code isn't currently flake8 compliant, but we're trying to correct that)
- [X] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder

Note the new setup.bash installer has no file overlap with the old one so legacy-setup.bash will work as if you were running setup.bash before this PR.

Look for another PR in a a few days to update the docs and do some minor setup.bash output clean-up.