### PR TITLE
Manually set parent of duplicate

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -560,6 +560,22 @@ def edit_finding(request, fid):
                 new_finding.false_p = False
                 new_finding.mitigated = None
                 new_finding.mitigated_by = None
+            if new_finding.duplicate:
+                new_finding.duplicate = True
+                new_finding.active = False
+                new_finding.verified = False
+                parent_find_string = request.POST.get('duplicate_choice', '')
+                if parent_find_string:
+                    parent_find = Finding.objects.get(id=int(parent_find_string.split(':')[0]))
+                    new_finding.duplicate_finding = parent_find
+                    parent_find.duplicate_list.add(new_finding)
+                    parent_find.found_by.add(new_finding.test.test_type)
+            if not new_finding.duplicate and new_finding.duplicate_finding:
+                parent_find = new_finding.duplicate_finding
+                if parent_find.found_by is not new_finding.found_by:
+                    parent_find.duplicate_list.remove(new_finding)
+                parent_find.found_by.remove(new_finding.test.test_type)
+                new_finding.duplicate_finding = None
 
             create_template = new_finding.is_template
             # always false now since this will be deprecated soon in favor of new Finding_Template model
@@ -648,12 +664,22 @@ def edit_finding(request, fid):
         form.fields['endpoints'].queryset = finding.endpoints.all()
     form.initial['tags'] = [tag.name for tag in finding.tags]
 
+    if finding.test.engagement.deduplication_on_engagement:
+        finding_dupes = Finding.objects.all().filter(
+            test__engagement=finding.test.engagement).filter(
+            title=finding.title).exclude(
+            id=finding.id)
+    else:
+        finding_dupes = Finding.objects.all().filter(
+            title=finding.title).exclude(
+            id=finding.id)
     product_tab = Product_Tab(finding.test.engagement.product.id, title="Edit Finding", tab="findings")
     return render(request, 'dojo/edit_findings.html', {
         'product_tab': product_tab,
         'form': form,
         'finding': finding,
-        'jform': jform
+        'jform': jform,
+        'dupes': finding_dupes,
     })
 
 

--- a/dojo/templates/dojo/edit_findings.html
+++ b/dojo/templates/dojo/edit_findings.html
@@ -47,6 +47,21 @@
               <input type="hidden" name="page" value="{{ request.GET.page|paginator_form }}">
             {% endif %}
             {% include "dojo/form_fields.html" with form=form %}
+            <div class="form-group hidden">
+                {% if dupes %}
+                    <label class="col-sm-2 control-label" for="dupe_choice">Parent Duplicate</label>
+                    <div class="col-sm-10">
+                        <select class="form-control" name=duplicate_choice id="dupe_choice">
+                            {% for dupe in dupes %}
+                                <option>{{ dupe.id }}: {{ dupe.title }},
+                                        {{ dupe.test.engagement.product }}/{{ dupe.test.engagement }}/{{ dupte.test }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                {% endif %}
+            </div>
+
             {% if jform %}
                 {% include "dojo/form_fields.html" with form=jform %}
             {% endif %}
@@ -122,6 +137,31 @@
                 });
                 mde.render();
             });
+        });
+
+        window.onload = function() {
+            var menu = document.getElementById("dupe_choice").parentElement.parentElement
+            var dupe_box = document.getElementById("id_duplicate").parentElement.parentElement.parentElement.parentElement
+            if ($("#id_duplicate").prop("checked")) {
+                dupe_box.insertAdjacentElement("afterend", menu)
+                menu.setAttribute("class", "form-group");
+            }
+            else {
+                menu.setAttribute("class", "form-group hidden");
+            }
+        };
+
+        $("#id_duplicate").change(function () {
+            var menu = document.getElementById("dupe_choice").parentElement.parentElement
+            var dupe_box = document.getElementById("id_duplicate").parentElement.parentElement.parentElement.parentElement
+            if ($(this).prop("checked")) {
+                dupe_box.insertAdjacentElement("afterend", menu)
+                menu.setAttribute("class", "form-group");
+            }
+            else {
+                menu.setAttribute("class", "form-group hidden");
+            }
+
         });
 
         $("#add_finding").submit(function () {


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Motivated by #1510 

Findings that are manually marked as duplicate now provide a link to the original finding and will appear in the parent findings duplicate list. Duplicates are determined by title only. Information displayed on each finding is as follows:

id: title, product/engagement/test

The dropdown menu will only appear if the the duplicate box is selected and there are other findings that have a matching title.

Here is an example:
<img width="783" alt="Screen Shot 2019-08-21 at 12 27 15 PM" src="https://user-images.githubusercontent.com/46459665/63453773-06d9c780-c40f-11e9-92b6-946e3843466e.png">

- [x] Your code is flake8 compliant 
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.