### PR TITLE
Amending fixtures for test_type, adding twistlock, blackduck and kiuwan

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -286,10 +286,31 @@
     "pk": 41
   },
   {
-      "fields": {
-        "name": "Netsparker Scanner"
-      },
-      "model": "dojo.test_type",
-      "pk": 49
+    "fields": {
+      "name": "Netsparker Scanner"
+    },
+    "model": "dojo.test_type",
+    "pk": 49
+  },
+  {
+    "fields": {
+      "name": "Twistlock Image Scan"
+    },
+    "model": "dojo.test_type",
+    "pk": 50
+  },
+  {
+    "fields": {
+      "name": "Blackduck Hub Scan"
+    },
+    "model": "dojo.test_type",
+    "pk": 51
+  },
+  {
+    "fields": {
+      "name": "Kiuwan Scan"
+    },
+    "model": "dojo.test_type",
+    "pk": 52
   }
 ]


### PR DESCRIPTION
Realized that test_type were missing the twistlock and blackduck parsers. Amended fixtures here, including @dr3dd589's Kiuwan parser.