### PR TITLE
fix dependency-check cwe parsing

### DIFF
--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -22,7 +22,11 @@ class DependencyCheckParser(object):
 
     def get_finding_from_vulnerability(self, vulnerability, filename, test):
         name = self.get_field_value(vulnerability, 'name')
-        cwe_field = self.get_field_value(vulnerability, 'cwe')
+        cwes_node = vulnerability.find(self.namespace + 'cwes')
+        if cwes_node is not None:
+            cwe_field = self.get_field_value(cwes_node, 'cwe')
+        else:
+            cwe_field = self.get_field_value(vulnerability, 'cwe')
         description = self.get_field_value(vulnerability, 'description')
 
         title = '{0} | {1}'.format(filename, name)


### PR DESCRIPTION
Fixes #1610 

If several `<cwe>` within node `<cwes>` the first one is taken. DD's model does not allow for several today.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.