### PR TITLE
fix utf-8 non-ascii char in source code filenames for checkmarx parser

### DIFF
--- a/dojo/tools/checkmarx/parser.py
+++ b/dojo/tools/checkmarx/parser.py
@@ -59,7 +59,7 @@ class CheckmarxXMLParser(object):
                 deeplink = "[{}]({})".format(result.get('DeepLink'), result.get('DeepLink'))
                 findingdetail = "{}**Finding Link:** {}\n\n".format(findingdetail, deeplink)
 
-                dupe_key = "{}{}{}{}".format(categories, cwe, name, result.get('FileName'))
+                dupe_key = "{}{}{}{}".format(categories, cwe, name, result.get('FileName').encode('utf-8'))
 
                 if dupe_key in dupes:
                     find = dupes[dupe_key]
@@ -84,7 +84,7 @@ class CheckmarxXMLParser(object):
                                    mitigation=mitigation,
                                    impact=impact,
                                    references=references,
-                                   file_path=pathnode.find('FileName').text,
+                                   file_path=pathnode.find('FileName').text.encode('utf-8'),
                                    line=pathnode.find('Line').text,
                                    url='N/A',
                                    date=find_date,
@@ -117,7 +117,7 @@ class CheckmarxXMLParser(object):
 
                 self.result_dupes[result_dupes_key] = True
 
-        if title and pathnode.find('FileName').text:
-            title = "{} ({})".format(title, ntpath.basename(pathnode.find('FileName').text))
+        if title and pathnode.find('FileName').text.encode('utf-8'):
+            title = "{} ({})".format(title, ntpath.basename(pathnode.find('FileName').text.encode('utf-8')))
 
         return title, findingdetail, pathnode

--- a/dojo/unittests/scans/checkmarx/utf8_various_non_ascii_char.xml
+++ b/dojo/unittests/scans/checkmarx/utf8_various_non_ascii_char.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <CxXMLResults InitiatorName="Initiator Name" Owner="domain\user" ScanId="1000227" ProjectId="121" ProjectName="Webgoat" TeamFullPathOnReportDate="team\full\path" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121" ScanStart="Sunday, February 25, 2018 11:35:52 AM" Preset="Checkmarx Default" ScanTime="00h:07m:13s" LinesOfCodeScanned="92054" FilesScanned="480" ReportCreationTime="Sunday, April 21, 2019 10:30:08 PM" Team="team_name" CheckmarxVersion="8.6.0 HF1" ScanComments="" ScanType="Full" SourceOrigin="LocalPath" Visibility="Public">
   <Query id="595" categories="PCI DSS v3.2;PCI DSS (3.2) - 6.5.7 - Cross-site scripting (XSS),OWASP Top 10 2013;A3-Cross-Site Scripting (XSS),FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-15 Information Output Filtering (P0),OWASP Top 10 2017;A7-Cross-Site Scripting (XSS)" cweId="79" name="Stored_XSS" group="Java_High_Risk" Severity="High" Language="Java" LanguageHash="0125540914009541" LanguageChangeDate="2018-02-12T00:00:00.0000000" SeverityIndex="3" QueryPath="Java\Cx\Java High Risk\Stored XSS Version:2" QueryVersionCode="56163505">
-    <Result NodeId="10002270028" FileName="WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java" Status="New" Line="39" Column="59" FalsePositive="False" Severity="High" AssignToUser="" state="0" Remark="" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121&amp;pathid=28" SeverityIndex="3">
+    <Result NodeId="10002270028" FileName="WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ/Users.java" Status="New" Line="39" Column="59" FalsePositive="False" Severity="High" AssignToUser="" state="0" Remark="" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121&amp;pathid=28" SeverityIndex="3">
       <Path ResultId="1000227" PathId="28" SimilarityId="1574221060">
         <PathNode>
-          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ/Users.java</FileName>
           <Line>39</Line>
           <Column>59</Column>
           <NodeId>1</NodeId>
@@ -19,7 +19,7 @@
           </Snippet>
         </PathNode>
         <PathNode>
-          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.javaé</FileName>
           <Line>39</Line>
           <Column>27</Column>
           <NodeId>2</NodeId>
@@ -29,7 +29,7 @@
           <Snippet>
             <Line>
               <Number>39</Number>
-              <Code>                ResultSet results = statement.executeQuery(query);//Ã©e ÃƒÂ©</Code>
+              <Code>                ResultSet results = statement.executeQuery(query);//all latins non ascii with extended: U+00A1   to U+017F  (ref https://www.utf8-chartable.de/unicode-utf8-table.pl): ¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ</Code>
             </Line>
           </Snippet>
         </PathNode>
@@ -44,7 +44,7 @@
           <Snippet>
             <Line>
               <Number>46</Number>
-              <Code>                    while (results.next()) {</Code>
+              <Code>                    while (results.next()) { // other: ƒ</Code>
             </Line>
           </Snippet>
         </PathNode>
@@ -139,7 +139,7 @@
           </Snippet>
         </PathNode>
         <PathNode>
-          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ/Users.java</FileName>
           <Line>58</Line>
           <Column>28</Column>
           <NodeId>10</NodeId>


### PR DESCRIPTION
We have done a couple of fixes already on this but we haven't fixed it for filenames. 

When non-ascii utf-8 characters are found in source code filenames, importing the report makes defectdojo fail with errors like: 
`'ascii' codec can't encode character u'\xe9' in position 24: ordinal not in range(128)`

I've also enriched the checkmarx parser unit test with this case.