### PR TITLE
fix merge button visibility in view_test

### DIFF
--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -141,7 +141,7 @@
               <span class="caret"></span>
           </button>
           <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
-            {% if tab_product %}
+            {% if product_tab %}
             <button type="button" class="btn btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
               <a class="white-color merge" href="#" alt="Merge Findings">
                 <i class="fa fa-compress"></i>


### PR DESCRIPTION
The merge button is never shown because the `view_test.html` page is looking for a variable called `tab_product` which isn't used anywhere in the DD code base as far as I can see.
In other places the variable referenced is `product_tab`, so this PR uses that same variable now also for `view_test.html` and now the merge button is visible in expected scenario's.