### PR TITLE
Add option to move engagements to different products

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -109,6 +109,7 @@ def new_engagement(request):
             new_eng.api_test = False
             new_eng.pen_test = False
             new_eng.check_list = False
+            new_eng.product_id = form.cleaned_data.get('product').id
             new_eng.save()
             tags = request.POST.getlist('tags')
             t = ", ".join(tags)
@@ -126,7 +127,6 @@ def new_engagement(request):
                     reverse('view_engagement', args=(new_eng.id, )))
     else:
         form = EngForm(initial={'date': timezone.now().date()})
-
     add_breadcrumb(title="New Engagement", top_level=False, request=request)
     return render(request, 'dojo/new_eng.html', {
         'form': form,
@@ -161,6 +161,7 @@ def edit_engagement(request, eid):
                 temp_form.active = False
             elif(temp_form.active is False):
                 temp_form.active = True
+            temp_form.product_id = form.cleaned_data.get('product').id
             temp_form.save()
             tags = request.POST.getlist('tags')
             t = ", ".join(tags)
@@ -177,7 +178,7 @@ def edit_engagement(request, eid):
                 return HttpResponseRedirect(
                     reverse('view_engagement', args=(eng.id, )))
     else:
-        form = EngForm(instance=eng, cicd=ci_cd_form, product=eng.product.id)
+        form = EngForm(initial={'product': eng.product.id}, instance=eng, cicd=ci_cd_form, product=eng.product.id)
         try:
             # jissue = JIRA_Issue.objects.get(engagement=eng)
             enabled = True

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -589,6 +589,9 @@ class EngForm(forms.ModelForm):
                   "listings.")
     description = forms.CharField(widget=forms.Textarea(attrs={}),
                                   required=False, help_text="Description of the engagement and details regarding the engagement.")
+    product = forms.ModelChoiceField(label='Product',
+                                       queryset=Product.objects.all().order_by('name'),
+                                       required=True)
     tags = forms.CharField(widget=forms.SelectMultiple(choices=[]),
                            required=False,
                            help_text="Add tags that help describe this engagement.  "

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -635,7 +635,7 @@ def new_eng_for_app(request, pid, cicd=False):
             new_eng.api_test = False
             new_eng.pen_test = False
             new_eng.check_list = False
-            new_eng.product = prod
+            new_eng.product_id = form.cleaned_data.get('product').id
             if new_eng.threat_model:
                 new_eng.progress = 'threat_model'
             else:
@@ -671,7 +671,7 @@ def new_eng_for_app(request, pid, cicd=False):
             else:
                 return HttpResponseRedirect(reverse('view_engagement', args=(new_eng.id,)))
     else:
-        form = EngForm(initial={'lead': request.user, 'target_start': timezone.now().date(), 'target_end': timezone.now().date() + timedelta(days=7)}, cicd=cicd, product=prod.id)
+        form = EngForm(initial={'lead': request.user, 'target_start': timezone.now().date(), 'target_end': timezone.now().date() + timedelta(days=7), 'product': prod.id}, cicd=cicd, product=prod.id)
         if(get_system_setting('enable_jira')):
             if JIRA_PKey.objects.filter(product=prod).count() != 0:
                 jform = JIRAFindingForm(prefix='jiraform', enabled=JIRA_PKey.objects.get(product=prod).push_all_issues)


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Motivated by #1503 

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
