### PR TITLE
Twistlock parser fix for riskFactors + cve field

### DIFF
--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -54,6 +54,7 @@ def get_item(vulnerability, test):
     vector = vulnerability['vector'] if 'vector' in vulnerability else "CVSS vector not provided. "
     status = vulnerability['status'] if 'status' in vulnerability else "There seems to be no fix yet. Please check description field."
     cvss = vulnerability['cvss'] if 'cvss' in vulnerability else "No CVSS score yet."
+    riskFactors = vulnerability['riskFactors'] if 'riskFactors' in vulnerability else "No risk factors."
 
     # create the finding object
     finding = Finding(
@@ -71,7 +72,7 @@ def get_item(vulnerability, test):
         duplicate=False,
         out_of_scope=False,
         mitigated=None,
-        severity_justification="{}({})\n\n{}".format(vector, cvss, vulnerability['riskFactors']),
+        severity_justification="{}({})\n\n{}".format(vector, cvss, riskFactors),
         impact=severity)
 
     finding.description = finding.description.strip()

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -59,6 +59,7 @@ def get_item(vulnerability, test):
     # create the finding object
     finding = Finding(
         title=vulnerability['id'] + ": " + vulnerability['packageName'] + " - " + vulnerability['packageVersion'],
+        cve=vulnerability['id'],
         test=test,
         severity=severity,
         description=vulnerability['description'] + "<p> Vulnerable Package: " +


### PR DESCRIPTION
Got bitten by it today. This fixes it.

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes should include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
