### PR TITLE
prevent sb-admin-2 from 4.0.0 upgrade

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -28,7 +28,7 @@
     "@yarn_components/mocha": "mochajs/mocha#~1.17.1",
     "@yarn_components/moment": "moment/moment#^2.9.0",
     "@yarn_components/morrisjs": "morrisjs/morris.js#~0.5.1",
-    "@yarn_components/startbootstrap-sb-admin-2": "BlackrockDigital/startbootstrap-sb-admin-2#*",
+    "@yarn_components/startbootstrap-sb-admin-2": "BlackrockDigital/startbootstrap-sb-admin-2#~3.3.7+1",
     "@yarn_components/simplemde": "sparksuite/simplemde-markdown-editor#1.11.2"
   },
   "engines": {


### PR DESCRIPTION
Posted screenshots in slack of the issue.

After ~2.5yrs, startbootstrap-sb-admin-2 updated from 3.3.7+1 to 4.0.0 [reference](https://github.com/BlackrockDigital/startbootstrap-sb-admin-2/releases).  This happened January 29.

The changes are significant and break the UI (no longer a `/dist` folder, and major css changes that modify the left icon bar's width to about the whole page, etc).  This change locks `startbootstrap-sb-admin-2` to the known good version.