### PR TITLE
Handle Burp Collaborator issues

### DIFF
--- a/dojo/tools/burp/parser.py
+++ b/dojo/tools/burp/parser.py
@@ -192,6 +192,35 @@ def get_item(item_node, test):
         except:
             response = ""
         unsaved_req_resp.append({"req": request, "resp": response})
+    collab_details = list()
+    collab_text = None
+    for event in item_node.findall('./collaboratorEvent'):
+        collab_details.append(event.findall('interactionType')[0].text)
+        collab_details.append(event.findall('originIp')[0].text)
+        collab_details.append(event.findall('time')[0].text)
+        if collab_details[0] == 'DNS':
+            collab_details.append(event.findall('lookupType')[0].text)
+            collab_details.append(event.findall('lookupHost')[0].text)
+            collab_text = "The Collaborator server received a " + collab_details[0] + " lookup of type " + collab_details[3] + \
+                " for the domain name " + \
+                collab_details[4] + " at " + collab_details[2] + \
+                " originating from " + collab_details[1] + " ."
+
+        for request_response in event.findall('./requestresponse'):
+            try:
+                request = request_response.findall('request')[0].text
+            except:
+                request = ""
+            try:
+                response = request_response.findall('response')[0].text
+            except:
+                response = ""
+            unsaved_req_resp.append({"req": request, "resp": response})
+        if collab_details[0] == 'HTTP':
+            collab_text = "The Collaborator server received an " + \
+                collab_details[0] + " request at " + collab_details[2] + \
+                " originating from " + collab_details[1] + " ."
+
 
     try:
         dupe_endpoint = Endpoint.objects.get(
@@ -248,6 +277,8 @@ def get_item(item_node, test):
     detail = do_clean(item_node.findall('issueDetail'))
     if detail:
         detail = text_maker.handle(detail)
+        if collab_text:
+            detail = text_maker.handle(detail+'<p>'+collab_text+'</p>')
 
     remediation = do_clean(item_node.findall('remediationBackground'))
     if remediation:

--- a/dojo/tools/burp/parser.py
+++ b/dojo/tools/burp/parser.py
@@ -278,7 +278,7 @@ def get_item(item_node, test):
     if detail:
         detail = text_maker.handle(detail)
         if collab_text:
-            detail = text_maker.handle(detail+'<p>'+collab_text+'</p>')
+            detail = text_maker.handle(detail + '<p>' + collab_text + '</p>')
 
     remediation = do_clean(item_node.findall('remediationBackground'))
     if remediation:


### PR DESCRIPTION
This is an enhancement in order to handle findings that contain Burp collaborator interactions which have additional request/response pairs and additional information that was normally ignored or breaking the importing of the report .

The collaborator interaction data is being aggregated and then added to the description of the finding as well as the additional request/response pairs from the server->collaborator . Also attached the applicable report files .

[TestBurpScan4.xml.txt](https://github.com/DefectDojo/django-DefectDojo/files/3056037/TestBurpScan4.xml.txt)
[TestBurpScan5.xml.txt](https://github.com/DefectDojo/django-DefectDojo/files/3056039/TestBurpScan5.xml.txt)



Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [X] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Add applicable tests to the unit tests.
