### PR TITLE
make deduplication_on_engagement work with close_old_findings

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -623,18 +623,18 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
             old_findings = None
             if test.engagement.deduplication_on_engagement:
                 old_findings = Finding.objects.exclude(test=test) \
-                                                        .exclude(hash_code__in=new_hash_codes) \
-                                                        .exclude(hash_code__in=skipped_hashcodes) \
-                                        .filter(test__engagement=test.engagement,
-                                                test__test_type=test_type,
-                                                active=True)
+                                              .exclude(hash_code__in=new_hash_codes) \
+                                              .exclude(hash_code__in=skipped_hashcodes) \
+                                              .filter(test__engagement=test.engagement,
+                                                  test__test_type=test_type,
+                                                  active=True)
             else:
                 old_findings = Finding.objects.exclude(test=test) \
-                                                        .exclude(hash_code__in=new_hash_codes) \
-                                                        .exclude(hash_code__in=skipped_hashcodes) \
-                                        .filter(test__engagement__product=test.engagement.product,
-                                                test__test_type=test_type,
-                                                active=True)
+                                              .exclude(hash_code__in=new_hash_codes) \
+                                              .exclude(hash_code__in=skipped_hashcodes) \
+                                              .filter(test__engagement__product=test.engagement.product,
+                                                  test__test_type=test_type,
+                                                  active=True)
 
             for old_finding in old_findings:
                 old_finding.active = False

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -620,12 +620,23 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         if close_old_findings:
             # Close old active findings that are not reported by this scan.
             new_hash_codes = test.finding_set.values('hash_code')
-            for old_finding in Finding.objects.exclude(test=test) \
-                                              .exclude(hash_code__in=new_hash_codes) \
-                                              .exclude(hash_code__in=skipped_hashcodes) \
-                               .filter(test__engagement__product=test.engagement.product,
-                                       test__test_type=test_type,
-                                       active=True):
+            old_findings = None
+            if test.engagement.deduplication_on_engagement:
+                old_findings = Finding.objects.exclude(test=test) \
+                                                        .exclude(hash_code__in=new_hash_codes) \
+                                                        .exclude(hash_code__in=skipped_hashcodes) \
+                                        .filter(test__engagement=test.engagement,
+                                                test__test_type=test_type,
+                                                active=True)
+            else:
+                old_findings = Finding.objects.exclude(test=test) \
+                                                        .exclude(hash_code__in=new_hash_codes) \
+                                                        .exclude(hash_code__in=skipped_hashcodes) \
+                                        .filter(test__engagement__product=test.engagement.product,
+                                                test__test_type=test_type,
+                                                active=True)
+
+            for old_finding in old_findings:
                 old_finding.active = False
                 old_finding.mitigated = datetime.datetime.combine(
                     test.target_start,


### PR DESCRIPTION
During #983 and #1002 I realized that deduplication_on_engagement is not yet support with close_old_findings during imports. I think this is needed because otherwise the import could close findings in other engagements and the whole idea of deduplication_on_engagement (I think) is to keep all "duplicate checks" inside the engagement instead of the product.