### PR TITLE
Fix 1176 checkmarx deduplication

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1551,11 +1551,11 @@ class ReImportScanValidation(Validation):
         if 'test' not in bundle.data:
             errors.setdefault('test', []).append('test must be given')
         else:
-            # verify the engagement is valid
+            # verify the test is valid
             try:
                 get_pk_from_uri(uri=bundle.data['test'])
             except NotFound:
-                errors.setdefault('engagement', []).append('A valid engagement must be supplied. Ex. /api/v1/engagements/1/')
+                errors.setdefault('test', []).append('A valid test must be supplied. Ex. /api/v1/tests/1/')
         scan_type_list = list(map(lambda x: x[0], ImportScanForm.SCAN_TYPE_CHOICES))
         if 'scan_type' in bundle.data:
             if bundle.data['scan_type'] not in scan_type_list:

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -510,6 +510,12 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'DEBUG',
             'propagate': False,
+        },
+        # Can be very verbose when many findings exist
+        'dojo.specific-loggers.deduplication': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
         }
     }
 }

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -514,7 +514,7 @@ LOGGING = {
         # Can be very verbose when many findings exist
         'dojo.specific-loggers.deduplication': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': False,
         }
     }

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -27,6 +27,7 @@ lvl = getattr(settings, 'LOG_LEVEL', logging.DEBUG)
 logging.basicConfig(format=fmt, level=lvl)
 
 logger = get_task_logger(__name__)
+deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 
 # Logs the error to the alerts table, which appears in the notification toolbar
@@ -261,7 +262,7 @@ def add_comment_task(find, note):
 
 @app.task(name='async_dedupe')
 def async_dedupe(new_finding, *args, **kwargs):
-    logger.info("running deduplication")
+    deduplicationLogger.debug("running deduplication")
     sync_dedupe(new_finding, *args, **kwargs)
 
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -31,6 +31,7 @@ from requests.auth import HTTPBasicAuth
 
 import logging
 logger = logging.getLogger(__name__)
+deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 
 """
@@ -75,8 +76,15 @@ def is_deduplication_on_engagement_mismatch(new_finding, to_duplicate_finding):
 
 
 def sync_dedupe(new_finding, *args, **kwargs):
-    logger.debug('sync_dedupe for: ' + str(new_finding.id) +
+    deduplicationLogger.debug('sync_dedupe for: ' + str(new_finding.id) +
                  ":" + str(new_finding.title))
+    # ---------------------------------------------------------
+    # 1) Collects all the findings that have the same:
+    #      (title  and static_finding and dynamic_finding ane date__lte)
+    #      or (CWE and static_finding and dynamic_finding ane date__lte)
+    #    as the new one
+    #    (this is "cond1")
+    # ---------------------------------------------------------
     if new_finding.test.engagement.deduplication_on_engagement:
         eng_findings_cwe = Finding.objects.filter(
             test__engagement=new_finding.test.engagement,
@@ -116,20 +124,38 @@ def sync_dedupe(new_finding, *args, **kwargs):
         flag_line_path = False
         flag_hash = False
         if is_deduplication_on_engagement_mismatch(new_finding, find):
-            logger.debug(
+            deduplicationLogger.debug(
                 'deduplication_on_engagement_mismatch, skipping dedupe.')
             continue
+        # ---------------------------------------------------------
+        # 2) If existing and new findings have endpoints: compare them all
+        #    Else look at line+file_path
+        #    (if new finding is not static, do not deduplicate)
+        # ---------------------------------------------------------
         if find.endpoints.count() != 0 and new_finding.endpoints.count() != 0:
             list1 = new_finding.endpoints.all()
             list2 = find.endpoints.all()
             if all(x in list1 for x in list2):
                 flag_endpoints = True
-        elif find.line == new_finding.line and find.file_path == new_finding.file_path and new_finding.static_finding and len(
-                new_finding.file_path) > 0:
-            flag_line_path = True
+        elif new_finding.static_finding and len(new_finding.file_path) > 0:
+            if(str(find.line) == new_finding.line and find.file_path == new_finding.file_path):
+                flag_line_path = True
+            else:
+                deduplicationLogger.debug("no endpoints on one of the findings and file_path doesn't match")
+        else:
+            deduplicationLogger.debug("no endpoints on one of the findings and the new finding is either dynamic or doesn't have a file_path; Deduplication will not occur")
         if find.hash_code == new_finding.hash_code:
             flag_hash = True
+        deduplicationLogger.debug(
+            'deduplication flags for new finding ' + str(new_finding.id) + ' and existing finding ' + str(find.id) +
+            ' flag_endpoints: ' + str(flag_endpoints) + ' flag_line_path:' + str(flag_line_path) + ' flag_hash:' + str(flag_hash))
+        # ---------------------------------------------------------
+        # 3) Findings are duplicate if (cond1 is true) and they have the same:
+        #    hash
+        #    and (endpoints or (line and file_path)
+        # ---------------------------------------------------------
         if ((flag_endpoints or flag_line_path) and flag_hash):
+            deduplicationLogger.debug('New finding ' + str(new_finding.id) + ' is a duplicate of existing finding ' + str(find.id))
             new_finding.duplicate = True
             new_finding.active = False
             new_finding.verified = False

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -80,8 +80,8 @@ def sync_dedupe(new_finding, *args, **kwargs):
                  ":" + str(new_finding.title))
     # ---------------------------------------------------------
     # 1) Collects all the findings that have the same:
-    #      (title  and static_finding and dynamic_finding ane date__lte)
-    #      or (CWE and static_finding and dynamic_finding ane date__lte)
+    #      (title  and static_finding and dynamic_finding)
+    #      or (CWE and static_finding and dynamic_finding)
     #    as the new one
     #    (this is "cond1")
     # ---------------------------------------------------------

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -90,33 +90,39 @@ def sync_dedupe(new_finding, *args, **kwargs):
             test__engagement=new_finding.test.engagement,
             cwe=new_finding.cwe,
             static_finding=new_finding.static_finding,
-            dynamic_finding=new_finding.dynamic_finding,
-            date__lte=new_finding.date).exclude(id=new_finding.id).exclude(
-            cwe=0).exclude(duplicate=True)
+            dynamic_finding=new_finding.dynamic_finding
+                                                  ).exclude(id=new_finding.id
+                                                            ).exclude(cwe=0
+                                                                      ).exclude(duplicate=True)
         eng_findings_title = Finding.objects.filter(
             test__engagement=new_finding.test.engagement,
             title=new_finding.title,
             static_finding=new_finding.static_finding,
-            dynamic_finding=new_finding.dynamic_finding,
-            date__lte=new_finding.date).exclude(id=new_finding.id).exclude(
-            duplicate=True)
+            dynamic_finding=new_finding.dynamic_finding
+                                                   ).exclude(id=new_finding.id
+                                                             ).exclude(duplicate=True)
     else:
         eng_findings_cwe = Finding.objects.filter(
             test__engagement__product=new_finding.test.engagement.product,
             cwe=new_finding.cwe,
             static_finding=new_finding.static_finding,
-            dynamic_finding=new_finding.dynamic_finding,
-            date__lte=new_finding.date).exclude(id=new_finding.id).exclude(
-            cwe=0).exclude(duplicate=True)
+            dynamic_finding=new_finding.dynamic_finding
+                                                  ).exclude(id=new_finding.id
+                                                            ).exclude(cwe=0
+                                                                      ).exclude(duplicate=True)
         eng_findings_title = Finding.objects.filter(
             test__engagement__product=new_finding.test.engagement.product,
             title=new_finding.title,
             static_finding=new_finding.static_finding,
-            dynamic_finding=new_finding.dynamic_finding,
-            date__lte=new_finding.date).exclude(id=new_finding.id).exclude(
-            duplicate=True)
+            dynamic_finding=new_finding.dynamic_finding
+                                                    ).exclude(id=new_finding.id
+                                                              ).exclude(duplicate=True)
 
     total_findings = eng_findings_cwe | eng_findings_title
+    deduplicationLogger.debug("Found " +
+        str(len(eng_findings_cwe)) + " findings with same cwe, " +
+        str(len(eng_findings_title)) + " findings with same title: " +
+        str(len(total_findings)) + " findings with either same title or same cwe")
     # total_findings = total_findings.order_by('date')
 
     for find in total_findings:


### PR DESCRIPTION
Fixes https://github.com/DefectDojo/django-DefectDojo/issues/1176 for APIv1 and gui import. Add debug logs

Regarding the deduplication: 
- fix comparison between  find.line and new_finding.line which was always false due to different types ( find.line is a long while new_finding.line is a string)
- Remove date from the comparison: when importing through APIv1 date is given by scan-date field. When importing through the GUI, date is given by "Scan Completion Date". Findings may be duplicate no matter which scan dates are given

Regarding the logs: 
- I have created a specific logger to be able to tune it independently of the utils.py logger. When there are many findings, we'll have logs for each finding in the database if the logger is configured in debug. For this reason, by default the logger is configured at level INFO (see settings.dist.py). To activate deduplication logs, set level as DEBUG. By the way do we have a technical documentation for this kind of tips? 

At this point, I'm still unsure that this algorithm is required and that everything couln't be handled with the hash_code only, which would be more performant and simpler (if required by making the hash computation evolve). However for now I have stuck to the existing behavior as much as possible and have just made checkmarx deduplication work. More advanced rework can be handled in https://github.com/DefectDojo/django-DefectDojo/issues/1145 

Remaining:
- unit tests -> GSOC? We have only APIv2 unit tests for scan import, no APIv1 test (nor GUI import tests). Testing data can be found in the issue.
- APIv2 (I think I won't be using it because of the limitations pointed in https://github.com/DefectDojo/django-DefectDojo/issues/1145 so...)
