### PR TITLE
Fix(helm): logLevel and resource.requests are set on wrong level

### DIFF
--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -21,8 +21,9 @@ celery:
     affinity: {}
     nodeSelector: {}
     resources:
-      cpu: 100m
-      memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
     tolerations: []
   worker:
     affinity: {}
@@ -32,8 +33,9 @@ celery:
     nodeSelector: {}
     replicas: 1
     resources:
-      cpu: 100m
-      memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
     tolerations: []
 
 django:
@@ -46,24 +48,27 @@ django:
   nginx:
     repository: defectdojo/defectdojo-nginx
     resources:
-      cpu: 100m
-      memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
   nodeSelector: {}
   replicas: 1
   tolerations: []
   uwsgi:
     repository: defectdojo/defectdojo-django
     resources:
-      cpu: 100m
-      memory: 128Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
 
 initializer:
   run: true
   repository: defectdojo/defectdojo-django
   keepSeconds: 60
   resources:
-    cpu: 100m
-    memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
 mysql:
   enabled: true

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -16,9 +16,9 @@ admin:
 celery:
   broker: rabbitmq
   repository: defectdojo/defectdojo-django
+  logLevel: DEBUG
   beat:
     affinity: {}
-    logLevel: DEBUG
     nodeSelector: {}
     resources:
       cpu: 100m


### PR DESCRIPTION
The logLevel is used only in the ConfigMap which is shared by the worker and beat.
Also the resource requests are missing a subkey.
With these changes the helm chart should be fully functioning.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant (DefectDojo's code isn't currently flake8 compliant, but we're trying to correct that.)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes should include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.
