### PR TITLE
Added DawnScanner json report importer

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -263,7 +263,14 @@
     },
     "model": "dojo.test_type",
     "pk": 38
-  },
+	},
+  {
+    "fields": {
+      "name": "DawnScanner Scan"
+    },
+    "model": "dojo.test_type",
+    "pk": 39
+  },	
   {
       "fields": {
         "name": "Netsparker Scanner"

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -280,7 +280,8 @@ class ImportScanForm(forms.Form):
                          ("AWS Scout2 Scan", "AWS Scout2 Scan"),
                          ("AWS Prowler Scan", "AWS Prowler Scan"),
                          ("PHP Security Audit v2", "PHP Security Audit v2"),
-                         ("Safety Scan", "Safety Scan"))
+                         ("Safety Scan", "Safety Scan"),
+                         ("DawnScanner Scan", "DawnScanner Scan"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
 

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -39,6 +39,7 @@
 	<li><b>Contrast Scanner</b> - CSV Report</b></li>
 	<li><b>Checkmarx Detailed XML Report</b></li>
 	<li><b>Crashtest Security JUnit XML Report</b></li>
+	<li><b>DawnScanner</b> - Dawnscanner (-j) output file can be imported in JSON format.</li>
 	<li><b>Dependency Check</b> - OWASP Dependency Check output can be imported in Xml format.</li>
 	<li><b>Generic Findings Import</b> - Import Generic findings in CSV format.</li>
 	<li><b>Gosec Scanner </b> - Import Gosec Scanner findings in JSON format.</li>

--- a/dojo/tools/dawnscanner/__init__.py
+++ b/dojo/tools/dawnscanner/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'jaguasch'

--- a/dojo/tools/dawnscanner/parser.py
+++ b/dojo/tools/dawnscanner/parser.py
@@ -5,8 +5,9 @@ import json
 import hashlib
 from dojo.models import Finding
 
+
 class DawnScannerParser(object):
-    def __init__(self, filename, test):   
+    def __init__(self, filename, test):
         data = json.load(filename)
 
         dupes = dict()
@@ -27,7 +28,6 @@ class DawnScannerParser(object):
 
             # Finding details information
             findingdetail = item['message'].encode('ascii', 'ignore')
-            
             sev = item['severity'].capitalize()
             mitigation = item['remediation']
             references = item['cve_link']

--- a/dojo/tools/dawnscanner/parser.py
+++ b/dojo/tools/dawnscanner/parser.py
@@ -1,0 +1,59 @@
+__author__ = 'jaguasch'
+
+from dateutil import parser
+import json
+import hashlib
+from dojo.models import Finding
+
+class DawnScannerParser(object):
+    def __init__(self, filename, test):   
+        data = json.load(filename)
+
+        dupes = dict()
+        find_date = parser.parse(data['scan_started'])
+
+        for item in data['vulnerabilities']:
+            categories = ''
+            language = ''
+            mitigation = ''
+            impact = ''
+            references = ''
+            findingdetail = ''
+            title = ''
+            group = ''
+            status = ''
+
+            title = item['name']
+
+            # Finding details information
+            findingdetail = item['message'].encode('ascii', 'ignore')
+            
+            sev = item['severity'].capitalize()
+            mitigation = item['remediation']
+            references = item['cve_link']
+
+            dupe_key = hashlib.md5(sev + '|' + title).hexdigest()
+
+            if dupe_key in dupes:
+                find = dupes[dupe_key]
+            else:
+                dupes[dupe_key] = True
+
+                find = Finding(
+                    title=title,
+                    test=test,
+                    active=False,
+                    verified=False,
+                    description=findingdetail,
+                    severity=sev,
+                    numerical_severity=Finding.get_numerical_severity(sev),
+                    mitigation=mitigation,
+                    impact=impact,
+                    references=references,
+                    url='N/A',
+                    date=find_date,
+                    static_finding=True)
+
+                dupes[dupe_key] = find
+
+        self.items = dupes.values()

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -134,7 +134,7 @@ def import_parser_factory(file, test, scan_type=None):
     elif scan_type == 'Safety Scan':
         parser = SafetyParser(file, test)
     elif scan_type == 'DawnScanner Scan':
-        parser = DawnScannerParser(file, test)        
+        parser = DawnScannerParser(file, test)
     else:
         raise ValueError('Unknown Test Type')
 

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -39,6 +39,7 @@ from dojo.tools.brakeman.parser import BrakemanScanParser
 from dojo.tools.spotbugs.parser import SpotbugsXMLParser
 from dojo.tools.safety.parser import SafetyParser
 from dojo.tools.clair_klar.parser import ClairKlarParser
+from dojo.tools.dawnscanner.parser import DawnScannerParser
 
 __author__ = 'Jay Paz'
 
@@ -132,6 +133,8 @@ def import_parser_factory(file, test, scan_type=None):
         parser = SpotbugsXMLParser(file, test)
     elif scan_type == 'Safety Scan':
         parser = SafetyParser(file, test)
+    elif scan_type == 'DawnScanner Scan':
+        parser = DawnScannerParser(file, test)        
     else:
         raise ValueError('Unknown Test Type')
 


### PR DESCRIPTION
I followed [these instructions](https://github.com/DefectDojo/django-DefectDojo/wiki/Creating-a-new-importer-(scanner)) to add **dawnscanner** JSON report importer (https://github.com/thesp0nge/dawnscanner). 

**dawnscanner** is another security scanner for ruby web applications, including _Rails_, _Sinatra_ and _Padrino_.

**dawnscanner** supports JSON output (with -j option)
