### PR TITLE
Fix json based import scanners

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -775,7 +775,9 @@ def mktemplate(request, fid):
             references=finding.references,
             numerical_severity=finding.numerical_severity)
         template.save()
-        template.tags = finding.tags
+        tags = [tag.name for tag in list(finding.tags)]
+        t = ", ".join(tags)
+        template.tags = t
         messages.add_message(
             request,
             messages.SUCCESS,

--- a/dojo/object/parser.py
+++ b/dojo/object/parser.py
@@ -47,7 +47,7 @@ def import_object_eng(request, engagement, json_data):
 
     # Retrieve the files currently set for this product
     object_queryset = Objects.objects.filter(product=engagement.product.id).order_by('-path')
-    data = json.load(json_data)
+    data = json.loads(json_data.read().decode())
 
     # Set default review status
     review_status_id = 1

--- a/dojo/object/parser.py
+++ b/dojo/object/parser.py
@@ -81,13 +81,13 @@ def import_object_eng(request, engagement, json_data):
                     Tag.objects.update_tags(object, tag.name)
 
         full_url = None
-        type = None
+        file_type = None
         percentUnchanged = None
         build_id = None
         if "full_url" in file:
             full_url = file["full_url"]
         if "type" in file:
-            type = file["type"]
+            file_type = file["type"]
         if "percentUnchanged" in file:
             percentUnchanged = file["percentUnchanged"]
         if "build_id" in file:
@@ -101,7 +101,7 @@ def import_object_eng(request, engagement, json_data):
             create_alert = True
 
         # Save the changed files to the engagement view
-        object_eng = Objects_Engagement(engagement=engagement, object_id=found_object, full_url=full_url, type=type, percentUnchanged=percentUnchanged, build_id=build_id)
+        object_eng = Objects_Engagement(engagement=engagement, object_id=found_object, full_url=full_url, type=file_type, percentUnchanged=percentUnchanged, build_id=build_id)
         object_eng.save()
 
     # Create the notification

--- a/dojo/object/parser.py
+++ b/dojo/object/parser.py
@@ -47,7 +47,11 @@ def import_object_eng(request, engagement, json_data):
 
     # Retrieve the files currently set for this product
     object_queryset = Objects.objects.filter(product=engagement.product.id).order_by('-path')
-    data = json.loads(str(json_data.read(), 'utf-8'))
+    tree = json_data.read()
+    if isinstance(type(tree), (bytes, bytearray)):
+        data = json.loads(str(tree, 'utf-8'))
+    else:
+        data = json.loads(tree)
 
     # Set default review status
     review_status_id = 1

--- a/dojo/object/parser.py
+++ b/dojo/object/parser.py
@@ -47,7 +47,7 @@ def import_object_eng(request, engagement, json_data):
 
     # Retrieve the files currently set for this product
     object_queryset = Objects.objects.filter(product=engagement.product.id).order_by('-path')
-    data = json.loads(json_data.read().decode())
+    data = json.loads(str(json_data.read(), 'utf-8'))
 
     # Set default review status
     review_status_id = 1

--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 class AnchoreEngineScanParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
         dupes = dict()
         find_date = datetime.now()
 

--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -7,7 +7,11 @@ from datetime import datetime
 
 class AnchoreEngineScanParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
+        else:
+            data = json.loads(tree)
         dupes = dict()
         find_date = datetime.now()
 

--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -7,7 +7,7 @@ from datetime import datetime
 
 class AnchoreEngineScanParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
         dupes = dict()
         find_date = datetime.now()
 

--- a/dojo/tools/arachni/parser.py
+++ b/dojo/tools/arachni/parser.py
@@ -24,7 +24,7 @@ class ArachniJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/arachni/parser.py
+++ b/dojo/tools/arachni/parser.py
@@ -24,7 +24,7 @@ class ArachniJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/arachni/parser.py
+++ b/dojo/tools/arachni/parser.py
@@ -24,7 +24,11 @@ class ArachniJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/bandit/parser.py
+++ b/dojo/tools/bandit/parser.py
@@ -7,7 +7,7 @@ from dojo.models import Finding
 
 class BanditParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
         dupes = dict()
         if "generated_at" in data:
             find_date = datetime.strptime(data["generated_at"], '%Y-%m-%dT%H:%M:%SZ')

--- a/dojo/tools/bandit/parser.py
+++ b/dojo/tools/bandit/parser.py
@@ -7,7 +7,7 @@ from dojo.models import Finding
 
 class BanditParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
         dupes = dict()
         if "generated_at" in data:
             find_date = datetime.strptime(data["generated_at"], '%Y-%m-%dT%H:%M:%SZ')

--- a/dojo/tools/bandit/parser.py
+++ b/dojo/tools/bandit/parser.py
@@ -7,7 +7,11 @@ from dojo.models import Finding
 
 class BanditParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
+        else:
+            data = json.loads(tree)
         dupes = dict()
         if "generated_at" in data:
             find_date = datetime.strptime(data["generated_at"], '%Y-%m-%dT%H:%M:%SZ')

--- a/dojo/tools/brakeman/parser.py
+++ b/dojo/tools/brakeman/parser.py
@@ -7,7 +7,7 @@ from dojo.models import Finding
 
 class BrakemanScanParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
         dupes = dict()
         find_date = parser.parse(data['scan_info']['end_time'])
 

--- a/dojo/tools/brakeman/parser.py
+++ b/dojo/tools/brakeman/parser.py
@@ -7,7 +7,11 @@ from dojo.models import Finding
 
 class BrakemanScanParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
+        else:
+            data = json.loads(tree)
         dupes = dict()
         find_date = parser.parse(data['scan_info']['end_time'])
 

--- a/dojo/tools/brakeman/parser.py
+++ b/dojo/tools/brakeman/parser.py
@@ -7,7 +7,7 @@ from dojo.models import Finding
 
 class BrakemanScanParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
         dupes = dict()
         find_date = parser.parse(data['scan_info']['end_time'])
 

--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -15,7 +15,7 @@ class ClairParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
             subtree = tree.get('vulnerabilities')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -15,7 +15,7 @@ class ClairParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
             subtree = tree.get('vulnerabilities')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -15,7 +15,11 @@ class ClairParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
             subtree = tree.get('vulnerabilities')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/clair_klar/parser.py
+++ b/dojo/tools/clair_klar/parser.py
@@ -21,7 +21,11 @@ class ClairKlarParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
             subtree = tree.get('Vulnerabilities')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/clair_klar/parser.py
+++ b/dojo/tools/clair_klar/parser.py
@@ -21,7 +21,7 @@ class ClairKlarParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
             subtree = tree.get('Vulnerabilities')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/clair_klar/parser.py
+++ b/dojo/tools/clair_klar/parser.py
@@ -21,7 +21,7 @@ class ClairKlarParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
             subtree = tree.get('Vulnerabilities')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/dawnscanner/parser.py
+++ b/dojo/tools/dawnscanner/parser.py
@@ -8,7 +8,7 @@ from dojo.models import Finding
 
 class DawnScannerParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
 
         dupes = dict()
         find_date = parser.parse(data['scan_started'])

--- a/dojo/tools/dawnscanner/parser.py
+++ b/dojo/tools/dawnscanner/parser.py
@@ -8,7 +8,7 @@ from dojo.models import Finding
 
 class DawnScannerParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
 
         dupes = dict()
         find_date = parser.parse(data['scan_started'])

--- a/dojo/tools/dawnscanner/parser.py
+++ b/dojo/tools/dawnscanner/parser.py
@@ -8,7 +8,11 @@ from dojo.models import Finding
 
 class DawnScannerParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        data = filename.read()
+        if isinstance(type(data), (bytes, bytearray)):
+            tree = json.loads(str(data, 'utf-8'))
+        else:
+            tree = json.loads(data)
 
         dupes = dict()
         find_date = parser.parse(data['scan_started'])

--- a/dojo/tools/dawnscanner/parser.py
+++ b/dojo/tools/dawnscanner/parser.py
@@ -8,11 +8,11 @@ from dojo.models import Finding
 
 class DawnScannerParser(object):
     def __init__(self, filename, test):
-        data = filename.read()
-        if isinstance(type(data), (bytes, bytearray)):
-            tree = json.loads(str(data, 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
         else:
-            tree = json.loads(data)
+            data = json.loads(tree)
 
         dupes = dict()
         find_date = parser.parse(data['scan_started'])

--- a/dojo/tools/gosec/parser.py
+++ b/dojo/tools/gosec/parser.py
@@ -4,7 +4,11 @@ from dojo.models import Finding
 
 class GosecScannerParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        data = filename.read()
+        if isinstance(type(data), (bytes, bytearray)):
+            tree = json.loads(str(data, 'utf-8'))
+        else:
+            tree = json.loads(data)
         dupes = dict()
 
         for item in data["Issues"]:

--- a/dojo/tools/gosec/parser.py
+++ b/dojo/tools/gosec/parser.py
@@ -4,11 +4,11 @@ from dojo.models import Finding
 
 class GosecScannerParser(object):
     def __init__(self, filename, test):
-        data = filename.read()
-        if isinstance(type(data), (bytes, bytearray)):
-            tree = json.loads(str(data, 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
         else:
-            tree = json.loads(data)
+            data = json.loads(tree)
         dupes = dict()
 
         for item in data["Issues"]:

--- a/dojo/tools/gosec/parser.py
+++ b/dojo/tools/gosec/parser.py
@@ -4,7 +4,7 @@ from dojo.models import Finding
 
 class GosecScannerParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
         dupes = dict()
 
         for item in data["Issues"]:

--- a/dojo/tools/gosec/parser.py
+++ b/dojo/tools/gosec/parser.py
@@ -4,7 +4,7 @@ from dojo.models import Finding
 
 class GosecScannerParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
         dupes = dict()
 
         for item in data["Issues"]:

--- a/dojo/tools/jfrogxray/parser.py
+++ b/dojo/tools/jfrogxray/parser.py
@@ -14,7 +14,7 @@ class XrayJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/jfrogxray/parser.py
+++ b/dojo/tools/jfrogxray/parser.py
@@ -14,7 +14,11 @@ class XrayJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/jfrogxray/parser.py
+++ b/dojo/tools/jfrogxray/parser.py
@@ -14,7 +14,7 @@ class XrayJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/mobsf/parser.py
+++ b/dojo/tools/mobsf/parser.py
@@ -9,7 +9,11 @@ from django.utils.html import strip_tags
 
 class MobSFParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        data = filename.read()
+        if isinstance(type(data), (bytes, bytearray)):
+            tree = json.loads(str(data, 'utf-8'))
+        else:
+            tree = json.loads(data)
         find_date = datetime.now()
         dupes = {}
         test_description = ""

--- a/dojo/tools/mobsf/parser.py
+++ b/dojo/tools/mobsf/parser.py
@@ -9,7 +9,7 @@ from django.utils.html import strip_tags
 
 class MobSFParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
         find_date = datetime.now()
         dupes = {}
         test_description = ""

--- a/dojo/tools/mobsf/parser.py
+++ b/dojo/tools/mobsf/parser.py
@@ -9,7 +9,7 @@ from django.utils.html import strip_tags
 
 class MobSFParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
         find_date = datetime.now()
         dupes = {}
         test_description = ""

--- a/dojo/tools/mobsf/parser.py
+++ b/dojo/tools/mobsf/parser.py
@@ -9,11 +9,11 @@ from django.utils.html import strip_tags
 
 class MobSFParser(object):
     def __init__(self, filename, test):
-        data = filename.read()
-        if isinstance(type(data), (bytes, bytearray)):
-            tree = json.loads(str(data, 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
         else:
-            tree = json.loads(data)
+            data = json.loads(tree)
         find_date = datetime.now()
         dupes = {}
         test_description = ""

--- a/dojo/tools/mozilla_observatory/parser.py
+++ b/dojo/tools/mozilla_observatory/parser.py
@@ -12,7 +12,7 @@ class MozillaObservatoryJSONParser(object):
         self.items = ()
         if file is None:
             return
-        tree = json.load(file)
+        tree = json.loads(file.read().decode())
         for content in tree:
             node = tree[content]
             if not node['pass']:

--- a/dojo/tools/mozilla_observatory/parser.py
+++ b/dojo/tools/mozilla_observatory/parser.py
@@ -12,7 +12,7 @@ class MozillaObservatoryJSONParser(object):
         self.items = ()
         if file is None:
             return
-        tree = json.loads(file.read().decode())
+        tree = json.loads(str(file.read(), 'utf-8'))
         for content in tree:
             node = tree[content]
             if not node['pass']:

--- a/dojo/tools/mozilla_observatory/parser.py
+++ b/dojo/tools/mozilla_observatory/parser.py
@@ -12,7 +12,11 @@ class MozillaObservatoryJSONParser(object):
         self.items = ()
         if file is None:
             return
-        tree = json.loads(str(file.read(), 'utf-8'))
+        data = file.read()
+        if isinstance(type(data), (bytes, bytearray)):
+            tree = json.loads(str(data, 'utf-8'))
+        else:
+            tree = json.loads(data)
         for content in tree:
             node = tree[content]
             if not node['pass']:

--- a/dojo/tools/netsparker/parser.py
+++ b/dojo/tools/netsparker/parser.py
@@ -16,7 +16,7 @@ def cleantags(text):
 
 class NetsparkerParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
         dupes = dict()
 
         for item in data["Vulnerabilities"]:

--- a/dojo/tools/netsparker/parser.py
+++ b/dojo/tools/netsparker/parser.py
@@ -16,7 +16,11 @@ def cleantags(text):
 
 class NetsparkerParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
+        else:
+            data = json.loads(tree)
         dupes = dict()
 
         for item in data["Vulnerabilities"]:

--- a/dojo/tools/netsparker/parser.py
+++ b/dojo/tools/netsparker/parser.py
@@ -16,7 +16,7 @@ def cleantags(text):
 
 class NetsparkerParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
         dupes = dict()
 
         for item in data["Vulnerabilities"]:

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -18,7 +18,7 @@ class NpmAuditParser(object):
             self.items = []
             return
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
             subtree = tree.get('advisories')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -18,7 +18,11 @@ class NpmAuditParser(object):
             self.items = []
             return
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
             subtree = tree.get('advisories')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -18,7 +18,7 @@ class NpmAuditParser(object):
             self.items = []
             return
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
             subtree = tree.get('advisories')
         except:
             raise Exception("Invalid format")

--- a/dojo/tools/nsp/parser.py
+++ b/dojo/tools/nsp/parser.py
@@ -1,7 +1,7 @@
 import json
 
-from dojo.models import Finding, Endpoint
-from django.utils.encoding import smart_text, force_str
+from dojo.models import Finding
+
 
 class NspParser(object):
     def __init__(self, json_output, test):
@@ -15,7 +15,7 @@ class NspParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
         except:
             raise Exception("Invalid format")
 
@@ -36,7 +36,7 @@ def get_item(item_node, test):
 
     # Following the CVSS Scoring per https://nvd.nist.gov/vuln-metrics/cvss
 
-    if item_node['cvss_score'] <= 3.9 :
+    if item_node['cvss_score'] <= 3.9:
         severity = "Low"
     elif item_node['cvss_score'] > 4.0 and item_node['cvss_score'] <= 6.9:
         severity = "Medium"

--- a/dojo/tools/nsp/parser.py
+++ b/dojo/tools/nsp/parser.py
@@ -15,7 +15,7 @@ class NspParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/nsp/parser.py
+++ b/dojo/tools/nsp/parser.py
@@ -15,7 +15,11 @@ class NspParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/php_security_audit_v2/parser.py
+++ b/dojo/tools/php_security_audit_v2/parser.py
@@ -5,7 +5,7 @@ from dojo.models import Finding
 
 class PhpSecurityAuditV2(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
         dupes = dict()
 
         for filepath, report in list(data["files"].items()):

--- a/dojo/tools/php_security_audit_v2/parser.py
+++ b/dojo/tools/php_security_audit_v2/parser.py
@@ -5,7 +5,7 @@ from dojo.models import Finding
 
 class PhpSecurityAuditV2(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
         dupes = dict()
 
         for filepath, report in list(data["files"].items()):

--- a/dojo/tools/php_security_audit_v2/parser.py
+++ b/dojo/tools/php_security_audit_v2/parser.py
@@ -5,7 +5,11 @@ from dojo.models import Finding
 
 class PhpSecurityAuditV2(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        tree = filename.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
+        else:
+            data = json.loads(tree)
         dupes = dict()
 
         for filepath, report in list(data["files"].items()):

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -18,7 +18,11 @@ class PhpSymfonySecurityCheckParser(object):
             self.items = []
             return
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -18,7 +18,7 @@ class PhpSymfonySecurityCheckParser(object):
             self.items = []
             return
         try:
-            tree = json.load(json_file)
+            tree = json.loads(json_file.read().decode())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -18,7 +18,7 @@ class PhpSymfonySecurityCheckParser(object):
             self.items = []
             return
         try:
-            tree = json.loads(json_file.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/retirejs/parser.py
+++ b/dojo/tools/retirejs/parser.py
@@ -19,7 +19,7 @@ class RetireJsParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/retirejs/parser.py
+++ b/dojo/tools/retirejs/parser.py
@@ -19,7 +19,7 @@ class RetireJsParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/retirejs/parser.py
+++ b/dojo/tools/retirejs/parser.py
@@ -19,7 +19,11 @@ class RetireJsParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -18,7 +18,7 @@ class SafetyParser(object):
             self.items = []
 
     def parse_json(self, json_output):
-        json_obj = json.load(json_output)
+        json_obj = json.loads(json_output.read().decode())
         tree = {l[4]: {'package': str(l[0]),
                        'affected': str(l[1]),
                        'installed': str(l[2]),

--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -18,7 +18,11 @@ class SafetyParser(object):
             self.items = []
 
     def parse_json(self, json_output):
-        json_obj = json.loads(str(json_output.read(), 'utf-8'))
+        data = json_output.read()
+        if isinstance(type(data), (bytes, bytearray)):
+            json_obj = json.loads(str(data, 'utf-8'))
+        else:
+            json_obj = json.loads(data)
         tree = {l[4]: {'package': str(l[0]),
                        'affected': str(l[1]),
                        'installed': str(l[2]),

--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -18,7 +18,7 @@ class SafetyParser(object):
             self.items = []
 
     def parse_json(self, json_output):
-        json_obj = json.loads(json_output.read().decode())
+        json_obj = json.loads(str(json_output.read(), 'utf-8'))
         tree = {l[4]: {'package': str(l[0]),
                        'affected': str(l[1]),
                        'installed': str(l[2]),

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -15,7 +15,11 @@ class SnykParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -15,7 +15,7 @@ class SnykParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -15,7 +15,7 @@ class SnykParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/sonatype/parser.py
+++ b/dojo/tools/sonatype/parser.py
@@ -18,7 +18,7 @@ class SonatypeJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/sonatype/parser.py
+++ b/dojo/tools/sonatype/parser.py
@@ -18,7 +18,7 @@ class SonatypeJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/sonatype/parser.py
+++ b/dojo/tools/sonatype/parser.py
@@ -18,7 +18,11 @@ class SonatypeJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/ssl_labs/parser.py
+++ b/dojo/tools/ssl_labs/parser.py
@@ -7,7 +7,7 @@ import json
 
 class SSLlabsParser(object):
     def __init__(self, filename, test):
-        data = json.load(filename)
+        data = json.loads(filename.read().decode())
 
         find_date = datetime.now()
         dupes = {}

--- a/dojo/tools/ssl_labs/parser.py
+++ b/dojo/tools/ssl_labs/parser.py
@@ -7,7 +7,7 @@ import json
 
 class SSLlabsParser(object):
     def __init__(self, filename, test):
-        data = json.loads(filename.read().decode())
+        data = json.loads(str(filename.read(), 'utf-8'))
 
         find_date = datetime.now()
         dupes = {}

--- a/dojo/tools/ssl_labs/parser.py
+++ b/dojo/tools/ssl_labs/parser.py
@@ -7,7 +7,11 @@ import json
 
 class SSLlabsParser(object):
     def __init__(self, filename, test):
-        data = json.loads(str(filename.read(), 'utf-8'))
+        tree = json_output.read()
+        if isinstance(type(tree), (bytes, bytearray)):
+            data = json.loads(str(tree, 'utf-8'))
+        else:
+            data = json.loads(tree)
 
         find_date = datetime.now()
         dupes = {}

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -14,7 +14,7 @@ class TwistlockParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.read().decode())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -14,7 +14,11 @@ class TwistlockParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(str(json_output.read(), 'utf-8'))
+            data = json_output.read()
+            if isinstance(type(data), (bytes, bytearray)):
+                tree = json.loads(str(data, 'utf-8'))
+            else:
+                tree = json.loads(data)
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -14,7 +14,7 @@ class TwistlockParser(object):
 
     def parse_json(self, json_output):
         try:
-            tree = json.loads(json_output.read().decode())
+            tree = json.loads(str(json_output.read(), 'utf-8'))
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -12,7 +12,11 @@ class WhitesourceJSONParser(object):
         if file is None:
             return
 
-        content = json.loads(str(file.read(), 'utf-8'))
+        data = file.read()
+        if isinstance(type(data), (bytes, bytearray)):
+            content = json.loads(str(data, 'utf-8'))
+        else:
+            content = json.loads(data)
         if "vulnerabilities" in content:
             tree_node = content['vulnerabilities']
             for node in tree_node:

--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -12,7 +12,7 @@ class WhitesourceJSONParser(object):
         if file is None:
             return
 
-        content = json.load(file)
+        content = json.loads(file.read().decode())
         if "vulnerabilities" in content:
             tree_node = content['vulnerabilities']
             for node in tree_node:

--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -12,7 +12,7 @@ class WhitesourceJSONParser(object):
         if file is None:
             return
 
-        content = json.loads(file.read().decode())
+        content = json.loads(str(file.read(), 'utf-8'))
         if "vulnerabilities" in content:
             tree_node = content['vulnerabilities']
             for node in tree_node:

--- a/dojo/tools/wpscan/parser.py
+++ b/dojo/tools/wpscan/parser.py
@@ -14,7 +14,11 @@ class WpscanJSONParser(object):
         self.items = ()
         if file is None:
             return
-        tree = json.loads(str(file.read(), 'utf-8'))
+        data = file.read()
+        if isinstance(type(data), (bytes, bytearray)):
+            tree = json.loads(str(data, 'utf-8'))
+        else:
+            tree = json.loads(data)
         for content in tree:
             node = tree[content]
             vuln_arr = []

--- a/dojo/tools/wpscan/parser.py
+++ b/dojo/tools/wpscan/parser.py
@@ -14,7 +14,7 @@ class WpscanJSONParser(object):
         self.items = ()
         if file is None:
             return
-        tree = json.load(file)
+        tree = json.loads(file.read().decode())
         for content in tree:
             node = tree[content]
             vuln_arr = []

--- a/dojo/tools/wpscan/parser.py
+++ b/dojo/tools/wpscan/parser.py
@@ -14,7 +14,7 @@ class WpscanJSONParser(object):
         self.items = ()
         if file is None:
             return
-        tree = json.loads(file.read().decode())
+        tree = json.loads(str(file.read(), 'utf-8'))
         for content in tree:
             node = tree[content]
             vuln_arr = []


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

At some point, importing scanners based on the JSON format was broken. When parsing the JSON file, contents would be read in as bytes instead of strings, and trigger an exception. With these changes, scans are read and decoded to strings, and then parsed.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.