### PR TITLE
Simplified MRO of API v2 view sets

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1,37 +1,36 @@
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
-from rest_framework import viewsets, mixins
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import mixins, viewsets
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import detail_route
-from django_filters.rest_framework import DjangoFilterBackend
 
 from dojo.engagement.services import close_engagement, reopen_engagement
 from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment
-
 from dojo.api_v2 import serializers, permissions
 
 
-class EndPointViewSet(mixins.ListModelMixin,
-                      mixins.RetrieveModelMixin,
-                      mixins.UpdateModelMixin,
-                      mixins.DestroyModelMixin,
-                      mixins.CreateModelMixin,
-                      viewsets.GenericViewSet):
+class CRUModelViewSet(
+        mixins.ListModelMixin,
+        mixins.RetrieveModelMixin,
+        mixins.CreateModelMixin,
+        mixins.UpdateModelMixin,
+        viewsets.GenericViewSet
+):
+    """A view set supporting anything except for deletion."""
+
+
+class EndPointViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.EndpointSerializer
     queryset = Endpoint.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'host', 'product')
 
 
-class EngagementViewSet(mixins.ListModelMixin,
-                        mixins.RetrieveModelMixin,
-                        mixins.UpdateModelMixin,
-                        mixins.DestroyModelMixin,
-                        mixins.CreateModelMixin,
-                        viewsets.GenericViewSet):
+class EngagementViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.EngagementSerializer
     queryset = Engagement.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -53,11 +52,7 @@ class EngagementViewSet(mixins.ListModelMixin,
         return HttpResponse()
 
 
-class FindingTemplatesViewSet(mixins.ListModelMixin,
-                              mixins.RetrieveModelMixin,
-                              mixins.UpdateModelMixin,
-                              mixins.CreateModelMixin,
-                              viewsets.GenericViewSet):
+class FindingTemplatesViewSet(CRUModelViewSet):
     serializer_class = serializers.FindingTemplateSerializer
     queryset = Finding_Template.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -65,12 +60,7 @@ class FindingTemplatesViewSet(mixins.ListModelMixin,
                      'mitigation')
 
 
-class FindingViewSet(mixins.ListModelMixin,
-                     mixins.RetrieveModelMixin,
-                     mixins.UpdateModelMixin,
-                     mixins.DestroyModelMixin,
-                     mixins.CreateModelMixin,
-                     viewsets.GenericViewSet):
+class FindingViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.FindingSerializer
     queryset = Finding.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -87,36 +77,21 @@ class FindingViewSet(mixins.ListModelMixin,
             return serializers.FindingSerializer
 
 
-class JiraConfigurationsViewSet(mixins.ListModelMixin,
-                                mixins.RetrieveModelMixin,
-                                mixins.DestroyModelMixin,
-                                mixins.UpdateModelMixin,
-                                mixins.CreateModelMixin,
-                                viewsets.GenericViewSet):
+class JiraConfigurationsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.JIRAConfSerializer
     queryset = JIRA_Conf.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'url')
 
 
-class JiraIssuesViewSet(mixins.ListModelMixin,
-                        mixins.RetrieveModelMixin,
-                        mixins.DestroyModelMixin,
-                        mixins.CreateModelMixin,
-                        mixins.UpdateModelMixin,
-                        viewsets.GenericViewSet):
+class JiraIssuesViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.JIRAIssueSerializer
     queryset = JIRA_Issue.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'jira_id', 'jira_key')
 
 
-class JiraViewSet(mixins.ListModelMixin,
-                  mixins.RetrieveModelMixin,
-                  mixins.DestroyModelMixin,
-                  mixins.UpdateModelMixin,
-                  mixins.CreateModelMixin,
-                  viewsets.GenericViewSet):
+class JiraViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.JIRASerializer
     queryset = JIRA_PKey.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -125,23 +100,14 @@ class JiraViewSet(mixins.ListModelMixin,
                      'push_notes')
 
 
-class DojoMetaViewSet(mixins.ListModelMixin,
-                     mixins.RetrieveModelMixin,
-                     mixins.DestroyModelMixin,
-                     mixins.CreateModelMixin,
-                     mixins.UpdateModelMixin,
-                     viewsets.GenericViewSet):
+class DojoMetaViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.MetaSerializer
     queryset = DojoMeta.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'product', 'endpoint', 'name')
 
 
-class ProductViewSet(mixins.ListModelMixin,
-                     mixins.RetrieveModelMixin,
-                     mixins.CreateModelMixin,
-                     mixins.UpdateModelMixin,
-                     viewsets.GenericViewSet):
+class ProductViewSet(CRUModelViewSet):
     serializer_class = serializers.ProductSerializer
     # TODO: prefetch
     queryset = Product.objects.all()
@@ -159,23 +125,15 @@ class ProductViewSet(mixins.ListModelMixin,
             return Product.objects.all()
 
 
-class ProductTypeViewSet(mixins.ListModelMixin,
-                         mixins.RetrieveModelMixin,
-                         mixins.CreateModelMixin,
-                         mixins.UpdateModelMixin,
-                         viewsets.GenericViewSet):
+class ProductTypeViewSet(CRUModelViewSet):
     serializer_class = serializers.ProductTypeSerializer
     queryset = Product_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('id', 'name', 'critical_product', 'key_product', 'created', 'updated')
+    filter_fields = ('id', 'name', 'critical_product',
+                     'key_product', 'created', 'updated')
 
 
-class ScanSettingsViewSet(mixins.ListModelMixin,
-                          mixins.RetrieveModelMixin,
-                          mixins.DestroyModelMixin,
-                          mixins.UpdateModelMixin,
-                          mixins.CreateModelMixin,
-                          viewsets.GenericViewSet):
+class ScanSettingsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.ScanSettingsSerializer
     queryset = ScanSettings.objects.all()
     permission_classes = (permissions.UserHasScanSettingsPermission,
@@ -197,9 +155,7 @@ class ScanSettingsViewSet(mixins.ListModelMixin,
             return ScanSettings.objects.all()
 
 
-class ScansViewSet(mixins.ListModelMixin,
-                   mixins.RetrieveModelMixin,
-                   viewsets.GenericViewSet):
+class ScansViewSet(viewsets.ReadOnlyModelViewSet):
     # TODO: ipscans
     serializer_class = serializers.ScanSerializer
     queryset = Scan.objects.all()
@@ -216,11 +172,7 @@ class ScansViewSet(mixins.ListModelMixin,
             return Scan.objects.all()
 
 
-class StubFindingsViewSet(mixins.ListModelMixin,
-                          mixins.RetrieveModelMixin,
-                          mixins.CreateModelMixin,
-                          mixins.UpdateModelMixin,
-                          viewsets.GenericViewSet):
+class StubFindingsViewSet(CRUModelViewSet):
     serializer_class = serializers.StubFindingSerializer
     queryset = Stub_Finding.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -233,22 +185,13 @@ class StubFindingsViewSet(mixins.ListModelMixin,
             return serializers.StubFindingSerializer
 
 
-class DevelopmentEnvironmentViewSet(mixins.ListModelMixin,
-                                    mixins.RetrieveModelMixin,
-                                    mixins.CreateModelMixin,
-                                    mixins.UpdateModelMixin,
-                                    viewsets.GenericViewSet):
+class DevelopmentEnvironmentViewSet(CRUModelViewSet):
     serializer_class = serializers.DevelopmentEnvironmentSerializer
     queryset = Development_Environment.objects.all()
     filter_backends = (DjangoFilterBackend,)
 
 
-class TestsViewSet(mixins.ListModelMixin,
-                   mixins.RetrieveModelMixin,
-                   mixins.UpdateModelMixin,
-                   mixins.DestroyModelMixin,
-                   mixins.CreateModelMixin,
-                   viewsets.GenericViewSet):
+class TestsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.TestSerializer
     queryset = Test.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -263,34 +206,20 @@ class TestsViewSet(mixins.ListModelMixin,
             return serializers.TestSerializer
 
 
-class TestTypesViewSet(mixins.ListModelMixin,
-                       mixins.RetrieveModelMixin,
-                       mixins.UpdateModelMixin,
-                       mixins.CreateModelMixin,
-                       viewsets.GenericViewSet):
+class TestTypesViewSet(CRUModelViewSet):
     serializer_class = serializers.TestTypeSerializer
     queryset = Test_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
 
 
-class ToolConfigurationsViewSet(mixins.ListModelMixin,
-                                mixins.RetrieveModelMixin,
-                                mixins.CreateModelMixin,
-                                mixins.UpdateModelMixin,
-                                mixins.DestroyModelMixin,
-                                viewsets.GenericViewSet):
+class ToolConfigurationsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.ToolConfigurationSerializer
     queryset = Tool_Configuration.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'name', 'tool_type', 'url', 'authentication_type')
 
 
-class ToolProductSettingsViewSet(mixins.ListModelMixin,
-                                 mixins.RetrieveModelMixin,
-                                 mixins.DestroyModelMixin,
-                                 mixins.CreateModelMixin,
-                                 mixins.UpdateModelMixin,
-                                 viewsets.GenericViewSet):
+class ToolProductSettingsViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.ToolProductSettingsSerializer
     queryset = Tool_Product_Settings.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -298,34 +227,31 @@ class ToolProductSettingsViewSet(mixins.ListModelMixin,
                      'tool_project_id', 'url')
 
 
-class ToolTypesViewSet(mixins.ListModelMixin,
-                       mixins.RetrieveModelMixin,
-                       mixins.DestroyModelMixin,
-                       mixins.CreateModelMixin,
-                       mixins.UpdateModelMixin,
-                       viewsets.GenericViewSet):
+class ToolTypesViewSet(viewsets.ModelViewSet):
     serializer_class = serializers.ToolTypeSerializer
     queryset = Tool_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'name', 'description')
 
 
-class UsersViewSet(mixins.ListModelMixin,
-                   mixins.RetrieveModelMixin,
-                   viewsets.GenericViewSet):
+class UsersViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.UserSerializer
     queryset = User.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'username', 'first_name', 'last_name')
 
 
-class ImportScanView(mixins.CreateModelMixin,
-                     viewsets.GenericViewSet):
+class ImportScanViewSet(
+        mixins.CreateModelMixin,
+        viewsets.GenericViewSet
+):
     serializer_class = serializers.ImportScanSerializer
     queryset = Test.objects.all()
 
 
-class ReImportScanView(mixins.CreateModelMixin,
-                       viewsets.GenericViewSet):
+class ReImportScanViewSet(
+        mixins.CreateModelMixin,
+        viewsets.GenericViewSet
+):
     serializer_class = serializers.ReImportScanSerializer
     queryset = Test.objects.all()

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -8,7 +8,7 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView
+    UsersViewSet, ImportScanViewSet
 
 from django.core.urlresolvers import reverse
 from rest_framework.authtoken.models import Token
@@ -471,7 +471,7 @@ class ImportScanTest(BaseClass.RESTEndpointTest):
     def __init__(self, *args, **kwargs):
         self.endpoint_model = Test
         self.viewname = 'importscan'
-        self.viewset = ImportScanView
+        self.viewset = ImportScanViewSet
         self.payload = {
             "scan_date": '2017-12-30',
             "minimum_severity": 'Low',

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -22,8 +22,8 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, TestTypesViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
-    DevelopmentEnvironmentViewSet
+    UsersViewSet, ImportScanViewSet, ReImportScanViewSet, \
+    ProductTypeViewSet, DojoMetaViewSet, DevelopmentEnvironmentViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -106,8 +106,9 @@ v2_api.register(r'tool_configurations', ToolConfigurationsViewSet)
 v2_api.register(r'tool_product_settings', ToolProductSettingsViewSet)
 v2_api.register(r'tool_types', ToolTypesViewSet)
 v2_api.register(r'users', UsersViewSet)
-v2_api.register(r'import-scan', ImportScanView, base_name='importscan')
-v2_api.register(r'reimport-scan', ReImportScanView, base_name='reimportscan')
+v2_api.register(r'import-scan', ImportScanViewSet, base_name='importscan')
+v2_api.register(r'reimport-scan', ReImportScanViewSet,
+                base_name='reimportscan')
 v2_api.register(r'metadata', DojoMetaViewSet, base_name='metadata')
 
 
@@ -165,14 +166,17 @@ urlpatterns = [
     url(r'^%s' % get_system_setting('url_prefix'), include(ur)),
     url(r'^api/v2/api-token-auth/', tokenviews.obtain_auth_token),
     url(r'^api/v2/doc/', schema_view, name="api_v2_schema"),
-    url(r'^robots.txt', lambda x: HttpResponse("User-Agent: *\nDisallow: /", content_type="text/plain"), name="robots_file"),
+    url(r'^robots.txt', lambda x: HttpResponse(
+        "User-Agent: *\nDisallow: /", content_type="text/plain"), name="robots_file"),
 
 ]
 
 if hasattr(settings, 'DJANGO_ADMIN_ENABLED'):
     if settings.DJANGO_ADMIN_ENABLED:
         #  django admin
-        urlpatterns += [url(r'^%sadmin/' % get_system_setting('url_prefix'), include(admin.site.urls))]
+        urlpatterns += [url(r'^%sadmin/' %
+                            get_system_setting('url_prefix'), include(admin.site.urls))]
 
 if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    urlpatterns += static(settings.MEDIA_URL,
+                          document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
These simplifications make it easier to see what methods are supported per endpoint by using djangorestframework's convenience types.