### PR TITLE
New feature request: Allow decoupling test_type and scan_type method when importing from API

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -21,12 +21,13 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Finding_Template, Test_Type, Development_Environment, \
     BurpRawRequestResponse, Endpoint, Notes, JIRA_PKey, JIRA_Conf, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
-    Languages, Language_Type, App_Analysis
+    Languages, Language_Type, App_Analysis, Product_Type
 from dojo.forms import ProductForm, EngForm, TestForm, \
     ScanSettingsForm, FindingForm, StubFindingForm, FindingTemplateForm, \
     ImportScanForm, SEVERITY_CHOICES, JIRAForm, JIRA_PKeyForm, EditEndpointForm, \
     JIRA_IssueForm, ToolConfigForm, ToolProductSettingsForm, \
-    ToolTypeForm, LanguagesTypeForm, Languages_TypeTypeForm, App_AnalysisTypeForm
+    ToolTypeForm, LanguagesTypeForm, Languages_TypeTypeForm, App_AnalysisTypeForm, \
+    Development_EnvironmentForm, Product_TypeForm, Test_TypeForm
 from dojo.tools.factory import import_parser_factory
 from datetime import datetime
 from object.parser import import_object_eng
@@ -325,6 +326,40 @@ class UserResource(BaseModelResource):
 
 
 """
+    /api/v1/product_types/
+    GET [/id/], DELETE [/id/]
+    Expects: no params
+    Returns product_types: ALL
+    Relevant apply filter ?id=?
+
+    POST, PUT [/id/]
+    Expects *name
+"""
+
+
+class ProductTypeResource(BaseModelResource):
+
+    class Meta:
+        resource_name = 'product_types'
+        list_allowed_methods = ['get', 'post']
+        # disabled delete. Should not be allowed without fine authorization.
+        detail_allowed_methods = ['get', 'post', 'put']
+        queryset = Product_Type.objects.all().order_by('id')
+        include_resource_uri = True
+        filtering = {
+            'id': ALL,
+            'name': ALL,
+        }
+        authentication = DojoApiKeyAuthentication()
+        authorization = DjangoAuthorization()
+        serializer = Serializer(formats=['json'])
+
+        @property
+        def validation(self):
+            return ModelFormValidation(form_class=Product_TypeForm, resource=ProductTypeResource)
+
+
+"""
     POST, PUT
     Expects *product name, *description, *prod_type [1-7]
 """
@@ -449,7 +484,6 @@ class Tool_ConfigurationResource(BaseModelResource):
             'id': ALL,
             'name': ALL,
             'tool_type': ALL_WITH_RELATIONS,
-            'name': ALL,
             'tool_project_id': ALL,
             'url': ALL,
             'authentication_type': ALL,
@@ -604,7 +638,7 @@ class LanguageTypeResource(BaseModelResource):
     Returns Tool_ConfigurationResource
     Relevant apply filter ?test_type=?, ?id=?
 
-    POST, PUT, DLETE [/id/]
+    POST, PUT, DELETE [/id/]
 """
 
 
@@ -670,7 +704,6 @@ class ToolProductSettingsResource(BaseModelResource):
             'name': ALL,
             'product': ALL_WITH_RELATIONS,
             'tool_configuration': ALL_WITH_RELATIONS,
-            'name': ALL,
             'tool_project_id': ALL,
             'url': ALL,
         }
@@ -821,6 +854,74 @@ class JiraResource(BaseModelResource):
         @property
         def validation(self):
             return ModelFormValidation(form_class=JIRA_PKeyForm, resource=JiraResource)
+
+
+"""
+    /api/v1/environments/
+    GET [/id/]
+    Expects: no params
+    Returns environments: ALL
+    Relevant apply filter ?id=?
+
+    POST, PUT [/id/]
+    Expects *name
+"""
+
+
+class DevelopmentEnvironmentResource(BaseModelResource):
+
+    class Meta:
+        resource_name = 'development_environments'
+        list_allowed_methods = ['get', 'post']
+        # disabled delete. Should not be allowed without fine authorization.
+        detail_allowed_methods = ['get', 'post', 'put']
+        queryset = Development_Environment.objects.all().order_by('id')
+        include_resource_uri = True
+        filtering = {
+            'id': ALL,
+            'name': ALL,
+        }
+        authentication = DojoApiKeyAuthentication()
+        authorization = DjangoAuthorization()
+        serializer = Serializer(formats=['json'])
+
+        @property
+        def validation(self):
+            return ModelFormValidation(form_class=Development_EnvironmentForm, resource=DevelopmentEnvironmentResource)
+
+
+"""
+    /api/v1/test_types/
+    GET [/id/]
+    Expects: no params
+    Returns environments: ALL
+    Relevant apply filter ?id=?
+
+    POST, PUT [/id/]
+    Expects *name
+"""
+
+
+class TestTypeResource(BaseModelResource):
+
+    class Meta:
+        resource_name = 'test_types'
+        list_allowed_methods = ['get', 'post']
+        # disabled delete. Should not be allowed without fine authorization.
+        detail_allowed_methods = ['get', 'post', 'put']
+        queryset = Test_Type.objects.all().order_by('id')
+        include_resource_uri = True
+        filtering = {
+            'id': ALL,
+            'name': ALL,
+        }
+        authentication = DojoApiKeyAuthentication()
+        authorization = DjangoAuthorization()
+        serializer = Serializer(formats=['json'])
+
+        @property
+        def validation(self):
+            return ModelFormValidation(form_class=Test_TypeForm, resource=TestTypeResource)
 
 
 """
@@ -1219,6 +1320,15 @@ class ImportScanValidation(Validation):
                 errors.setdefault('scan_type', []).append('scan_type must be one of the following: ' + ', '.join(scan_type_list))
         else:
             errors.setdefault('scan_type', []).append('A scan_type must be given so we know how to import the scan file.')
+        try:
+            if 'test_type' in bundle.data:
+                Test_Type.objects.get(name=bundle.data.get('test_type'))
+            else:
+                bundle.data['test_type'] = bundle.data.get('scan_type')
+        except Test_Type.DoesNotExist:
+            errors.setdefault('test_type', []).append(
+                'test_type must be one of the following: ' +
+                ', '.join(Test_Type.objects.values_list("name", flat=True)))
         severity_list = list(map(lambda x: x[0], SEVERITY_CHOICES))
         if 'minimum_severity' in bundle.data:
             if bundle.data['minimum_severity'] not in severity_list:
@@ -1283,6 +1393,7 @@ class ImportScanResource(MultipartResource, Resource):
     active = fields.BooleanField(attribute='active')
     verified = fields.BooleanField(attribute='verified')
     scan_type = fields.CharField(attribute='scan_type')
+    test_type = fields.CharField(attribute='test_type')
     tags = fields.CharField(attribute='tags')
     file = fields.FileField(attribute='file')
     engagement = fields.CharField(attribute='engagement')
@@ -1334,7 +1445,7 @@ class ImportScanResource(MultipartResource, Resource):
         bundle = self.full_hydrate(bundle)
 
         # We now have all the options we need and will just replicate the process in views.py
-        tt, t_created = Test_Type.objects.get_or_create(name=bundle.data['scan_type'])
+        tt, t_created = Test_Type.objects.get_or_create(name=bundle.data.get('test_type', bundle.data['scan_type']))
         # will save in development environment
         environment, env_created = Development_Environment.objects.get_or_create(name="Development")
 
@@ -1353,7 +1464,7 @@ class ImportScanResource(MultipartResource, Resource):
         t.tags = bundle.data['tags']
 
         try:
-            parser = import_parser_factory(bundle.data['file'], t)
+            parser = import_parser_factory(bundle.data['file'], t, bundle.data['scan_type'])
         except ValueError:
             raise NotFound("Parser ValueError")
 
@@ -1535,7 +1646,7 @@ class ReImportScanResource(MultipartResource, Resource):
         active = bundle.obj.__getattr__('active')
 
         try:
-            parser = import_parser_factory(bundle.data['file'], test)
+            parser = import_parser_factory(bundle.data['file'], test, scan_type)
         except ValueError:
             raise NotFound("Parser ValueError")
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -328,6 +328,13 @@ class JIRASerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class DevelopmentEnvironmentSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Development_Environment
+        fields = '__all__'
+
+
 class TestSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
     test_type_name = serializers.ReadOnlyField()
@@ -502,6 +509,8 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     verified = serializers.BooleanField(default=True)
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
+    test_type = serializers.ChoiceField(
+        choices=Test_Type.objects.all())
     file = serializers.FileField()
     engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all())
@@ -518,7 +527,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         skip_duplicates = data['skip_duplicates']
         close_old_findings = data['close_old_findings']
         test_type, created = Test_Type.objects.get_or_create(
-            name=data['scan_type'])
+            name=data.get('test_type', data['scan_type']))
         environment, created = Development_Environment.objects.get_or_create(
             name='Development')
         test = Test(

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -509,8 +509,8 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     verified = serializers.BooleanField(default=True)
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
-    test_type = serializers.ChoiceField(
-        choices=Test_Type.objects.values_list('name', flat=True), required=False)
+    test_type = serializers.PrimaryKeyRelatedField(
+        queryset=Test_Type.objects.all(), required=False)
     file = serializers.FileField()
     engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all())

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -510,7 +510,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
     test_type = serializers.ChoiceField(
-        choices=Test_Type.objects.all(), required=False)
+        choices=Test_Type.objects.values_list('name', flat=True), required=False)
     file = serializers.FileField()
     engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all())

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -509,8 +509,8 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     verified = serializers.BooleanField(default=True)
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
-    test_type = serializers.PrimaryKeyRelatedField(
-        queryset=Test_Type.objects.all(), required=False)
+    test_type = serializers.ChoiceField(
+        choices=ImportScanForm.SCAN_TYPE_CHOICES, required=False)
     file = serializers.FileField()
     engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all())

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -510,7 +510,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
     test_type = serializers.ChoiceField(
-        choices=Test_Type.objects.all())
+        choices=Test_Type.objects.all(), required=False)
     file = serializers.FileField()
     engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all())

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -5,7 +5,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
-    Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta
+    Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment
 
 from dojo.api_v2 import serializers, permissions
 
@@ -145,6 +145,8 @@ class ProductViewSet(mixins.ListModelMixin,
 
 class ProductTypeViewSet(mixins.ListModelMixin,
                          mixins.RetrieveModelMixin,
+                         mixins.CreateModelMixin,
+                         mixins.UpdateModelMixin,
                          viewsets.GenericViewSet):
     serializer_class = serializers.ProductTypeSerializer
     queryset = Product_Type.objects.all()
@@ -215,6 +217,16 @@ class StubFindingsViewSet(mixins.ListModelMixin,
             return serializers.StubFindingSerializer
 
 
+class DevelopmentEnvironmentViewSet(mixins.ListModelMixin,
+                                    mixins.RetrieveModelMixin,
+                                    mixins.CreateModelMixin,
+                                    mixins.UpdateModelMixin,
+                                    viewsets.GenericViewSet):
+    serializer_class = serializers.DevelopmentEnvironmentSerializer
+    queryset = Development_Environment.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+
+
 class TestsViewSet(mixins.ListModelMixin,
                    mixins.RetrieveModelMixin,
                    mixins.UpdateModelMixin,
@@ -235,6 +247,9 @@ class TestsViewSet(mixins.ListModelMixin,
 
 
 class TestTypesViewSet(mixins.ListModelMixin,
+                       mixins.RetrieveModelMixin,
+                       mixins.UpdateModelMixin,
+                       mixins.CreateModelMixin,
                        viewsets.GenericViewSet):
     serializer_class = serializers.TestTypeSerializer
     queryset = Test_Type.objects.all()

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -41,7 +41,8 @@ __author__ = 'Jay Paz'
 
 
 def import_parser_factory(file, test, scan_type=None):
-    scan_type = test.test_type.name
+    if scan_type is None:
+        scan_type = test.test_type.name
     if scan_type == "Burp Scan":
         parser = BurpXmlParser(file, test)
     elif scan_type == "Nessus Scan":

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -16,13 +16,14 @@ from dojo.api import UserResource, ProductResource, EngagementResource, \
     ReImportScanResource, JiraResource, JIRA_ConfResource, EndpointResource, \
     JIRA_IssueResource, ToolProductSettingsResource, Tool_ConfigurationResource, \
     Tool_TypeResource, LanguagesResource, LanguageTypeResource, App_AnalysisResource, \
-    BuildDetails
+    BuildDetails, DevelopmentEnvironmentResource, ProductTypeResource, TestTypeResource
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, TestTypesViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet
+    UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
+    DevelopmentEnvironmentViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -59,7 +60,10 @@ admin.autodiscover()
 v1_api = Api(api_name='v1', )
 v1_api.register(UserResource())
 v1_api.register(ProductResource())
+v1_api.register(ProductTypeResource())
 v1_api.register(EngagementResource())
+v1_api.register(DevelopmentEnvironmentResource())
+v1_api.register(TestTypeResource())
 v1_api.register(TestResource())
 v1_api.register(FindingResource())
 v1_api.register(FindingTemplateResource())
@@ -85,6 +89,7 @@ v1_api.register(BuildDetails())
 v2_api = DefaultRouter()
 v2_api.register(r'endpoints', EndPointViewSet)
 v2_api.register(r'engagements', EngagementViewSet)
+v2_api.register(r'development_environments', DevelopmentEnvironmentViewSet)
 v2_api.register(r'finding_templates', FindingTemplatesViewSet)
 v2_api.register(r'findings', FindingViewSet)
 v2_api.register(r'jira_configurations', JiraConfigurationsViewSet)


### PR DESCRIPTION
This feature allows to create a test with an specific test_type decoupling it from value of scan_type when importing findings from API

Additional features added: Extended API v1 and v2 to allow:
- For v1:
  - create and update Product_Type
  - create and update Development_Environment
  - create and update Test_Type
- For v2:
  - create and update Development_Environment
- For both versions:
  - Be able to override the test_type created independently of scan_type selected
