### PR TITLE
fix introduced regression to ingesting Xray scan

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -481,7 +481,7 @@
 	},
 	{
 	   "fields": {
-	      "name": "JFrogXray Scan"
+	      "name": "JFrog Xray Scan"
 		},
 		"model": "dojo.test_type",
 		"pk": 161

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -319,7 +319,7 @@ class ImportScanForm(forms.Form):
                          ("Microfocus Webinspect Scan", "Microfocus Webinspect Scan"),
                          ("Wpscan", "Wpscan"),
                          ("Sslscan", "Sslscan"),
-                         ("JFrogXray Scan", "JFrog Xray Scan"),
+                         ("JFrog Xray Scan", "JFrog Xray Scan"),
                          ("Sslyze Scan", "Sslyze Scan"),
                          ("Testssl Scan", "Testssl Scan"),
                          ("Hadolint Dockerfile check", "Hadolint Dockerfile check"),


### PR DESCRIPTION
Signed-off-by: Fred Blaise <fred.blaise@protonmail.com>

Found out some space removal introduced a month ago during some "cleanup", breaking XRay ingestion. Fixing these here.

This broke the intake with error `Unknown Test Type`.