### PR TITLE
Declare exposed port in nginx docker configuration

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -68,4 +68,5 @@ ENV \
   DD_UWSGI_HOST="uwsgi" \
   DD_UWSGI_PORT="3031"
 USER 1001
+EXPOSE 8080
 ENTRYPOINT ["/entrypoint-nginx.sh"]


### PR DESCRIPTION
Many third party software uses dockercompose declarations to discover things like which port may map to publish the application.