### PR TITLE
Fix bulk edit in findings and nessus report parsing

### DIFF
--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -343,10 +343,10 @@
 
             $('#id_status').on('click', function (e) {
                 var checked = this.checked;
-                $('#id_active').prop('disabled', !checked);
-                $('#id_verified').prop('disabled', !checked);
-                $('#id_false_p').prop('disabled', !checked);
-                $('#id_out_of_scope').prop('disabled', !checked);
+                $('#bulk_edit_menu #id_active').prop('disabled', !checked);
+                $('#bulk_edit_menu #id_verified').prop('disabled', !checked);
+                $('#bulk_edit_menu #id_false_p').prop('disabled', !checked);
+                $('#bulk_edit_menu #id_out_of_scope').prop('disabled', !checked);
             })
             // Keep the dropdown menu open for selecting severity status
             $('.dropdown-menu').click(function(e) {

--- a/dojo/tools/nessus/parser.py
+++ b/dojo/tools/nessus/parser.py
@@ -100,7 +100,9 @@ class NessusCSVParser(object):
                             dat['references'] = var
                     elif heading[i] == "Plugin Output":
                         dat['plugin_output'] = "\nPlugin output(" + \
-                                               dat['endpoint'] + "):" + str(var) + "\n"
+                                               dat['endpoint'] + \
+                                               "):\n```\n" + str(var) + \
+                                               "\n```\n"
 
                 if not dat['severity']:
                     dat['severity'] = "Info"
@@ -171,7 +173,9 @@ class NessusXMLParser(object):
                         description = item.find("synopsis").text + "\n\n"
                     if item.findtext("plugin_output"):
                         plugin_output = "Plugin Output: " + ip + (
-                            (":" + port) if port is not None else "") + " " + item.find("plugin_output").text + "\n\n"
+                            (":" + port) if port is not None else "") + \
+                            " \n```\n" + item.find("plugin_output").text + \
+                            "\n```\n\n"
                         description += plugin_output
 
                     nessus_severity_id = int(item.attrib["severity"])


### PR DESCRIPTION
- Fix bulk status change in findings(verified, false positive and out of scope): there was a problem with several same id attributes on the same page.  
- Fix Nessus report parsing: if Nessus plugin output contains HTML, the finding page markup is broken. Plugin output is now wrapped in a code block.