### PR TITLE
Fix: Review Finding Without Jira Ticket But With Jira Config

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -347,10 +347,13 @@ def defect_finding_review(request, fid):
                 finding.last_reviewed = finding.mitigated
                 finding.last_reviewed_by = request.user
                 finding.endpoints.clear()
-                jira = get_jira_connection(finding)
-                if jira:
-                    j_issue = JIRA_Issue.objects.get(finding=finding)
-                    issue = jira.issue(j_issue.jira_id)
+
+            jira = get_jira_connection(finding)
+            if jira and JIRA_Issue.objects.filter(finding=finding).exists():
+                j_issue = JIRA_Issue.objects.get(finding=finding)
+                issue = jira.issue(j_issue.jira_id)
+
+                if defect_choice == "Close Finding":
                     # If the issue id is closed jira will return Reopen Issue
                     resolution_id = jira_get_resolution_id(jira, issue,
                                                            "Reopen Issue")
@@ -359,16 +362,13 @@ def defect_finding_review(request, fid):
                             jira, issue, "Resolve Issue")
                         jira_change_resolution_id(jira, issue, resolution_id)
                         new_note.entry = new_note.entry + "\nJira issue set to resolved."
-            else:
-                # Re-open finding with notes stating why re-open
-                jira = get_jira_connection(finding)
-                j_issue = JIRA_Issue.objects.get(finding=finding)
-                issue = jira.issue(j_issue.jira_id)
-                resolution_id = jira_get_resolution_id(jira, issue,
-                                                       "Resolve Issue")
-                if resolution_id is not None:
-                    jira_change_resolution_id(jira, issue, resolution_id)
-                    new_note.entry = new_note.entry + "\nJira issue re-opened."
+                else:
+                    # Re-open finding with notes stating why re-open
+                    resolution_id = jira_get_resolution_id(jira, issue,
+                                                        "Resolve Issue")
+                    if resolution_id is not None:
+                        jira_change_resolution_id(jira, issue, resolution_id)
+                        new_note.entry = new_note.entry + "\nJira issue re-opened."
 
             # Update Dojo and Jira with a notes
             add_comment(finding, new_note, force_push=True)


### PR DESCRIPTION
Hi,

I tried to create a PR compatible to your `CONTBUTION.md`, but I'm not a 100% sure if I did everything needed. Please give me a hint, if I'm missing something. I'm happy to update my code where it's needed.

You can see the differences easier with `git diff -w`

---

This commit fixes an issue during finding review. As soon as you have
Jira configured, but no Jira ticket appended, an exception was thrown
because the system wanted to close the Jira ticket at the same time.
The Jira ticket is now no longer required - you can close the finding
without a related Jira ticket.

Closes #1081
