### PR TITLE
Enhancement for #1211

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -623,6 +623,8 @@
                 });
                 $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "alerts" %}"><strong>See All Alerts </strong>' +
                                              '<i class="fa fa-angle-right"></i></a></li>');
+                $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "delete_alerts" %}"><strong>Clear All Alerts </strong>' +
+                                           '<i class="fa fa-angle-right"></i></a></li>');
             });
         }
     });

--- a/dojo/templates/dojo/delete_alerts.html
+++ b/dojo/templates/dojo/delete_alerts.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+{% block content %}
+    <h3> Delete All alerts {{ product }}</h3>
+    <p>
+        Delete all alerts will remove all alerts from this instance
+    </p>
+    <div class="danger-zone panel panel-danger">
+        <div class="panel-heading">
+            <h3>Danger Zone</h3>
+        </div>
+
+        <div>
+            <h4>The following alerts will be deleted</h4>
+        </div>
+        {% for alert in alerts %}
+            <tr>
+                <td>{%if alert.url %}<a href="{{ alert.url }}">{% endif %}{{ alert.title|linebreaks }}{% if alert.url %}</a>{% endif %}</td>
+            </tr>
+        {% endfor %}
+        <form class="form-horizontal" method="post">
+            {% csrf_token %}
+            {{ form }}
+
+            <div class="form-group">
+                <button class="btn btn-danger" type="submit" name="delete_name" value="delete_test">Delete Alert</button>
+            </div>
+        </form>
+    </div>
+    <br/>
+    <br/>
+{% endblock %}

--- a/dojo/user/urls.py
+++ b/dojo/user/urls.py
@@ -24,4 +24,5 @@ urlpatterns = [
         name='delete_user'),
     url(r'^api/key$', views.api_key, name='api_key'),
     url(r'^api/key-v2$', views.api_v2_key, name='api_v2_key'),
+    url(r'^delete_alerts$', views.delete_alerts, name='delete_alerts'),
 ]

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -313,6 +313,21 @@ def edit_user(request, uid):
         'contact_form': contact_form,
         'to_edit': user})
 
+def delete_alerts(request):
+   alerts = Alerts.objects.filter(user_id=request.user)
+
+   if request.method == 'POST':
+       removed_alerts = request.POST.getlist('alert_select')
+       alerts.filter().delete()
+       messages.add_message(request,
+                                    messages.SUCCESS,
+                                    'Alerts removed.',
+                                    extra_tags='alert-success')
+       return HttpResponseRedirect('alerts')
+
+   return render(request,
+                 'dojo/delete_alerts.html',
+                 {'alerts': alerts})
 
 @user_passes_test(lambda u: u.is_superuser)
 def delete_user(request, uid):


### PR DESCRIPTION
This is my enhancement for #1211. Added a "Clear all alerts" tab below the "See all alerts" option in the Alerts drop-down menu. Clicking on clear all alerts prompts the user with a page stating "The following alerts will be deleted" followed by the titles of the alerts, and a delete alert button. Clicking on delete alerts will purge all alerts.