### PR TITLE
Made side menu accessible to assistive technologies

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -24,7 +24,7 @@
     "@yarn_components/jquery-ui": "components/jqueryui#*",
     "@yarn_components/jquery.hotkeys": "jeresig/jquery.hotkeys#master",
     "@yarn_components/justgage": "toorshia/justgage#*",
-    "@yarn_components/metisMenu": "onokumus/metisMenu#~1.1.3",
+    "@yarn_components/metisMenu": "onokumus/metisMenu#~3.0.4",
     "@yarn_components/mocha": "mochajs/mocha#~1.17.1",
     "@yarn_components/moment": "moment/moment#^2.9.0",
     "@yarn_components/morrisjs": "morrisjs/morris.js#~0.5.1",

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1018,23 +1018,20 @@ div.custom-search-form {
         left: 100%;
         top: 0;
         min-width: 200px;
-        display: none;
-        border-radius: 4px;
-    }
-
-    #side-menu li:hover > ul,
-    #side-menu li:hover > ul.collapse {
-        display: block !important;
         height: auto !important;
+	display: none;
         z-index: 10000;
         background-color: #fff;
         background-clip: padding-box;
-        visibility: visible;
         border: 1px solid rgba(0, 0, 0, .15);
         border-left-width: 0;
         border-radius: 4px;
         box-shadow: 0 6px 12px rgba(0, 0, 0, .175);
-        border-radius: 4px;
+    }
+
+    #side-menu > li.mm-active ul,
+    #side-menu > li:hover ul {
+        display: block !important;
     }
 
     body.min #page-wrapper {

--- a/dojo/static/dojo/js/index.js
+++ b/dojo/static/dojo/js/index.js
@@ -77,13 +77,11 @@ function sidebar() {  // minimize side nav bar
         width = '175px';
         fontSize = '14px';
         speed = 100;
-        $('a#minimize-menu').attr('title', 'Collapse Menu');
     }
     else {
         action = 'min';
         remove = 'max';
         $.cookie('dojo-sidebar', 'min', {expires: 10000, path: '/'});
-        $('a#minimize-menu').attr('title', 'Expand Menu')
     }
 
     $('body').switchClass(remove, action);

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -86,7 +86,7 @@
                     <!-- /input-group -->
                 </li>
                     <li class="dropdown">
-                        <a class="dropdown-toggle dropdown-toggle-h{% alert_count %}" data-toggle="dropdown" href="#">
+			    <a class="dropdown-toggle dropdown-toggle-h{% alert_count %}" data-toggle="dropdown" href="#" aria-label="{% alert_count %} Alerts">
                             <i class="fa fa-bell fa-fw"></i><span
                             id="alert_count" class="badge badge-count badge-count{% alert_count %}">{% alert_count %}</span>
                             <i class="fa fa-caret-down"></i>
@@ -97,7 +97,7 @@
                     </li>
                 {% endif %}
                 <li class="dropdown">
-                    <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                    <a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-label="User Menu">
                         <i class="fa fa-user fa-fw"></i> <i class="fa fa-caret-down"></i>
                     </a>
                     <ul class="dropdown-menu dropdown-user">
@@ -131,15 +131,18 @@
 
                             {% if request.user.is_staff %}
                                 <li>
-                                    <a href="{% url 'dashboard' %}"><i class="fa fa-dashboard fa-fw"></i> <span>Dashboard</span></a>
+                                    <a href="{% url 'dashboard' %}" aria-label="Dashboard"><i class="fa fa-dashboard fa-fw"></i><span>Dashboard</span></a>
                                 </li>
                             {% endif %}
                             <li>
                                 {% if request.user.is_staff %}
-                                    <a href="#"><i class="fa fa-list fa-fw"></i> <span>Products</span>
-                                        <span class="glyphicon arrow"></span></a>
+                                    <a href="#" aria-expanded="false" aria-label="Products">
+                                        <i class="fa fa-list fa-fw"></i>
+                                        <span>Products</span>
+                                        <span class="glyphicon arrow"></span>
+                                    </a>
                                 {% elif request.user.is_authenticated %}
-                                    <a href="{% url 'product' %}" title="Product Listing"><i class="fa fa-list fa-fw"></i> <span>Products</span></a>
+                                <a href="{% url 'product' %}" title="Products" aria-label="Products"><i class="fa fa-list fa-fw"></i><span>Products</span></a>
                                 {% endif %}
                                 {% if request.user.is_staff %}
                                     <ul class="nav nav-second-level">
@@ -161,8 +164,11 @@
                             </li>
                             {% if request.user.is_staff %}
                                 <li>
-                                    <a href="#"><i class="fa fa-inbox fa-fw"></i> <span>Engagements</span><span
-                                            class="glyphicon arrow"></span></a>
+                                    <a href="#" aria-expanded="false" aria-label="Engagements">
+                                        <i class="fa fa-inbox fa-fw"></i>
+                                        <span>Engagements</span>
+                                        <span class="glyphicon arrow"></span>
+                                    </a>
                                     <ul class="nav nav-second-level">
                                         <li>
                                             <a href="{% url 'engagement' %}">All Engagements</a>
@@ -177,8 +183,11 @@
                                     <!-- /.nav-second-level -->
                                 </li>
                                 <li>
-                                    <a href="#"><i class="fa fa-bug fa-fw"></i> <span>Findings</span><span
-                                            class="glyphicon arrow"></span></a>
+                                    <a href="#" aria-expanded="false" aria-label="Findings">
+                                        <i class="fa fa-bug fa-fw"></i>
+                                        <span>Findings</span>
+                                        <span class="glyphicon arrow"></span>
+				    </a>
                                     <ul class="nav nav-second-level">
                                         <li>
                                             <a href="{% url 'open_findings' %}">Open Findings</a>
@@ -199,8 +208,11 @@
                                     <!-- /.nav-second-level -->
                                 </li>
                                 <li>
-                                    <a href="#"><i class="fa fa-sitemap fa-fw"></i> <span>Endpoints</span><span
-                                            class="glyphicon arrow"></span></a>
+                                    <a href="#" aria-expanded="false" aria-label="Endpoints">
+					                    <i class="fa fa-sitemap fa-fw"></i>
+                                        <span>Endpoints</span>
+                                        <span class="glyphicon arrow"></span>
+                                    </a>
                                     <ul class="nav nav-second-level">
                                         <li>
                                             <a href="{% url 'endpoints' %}">All Endpoints</a>
@@ -215,8 +227,11 @@
                             {% endif %}
                             {% if request.user.is_authenticated %}
                             <li>
-                                <a href="{% url 'reports' %}"><i class="fa fa-file-text-o fa-fw"></i> <span>Reports</span><span
-                                        class="glyphicon arrow"></span></a>
+                                <a href="#" aria-expanded="false" aria-label="Reports">
+				                    <i class="fa fa-file-text-o fa-fw"></i>
+                                    <span>Reports</span>
+                                    <span class="glyphicon arrow"></span>
+                                </a>
                                 <ul class="nav nav-second-level">
                                     <li><a href="{% url 'reports' %}"> All Reports </a></li>
                                     <li><a href="{% url 'report_builder' %}"> Report Builder </a></li>
@@ -224,8 +239,11 @@
                                 <!-- /.nav-second-level -->
                             </li>
                             <li>
-                                <a href="/metrics"><i class="fa fa-bar-chart fa-fw"></i> <span>Metrics</span><span
-                                        class="glyphicon arrow"></span></a>
+                                <a href="#" aria-expanded="false" aria-label="Metrics">
+				                    <i class="fa fa-bar-chart fa-fw"></i>
+                                    <span>Metrics</span>
+                                    <span class="glyphicon arrow"></span>
+                                </a>
                                 <ul class="nav nav-second-level">
                                     <li><a href="{% url 'critical_product_metrics' %}"> Critical Product Metrics </a></li>
                                     <li><a href="{% url 'metrics_product_type' %}"> Product Type Metrics </a></li>
@@ -242,17 +260,24 @@
                             {% endif %}
                             {% if request.user.is_staff %}
                                 <li>
-                                    <a href="{% url 'users' %}"><i class="fa fa-user fa-fw"></i> <span>Users</span></a>
+                                    <a href="{% url 'users' %}" aria-disabled="true" aria-expanded="false" aria-label="Users">
+                                        <i class="fa fa-user fa-fw"></i>
+                                        <span>Users</span>
+                                    </a>
                                 </li>
                             {% endif %}
                             {% if request.user.is_staff %}
                                 <li>
-                                    <a href="{% url 'engagement_calendar' %}"><i class="fa fa-calendar fa-fw"></i>
-                                        <span>Calendar</span></a>
+				                    <a href="{% url 'engagement_calendar' %}" aria-disabled="true" aria-expanded="false" aria-label="Calendar">
+                                        <i class="fa fa-calendar fa-fw"></i>
+                                        <span>Calendar</span>
+                                    </a>
                                 </li>
                                 <li>
-                                    <a href="{% url 'jira' %}"><i class="fa fa-cog fa-fw"></i>
-                                        <span>Configuration</span></a>
+				                    <a href="#" aria-expanded="false" aria-label="Configuration">
+                                        <i class="fa fa-cog fa-fw"></i>
+                                        <span>Configuration</span>
+                                    </a>
                                     <ul class="nav nav-second-level">
                                         <li><a href="{% url 'cred' %}">Credential Manager </a></li>
                                         {% if "enable_jira"|get_system_setting %}
@@ -272,7 +297,7 @@
                         {% endblock %}
 
                         <li id="min-menu">
-                            <a href="#" id="minimize-menu">
+                            <a href="#" id="minimize-menu" title="Expand/Collapse Menu" aria-label="Expand/Collapse Menu">
                                 <i id="nav-minimize-menu-li" class="fa fa-arrow-circle-right fa-fw"></i>
                                 <span>Collapse Menu</span>
                             </a>


### PR DESCRIPTION
This PR makes the side menu accessible to assistive technologies such as screenreaders for visually impaired users.

The metismenu plugin has been upgraded to the latest version (v3.0.4), too.
