### PR TITLE
tune uwsgi read timeout

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -6,3 +6,4 @@ exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application
+  --http-timeout 1800

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -28,6 +28,7 @@ http {
     location / {
       include /run/uwsgi_pass;
       include /etc/nginx/wsgi_params;
+      uwsgi_read_timeout 1800;
     }
     error_page 500 502 503 504 /50x.html;
   }


### PR DESCRIPTION
Troubleshoots 'upstream timed out' on POST import_scan_results when importing big checkmarx reports (60MB; 3k findings)
```
172.18.0.1 - - [08/Apr/2019:16:08:49 +0000] "GET /alerts/count HTTP/1.1" 200 12 "http://localhost:8080/engagement/1/import_scan_results" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.86 Safari/537.36" "-"
2019/04/08 16:09:51 [error] 6#6: *1 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 172.18.0.1, server: , request: "POST /engagement/1/import_scan_results HTTP/1.1", upstream: "uwsgi://172.18.0.4:3031", host: "localhost:8080", referrer: "http://localhost:8080/engagement/1/import_scan_results"

```

this configuration is for 30mn (10mn wasn't enough)
