### PR TITLE
add missing volumes in docker dev mode

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -4,7 +4,7 @@
 # The code for the build image should be idendical with the code in
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
-# Using 3.5.7 to avoid compatibility issues that may be introduced by python 3.5.6 and 3.5.7. 
+# Using 3.5.7 to avoid compatibility issues that may be introduced by python 3.6 and 3.7.
 # Please upgrade before end-of-life in september 2020!
 # Ref: https://devguide.python.org/#branchstatus
 FROM python:3.5.7-buster@sha256:4598d4365bb7a8628ba840f87406323e699c4da01ae6f926ff33787c63230779 as build

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -10,6 +10,12 @@ services:
   celeryworker:
     volumes:
       - '.:/app:z'
+  celerybeat:
+    volumes:
+      - '.:/app:z'
+  initializer:
+    volumes:
+      - '.:/app:z'
   nginx:
     volumes:
       - './dojo/static/dojo:/usr/share/nginx/html/static/dojo'


### PR DESCRIPTION
In docker dev mode, the volumes for the initializer and celerybeat containers are missing. 
- For the initializer it's important for db_migrations: without this volumes, we still needed to rebuild the django image after each change, even in dev mode (because the db_migrations are done in the initializer container, not uwsgi which already has this volume)
- add also celerybeat for completeness


'+ fixing a typo in Dockerfile.django