### PR TITLE
Enhancement #1155

### DIFF
--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -110,6 +110,8 @@
                             <th>Title</th>
                             <th>Date</th>
                             <th>Product</th>
+                            <th>Engagement</th>
+                            <th>Associated Test</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -117,7 +119,7 @@
                             <tr>
                                 <td>
                                   <span class="label severity severity-{{ finding.object.severity }}">
-                                      {{ finding.object.severity_display }}
+                                     {{ finding.object.severity_display }}
                                   </span>
                                 </td>
                                 <td><a class="search-finding"
@@ -137,6 +139,18 @@
                                              href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
                                       {% endfor %}
                                   </sup>
+                                </td>
+                                <td>
+                                    <a href="{% url 'view_engagement' finding.object.test.engagement.id %}">{{ finding.object.test.engagement.name }}</a>
+                                </td>
+                                <td>
+                                    <a href="{% url 'view_test' finding.object.test.id %}">
+                                        {% if finding.object.test.title is None %}
+                                            {{finding.object.test.test_type}}
+                                        {% else %}
+                                            {{finding.object.test.title }}
+                                        {% endif %}
+                                    </a>
                                 </td>
                               </tr>
                         {% endfor %}


### PR DESCRIPTION
This is my enhancement for #1155. Added columns for engagement and associated test whenever a finding is pulled up in the simple search. The engagement column lists the engagement that the finding is associated with. The associated test column displays the test that the finding is associated with. If the associated test is not titled, the associated scan is displayed instead. 