### PR TITLE
json_output doesnt exist

### DIFF
--- a/dojo/tools/ssl_labs/parser.py
+++ b/dojo/tools/ssl_labs/parser.py
@@ -7,7 +7,7 @@ import json
 
 class SSLlabsParser(object):
     def __init__(self, filename, test):
-        tree = json_output.read()
+        tree = filename.read()
         try:
             data = json.loads(str(tree, 'utf-8'))
         except:


### PR DESCRIPTION

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] Add applicable tests to the unit tests.

Just check the diff and you'll understand, ssllab parser never worked.