### PR TITLE
View engagement: order tests by type and updated

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -245,7 +245,7 @@ def delete_engagement(request, eid):
 
 def view_engagement(request, eid):
     eng = get_object_or_404(Engagement, id=eid)
-    tests = Test.objects.filter(engagement=eng).order_by('test_type__name')
+    tests = Test.objects.filter(engagement=eng).order_by('test_type__name', '-updated')
     prod = eng.product
     auth = request.user.is_staff or request.user in prod.authorized_users.all()
     risks_accepted = eng.risk_acceptance.all()


### PR DESCRIPTION
On the view engagement page currently the list of tests is ordered only by name (test_type__name).
Apart from that it relies on the natural ordering of the tests.
I think it would be best to ensure the newest tests are on type. Especially in a CI/CD scenario you can have lots of tests and you don't want to be scrolling or pagina too much.
Let me know what you think. I would even go further and only order by '-updated' and leave out the ordering by test name.