### PR TITLE
Fix Jira status bug

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -128,7 +128,8 @@ def open_findings(request, pid=None, eid=None, view=None):
         jira_config = JIRA_PKey.objects.filter(product__engagement=eid).first()
     else:
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
-    # raise Exception('Stop')
+    if jira_config:
+        jira_config = jira_config.conf_id
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -71,6 +71,8 @@ def view_test(request, tid):
     product_tab = Product_Tab(prod.id, title="Test", tab="engagements")
     product_tab.setEngagement(test.engagement)
     jira_config = JIRA_PKey.objects.filter(product=prod.id).first()
+    if jira_config:
+        jira_config = jira_config.conf_id
     return render(request, 'dojo/view_test.html',
                   {'test': test,
                    'product_tab': product_tab,


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

If a product originally had a Jira configuration, but was later disabled, the Jira product key would still be associated with the product. This new check ensure that a configuration is present, _and_ also active before displaying Jira status such as age and most recent modification.

This is the last time this will happen!

- [x] Your code is flake8 compliant 
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.