### PR TITLE
Disable social-auth by default

### DIFF
--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
     <h3>Login</h3>
-
     <form class="form-horizontal" method="POST"> {% csrf_token %}
         <fieldset class="col-md-offset-3 col-md-6">
             {% include "dojo/form_fields.html" with form=form %}
@@ -11,29 +10,33 @@
                     <i class="fa fa-eye"></i>
                     <span><b>Show Password</b></span>
                 </div>
+                {% if GOOGLE_ENABLED == False and OKTA_ENABLED == False %}
+                    <div class="col-sm-offset-1 col-sm-1">
+                        <button class="btn btn-success">Login</button>
+                    </div>
+                {% endif %}
             </div>
             <div class="form-group">
+                {% if GOOGLE_ENABLED == True or OKTA_ENABLED == True %}
                     <div class="col-sm-offset-1 col-sm-1">
                             <button class="btn btn-success">Login</button>
                     </div>
-                <div class="col-sm-offset-1 col-sm-3">
-                    <button class="btn btn-success" type="button">
-                        {% if GOOGLE_ENABLED == True %}
+                {% endif %}
+                {% if GOOGLE_ENABLED == True %}
+                    <div class="col-sm-offset-1 col-sm-3">
+                        <button class="btn btn-success" type="button">
                             <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.GET.next }}" style="color: rgb(255,255,255)">Login with Google</a>
-                        {% else %}
-                            <a href="https://defectdojo.readthedocs.io/en/latest/social-authentication.html#google" style="color: rgb(255,255,255)">Login with Google</a>
-                        {% endif %}
-                    </button>
-                </div>
-                <div class="col-sm-offset-1 col-sm-1">
-                    <button class="btn btn-success" type="button">
-                        {% if OKTA_ENABLED == True %}
+                        </button>
+                    </div>
+                {% endif %}
+
+                {% if OKTA_ENABLED == True %}
+                    <div class="col-sm-offset-1 col-sm-1">
+                        <button class="btn btn-success" type="button">
                             <a href="{% url 'social:begin' 'okta-oauth2' %}?next={{ request.GET.next }}" style="color: rgb(255,255,255)">Login with OKTA</a>
-                        {% else %}
-                            <a href="https://defectdojo.readthedocs.io/en/latest/social-authentication.html#okta" style="color: rgb(255,255,255)">Login with OKTA</a>
-                        {% endif %}
-                    </button>
-                </div>
+                        </button>
+                    </div>
+                {% endif %}
             </div>
         </fieldset>
     </form>


### PR DESCRIPTION
Social Authentication via Google or OKTA is now disabled by default. Users will need to navigate to the documentation for guidance with setup and enabling.

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
