### PR TITLE
Fix deprecated filter argument

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -333,7 +333,7 @@ class OpenFindingFilter(DojoFilter):
         queryset=Product.objects.all(),
         label="Product")
     if get_system_setting('enable_jira'):
-        jira_issue = BooleanFilter(name='jira_issue',
+        jira_issue = BooleanFilter(field_name='jira_issue',
                                    lookup_expr='isnull',
                                    exclude=True,
                                    label='JIRA issue')


### PR DESCRIPTION
When jira is enabled, accessing Findings view results in a 500 error due to finding filter uses a deprecated argument (name) instead new one (field_name). This PR fix this issue.

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
