### PR TITLE
Fix python3 migration issue #1287

### DIFF
--- a/dojo/db_migrations/0001_initial.py
+++ b/dojo/db_migrations/0001_initial.py
@@ -722,7 +722,7 @@ class Migration(migrations.Migration):
                 ('enable_product_grade', models.BooleanField(default=False, help_text='Displays a grade letter next to a product to show the overall health.', verbose_name='Enable Product Grading')),
                 ('product_grade', models.CharField(blank=True, max_length=800)),
                 ('product_grade_a', models.IntegerField(default=90, help_text=b"Percentage score for an 'A' >=", verbose_name='Grade A')),
-                ('product_grade_', models.IntegerField(default=80, help_text=b"Percentage score for a '' >=", verbose_name='Grade ')),
+                ('product_grade_b', models.IntegerField(default=80, help_text=b"Percentage score for a '' >=", verbose_name='Grade ')),
                 ('product_grade_c', models.IntegerField(default=70, help_text=b"Percentage score for a 'C' >=", verbose_name='Grade C')),
                 ('product_grade_d', models.IntegerField(default=60, help_text=b"Percentage score for a 'D' >=", verbose_name='Grade D')),
                 ('product_grade_f', models.IntegerField(default=59, help_text=b"Percentage score for an 'F' <=", verbose_name='Grade F')),

--- a/dojo/db_migrations/0006_django2_upgrade.py
+++ b/dojo/db_migrations/0006_django2_upgrade.py
@@ -158,7 +158,7 @@ class Migration(migrations.Migration):
             name='product_grade_a',
             field=models.IntegerField(default=90, help_text="Percentage score for an 'A' >=", verbose_name='Grade A'),
         ),
-				migrations.AlterField(
+	migrations.AlterField(
             model_name='system_settings',
             name='product_grade_b',
             field=models.IntegerField(default=80, help_text="Percentage score for a 'B' >=", verbose_name='Grade B'),

--- a/dojo/db_migrations/0006_django2_upgrade.py
+++ b/dojo/db_migrations/0006_django2_upgrade.py
@@ -158,7 +158,7 @@ class Migration(migrations.Migration):
             name='product_grade_a',
             field=models.IntegerField(default=90, help_text="Percentage score for an 'A' >=", verbose_name='Grade A'),
         ),
-	migrations.AlterField(
+        migrations.AlterField(
             model_name='system_settings',
             name='product_grade_b',
             field=models.IntegerField(default=80, help_text="Percentage score for a 'B' >=", verbose_name='Grade B'),

--- a/dojo/db_migrations/0006_django2_upgrade.py
+++ b/dojo/db_migrations/0006_django2_upgrade.py
@@ -13,15 +13,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='system_settings',
-            name='product_grade_',
-        ),
-        migrations.AddField(
-            model_name='system_settings',
-            name='product_grade_b',
-            field=models.IntegerField(default=80, help_text="Percentage score for a 'B' >=", verbose_name='Grade B'),
-        ),
         migrations.AlterField(
             model_name='child_rule',
             name='match_field',
@@ -166,6 +157,11 @@ class Migration(migrations.Migration):
             model_name='system_settings',
             name='product_grade_a',
             field=models.IntegerField(default=90, help_text="Percentage score for an 'A' >=", verbose_name='Grade A'),
+        ),
+				migrations.AlterField(
+            model_name='system_settings',
+            name='product_grade_b',
+            field=models.IntegerField(default=80, help_text="Percentage score for a 'B' >=", verbose_name='Grade B'),
         ),
         migrations.AlterField(
             model_name='system_settings',


### PR DESCRIPTION
Related to #1287

During the python3 migration 'product_grade_b'  was accidentally renamed to 'product_grade_'. This PR reverts the renaming.

This PR may break current installation which are based on the dev branch (python3) but makes the current branch compatible with installations which are based on the master branch. 

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
