### PR TITLE
Fix burp issues that don't have a req/resp pair

### DIFF
--- a/dojo/tools/burp/parser.py
+++ b/dojo/tools/burp/parser.py
@@ -183,8 +183,14 @@ def get_item(item_node, test):
 
     unsaved_req_resp = list()
     for request_response in item_node.findall('./requestresponse'):
-        request = request_response.findall('request')[0].text
-        response = request_response.findall('response')[0].text
+        try:
+            request = request_response.findall('request')[0].text
+        except:
+            request = ""
+        try:
+            response = request_response.findall('response')[0].text
+        except:
+            response = ""
         unsaved_req_resp.append({"req": request, "resp": response})
 
     try:


### PR DESCRIPTION
Some burp issues don't have a request/response pair , for example OS Command Injection with a timeout will only have a request and not a response .

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Add applicable tests to the unit tests.
