### PR TITLE
deduplication: fix bug in skip_duplicates for deduplication_on_engagement

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -557,13 +557,16 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
             for item in parser.items:
                 if skip_duplicates:
                     hash_code = item.compute_hash_code()
+
                     if ((test.engagement.deduplication_on_engagement and
-                        Finding.objects.filter(Q(active=True) | Q(false_p=True) | Q(duplicate=True),
-                                              test__engagement=test.engagement,
-                                              hash_code=hash_code).exists()) or
-                       (Finding.objects.filter(Q(active=True) | Q(false_p=True) | Q(duplicate=True),
-                                              test__engagement__product=test.engagement.product,
-                                              hash_code=hash_code).exists())):
+                             Finding.objects.filter(Q(active=True) | Q(false_p=True) | Q(duplicate=True),
+                             test__engagement=test.engagement,
+                             hash_code=hash_code).exists()) or
+                        (not test.engagement.deduplication_on_engagement and
+                            Finding.objects.filter(Q(active=True) | Q(false_p=True) | Q(duplicate=True),
+                                                    test__engagement__product=test.engagement.product,
+                                                    hash_code=hash_code).exists())):
+
                         skipped_hashcodes.append(hash_code)
                         continue
 


### PR DESCRIPTION
deduplication: fix bug in skip_duplicates for deduplication_on_engagement.

with skip_duplicates and duplication_on_engagement it was looking for duplicates in the engagement AND in the product, this commit fixes that. it was introduced recently in #1007