### PR TITLE
Fix bug when displaying accepted findings

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -521,7 +521,7 @@ class AcceptedFindingFilter(DojoFilter):
         cwe = dict()
         cwe = dict([finding.cwe, finding.cwe]
                    for finding in self.queryset.distinct()
-                   if finding.cwe > 0 and finding.cwe not in cwe)
+                   if type(finding.cwe) is int and finding.cwe > 0 and finding.cwe not in cwe)
         cwe = collections.OrderedDict(sorted(cwe.items()))
         self.form.fields['cwe'].choices = list(cwe.items())
         self.form.fields['severity'].choices = self.queryset.order_by(


### PR DESCRIPTION
If the cwe is None (which is the default), displaying the accepted finding will throw a type error. This is a relict form the python 3 migration: https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons

on behalf of DB Systel GmbH

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.