### PR TITLE
Mark finding as inactive if specified by a parser

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -544,8 +544,10 @@ def import_scan_results(request, eid=None, pid=None):
                     item.last_reviewed = timezone.now()
                     item.last_reviewed_by = request.user
                     if form.get_scan_type() != "Generic Findings Import":
-                        item.active = active
-                        item.verified = verified
+                        if not item.active:
+                            item.active = active
+                        if not item.verified:
+                            item.verified = verified
                     item.save(dedupe_option=False, false_history=True)
 
                     if hasattr(item, 'unsaved_req_resp') and len(


### PR DESCRIPTION
If a finding is marked as active by a parser it overwrites the default value. This should also be possible if a finding is marked as deactivated or mitigated.

On behalf of DB Systel GmbH

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [] Add applicable tests to the unit tests.