### PR TITLE
Ease use of external db in helm charts

### DIFF
--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Create chart name and version as used by the chart label.
   Determine the hostname to use for PostgreSQL/mySQL.
 */}}
 {{- define "postgresql.hostname" -}}
-{{- if eq .Values.database.type "postgresql" -}}
+{{- if eq .Values.database "postgresql" -}}
 {{- if .Values.postgresql.enabled -}}
 {{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -45,7 +45,7 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 {{- end -}}
 {{- define "mysql.hostname" -}}
-{{- if eq .Values.database.type "mysql" -}}
+{{- if eq .Values.database "mysql" -}}
 {{- if .Values.mysql.enabled -}}
 {{- printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" -}}
 {{- else -}}

--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -30,3 +30,26 @@ Create chart name and version as used by the chart label.
 {{- define "defectdojo.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+
+{{/*
+  Determine the hostname to use for PostgreSQL/mySQL.
+*/}}
+{{- define "postgresql.hostname" -}}
+{{- if eq .Values.database.type "postgresql" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" .Values.postgresql.postgresServer -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- define "mysql.hostname" -}}
+{{- if eq .Values.database.type "mysql" -}}
+{{- if .Values.mysql.enabled -}}
+{{- printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" .Values.mysql.mysqlServer -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -40,8 +40,13 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.database }}
-                  key: {{ .Values.database }}-password
+                  {{- if eq .Values.database "postgresql" }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+                  key: postgres-password
+                  {{- else if eq .Values.database "mysql" }}
+                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                  key: mysql-password
+                  {{- end }}   }-password
           resources:
             {{- toYaml .Values.celery.beat.resources | nindent 12 }}
       {{- with .Values.celery.beat.nodeSelector }}

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -46,7 +46,7 @@ spec:
                   {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
                   key: mysql-password
-                  {{- end }}   }-password
+                  {{- end }}
           resources:
             {{- toYaml .Values.celery.beat.resources | nindent 12 }}
       {{- with .Values.celery.beat.nodeSelector }}

--- a/helm/defectdojo/templates/celery-deployment.yaml
+++ b/helm/defectdojo/templates/celery-deployment.yaml
@@ -40,7 +40,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
                   key: postgres-password
                   {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/celery-deployment.yaml
+++ b/helm/defectdojo/templates/celery-deployment.yaml
@@ -39,10 +39,10 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if eq .Values.database.type "postgresql" }}
+                  {{- if eq .Values.database "postgresql" }}
                   name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
                   key: postgres-password
-                  {{- else if eq .Values.database.type "mysql" }}
+                  {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
                   key: mysql-password
                   {{- end }}   

--- a/helm/defectdojo/templates/celery-deployment.yaml
+++ b/helm/defectdojo/templates/celery-deployment.yaml
@@ -39,8 +39,13 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.database }}
-                  key: {{ .Values.database }}-password
+                  {{- if eq .Values.database.type "postgresql" }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  key: postgres-password
+                  {{- else if eq .Values.database.type "mysql" }}
+                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                  key: mysql-password
+                  {{- end }}   
           resources:
             {{- toYaml .Values.celery.resources | nindent 12 }}
       {{- with .Values.celery.nodeSelector }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -40,10 +40,10 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if eq .Values.database.type "postgresql" }}
+                  {{- if eq .Values.database "postgresql" }}
                   name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
                   key: postgres-password
-                  {{- else if eq .Values.database.type "mysql" }}
+                  {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
                   key: mysql-password
                   {{- end }}   

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -40,8 +40,13 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.database }}
-                  key: {{ .Values.database }}-password
+                  {{- if eq .Values.database.type "postgresql" }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  key: postgres-password
+                  {{- else if eq .Values.database.type "mysql" }}
+                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                  key: mysql-password
+                  {{- end }}   
           resources:
             {{- toYaml .Values.celery.worker.resources | nindent 12 }}
       {{- with .Values.celery.worker.nodeSelector }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -41,7 +41,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
                   key: postgres-password
                   {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -20,8 +20,8 @@ data:
   DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}5672{{ end }}{{ if eq .Values.celery.broker "redis" }}6379{{ end }}'
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}
   DD_DATABASE_ENGINE: django.db.backends.{{ if eq .Values.database "postgresql" }}postgresql_psycopg2{{ end }}{{ if eq .Values.database "mysql" }}mysql{{ end }}
-  DD_DATABASE_HOST: {{ $fullName }}-{{ .Values.database }}
-  DD_DATABASE_PORT: '{{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.service.port }}{{ end }}{{ if eq .Values.database "mysql" }}3306{{ end }}'
+  DD_DATABASE_HOST: { if eq .Values.database "postgresql" }}{{ template "postgresql.hostname" . }}{{ end }}{{ if eq .Values.database "mysql" }}{{ template "mysql.hostname" . }}{{ end }}
+  DD_DATABASE_PORT: {{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.service.port }}{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.mysql.service.port }}{{ end }}
   DD_DATABASE_USER: {{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.postgresqlUsername }}{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.mysql.mysqlUser }}{{ end }}
   DD_INITIALIZE: '{{ .Values.initializer.run }}'
   DD_UWSGI_ENDPOINT: /run/uwsgi.sock

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -21,7 +21,7 @@ data:
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}
   DD_DATABASE_ENGINE: django.db.backends.{{ if eq .Values.database "postgresql" }}postgresql_psycopg2{{ end }}{{ if eq .Values.database "mysql" }}mysql{{ end }}
   DD_DATABASE_HOST: {{ if eq .Values.database "postgresql" }}{{ template "postgresql.hostname" . }}{{ end }}{{ if eq .Values.database "mysql" }}{{ template "mysql.hostname" . }}{{ end }}
-  DD_DATABASE_PORT: {{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.service.port }}{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.mysql.service.port }}{{ end }}
+  DD_DATABASE_PORT: '{{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.service.port }}{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.mysql.service.port }}{{ end }}'
   DD_DATABASE_USER: {{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.postgresqlUsername }}{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.mysql.mysqlUser }}{{ end }}
   DD_INITIALIZE: '{{ .Values.initializer.run }}'
   DD_UWSGI_ENDPOINT: /run/uwsgi.sock

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -20,7 +20,7 @@ data:
   DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}5672{{ end }}{{ if eq .Values.celery.broker "redis" }}6379{{ end }}'
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}
   DD_DATABASE_ENGINE: django.db.backends.{{ if eq .Values.database "postgresql" }}postgresql_psycopg2{{ end }}{{ if eq .Values.database "mysql" }}mysql{{ end }}
-  DD_DATABASE_HOST: { if eq .Values.database "postgresql" }}{{ template "postgresql.hostname" . }}{{ end }}{{ if eq .Values.database "mysql" }}{{ template "mysql.hostname" . }}{{ end }}
+  DD_DATABASE_HOST: {{ if eq .Values.database "postgresql" }}{{ template "postgresql.hostname" . }}{{ end }}{{ if eq .Values.database "mysql" }}{{ template "mysql.hostname" . }}{{ end }}
   DD_DATABASE_PORT: {{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.service.port }}{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.mysql.service.port }}{{ end }}
   DD_DATABASE_USER: {{ if eq .Values.database "postgresql" }}{{ .Values.postgresql.postgresqlUsername }}{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.mysql.mysqlUser }}{{ end }}
   DD_INITIALIZE: '{{ .Values.initializer.run }}'

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -45,8 +45,13 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.database }}
-                  key: {{ .Values.database }}-password
+                  {{- if eq .Values.database.type "postgresql" }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  key: postgres-password
+                  {{- else if eq .Values.database.type "mysql" }}
+                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                  key: mysql-password
+                  {{- end }}   
           resources:
             {{- toYaml .Values.django.uwsgi.resources | nindent 12 }}
         - name: nginx

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -45,10 +45,10 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if eq .Values.database.type "postgresql" }}
+                  {{- if eq .Values.database "postgresql" }}
                   name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
                   key: postgres-password
-                  {{- else if eq .Values.database.type "mysql" }}
+                  {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
                   key: mysql-password
                   {{- end }}   

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -46,7 +46,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
                   key: postgres-password
                   {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -32,8 +32,13 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.database }}
-                  key: {{ .Values.database }}-password
+                  {{- if eq .Values.database.type "postgresql" }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  key: postgres-password
+                  {{- else if eq .Values.database.type "mysql" }}
+                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                  key: mysql-password
+                  {{- end }}   
           resources:
             {{- toYaml .Values.initializer.resources | nindent 10 }}
       restartPolicy: Never

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -33,7 +33,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
+                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
                   key: postgres-password
                   {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -32,10 +32,10 @@ spec:
             - name: DD_DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  {{- if eq .Values.database.type "postgresql" }}
+                  {{- if eq .Values.database "postgresql" }}
                   name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.postgresPasswordSecret }} {{- end }}
                   key: postgres-password
-                  {{- else if eq .Values.database.type "mysql" }}
+                  {{- else if eq .Values.database "mysql" }}
                   name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
                   key: mysql-password
                   {{- end }}   

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -1,6 +1,9 @@
 ---
 # Global settings
 createSecret: true
+## Configuration value to select database type
+## Option to use "postgresql" or "mysql" database type, by default "postgresql" is chosen
+## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select
 database: mysql
 host: defectdojo.default.minikube.local
 imagePullPolicy: Always
@@ -73,6 +76,14 @@ mysql:
   enabled: true
   mysqlUser: defectdojo
   mysqlDatabase: defectdojo
+  service:
+    port: 3306  
+  # To use an external mySQL instance, set enabled to false and uncomment
+  # the line below:
+  # mysqlServer: ""
+  # To use an external secret for the password for an external mySQL instance,
+  # set enabled to false and provide the name of the secret on the line below:
+  # mysqlPasswordSecret: ""  
 
 postgresql:
   enabled: false
@@ -82,6 +93,15 @@ postgresql:
     enabled: false
   replication:
     enabled: false
+  service:
+    port: 5432  
+  # To use an external PostgreSQL instance, set enabled to false and uncomment
+  # the line below:
+  # postgresServer: ""
+  # To use an external secret for the password for an external PostgreSQL
+  # instance, set enabled to false and provide the name of the secret on the
+  # line below:
+  # postgresPasswordSecret: ""    
 
 rabbitmq:
   enabled: true

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -98,10 +98,10 @@ postgresql:
   # To use an external PostgreSQL instance, set enabled to false and uncomment
   # the line below:
   # postgresServer: ""
-  # To use an external secret for the password for an external PostgreSQL
+  # To use an external secret for the password for PostgreSQL
   # instance, set enabled to false and provide the name of the secret on the
   # line below:
-  # postgresPasswordSecret: ""    
+  # existingSecret: ""    
 
 rabbitmq:
   enabled: true


### PR DESCRIPTION
When deploying defect dojo using the helm chart, is not easy to use an external Relational Database ( that may be a better solution in production in example).
This PR aim to ease the use of an external DB with the helm charts

- [X] Your code is flake8 compliant 
- [X] Your code is python 3.5 compliant
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [X] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [X] Add applicable tests to the unit tests.