### PR TITLE
Fix #1428: unit-tests not working in docker env

### DIFF
--- a/Dockerfile.busybox
+++ b/Dockerfile.busybox
@@ -1,0 +1,2 @@
+FROM busybox:1.31.0-musl
+ENTRYPOINT ["/bin/echo", "hello world"]

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -58,6 +58,7 @@ COPY \
   docker/entrypoint-uwsgi.sh \
   docker/entrypoint-uwsgi-dev.sh \
   docker/entrypoint-unit-tests.sh \
+  docker/entrypoint-unit-tests-devDocker.sh \
   docker/wait-for-it.sh \
   /
 COPY wsgi.py manage.py tests/unit-tests.sh ./

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -2,8 +2,8 @@
 version: '3.7'
 services:
   nginx:
-    image: hello-world
-    entrypoint: []
+    image: busybox:1.31
+    entrypoint: ["/bin/echo", "hello world"]
   uwsgi:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-unit-tests-devDocker.sh']
     volumes:

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -2,8 +2,10 @@
 version: '3.7'
 services:
   nginx:
-    image: busybox:1.31
-    entrypoint: ["/bin/echo", "hello world"]
+    build: 
+      context: ./
+      dockerfile: Dockerfile.busybox
+    image: defectdojo/defectdojo-busybox:${NGINX_VERSION:-latest}
   uwsgi:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-unit-tests-devDocker.sh']
     volumes:


### PR DESCRIPTION
The fix includes: 
- add docker/entrypoint-unit-tests-devDocker.sh entrypoint file in Dockerfile.django (merge error from python2 branch I guess)
- replace hello-world image by busybox with fixed version
  - for some reason the hello-world image wasn't working anymore with [] entrypoint. Maybe due to a change in the docker image itself. while looking for a solution i've found this busybox image which is also much smaller.
  - I have fixed the image version for more stability

The last issue remaining is those multiple occurences of errors 
```
celeryworker_1  | [2019-07-29 08:29:50,725: ERROR/MainProcess] Task dojo.tasks.async_dupe_delete[0ac89d26-4462-4440-81e1-ce0b6aac82b7] raised unexpected: DoesNotExist('System_Settings matching query does not exist.')
```

although it's not preventing the tests from running:
```
uwsgi_1         | Ran 242 tests in 55.058s
uwsgi_1         |
uwsgi_1         | OK (skipped=14)

```