### PR TITLE
Implement Azure AD Tenant OAuth. Fix #1307

### DIFF
--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -5,4 +5,5 @@ from django.conf import settings
 def globalize_oauth_vars(request):
     # return the value you want as a dictionnary. you may add multiple values in there.
     return {'GOOGLE_ENABLED': settings.GOOGLE_OAUTH_ENABLED,
-            'OKTA_ENABLED': settings.OKTA_OAUTH_ENABLED}
+            'OKTA_ENABLED': settings.OKTA_OAUTH_ENABLED,
+            'AZUREAD_TENANT_OAUTH2_ENABLED': settings.AZUREAD_TENANT_OAUTH2_ENABLED}

--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -1,12 +1,53 @@
+from django.conf import settings
+from social_core.backends.azuread_tenant import AzureADTenantOAuth2
+from social_core.backends.google import GoogleOAuth2
+
+
 def social_uid(backend, details, response, *args, **kwargs):
-    uid = backend.get_user_id(details, response)
-    # Used for most backends
-    if uid:
-        return {'uid': uid}
-    # Until OKTA PR in social-core is merged
-    # This modified way needs to work
+    if settings.AZUREAD_TENANT_OAUTH2_ENABLED and isinstance(backend, AzureADTenantOAuth2):
+        """Return user details from Azure AD account"""
+        fullname, first_name, last_name, upn = (
+            response.get('name', ''),
+            response.get('given_name', ''),
+            response.get('family_name', ''),
+            response.get('upn'),
+        )
+        uid = backend.get_user_id(details, response)
+        return {'username': upn,
+                'email': upn,
+                'fullname': fullname,
+                'first_name': first_name,
+                'last_name': last_name,
+                'uid': uid}
+    elif settings.GOOGLE_OAUTH_ENABLED and isinstance(backend, GoogleOAuth2):
+        """Return user details from Google account"""
+        if 'sub' in response:
+            google_uid = response['sub']
+        elif 'email' in response:
+            google_uid = response['email']
+        else:
+            google_uid = response['id']
+        fullname, first_name, last_name, email = (
+            response.get('fullname', ''),
+            response.get('first_name', ''),
+            response.get('last_name', ''),
+            response.get('email'),
+        )
+        return {'username': email,
+                'email': email,
+                'fullname': fullname,
+                'first_name': first_name,
+                'last_name': last_name,
+                'uid': google_uid}
     else:
-        return {'uid': response.get('preferred_username')}
+        uid = backend.get_user_id(details, response)
+        # Used for most backends
+        if uid:
+            return {'uid': uid}
+        # Until OKTA PR in social-core is merged
+        # This modified way needs to work
+        else:
+            return {'uid': response.get('preferred_username')}
 
 
 def modify_permissions(backend, uid, user=None, social=None, *args, **kwargs):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -66,11 +66,18 @@ env = environ.Env(
     DD_SECRET_KEY=(str, '.'),
     DD_CREDENTIAL_AES_256_KEY=(str, '.'),
     DD_DATA_UPLOAD_MAX_MEMORY_SIZE=(int, 8388608),  # Max post size set to 8mb
+    DD_SOCIAL_AUTH_GOOGLE_OAUTH2_ENABLE=(bool, 'False'),
     DD_SOCIAL_AUTH_GOOGLE_OAUTH2_KEY=(str, ''),
     DD_SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET=(str, ''),
+    DD_SOCIAL_AUTH_OKTA_OAUTH2_ENABLED=(bool, 'False'),
     DD_SOCIAL_AUTH_OKTA_OAUTH2_KEY=(str, ''),
     DD_SOCIAL_AUTH_OKTA_OAUTH2_SECRET=(str, ''),
     DD_SOCIAL_AUTH_OKTA_OAUTH2_API_URL=(str, 'https://{your-org-url}/oauth2/default'),
+    DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_ENABLED=(bool, 'False'),
+    DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY=(str, ''),
+    DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET=(str, ''),
+    DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID=(str, ''),
+    DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_RESOURCE=(str, 'https://graph.microsoft.com/'),
 )
 
 
@@ -246,6 +253,7 @@ LOGIN_URL = '/login'
 AUTHENTICATION_BACKENDS = (
     'social_core.backends.google.GoogleOAuth2',
     'dojo.okta.OktaOAuth2',
+    'social_core.backends.azuread_tenant.AzureADTenantOAuth2',
     'django.contrib.auth.backends.RemoteUserBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
@@ -256,6 +264,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.auth_allowed',
     'social_core.pipeline.social_auth.social_user',
     'social_core.pipeline.user.get_username',
+    'social_core.pipeline.social_auth.associate_by_email',
     'social_core.pipeline.user.create_user',
     'dojo.pipeline.modify_permissions',
     'social_core.pipeline.social_auth.associate_user',
@@ -266,15 +275,22 @@ SOCIAL_AUTH_PIPELINE = (
 SOCIAL_AUTH_STRATEGY = 'social_django.strategy.DjangoStrategy'
 SOCIAL_AUTH_STORAGE = 'social_django.models.DjangoStorage'
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'first_name', 'last_name', 'email']
+SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL = True
 
-GOOGLE_OAUTH_ENABLED = False
+GOOGLE_OAUTH_ENABLED = env('DD_SOCIAL_AUTH_GOOGLE_OAUTH2_ENABLE')
 SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = env('DD_SOCIAL_AUTH_GOOGLE_OAUTH2_KEY')
 SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = env('DD_SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET')
 
-OKTA_OAUTH_ENABLED = False
+OKTA_OAUTH_ENABLED = env('DD_SOCIAL_AUTH_OKTA_OAUTH2_ENABLED')
 SOCIAL_AUTH_OKTA_OAUTH2_KEY = env('DD_SOCIAL_AUTH_OKTA_OAUTH2_KEY')
 SOCIAL_AUTH_OKTA_OAUTH2_SECRET = env('DD_SOCIAL_AUTH_OKTA_OAUTH2_SECRET')
 SOCIAL_AUTH_OKTA_OAUTH2_API_URL = env('DD_SOCIAL_AUTH_OKTA_OAUTH2_API_URL')
+
+AZUREAD_TENANT_OAUTH2_ENABLED = env('DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_ENABLED')
+SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY = env('DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY')
+SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET = env('DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET')
+SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID = env('DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID')
+SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_RESOURCE = env('DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_RESOURCE')
 
 LOGIN_EXEMPT_URLS = (
     r'^%sstatic/' % URL_PREFIX,
@@ -285,6 +301,7 @@ LOGIN_EXEMPT_URLS = (
     r'^%sapi/v2/' % URL_PREFIX,
     r'complete/google-oauth2/',
     r'complete/okta-oauth2/',
+    r'complete/azuread-tenant-oauth2/',
 )
 
 # ------------------------------------------------------------------------------

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -10,33 +10,42 @@
                     <i class="fa fa-eye"></i>
                     <span><b>Show Password</b></span>
                 </div>
-                {% if GOOGLE_ENABLED == False and OKTA_ENABLED == False %}
+                {% if GOOGLE_ENABLED is False and OKTA_ENABLED is False and AZUREAD_TENANT_OAUTH2_ENABLED is False %}
                     <div class="col-sm-offset-1 col-sm-1">
                         <button class="btn btn-success">Login</button>
                     </div>
                 {% endif %}
             </div>
             <div class="form-group">
-                {% if GOOGLE_ENABLED == True or OKTA_ENABLED == True %}
+                {% if GOOGLE_ENABLED or OKTA_ENABLED or AZUREAD_TENANT_OAUTH2_ENABLED is True %}
                     <div class="col-sm-offset-1 col-sm-1">
                             <button class="btn btn-success">Login</button>
                     </div>
                 {% endif %}
-                {% if GOOGLE_ENABLED == True %}
-                    <div class="col-sm-offset-1 col-sm-3">
+                {% if GOOGLE_ENABLED is True %}
+                    <div class="col-sm-offset-1 col-sm-2">
                         <button class="btn btn-success" type="button">
                             <a href="{% url 'social:begin' 'google-oauth2' %}?next={{ request.GET.next }}" style="color: rgb(255,255,255)">Login with Google</a>
                         </button>
                     </div>
                 {% endif %}
 
-                {% if OKTA_ENABLED == True %}
-                    <div class="col-sm-offset-1 col-sm-1">
+                {% if OKTA_ENABLED is True %}
+                    <div class="col-sm-offset-1 col-sm-2">
                         <button class="btn btn-success" type="button">
                             <a href="{% url 'social:begin' 'okta-oauth2' %}?next={{ request.GET.next }}" style="color: rgb(255,255,255)">Login with OKTA</a>
                         </button>
                     </div>
                 {% endif %}
+
+                {% if AZUREAD_TENANT_OAUTH2_ENABLED is True %}
+                    <div class="col-sm-offset-1 col-sm-2">
+                        <button class="btn btn-success" type="button">
+                            <a href="{% url 'social:begin' 'azuread-tenant-oauth2' %}?next={{ request.GET.next }}" style="color: rgb(255,255,255)">Login with Azure AD</a>
+                        </button>
+                    </div>
+                {% endif %}
+
             </div>
         </fieldset>
     </form>

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -168,7 +168,6 @@ urlpatterns = [
     url(r'^api/v2/api-token-auth/', tokenviews.obtain_auth_token),
     url(r'^api/v2/doc/', schema_view, name="api_v2_schema"),
     url(r'^robots.txt', lambda x: HttpResponse("User-Agent: *\nDisallow: /", content_type="text/plain"), name="robots_file"),
-
 ]
 
 if hasattr(settings, 'DJANGO_ADMIN_ENABLED'):


### PR DESCRIPTION
As more and more enterprises are leveraging Office 365 and Azure,
implementing Azure AD authentication using OAuth would be extremely
helpful as an alternative from relying on AD/LDAP connectivity, enabling
admins to deploy Defect Dojo in the cloud without having to send
authentication requests back to on-premises AD/LDAP.

This implementation is based on social-core, building upon the
pre-existing OKTA and Google integration.

When submitting a pull request, please make sure you have completed the following checklist:

- [X] Your code is flake8 compliant 
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
    - PR for documentation has been created on https://github.com/DefectDojo/Documentation/pull/53 
 but also including documentation here 
- [N/A] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [N/A] Add applicable tests to the unit tests.

Azure Active Directory Tenant Configuration
-------------------------------------------
You can now use your corporate Azure Active Directory to authenticate users to Defect Dojo.
Users will be using your corporate Azure AD account (A.K.A. Office 365 identity) to authenticate via OAuth, and all the conditional access rules and benefits from Azure Active Directory will also apply to the Defect Dojo Authentication.
Once the user signs in, it will try to match the UPN of the user to an existing e-mail from a user in Defect Dojo, and if no match is found, a new user will be created in Defect Dojo, associated with the unique id/value of the user provided by your Azure AD tenant. Then, you can assign roles to this user, such as ‘staff‘ or ‘superuser‘

1. Navigate to the following address and follow instructions to create a new app registration

  * https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app

2. Once you register an app, take note of the following information:

  * **Application (client) ID**
  * **Directory (tenant) ID** 
  * Under Certificates & Secrets, create a new **Client Secret** 
  
3. Under Authentication > Redirect URIs, add a *WEB* type of uri where the redirect points to

  * http://localhost:8080/complete/azuread-tenant-oauth2/  
  * **OR**   
  * http://the_hostname_you_have_dojo_deployed:your_server_port/complete/azuread-tenant-oauth2/

4. Now, edit the dojo/settings.py file and edit/replace the following information:

  * DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_KEY=(str, '**YOUR_APPLICATION_ID_FROM_STEP_ABOVE**'),
  * DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_SECRET=(str, '**YOUR_CLIENT_SECRET_FROM_STEP_ABOVE**''),
  * DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_TENANT_ID=(str, '**YOUR_DIRECTORY_ID_FROM_STEP_ABOVE**''),
  * AZUREAD_TENANT_OAUTH2_ENABLED = **True** 
  
5. Restart your Dojo, and you should now see a **Login with Azure AD** button on the login page which should *magically* work