### PR TITLE
Adding defectDojo_engagement_survey to Installed Apps

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -436,6 +436,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'defectDojo_engagement_survey',
     'polymorphic',  # provides admin templates
     'overextends',
     'django.contrib.admin',


### PR DESCRIPTION
After the merge of PR # 1601, the dev branch was throwing the error specified below. 

`RuntimeError: Model class defectDojo_engagement_survey.models.Question doesn't declare an explicit app_label and isn't in an application in INSTALLED_APPS. error 
`

This commits addresses the error by adding the engagement_survey  to installed apps.
