### PR TITLE
Add 'stale' tag for findings that are closed because they no longer appear in scan results/imports

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -17,7 +17,7 @@ import datetime
 import six
 from django.utils.translation import ugettext_lazy as _
 import json
-
+from tagging.models import Tag
 
 class TagList(list):
     def __init__(self, *args, **kwargs):
@@ -649,6 +649,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 old_finding.notes.create(author=self.context['request'].user,
                                          entry="This finding has been automatically closed"
                                          " as it is not present anymore in recent scans.")
+                Tag.objects.add_tag(old_finding, 'stale')
                 old_finding.save()
                 title = 'An old finding has been closed for "{}".' \
                         .format(test.engagement.product.name)


### PR DESCRIPTION
Add 'stale' tag for findings that are closed because they no longer appear in scan results/imports

This will make it more clear which findings (in a list view) are closed because they are 'stale'.