### PR TITLE
Adding support for Safety scans

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -249,5 +249,12 @@
     	},
 	    "model": "dojo.test_type",
 		"pk": 35
+	},
+	{
+	    "fields": {
+            "name": "Safety Scan"
+    	},
+	    "model": "dojo.test_type",
+		"pk": 36
 	}
 ]

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -271,7 +271,8 @@ class ImportScanForm(forms.Form):
                          ("SpotBugs Scan", "SpotBugs Scan"),
                          ("AWS Scout2 Scan", "AWS Scout2 Scan"),
                          ("AWS Prowler Scan", "AWS Prowler Scan"),
-                         ("PHP Security Audit v2", "PHP Security Audit v2"))
+                         ("PHP Security Audit v2", "PHP Security Audit v2"),
+                         ("Safety Scan", "Safety Scan"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
 

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -53,6 +53,7 @@
 	<li><b>Qualys</b> - Qualys output files can be imported in XML format.</li>
 	<li><b>Qualys WebScan</b> - Qualys WebScan output files can be imported in XML format.</li>
 	<li><b>Retire.js</b> - Retire.js JavaScript scan (--js) output file can be imported in JSON format.</li>
+	<li><b>Safety Scan</b> - Safety scan (--json) output file can be imported in JSON format.</li>
 	<li><b>SKF Scan</b> - Output of SKF Sprint summary export.</li>
 	<li><b>Snyk</b> - Snyk output file (snyk test --json > snyk.json) can be imported in JSON format.</li>
   <li><b>SonarQube</b> - SonarQube output file can be imported in HTML format.</li>

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -36,6 +36,7 @@ from dojo.tools.awsscout2.parser import AWSScout2Parser
 from dojo.tools.awsprowler.parser import AWSProwlerParser
 from dojo.tools.brakeman.parser import BrakemanScanParser
 from dojo.tools.spotbugs.parser import SpotbugsXMLParser
+from dojo.tools.safety.parser import SafetyParser
 
 __author__ = 'Jay Paz'
 
@@ -122,6 +123,8 @@ def import_parser_factory(file, test, scan_type=None):
         parser = BrakemanScanParser(file, test)
     elif scan_type == 'SpotBugs Scan':
         parser = SpotbugsXMLParser(file, test)
+    elif scan_type == 'Safety Scan':
+        parser = SafetyParser(file, test)
     else:
         raise ValueError('Unknown Test Type')
 

--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -39,7 +39,7 @@ class SafetyParser(object):
 
 
 def get_item(item_node, test, safety_db):
-    severity = 'Info' # Because Safety doesn't include severity rating
+    severity = 'Info'  # Because Safety doesn't include severity rating
     cve = ''.join(a['cve'] for a in safety_db[item_node['package']] if a['id'] == 'pyup.io-' + item_node['id'])
     title = item_node['package'] + " (" + item_node['affected'] + ")"
     if cve:
@@ -68,5 +68,3 @@ def get_item(item_node, test, safety_db):
                       impact="No impact provided")
 
     return finding
-
-print "Hello"

--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -1,0 +1,72 @@
+import json
+import urllib
+from dojo.models import Finding
+
+
+class SafetyParser(object):
+    def __init__(self, json_output, test):
+
+        # Grab Safety DB for CVE lookup
+        url = "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json"
+        response = urllib.urlopen(url)
+        safety_db = json.loads(response.read())
+
+        tree = self.parse_json(json_output)
+
+        if tree:
+            self.items = [data for data in self.get_items(tree, test, safety_db)]
+        else:
+            self.items = []
+
+    def parse_json(self, json_output):
+        json_obj = json.load(json_output)
+        tree = {l[4]: {'package': str(l[0]),
+                       'affected': str(l[1]),
+                       'installed': str(l[2]),
+                       'description': str(l[3]),
+                       'id': str(l[4])}
+                for l in json_obj}
+        return tree
+
+    def get_items(self, tree, test, safety_db):
+        items = {}
+
+        for key, node in tree.iteritems():
+            item = get_item(node, test, safety_db)
+            items[key] = item
+
+        return items.values()
+
+
+def get_item(item_node, test, safety_db):
+    severity = 'Info' # Because Safety doesn't include severity rating
+    cve = ''.join(a['cve'] for a in safety_db[item_node['package']] if a['id'] == 'pyup.io-' + item_node['id'])
+    title = item_node['package'] + " (" + item_node['affected'] + ")"
+    if cve:
+        title = title + " | " + cve
+    else:
+        cve = "N/A"
+
+    finding = Finding(title=title,
+                      test=test,
+                      severity=severity,
+                      description=item_node['description'] +
+                                  "\n Vulnerable Package: " + item_node['package'] +
+                                  "\n Installed Version: " + item_node['installed'] +
+                                  "\n Vulnerable Versions: " + item_node['affected'] +
+                                  "\n CVE: " + cve +
+                                  "\n ID: " + item_node['id'],
+                      cwe=1035,  # Vulnerable Third Party Component
+                      mitigation="No mitigation provided",
+                      references="No reference provided",
+                      active=False,
+                      verified=False,
+                      false_p=False,
+                      duplicate=False,
+                      out_of_scope=False,
+                      mitigated=None,
+                      impact="No impact provided")
+
+    return finding
+
+print "Hello"


### PR DESCRIPTION
Adds support for Saftey scanner released by pyup.io detailed [here](https://github.com/pyupio/safety). I wasn't able to find the mentioned /docs folder so mentioned documentation has not been included. PR [#7](https://github.com/DefectDojo/sample-scan-files/pull/7) has also been submitted to [sample-scan-files](https://github.com/DefectDojo/sample-scan-files) with sample scan data.

Safety does not include severity levels for each finding, so all findings are being set to Info as is seen with other scanners. CVE data is not included in scan json data, so the Safety DB JSON is obtained to be included. 

- [X] Your code is flake8 compliant (Dojo's code isn't currently flake8 compliant, but we're trying to correct that)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation under the /docs folder
