### PR TITLE
Use severity field instead of cvss score to classify

### DIFF
--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -37,16 +37,14 @@ class TwistlockParser(object):
 
 def get_item(vulnerability, test):
     # Following the CVSS Scoring per https://nvd.nist.gov/vuln-metrics/cvss
-    if 'cvss' in vulnerability:
+    if 'severity' in vulnerability:
         # If we're dealing with a license finding, there will be no cvssScore
-        if vulnerability['cvss'] <= 3.9:
-            severity = "Low"
-        elif vulnerability['cvss'] > 4.0 and vulnerability['cvss'] <= 6.9:
-            severity = "Medium"
-        elif vulnerability['cvss'] > 7.0 and vulnerability['cvss'] <= 8.9:
+        if vulnerability['severity'] == 'important':
             severity = "High"
+        elif vulnerability['severity'] == 'moderate':
+            severity = "Medium"
         else:
-            severity = "Critical"
+            severity = vulnerability['severity'].title()
     # TODO: some seem to not have anything. Needs UNKNOWN new status in the model. Some vuln do not yet have cvss assigned.
     else:
         severity = "Info"
@@ -65,7 +63,7 @@ def get_item(vulnerability, test):
         description=vulnerability['description'] + "<p> Vulnerable Package: " +
         vulnerability['packageName'] + "</p><p> Current Version: " + str(
             vulnerability['packageVersion']) + "</p>",
-        mitigation=status,
+        mitigation=status.title(),
         references=vulnerability['link'],
         active=False,
         verified=False,
@@ -73,7 +71,7 @@ def get_item(vulnerability, test):
         duplicate=False,
         out_of_scope=False,
         mitigated=None,
-        severity_justification="{}({})\n\n{}".format(vector, cvss, riskFactors),
+        severity_justification="{} (CVSS v3 base score: {})\n\n{}".format(vector, cvss, riskFactors),
         impact=severity)
 
     finding.description = finding.description.strip()


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2. Please submit your pull requests to the 'python3_dev' branch as the 'dev' branch is only for bug fixes. Any PR's submitted to the 'dev' branch should also be converted to Python3 and submited to the 'python3_dev' branch. 

Fixes #1302 

Added minor cosmetic changes as well. Tested locally.

> Merging against `dev` which is now the python3 one, if I am not mistaken.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
