### PR TITLE
Fix max_length on primary key Product.name

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -279,7 +279,7 @@ class Contact(models.Model):
 
 
 class Product_Type(models.Model):
-    name = models.CharField(max_length=300, unique=True)
+    name = models.CharField(max_length=255, unique=True)
     critical_product = models.BooleanField(default=False)
     key_product = models.BooleanField(default=False)
     updated = models.DateTimeField(auto_now=True, null=True)


### PR DESCRIPTION
See https://docs.djangoproject.com/en/2.1/ref/databases/#notes-on-specific-fields
Fixed error (mysql):

==> logs/dojo.log <==
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/commands/runserver.py", line 124, in inner_run
    self.check(display_num_errors=True)
  File "/usr/local/lib/python2.7/dist-packages/django/core/management/base.py", line 405, in check
    raise SystemCheckError(msg)
django.core.management.base.SystemCheckError: SystemCheckError: System check identified some issues:

ERRORS:
dojo.Product_Type.name: (mysql.E001) MySQL does not allow unique CharFields to have a max_length > 255.