### PR TITLE
promote_to_finding crash on endpoints

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1066,7 +1066,7 @@ def promote_to_finding(request, fid):
             new_finding.out_of_scope = False
 
             new_finding.save()
-            new_finding.endpoints = form.cleaned_data['endpoints']
+            new_finding.endpoints.set(form.cleaned_data['endpoints'])
             new_finding.save()
 
             finding.delete()


### PR DESCRIPTION
When submitting a pull request, please make sure you have completed the follwing checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] Add applicable tests to the unit tests.

```
uwsgi_1         | Internal Server Error: /stub_finding/1/promote
uwsgi_1         | Traceback (most recent call last):
uwsgi_1         |   File "/usr/local/lib/python3.5/site-packages/django/core/handlers/exception.py", line 34, in inner
uwsgi_1         |     response = get_response(request)
uwsgi_1         |   File "/usr/local/lib/python3.5/site-packages/django/core/handlers/base.py", line 115, in _get_response
uwsgi_1         |     response = self.process_exception_by_middleware(e, request)
uwsgi_1         |   File "/usr/local/lib/python3.5/site-packages/django/core/handlers/base.py", line 113, in _get_response
uwsgi_1         |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
uwsgi_1         |   File "/usr/local/lib/python3.5/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
uwsgi_1         |     return view_func(request, *args, **kwargs)
uwsgi_1         |   File "./dojo/finding/views.py", line 1042, in promote_to_finding
uwsgi_1         |     new_finding.endpoints = form.cleaned_data['endpoints']
uwsgi_1         |   File "/usr/local/lib/python3.5/site-packages/django/db/models/fields/related_descriptors.py", line 538, in __set__
uwsgi_1         |     % self._get_set_deprecation_msg_params(),
uwsgi_1         | TypeError: Direct assignment to the forward side of a many-to-many set is prohibited. Use endpoints.set() instead.
```