### PR TITLE
fix bug with jumping sidebar

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -127,7 +127,7 @@
             </ul>
             <!-- /.navbar-top-links -->
 
-            <div class="navbar-default sidebar" role="navigation">
+            <div class="navbar-default sidebar navbar-fixed-top" role="navigation">
                 <div class="sidebar-nav navbar-collapse">
                     <ul class="nav" id="side-menu">
                         {% block sidebar-items %}


### PR DESCRIPTION
The sidebar jumps down if you hover over it. Now the sidebar remains on the top.

![image](https://user-images.githubusercontent.com/16321214/64782842-879b6780-d566-11e9-88e5-6fb2c512fc87.png)

![image](https://user-images.githubusercontent.com/16321214/64782810-6d618980-d566-11e9-96a7-10c16997a5a0.png)


On behalf of DB System GmbH

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.