### PR TITLE
[Dev] Modify installation README's

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -2,7 +2,7 @@
 
 Docker compose is not intended for production use.
 If you want to deploy a containerized DefectDojo to a production environment,
-use the [Helm and Kubernetes](KUBERNETES.md) approach.
+use the [Default installation](setup/README.md) approach.
 
 ## Prerequisites
 *  Docker version

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Navigate to <http://localhost:8080>.
 For detailed documentation you can visit
 [Read the Docs](https://defectdojo.readthedocs.io/).
 
-## Installation Options
+## Supported Installation Options
 
-* [Kubernetes](KUBERNETES.md)
+* [Setup.bash](setup/README.md)
 * [Docker](DOCKER.md)
 
 ## Getting Started

--- a/docker/setEnv.sh
+++ b/docker/setEnv.sh
@@ -20,7 +20,15 @@ function show_current {
 function get_current {
     if [ -L ${override_link} ]
     then
-        current_env=$(expr $(basename $(readlink -f docker-compose.override.yml)) : "^docker-compose.override.\(.*\).yml$")
+        # Check for Mac OSX 
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            # readlink is not native to mac, so this will work in it's place.
+            symlink=$(python3 -c "import os; print(os.path.realpath('docker-compose.override.yml'))")
+        else
+            # Maintain the cleaner way
+            symlink=$(readlink -f docker-compose.override.yml)
+        fi
+        current_env=$(expr $(basename symlink) : "^docker-compose.override.\(.*\).yml$")
     else
         current_env=release
     fi

--- a/setup/README.MD
+++ b/setup/README.MD
@@ -27,7 +27,7 @@ All installs make these assumption:
 * * Running setup.bash without editing template-env assumes a single-server install.
 * * Running setup.bash without editing template-env non-interactively assumes a single-server install with MySQL
 * Any install configuration variable can be overridden by setting an environmental variable
-* One of the following OSes is used as the base for the install
+* One of the following Operating Systems is used as the base for the install
 * * Ubuntu Linux - officially supported versions: 16.04 LTS, 18.04 LTS
 * * CentOS - officially supported versions: ?
 * * Mac OS X - officially supported versions: ?
@@ -66,7 +66,7 @@ setup.bash => the main install program
         ├── prompt.sh
 ```
 
-Install configuration is in config-vars.sh contains the following install options and default values:
+Install configuration is in [config-vars.sh](scripts/common/config-vars.sh) contains the following install options and default values:
 
 **Format for this list:** *install option* [default value] - *definition*
 
@@ -94,7 +94,6 @@ Install configuration is in config-vars.sh contains the following install option
 
 Configuration items for setup.py are in template-env in ./dojo/settings/ and contain
 
-* 
 
 ### Installers workflow
 
@@ -111,6 +110,5 @@ Configuration items for setup.py are in template-env in ./dojo/settings/ and con
 * REPO_BASE : The full path to where the DefectDojo source was cloned usually /opt/dojo/django-DefectDojo
 * LIB_PATH : The full path to where the configuration values and libraries are for the DefectDojo installer which is SETUP_BASE + /scripts/common/
 * DB_TYPPE : The database type DefectDojo will use - currently either SQLite, MySQL or PostgreSQL
-* 
 
 


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Drop Kubernetes from supported installation method in favor of setup.bash.
Fix syntax error for OSX users when selecting docker-compose environments.

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.