### PR TITLE
Repair Simple Metrics data displayed on /metrics/simple route

### DIFF
--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -357,7 +357,8 @@ def simple_metrics(request):
                                        false_p=False,
                                        duplicate=False,
                                        out_of_scope=False,
-                                       date=now,
+                                       date__year=now.year,
+                                       date__month=now.month,
                                        ).distinct()
 
         for f in total.all():


### PR DESCRIPTION
Hi !
Metrics on  /metrics/simple only return values from the day instead of the month (or the chosen month).
So i added in the djangoo orm filter the precision of a month instead of taking only one day.
I may recommend also to change the name of the variable "now" to "date_asked" or something like that, but it is your code :)
Very nice project !!!!
