### PR TITLE
Fix markdown_render function

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -18,6 +18,8 @@ import dateutil.relativedelta
 import datetime
 from ast import literal_eval
 from urlparse import urlparse
+import bleach
+from bleach_whitelist import markdown_tags, markdown_attrs
 
 register = template.Library()
 
@@ -31,8 +33,8 @@ class EscapeHtml(Extension):
 @register.filter
 def markdown_render(value):
     if value:
-        return mark_safe(markdown.markdown(value, extensions=[EscapeHtml(), 'markdown.extensions.nl2br', 'markdown.extensions.sane_lists', 'markdown.extensions.codehilite', 'markdown.extensions.fenced_code', 'markdown.extensions.toc', 'markdown.extensions.tables']))
-
+        value = bleach.clean(markdown.markdown(value), markdown_tags, markdown_attrs)
+        return mark_safe(markdown.markdown(value, extensions=['markdown.extensions.nl2br', 'markdown.extensions.sane_lists', 'markdown.extensions.codehilite', 'markdown.extensions.fenced_code', 'markdown.extensions.toc', 'markdown.extensions.tables']))
 
 @register.filter(name='ports_open')
 def ports_open(value):

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,5 @@ urllib3>=1.23
 uWSGI==2.0.18
 vobject==0.9.5
 whitenoise>=4.0
+bleach>=3.1.0
+bleach-whitelist>=0.0.10


### PR DESCRIPTION

Fix markdown_render function that executing markdown javascript payload.
eg : `[xss](javascript:window.onerror=alert;throw%20document.cookie)`

- [x] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes should include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
