### PR TITLE
Feature/fix env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${DEFECT_DOJO_MYSQL_ROOT_PASSWORD:-defectojo}
       MYSQL_DATABASE: 'dojodb'
       MYSQL_USER: 'dojo'
-      MYSQL_PASSWORD: ${DD_DATABASE_PASsWORD:-dojodbpwd}
+      MYSQL_PASSWORD: ${DD_DATABASE_PASSWORD:-dojodbpwd}
     hostname: 'mysql'
     image: 'mysql:5.7'
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       - proxy
     volumes:
       - './docker/static:/opt/django-DefectDojo/static'
-      - './docker/entrypoint.sh:/opt/django-DefectDojo/docker/entrypoint.sh'
 
   mysql:
     command: '--default-authentication-plugin=mysql_native_password'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,13 +21,13 @@ services:
     depends_on:
       - mysql
     environment:
-      DEFECT_DOJO_ADMIN_PASSWORD: ${DEFECT_DOJO_ADMIN_PASSWORD:-admin}
-      DEFECT_DOJO_DEFAULT_DATABASE_HOST: 'mysql'
-      DEFECT_DOJO_DEFAULT_DATABASE_PORT: '3306'
-      DEFECT_DOJO_DEFAULT_DATABASE_NAME: 'dojodb'
-      DEFECT_DOJO_DEFAULT_DATABASE_USER: 'dojo'
-      DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD: ${DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD:-dojodbpwd}
-      DD_DATABASE_URL: 'mysql://dojo:${DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD:-dojodbpwd}@mysql:3306/dojodb'
+      DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-admin}
+      DD_DATABASE_TYPE: 'mysql'
+      DD_DATABASE_HOST: 'mysql'
+      DD_DATABASE_PORT: '3306'
+      DD_DATABASE_NAME: 'dojodb'
+      DD_DATABASE_USER: 'dojo'
+      DD_DATABASE_PASSWORD: ${DD_DATABASE_PASsWORD:-dojodbpwd}
       DD_ALLOWED_HOSTS: '*'
       DD_SECRET_KEY: ${DD_SECRET_KEY:-"hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq"}
       DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-"&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw"}
@@ -37,6 +37,7 @@ services:
       - proxy
     volumes:
       - './docker/static:/opt/django-DefectDojo/static'
+      - './docker/entrypoint.sh:/opt/django-DefectDojo/docker/entrypoint.sh'
 
   mysql:
     command: '--default-authentication-plugin=mysql_native_password'
@@ -45,7 +46,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${DEFECT_DOJO_MYSQL_ROOT_PASSWORD:-defectojo}
       MYSQL_DATABASE: 'dojodb'
       MYSQL_USER: 'dojo'
-      MYSQL_PASSWORD: ${DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD:-dojodbpwd}
+      MYSQL_PASSWORD: ${DD_DATABASE_PASsWORD:-dojodbpwd}
     hostname: 'mysql'
     image: 'mysql:5.7'
     networks:
@@ -65,9 +66,9 @@ services:
       - '8080:80'
       - '4443:443'
     volumes:
-      - "$PWD/docker/nginx.conf:/etc/nginx/nginx.conf:ro"
-      - "$PWD/docker/cert.pem:/cert.pem:ro"
-      - "$PWD/docker/key.pem:/key.pem:ro"
+      - "./docker/nginx.conf:/etc/nginx/nginx.conf:ro"
+      - "./docker/cert.pem:/cert.pem:ro"
+      - "./docker/key.pem:/key.pem:ro"
       # This gives Nginx access to the static assets compiled by Django.
       - './docker/static:/usr/share/nginx/html/static:ro'
     healthcheck:

--- a/docker/docker-startup.bash
+++ b/docker/docker-startup.bash
@@ -36,13 +36,13 @@ else
     echo "=============================================================================="
     echo
     #Make sure MySQL is up and running, run the mysql script to check the port and report back
-    bash ./wait-for-it.sh $DEFECT_DOJO_DEFAULT_DATABASE_HOST:$DEFECT_DOJO_DEFAULT_DATABASE_PORT
+    bash ./wait-for-it.sh $DD_DATABASE_HOST:$DD_DATABASE_PORT
 
     if [ $? -eq 0 ]; then
       echo "Database server is up and running."
       echo
-      if [ $(mysql -N -s -u$DEFECT_DOJO_DEFAULT_DATABASE_USER -p$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD $DEFECT_DOJO_DEFAULT_DATABASE_NAME --host $DEFECT_DOJO_DEFAULT_DATABASE_HOST --port $DEFECT_DOJO_DEFAULT_DATABASE_PORT -e \
-          "select count(*) from information_schema.tables where table_schema='$DEFECT_DOJO_DEFAULT_DATABASE_NAME' and table_name='dojo_product';") -eq 1 ]; then
+      if [ $(mysql -N -s -u$DD_DATABASE_USER -p$DD_DATABASE_PASsWORD $DD_DATABASE_NAME --host $DD_DATABASE_HOST --port $DD_DATABASE_PORT -e \
+          "select count(*) from information_schema.tables where table_schema='$DD_DATABASE_NAME' and table_name='dojo_product';") -eq 1 ]; then
           echo "DB Exists."
       else
         setupdb
@@ -70,7 +70,7 @@ else
     fi
 
     echo "=============================================================================="
-    echo "Login with $DOJO_ADMIN_USER/$DEFECT_DOJO_DEFAULT_DATABASE_USER"
+    echo "Login with $DOJO_ADMIN_USER/$DD_DATABASE_USER"
     echo "URL: http://localhost:$PORT"
     echo "=============================================================================="
     echo

--- a/docker/docker-startup.bash
+++ b/docker/docker-startup.bash
@@ -41,7 +41,7 @@ else
     if [ $? -eq 0 ]; then
       echo "Database server is up and running."
       echo
-      if [ $(mysql -N -s -u$DD_DATABASE_USER -p$DD_DATABASE_PASsWORD $DD_DATABASE_NAME --host $DD_DATABASE_HOST --port $DD_DATABASE_PORT -e \
+      if [ $(mysql -N -s -u$DD_DATABASE_USER -p$DD_DATABASE_PASSWORD $DD_DATABASE_NAME --host $DD_DATABASE_HOST --port $DD_DATABASE_PORT -e \
           "select count(*) from information_schema.tables where table_schema='$DD_DATABASE_NAME' and table_name='dojo_product';") -eq 1 ]; then
           echo "DB Exists."
       else

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,15 +1,23 @@
 #!/bin/sh
 
 # Waits for the database to come up.
-./docker/wait-for-it.sh $DEFECT_DOJO_DEFAULT_DATABASE_HOST:$DEFECT_DOJO_DEFAULT_DATABASE_PORT
+./docker/wait-for-it.sh $DD_DATABASE_HOST:$DD_DATABASE_PORT
+
+if [ -z "$DD_DATABASE_URL" ]; then
+  if [ -z "$DD_DATABASE_PASSWORD" ]; then
+      echo "Please set DD_DATABASE_URL or other DD_DATABASE_HOST, DD_DATABASE_USER, DD_DATABASE_PASSWORD, ..."
+      exit 1
+  fi
+  export DD_DATABASE_URL="$DD_DATABASE_TYPE://$DD_DATABASE_USER:$DD_DATABASE_PASSWORD@$DD_DATABASE_HOST:$DD_DATABASE_PORT/$DD_DATABASE_NAME"
+fi
 
 if [ ! -f "/opt/django-DefectDojo/static/docker_complete" ]; then
   python manage.py makemigrations dojo
   python manage.py makemigrations --merge --noinput
   python manage.py migrate
 
-  if [ -z "$DEFECT_DOJO_ADMIN_PASSWORD" ]; then
-      DEFECT_DOJO_ADMIN_PASSWORD="admin"
+  if [ -z "$DD_ADMIN_PASSWORD" ]; then
+      DD_ADMIN_PASSWORD="admin"
   fi
 
   # The '&&' is critical here. If the admin user is already created, setting the

--- a/docker/setup-superuser.expect
+++ b/docker/setup-superuser.expect
@@ -3,7 +3,7 @@
 set timeout -1;
 spawn /usr/bin/python manage.py changepassword admin;
 expect {
-    "Password:" { exp_send "$env(DEFECT_DOJO_ADMIN_PASSWORD)\r" ; exp_continue }
-    "Password (again):" { exp_send "$env(DEFECT_DOJO_ADMIN_PASSWORD)\r" ; exp_continue }
+    "Password:" { exp_send "$env(DD_ADMIN_PASSWORD)\r" ; exp_continue }
+    "Password (again):" { exp_send "$env(DD_ADMIN_PASSWORD)\r" ; exp_continue }
     eof
 }

--- a/entrypoint_scripts/common/dojo-shared-resources.sh
+++ b/entrypoint_scripts/common/dojo-shared-resources.sh
@@ -93,10 +93,10 @@ function createadmin() {
     if [ -z "$DEFECT_DOJO_ADMIN_EMAIL" ]; then
         DEFECT_DOJO_ADMIN_EMAIL='admin@localhost.local'
     fi
-    if [ -z "$DEFECT_DOJO_ADMIN_PASSWORD" ]; then
-        DEFECT_DOJO_ADMIN_PASSWORD="admin"
+    if [ -z "$DD_ADMIN_PASSWORD" ]; then
+        DD_ADMIN_PASSWORD="admin"
     fi
-    export DEFECT_DOJO_ADMIN_PASSWORD=$DEFECT_DOJO_ADMIN_PASSWORD
+    export DD_ADMIN_PASSWORD=$DD_ADMIN_PASSWORD
     #creating default admin user
     python manage.py createsuperuser --noinput --username="$DEFECT_DOJO_ADMIN_NAME" --email="$DEFECT_DOJO_ADMIN_EMAIL"
     docker/setup-superuser.expect
@@ -214,28 +214,28 @@ function ensure_mysql_application_db() {
     # Allow script to be called non-interactively using:
     if [ "$AUTO_DOCKER" == "yes" ]; then
         echo "Setting values for MySQL install"
-        if [ -z "$DEFECT_DOJO_DEFAULT_DATABASE_HOST" ]; then
-            DEFECT_DOJO_DEFAULT_DATABASE_HOST="localhost"
+        if [ -z "$DD_DATABASE_HOST" ]; then
+            DD_DATABASE_HOST="localhost"
         fi
-        if [ -z "$DEFECT_DOJO_DEFAULT_DATABASE_PORT" ]; then
-            DEFECT_DOJO_DEFAULT_DATABASE_PORT="3306"
+        if [ -z "$DD_DATABASE_PORT" ]; then
+            DD_DATABASE_PORT="3306"
         fi
-        if [ -z "$DEFECT_DOJO_DEFAULT_DATABASE_USER" ]; then
-            DEFECT_DOJO_DEFAULT_DATABASE_USER="root"
+        if [ -z "$DD_DATABASE_USER" ]; then
+            DD_DATABASE_USER="root"
         fi
-        if [ -z "$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD" -a "$BATCH_MODE" == "yes" ]; then
+        if [ -z "$DD_DATABASE_PASsWORD" -a "$BATCH_MODE" == "yes" ]; then
             echo "SQL Password not provided, exiting"
             exit 1
         else
-            DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD="dojodb_install"
+            DD_DATABASE_PASsWORD="dojodb_install"
         fi
-        if [ -z "$DEFECT_DOJO_DEFAULT_DATABASE_NAME" ]; then
-            DEFECT_DOJO_DEFAULT_DATABASE_NAME="dojodb"
+        if [ -z "$DD_DATABASE_NAME" ]; then
+            DD_DATABASE_NAME="dojodb"
         fi
     fi
 
-    if mysql -fs --protocol=TCP -h "$DEFECT_DOJO_DEFAULT_DATABASE_HOST" -P "$DEFECT_DOJO_DEFAULT_DATABASE_PORT" -u"$DEFECT_DOJO_DEFAULT_DATABASE_USER" -p"$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD" "$DEFECT_DOJO_DEFAULT_DATABASE_NAME" >/dev/null 2>&1 </dev/null; then
-        echo "Database $DEFECT_DOJO_DEFAULT_DATABASE_NAME already exists!"
+    if mysql -fs --protocol=TCP -h "$DD_DATABASE_HOST" -P "$DD_DATABASE_PORT" -u"$DD_DATABASE_USER" -p"$DD_DATABASE_PASsWORD" "$DD_DATABASE_NAME" >/dev/null 2>&1 </dev/null; then
+        echo "Database $DD_DATABASE_NAME already exists!"
         echo
         if [ "$AUTO_DOCKER" == "yes" ] || [ "$BATCH_MODE" == "yes" ]; then
             if [ -z "$FLUSHDB" ]; then
@@ -244,21 +244,21 @@ function ensure_mysql_application_db() {
                 DELETE="$FLUSHDB"
             fi
         else
-            read -p "Drop database $DEFECT_DOJO_DEFAULT_DATABASE_NAME? [Y/n] " DELETE
+            read -p "Drop database $DD_DATABASE_NAME? [Y/n] " DELETE
         fi
         if [[ ! $DELETE =~ ^[nN]$ ]]; then
-            mysqladmin -f --protocol=TCP --host="$DEFECT_DOJO_DEFAULT_DATABASE_HOST" --port="$DEFECT_DOJO_DEFAULT_DATABASE_PORT" --user="$DEFECT_DOJO_DEFAULT_DATABASE_USER" --password="$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD" drop "$DEFECT_DOJO_DEFAULT_DATABASE_NAME"
-            mysqladmin    --protocol=TCP --host="$DEFECT_DOJO_DEFAULT_DATABASE_HOST" --port="$DEFECT_DOJO_DEFAULT_DATABASE_PORT" --user="$DEFECT_DOJO_DEFAULT_DATABASE_USER" --password="$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD" create "$DEFECT_DOJO_DEFAULT_DATABASE_NAME"
+            mysqladmin -f --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASsWORD" drop "$DD_DATABASE_NAME"
+            mysqladmin    --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASsWORD" create "$DD_DATABASE_NAME"
         fi
     else
         echo "Setting password..."
         # Set the root password for mysql
         set_random_mysql_db_pwd
         sudo service mysql start
-        if mysqladmin --protocol=TCP --host="$DEFECT_DOJO_DEFAULT_DATABASE_HOST" --port="$DEFECT_DOJO_DEFAULT_DATABASE_PORT" --user="$DEFECT_DOJO_DEFAULT_DATABASE_USER" --password="$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD" create $DEFECT_DOJO_DEFAULT_DATABASE_NAME; then
-            echo "Created database $DEFECT_DOJO_DEFAULT_DATABASE_NAME."
+        if mysqladmin --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASsWORD" create $DD_DATABASE_NAME; then
+            echo "Created database $DD_DATABASE_NAME."
         else
-            echo "Error! Failed to create database $DEFECT_DOJO_DEFAULT_DATABASE_NAME. Check your credentials."
+            echo "Error! Failed to create database $DD_DATABASE_NAME. Check your credentials."
             echo
             ensure_mysql_application_db
         fi
@@ -267,22 +267,22 @@ function ensure_mysql_application_db() {
 
 # Ensures the Postgres application DB is present
 function ensure_postgres_application_db() {
-    read -p "Postgres host: " $DEFECT_DOJO_DEFAULT_DATABASE_HOST
-    read -p "Postgres port: " $DEFECT_DOJO_DEFAULT_DATABASE_PORT
-    read -p "Postgres user (should already exist): " $DEFECT_DOJO_DEFAULT_DATABASE_USER
+    read -p "Postgres host: " $DD_DATABASE_HOST
+    read -p "Postgres port: " $DD_DATABASE_PORT
+    read -p "Postgres user (should already exist): " $DD_DATABASE_USER
     stty -echo
-    read -p "Password for user: " $DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD; echo
+    read -p "Password for user: " $DD_DATABASE_PASsWORD; echo
     stty echo
-    read -p "Database name (should NOT exist): " $DEFECT_DOJO_DEFAULT_DATABASE_NAME
+    read -p "Database name (should NOT exist): " $DD_DATABASE_NAME
 
-    if [ "$( PGPASSWORD=$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD psql -h $DEFECT_DOJO_DEFAULT_DATABASE_HOST -p $DEFECT_DOJO_DEFAULT_DATABASE_PORT -U $DEFECT_DOJO_DEFAULT_DATABASE_USER -tAc "SELECT 1 FROM pg_database WHERE datname='$DEFECT_DOJO_DEFAULT_DATABASE_NAME'" )" = '1' ]
+    if [ "$( PGPASSWORD=$DD_DATABASE_PASsWORD psql -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER -tAc "SELECT 1 FROM pg_database WHERE datname='$DD_DATABASE_NAME'" )" = '1' ]
     then
-        echo "Database $DEFECT_DOJO_DEFAULT_DATABASE_NAME already exists!"
+        echo "Database $DD_DATABASE_NAME already exists!"
         echo
-        read -p "Drop database $DEFECT_DOJO_DEFAULT_DATABASE_NAME? [Y/n] " DELETE
+        read -p "Drop database $DD_DATABASE_NAME? [Y/n] " DELETE
         if [[ ! $DELETE =~ ^[nN]$ ]]; then
-            PGPASSWORD=$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD dropdb $DEFECT_DOJO_DEFAULT_DATABASE_NAME -h $DEFECT_DOJO_DEFAULT_DATABASE_HOST -p $DEFECT_DOJO_DEFAULT_DATABASE_PORT -U $DEFECT_DOJO_DEFAULT_DATABASE_USER
-            PGPASSWORD=$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD createdb $DEFECT_DOJO_DEFAULT_DATABASE_NAME -h $DEFECT_DOJO_DEFAULT_DATABASE_HOST -p $DEFECT_DOJO_DEFAULT_DATABASE_PORT -U $DEFECT_DOJO_DEFAULT_DATABASE_USER
+            PGPASSWORD=$DD_DATABASE_PASsWORD dropdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
+            PGPASSWORD=$DD_DATABASE_PASsWORD createdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
         else
             read -p "Try and install anyway? [Y/n] " INSTALL
             if [[ $INSTALL =~ ^[nN]$ ]]; then
@@ -291,12 +291,12 @@ function ensure_postgres_application_db() {
             fi
         fi
     else
-        PGPASSWORD=$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD createdb $DEFECT_DOJO_DEFAULT_DATABASE_NAME -h $DEFECT_DOJO_DEFAULT_DATABASE_HOST -p $DEFECT_DOJO_DEFAULT_DATABASE_PORT -U $DEFECT_DOJO_DEFAULT_DATABASE_USER
+        PGPASSWORD=$DD_DATABASE_PASsWORD createdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
         if [ $? = 0 ]
         then
-            echo "Created database $DEFECT_DOJO_DEFAULT_DATABASE_NAME."
+            echo "Created database $DD_DATABASE_NAME."
         else
-            echo "Error! Failed to create database $DEFECT_DOJO_DEFAULT_DATABASE_NAME. Check your credentials."
+            echo "Error! Failed to create database $DD_DATABASE_NAME. Check your credentials."
             echo
             ensure_postgres_application_db
         fi
@@ -447,10 +447,10 @@ function prepare_settings_file() {
     if [ "$DBTYPE" == "$SQLITE" ]; then
         echo 'DD_DATABASE_URL="sqlite:///defectdojo.db"' >> ${ENV_SETTINGS_FILE}
     elif [ "$DBTYPE" == "$MYSQL" ]; then
-        SAFE_URL=$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_USER")":"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD")"@"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_HOST")":"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_PORT")"/"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_NAME")
+        SAFE_URL=$(urlenc "$DD_DATABASE_USER")":"$(urlenc "$DD_DATABASE_PASsWORD")"@"$(urlenc "$DD_DATABASE_HOST")":"$(urlenc "$DD_DATABASE_PORT")"/"$(urlenc "$DD_DATABASE_NAME")
         echo "DD_DATABASE_URL=mysql://$SAFE_URL" >> ${ENV_SETTINGS_FILE}
     elif [ "$DBTYPE" == "$POSTGRES" ]; then
-        SAFE_URL=$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_USER")":"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD")"@"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_HOST")":"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_PORT")"/"$(urlenc "$DEFECT_DOJO_DEFAULT_DATABASE_NAME")
+        SAFE_URL=$(urlenc "$DD_DATABASE_USER")":"$(urlenc "$DD_DATABASE_PASsWORD")"@"$(urlenc "$DD_DATABASE_HOST")":"$(urlenc "$DD_DATABASE_PORT")"/"$(urlenc "$DD_DATABASE_NAME")
         echo "DD_DATABASE_URL=postgres://$SAFE_URL" >> ${ENV_SETTINGS_FILE}
     fi
 
@@ -539,10 +539,10 @@ function set_random_mysql_db_pwd() {
   sudo mysqld_safe --skip-grant-tables >/dev/null 2>&1 &
   sleep 5
   DB_ROOT_PASS_LEN=`shuf -i 50-60 -n 1`
-  if [[ -z "$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD" ]]; then
-    DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
+  if [[ -z "$DD_DATABASE_PASsWORD" ]]; then
+    DD_DATABASE_PASsWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
   fi
-  mysql mysql -e "UPDATE user SET authentication_string=PASSWORD('$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD'), plugin='mysql_native_password' WHERE User='root';FLUSH PRIVILEGES;"
+  mysql mysql -e "UPDATE user SET authentication_string=PASSWORD('$DD_DATABASE_PASsWORD'), plugin='mysql_native_password' WHERE User='root';FLUSH PRIVILEGES;"
   sudo service mysql stop
 }
 

--- a/entrypoint_scripts/run/startup-docker.bash
+++ b/entrypoint_scripts/run/startup-docker.bash
@@ -21,33 +21,33 @@ if cat dojo/settings/.env.prod | grep -q "mysql://root:dojodb_install@localhost:
 	# Reset mysql password
 	set_random_mysql_db_pwd
 	DBTYPE=1
-	DEFECT_DOJO_DEFAULT_DATABASE_USER=root
-	DEFECT_DOJO_DEFAULT_DATABASE_HOST=localhost
-	DEFECT_DOJO_DEFAULT_DATABASE_PORT=3306
-	DEFECT_DOJO_DEFAULT_DATABASE_NAME=dojodb
+	DD_DATABASE_USER=root
+	DD_DATABASE_HOST=localhost
+	DD_DATABASE_PORT=3306
+	DD_DATABASE_NAME=dojodb
 
 	# Set the settings file
 	prepare_settings_file
 
 	# Reset admin user or use user supplied password
-	if [[ -z $DEFECT_DOJO_ADMIN_PASSWORD ]]; then
+	if [[ -z $DD_ADMIN_PASSWORD ]]; then
 		DB_ROOT_PASS_LEN=`shuf -i 20-25 -n 1`
-	  DEFECT_DOJO_ADMIN_PASSWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
+	  DD_ADMIN_PASSWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
 	fi
   sudo chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
   && sudo service mysql start
-	entrypoint_scripts/common/setup-superuser.expect admin "$DEFECT_DOJO_ADMIN_PASSWORD"
+	entrypoint_scripts/common/setup-superuser.expect admin "$DD_ADMIN_PASSWORD"
 
 	#DB_ROOT_PASS_USER=`pwgen -scn $DB_ROOT_PASS_LEN 1`
-	#entrypoint_scripts/common/setup-superuser.expect product_manager "$DEFECT_DOJO_ADMIN_PASSWORD"
+	#entrypoint_scripts/common/setup-superuser.expect product_manager "$DD_ADMIN_PASSWORD"
 
-	#DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
-	#entrypoint_scripts/common/setup-superuser.expect user2 "$DEFECT_DOJO_DEFAULT_DATABASE_PASSWORD"
+	#DD_DATABASE_PASsWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
+	#entrypoint_scripts/common/setup-superuser.expect user2 "$DD_DATABASE_PASsWORD"
 
 	echo
 	echo "=============================================================================="
 	echo " SUCCESS! Please login at: http://localhost:$PORT"
-	echo " admin / $DEFECT_DOJO_ADMIN_PASSWORD"
+	echo " admin / $DD_ADMIN_PASSWORD"
 	echo "=============================================================================="
 	echo
 else

--- a/entrypoint_scripts/test/travis-integration-test.sh
+++ b/entrypoint_scripts/test/travis-integration-test.sh
@@ -11,11 +11,11 @@ travis_fold start travis_integration_install
 
 # Docker Build
 export DOJO_ADMIN_USER='admin'
-export DEFECT_DOJO_ADMIN_PASSWORD='admin'
-export DOJO_ADMIN_PASSWORD=$DEFECT_DOJO_ADMIN_PASSWORD
+export DD_ADMIN_PASSWORD='admin'
+export DOJO_ADMIN_PASSWORD=$DD_ADMIN_PASSWORD
 export CONTAINER_NAME=defect_dojo_integration
 docker build --target dev-mysql-self-contained -t $REPO .
-docker run -e DEFECT_DOJO_ADMIN_PASSWORD=$DEFECT_DOJO_ADMIN_PASSWORD -e ACTION=p -d -p 127.0.0.1:8000:8000 --name=$CONTAINER_NAME $REPO
+docker run -e DD_ADMIN_PASSWORD=$DD_ADMIN_PASSWORD -e ACTION=p -d -p 127.0.0.1:8000:8000 --name=$CONTAINER_NAME $REPO
 docker logs $CONTAINER_NAME
 # Turn off Zap tests while re-configuring how they run
 #- docker run -d --name zap --link $CONTAINER_NAME -p 127.0.0.1:8080:8080 -i owasp/zap2docker-stable zap.sh -daemon -host 0.0.0.0 -port 8080 -config api.disablekey=true


### PR DESCRIPTION
* Remove duplicate set of env. vars for DB_DATABASE_URL and DB_DATABASE_*
* Fix docker-compose $PWD
* Make it possible to use DB_DATABASE_* instead of DB_DATABASE_URL, e.g. to support usage of secrets for kubernetes.
