### PR TITLE
Fix test_type.json fixture

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -236,10 +236,11 @@
 		"model": "dojo.test_type",
 		"pk": 33
 	},
-  "fields": {
-      "name": "PHP Security Audit v2"
-    },
-    "model": "dojo.test_type",
-    "pk": 34
-  }
+	{
+  		"fields": {
+      			"name": "PHP Security Audit v2"
+    		},
+    		"model": "dojo.test_type",
+    		"pk": 34
+  	}
 ]


### PR DESCRIPTION
This file is currently causing an error in entrypoint_scripts/common/dojo-shared-resources.sh

- [x] Your code is flake8 compliant (Dojo's code isn't currently flake8 compliant, but we're trying to correct that)
