### PR TITLE
Refractor deduplication and implement with django signals

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1703,7 +1703,7 @@ class ReImportScanResource(MultipartResource, Resource):
                     item.last_reviewed_by = bundle.request.user
                     item.verified = verified
                     item.active = active
-                    item.save()
+                    item.save(dedupe_option=False)
                     finding_added_count += 1
                     new_items.append(item.id)
                     find = item
@@ -1737,6 +1737,7 @@ class ReImportScanResource(MultipartResource, Resource):
 
                     if item.unsaved_tags is not None:
                         find.tags = item.unsaved_tags
+                find.save()
             # calculate the difference
             to_mitigate = set(original_items) - set(new_items)
             for finding_id in to_mitigate:

--- a/dojo/db_migrations/0009_endpoint_remediation.py
+++ b/dojo/db_migrations/0009_endpoint_remediation.py
@@ -15,4 +15,9 @@ class Migration(migrations.Migration):
             name='remediated',
             field=models.BooleanField(blank=True, default=False),
         ),
+        migrations.AlterField(
+            model_name='finding',
+            name='dynamic_finding',
+            field=models.BooleanField(default=True),
+        ),
     ]

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -23,6 +23,7 @@ from tagging.registry import register as tag_register
 from multiselectfield import MultiSelectField
 from django import forms
 from django.utils.translation import gettext as _
+from dojo.signals import dedupe_signal
 
 fmt = getattr(settings, 'LOG_FORMAT', None)
 lvl = getattr(settings, 'LOG_LEVEL', logging.DEBUG)
@@ -1008,6 +1009,18 @@ class Endpoint(models.Model):
         else:
             return self.host
 
+    @property
+    def host_with_port(self):
+        host = self.host
+        port = self.port
+        scheme = self.protocol
+        if ":" in host:
+            return host
+        elif (port is None) and (scheme == "https"):
+            return host + ':443'
+        elif (port is None) and (scheme == "http"):
+            return host + ':80'
+
 
 class NoteHistory(models.Model):
     data = models.TextField()
@@ -1172,7 +1185,7 @@ class Finding(models.Model):
     file_path = models.CharField(null=True, blank=True, max_length=1000)
     found_by = models.ManyToManyField(Test_Type, editable=False)
     static_finding = models.BooleanField(default=False)
-    dynamic_finding = models.BooleanField(default=False)
+    dynamic_finding = models.BooleanField(default=True)
     created = models.DateTimeField(auto_now_add=True, null=True)
     scanner_confidence = models.IntegerField(null=True, blank=True, default=None, editable=False, help_text="Confidence level of vulnerability which is supplied by the scannner.")
 
@@ -1184,11 +1197,14 @@ class Finding(models.Model):
 
     def compute_hash_code(self):
         hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + self.description
-
         if self.dynamic_finding:
             endpoint_str = ''
-            for e in self.endpoints.all():
-                endpoint_str += str(e)
+            if len(self.unsaved_endpoints) > 0 and self.id is None:
+                for e in self.unsaved_endpoints:
+                    endpoint_str += str(e.host_with_port)
+            else:
+                for e in self.endpoints.all():
+                    endpoint_str += str(e.host_with_port)
             if endpoint_str:
                 hash_string = hash_string + endpoint_str
         try:
@@ -1343,17 +1359,20 @@ class Finding(models.Model):
             super(Finding, self).save(*args, **kwargs)
         else:
             super(Finding, self).save(*args, **kwargs)
+
+        if (self.line is not None and self.file_path is not None) and (self.endpoints.count() == 0):
+            self.static_finding = True
+            self.dynamic_finding = False
+        elif (self.line is not None and self.file_path is not None):
+            self.static_finding = True
+
         # Compute hash code before dedupe
-        if self.hash_code is None:
-            self.hash_code = self.compute_hash_code()
+        if (self.hash_code is None):
+            if((self.dynamic_finding and (self.endpoints.count() > 0)) or
+                    (self.static_finding and (self.line is not None and self.file_path is not None))):
+                self.hash_code = self.compute_hash_code()
         self.found_by.add(self.test.test_type)
-        if self.test.test_type.static_tool and self.test.test_type.dynamic_tool:
-            self.static_finding = True
-            self.dynamic_finding = True
-        elif self.test.test_type.static_tool:
-            self.static_finding = True
-        elif self.test.test_type.dynamic_tool:
-            self.dynamic_finding = True
+
         if rules_option:
             from dojo.tasks import async_rules
             from dojo.utils import sync_rules
@@ -1371,13 +1390,12 @@ class Finding(models.Model):
         self.numerical_severity = Finding.get_numerical_severity(self.severity)
         super(Finding, self).save()
         system_settings = System_Settings.objects.get()
-        if (dedupe_option):
+        if dedupe_option and self.hash_code is not None:
             if system_settings.enable_deduplication:
                 from dojo.tasks import async_dedupe
-                from dojo.utils import sync_dedupe
                 try:
                     if self.reporter.usercontactinfo.block_execution:
-                        sync_dedupe(self, *args, **kwargs)
+                        dedupe_signal.send(sender=self.__class__, new_finding=self)
                     else:
                         async_dedupe.delay(self, *args, **kwargs)
                 except:

--- a/dojo/signals.py
+++ b/dojo/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+dedupe_signal = Signal(providing_args=["new_finding"])

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -10,10 +10,11 @@ from celery.utils.log import get_task_logger
 from celery.decorators import task
 from dojo.models import Product, Finding, Engagement, System_Settings
 from django.utils import timezone
+from dojo.signals import dedupe_signal
 
 import pdfkit
 from dojo.celery import app
-from dojo.utils import sync_dedupe, sync_false_history, calculate_grade
+from dojo.utils import sync_false_history, calculate_grade
 from dojo.reports.widgets import report_widget_factory
 from dojo.utils import add_comment, add_epic, add_issue, update_epic, update_issue, \
                        close_epic, create_notification, sync_rules
@@ -260,7 +261,7 @@ def add_comment_task(find, note):
 @app.task(name='async_dedupe')
 def async_dedupe(new_finding, *args, **kwargs):
     deduplicationLogger.debug("running deduplication")
-    sync_dedupe(new_finding, *args, **kwargs)
+    dedupe_signal.send(sender=new_finding.__class__, new_finding=new_finding)
 
 
 @app.task(name='applying rules')

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -551,7 +551,7 @@ def re_import_scan_results(request, tid):
                         item.last_reviewed_by = request.user
                         item.verified = verified
                         item.active = active
-                        item.save()
+                        item.save(dedupe_option=False)
                         finding_added_count += 1
                         new_items.append(item.id)
                         find = item
@@ -594,6 +594,7 @@ def re_import_scan_results(request, tid):
                         if item.unsaved_tags is not None:
                             find.tags = item.unsaved_tags
 
+                    find.save()
                 # calculate the difference
                 to_mitigate = set(original_items) - set(new_items)
                 for finding_id in to_mitigate:

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -24,9 +24,8 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from jira import JIRA
 from jira.exceptions import JIRAError
-# from django.dispatch import receiver
-# from django.core.signals import request_finished
-# from dojo.signals import dedupe_signal
+from django.dispatch import receiver
+from dojo.signals import dedupe_signal
 
 from dojo.models import Finding, Engagement, Finding_Template, Product, JIRA_PKey, JIRA_Issue, \
     Dojo_User, User, Alerts, System_Settings, Notifications, UserContactInfo, Endpoint, Benchmark_Type, \
@@ -80,146 +79,86 @@ def is_deduplication_on_engagement_mismatch(new_finding, to_duplicate_finding):
     return not new_finding.test.engagement.deduplication_on_engagement and to_duplicate_finding.test.engagement.deduplication_on_engagement
 
 
-# @receiver(dedupe_signal)
-def sync_dedupe(new_finding, *args, **kwargs):
-    # import sys
-    # system_settings = System_Settings.objects.get()
-    # if system_settings.enable_deduplication:
-    #     request_finished.connect(sync_dedupe, dispatch_uid="DefectDojo")
-    #     new_finding = kwargs['instance']
-    deduplicationLogger.debug('sync_dedupe for: ' + str(new_finding.id) +
-                 ":" + str(new_finding.title))
-    # sys.stderr.write('\n\nsync_dedupe for: ' + str(new_finding.id) +
-    #             " :: " + str(new_finding.title) + " :: " + str(new_finding.cwe) + '\n\n')
-    # ---------------------------------------------------------
-    # 1) Collects all the findings that have the same:
-    #      (title  and static_finding and dynamic_finding)
-    #      or (CWE and static_finding and dynamic_finding)
-    #    as the new one
-    #    (this is "cond1")
-    # ---------------------------------------------------------
-    if new_finding.test.engagement.deduplication_on_engagement:
-        # sys.stderr.write('Deduping on Engagements')
-        eng_findings_cwe = Finding.objects.filter(
-            test__engagement=new_finding.test.engagement,
-            cwe=new_finding.cwe).exclude(id=new_finding.id).exclude(cwe=0).exclude(duplicate=True)
-        eng_findings_title = Finding.objects.filter(
-            test__engagement=new_finding.test.engagement,
-            title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True)
-    else:
-        # sys.stderr.write('Deduping on Products')
-        eng_findings_cwe = Finding.objects.filter(
-            test__engagement__product=new_finding.test.engagement.product,
-            cwe=new_finding.cwe).exclude(id=new_finding.id).exclude(cwe=0).exclude(duplicate=True)
-        eng_findings_title = Finding.objects.filter(
-            test__engagement__product=new_finding.test.engagement.product,
-            title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True)
-
-    # prods = Finding.objects.filter(test__engagement__product=new_finding.test.engagement.product).exclude(id=new_finding.id).exclude(duplicate=True)
-    # sys.stderr.write("\n\nTotal Findings in object :: " + str(len(prods)) + '\n')
-    # for find in prods:
-    #     sys.stderr.write(str(find.id) + " :: " + find.title + " :: " + str(find.cwe) + "\n")
-    #     if find.title == new_finding.title and find.cwe == new_finding.cwe:
-    #         sys.stderr.write(" - MATCH")
-
-    # prod1 = prods.filter(title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True)
-    # sys.stderr.write("\n\nTotal Findings (Title) in object :: " + str(len(prod1)) + '\n')
-    # for find in prod1:
-    #     sys.stderr.write(str(find.id) + " :: " + find.title + " :: " + str(find.cwe) + "\n")
-    #     if find.title == new_finding.title and find.cwe == new_finding.cwe:
-    #         sys.stderr.write(" - MATCH")
-
-    # prod2 = prods.filter(title=new_finding.title, cwe=new_finding.cwe).exclude(id=new_finding.id).exclude(duplicate=True)
-    # sys.stderr.write("\n\nTotal Findings (Title, CWE) in object :: " + str(len(prod2)) + '\n')
-    # for find in prod2:
-    #     sys.stderr.write(str(find.id) + " :: " + find.title + " :: " + str(find.cwe) + "\n")
-    #     if find.title == new_finding.title and find.cwe == new_finding.cwe:
-    #         sys.stderr.write(" - MATCH")
-
-    # prod3 = Finding.objects.filter(static_finding=new_finding.static_finding, dynamic_finding=new_finding.dynamic_finding, cwe=new_finding.cwe, title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True)
-    # sys.stderr.write("\n\nTotal Findings (Static/Dynamic, CWE, Title) in object :: " + str(len(prod3)) + '\n')
-    # for find in prod3:
-    #     sys.stderr.write(str(find.id) + " :: " + find.title + " :: " + str(find.cwe) + "\n")
-    #     if find.title == new_finding.title and find.cwe == new_finding.cwe:
-    #         sys.stderr.write(" - MATCH")
-
-    # sys.stderr.write("\n\nCWE Findings in object :: " + str(len(eng_findings_cwe)) + '\n')
-    # for find in eng_findings_cwe:
-    #     sys.stderr.write(str(find.id) + " :: " + find.title + " :: " + str(find.cwe) + "\n")
-
-    # sys.stderr.write("\n\nTitle Findings in object :: " + str(len(eng_findings_title)) + '\n')
-    # for find in eng_findings_title:
-    #     sys.stderr.write(str(find.id) + " :: " + find.title + " :: " + str(find.cwe) + "\n")
-
-    total_findings = eng_findings_cwe | eng_findings_title
-
-    deduplicationLogger.debug("Found " +
-        str(len(eng_findings_cwe)) + " findings with same cwe, " +
-        str(len(eng_findings_title)) + " findings with same title: " +
-        str(len(total_findings)) + " findings with either same title or same cwe")
-
-    # sys.stderr.write("Found " +
-    #     str(len(eng_findings_cwe)) + " findings with same cwe, " +
-    #     str(len(eng_findings_title)) + " findings with same title: " +
-    #     str(len(total_findings)) + " findings with either same title or same cwe")
-    # total_findings = total_findings.order_by('date')
-
-    for find in total_findings:
-        flag_endpoints = False
-        flag_line_path = False
-        flag_hash = False
-        if is_deduplication_on_engagement_mismatch(new_finding, find):
-            deduplicationLogger.debug(
-                'deduplication_on_engagement_mismatch, skipping dedupe.')
-            # sys.stderr.write('deduplication_on_engagement_mismatch, skipping dedupe.')
-            continue
+@receiver(dedupe_signal, sender=Finding)
+def sync_dedupe(sender, *args, **kwargs):
+    system_settings = System_Settings.objects.get()
+    if system_settings.enable_deduplication:
+        new_finding = kwargs['new_finding']
+        deduplicationLogger.debug('sync_dedupe for: ' + str(new_finding.id) +
+                    ":" + str(new_finding.title))
         # ---------------------------------------------------------
-        # 2) If existing and new findings have endpoints: compare them all
-        #    Else look at line+file_path
-        #    (if new finding is not static, do not deduplicate)
+        # 1) Collects all the findings that have the same:
+        #      (title  and static_finding and dynamic_finding)
+        #      or (CWE and static_finding and dynamic_finding)
+        #    as the new one
+        #    (this is "cond1")
         # ---------------------------------------------------------
-        if find.endpoints.count() != 0 and new_finding.endpoints.count() != 0:
-            list1 = new_finding.endpoints.all()
-            list2 = find.endpoints.all()
-            if all(x in list1 for x in list2):
-                flag_endpoints = True
-                # sys.stderr.write("Endpoints match!")
-        elif new_finding.static_finding and len(new_finding.file_path) > 0:
-            if find.line == new_finding.line and find.file_path == new_finding.file_path:
-                flag_line_path = True
-                # sys.stderr.write("Line number and file path match!")
-            else:
-                deduplicationLogger.debug("no endpoints on one of the findings and file_path doesn't match")
-                # sys.stderr.write("no endpoints on one of the findings and file_path doesn't match")
-                # sys.stderr.write("old line# :: " + str(find.line) + "\told path :: " + str(find.file_path))
-                # sys.stderr.write("new line# :: " + str(new_finding.line) + "\tnew path :: " + str(new_finding.file_path))
+        if new_finding.test.engagement.deduplication_on_engagement:
+            eng_findings_cwe = Finding.objects.filter(
+                test__engagement=new_finding.test.engagement,
+                cwe=new_finding.cwe).exclude(id=new_finding.id).exclude(cwe=0).exclude(duplicate=True)
+            eng_findings_title = Finding.objects.filter(
+                test__engagement=new_finding.test.engagement,
+                title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True)
         else:
-            deduplicationLogger.debug("no endpoints on one of the findings and the new finding is either dynamic or doesn't have a file_path; Deduplication will not occur")
-        if find.hash_code == new_finding.hash_code:
-            flag_hash = True
-            # sys.stderr.write("Hashcodes match!")
-        # else:
-            # sys.stderr.write("old hash :: " + str(find.hash_code) + "\nnew hash :: " + str(new_finding.hash_code))
-        deduplicationLogger.debug(
-            'deduplication flags for new finding ' + str(new_finding.id) + ' and existing finding ' + str(find.id) +
-            ' flag_endpoints: ' + str(flag_endpoints) + ' flag_line_path:' + str(flag_line_path) + ' flag_hash:' + str(flag_hash))
-        # sys.stderr.write('deduplication flags for new finding ' + str(new_finding.id) + ' and existing finding ' + str(find.id) +
-        #     ' flag_endpoints: ' + str(flag_endpoints) + ' flag_line_path:' + str(flag_line_path) + ' flag_hash:' + str(flag_hash))
-        # ---------------------------------------------------------
-        # 3) Findings are duplicate if (cond1 is true) and they have the same:
-        #    hash
-        #    and (endpoints or (line and file_path)
-        # ---------------------------------------------------------
-        if ((flag_endpoints or flag_line_path) and flag_hash):
-            deduplicationLogger.debug('New finding ' + str(new_finding.id) + ' is a duplicate of existing finding ' + str(find.id))
-            # sys.stderr.write('New finding ' + str(new_finding.id) + ' is a duplicate of existing finding ' + str(find.id))
-            new_finding.duplicate = True
-            new_finding.active = False
-            new_finding.verified = False
-            new_finding.duplicate_finding = find
-            find.duplicate_list.add(new_finding)
-            find.found_by.add(new_finding.test.test_type)
-            super(Finding, new_finding).save(*args, **kwargs)
+            eng_findings_cwe = Finding.objects.filter(
+                test__engagement__product=new_finding.test.engagement.product,
+                cwe=new_finding.cwe).exclude(id=new_finding.id).exclude(cwe=0).exclude(duplicate=True)
+            eng_findings_title = Finding.objects.filter(
+                test__engagement__product=new_finding.test.engagement.product,
+                title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True)
+
+        total_findings = eng_findings_cwe | eng_findings_title
+        deduplicationLogger.debug("Found " +
+            str(len(eng_findings_cwe)) + " findings with same cwe, " +
+            str(len(eng_findings_title)) + " findings with same title: " +
+            str(len(total_findings)) + " findings with either same title or same cwe")
+
+        # total_findings = total_findings.order_by('date')
+        for find in total_findings:
+            flag_endpoints = False
+            flag_line_path = False
+            flag_hash = False
+            if is_deduplication_on_engagement_mismatch(new_finding, find):
+                deduplicationLogger.debug(
+                    'deduplication_on_engagement_mismatch, skipping dedupe.')
+                continue
+            # ---------------------------------------------------------
+            # 2) If existing and new findings have endpoints: compare them all
+            #    Else look at line+file_path
+            #    (if new finding is not static, do not deduplicate)
+            # ---------------------------------------------------------
+            if find.endpoints.count() != 0 and new_finding.endpoints.count() != 0:
+                list1 = [e.host_with_port for e in new_finding.endpoints.all()]
+                list2 = [e.host_with_port for e in find.endpoints.all()]
+                if all(x in list1 for x in list2):
+                    flag_endpoints = True
+            elif new_finding.static_finding and len(new_finding.file_path) > 0:
+                if str(find.line) == str(new_finding.line) and find.file_path == new_finding.file_path:
+                    flag_line_path = True
+                else:
+                    deduplicationLogger.debug("no endpoints on one of the findings and file_path doesn't match")
+            else:
+                deduplicationLogger.debug("no endpoints on one of the findings and the new finding is either dynamic or doesn't have a file_path; Deduplication will not occur")
+            if find.hash_code == new_finding.hash_code:
+                flag_hash = True
+            deduplicationLogger.debug(
+                'deduplication flags for new finding ' + str(new_finding.id) + ' and existing finding ' + str(find.id) +
+                ' flag_endpoints: ' + str(flag_endpoints) + ' flag_line_path:' + str(flag_line_path) + ' flag_hash:' + str(flag_hash))
+            # ---------------------------------------------------------
+            # 3) Findings are duplicate if (cond1 is true) and they have the same:
+            #    hash
+            #    and (endpoints or (line and file_path)
+            # ---------------------------------------------------------
+            if ((flag_endpoints or flag_line_path) and flag_hash):
+                deduplicationLogger.debug('New finding ' + str(new_finding.id) + ' is a duplicate of existing finding ' + str(find.id))
+                new_finding.duplicate = True
+                new_finding.active = False
+                new_finding.verified = False
+                new_finding.duplicate_finding = find
+                find.duplicate_list.add(new_finding)
+                find.found_by.add(new_finding.test.test_type)
+                super(Finding, new_finding).save()
 
 
 def sync_rules(new_finding, *args, **kwargs):

--- a/tests/dedupe_scans/dedupe_cross_1.csv
+++ b/tests/dedupe_scans/dedupe_cross_1.csv
@@ -1,4 +1,4 @@
 Date,Title,CweId,Url,Severity,Description,Mitigation,Impact,References,Active,Verified,FalsePositive,Duplicate
-01/30/2018,Matching title and Endpoints (DUPE),23,0.0.0.0,Critical,Test Description,,,,False,False,False,False
-01/30/2018,Matching title not Endpoints,23,1.1.1.1,Critical,Test Description,,,,False,False,False,False
-01/30/2018,Differing title and Endpoints,24,0.0.0.0,Critical,Test Description,,,,False,False,False,False
+01/30/2018,Matching title and Endpoints (DUPE),23,https://www.same.com/samesies,Critical,Test Description,,,,False,False,False,False
+01/30/2018,Matching title not Endpoints,23,https://www.weird.com/so-weird,Critical,Test Description,,,,False,False,False,False
+01/30/2018,Differing title and Endpoints,24,https://www.same.com/samesies,Critical,Test Description,,,,False,False,False,False

--- a/tests/dedupe_scans/dedupe_endpoint_1.xml
+++ b/tests/dedupe_scans/dedupe_endpoint_1.xml
@@ -10,7 +10,7 @@
 		<CVE-ID></CVE-ID>
 		<CVSSv3></CVSSv3>
 		<Risk>CRITICAL</Risk>
-		<URL>0.0.0.0</URL>
+		<URL>https://www.same.com/samesies</URL>
 		<Description>Test Description</Description>
 		<PoC></PoC>
 	</Vulnerability>
@@ -25,7 +25,7 @@
 		<CVE-ID></CVE-ID>
 		<CVSSv3></CVSSv3>
 		<Risk>CRITICAL</Risk>
-		<URL>0.0.0.0</URL>
+		<URL>https://www.same.com/samesies</URL>
 		<Description>Test Description</Description>
 		<PoC></PoC>
 	</Vulnerability>
@@ -40,7 +40,7 @@
 		<CVE-ID></CVE-ID>
 		<CVSSv3></CVSSv3>
 		<Risk>CRITICAL</Risk>
-		<URL>0.0.0.0</URL>
+		<URL>https://www.same.com/samesies</URL>
 		<Description>Test Description</Description>
 		<PoC></PoC>
 	</Vulnerability>

--- a/tests/dedupe_scans/dedupe_endpoint_2.xml
+++ b/tests/dedupe_scans/dedupe_endpoint_2.xml
@@ -10,7 +10,7 @@
 		<CVE-ID></CVE-ID>
 		<CVSSv3></CVSSv3>
 		<Risk>CRITICAL</Risk>
-		<URL>0.0.0.0</URL>
+		<URL>https://www.same.com/samesies</URL>
 		<Description>Test Description</Description>
 		<PoC></PoC>
 	</Vulnerability>
@@ -25,7 +25,7 @@
 		<CVE-ID></CVE-ID>
 		<CVSSv3></CVSSv3>
 		<Risk>CRITICAL</Risk>
-		<URL>1.1.1.1</URL>
+		<URL>https://www.weird.com/so-weird</URL>
 		<Description>Test Description</Description>
 		<PoC></PoC>
 	</Vulnerability>
@@ -40,7 +40,7 @@
 		<CVE-ID></CVE-ID>
 		<CVSSv3></CVSSv3>
 		<Risk>CRITICAL</Risk>
-		<URL>0.0.0.0</URL>
+		<URL>https://www.same.com/samesies</URL>
 		<Description>Test Description</Description>
 		<PoC></PoC>
 	</Vulnerability>

--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -329,24 +329,6 @@ class DedupeTest(unittest.TestCase):
                 dupe_count += 1
         self.assertEqual(dupe_count, 1)
 
-    def test_remove_blank_endpoints(self):
-        driver = self.login_page()
-        driver.get(self.base_url + "endpoint")
-        while True:
-            text = driver.find_element_by_tag_name("BODY").text
-            if 'No endpoints' in text:
-                return
-            else:
-                driver.find_element_by_id("select_all").click()
-                driver.find_element_by_css_selector("i.fa.fa-trash").click()
-                try:
-                    WebDriverWait(driver, 1).until(EC.alert_is_present(),
-                                                'Timed out waiting for PA creation ' +
-                                                'confirmation popup to appear.')
-                    driver.switch_to.alert.accept()
-                except TimeoutException:
-                    print("Alert did not show.")
-
     def tearDown(self):
         self.driver.quit()
         self.assertEqual([], self.verificationErrors)
@@ -377,7 +359,6 @@ def suite():
     suite.addTest(DedupeTest('test_import_cross_test'))
     suite.addTest(DedupeTest('test_check_cross_status'))
     # Clean up
-    suite.addTest(DedupeTest('test_remove_blank_endpoints'))
     suite.addTest(product_unit_test.ProductTest('test_delete_product'))
     return suite
 


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Deduplication has been heavily tested and tweaked to fit the the description found in the documentation. Major difference here is now new findings will default to being of type dynamic. This change was motivated as a tweak to deduplication to standardize how a finding will be declared as a duplicate. Too many factors were left as a responsibility of a scan parser.

A new finding will default to dynamic. If mentioned finding has a line number and path, but no endpoints, it will be defined as static instead. If at any time a finding has a line number, file path, and any number of endpoints, it will be declared as both static and dynamic. All of these checks take place when a finding is saved so that they may be updated without explicit command.
When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.
