### PR TITLE
Ensure BURP report tags are not empty. Fix #1224

### DIFF
--- a/dojo/tools/burp/parser.py
+++ b/dojo/tools/burp/parser.py
@@ -145,7 +145,8 @@ def do_clean(value):
     if value is not None:
         if len(value) > 0:
             for x in value:
-                myreturn += x.text
+                if x.text is not None:
+                    myreturn += x.text
     return myreturn
 
 


### PR DESCRIPTION
BURP report format in XML is creating tags that may or may not containing a value, even though an XML tag exists.

With this change, we maintain backward compatibility, but also perform a check to see if a VALUE exists after we validated a TAG exists, thus addressing hard to re-produce issues whenever we have empty values for empty remediation/issueBackground tags.

There is also a PR for an example burp report found at: https://github.com/DefectDojo/sample-scan-files/pull/31 
