### PR TITLE
Fix scan date when reuploading scans

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -760,7 +760,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     new_items.append(finding)
                 else:
                     item.test = test
-                    item.date = test.target_start
+                    item.date = scan_date
                     item.reporter = self.context['request'].user
                     item.last_reviewed = timezone.now()
                     item.last_reviewed_by = self.context['request'].user

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -545,7 +545,7 @@ def re_import_scan_results(request, tid):
                         new_items.append(find.id)
                     else:
                         item.test = t
-                        item.date = t.target_start
+                        item.date = scan_date
                         item.reporter = request.user
                         item.last_reviewed = timezone.now()
                         item.last_reviewed_by = request.user


### PR DESCRIPTION
Use the scan date in findings during a reupload instead of the date from the test. In a finding you want to know when the finding was found and not when the test started.
(on behalf of DB Systel GmbH)

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
