### PR TITLE
annotations and secretName

### DIFF
--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -10,14 +10,17 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "defectdojo.chart" . }}
+{{- with .Values.django.ingress.annotations }}
   annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.org/ssl-services: {{ $fullName }}-nginx
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   tls:
     - hosts:
         - {{ .Values.host }}
+    {{- if .Values.django.ingress.secretName }}
       secretName: {{ .Values.django.ingress.secretName }}
+    {{- end }}
   rules:
     - host: {{ .Values.host }}
       http:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -41,6 +41,8 @@ django:
   ingress:
     enabled: true
     secretName: defectdojo-tls
+    annotations:
+      kubernetes.io/ingress.class: nginx
   nginx:
     repository: defectdojo/defectdojo-nginx
     resources:


### PR DESCRIPTION
- Added the possibility to define more annotations for django ingress manifest 
- Added the possibility to set an secretName for the ingress tls part. 
Background is that it is possible to set a default tls secret in the nginx-ingress-controller: `--default-ssl-certificate` which catches all and could make sense if you have multiple ingress controllers with specific wildcard certificates. More information: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/cli-arguments.md

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Add applicable tests to the unit tests.