### PR TITLE
remove http timeout from the entrypoint as it's not required

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -6,4 +6,3 @@ exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application
-  --http-timeout 1800


### PR DESCRIPTION
After more testing, this timeout is not required: the one set in the nginx.conf alone seems enough right now. 
Anyway this parameter was not active as I've lost a backslash when merging
