### PR TITLE
increase strip from 20 to 200 chars

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1337,8 +1337,8 @@ def process_notifications(request, note, parent_url, parent_title):
         if User.objects.filter(is_active=True, username=username).exists()
     ]  # is_staff also?
     user_posting = request.user
-    if len(note.entry) > 20:
-        note.entry = note.entry[:20]
+    if len(note.entry) > 200:
+        note.entry = note.entry[:200]
         note.entry += "..."
     create_notification(
         event='user_mentioned',


### PR DESCRIPTION
Fixes #1571 

The idea is to not have to go to DD to see a note of a reasonable size (arbitrarily, 200 chars).

I don't think the threat model for DD accounts for the note information not to be sent to unauthorized parties anyways, since whatever generic email address could be put at the global settings level. In the case of SAML, the user email is also assumed to be correct and owned by said user.

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [ ] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.