### PR TITLE
Update documentation related to #1089

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -50,6 +50,7 @@ DD_INITIALIZE=false to prevent re-initialization.
 For developing the easiset way to make changes is to startup DefectDojo in debug by running:
 
 ```zsh
+docker build -t defectdojo/defectdojo-build -f Dockerfile.build .
 . docker/aliases_dev.sh
 docker-compose up
 ```
@@ -57,6 +58,7 @@ docker-compose up
 or
 
 ```zsh
+docker build -t defectdojo/defectdojo-build -f Dockerfile.build .
 docker-compose -f docker-compose_base.yml -f docker-compose_uwsgi-dev.yml up
 ```
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -71,12 +71,8 @@ The initializer container can be disabled by exporting: `export DD_INITIALIZE=fa
 Build the docker containers locally for testing purposes.
 
 ```zsh
-# Build Dev Compose
-docker-compose build
-
-or:
-
 # Build images
+docker build -t defectdojo/defectdojo-build -f Dockerfile.build .
 docker build -t defectdojo/defectdojo-django -f Dockerfile.django .
 docker build -t defectdojo/defectdojo-nginx -f Dockerfile.nginx .
 ```

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -89,6 +89,7 @@ helm install \
 
 ```zsh
 # Build images
+docker build -t defectdojo/defectdojo-build -f Dockerfile.build .
 docker build -t defectdojo/defectdojo-django -f Dockerfile.django .
 docker build -t defectdojo/defectdojo-nginx -f Dockerfile.nginx .
 ```


### PR DESCRIPTION
Update the documentation on how docker images are build locally - Related to pull request #1089.

The docker-compose build does not work if someone wants to build all images locally, so I removed it. 
