### PR TITLE
Bundle-audit tool output importer

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -270,14 +270,21 @@
     },
     "model": "dojo.test_type",
     "pk": 39
-	},	
+	},
   {
     "fields": {
       "name": "Anchore Engine Scan"
     },
     "model": "dojo.test_type",
     "pk": 40
-  },		
+	},
+  {
+    "fields": {
+      "name": "Bundler-Audit Scan"
+    },
+    "model": "dojo.test_type",
+    "pk": 41
+  },
   {
       "fields": {
         "name": "Netsparker Scanner"

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -282,7 +282,8 @@ class ImportScanForm(forms.Form):
                          ("PHP Security Audit v2", "PHP Security Audit v2"),
                          ("Safety Scan", "Safety Scan"),
                          ("DawnScanner Scan", "DawnScanner Scan"),
-                         ("Anchore Engine Scan", "Anchore Engine Scan"))
+                         ("Anchore Engine Scan", "Anchore Engine Scan"),
+                         ("Bundler-Audit Scan", "Bundler-Audit Scan"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
 

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -32,6 +32,7 @@
 	<li><b>Arachni Scanner</b> - Arachni JSON report format.</li>
 	<li><b>AppSpider (Rapid7)</b> - Use the VulnerabilitiesSummary.xml file found in the zipped report download.</li>
 	<li><b>Bandit</b> - JSON report format</li>
+	<li><b>Bundler-Audit Scan</b> - 'bundler-audit check' output (in plain text)</li>
 	<li><b>Burp XML</b> - When the Burp report is generated, the recommended option is Base64 encoding both the request and
 	    response fields. These fields will be processed and made available in the 'Finding View' page.</li>
 	<li><b>Brakeman Scan</b> - Import Brakeman Scanner findings in JSON format.</li>

--- a/dojo/tools/bundler_audit/__init__.py
+++ b/dojo/tools/bundler_audit/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'jaguasch'

--- a/dojo/tools/bundler_audit/parser.py
+++ b/dojo/tools/bundler_audit/parser.py
@@ -1,6 +1,5 @@
 __author__ = 'jaguasch'
 
-from dateutil import parser
 import hashlib
 from datetime import datetime
 from dojo.models import Finding
@@ -10,9 +9,7 @@ class BundlerAuditParser(object):
     def __init__(self, filename, test):
         lines = filename.read()
         dupes = dict()
-
         find_date = datetime.now()
-
         warnings = lines.split('\n\n')
 
         for warning in warnings:
@@ -20,41 +17,34 @@ class BundlerAuditParser(object):
                 continue
 
             gem_report_fields = warning.split('\n')
-            
             for field in gem_report_fields:
                 if field.startswith('Name'):
-                    gem_name = field.replace('Name: ','')        
+                    gem_name = field.replace('Name: ', '')
                 elif field.startswith('Version'):
-                    gem_version = field.replace('Version: ','')        
+                    gem_version = field.replace('Version: ', '')
                 elif field.startswith('Advisory'):
-                    advisory_cve = field.replace('Advisory: ','')
+                    advisory_cve = field.replace('Advisory: ', '')
                 elif field.startswith('Criticality'):
-                    criticality = field.replace('Criticality: ','')
+                    criticality = field.replace('Criticality: ', '')
                     if criticality.lower() == 'unknown':
                         sev = "Medium"
                     else:
                         sev = criticality
                 elif field.startswith('URL'):
-                    advisory_url = field.replace('URL: ','')    
+                    advisory_url = field.replace('URL: ', '')
                 elif field.startswith('Title'):
-                    advisory_title = field.replace('Title: ','')     
+                    advisory_title = field.replace('Title: ', '')
                 elif field.startswith('Solution'):
-                    advisory_solution = field.replace('Solution: ','')
+                    advisory_solution = field.replace('Solution: ', '')
 
-                    
-            title = "Gem " + gem_name + ": " + advisory_title + " [" + advisory_cve + "]"
-            
+            title = "Gem " + gem_name + ": " + advisory_title + " [" + advisory_cve + "]"          
             findingdetail = "Gem **" + gem_name + "** has known security issues:\n"
             findingdetail += '**Name**: ' + gem_name + '\n'
             findingdetail += '**Version**: ' + gem_version + '\n'
             findingdetail += '**Advisory**: ' + advisory_cve + '\n'
-
-            
             mitigation = advisory_solution
             references = advisory_url
             fingerprint = "bundler-audit" + gem_name + gem_version + advisory_cve + sev
-            
-            
             dupe_key = hashlib.md5(fingerprint).hexdigest()
             
             if dupe_key in dupes:
@@ -79,3 +69,4 @@ class BundlerAuditParser(object):
                 dupes[dupe_key] = find
 
         self.items = dupes.values()
+        

--- a/dojo/tools/bundler_audit/parser.py
+++ b/dojo/tools/bundler_audit/parser.py
@@ -37,7 +37,7 @@ class BundlerAuditParser(object):
                 elif field.startswith('Solution'):
                     advisory_solution = field.replace('Solution: ', '')
 
-            title = "Gem " + gem_name + ": " + advisory_title + " [" + advisory_cve + "]"          
+            title = "Gem " + gem_name + ": " + advisory_title + " [" + advisory_cve + "]"
             findingdetail = "Gem **" + gem_name + "** has known security issues:\n"
             findingdetail += '**Name**: ' + gem_name + '\n'
             findingdetail += '**Version**: ' + gem_version + '\n'
@@ -46,7 +46,6 @@ class BundlerAuditParser(object):
             references = advisory_url
             fingerprint = "bundler-audit" + gem_name + gem_version + advisory_cve + sev
             dupe_key = hashlib.md5(fingerprint).hexdigest()
-            
             if dupe_key in dupes:
                 find = dupes[dupe_key]
             else:
@@ -69,4 +68,3 @@ class BundlerAuditParser(object):
                 dupes[dupe_key] = find
 
         self.items = dupes.values()
-        

--- a/dojo/tools/bundler_audit/parser.py
+++ b/dojo/tools/bundler_audit/parser.py
@@ -1,0 +1,81 @@
+__author__ = 'jaguasch'
+
+from dateutil import parser
+import hashlib
+from datetime import datetime
+from dojo.models import Finding
+
+
+class BundlerAuditParser(object):
+    def __init__(self, filename, test):
+        lines = filename.read()
+        dupes = dict()
+
+        find_date = datetime.now()
+
+        warnings = lines.split('\n\n')
+
+        for warning in warnings:
+            if not warning.startswith('Name'):
+                continue
+
+            gem_report_fields = warning.split('\n')
+            
+            for field in gem_report_fields:
+                if field.startswith('Name'):
+                    gem_name = field.replace('Name: ','')        
+                elif field.startswith('Version'):
+                    gem_version = field.replace('Version: ','')        
+                elif field.startswith('Advisory'):
+                    advisory_cve = field.replace('Advisory: ','')
+                elif field.startswith('Criticality'):
+                    criticality = field.replace('Criticality: ','')
+                    if criticality.lower() == 'unknown':
+                        sev = "Medium"
+                    else:
+                        sev = criticality
+                elif field.startswith('URL'):
+                    advisory_url = field.replace('URL: ','')    
+                elif field.startswith('Title'):
+                    advisory_title = field.replace('Title: ','')     
+                elif field.startswith('Solution'):
+                    advisory_solution = field.replace('Solution: ','')
+
+                    
+            title = "Gem " + gem_name + ": " + advisory_title + " [" + advisory_cve + "]"
+            
+            findingdetail = "Gem **" + gem_name + "** has known security issues:\n"
+            findingdetail += '**Name**: ' + gem_name + '\n'
+            findingdetail += '**Version**: ' + gem_version + '\n'
+            findingdetail += '**Advisory**: ' + advisory_cve + '\n'
+
+            
+            mitigation = advisory_solution
+            references = advisory_url
+            fingerprint = "bundler-audit" + gem_name + gem_version + advisory_cve + sev
+            
+            
+            dupe_key = hashlib.md5(fingerprint).hexdigest()
+            
+            if dupe_key in dupes:
+                find = dupes[dupe_key]
+            else:
+                dupes[dupe_key] = True
+
+                find = Finding(
+                    title=title,
+                    test=test,
+                    active=False,
+                    verified=False,
+                    description=findingdetail,
+                    severity=sev,
+                    numerical_severity=Finding.get_numerical_severity(sev),
+                    mitigation=mitigation,
+                    references=references,
+                    url='N/A',
+                    date=find_date,
+                    static_finding=True)
+
+                dupes[dupe_key] = find
+
+        self.items = dupes.values()

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -41,6 +41,7 @@ from dojo.tools.safety.parser import SafetyParser
 from dojo.tools.clair_klar.parser import ClairKlarParser
 from dojo.tools.dawnscanner.parser import DawnScannerParser
 from dojo.tools.anchore_engine.parser import AnchoreEngineScanParser
+from dojo.tools.bundler_audit.parser import BundlerAuditParser
 
 __author__ = 'Jay Paz'
 
@@ -138,6 +139,8 @@ def import_parser_factory(file, test, scan_type=None):
         parser = DawnScannerParser(file, test)
     elif scan_type == 'Anchore Engine Scan':
         parser = AnchoreEngineScanParser(file, test)
+    elif scan_type == 'Bundler-Audit Scan':
+        parser = BundlerAuditParser(file, test)
     else:
         raise ValueError('Unknown Test Type')
 


### PR DESCRIPTION
> bundler-audit is a patch-level verification for Bundler

Tool URL: https://github.com/rubysec/bundler-audit

**bundler-audit** tool outputs results in standard output, formatted as multi-line with headers like the GEM name and version with vulnerabilities, CVE, description of the issue, mitigation and URL with the Advisory reference.

Tool can be executed with ```bundle-audit check``` on the ruby project folder where the ```Gemfile.lock``` file is

Sample scan file in this PR: https://github.com/DefectDojo/sample-scan-files/pull/14

This parser will import the findings