### PR TITLE
Make finding images downloadable via API

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from rest_framework import serializers
 from django.core.exceptions import ValidationError
 from django.utils import timezone
+import base64
 import datetime
 import six
 from django.utils.translation import ugettext_lazy as _
@@ -375,14 +376,14 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
 
 
 class FindingImageSerializer(serializers.ModelSerializer):
-    url = serializers.SerializerMethodField()
+    base64 = serializers.SerializerMethodField()
 
     class Meta:
         model = FindingImage
-        fields = ["caption", "id", "url"]
+        fields = ["base64", "caption", "id"]
 
-    def get_url(self, obj):
-        return obj.image.url
+    def get_base64(self, obj):
+        return base64.b64encode(obj.image.read())
 
 
 class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):


### PR DESCRIPTION
This addresses and closes #1526.

Finding images are now provided as base64 encoded strings via the REST API. So, everyone having access to a finding now also has access to associated images.

When submitting a pull request, please make sure you have completed the following checklist:

- [X] Your code is flake8 compliant 
- [X] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.