### PR TITLE
Product details rendering fix. Fixes #1305

### DIFF
--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -144,10 +144,9 @@
     </div>
   </div>
 </div>
-</div>
-  <!-- Benchmark Tab -->
+      <!-- Benchmark Tab -->
 <div class="row">
-  <div class="col-md-8">
+  <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title"><span class ="fa fa-balance-scale" aria-hidden="true"></span> Benchmark Progress </h3>
@@ -176,6 +175,7 @@
         </ul>
     </div>
   </div>
+</div>
 </div>
 <!-- Meta Data -->
 <div class="col-md-4">


### PR DESCRIPTION
After the "Benchmark Progress" feature implementation, the Metadata and
Contacts area is not rendering on the right side of the screen as they
used to, and now render below the benchmark progress.

This commit fixes the mismatched div entries and size of the benchmark
the panel so the page can properly render