### PR TITLE
Enhancement #1238

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -198,6 +198,16 @@ def closed_findings(request, pid=None):
 
 def view_finding(request, fid):
     finding = get_object_or_404(Finding, id=fid)
+    findings = Finding.objects.filter(test=finding.test).order_by('numerical_severity')
+    try:
+        prev_finding = findings[(list(findings).index(finding))-1]
+    except AssertionError:
+        prev_finding = finding
+    try:
+        next_finding = findings[(list(findings).index(finding))+1]
+    except IndexError:
+        next_finding = finding
+    findings = [finding.id for finding in findings]
     cred_finding = Cred_Mapping.objects.filter(
         finding=finding.id).select_related('cred_id').order_by('cred_id')
     creds = Cred_Mapping.objects.filter(
@@ -268,7 +278,7 @@ def view_finding(request, fid):
         burp_response = None
 
     product_tab = Product_Tab(finding.test.engagement.product.id, title="View Finding", tab="findings")
-
+    lastPos = (len(findings)) - 1
     return render(
         request, 'dojo/view_finding.html', {
             'product_tab': product_tab,
@@ -285,7 +295,11 @@ def view_finding(request, fid):
             'notes': notes,
             'form': form,
             'cwe_template': cwe_template,
-            'found_by': finding.found_by.all().distinct()
+            'found_by': finding.found_by.all().distinct(),
+            'findings_list': findings,
+            'findings_list_lastElement': findings[lastPos],
+            'prev_finding': prev_finding,
+            'next_finding': next_finding
         })
 
 

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -660,6 +660,9 @@
 
     {% include "dojo/snippets/comments.html" with notes=notes object=finding destination="finding" %}
 
+    <div class="PrevAndNext_Buttons">
+    </div>
+
     <div class="protip">
        <i class="fa fa-lightbulb-o"></i> <strong>ProTip!</strong> Type <kbd>e</kbd> to edit any finding.
     </div>
@@ -668,6 +671,17 @@
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
+        var firstID = {{findings_list.0}};
+        var currentID = {{finding.id}};
+        var lastID = {{findings_list_lastElement}};
+        if(currentID != firstID)
+        {
+            $('.PrevAndNext_Buttons').append('<a href="{% url 'view_finding' prev_finding.id %}" class="btn btn-primary">Previous Finding</a> ');
+        }
+        if(currentID != lastID)
+        {
+            $('.PrevAndNext_Buttons').append('<a href="{% url 'view_finding' next_finding.id %}" class="btn btn-primary">Next Finding</a>');
+        }
         //Ensures dropdown has proper zindex
         $('.table-responsive').on('show.bs.dropdown', function () {
           $('.table-responsive').css( "overflow", "inherit" );


### PR DESCRIPTION
This is my enhancement for #1238. Added Previous and Next buttons on view finding. Clicking next takes the user to the finding after the one it's currently looking at, and previous takes the user to the finding after. If the finding that the user is viewing if the first finding, the previous button will not display. Similar case with the next button; Next button is not displayed when the user is looking at the last finding. 