### PR TITLE
fix a naive datetime for Finding.mitigated

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -8,6 +8,7 @@ from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools.factory import import_parser_factory
 from dojo.utils import create_notification
 from django.core.validators import URLValidator, validate_ipv46_address
+from django.conf import settings
 from django.urls import reverse
 from rest_framework import serializers
 from django.core.exceptions import ValidationError
@@ -653,6 +654,10 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 old_finding.mitigated = datetime.datetime.combine(
                     test.target_start,
                     timezone.now().time())
+                if settings.USE_TZ:
+                   old_finding.mitigated = timezone.make_aware(
+                        old_finding.mitigated,
+                        timezone.get_default_timezone()) 
                 old_finding.mitigated_by = self.context['request'].user
                 old_finding.notes.create(author=self.context['request'].user,
                                          entry="This finding has been automatically closed"
@@ -808,6 +813,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 finding.mitigated = datetime.datetime.combine(
                     scan_date,
                     timezone.now().time())
+                if settings.USE_TZ:
+                    finding.mitigated = timezone.make_aware(
+                        finding.mitigated,
+                        timezone.get_default_timezone())
                 finding.mitigated_by = self.context['request'].user
                 finding.active = False
                 finding.save()

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -655,9 +655,9 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     test.target_start,
                     timezone.now().time())
                 if settings.USE_TZ:
-                   old_finding.mitigated = timezone.make_aware(
+                    old_finding.mitigated = timezone.make_aware(
                         old_finding.mitigated,
-                        timezone.get_default_timezone()) 
+                        timezone.get_default_timezone())
                 old_finding.mitigated_by = self.context['request'].user
                 old_finding.notes.create(author=self.context['request'].user,
                                          entry="This finding has been automatically closed"


### PR DESCRIPTION


This merge request will fix the following Warning when mitigation performed by an api_v2 request:
![image](https://user-images.githubusercontent.com/657615/60499761-c341c780-9cc1-11e9-978b-46c19553d86d.png)


**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.