### PR TITLE
Add Kubernetes option in ISSUE_TEMPLATE.md

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -15,8 +15,9 @@ Please include the version number (ex: Ubuntu 16.04)
 
 ### Install
 
-- [ ] setup.bash
-- [ ] docker
+- [ ] Kubernetes
+- [ ] Docker
+- [ ] setup.bash / legacy-setup.bash
 
 ### DefectDojo Version
 


### PR DESCRIPTION
Since deploying to Kubernetes is now in 'master', and setup.bash has
been renamed legacy-setup.bash, add an option to declare issues
related to Kubernetes deployments.
Keeping the setup.bash option at the moment, for transition from legacy.

Signed-off-by: Piotr PAWLICKI <piotrek@seovya.net>

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [X] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.) :arrow_right: not code
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR. :arrow_right: not a new feature
- [X] Add applicable tests to the unit tests. :arrow_right: not applicable
