### PR TITLE
Add cve field to Blackduck parser

### DIFF
--- a/dojo/tools/blackduck/parser.py
+++ b/dojo/tools/blackduck/parser.py
@@ -63,6 +63,7 @@ class BlackduckHubCSVParser(object):
 
                 finding = Finding(title=title,
                                   cwe=int(cwe),
+                                  cve=cve,
                                   test=test,
                                   active=False,
                                   verified=False,


### PR DESCRIPTION
Forgot the cve field when creating the parser. This fixes it.

Please submit your pull requests to the 'dev' branch.

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes should include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
