### PR TITLE
Show more elements on a page

### DIFF
--- a/dojo/templates/dojo/paging_snippet.html
+++ b/dojo/templates/dojo/paging_snippet.html
@@ -28,6 +28,10 @@
                             <li><a href="?{% url_replace request 'page_size' 75 %}">75</a></li>
                             <li><a href="?{% url_replace request 'page_size' 100 %}">100</a></li>
                             <li><a href="?{% url_replace request 'page_size' 150 %}">150</a></li>
+                            {% if page.paginator.count > 500 %}
+                            <li><a href="?{% url_replace request 'page_size' 500 %}">500</a></li>
+                            {% endif %}
+                            <li><a href="?{% url_replace request 'page_size' page.paginator.count %}">All</a></li>
                         </ul>
                     </div>
                 </li>


### PR DESCRIPTION
Add options to show all and 500 elements on a page with pagination

On behalf of DB Systel GmbH

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [] Add applicable tests to the unit tests.