### PR TITLE
Fix Whitesource parser

### DIFF
--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -22,11 +22,11 @@ class WhitesourceJSONParser(object):
             for node in tree_node:
                 title = node['name'] + " | " + node['project']
                 severity = node['severity'].lower().capitalize()
-                description = "**Description** : " + node['description'] + "\n\n" + \
-                            "**Library Name** : " + node['library']['name'] + "\n\n" + \
-                            "**Library Filename** : " + node['library']['filename'] + "\n\n" + \
-                            "**Library Description** : " + node['library']['description'] + "\n\n" + \
-                            "**Library Type** : " + node['library']['type'] + "\n"
+                description = "**Description** : " + node.get('description', "") + "\n\n" + \
+                            "**Library Name** : " + node['library'].get('name', "") + "\n\n" + \
+                            "**Library Filename** : " + node['library'].get('filename', "") + "\n\n" + \
+                            "**Library Description** : " + node['library'].get('description', "") + "\n\n" + \
+                            "**Library Type** : " + node['library'].get('type', "") + "\n"
                 try:
                     mitigation = "**fixResolution** : " + node['topFix']['fixResolution'] + "\n" + \
                                 "**Message** : " + node['topFix']['message'] + "\n"


### PR DESCRIPTION
The whitesource parser fails if the report does not contain all information. Now it uses an empty string as default value instead.

On behalft of DB Systel GmbH

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [] Add applicable tests to the unit tests.