### PR TITLE
Fix DefectDojo build caused by Python3 docker update

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -34,6 +34,7 @@ RUN \
     libtiff5 \
     dnsutils \
     default-mysql-client \
+    libmariadb3 \
     xmlsec1 \
     git \
     # only required for the dbshell (used by the initializer job)

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -10,7 +10,7 @@ RUN \
   apt-get -y update && \
   apt-get -y install \
     dnsutils \
-    mysql-client \
+    default-mysql-client \
     postgresql-client \
     xmlsec1 \
     git \
@@ -33,8 +33,7 @@ RUN \
     libjpeg62 \
     libtiff5 \
     dnsutils \
-    mysql-client \
-    libmariadbclient18 \
+    default-mysql-client \
     xmlsec1 \
     git \
     # only required for the dbshell (used by the initializer job)

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -9,7 +9,7 @@ RUN \
   apt-get -y update && \
   apt-get -y install \
     dnsutils \
-    mysql-client \
+    default-mysql-client \
     postgresql-client \
     xmlsec1 \
     git \


### PR DESCRIPTION
The python3 docker image was updated to debian buster (https://github.com/docker-library/python/commit/2a11f610a56ff3c0f0157790dde940894fad7a1a). This breaks the current docker build, so we have to update/rename some packages.

---
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
