### PR TITLE
Remove JIRA status if product is not configured

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -115,17 +115,20 @@ def open_findings(request, pid=None, eid=None, view=None):
 
     product_tab = None
     active_tab = None
+    jira_config = None
 
     # Only show product tab view in product or engagement
     if pid:
         show_product_column = False
         product_tab = Product_Tab(pid, title="Findings", tab="findings")
+        jira_config = JIRA_PKey.objects.filter(product=pid)[0].conf_id
     elif eid and pid_local:
         show_product_column = False
         product_tab = Product_Tab(pid_local, title=eng.name, tab="engagements")
+        jira_config = JIRA_PKey.objects.filter(product__engagement=eid)[0].conf_id
     else:
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
-
+    # raise Exception('Stop')
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,
@@ -138,6 +141,7 @@ def open_findings(request, pid=None, eid=None, view=None):
             'filter_name': filter_name,
             'title': title,
             'tag_input': tags,
+            'jira_config': jira_config,
         })
 
 

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -138,8 +138,10 @@
                             <th>Status</th>
                             <th></th>
                             {% if "enable_jira"|get_system_setting %}
-                              <th>JIRA Age</th>
-                              <th>JIRA Change</th>
+                              {% if jira_config and product_tab or not product_tab %}
+                                <th>JIRA Age</th>
+                                <th>JIRA Change</th>
+                              {% endif %}
                             {% endif%}
                             {% if show_product_column and product_tab is None %}
                             <th class="nowrap">{% dojo_sort request 'Product' 'test__engagement__product__name'%}</th>
@@ -318,21 +320,21 @@
                                     {% endif %}
                                   {% endif %}
                                 </td>
-
-                                <td class="nowrap">
-                                  {% if "enable_jira"|get_system_setting %}
-                                    {% if finding.jira_creation %}
-                                      {{ finding.jira_creation|timesince }} 
-                                    {% endif %} 
+                                {% if "enable_jira"|get_system_setting %}
+                                  {% if jira_config and product_tab or not product_tab %}
+                                      <td class="nowrap">
+                                        {% if finding.jira_creation %}
+                                          {{ finding.jira_creation|timesince }} 
+                                        {% endif %} 
+                                      </td>
+                                      <td class="nowrap">
+                                        {% if finding.jira_change %}
+                                          {{ finding.jira_change|timesince }} 
+                                        {% endif %}
+                                      </td> 
                                   {% endif %}
-                                </td>
-                                <td class="nowrap">
-                                  {% if "enable_jira"|get_system_setting %}
-                                    {% if finding.jira_change %}
-                                      {{ finding.jira_change|timesince }} 
-                                    {% endif %} 
-                                  {% endif %}
-                                </td>
+                                {% endif %}
+                                
 
 
                                 {% if show_product_column and product_tab is None %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -196,9 +196,11 @@
                     <th>Reporter</th>
                     <th>Status</th>
                     {% if "enable_jira"|get_system_setting %}
-                    <th>Jira</th>
-                    <th>Jira Age</th>
-                    <th>Jira Change</th>
+                        {% if jira_config and product_tab or not product_tab %}
+                            <th>Jira</th>
+                            <th>Jira Age</th>
+                            <th>Jira Change</th>
+                        {% endif %}
                     {% endif %}
                 </tr>
                 </thead>
@@ -420,23 +422,24 @@
                         {% endif %}
                         </td>
                         {% if "enable_jira"|get_system_setting %}
-                            <td>
-                            <a href="{{finding.jira_conf.url}}/browse/{{finding.jira.jira_key}}" target="_blank"> {{finding.jira.jira_key}} </a>
-                            </td>
-                            <td class="nowrap">
-                                {% if "enable_jira"|get_system_setting %}
+                            {% if jira_config and product_tab or not product_tab %}
+                                <td>
+                                    <a href="{{finding.jira_conf.url}}/browse/{{finding.jira.jira_key}}" target="_blank"> {{finding.jira.jira_key}} </a>
+                                </td>
+                                
                                 {% if finding.jira_creation %}
-                                    {{ finding.jira_creation|timesince }} 
+                                    <td class="nowrap">
+                                        {{ finding.jira_creation|timesince }} 
+                                    </td>
                                 {% endif %} 
-                                {% endif %}
-                            </td>
-                            <td class="nowrap">
-                                {% if "enable_jira"|get_system_setting %}
+                            
                                 {% if finding.jira_change %}
-                                    {{ finding.jira_change|timesince }} 
+                                    <td class="nowrap">
+                                        {{ finding.jira_change|timesince }} 
+                                    </td>
                                 {% endif %} 
-                                {% endif %}
-                            </td>
+                                    
+                            {% endif %}
                         {% endif %}
                     </tr>
                 {% endfor %}

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -70,6 +70,7 @@ def view_test(request, tid):
 
     product_tab = Product_Tab(prod.id, title="Test", tab="engagements")
     product_tab.setEngagement(test.engagement)
+    jira_config = JIRA_PKey.objects.filter(product=prod.id)[0].conf_id
     return render(request, 'dojo/view_test.html',
                   {'test': test,
                    'product_tab': product_tab,
@@ -83,7 +84,8 @@ def view_test(request, tid):
                    'show_re_upload': show_re_upload,
                    'creds': creds,
                    'cred_test': cred_test,
-                   'tag_input': tags
+                   'tag_input': tags,
+                   'jira_config': jira_config,
                    })
 
 


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Motivated by #1496 
Findings no longer display Jira status if the associated product is not configured with Jira. If a user is looking at all findings independent from products, the Jira statuses will appear simply if Jira is enabled.

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.