### PR TITLE
Fix Trufflehog and change dedupe test file path

### DIFF
--- a/dojo/tools/trufflehog/parser.py
+++ b/dojo/tools/trufflehog/parser.py
@@ -69,7 +69,10 @@ class TruffleHogJSONParser(object):
 
     def parse_json(self, json_output):
         try:
-            json_data = json.loads(json_output)
+            try:
+                json_data = json.loads(str(json_output, 'utf-8'))
+            except:
+                json_data = json.loads(json_output)
         except ValueError:
             raise Exception("Invalid format")
 

--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -29,6 +29,7 @@ class DedupeTest(unittest.TestCase):
         self.base_url = "http://localhost:8000/"
         self.verificationErrors = []
         self.accept_next_alert = True
+        self.relative_path = dir_path = os.path.dirname(os.path.realpath(__file__))
 
     def login_page(self):
         driver = self.driver
@@ -105,7 +106,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_path_1.json")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_path_1.json")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
         # Second test
         driver.get(self.base_url + "engagement")
@@ -115,7 +116,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_path_2.json")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_path_2.json")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
 
     def test_check_path_status(self):
@@ -168,7 +169,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
         # Second test
         driver.get(self.base_url + "engagement")
@@ -178,7 +179,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_endpoint_2.xml")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_2.xml")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
 
     def test_check_endpoint_status(self):
@@ -231,7 +232,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
         # Second test
         driver.get(self.base_url + "engagement")
@@ -241,7 +242,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_cross_1.csv")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_cross_1.csv")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
 
     def test_check_same_eng_status(self):
@@ -303,7 +304,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan Results").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_endpoint_1.xml")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_endpoint_1.xml")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
         # Second test
         driver.get(self.base_url + "engagement")
@@ -313,7 +314,7 @@ class DedupeTest(unittest.TestCase):
         driver.find_element_by_link_text("Re-Upload Scan Results").click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[3]/div/div').click()
         driver.find_element_by_xpath('//*[@id="base-content"]/form/div[4]/div/div').click()
-        driver.find_element_by_id('id_file').send_keys("/Users/codymaffucci/Desktop/dedupe/tests/dedupe_scans/dedupe_cross_1.csv")
+        driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_cross_1.csv")
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
 
     def test_check_cross_status(self):


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Trufflehog fix motivated from #1482 
Dedupe path change is for obvious reasons. 

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
