### PR TITLE
Fixes an issue with certain reports

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1078,7 +1078,7 @@ class Finding(models.Model):
         ordering = ('numerical_severity', '-date', 'title')
 
     def compute_hash_code(self):
-        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + str(self.description)
+        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + self.description
         if self.dynamic_finding:
             endpoint_str = u''
             for e in self.endpoints.all():
@@ -1087,9 +1087,10 @@ class Finding(models.Model):
                 hash_string = hash_string + endpoint_str
         try:
             hash_string = hash_string.encode('utf-8').strip()
+            return hashlib.sha256(hash_string.encode('utf-8')).hexdigest()
         except:
             hash_string = hash_string.strip()
-        return hashlib.sha256(hash_string.encode('utf-8')).hexdigest()
+            return hashlib.sha256(hash_string).hexdigest()
 
     def duplicate_finding_set(self):
         return self.duplicate_list.all().order_by('title')


### PR DESCRIPTION
Uploading a burp suite report that contained certain characters ended up with throwing errors due to the `str(self.description)` which would end up with a partial report upload .
For example the "Interesting input handling: Magic value: null" issue generated by the Burp Pro Plugin Backslash Powered Scanner ended up not uploading due to the fact that it contained a multi-line table .

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Add applicable tests to the unit tests.
