### PR TITLE
Disable the 'push to jira' checkbox prevent accidental overwrite

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1768,7 +1768,7 @@ class JIRAFindingForm(forms.Form):
     def __init__(self, *args, **kwargs):
         self.enabled = kwargs.pop('enabled')
         super(JIRAFindingForm, self).__init__(*args, **kwargs)
-        self.fields['push_to_jira'] = forms.BooleanField(initial=self.enabled)
+        self.fields['push_to_jira'] = forms.BooleanField()
         self.fields['push_to_jira'].required = False
 
     push_to_jira = forms.BooleanField(required=False)

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1770,5 +1770,6 @@ class JIRAFindingForm(forms.Form):
         super(JIRAFindingForm, self).__init__(*args, **kwargs)
         self.fields['push_to_jira'] = forms.BooleanField()
         self.fields['push_to_jira'].required = False
+        self.fields['push_to_jira'].help_text = "Checking this will overwrite content of your JIRA issue, or create one."
 
     push_to_jira = forms.BooleanField(required=False)


### PR DESCRIPTION
Disable the 'push to jira' checkbox, as to prevent accidental override in jira.

For example, a user enters the relationship through the `jira_finding_mappings` endpoint (v2). This offers a little safeguard without moving much of the code, especially if several users review and are not necessarily aware of the inner workings (most of them).

Ideally, a little "?" should be put next to the checkbox to warn about the potential risk.

@aaronweaver @valentijnscholten could this be something intermediate while waiting for a proper implementation of #1040 ?

**Note: DefectDojo is now on Python3 and Django 2.2. Please submit your pull requests to the 'python3_dev' branch as the 'dev' branch is only for bug fixes. Any PR's submitted to the 'dev' branch should also be converted to Python3 and submited to the 'python3_dev' branch. 

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
