### PR TITLE
Fixes UTF-8 issues when computing Hashes

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1078,7 +1078,7 @@ class Finding(models.Model):
         ordering = ('numerical_severity', '-date', 'title')
 
     def compute_hash_code(self):
-        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + str(self.description).decode('utf-8')
+        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + self.description
 
         if self.dynamic_finding:
             endpoint_str = u''
@@ -1091,8 +1091,7 @@ class Finding(models.Model):
             return hashlib.sha256(hash_string.encode('utf-8')).hexdigest()
         except:
             hash_string = hash_string.strip()
-
-        return hashlib.sha256(hash_string).hexdigest()
+            return hashlib.sha256(hash_string).hexdigest()
 
 
     def duplicate_finding_set(self):

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -80,6 +80,6 @@ def get_item(vulnerability, test):
         mitigated=None,
         impact=severity)
 
-    finding.description = finding.description.encode('utf-8').strip()
+    finding.description = finding.description.strip()
 
     return finding


### PR DESCRIPTION
Fixes an issue where reports containing certain characters were not being properly decoded by `str(self.description)`
Waiting for @madchap to also confirm that snyk reports are coming in nicely with these changes .

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Add applicable tests to the unit tests.
