### PR TITLE
fix #1431: checkmarx imports bytes instead of strings and add unit tests

### DIFF
--- a/dojo/tools/checkmarx/parser.py
+++ b/dojo/tools/checkmarx/parser.py
@@ -84,7 +84,7 @@ class CheckmarxXMLParser(object):
                                    mitigation=mitigation,
                                    impact=impact,
                                    references=references,
-                                   file_path=pathnode.find('FileName').text.encode('utf-8'),
+                                   file_path=pathnode.find('FileName').text,
                                    line=pathnode.find('Line').text,
                                    url='N/A',
                                    date=find_date,
@@ -108,22 +108,22 @@ class CheckmarxXMLParser(object):
                 if result_dupes_key not in self.result_dupes:
 
                     if pathnode.find('Line').text is not None:
-                        findingdetail = "{}**Line Number:** {}\n".format(findingdetail, pathnode.find('Line').text.encode('utf-8'))
+                        findingdetail = "{}**Line Number:** {}\n".format(findingdetail, pathnode.find('Line').text)
 
                     if pathnode.find('Column').text is not None:
-                        findingdetail = "{}**Column:** {}\n".format(findingdetail, pathnode.find('Column').text.encode('utf-8'))
+                        findingdetail = "{}**Column:** {}\n".format(findingdetail, pathnode.find('Column').text)
 
                     if pathnode.find('Name').text is not None:
-                        findingdetail = "{}**Source Object:** {}\n".format(findingdetail, pathnode.find('Name').text.encode('utf-8'))
+                        findingdetail = "{}**Source Object:** {}\n".format(findingdetail, pathnode.find('Name').text)
 
                     for codefragment in pathnode.findall('Snippet/Line'):
-                        findingdetail = "{}**Number:** {}\n**Code:** {}\n".format(findingdetail, codefragment.find('Number').text, codefragment.find('Code').text.encode('utf-8').strip())
+                        findingdetail = "{}**Number:** {}\n**Code:** {}\n".format(findingdetail, codefragment.find('Number').text, codefragment.find('Code').text.strip())
 
                     findingdetail = '{}-----\n'.format(findingdetail)
 
                 self.result_dupes[result_dupes_key] = True
 
-        if title and pathnode.find('FileName').text.encode('utf-8'):
-            title = "{} ({})".format(title, ntpath.basename(pathnode.find('FileName').text.encode('utf-8')))
+        if title and pathnode.find('FileName') != None:
+            title = "{} ({})".format(title, ntpath.basename(pathnode.find('FileName').text))
 
         return title, findingdetail, pathnode

--- a/dojo/tools/checkmarx/parser.py
+++ b/dojo/tools/checkmarx/parser.py
@@ -123,7 +123,7 @@ class CheckmarxXMLParser(object):
 
                 self.result_dupes[result_dupes_key] = True
 
-        if title and pathnode.find('FileName') != None:
+        if title and pathnode.find('FileName').text:
             title = "{} ({})".format(title, ntpath.basename(pathnode.find('FileName').text))
 
         return title, findingdetail, pathnode

--- a/dojo/unittests/test_apiv2_scan_import_options.py
+++ b/dojo/unittests/test_apiv2_scan_import_options.py
@@ -8,7 +8,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 class ScanImportOptionsTest(APITestCase):
     """
     Test the options `skip_duplicates` and `close_old_findings` for the scan
-    import APIv2 endpoint.
+    import APIv2 endpoint with ZAP
     """
     fixtures = ['dojo_testdata.json']
     EMPTY_ZAP_SCAN = """<?xml version="1.0"?>

--- a/dojo/unittests/test_checkmarx_parser.py
+++ b/dojo/unittests/test_checkmarx_parser.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from dojo.models import Test, Engagement, Product
 from dojo.tools.checkmarx.parser import CheckmarxXMLParser
+import datetime
 
 
 class TestCheckmarxParser(TestCase):
@@ -27,6 +28,103 @@ class TestCheckmarxParser(TestCase):
         self.parser = CheckmarxXMLParser(my_file_handle, test)
         my_file_handle.close()
         self.assertEqual(1, len(self.parser.items))
+        # check content
+        item = self.parser.items[0]
+        self.assertEqual(str, type(self.parser.items[0].title))
+        self.assertEqual("Stored XSS (Users.java)", item.title)
+        self.assertEqual(int, type(item.cwe))
+        self.assertEqual(79, item.cwe)
+        self.assertEqual(bool, type(item.active))
+        self.assertEqual(False, item.active)
+        self.assertEqual(bool, type(item.verified))
+        self.assertEqual(False, item.verified)
+        self.assertEqual(str, type(item.description))
+        self.assertMultiLineEqual("**Category:** PCI DSS v3.2;PCI DSS (3.2) - 6.5.7 - Cross-site scripting (XSS),OWASP Top 10 2013;A3-Cross-Site Scripting (XSS),FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-15 Information Output Filtering (P0),OWASP Top 10 2017;A7-Cross-Site Scripting (XSS)\n"
+            "**Language:** Java\n"
+            "**Group:** Java High Risk\n"
+            "**Status:** New\n"
+            "**Finding Link:** [https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&projectid=121&pathid=28](https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&projectid=121&pathid=28)\n"
+            "\n"
+            "**Line Number:** 39\n"
+            "**Column:** 59\n"
+            "**Source Object:** executeQuery\n"
+            "**Number:** 39\n"
+            "**Code:** ResultSet results = statement.executeQuery(query);\n"
+            "-----\n"
+            "**Line Number:** 39\n"
+            "**Column:** 27\n"
+            "**Source Object:** results\n"
+            "**Number:** 39\n"
+            "**Code:** ResultSet results = statement.executeQuery(query);\n"
+            "-----\n"
+            "**Line Number:** 46\n"
+            "**Column:** 28\n"
+            "**Source Object:** results\n"
+            "**Number:** 46\n"
+            "**Code:** while (results.next()) {\n"
+            "-----\n"
+            "**Line Number:** 47\n"
+            "**Column:** 34\n"
+            "**Source Object:** results\n"
+            "**Number:** 47\n"
+            "**Code:** int id = results.getInt(0);\n"
+            "-----\n"
+            "**Line Number:** 53\n"
+            "**Column:** 64\n"
+            "**Source Object:** getString\n"
+            "**Number:** 53\n"
+            "**Code:** userMap.put(\"cookie\", results.getString(5));\n"
+            "-----\n"
+            "**Line Number:** 53\n"
+            "**Column:** 36\n"
+            "**Source Object:** put\n"
+            "**Number:** 53\n"
+            "**Code:** userMap.put(\"cookie\", results.getString(5));\n"
+            "-----\n"
+            "**Line Number:** 54\n"
+            "**Column:** 25\n"
+            "**Source Object:** userMap\n"
+            "**Number:** 54\n"
+            "**Code:** userMap.put(\"loginCOunt\",Integer.toString(results.getInt(6)));\n"
+            "-----\n"
+            "**Line Number:** 55\n"
+            "**Column:** 44\n"
+            "**Source Object:** userMap\n"
+            "**Number:** 55\n"
+            "**Code:** allUsersMap.put(id,userMap);\n"
+            "-----\n"
+            "**Line Number:** 55\n"
+            "**Column:** 40\n"
+            "**Source Object:** put\n"
+            "**Number:** 55\n"
+            "**Code:** allUsersMap.put(id,userMap);\n"
+            "-----\n"
+            "**Line Number:** 58\n"
+            "**Column:** 28\n"
+            "**Source Object:** allUsersMap\n"
+            "**Number:** 58\n"
+            "**Code:** return allUsersMap;\n"
+            "-----\n",
+            item.description)
+        self.assertEqual(str, type(item.severity))
+        self.assertEqual("High", item.severity)
+        self.assertEqual(str, type(item.numerical_severity))
+        self.assertEqual("S1", item.numerical_severity)
+        self.assertEqual(str, type(item.mitigation))
+        self.assertEqual("N/A", item.mitigation)
+        self.assertEqual(str, type(item.references))
+        self.assertEqual("", item.references)
+        self.assertEqual(str, type(item.file_path))
+        self.assertEqual("WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java", item.file_path)
+        self.assertEqual(str, type(item.line))
+        self.assertEqual("58", item.line)
+        self.assertEqual(str, type(item.url))
+        self.assertEqual("N/A", item.url)
+        # ScanStart
+        self.assertEqual(datetime.datetime, type(item.date))
+        self.assertEqual(datetime.datetime(2018, 2, 25, 11, 35, 52), item.date)
+        self.assertEqual(bool, type(item.static_finding))
+        self.assertEqual(True, item.static_finding)
 
     def test_parse_file_with_multiple_vulnerabilities_has_multiple_findings(self):
         my_file_handle = open("dojo/unittests/scans/checkmarx/multiple_findings.xml")
@@ -50,6 +148,103 @@ class TestCheckmarxParser(TestCase):
         self.parser = CheckmarxXMLParser(my_file_handle, test)
         my_file_handle.close()
         self.assertEqual(1, len(self.parser.items))
+        # check content
+        item = self.parser.items[0]
+        self.assertEqual(str, type(self.parser.items[0].title))
+        self.assertEqual("Stored XSS (Users.java)", item.title)
+        self.assertEqual(int, type(item.cwe))
+        self.assertEqual(79, item.cwe)
+        self.assertEqual(bool, type(item.active))
+        self.assertEqual(False, item.active)
+        self.assertEqual(bool, type(item.verified))
+        self.assertEqual(False, item.verified)
+        self.assertEqual(str, type(item.description))
+        self.assertMultiLineEqual("**Category:** PCI DSS v3.2;PCI DSS (3.2) - 6.5.7 - Cross-site scripting (XSS),OWASP Top 10 2013;A3-Cross-Site Scripting (XSS),FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-15 Information Output Filtering (P0),OWASP Top 10 2017;A7-Cross-Site Scripting (XSS)\n"
+            "**Language:** Java\n"
+            "**Group:** Java High Risk\n"
+            "**Status:** New\n"
+            "**Finding Link:** [https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&projectid=121&pathid=28](https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&projectid=121&pathid=28)\n"
+            "\n"
+            "**Line Number:** 39\n"
+            "**Column:** 59\n"
+            "**Source Object:** executeQuery\n"
+            "**Number:** 39\n"
+            "**Code:** ResultSet results = statement.executeQuery(query);//�\n"
+            "-----\n"
+            "**Line Number:** 39\n"
+            "**Column:** 27\n"
+            "**Source Object:** results\n"
+            "**Number:** 39\n"
+            "**Code:** ResultSet results = statement.executeQuery(query);\n"
+            "-----\n"
+            "**Line Number:** 46\n"
+            "**Column:** 28\n"
+            "**Source Object:** results\n"
+            "**Number:** 46\n"
+            "**Code:** while (results.next()) {\n"
+            "-----\n"
+            "**Line Number:** 47\n"
+            "**Column:** 34\n"
+            "**Source Object:** results\n"
+            "**Number:** 47\n"
+            "**Code:** int id = results.getInt(0);\n"
+            "-----\n"
+            "**Line Number:** 53\n"
+            "**Column:** 64\n"
+            "**Source Object:** getString\n"
+            "**Number:** 53\n"
+            "**Code:** userMap.put(\"cookie\", results.getString(5));\n"
+            "-----\n"
+            "**Line Number:** 53\n"
+            "**Column:** 36\n"
+            "**Source Object:** put\n"
+            "**Number:** 53\n"
+            "**Code:** userMap.put(\"cookie\", results.getString(5));\n"
+            "-----\n"
+            "**Line Number:** 54\n"
+            "**Column:** 25\n"
+            "**Source Object:** userMap\n"
+            "**Number:** 54\n"
+            "**Code:** userMap.put(\"loginCOunt\",Integer.toString(results.getInt(6)));\n"
+            "-----\n"
+            "**Line Number:** 55\n"
+            "**Column:** 44\n"
+            "**Source Object:** userMap\n"
+            "**Number:** 55\n"
+            "**Code:** allUsersMap.put(id,userMap);\n"
+            "-----\n"
+            "**Line Number:** 55\n"
+            "**Column:** 40\n"
+            "**Source Object:** put\n"
+            "**Number:** 55\n"
+            "**Code:** allUsersMap.put(id,userMap);\n"
+            "-----\n"
+            "**Line Number:** 58\n"
+            "**Column:** 28\n"
+            "**Source Object:** allUsersMap\n"
+            "**Number:** 58\n"
+            "**Code:** return allUsersMap;\n"
+            "-----\n",
+            item.description)
+        self.assertEqual(str, type(item.severity))
+        self.assertEqual("High", item.severity)
+        self.assertEqual(str, type(item.numerical_severity))
+        self.assertEqual("S1", item.numerical_severity)
+        self.assertEqual(str, type(item.mitigation))
+        self.assertEqual("N/A", item.mitigation)
+        self.assertEqual(str, type(item.references))
+        self.assertEqual("", item.references)
+        self.assertEqual(str, type(item.file_path))
+        self.assertEqual("WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java", item.file_path)
+        self.assertEqual(str, type(item.line))
+        self.assertEqual("58", item.line)
+        self.assertEqual(str, type(item.url))
+        self.assertEqual("N/A", item.url)
+        # ScanStart
+        self.assertEqual(datetime.datetime, type(item.date))
+        self.assertEqual(datetime.datetime(2018, 2, 25, 11, 35, 52), item.date)
+        self.assertEqual(bool, type(item.static_finding))
+        self.assertEqual(True, item.static_finding)
 
     def test_parse_file_with_utf8_various_non_ascii_char(self):
         my_file_handle = open("dojo/unittests/scans/checkmarx/utf8_various_non_ascii_char.xml")
@@ -61,3 +256,100 @@ class TestCheckmarxParser(TestCase):
         self.parser = CheckmarxXMLParser(my_file_handle, test)
         my_file_handle.close()
         self.assertEqual(1, len(self.parser.items))
+        # check content
+        item = self.parser.items[0]
+        self.assertEqual(str, type(self.parser.items[0].title))
+        self.assertEqual("Stored XSS (Users.java)", item.title)
+        self.assertEqual(int, type(item.cwe))
+        self.assertEqual(79, item.cwe)
+        self.assertEqual(bool, type(item.active))
+        self.assertEqual(False, item.active)
+        self.assertEqual(bool, type(item.verified))
+        self.assertEqual(False, item.verified)
+        self.assertEqual(str, type(item.description))
+        self.assertMultiLineEqual("**Category:** PCI DSS v3.2;PCI DSS (3.2) - 6.5.7 - Cross-site scripting (XSS),OWASP Top 10 2013;A3-Cross-Site Scripting (XSS),FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-15 Information Output Filtering (P0),OWASP Top 10 2017;A7-Cross-Site Scripting (XSS)\n"
+            "**Language:** Java\n"
+            "**Group:** Java High Risk\n"
+            "**Status:** New\n"
+            "**Finding Link:** [https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&projectid=121&pathid=28](https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&projectid=121&pathid=28)\n"
+            "\n"
+            "**Line Number:** 39\n"
+            "**Column:** 59\n"
+            "**Source Object:** executeQuery\n"
+            "**Number:** 39\n"
+            "**Code:** ResultSet results = statement.executeQuery(query);\n"
+            "-----\n"
+            "**Line Number:** 39\n"
+            "**Column:** 27\n"
+            "**Source Object:** results\n"
+            "**Number:** 39\n"
+            "**Code:** ResultSet results = statement.executeQuery(query);//all latins non ascii with extended: U+00A1   to U+017F  (ref https://www.utf8-chartable.de/unicode-utf8-table.pl): ¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ\n"
+            "-----\n"
+            "**Line Number:** 46\n"
+            "**Column:** 28\n"
+            "**Source Object:** results\n"
+            "**Number:** 46\n"
+            "**Code:** while (results.next()) { // other: ƒ\n"
+            "-----\n"
+            "**Line Number:** 47\n"
+            "**Column:** 34\n"
+            "**Source Object:** results\n"
+            "**Number:** 47\n"
+            "**Code:** int id = results.getInt(0);\n"
+            "-----\n"
+            "**Line Number:** 53\n"
+            "**Column:** 64\n"
+            "**Source Object:** getString\n"
+            "**Number:** 53\n"
+            "**Code:** userMap.put(\"cookie\", results.getString(5));\n"
+            "-----\n"
+            "**Line Number:** 53\n"
+            "**Column:** 36\n"
+            "**Source Object:** put\n"
+            "**Number:** 53\n"
+            "**Code:** userMap.put(\"cookie\", results.getString(5));\n"
+            "-----\n"
+            "**Line Number:** 54\n"
+            "**Column:** 25\n"
+            "**Source Object:** userMap\n"
+            "**Number:** 54\n"
+            "**Code:** userMap.put(\"loginCOunt\",Integer.toString(results.getInt(6)));\n"
+            "-----\n"
+            "**Line Number:** 55\n"
+            "**Column:** 44\n"
+            "**Source Object:** userMap\n"
+            "**Number:** 55\n"
+            "**Code:** allUsersMap.put(id,userMap);\n"
+            "-----\n"
+            "**Line Number:** 55\n"
+            "**Column:** 40\n"
+            "**Source Object:** put\n"
+            "**Number:** 55\n"
+            "**Code:** allUsersMap.put(id,userMap);\n"
+            "-----\n"
+            "**Line Number:** 58\n"
+            "**Column:** 28\n"
+            "**Source Object:** allUsersMap\n"
+            "**Number:** 58\n"
+            "**Code:** return allUsersMap;\n"
+            "-----\n",
+            item.description)
+        self.assertEqual(str, type(item.severity))
+        self.assertEqual("High", item.severity)
+        self.assertEqual(str, type(item.numerical_severity))
+        self.assertEqual("S1", item.numerical_severity)
+        self.assertEqual(str, type(item.mitigation))
+        self.assertEqual("N/A", item.mitigation)
+        self.assertEqual(str, type(item.references))
+        self.assertEqual("", item.references)
+        self.assertEqual(str, type(item.file_path))
+        self.assertEqual("WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/¡¢£¤¥¦§¨©ª«¬®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ/Users.java", item.file_path)
+        self.assertEqual(str, type(item.line))
+        self.assertEqual("58", item.line)
+        self.assertEqual(str, type(item.url))
+        self.assertEqual("N/A", item.url)
+        # ScanStart
+        self.assertEqual(datetime.datetime, type(item.date))
+        self.assertEqual(datetime.datetime(2018, 2, 25, 11, 35, 52), item.date)
+        self.assertEqual(bool, type(item.static_finding))
+        self.assertEqual(True, item.static_finding)


### PR DESCRIPTION
Fixes https://github.com/DefectDojo/django-DefectDojo/issues/1431
- remove utf-8 conversions: they are not needed in python3 as strings are utf-8 by default and those "encode" calls return bytes instead of string (thus appearing as b'mystring' in the GUI)
- improve unit test : add content check, not only counts