### PR TITLE
Added Api v2 Feature For Report Generation

### DIFF
--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -9,6 +9,7 @@ class UserHasProductPermission(permissions.BasePermission):
         return request.user in obj.authorized_users.all() or \
             request.user.is_staff
 
+
 class UserHasReportGeneratePermission(permissions.BasePermission):
     """
     @brief      To ensure that one user can only access authorized project
@@ -16,6 +17,7 @@ class UserHasReportGeneratePermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         return request.user in obj.product.authorized_users.all() or \
             request.user.is_staff
+
 
 class UserHasScanSettingsPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):

--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -9,6 +9,13 @@ class UserHasProductPermission(permissions.BasePermission):
         return request.user in obj.authorized_users.all() or \
             request.user.is_staff
 
+class UserHasReportGeneratePermission(permissions.BasePermission):
+    """
+    @brief      To ensure that one user can only access authorized project
+    """
+    def has_object_permission(self, request, view, obj):
+        return request.user in obj.product.authorized_users.all() or \
+            request.user.is_staff
 
 class UserHasScanSettingsPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -811,9 +811,11 @@ class FindingToFindingImagesSerializer(serializers.Serializer):
     finding_id = serializers.PrimaryKeyRelatedField(queryset=Finding.objects.all(), many=False, allow_null=True)
     images = FindingImageSerializer(many=True)
 
+
 class FindingToNotesSerializer(serializers.Serializer):
     finding_id = serializers.PrimaryKeyRelatedField(queryset=Finding.objects.all(), many=False, allow_null=True)
     notes = NoteSerializer(many=True)
+
 
 class ReportGenerateOptionSerializer(serializers.Serializer):
     include_finding_notes = serializers.BooleanField(default=False)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -798,3 +798,27 @@ class NoteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Notes
         fields = '__all__'
+
+
+class ReportGenerateOptionSerializer(serializers.Serializer):
+    include_finding_notes = serializers.BooleanField(default=False)
+    include_finding_images = serializers.BooleanField(default=False)
+    include_executive_summary = serializers.BooleanField(default=False)
+    include_table_of_contents = serializers.BooleanField(default=False)
+
+
+class ReportGenerateSerializer(serializers.Serializer):
+    product_type = ProductTypeSerializer(many=False, read_only=True)
+    product = ProductSerializer(many=False, read_only=True)
+    engagement = EngagementSerializer(many=False, read_only=True)
+    report_name = serializers.CharField(max_length=200)
+    report_info = serializers.CharField(max_length=200)
+    test = TestSerializer(many=False, read_only=True)
+    endpoint = EndpointSerializer(many=False, read_only=True)
+    endpoints = EndpointSerializer(many=True, read_only=True)
+    findings = FindingSerializer(many=True, read_only=True)
+    user = UserSerializer(many=False, read_only=True)
+    team_name = serializers.CharField(max_length=200)
+    title = serializers.CharField(max_length=200)
+    user_id = serializers.IntegerField()
+    host = serializers.CharField(max_length=200)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -3,7 +3,7 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Finding_Template, Test_Type, Development_Environment, NoteHistory, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Product_Type, JIRA_Conf, Endpoint, BurpRawRequestResponse, JIRA_PKey, \
-    Notes, DojoMeta
+    Notes, DojoMeta, FindingImage
 from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools.factory import import_parser_factory
 from django.core.validators import URLValidator, validate_ipv46_address
@@ -799,6 +799,17 @@ class NoteSerializer(serializers.ModelSerializer):
         model = Notes
         fields = '__all__'
 
+class FindingImageSerializer(serializers.ModelSerializer):
+    
+    class Meta:
+        model = FindingImage
+        fields = '__all__'
+
+
+class FindingToFindingImageSerializer(serializers.Serializer):
+    finding_id = serializers.PrimaryKeyRelatedField(queryset=Finding.objects.all(), many=False, allow_null=True)
+    images = FindingImageSerializer(many=True)
+
 
 class ReportGenerateOptionSerializer(serializers.Serializer):
     include_finding_notes = serializers.BooleanField(default=False)
@@ -817,6 +828,7 @@ class ReportGenerateSerializer(serializers.Serializer):
     endpoint = EndpointSerializer(many=False, read_only=True)
     endpoints = EndpointSerializer(many=True, read_only=True)
     findings = FindingSerializer(many=True, read_only=True)
+    finding_images = FindingToFindingImageSerializer(many=True, allow_null=True)
     user = UserSerializer(many=False, read_only=True)
     team_name = serializers.CharField(max_length=200)
     title = serializers.CharField(max_length=200)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -822,7 +822,20 @@ class ReportGenerateOptionSerializer(serializers.Serializer):
     include_table_of_contents = serializers.BooleanField(default=False)
 
 
+class ExecutiveSummarySerializer(serializers.Serializer):
+    engagement_name = serializers.CharField(max_length=200)
+    engagement_target_start = serializers.DateField()
+    engagement_target_end = serializers.DateField()
+    test_type_name = serializers.CharField(max_length=200)
+    test_target_start = serializers.DateTimeField()
+    test_target_end = serializers.DateTimeField()
+    test_environment_name = serializers.CharField(max_length=200)
+    test_strategy_ref = serializers.URLField(max_length=200, min_length=None, allow_blank=True)
+    total_findings = serializers.IntegerField()
+
+
 class ReportGenerateSerializer(serializers.Serializer):
+    executive_summary = ExecutiveSummarySerializer(many=False, allow_null=True)
     product_type = ProductTypeSerializer(many=False, read_only=True)
     product = ProductSerializer(many=False, read_only=True)
     engagement = EngagementSerializer(many=False, read_only=True)
@@ -832,10 +845,10 @@ class ReportGenerateSerializer(serializers.Serializer):
     endpoint = EndpointSerializer(many=False, read_only=True)
     endpoints = EndpointSerializer(many=True, read_only=True)
     findings = FindingSerializer(many=True, read_only=True)
-    finding_images = FindingToFindingImagesSerializer(many=True, allow_null=True)
-    finding_notes = FindingToNotesSerializer(many=True, allow_null=True)
     user = UserSerializer(many=False, read_only=True)
     team_name = serializers.CharField(max_length=200)
     title = serializers.CharField(max_length=200)
     user_id = serializers.IntegerField()
     host = serializers.CharField(max_length=200)
+    finding_images = FindingToFindingImagesSerializer(many=True, allow_null=True)
+    finding_notes = FindingToNotesSerializer(many=True, allow_null=True)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -807,10 +807,13 @@ class FindingImageSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-class FindingToFindingImageSerializer(serializers.Serializer):
+class FindingToFindingImagesSerializer(serializers.Serializer):
     finding_id = serializers.PrimaryKeyRelatedField(queryset=Finding.objects.all(), many=False, allow_null=True)
     images = FindingImageSerializer(many=True)
 
+class FindingToNotesSerializer(serializers.Serializer):
+    finding_id = serializers.PrimaryKeyRelatedField(queryset=Finding.objects.all(), many=False, allow_null=True)
+    notes = NoteSerializer(many=True)
 
 class ReportGenerateOptionSerializer(serializers.Serializer):
     include_finding_notes = serializers.BooleanField(default=False)
@@ -829,7 +832,8 @@ class ReportGenerateSerializer(serializers.Serializer):
     endpoint = EndpointSerializer(many=False, read_only=True)
     endpoints = EndpointSerializer(many=True, read_only=True)
     findings = FindingSerializer(many=True, read_only=True)
-    finding_images = FindingToFindingImageSerializer(many=True, allow_null=True)
+    finding_images = FindingToFindingImagesSerializer(many=True, allow_null=True)
+    finding_notes = FindingToNotesSerializer(many=True, allow_null=True)
     user = UserSerializer(many=False, read_only=True)
     team_name = serializers.CharField(max_length=200)
     title = serializers.CharField(max_length=200)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -799,8 +799,9 @@ class NoteSerializer(serializers.ModelSerializer):
         model = Notes
         fields = '__all__'
 
+
 class FindingImageSerializer(serializers.ModelSerializer):
-    
+
     class Meta:
         model = FindingImage
         fields = '__all__'

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -736,7 +736,8 @@ def report_generate(request, obj, options):
                 engmnts = prod_typ.engagement_set.all()
                 if engmnts:
                     for eng in engmnts:
-                        engagement_name = eng.name
+                        if eng.name:
+                            engagement_name = eng.name
                         engagement_target_start = eng.target_start
                         if eng.target_end:
                             engagement_target_end = eng.target_end
@@ -745,7 +746,8 @@ def report_generate(request, obj, options):
                         if eng.test_set.all():
                             for t in eng.test_set.all():
                                 test_type_name = t.test_type.name
-                                test_environment_name = t.environment.name
+                                if test.environment:
+                                    test_environment_name = t.environment.name
                                 test_target_start = t.target_start
                                 if t.target_end:
                                     test_target_end = t.target_end
@@ -761,7 +763,8 @@ def report_generate(request, obj, options):
             engs = obj.engagement_set.all()
             if engs:
                 for eng in engs:
-                    engagement_name = eng.name
+                    if eng.name:
+                        engagement_name = eng.name
                     engagement_target_start = eng.target_start
                     if eng.target_end:
                         engagement_target_end = eng.target_end
@@ -771,7 +774,8 @@ def report_generate(request, obj, options):
                     if eng.test_set.all():
                         for t in eng.test_set.all():
                             test_type_name = t.test_type.name
-                            test_environment_name = t.environment.name
+                            if t.environment:
+                                test_environment_name = t.environment.name
                     if eng.test_strategy:
                         test_strategy_ref = eng.test_strategy
                     else:
@@ -780,7 +784,8 @@ def report_generate(request, obj, options):
 
         elif type(obj).__name__ == "Engagement":
             eng = obj
-            engagement_name = eng.name
+            if eng.name:
+                engagement_name = eng.name
             engagement_target_start = eng.target_start
             if eng.target_end:
                 engagement_target_end = eng.target_end
@@ -790,7 +795,8 @@ def report_generate(request, obj, options):
             if eng.test_set.all():
                 for t in eng.test_set.all():
                     test_type_name = t.test_type.name
-                    test_environment_name = t.environment.name
+                    if t.environment:
+                        test_environment_name = t.environment.name
             if eng.test_strategy:
                 test_strategy_ref = eng.test_strategy
             else:

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -703,7 +703,7 @@ def report_generate(request, obj, options):
                     }
                 )
         result['finding_images'] = finding_images
-    
+
     if include_finding_notes:
         for finding in findings.qs.order_by('numerical_severity'):
             notes = finding.notes.all()

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponse, Http404, JsonResponse
+from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
 from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
@@ -14,13 +14,12 @@ from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Find
 
 from dojo.endpoint.views import get_endpoint_ids
 from dojo.reports.views import report_url_resolver
-from dojo.filters import ReportFindingFilter, ReportAuthedFindingFilter, EndpointReportFilter, ReportFilter, \
-    EndpointFilter
+from dojo.filters import ReportFindingFilter, ReportAuthedFindingFilter
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from datetime import datetime
 from django.utils import timezone
-from dojo.utils import get_system_setting, get_period_counts_legacy
+from dojo.utils import get_period_counts_legacy
 
 from dojo.api_v2 import serializers, permissions
 
@@ -56,7 +55,7 @@ class EndPointViewSet(mixins.ListModelMixin,
             options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
             options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
         else:
-            return Response(report_options.errors, 
+            return Response(report_options.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 
         data = report_generate(request, endpoint, options)
@@ -110,7 +109,7 @@ class EngagementViewSet(mixins.ListModelMixin,
             options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
             options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
         else:
-            return Response(report_options.errors, 
+            return Response(report_options.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 
         data = report_generate(request, engagement, options)
@@ -164,7 +163,7 @@ class FindingViewSet(mixins.ListModelMixin,
             return serializers.FindingCreateSerializer
         else:
             return serializers.FindingSerializer
-    
+
     @action(detail=False, methods=['post'])
     def generate_report(self, request):
         # finding = get_object_or_404(Endpoint.objects, id=pk)
@@ -178,7 +177,7 @@ class FindingViewSet(mixins.ListModelMixin,
             options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
             options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
         else:
-            return Response(report_options.errors, 
+            return Response(report_options.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 
         data = report_generate(request, findings, options)
@@ -270,7 +269,7 @@ class ProductViewSet(mixins.ListModelMixin,
             options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
             options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
         else:
-            return Response(report_options.errors, 
+            return Response(report_options.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 
         data = report_generate(request, product, options)
@@ -294,6 +293,7 @@ class ProductTypeViewSet(mixins.ListModelMixin,
                 prod_type__authorized_users__in=[self.request.user])
         else:
             return Product_Type.objects.all()
+
     @detail_route(methods=['post'], permission_classes=[permissions.UserHasReportGeneratePermission])
     def generate_report(self, request, pk=None):
         product_type = get_object_or_404(Product_Type.objects, id=pk)
@@ -307,7 +307,7 @@ class ProductTypeViewSet(mixins.ListModelMixin,
             options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
             options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
         else:
-            return Response(report_options.errors, 
+            return Response(report_options.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 
         data = report_generate(request, product_type, options)
@@ -420,7 +420,7 @@ class TestsViewSet(mixins.ListModelMixin,
             return serializers.TestCreateSerializer
         else:
             return serializers.TestSerializer
-    
+
     @detail_route(methods=['post'], permission_classes=[permissions.UserHasReportGeneratePermission])
     def generate_report(self, request, pk=None):
         test = get_object_or_404(Test.objects, id=pk)
@@ -434,7 +434,7 @@ class TestsViewSet(mixins.ListModelMixin,
             options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
             options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
         else:
-            return Response(report_options.errors, 
+            return Response(report_options.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 
         data = report_generate(request, test, options)
@@ -544,7 +544,7 @@ def report_generate(request, obj, options):
     include_finding_images = False
     include_executive_summary = False
     include_table_of_contents = False
-    
+
     report_info = "Generated By %s on %s" % (
         user.get_full_name(), (timezone.now().strftime("%m/%d/%Y %I:%M%p %Z")))
 
@@ -608,13 +608,13 @@ def report_generate(request, obj, options):
 
     elif type(obj).__name__ == "Engagement":
         engagement = obj
-        findings = ReportFindingFilter(request.GET,
-                                       queryset=Finding.objects.filter(test__engagement=engagement,
-                                            ).prefetch_related(
-                                                'test',
-                                                'test__engagement__product',
-                                                'test__engagement__product__prod_type').distinct()
-                                            )
+        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
+            test__engagement=engagement,
+        ).prefetch_related(
+            'test',
+            'test__engagement__product',
+            'test__engagement__product__prod_type'
+        ).distinct())
         report_name = "Engagement Report: " + str(engagement)
 
         report_title = "Engagement Report"
@@ -646,20 +646,23 @@ def report_generate(request, obj, options):
         report_title = "Endpoint Report"
         report_subtitle = host
         findings = ReportFindingFilter(request.GET,
-                                       queryset=Finding.objects.filter(endpoints__in=endpoints,
-                                            ).prefetch_related(
-                                                'test',
-                                                'test__engagement__product',
-                                                'test__engagement__product__prod_type').distinct()
-                                            )
+            queryset=Finding.objects.filter(
+                endpoints__in=endpoints,
+            ).prefetch_related(
+                'test',
+                'test__engagement__product',
+                'test__engagement__product__prod_type'
+            ).distinct())
 
     elif type(obj).__name__ == "QuerySet":
         findings = ReportAuthedFindingFilter(request.GET,
-                                             queryset=obj.prefetch_related(
-                                                'test',
-                                                'test__engagement__product',
-                                                'test__engagement__product__prod_type').distinct(),
-                                             user=request.user)
+            queryset=obj.prefetch_related(
+                'test',
+                'test__engagement__product',
+                'test__engagement__product__prod_type'
+            ).distinct(),
+            user=request.user
+        )
         report_name = 'Finding'
         report_type = 'Finding'
         report_title = "Finding Report"
@@ -682,25 +685,25 @@ def report_generate(request, obj, options):
                     }
                 )
 
-
-    result = {  'product_type': product_type,
-                'product': product,
-                'engagement': engagement,
-                'report_name': report_name,
-                'report_info': report_info,
-                'test': test,
-                'endpoint': endpoint,
-                'endpoints': endpoints,
-                'findings': findings.qs.order_by('numerical_severity'),
-                'include_finding_notes': include_finding_notes,
-                'finding_images': finding_images,
-                'include_executive_summary': include_executive_summary,
-                'include_table_of_contents': include_table_of_contents,
-                'user': user,
-                'team_name': settings.TEAM_NAME,
-                'title': 'Generate Report',
-                'user_id': request.user.id,
-                'host': report_url_resolver(request),
-            }
+    result = {
+        'product_type': product_type,
+        'product': product,
+        'engagement': engagement,
+        'report_name': report_name,
+        'report_info': report_info,
+        'test': test,
+        'endpoint': endpoint,
+        'endpoints': endpoints,
+        'findings': findings.qs.order_by('numerical_severity'),
+        'include_finding_notes': include_finding_notes,
+        'finding_images': finding_images,
+        'include_executive_summary': include_executive_summary,
+        'include_table_of_contents': include_table_of_contents,
+        'user': user,
+        'team_name': settings.TEAM_NAME,
+        'title': 'Generate Report',
+        'user_id': request.user.id,
+        'host': report_url_resolver(request),
+    }
 
     return result

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -668,6 +668,20 @@ def report_generate(request, obj, options):
     else:
         raise Http404()
 
+    finding_notes = []
+    finding_images = []
+
+    if include_finding_images:
+        for finding in findings.qs.order_by('numerical_severity'):
+            images = finding.images.all()
+            if images:
+                finding_images.append(
+                    {
+                        "finding_id": finding,
+                        "images": images
+                    }
+                )
+
 
     result = {  'product_type': product_type,
                 'product': product,
@@ -679,7 +693,7 @@ def report_generate(request, obj, options):
                 'endpoints': endpoints,
                 'findings': findings.qs.order_by('numerical_severity'),
                 'include_finding_notes': include_finding_notes,
-                'include_finding_images': include_finding_images,
+                'finding_images': finding_images,
                 'include_executive_summary': include_executive_summary,
                 'include_table_of_contents': include_table_of_contents,
                 'user': user,

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -684,11 +684,11 @@ def report_generate(request, obj, options):
         test_type_name = None
         test_target_start = None
         test_target_end = None
-        test_environment_name = "unknown" # a default of "unknown"
+        test_environment_name = "unknown"  # a default of "unknown"
         test_strategy_ref = None
         total_findings = 0
-        
-        if type(obj).__name__ == "Product_Type":    
+
+        if type(obj).__name__ == "Product_Type":
             for prod_typ in obj.prod_type.all():
                 engmnts = prod_typ.engagement_set.all()
                 if engmnts:
@@ -713,7 +713,7 @@ def report_generate(request, obj, options):
                             else:
                                 test_strategy_ref = ""
                 total_findings = len(findings.qs.all())
-        
+
         elif type(obj).__name__ == "Product":
             engs = obj.engagement_set.all()
             if engs:
@@ -753,7 +753,7 @@ def report_generate(request, obj, options):
             else:
                 test_strategy_ref = ""
             total_findings = len(findings.qs.all())
-        
+
         elif type(obj).__name__ == "Test":
             t = obj
             test_type_name = t.test_type.name
@@ -771,8 +771,8 @@ def report_generate(request, obj, options):
             else:
                 engagement_target_end = "ongoing"
         else:
-            pass # do nothing
-        
+            pass  # do nothing
+
         executive_summary = {
             'engagement_name': engagement_name,
             'engagement_target_start': engagement_target_start,
@@ -797,7 +797,7 @@ def report_generate(request, obj, options):
                         "images": images
                     }
                 )
-    
+
     if include_finding_notes:
         for finding in findings.qs.order_by('numerical_severity'):
             notes = finding.notes.all()
@@ -805,7 +805,7 @@ def report_generate(request, obj, options):
                 finding_notes.append(
                     {
                         "finding_id": finding,
-                        "notes": notes.filter(private=False) # fetching only public notes for report
+                        "notes": notes.filter(private=False)  # fetching only public notes for report
                     }
                 )
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -684,6 +684,17 @@ def report_generate(request, obj, options):
                         "images": images
                     }
                 )
+    
+    if include_finding_notes:
+        for finding in findings.qs.order_by('numerical_severity'):
+            notes = finding.notes.all()
+            if notes:
+                finding_notes.append(
+                    {
+                        "finding_id": finding,
+                        "notes": notes.filter(private=False) # fetching only public notes for report
+                    }
+                )
 
     result = {
         'product_type': product_type,
@@ -695,7 +706,7 @@ def report_generate(request, obj, options):
         'endpoint': endpoint,
         'endpoints': endpoints,
         'findings': findings.qs.order_by('numerical_severity'),
-        'include_finding_notes': include_finding_notes,
+        'finding_notes': finding_notes,
         'finding_images': finding_images,
         'include_executive_summary': include_executive_summary,
         'include_table_of_contents': include_table_of_contents,

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1,15 +1,26 @@
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404, JsonResponse
 from django.shortcuts import get_object_or_404
-from rest_framework import viewsets, mixins
+from rest_framework import viewsets, mixins, status
+from rest_framework.response import Response
 from rest_framework.permissions import DjangoModelPermissions
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import detail_route, action
 from django_filters.rest_framework import DjangoFilterBackend
 
 from dojo.engagement.services import close_engagement, reopen_engagement
 from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, Notes, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
-    Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment
+    Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment, Dojo_User
+
+from dojo.endpoint.views import get_endpoint_ids
+from dojo.reports.views import report_url_resolver
+from dojo.filters import ReportFindingFilter, ReportAuthedFindingFilter, EndpointReportFilter, ReportFilter, \
+    EndpointFilter
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from datetime import datetime
+from django.utils import timezone
+from dojo.utils import get_system_setting, get_period_counts_legacy
 
 from dojo.api_v2 import serializers, permissions
 
@@ -31,6 +42,26 @@ class EndPointViewSet(mixins.ListModelMixin,
                 product__authorized_users__in=[self.request.user])
         else:
             return Endpoint.objects.all()
+
+    @detail_route(methods=['post'], permission_classes=[permissions.UserHasReportGeneratePermission])
+    def generate_report(self, request, pk=None):
+        endpoint = get_object_or_404(Endpoint.objects, id=pk)
+
+        options = {}
+        # prepare post data
+        report_options = serializers.ReportGenerateOptionSerializer(data=request.data)
+        if report_options.is_valid():
+            options['include_finding_notes'] = report_options.validated_data['include_finding_notes']
+            options['include_finding_images'] = report_options.validated_data['include_finding_images']
+            options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
+            options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
+        else:
+            return Response(report_options.errors, 
+                status=status.HTTP_400_BAD_REQUEST)
+
+        data = report_generate(request, endpoint, options)
+        report = serializers.ReportGenerateSerializer(data)
+        return Response(report.data)
 
 
 class EngagementViewSet(mixins.ListModelMixin,
@@ -65,6 +96,26 @@ class EngagementViewSet(mixins.ListModelMixin,
         eng = get_object_or_404(Engagement.objects, id=pk)
         reopen_engagement(eng)
         return HttpResponse()
+
+    @detail_route(methods=['post'], permission_classes=[permissions.UserHasReportGeneratePermission])
+    def generate_report(self, request, pk=None):
+        engagement = get_object_or_404(Engagement.objects, id=pk)
+
+        options = {}
+        # prepare post data
+        report_options = serializers.ReportGenerateOptionSerializer(data=request.data)
+        if report_options.is_valid():
+            options['include_finding_notes'] = report_options.validated_data['include_finding_notes']
+            options['include_finding_images'] = report_options.validated_data['include_finding_images']
+            options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
+            options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
+        else:
+            return Response(report_options.errors, 
+                status=status.HTTP_400_BAD_REQUEST)
+
+        data = report_generate(request, engagement, options)
+        report = serializers.ReportGenerateSerializer(data)
+        return Response(report.data)
 
 
 class FindingTemplatesViewSet(mixins.ListModelMixin,
@@ -113,6 +164,26 @@ class FindingViewSet(mixins.ListModelMixin,
             return serializers.FindingCreateSerializer
         else:
             return serializers.FindingSerializer
+    
+    @action(detail=False, methods=['post'])
+    def generate_report(self, request):
+        # finding = get_object_or_404(Endpoint.objects, id=pk)
+        findings = Finding.objects.all()
+        options = {}
+        # prepare post data
+        report_options = serializers.ReportGenerateOptionSerializer(data=request.data)
+        if report_options.is_valid():
+            options['include_finding_notes'] = report_options.validated_data['include_finding_notes']
+            options['include_finding_images'] = report_options.validated_data['include_finding_images']
+            options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
+            options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
+        else:
+            return Response(report_options.errors, 
+                status=status.HTTP_400_BAD_REQUEST)
+
+        data = report_generate(request, findings, options)
+        report = serializers.ReportGenerateSerializer(data)
+        return Response(report.data)
 
 
 class JiraConfigurationsViewSet(mixins.ListModelMixin,
@@ -186,6 +257,26 @@ class ProductViewSet(mixins.ListModelMixin,
         else:
             return Product.objects.all()
 
+    @detail_route(methods=['post'], permission_classes=[permissions.UserHasReportGeneratePermission])
+    def generate_report(self, request, pk=None):
+        product = get_object_or_404(Product.objects, id=pk)
+
+        options = {}
+        # prepare post data
+        report_options = serializers.ReportGenerateOptionSerializer(data=request.data)
+        if report_options.is_valid():
+            options['include_finding_notes'] = report_options.validated_data['include_finding_notes']
+            options['include_finding_images'] = report_options.validated_data['include_finding_images']
+            options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
+            options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
+        else:
+            return Response(report_options.errors, 
+                status=status.HTTP_400_BAD_REQUEST)
+
+        data = report_generate(request, product, options)
+        report = serializers.ReportGenerateSerializer(data)
+        return Response(report.data)
+
 
 class ProductTypeViewSet(mixins.ListModelMixin,
                          mixins.RetrieveModelMixin,
@@ -203,6 +294,25 @@ class ProductTypeViewSet(mixins.ListModelMixin,
                 prod_type__authorized_users__in=[self.request.user])
         else:
             return Product_Type.objects.all()
+    @detail_route(methods=['post'], permission_classes=[permissions.UserHasReportGeneratePermission])
+    def generate_report(self, request, pk=None):
+        product_type = get_object_or_404(Product_Type.objects, id=pk)
+
+        options = {}
+        # prepare post data
+        report_options = serializers.ReportGenerateOptionSerializer(data=request.data)
+        if report_options.is_valid():
+            options['include_finding_notes'] = report_options.validated_data['include_finding_notes']
+            options['include_finding_images'] = report_options.validated_data['include_finding_images']
+            options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
+            options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
+        else:
+            return Response(report_options.errors, 
+                status=status.HTTP_400_BAD_REQUEST)
+
+        data = report_generate(request, product_type, options)
+        report = serializers.ReportGenerateSerializer(data)
+        return Response(report.data)
 
 
 class ScanSettingsViewSet(mixins.ListModelMixin,
@@ -310,6 +420,26 @@ class TestsViewSet(mixins.ListModelMixin,
             return serializers.TestCreateSerializer
         else:
             return serializers.TestSerializer
+    
+    @detail_route(methods=['post'], permission_classes=[permissions.UserHasReportGeneratePermission])
+    def generate_report(self, request, pk=None):
+        test = get_object_or_404(Test.objects, id=pk)
+
+        options = {}
+        # prepare post data
+        report_options = serializers.ReportGenerateOptionSerializer(data=request.data)
+        if report_options.is_valid():
+            options['include_finding_notes'] = report_options.validated_data['include_finding_notes']
+            options['include_finding_images'] = report_options.validated_data['include_finding_images']
+            options['include_executive_summary'] = report_options.validated_data['include_executive_summary']
+            options['include_table_of_contents'] = report_options.validated_data['include_table_of_contents']
+        else:
+            return Response(report_options.errors, 
+                status=status.HTTP_400_BAD_REQUEST)
+
+        data = report_generate(request, test, options)
+        report = serializers.ReportGenerateSerializer(data)
+        return Response(report.data)
 
 
 class TestTypesViewSet(mixins.ListModelMixin,
@@ -390,3 +520,173 @@ class NotesViewSet(mixins.ListModelMixin,
     filter_fields = ('id', 'entry', 'author',
                     'private', 'date', 'edited',
                     'edit_time', 'editor')
+
+
+def report_generate(request, obj, options):
+    user = Dojo_User.objects.get(id=request.user.id)
+    product_type = None
+    product = None
+    engagement = None
+    test = None
+    endpoint = None
+    endpoints = None
+    endpoint_all_findings = None
+    endpoint_monthly_counts = None
+    endpoint_active_findings = None
+    accepted_findings = None
+    open_findings = None
+    closed_findings = None
+    verified_findings = None
+    report_title = None
+    report_subtitle = None
+
+    include_finding_notes = False
+    include_finding_images = False
+    include_executive_summary = False
+    include_table_of_contents = False
+    
+    report_info = "Generated By %s on %s" % (
+        user.get_full_name(), (timezone.now().strftime("%m/%d/%Y %I:%M%p %Z")))
+
+    # generate = "_generate" in request.GET
+    report_name = str(obj)
+    report_type = type(obj).__name__
+
+    include_finding_notes = options.get('include_finding_notes', False)
+    include_finding_images = options.get('include_finding_images', False)
+    include_executive_summary = options.get('include_executive_summary', False)
+    include_table_of_contents = options.get('include_table_of_contents', False)
+
+    if type(obj).__name__ == "Product_Type":
+        product_type = obj
+
+        report_name = "Product Type Report: " + str(product_type)
+        report_title = "Product Type Report"
+        report_subtitle = str(product_type)
+
+        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
+            test__engagement__product__prod_type=product_type).distinct().prefetch_related('test',
+                                                                                           'test__engagement__product',
+                                                                                           'test__engagement__product__prod_type'))
+        products = Product.objects.filter(prod_type=product_type,
+                                          engagement__test__finding__in=findings.qs).distinct()
+        engagements = Engagement.objects.filter(product__prod_type=product_type,
+                                                test__finding__in=findings.qs).distinct()
+        tests = Test.objects.filter(engagement__product__prod_type=product_type,
+                                    finding__in=findings.qs).distinct()
+        if findings:
+            start_date = timezone.make_aware(datetime.combine(findings.qs.last().date, datetime.min.time()))
+        else:
+            start_date = timezone.now()
+
+        end_date = timezone.now()
+
+        r = relativedelta(end_date, start_date)
+        months_between = (r.years * 12) + r.months
+        # include current month
+        months_between += 1
+
+        endpoint_monthly_counts = get_period_counts_legacy(findings.qs.order_by('numerical_severity'), findings.qs.order_by('numerical_severity'), None,
+                                                            months_between, start_date,
+                                                            relative_delta='months')
+
+    elif type(obj).__name__ == "Product":
+        product = obj
+
+        report_name = "Product Report: " + str(product)
+        report_title = "Product Report"
+        report_subtitle = str(product)
+        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
+            test__engagement__product=product).distinct().prefetch_related('test',
+                                                                           'test__engagement__product',
+                                                                           'test__engagement__product__prod_type'))
+        ids = set(finding.id for finding in findings.qs)
+        engagements = Engagement.objects.filter(test__finding__id__in=ids).distinct()
+        tests = Test.objects.filter(finding__id__in=ids).distinct()
+        ids = get_endpoint_ids(Endpoint.objects.filter(product=product).distinct())
+        endpoints = Endpoint.objects.filter(id__in=ids)
+
+    elif type(obj).__name__ == "Engagement":
+        engagement = obj
+        findings = ReportFindingFilter(request.GET,
+                                       queryset=Finding.objects.filter(test__engagement=engagement,
+                                            ).prefetch_related(
+                                                'test',
+                                                'test__engagement__product',
+                                                'test__engagement__product__prod_type').distinct()
+                                            )
+        report_name = "Engagement Report: " + str(engagement)
+
+        report_title = "Engagement Report"
+        report_subtitle = str(engagement)
+
+        ids = set(finding.id for finding in findings.qs)
+        tests = Test.objects.filter(finding__id__in=ids).distinct()
+        ids = get_endpoint_ids(Endpoint.objects.filter(product=engagement.product).distinct())
+        endpoints = Endpoint.objects.filter(id__in=ids)
+
+    elif type(obj).__name__ == "Test":
+        test = obj
+        findings = ReportFindingFilter(request.GET,
+                                       queryset=Finding.objects.filter(test=test).prefetch_related(
+                                            'test',
+                                            'test__engagement__product',
+                                            'test__engagement__product__prod_type').distinct())
+        report_name = "Test Report: " + str(test)
+        report_title = "Test Report"
+        report_subtitle = str(test)
+
+    elif type(obj).__name__ == "Endpoint":
+        endpoint = obj
+        host = endpoint.host_no_port
+        report_name = "Endpoint Report: " + host
+        report_type = "Endpoint"
+        endpoints = Endpoint.objects.filter(host__regex="^" + host + ":?",
+                                            product=endpoint.product).distinct()
+        report_title = "Endpoint Report"
+        report_subtitle = host
+        findings = ReportFindingFilter(request.GET,
+                                       queryset=Finding.objects.filter(endpoints__in=endpoints,
+                                            ).prefetch_related(
+                                                'test',
+                                                'test__engagement__product',
+                                                'test__engagement__product__prod_type').distinct()
+                                            )
+
+    elif type(obj).__name__ == "QuerySet":
+        findings = ReportAuthedFindingFilter(request.GET,
+                                             queryset=obj.prefetch_related(
+                                                'test',
+                                                'test__engagement__product',
+                                                'test__engagement__product__prod_type').distinct(),
+                                             user=request.user)
+        report_name = 'Finding'
+        report_type = 'Finding'
+        report_title = "Finding Report"
+        report_subtitle = ''
+
+    else:
+        raise Http404()
+
+
+    result = {  'product_type': product_type,
+                'product': product,
+                'engagement': engagement,
+                'report_name': report_name,
+                'report_info': report_info,
+                'test': test,
+                'endpoint': endpoint,
+                'endpoints': endpoints,
+                'findings': findings.qs.order_by('numerical_severity'),
+                'include_finding_notes': include_finding_notes,
+                'include_finding_images': include_finding_images,
+                'include_executive_summary': include_executive_summary,
+                'include_table_of_contents': include_table_of_contents,
+                'user': user,
+                'team_name': settings.TEAM_NAME,
+                'title': 'Generate Report',
+                'user_id': request.user.id,
+                'host': report_url_resolver(request),
+            }
+
+    return result

--- a/dojo/static/dojo/js/index.js
+++ b/dojo/static/dojo/js/index.js
@@ -245,3 +245,17 @@ function togglePassVisibility() {
     }
 } 
 
+function asciidocDownload() {
+    var element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + 
+        encodeURIComponent(document.getElementById('base-content').innerText));
+    element.setAttribute('download', 'asciidoc-report.txt');
+  
+    element.style.display = 'none';
+    document.body.appendChild(element);
+  
+    element.click();
+  
+    document.body.removeChild(element);
+  }
+

--- a/dojo/templates/dojo/asciidoc_report.html
+++ b/dojo/templates/dojo/asciidoc_report.html
@@ -5,6 +5,11 @@
     {% load humanize %}
     {% load get_endpoint_status %}
     {% load get_note_status %}
+    
+    <button onclick="asciidocDownload()" class="btn btn-primary" type="button">
+        Dowload Report
+    </button>
+
     {% if product_type %}
         <h2>= {{ product_type }} =</h2>
     {% elif product %}
@@ -481,3 +486,4 @@
         {% endfor %}
     {% endif %}
 {% endblock %}
+


### PR DESCRIPTION
After Trying to add Ability to generate report through Api as requested in Issue #1352 .  I discovered that this would be a very huge enhancement capability for defect-Dojo if reports can be generated in JSON format straight from Api without the GUI. So I took my time to get this done as best as I can.

When submitting a pull request, please make sure you have completed the following checklist:

- [X] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Add applicable tests to the unit tests.
