### PR TITLE
Harcoding fullcalendar pkg version. Fixes #1011

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -15,7 +15,7 @@
     "@yarn_components/flot.tooltip": "krzysu/flot.tooltip#~0.8.4",
     "@yarn_components/font-awesome": "FortAwesome/Font-Awesome#4.4.0",
     "@yarn_components/fontawesome": "FortAwesome/Font-Awesome#~4.5.0",
-    "@yarn_components/fullcalendar": "fullcalendar/fullcalendar#*",
+    "@yarn_components/fullcalendar": "fullcalendar/fullcalendar#3.9.0",
     "@yarn_components/google-code-prettify": "tcollard/google-code-prettify#~1.0.4",
     "@yarn_components/holderjs": "imsky/holder#~2.4.1",
     "@yarn_components/jquery": "jquery/jquery-dist#~3.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@yarn_components/flot.tooltip": "krzysu/flot.tooltip#~0.8.4",
     "@yarn_components/font-awesome": "FortAwesome/Font-Awesome#4.4.0",
     "@yarn_components/fontawesome": "FortAwesome/Font-Awesome#~4.5.0",
-    "@yarn_components/fullcalendar": "fullcalendar/fullcalendar#*",
+    "@yarn_components/fullcalendar": "fullcalendar/fullcalendar#3.9.0",
     "@yarn_components/google-code-prettify": "tcollard/google-code-prettify#~1.0.4",
     "@yarn_components/holderjs": "imsky/holder#~2.4.1",
     "@yarn_components/jquery": "jquery/jquery-dist#~3.3.1",


### PR DESCRIPTION
Since version 3.10.0, there are breaking changes in the fullcalendar
yarn package version, which breaks the calendar functionality on Dojo.

Jquery support has been removed on version 4.0 as seen on link:
https://fullcalendar.io/blog/2018/04/alpha-release-jquery-removal

Jquery version mismatches happen if we use version 3.10.0

Thus, hardcoding to version 3.9.0
