### PR TITLE
Test type shouldn't be limited to valid scan types

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -510,8 +510,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     verified = serializers.BooleanField(default=True)
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
-    test_type = serializers.ChoiceField(
-        choices=ImportScanForm.SCAN_TYPE_CHOICES, required=False)
+    test_type = serializers.CharField(required=False)
     file = serializers.FileField()
     engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all())


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2. Please submit your pull requests to the 'python3_dev' branch as the 'dev' branch is only for bug fixes. Any PR's submitted to the 'dev' branch should also be converted to Python3 and submited to the 'python3_dev' branch. 

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.
