### PR TITLE
Test verifying there are no unmigrated model changes

### DIFF
--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -2,6 +2,26 @@
 # Run available unittests with a simple setup
 
 cd /app
-python manage.py makemigrations dojo
-python manage.py migrate
-exec python manage.py test dojo.unittests --keepdb
+
+./manage.py makemigrations --no-input --check --dry-run || {
+    cat <<-EOF
+
+********************************************************************************
+
+You made changes to the models without creating a DB migration for them.
+
+**NEVER** change existing migrations, create a new one.
+
+If you're not familiar with migrations in Django, please read the
+great documentation thoroughly:
+https://docs.djangoproject.com/en/1.11/topics/migrations/
+
+********************************************************************************
+
+EOF
+    exit 1
+}
+
+./manage.py migrate
+
+exec ./manage.py test dojo.unittests


### PR DESCRIPTION
This PR is related to #1098 and adds the test as discussed with @aaronweaver.

Testing explicitly if migrations apply cleanly is not required, as the Django test runner applies them automatically before running the tests and hence would reveal problems itself.