### PR TITLE
cicd engagments: return to cicd overview after deleting a cicd engagement

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -223,7 +223,11 @@ def delete_engagement(request, eid):
                     messages.SUCCESS,
                     'Engagement and relationships removed.',
                     extra_tags='alert-success')
-                return HttpResponseRedirect(reverse("view_engagements", args=(product.id, )))
+
+                if engagement.engagement_type == 'CI/CD':
+                    return HttpResponseRedirect(reverse("view_engagements_cicd", args=(product.id, )))
+                else:
+                    return HttpResponseRedirect(reverse("view_engagements", args=(product.id, )))
 
     collector = NestedObjects(using=DEFAULT_DB_ALIAS)
     collector.collect([engagement])


### PR DESCRIPTION
Currently when deleting a cicd engagement, DD returns to the engagement overview screen instead of the *cicd* engagement overview screen.

I have used the same if statement found in 5 other places to fix this small nuisance