### PR TITLE
Dedupe functionaltiy doesn't correctly recognize all duplicates and l…

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1060,7 +1060,7 @@ class Finding(models.Model):
         ordering = ('numerical_severity', '-date', 'title')
 
     def compute_hash_code(self):
-        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path)
+        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + str(self.description)
         if self.dynamic_finding:
             endpoint_str = u''
             for e in self.endpoints.all():

--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -105,7 +105,8 @@ class VeracodeXMLParser(object):
                                 description=description +
                                 "\n\nVulnerable Module: " +
                                 flaw.attrib['module'] + ' Type: ' +
-                                flaw.attrib['type'],
+                                flaw.attrib['type'] + ' Issue ID: ' +
+                                flaw.attrib['issueid'],
                                 mitigated=mitigated,
                                 mitigated_by_id=mitigated_by_id,
                                 severity=sev,
@@ -132,7 +133,8 @@ class VeracodeXMLParser(object):
                                 description=description +
                                 "\n\nVulnerable Module: " +
                                 flaw.attrib['module'] + ' Type: ' +
-                                flaw.attrib['type'],
+                                flaw.attrib['type'] + ' Issue ID: ' +
+                                flaw.attrib['issueid'],
                                 severity=sev,
                                 numerical_severity=Finding.
                                 get_numerical_severity(sev),


### PR DESCRIPTION
…ooks at few original findings as duplicates too. This is to recreate the hash_code to look at the Description where the Issue ID is added to create a different dedupe hash so that only true duplicates are flagged by dedupe.

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant (Dojo's code isn't currently flake8 compliant, but we're trying to correct that)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder
