### PR TITLE
docker-compose fails with settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ credentials.
 ```sh
 git clone https://github.com/DefectDojo/django-DefectDojo
 cd django-DefectDojo
+# QuickFix
+cp dojo/settings/settings.dist.py dojo/settings/settings.py
 # building
 docker-compose build
 # running


### PR DESCRIPTION
For dev env. it is given to copy the settings.py.

I could not make it work without the copy step in docker-compose test env., too.