### PR TITLE
 Modify alert url to be compatible with any host/domain

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -413,8 +413,7 @@ def add_tests(request, eid):
                 title=new_test.test_type.name + " for " + eng.product.name,
                 test=new_test,
                 engagement=eng,
-                url=request.build_absolute_uri(
-                    reverse('view_engagement', args=(eng.id, ))))
+                url=reverse('view_engagement', args=(eng.id, )))
 
             if '_Add Another Test' in request.POST:
                 return HttpResponseRedirect(
@@ -599,8 +598,7 @@ def import_scan_results(request, eid=None, pid=None):
                     finding_count=finding_count,
                     test=t,
                     engagement=engagement,
-                    url=request.build_absolute_uri(
-                        reverse('view_test', args=(t.id, ))))
+                    url=reverse('view_test', args=(t.id, )))
 
                 return HttpResponseRedirect(
                     reverse('view_test', args=(t.id, )))

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -673,7 +673,7 @@ def request_finding_review(request, fid):
                                 title='Finding review requested',
                                 description='User %s has requested that you please review the finding "%s" for accuracy:\n\n%s' % (user, finding.title, new_note),
                                 icon='check',
-                                url=request.build_absolute_uri(reverse("view_finding", args=(finding.id,))))
+                                url=request.reverse("view_finding", args=(finding.id,)))
 
             messages.add_message(
                 request,

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -673,7 +673,7 @@ def request_finding_review(request, fid):
                                 title='Finding review requested',
                                 description='User %s has requested that you please review the finding "%s" for accuracy:\n\n%s' % (user, finding.title, new_note),
                                 icon='check',
-                                url=request.reverse("view_finding", args=(finding.id,)))
+                                url=reverse("view_finding", args=(finding.id,)))
 
             messages.add_message(
                 request,

--- a/dojo/object/parser.py
+++ b/dojo/object/parser.py
@@ -102,7 +102,7 @@ def import_object_eng(request, engagement, json_data):
 
     # Create the notification
     if create_alert:
-        create_notification(event='code_review', title='Manual Code Review Requested', description="Manual code review requested as tracked file changes were found in the latest build.", engagement=engagement, url=request.build_absolute_uri(reverse('view_object_eng', args=(engagement.id,))))
+        create_notification(event='code_review', title='Manual Code Review Requested', description="Manual code review requested as tracked file changes were found in the latest build.", engagement=engagement, url=reverse('view_object_eng', args=(engagement.id,)))
 
     # Create the test within the engagement
     if create_test_code_review:

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -454,7 +454,7 @@ def new_product(request):
                                                 messages.SUCCESS,
                                                 'JIRA information added successfully.',
                                                 extra_tags='alert-success')
-            create_notification(event='product_added', title=product.name, url=request.build_absolute_uri(reverse('view_product', args=(product.id,))))
+            create_notification(event='product_added', title=product.name, url=reverse('view_product', args=(product.id,)))
             return HttpResponseRedirect(reverse('view_product', args=(product.id,)))
     else:
         form = ProductForm()
@@ -632,7 +632,7 @@ def new_eng_for_app(request, pid, cicd=False):
                                  'Engagement added successfully.',
                                  extra_tags='alert-success')
 
-            create_notification(event='engagement_added', title=new_eng.name + " for " + prod.name, engagement=new_eng, url=request.build_absolute_uri(reverse('view_engagement', args=(new_eng.id,))), objowner=new_eng.lead)
+            create_notification(event='engagement_added', title=new_eng.name + " for " + prod.name, engagement=new_eng, url=reverse('view_engagement', args=(new_eng.id,)), objowner=new_eng.lead)
 
             if "_Add Tests" in request.POST:
                 return HttpResponseRedirect(reverse('add_tests', args=(new_eng.id,)))

--- a/dojo/templates/dojo/alerts.html
+++ b/dojo/templates/dojo/alerts.html
@@ -37,6 +37,9 @@
                 </div>
                 <button class="btn btn-primary pull-right" type="submit">Remove selected</button>
             </form>
+            <form method="get" action="{% url 'migrate_alerts' %}">
+                <button class="btn btn-primary pull-left" type="submit">Migrate Alerts</button>
+            </form>
         </div>
         <div class="col-md-12">
             <div class="clearfix">

--- a/dojo/templates/dojo/migrate_alerts.html
+++ b/dojo/templates/dojo/migrate_alerts.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block content %}
+    <h3> Migrate All alerts {{ product }}</h3>
+    <p>
+        Migrating all alerts will strip the alerts current url of everything but the path.
+    </p>
+    <div class="danger-zone panel panel-danger">
+        <div class="panel-heading">
+            <h3>Danger Zone</h3>
+        </div>
+
+        <form class="form-horizontal" method="post">
+            {% csrf_token %}
+            {{ form }}
+
+            <div class="form-group">
+                <button class="btn btn-danger" type="submit" name="migrate_name" value="migrate_alert">Migrate Alerts</button>
+            </div>
+        </form>
+    </div>
+    <br/>
+    <br/>
+{% endblock %}

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -631,7 +631,7 @@ def re_import_scan_results(request, tid):
                                                                  'mitigated') + '. Please manually verify each one.',
                                          extra_tags='alert-success')
 
-                create_notification(event='results_added', title=str(finding_count) + " findings for " + engagement.product.name, finding_count=finding_count, test=t, engagement=engagement, url=request.build_absolute_uri(reverse('view_test', args=(t.id,))))
+                create_notification(event='results_added', title=str(finding_count) + " findings for " + engagement.product.name, finding_count=finding_count, test=t, engagement=engagement, url=reverse('view_test', args=(t.id,)))
 
                 return HttpResponseRedirect(reverse('view_test', args=(t.id,)))
             except SyntaxError:

--- a/dojo/user/urls.py
+++ b/dojo/user/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
     url(r'^alerts$', views.alerts, name='alerts'),
     url(r'^alerts/json$', views.alerts_json, name='alerts_json'),
     url(r'^alerts/count$', views.alertcount, name='alertcount'),
+    url(r'^delete_alerts$', views.delete_alerts, name='delete_alerts'),
+    url(r'^migrate_alerts$', views.migrate_alerts, name='migrate_alerts'),
     url(r'^profile$', views.view_profile, name='view_profile'),
     url(r'^change_password$', views.change_password,
         name='change_password'),
@@ -24,5 +26,4 @@ urlpatterns = [
         name='delete_user'),
     url(r'^api/key$', views.api_key, name='api_key'),
     url(r'^api/key-v2$', views.api_v2_key, name='api_v2_key'),
-    url(r'^delete_alerts$', views.delete_alerts, name='delete_alerts'),
 ]

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -125,6 +125,47 @@ def alerts(request):
                   {'alerts': paged_alerts})
 
 
+def delete_alerts(request):
+    alerts = Alerts.objects.filter(user_id=request.user)
+
+    if request.method == 'POST':
+        removed_alerts = request.POST.getlist('alert_select')
+        alerts.filter().delete()
+        messages.add_message(request,
+                                        messages.SUCCESS,
+                                        'Alerts removed.',
+                                        extra_tags='alert-success')
+        return HttpResponseRedirect('alerts')
+
+    return render(request,
+                    'dojo/delete_alerts.html',
+                    {'alerts': alerts})
+
+
+def migrate_alerts(request):
+    alerts = Alerts.objects.filter(user_id=request.user)
+    dojo_types = ['engagement', 'test', 'product', 'finding']
+
+    if request.method == 'POST':
+        for alert in alerts:
+            url = alert.url
+            split_url = url.split('/')
+            item = set(dojo_types).intersection(split_url)
+            new_url = url[url.index(next(iter(item))) - 1:]
+            alert.url = new_url
+            alert.save()
+
+        messages.add_message(request,
+                                        messages.SUCCESS,
+                                        'Alerts migrated.',
+                                        extra_tags='alert-success')
+        return HttpResponseRedirect('alerts')
+
+    return render(request,
+                    'dojo/migrate_alerts.html',
+                    {'alerts': alerts})
+
+
 def alerts_json(request, limit=None):
     limit = request.GET.get('limit')
     if limit:
@@ -311,23 +352,6 @@ def edit_user(request, uid):
         'form': form,
         'contact_form': contact_form,
         'to_edit': user})
-
-
-def delete_alerts(request):
-    alerts = Alerts.objects.filter(user_id=request.user)
-
-    if request.method == 'POST':
-        removed_alerts = request.POST.getlist('alert_select')
-        alerts.filter().delete()
-        messages.add_message(request,
-                                        messages.SUCCESS,
-                                        'Alerts removed.',
-                                        extra_tags='alert-success')
-        return HttpResponseRedirect('alerts')
-
-    return render(request,
-                    'dojo/delete_alerts.html',
-                    {'alerts': alerts})
 
 
 @user_passes_test(lambda u: u.is_superuser)

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -30,7 +30,7 @@ class FindingTest(unittest.TestCase):
         # Allow a little time for the driver to initialize
         self.driver.implicitly_wait(30)
         # Set the base address of the dojo
-        self.base_url = "http://localhost:8080/"
+        self.base_url = "http://localhost:8000/"
         self.verificationErrors = []
         self.accept_next_alert = True
 

--- a/tests/Import_scanner_unit_test.py
+++ b/tests/Import_scanner_unit_test.py
@@ -32,11 +32,9 @@ class ScannerTest(unittest.TestCase):
         self.verificationErrors = []
         self.accept_next_alert = True
         self.repo_path = dir_path + '/scans'
-        try:
-            os.mkdir('scans')
-        except:
-            shutil.rmtree('scans')
-            os.mkdir('scans')
+        if os.path.isdir(self.repo_path):
+            shutil.rmtree(self.repo_path)
+        os.mkdir(self.repo_path)
         scan_types = git.Repo.clone_from('https://github.com/DefectDojo/sample-scan-files', self.repo_path)
         self.remove_items = ['__init__.py', '__init__.pyc', 'factory.py', 'factory.pyc',
                         'factory.py', 'LICENSE', 'README.md', '.gitignore', '.git', '__pycache__']
@@ -315,7 +313,7 @@ class ScannerTest(unittest.TestCase):
     def tearDown(self):
         self.driver.quit()
         self.assertEqual([], self.verificationErrors)
-        shutil.rmtree('scans')
+        shutil.rmtree(self.repo_path)
 
 
 def suite():


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Modifications motivated by issue #1314 

If data is imported from another instance, the domains found in the url field of an alert will most likely not match. After importing, run the alert migration process found at /migrate_alerts to strip the domain from each alert. They will be compatible with any instance after that. In addition to the conversion, all alerts made from here forward will have the relative path of the object referenced in the url field.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
