### PR TITLE
Pin versions of external docker images for more stability

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,22 @@ executed as smoothly as possible. During this process, DefectDojo will also be
 upgraded to Django 2.2.1. Going forward, the 'dev' branch will only accept
 bug fixes, Please instead contribute features / bug fixes  to the ‘python3_dev’ branch.
 
+## Python3 version
+For compatibility reasons, the code in dev branch should be python3.5 compliant.
+
+## Logging
+Logging is configured in `settings.dist.py`.
+
+Specific logger can be added. For example to activate logs related to the deduplication, change the level from DEBUG to INFO in:
+
+```
+          'dojo.specific-loggers.deduplication': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        }
+```
+
 ## Submitting Pull Requests
 
 The following are things to consider before submitting a pull request to
@@ -40,7 +56,9 @@ DefectDojo.
 
 0. All submitted code should conform to [__PEP8 standards__][pep8].
 
-0. Pull requests should be submitted to the 'master' branch.
+0. Pull requests should be submitted to the 'dev' or 'legacy-python2.7' branch.
+
+0. In dev branch, the code should be python 3.5 compliant.
 
 [dojo_settings]: /dojo/settings/settings.dist.py "DefectDojo settings file"
 [setup_py]: /setup.py "Python setup script"

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -4,7 +4,7 @@
 # The code for the build image should be idendical with the code in
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
-FROM python:3 as build
+FROM python:3.7.4-buster@sha256:7dd57761929672e7c2c18348d257ed5148fc6a971a13cfd8a3d1d8573226a5c2 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \
@@ -21,7 +21,7 @@ RUN \
 COPY requirements.txt ./
 RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM python:3-slim
+FROM python:3.7.4-slim-buster@sha256:93cb70c52a4351871557f1daa6cfaf6081840804f3f69a3c55b291bd58f75793
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -4,7 +4,10 @@
 # The code for the build image should be idendical with the code in
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
-FROM python:3.7.4-buster@sha256:7dd57761929672e7c2c18348d257ed5148fc6a971a13cfd8a3d1d8573226a5c2 as build
+# Using 3.5.7 to avoid compatibility issues that may be introduced by python 3.5.6 and 3.5.7. 
+# Please upgrade before end-of-life in september 2020!
+# Ref: https://devguide.python.org/#branchstatus
+FROM python:3.5.7-buster@sha256:4598d4365bb7a8628ba840f87406323e699c4da01ae6f926ff33787c63230779 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \
@@ -21,7 +24,7 @@ RUN \
 COPY requirements.txt ./
 RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM python:3.7.4-slim-buster@sha256:93cb70c52a4351871557f1daa6cfaf6081840804f3f69a3c55b291bd58f75793
+FROM python:3.5.7-slim-buster@sha256:127fee645393d311c7fbc5e8c2e5034f10a4e66b47c9273d4dbe5da2926fc3f2
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -3,7 +3,7 @@
 # The code for the build image should be idendical with the code in
 # Dockerfile.django to use the caching mechanism of Docker.
 
-FROM python:3.7.4-buster@sha256:7dd57761929672e7c2c18348d257ed5148fc6a971a13cfd8a3d1d8573226a5c2 as build
+FROM python:3.5.7-buster@sha256:4598d4365bb7a8628ba840f87406323e699c4da01ae6f926ff33787c63230779 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -3,7 +3,7 @@
 # The code for the build image should be idendical with the code in
 # Dockerfile.django to use the caching mechanism of Docker.
 
-FROM python:3 as build
+FROM python:3.7.4-buster@sha256:7dd57761929672e7c2c18348d257ed5148fc6a971a13cfd8a3d1d8573226a5c2 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \
@@ -55,7 +55,7 @@ RUN \
   python3 manage.py collectstatic --noinput && \
   true
 
-FROM nginx
+FROM nginx:1.17.2@sha256:eb3320e2f9ca409b7c0aa71aea3cf7ce7d018f03a372564dbdb023646958770b
 COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf /etc/nginx/
 COPY docker/entrypoint-nginx.sh /

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 When submitting a pull request, please make sure you have completed the following checklist:
 
 - [ ] Your code is flake8 compliant 
+- [ ] Your code is python 3.5 compliant
 - [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
 - [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
 - [ ] Add applicable tests to the unit tests.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Realtime discussion is done in the OWASP Slack Channel, #defectdojo.
 
 ![Twitter](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/Twitter_Logo.png)
 
+More info: [Contributing guideline](CONTRIBUTING.md)
+
 [DefectDojo Twitter Account](https://twitter.com/defectdojo) tweets project
 updates and changes.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       DD_ADMIN_LAST_NAME: ${DD_ADMIN_LAST_NAME:-User}
       DD_INITIALIZE: ${DD_INITIALIZE:-true}
   mysql:
-    image: mysql:5.7
+    image: mysql:5.7.27@sha256:540488d8f0e04c1077d17934d1c1511fe417e2221dff508ce4621f5efe6131db
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
       DD_DATABASE_URL: ${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}
@@ -71,6 +71,6 @@ services:
     volumes:
        - defectdojo_data:/var/lib/mysql
   rabbitmq:
-    image: rabbitmq:3.7
+    image: rabbitmq:3.7.17@sha256:12202c13c8e1d7f5688e733e04f3713cf25c4478dde62be691e0a1d2c9346d1c
 volumes:
   defectdojo_data: {}


### PR DESCRIPTION
We have discussed it a little bit in slack: this PR pins the external docker image versions in order to have a reproducible build and avoid issues like the one we had recently on mysql change within the python image.
I have also pinned the digests because identifiers like python:3.7.4-slim-buster are not immutable, meaning that the image can change and keep the same identifier. 
After this we'll need to update versions from time to time. 
I have found a project that automatically creates pull request when a new image is released we could try that? It's free for open source projects:
https://renovatebot.com/blog/docker-mutable-tags
https://github.com/marketplace/renovate/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW45NTk=#pricing-and-setup

NB: i have found that image id is different from digest. 
What needs to be used in "FROM" and "docker pull" is the digest, not the image id
To find an image digest:
```
$docker pull python:3.7.4-buster
3.7.4-buster: Pulling from library/python
Digest: sha256:7dd57761929672e7c2c18348d257ed5148fc6a971a13cfd8a3d1d8573226a5c2
Status: Image is up to date for python:3.7.4-buster
```
This digest can be used in dockerfile "from"
However the image id cannot: 
```
$docker images --no-trunc
REPOSITORY                     TAG                 IMAGE ID                                                                  CREATED             SIZE
python                         3.7.4-slim-buster   sha256:53951a775ee29fec2ff8f56b941c0a445b7569b7e04daae3861616000988ad1a   9 hours ago         179MB
```

This also shows image id and digests: 
https://github.com/docker-library/repo-info/blob/master/repos/python/tag-details.md
