### PR TITLE
Fix tables of contents and test pdf report

### DIFF
--- a/dojo/templates/dojo/asciidoc_report.html
+++ b/dojo/templates/dojo/asciidoc_report.html
@@ -502,6 +502,78 @@
             var toc = "";
             var level = 3;
 
+            document.getElementById("contents").innerHTML =
+                document.getElementById("contents").innerHTML.replace(
+                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
+                        if (openLevel != closeLevel || openLevel > 5) {
+                            return str;
+                        }
+
+                        if(tags)
+                        {
+                            openLevel = openLevel_t;
+                            id = id_t;
+                            titleText = titleText_t;
+                            closeLevel = closeLevel_t;
+                        }
+
+                        if (openLevel > level) {
+                            toc += (new Array(openLevel - level + 1)).join("<ul>");
+                        } else if (openLevel < level) {
+                            toc += (new Array(level - openLevel + 1)).join("</ul>");
+                        }
+
+                        level = parseInt(openLevel);
+                        
+                        var anchor = titleText.trim().replace(/ /g, "_");
+
+                        if(tags)
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "<sup>" + tags + "</sup></a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                        }
+                        else
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "</a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "</h" + closeLevel + "></a>";
+                        }
+
+                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                            + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                    }
+                );
+                
+            if (level) {
+                toc += (new Array(level + 1)).join("</ul>");
+            }
+
+            document.getElementById("toc").innerHTML += toc;
+        };
+
+/*
+        window.onload = function () {
+            var toc = "";
+            var level = 3;
+
             // Handle all elements exclusive of tags
             document.getElementById("contents").innerHTML =
                 document.getElementById("contents").innerHTML.replace(
@@ -561,7 +633,7 @@
 
             document.getElementById("toc").innerHTML += toc;
         };
-
+*/
     </script>
 {% endblock %}
 

--- a/dojo/templates/dojo/asciidoc_report.html
+++ b/dojo/templates/dojo/asciidoc_report.html
@@ -482,7 +482,7 @@
                             <p><b>==== Finding Notes: ====</b>
                                 <br>
                                     {% for note in notes reversed %}
-                                            {{ note.author }} - {{ note.date }} - {{ note }} +<br>
+                                            {{ note.author }} - {{ note.date }} - {{ note|linebreaks }} +<br>
                                     {% endfor %}
                             </p><br>
                         {% endif %}

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -547,13 +547,20 @@
             var toc = "";
             var level = 3;
 
-            // Handle all elements exclusive of tags
             document.getElementById("contents").innerHTML =
                 document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, closeLevel) {
+                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
                         if (openLevel != closeLevel || openLevel > 5) {
                             return str;
+                        }
+
+                        if(tags)
+                        {
+                            openLevel = openLevel_t;
+                            id = id_t;
+                            titleText = titleText_t;
+                            closeLevel = closeLevel_t;
                         }
 
                         if (openLevel > level) {
@@ -566,50 +573,35 @@
                         
                         var anchor = titleText.trim().replace(/ /g, "_");
 
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "</a></li>";
-                        }
-                        
-                        
-                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                            + titleText + "</h" + closeLevel + "></a>";
-                    }
-                );
+                        if(tags)
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "<sup>" + tags + "</sup></a></li>";
+                            }
 
-                // Handle findings with tags
-                document.getElementById("contents").innerHTML =
-                document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<sup>([^<]+)<\/sup>([^<]*)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, tags, junk, closeLevel) {
-                        if (openLevel != closeLevel || openLevel > 5) {
-                            return str;
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                        }
+                        else
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "</a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "</h" + closeLevel + "></a>";
                         }
 
-                        if (openLevel > level) {
-                            toc += (new Array(openLevel - level + 1)).join("<ul>");
-                        } else if (openLevel < level) {
-                            toc += (new Array(level - openLevel + 1)).join("</ul>");
-                        }
-
-                        level = parseInt(openLevel);
-                        
-                        var anchor = titleText.trim().replace(/ /g, "_");
-
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "<sup>" + tags + "</sup></a></li>";
-                        }
-                        
-                        
                         return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                             + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                     }

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -313,7 +313,7 @@
                                                     {{ note.date }}
                                                 </td>
                                                 <td>
-                                                    {{ note }}
+                                                    {{ note|linebreaks }}
                                                 </td>
                                             </tr>
                                         {% endfor %}

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -19,7 +19,7 @@
         {% if include_table_of_contents%}
 			<div class="row">
 				<div class="col-lg-12" id="toc">
-					<h3 id="table_of_contents">Table of Contents for {{ product.name }}</h3>
+					<h3 id="table_of_contents">Table of Contents for {{ engagement.name }}</h3>
 				</div>
 			</div>
 
@@ -756,13 +756,20 @@
             var toc = "";
             var level = 3;
 
-            // Handle all elements exclusive of tags
             document.getElementById("contents").innerHTML =
                 document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, closeLevel) {
+                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
                         if (openLevel != closeLevel || openLevel > 5) {
                             return str;
+                        }
+
+                        if(tags)
+                        {
+                            openLevel = openLevel_t;
+                            id = id_t;
+                            titleText = titleText_t;
+                            closeLevel = closeLevel_t;
                         }
 
                         if (openLevel > level) {
@@ -775,50 +782,35 @@
                         
                         var anchor = titleText.trim().replace(/ /g, "_");
 
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "</a></li>";
-                        }
-                        
-                        
-                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                            + titleText + "</h" + closeLevel + "></a>";
-                    }
-                );
+                        if(tags)
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "<sup>" + tags + "</sup></a></li>";
+                            }
 
-                // Handle findings with tags
-                document.getElementById("contents").innerHTML =
-                document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<sup>([^<]+)<\/sup>([^<]*)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, tags, junk, closeLevel) {
-                        if (openLevel != closeLevel || openLevel > 5) {
-                            return str;
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                        }
+                        else
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "</a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "</h" + closeLevel + "></a>";
                         }
 
-                        if (openLevel > level) {
-                            toc += (new Array(openLevel - level + 1)).join("<ul>");
-                        } else if (openLevel < level) {
-                            toc += (new Array(level - openLevel + 1)).join("</ul>");
-                        }
-
-                        level = parseInt(openLevel);
-                        
-                        var anchor = titleText.trim().replace(/ /g, "_");
-
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "<sup>" + tags + "</sup></a></li>";
-                        }
-                        
-                        
                         return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                             + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                     }

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -447,7 +447,7 @@
                                                     {{ note.date }}
                                                 </td>
                                                 <td>
-                                                    {{ note }}
+                                                    {{ note|linebreaks }}
                                                 </td>
                                             </tr>
                                         {% endfor %}

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -287,7 +287,7 @@
                                                     {{ note.date }}
                                                 </td>
                                                 <td>
-                                                    {{ note }}
+                                                    {{ note|linebreaks }}
                                                 </td>
                                             </tr>
                                         {% endfor %}

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -521,13 +521,20 @@
             var toc = "";
             var level = 3;
 
-            // Handle all elements exclusive of tags
             document.getElementById("contents").innerHTML =
                 document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, closeLevel) {
+                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
                         if (openLevel != closeLevel || openLevel > 5) {
                             return str;
+                        }
+
+                        if(tags)
+                        {
+                            openLevel = openLevel_t;
+                            id = id_t;
+                            titleText = titleText_t;
+                            closeLevel = closeLevel_t;
                         }
 
                         if (openLevel > level) {
@@ -540,50 +547,35 @@
                         
                         var anchor = titleText.trim().replace(/ /g, "_");
 
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "</a></li>";
-                        }
-                        
-                        
-                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                            + titleText + "</h" + closeLevel + "></a>";
-                    }
-                );
+                        if(tags)
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "<sup>" + tags + "</sup></a></li>";
+                            }
 
-                // Handle findings with tags
-                document.getElementById("contents").innerHTML =
-                document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<sup>([^<]+)<\/sup>([^<]*)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, tags, junk, closeLevel) {
-                        if (openLevel != closeLevel || openLevel > 5) {
-                            return str;
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                        }
+                        else
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "</a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "</h" + closeLevel + "></a>";
                         }
 
-                        if (openLevel > level) {
-                            toc += (new Array(openLevel - level + 1)).join("<ul>");
-                        } else if (openLevel < level) {
-                            toc += (new Array(level - openLevel + 1)).join("</ul>");
-                        }
-
-                        level = parseInt(openLevel);
-                        
-                        var anchor = titleText.trim().replace(/ /g, "_");
-
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "<sup>" + tags + "</sup></a></li>";
-                        }
-                        
-                        
                         return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                             + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                     }

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -865,13 +865,20 @@
             var toc = "";
             var level = 3;
 
-            // Handle all elements exclusive of tags
             document.getElementById("contents").innerHTML =
                 document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, closeLevel) {
+                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
                         if (openLevel != closeLevel || openLevel > 5) {
                             return str;
+                        }
+
+                        if(tags)
+                        {
+                            openLevel = openLevel_t;
+                            id = id_t;
+                            titleText = titleText_t;
+                            closeLevel = closeLevel_t;
                         }
 
                         if (openLevel > level) {
@@ -884,50 +891,35 @@
                         
                         var anchor = titleText.trim().replace(/ /g, "_");
 
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "</a></li>";
-                        }
-                        
-                        
-                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                            + titleText + "</h" + closeLevel + "></a>";
-                    }
-                );
+                        if(tags)
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "<sup>" + tags + "</sup></a></li>";
+                            }
 
-                // Handle findings with tags
-                document.getElementById("contents").innerHTML =
-                document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<sup>([^<]+)<\/sup>([^<]*)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, tags, junk, closeLevel) {
-                        if (openLevel != closeLevel || openLevel > 5) {
-                            return str;
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                        }
+                        else
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "</a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "</h" + closeLevel + "></a>";
                         }
 
-                        if (openLevel > level) {
-                            toc += (new Array(openLevel - level + 1)).join("<ul>");
-                        } else if (openLevel < level) {
-                            toc += (new Array(level - openLevel + 1)).join("</ul>");
-                        }
-
-                        level = parseInt(openLevel);
-                        
-                        var anchor = titleText.trim().replace(/ /g, "_");
-
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "<sup>" + tags + "</sup></a></li>";
-                        }
-                        
-                        
                         return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                             + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                     }

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -361,7 +361,7 @@
                                                         {{ note.date }}
                                                     </td>
                                                     <td>
-                                                        {{ note }}
+                                                        {{ note|linebreaks }}
                                                     </td>
                                                 </tr>
                                             {% endfor %}

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -427,7 +427,7 @@
                                                     {{ note.date }}
                                                 </td>
                                                 <td>
-                                                    {{ note }}
+                                                    {{ note|linebreaks }}
                                                 </td>
                                             </tr>
                                         {% endfor %}

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -796,13 +796,20 @@
             var toc = "";
             var level = 3;
 
-            // Handle all elements exclusive of tags
             document.getElementById("contents").innerHTML =
                 document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, closeLevel) {
+                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
                         if (openLevel != closeLevel || openLevel > 5) {
                             return str;
+                        }
+
+                        if(tags)
+                        {
+                            openLevel = openLevel_t;
+                            id = id_t;
+                            titleText = titleText_t;
+                            closeLevel = closeLevel_t;
                         }
 
                         if (openLevel > level) {
@@ -815,50 +822,35 @@
                         
                         var anchor = titleText.trim().replace(/ /g, "_");
 
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "</a></li>";
-                        }
-                        
-                        
-                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                            + titleText + "</h" + closeLevel + "></a>";
-                    }
-                );
+                        if(tags)
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "<sup>" + tags + "</sup></a></li>";
+                            }
 
-                // Handle findings with tags
-                document.getElementById("contents").innerHTML =
-                document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<sup>([^<]+)<\/sup>([^<]*)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, tags, junk, closeLevel) {
-                        if (openLevel != closeLevel || openLevel > 5) {
-                            return str;
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                        }
+                        else
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "</a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "</h" + closeLevel + "></a>";
                         }
 
-                        if (openLevel > level) {
-                            toc += (new Array(openLevel - level + 1)).join("<ul>");
-                        } else if (openLevel < level) {
-                            toc += (new Array(level - openLevel + 1)).join("</ul>");
-                        }
-
-                        level = parseInt(openLevel);
-                        
-                        var anchor = titleText.trim().replace(/ /g, "_");
-
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "<sup>" + tags + "</sup></a></li>";
-                        }
-                        
-                        
                         return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                             + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                     }

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -587,13 +587,20 @@
             var toc = "";
             var level = 3;
 
-            // Handle all elements exclusive of tags
             document.getElementById("contents").innerHTML =
                 document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, closeLevel) {
+                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
                         if (openLevel != closeLevel || openLevel > 5) {
                             return str;
+                        }
+
+                        if(tags)
+                        {
+                            openLevel = openLevel_t;
+                            id = id_t;
+                            titleText = titleText_t;
+                            closeLevel = closeLevel_t;
                         }
 
                         if (openLevel > level) {
@@ -606,50 +613,35 @@
                         
                         var anchor = titleText.trim().replace(/ /g, "_");
 
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "</a></li>";
-                        }
-                        
-                        
-                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                            + titleText + "</h" + closeLevel + "></a>";
-                    }
-                );
+                        if(tags)
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "<sup>" + tags + "</sup></a></li>";
+                            }
 
-                // Handle findings with tags
-                document.getElementById("contents").innerHTML =
-                document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<sup>([^<]+)<\/sup>([^<]*)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, tags, junk, closeLevel) {
-                        if (openLevel != closeLevel || openLevel > 5) {
-                            return str;
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                        }
+                        else
+                        {
+                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                            }
+                            else {
+                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                titleText + "</a></li>";
+                            }
+
+                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                + titleText + "</h" + closeLevel + "></a>";
                         }
 
-                        if (openLevel > level) {
-                            toc += (new Array(openLevel - level + 1)).join("<ul>");
-                        } else if (openLevel < level) {
-                            toc += (new Array(level - openLevel + 1)).join("</ul>");
-                        }
-
-                        level = parseInt(openLevel);
-                        
-                        var anchor = titleText.trim().replace(/ /g, "_");
-
-                        if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                        }
-                        else {
-                            toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                            titleText + "<sup>" + tags + "</sup></a></li>";
-                        }
-                        
-                        
                         return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                             + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                     }

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -347,7 +347,7 @@
                                                     {{ note.date }}
                                                 </td>
                                                 <td>
-                                                    {{ note }}
+                                                    {{ note|linebreaks }}
                                                 </td>
                                             </tr>
                                         {% endfor %}

--- a/dojo/templates/dojo/snippets/comments.html
+++ b/dojo/templates/dojo/snippets/comments.html
@@ -66,7 +66,7 @@
           {% endif %} 
       </div>
       <div class="panel-body">
-        {{ note }}
+        {{ note|linebreaks }}
       </div>
     </div>
   </div>

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -9,7 +9,7 @@
     <div class="container">
         <div class="row">
           <div class="col-lg-12">
-              <h3 id="product">Test Security Report for {{ test.engagement.product.name }}</h3>
+              <h3 id="product">Test Security Report for {{ test }}</h3>
               <p>
                 <strong>Engagement:</strong> {{ test.engagement.name }}
                 <br><strong>Test:</strong> {{ test }}
@@ -20,7 +20,7 @@
         {% if include_table_of_contents%}
 			<div class="row">
 				<div class="col-lg-12" id="toc">
-					<h3 id="table_of_contents">Table of Contents for {{ product.name }}</h3>
+					<h3 id="table_of_contents">Table of Contents for {{ test }}</h3>
 				</div>
 			</div>
 
@@ -446,16 +446,18 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
-    {% if include_executive_summary %}
-        <script src="{{ host }}{% static "jquery/dist/jquery.min.js" %}"></script>
-        <!-- Flot Charts JavaScript -->
-        <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>
-        <script src="{{ host }}{% static "flot/jquery.flot.js" %}"></script>
-        <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
-        <script src="{{ host }}{% static "flot/jquery.flot.time.js" %}"></script>
-        <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
-        <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
-        <script type="text/javascript">
+    
+    <script src="{{ host }}{% static "jquery/dist/jquery.min.js" %}"></script>
+    <!-- Flot Charts JavaScript -->
+    <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>
+    <script src="{{ host }}{% static "flot/jquery.flot.js" %}"></script>
+    <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
+    <script src="{{ host }}{% static "flot/jquery.flot.time.js" %}"></script>
+    <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
+    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
+    <script type="text/javascript">
+        
+        {% if include_executive_summary %}
             $(function () {
 
 
@@ -729,18 +731,27 @@
                             options);
                 }
             {%  endif %}
+        {% endif %}
+        window.onload = function () {
+            var toc = "";
+            var level = 3;
 
-            window.onload = function () {
-                var toc = "";
-                var level = 3;
-
-                // Handle all elements exclusive of tags
                 document.getElementById("contents").innerHTML =
                     document.getElementById("contents").innerHTML.replace(
-                        /<h([\d])([^<]*)>([^<]+)<\/h([\d])>/gi,
-                        function (str, openLevel, id, titleText, closeLevel) {
+                        /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                        function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
+                            console.log("str :: " + str)
                             if (openLevel != closeLevel || openLevel > 5) {
                                 return str;
+                            }
+
+                            
+                            if(tags)
+                            {
+                                openLevel = openLevel_t;
+                                id = id_t;
+                                titleText = titleText_t;
+                                closeLevel = closeLevel_t;
                             }
 
                             if (openLevel > level) {
@@ -753,50 +764,35 @@
                             
                             var anchor = titleText.trim().replace(/ /g, "_");
 
-                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                            }
-                            else {
-                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                titleText + "</a></li>";
-                            }
-                            
-                            
-                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                                + titleText + "</h" + closeLevel + "></a>";
-                        }
-                    );
+                            if(tags)
+                            {
+                                if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                    toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                                }
+                                else {
+                                    toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    titleText + "<sup>" + tags + "</sup></a></li>";
+                                }
 
-                    // Handle findings with tags
-                    document.getElementById("contents").innerHTML =
-                    document.getElementById("contents").innerHTML.replace(
-                        /<h([\d])([^<]*)>([^<]+)<sup>([^<]+)<\/sup>([^<]*)<\/h([\d])>/gi,
-                        function (str, openLevel, id, titleText, tags, junk, closeLevel) {
-                            if (openLevel != closeLevel || openLevel > 5) {
-                                return str;
+                                return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                    + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                            }
+                            else
+                            {
+                                if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                    toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                                }
+                                else {
+                                    toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    titleText + "</a></li>";
+                                }
+
+                                return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                    + titleText + "</h" + closeLevel + "></a>";
                             }
 
-                            if (openLevel > level) {
-                                toc += (new Array(openLevel - level + 1)).join("<ul>");
-                            } else if (openLevel < level) {
-                                toc += (new Array(level - openLevel + 1)).join("</ul>");
-                            }
-
-                            level = parseInt(openLevel);
-                            
-                            var anchor = titleText.trim().replace(/ /g, "_");
-
-                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
-                            }
-                            else {
-                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                titleText + "<sup>" + tags + "</sup></a></li>";
-                            }
-                            
-                            
                             return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                                 + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                         }
@@ -808,6 +804,5 @@
 
                 document.getElementById("toc").innerHTML += toc;
             };
-        </script>
-    {% endif %}
+    </script>
 {% endblock %}

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -428,7 +428,7 @@
                                                     {{ note.date }}
                                                 </td>
                                                 <td>
-                                                    {{ note }}
+                                                    {{ note|linebreaks }}
                                                 </td>
                                             </tr>
                                         {% endfor %}

--- a/dojo/templatetags/get_note_status.py
+++ b/dojo/templatetags/get_note_status.py
@@ -4,4 +4,5 @@ register = template.Library()
 
 @register.filter(name='get_public_notes')
 def get_public_notes(notes):
-    return notes.filter(private=False)
+    if notes:
+        return notes.filter(private=False)


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Changes motivated by #1554, #1555, and #1546

Generating a Test PDF report no longer throws a 500 error. Additionally, generating a table of contents for any of PDF reports now shows tagged findings in the correct severity sections. Newlines are also now respected in the text field of a note. Newlines will appear when veiwed in an individual finding as well as all pdf reports.

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.