### PR TITLE
Improve Retire.JS parser

### DIFF
--- a/dojo/tools/retirejs/parser.py
+++ b/dojo/tools/retirejs/parser.py
@@ -31,7 +31,8 @@ class RetireJsParser(object):
 
     def get_items(self, tree, test):
         items = {}
-
+        if 'data' in tree:
+            tree = tree['data']
         for node in tree:
             for result in node['results']:
                 if 'vulnerabilities' in result:
@@ -39,23 +40,22 @@ class RetireJsParser(object):
                         item = get_item(vulnerability, test, node['file'])
                         item.title += " (" + result['component'] + ", " + result['version'] + ")"
                         item.description += "\n\n Raw Result: " + str(json.dumps(vulnerability, indent=4, sort_keys=True))
-                        item.references = item.references.encode('utf-8')
-                        encrypted_file = node['file'].encode('utf-8')
-                        unique_key = item.title + hashlib.md5(item.references).hexdigest() + hashlib.md5(encrypted_file).hexdigest()
+                        item.references = item.references
+                        encrypted_file = node['file']
+                        unique_key = hashlib.md5((item.title + item.references + encrypted_file).encode()).hexdigest()
                         items[unique_key] = item
-
         return list(items.values())
 
 
 def get_item(item_node, test, file):
     title = ""
-
-    if 'summary' in item_node['identifiers']:
-        title = item_node['identifiers']['summary']
-    elif 'CVE' in item_node['identifiers']:
-        title = "".join(item_node['identifiers']['CVE'])
-    elif 'osvdb' in item_node['identifiers']:
-        title = "".join(item_node['identifiers']['osvdb'])
+    if 'identifiers' in item_node:
+        if 'summary' in item_node['identifiers']:
+            title = item_node['identifiers']['summary']
+        elif 'CVE' in item_node['identifiers']:
+            title = "".join(item_node['identifiers']['CVE'])
+        elif 'osvdb' in item_node['identifiers']:
+            title = "".join(item_node['identifiers']['osvdb'])
 
     finding = Finding(title=title,
                       test=test,
@@ -64,7 +64,7 @@ def get_item(item_node, test, file):
                       description=title + "\n\n Affected File - " + file,
                       file_path=file,
                       mitigation="No Mitigation Provided",
-                      references="\n\n".join(item_node['info']),
+                      references="\n".join(item_node['info']),
                       active=False,
                       verified=False,
                       false_p=False,


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Improve Retire.JS parser to work with other versions. Also fix references from being displayed as bytes instead of strings.

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.