### PR TITLE
Use git+https instead of git+git for GitHub on requirements.txt . Fixes #1297

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coverage==4.5.3
 defusedxml==0.6.0
 django_celery_results==1.1.1
 django-auditlog==0.4.5
-git+git://github.com/Maffooch/django-custom-field.git@master#egg=django-custom-field
+git+https://github.com/Maffooch/django-custom-field.git@master#egg=django-custom-field
 django-dbbackup>=3.2.0
 django-environ==0.4.5
 django-filter==2.0.0
@@ -19,7 +19,7 @@ django-rest-swagger==2.1.2
 django-slack==5.13.0
 django-tagging==0.4.6
 django-taggit-serializer==0.1.7
-git+git://github.com/Maffooch/django-tastypie-swagger@master#egg=django-tastypie-swagger
+git+https://github.com/Maffooch/django-tastypie-swagger@master#egg=django-tastypie-swagger
 django-tastypie==0.14.2
 django-watson==1.5.2
 Django==2.2.1


### PR DESCRIPTION
Using  git+git as the protocol for connectivity is not good corporate on 
environments, as this might not respect the proxy settings configured
on the server/client performing the install or the firewall might block port
9418 used by git protocol.

Using git+https will respect proxy settings and allow likely allows
the build to complete as it will pull the dependency from GitHub using HTTPS