### PR TITLE
Bug Fix Import OpenVas Scan Result

### DIFF
--- a/dojo/tools/openvas_csv/parser.py
+++ b/dojo/tools/openvas_csv/parser.py
@@ -1,9 +1,7 @@
 # Sorry for the lazyness but I just update the column name fields
 # Didn't change the class names, only the main one..
-#Import Scan Result Fix
 
 import io
-from io import TextIOWrapper
 import csv
 import hashlib
 from dojo.models import Finding, Endpoint
@@ -313,18 +311,14 @@ class OpenVASUploadCsvParser(object):
         if filename is None:
             self.items = ()
             return
-
-        row_number = 0
+        
         content = open(filename.temporary_file_path(),'rb')
         reportCSV = io.TextIOWrapper(content, encoding='utf-8 ', errors='replace')
-		
         reader = csv.reader(reportCSV, delimiter=',',quotechar='"')
-        print("Reader type is :")
-        print(type(reader))		
+
+	row_number = 0
         for row in reader:
             finding = Finding(test=test)
-            print("Row type is :")
-            print(type(row))
 
             if row_number == 0:
                 self.read_column_names(row)
@@ -334,7 +328,6 @@ class OpenVASUploadCsvParser(object):
             column_number = 0
             for column in row:
                 self.chain.process_column(self.column_names[column_number], column, finding)
-                print(self.column_names[column_number], column)
                 column_number += 1
 
             if finding is not None and row_number > 0:

--- a/dojo/tools/openvas_csv/parser.py
+++ b/dojo/tools/openvas_csv/parser.py
@@ -10,8 +10,6 @@ import re
 from urllib.parse import urlparse
 import socket
 
-
-
 class ColumnMappingStrategy(object):
 
     mapped_column = None

--- a/dojo/tools/openvas_csv/parser.py
+++ b/dojo/tools/openvas_csv/parser.py
@@ -309,10 +309,10 @@ class OpenVASUploadCsvParser(object):
         if filename is None:
             self.items = ()
             return
-        
-        content = open(filename.temporary_file_path(),'rb')
+
+        content = open(filename.temporary_file_path(), 'rb')
         reportCSV = io.TextIOWrapper(content, encoding='utf-8 ', errors='replace')
-        reader = csv.reader(reportCSV, delimiter=',',quotechar='"')
+        reader = csv.reader(reportCSV, delimiter=',', quotechar='"')
 
         row_number = 0
         for row in reader:

--- a/dojo/tools/openvas_csv/parser.py
+++ b/dojo/tools/openvas_csv/parser.py
@@ -316,7 +316,7 @@ class OpenVASUploadCsvParser(object):
         reportCSV = io.TextIOWrapper(content, encoding='utf-8 ', errors='replace')
         reader = csv.reader(reportCSV, delimiter=',',quotechar='"')
 
-	row_number = 0
+        row_number = 0
         for row in reader:
             finding = Finding(test=test)
 


### PR DESCRIPTION
Issues:
OpenVas Scan Result were not imported.

Solution:
Adapt the code for python 3
We've edit dojo/tools/openvas_csv/parser.py , now it is able to import the scan without a 500 error and with the Findings.

Related issues : https://github.com/DefectDojo/django-DefectDojo/issues/1575