### PR TITLE
fix deduplication_on_engagement that was broken due to optimistic linting

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -623,9 +623,9 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
             for old_finding in Finding.objects.exclude(test=test) \
                                               .exclude(hash_code__in=new_hash_codes) \
                                               .exclude(hash_code__in=skipped_hashcodes) \
-                               .filter(test__engagement__product=test.engagement.product,
-                                       test__test_type=test_type,
-                                       active=True):
+                                              .filter(test__engagement__product=test.engagement.product,
+                                                  test__test_type=test_type,
+                                                  active=True):
                 old_finding.active = False
                 old_finding.mitigated = datetime.datetime.combine(
                     test.target_start,


### PR DESCRIPTION
Regression was caused by e4cbdfa#diff-63c97e945dc0af3507d89798a8841819

I also fixed a typo and renamed a method to make its purpose more clear.

This fixes #983 and is an iteration of #1000 

I fixed all flake8 warnings shown by visual studio code.