### PR TITLE
Adjust finding status to display product metrics

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -183,7 +183,7 @@ def view_product_metrics(request, pid):
     verified_findings = Finding.objects.filter(test__engagement__product=prod,
                                                date__range=[start_date, end_date],
                                                false_p=False,
-                                               verified=True,
+                                               verified=False,
                                                duplicate=False,
                                                out_of_scope=False).order_by("date")
 
@@ -199,7 +199,7 @@ def view_product_metrics(request, pid):
     open_findings = Finding.objects.filter(test__engagement__product=prod,
                                            date__range=[start_date, end_date],
                                            false_p=False,
-                                           verified=True,
+                                           verified=False,
                                            duplicate=False,
                                            out_of_scope=False,
                                            active=True,
@@ -208,7 +208,7 @@ def view_product_metrics(request, pid):
     closed_findings = Finding.objects.filter(test__engagement__product=prod,
                                              date__range=[start_date, end_date],
                                              false_p=False,
-                                             verified=True,
+                                             verified=False,
                                              duplicate=False,
                                              out_of_scope=False,
                                              mitigated__isnull=False)
@@ -216,7 +216,7 @@ def view_product_metrics(request, pid):
     open_vulnerabilities = Finding.objects.filter(
         test__engagement__product=prod,
         false_p=False,
-        verified=True,
+        verified=False,
         duplicate=False,
         out_of_scope=False,
         active=True,
@@ -253,7 +253,7 @@ def view_product_metrics(request, pid):
     high_weekly = OrderedDict()
     medium_weekly = OrderedDict()
 
-    for v in verified_findings:
+    for v in open_findings:
         iso_cal = v.date.isocalendar()
         x = iso_to_gregorian(iso_cal[0], iso_cal[1], 1)
         y = x.strftime("<span class='small'>%m/%d<br/>%Y</span>")
@@ -271,7 +271,6 @@ def view_product_metrics(request, pid):
             else:
                 open_close_weekly[x]['open'] += 1
         else:
-
             if v.mitigated:
                 open_close_weekly[x] = {'closed': 1, 'open': 0, 'accepted': 0}
             else:

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -183,7 +183,7 @@ def view_product_metrics(request, pid):
     verified_findings = Finding.objects.filter(test__engagement__product=prod,
                                                date__range=[start_date, end_date],
                                                false_p=False,
-                                               verified=False,
+                                               verified=True,
                                                duplicate=False,
                                                out_of_scope=False).order_by("date")
 
@@ -199,7 +199,6 @@ def view_product_metrics(request, pid):
     open_findings = Finding.objects.filter(test__engagement__product=prod,
                                            date__range=[start_date, end_date],
                                            false_p=False,
-                                           verified=False,
                                            duplicate=False,
                                            out_of_scope=False,
                                            active=True,


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Based on previous discussions where it was decided that open findings didn't need to be marked as verified, this is a quick fix to display metrics in the Product's tab.

Fixes #1518 