### PR TITLE
API ImportScan Fix

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1463,7 +1463,8 @@ class ImportScanResource(MultipartResource, Resource):
         t.tags = bundle.data['tags']
 
         try:
-            parser = import_parser_factory(bundle.data['file'], t, True, True, bundle.data['scan_type'])
+            parser = import_parser_factory(bundle.data['file'], t, bundle.data['active'], bundle.data['verified'],
+                                           bundle.data['scan_type'])
         except ValueError:
             raise NotFound("Parser ValueError")
 
@@ -1645,7 +1646,7 @@ class ReImportScanResource(MultipartResource, Resource):
         active = bundle.obj.__getattr__('active')
 
         try:
-            parser = import_parser_factory(bundle.data['file'], test, True, True, scan_type)
+            parser = import_parser_factory(bundle.data['file'], test, active, verified, scan_type)
         except ValueError:
             raise NotFound("Parser ValueError")
 

--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1463,7 +1463,7 @@ class ImportScanResource(MultipartResource, Resource):
         t.tags = bundle.data['tags']
 
         try:
-            parser = import_parser_factory(bundle.data['file'], t, bundle.data['scan_type'])
+            parser = import_parser_factory(bundle.data['file'], t, True, True, bundle.data['scan_type'])
         except ValueError:
             raise NotFound("Parser ValueError")
 
@@ -1645,7 +1645,7 @@ class ReImportScanResource(MultipartResource, Resource):
         active = bundle.obj.__getattr__('active')
 
         try:
-            parser = import_parser_factory(bundle.data['file'], test, scan_type)
+            parser = import_parser_factory(bundle.data['file'], test, True, True, scan_type)
         except ValueError:
             raise NotFound("Parser ValueError")
 


### PR DESCRIPTION
This is a fix for the API ImportScan. Added True for the active and verified of the import parser factory calls. The two checks correspond to whether or not the user trusts the 'Active' and 'Verified' columns of a generic findings import file.