### PR TITLE
add documentation and configuration for https in docker

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -58,10 +58,11 @@ RUN \
 FROM nginx:1.17.2@sha256:eb3320e2f9ca409b7c0aa71aea3cf7ce7d018f03a372564dbdb023646958770b
 COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf /etc/nginx/
-COPY docker/entrypoint-nginx.sh /
+COPY docker/entrypoint-nginx.sh nginx/*.cer nginx/*.key /
 RUN \
   chmod -R g=u /var/cache/nginx && \
   chmod -R g=u /var/run && \
+  if [ -f /*.key -o -f /*.cer ]; then chown 1001 /*.key /*.cer; fi && \
   true
 ENV \
   DD_UWSGI_PASS="uwsgi_server" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - uwsgi
     ports:
-      - target: 8080
+      - target: ${DD_PORT:-8080}
         published: ${DD_PORT:-8080}
         protocol: tcp
         mode: host

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -2,34 +2,71 @@ worker_processes 1;
 error_log /var/log/nginx/error.log warn;
 pid /var/run/nginx.pid;
 events {
-  worker_connections  1024;
+    worker_connections    32;
 }
+
 http {
-  include /etc/nginx/mime.types;
-  default_type application/octet-stream;
-  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
-  access_log /var/log/nginx/access.log main;
-  client_max_body_size 800m;
-  sendfile on;
-  keepalive_timeout 65;
+    include                         /etc/nginx/mime.types;
+    default_type                    application/octet-stream;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+        '$status $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /var/log/nginx/access.log main;
+    client_max_body_size 800m;
+    sendfile                        on;
+    keepalive_timeout 65;
+
   upstream uwsgi_server {
     include /run/uwsgi_server;
   }
-  server {
-    listen 8080;
-    location = /50x.html {
-      root /usr/share/nginx/html;
+
+    server {
+        listen                      8080;
+        location / {
+            return                 301 https://$host$request_uri:8083;
+        }
     }
+
+    server {
+        listen                      8083 ssl;
+        server_name                 slnxkpsascaan27.renn.fr.sopra;
+        ssl_certificate             /slnxkpsascaan27.renn.fr.sopra.cer;
+        ssl_certificate_key         /slnxkpsascaan27.renn.fr.sopra.key;
+        ssl_session_cache           builtin:1000  shared:SSL:10m;
+        ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers                 HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+        ssl_prefer_server_ciphers   on;
+
+        location = /50x.html {
+            root                    /usr/share/nginx/html;
+        }
+
     location /static {
       alias /usr/share/nginx/html/static;
-    }
+        }
+
     location / {
       include /run/uwsgi_pass;
       include /etc/nginx/wsgi_params;
       uwsgi_read_timeout 1800;
+
+      # an HTTP header important enough to have its own Wikipedia entry:
+      #   http://en.wikipedia.org/wiki/X-Forwarded-For
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      # enable this if and only if you use HTTPS, this helps to
+      # set the proper protocol for doing redirects:
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      # pass the Host: header from the client right along so redirects
+      # can be set properly within the Rack application
+      proxy_set_header Host $host;
+
+      # we don't want nginx trying to do something clever with
+      # redirects, we set the Host: header above already.
+      proxy_redirect off;
     }
     error_page 500 502 503 504 /50x.html;
-  }
+
+    }
 }

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -1,0 +1,56 @@
+worker_processes 1;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+events {
+    worker_connections    32;
+}
+
+http {
+    include                         /etc/nginx/mime.types;
+    default_type                    application/octet-stream;
+  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log /var/log/nginx/access.log main;
+  client_max_body_size 800m;
+    sendfile                        on;
+	keepalive_timeout 65;
+
+  upstream uwsgi_server {
+    include /run/uwsgi_server;
+  }
+
+    server {
+        listen                      8080;
+        location / {
+            return                 301 https://$host$request_uri:8083;
+        }
+    }
+
+    server {
+        listen                      8083 ssl;
+        server_name                 your.servername.com;
+        ssl_certificate             /yourCertificate.cer;
+        ssl_certificate_key         /yourPrivateKey.key;
+        ssl_session_cache           builtin:1000  shared:SSL:10m;
+        ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
+        ssl_ciphers                 HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+        ssl_prefer_server_ciphers   on;
+
+        location = /50x.html {
+            root                    /usr/share/nginx/html;
+        }
+
+    location /static {
+      alias /usr/share/nginx/html/static;
+        }
+
+    location / {
+      include /run/uwsgi_pass;
+      include /etc/nginx/wsgi_params;
+      uwsgi_read_timeout 1800;
+    }
+    error_page 500 502 503 504 /50x.html;
+
+    }
+}

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -8,13 +8,13 @@ events {
 http {
     include                         /etc/nginx/mime.types;
     default_type                    application/octet-stream;
-  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                    '$status $body_bytes_sent "$http_referer" '
-                    '"$http_user_agent" "$http_x_forwarded_for"';
-  access_log /var/log/nginx/access.log main;
-  client_max_body_size 800m;
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+        '$status $body_bytes_sent "$http_referer" '
+        '"$http_user_agent" "$http_x_forwarded_for"';
+    access_log /var/log/nginx/access.log main;
+    client_max_body_size 800m;
     sendfile                        on;
-	keepalive_timeout 65;
+    keepalive_timeout 65;
 
   upstream uwsgi_server {
     include /run/uwsgi_server;
@@ -49,6 +49,22 @@ http {
       include /run/uwsgi_pass;
       include /etc/nginx/wsgi_params;
       uwsgi_read_timeout 1800;
+      
+      # an HTTP header important enough to have its own Wikipedia entry:
+      #   http://en.wikipedia.org/wiki/X-Forwarded-For
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      # enable this if and only if you use HTTPS, this helps to
+      # set the proper protocol for doing redirects:
+      proxy_set_header X-Forwarded-Proto $scheme;
+
+      # pass the Host: header from the client right along so redirects
+      # can be set properly within the Rack application
+      proxy_set_header Host $host;
+
+      # we don't want nginx trying to do something clever with
+      # redirects, we set the Host: header above already.
+      proxy_redirect off;
     }
     error_page 500 502 503 504 /50x.html;
 


### PR DESCRIPTION
Those are just a few tweaks and some documentation to simplify running defectDojo in https using docker-compose. 
I have created a new nginx.conf which is a mix between 
- nginx/nginx.conf which is the file we're currently using to run docker-compose
- docker/nginx.conf which is a file that configures nginx for https but which has become a little divergeant from the file the application is usually using.

I'm not sure that we should keep the nginx configuration under docker/ as it's not used anywhere as far as I can tell, but I'll leave it there in doubt.