### PR TITLE
Increase default number of uwsgi processes and threads

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -16,5 +16,7 @@ exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
-  --processes 4
+  --enable-threads \
+  --processes 2 \
+  --threads 2 \
   --py-autoreload 1

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -16,4 +16,5 @@ exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
+  --processes 4
   --py-autoreload 1

--- a/docker/entrypoint-uwsgi-ptvsd.sh
+++ b/docker/entrypoint-uwsgi-ptvsd.sh
@@ -17,5 +17,7 @@ exec uwsgi \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
   --py-autoreload 1 \
-  --enable-threads --lazy-apps --honour-stdin
+  --enable-threads --lazy-apps --honour-stdin \
+  --processes 2 \
+  --threads 2
   

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -5,4 +5,5 @@ umask 0002
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
+  --processes 4 \
   --wsgi dojo.wsgi:application

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -5,5 +5,7 @@ umask 0002
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
-  --processes 4 \
+  --enable-threads \
+  --processes 2 \
+  --threads 2 \
   --wsgi dojo.wsgi:application


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

The default operational mode of uwsgi is mono process. For example, if you import a big scan, you have to wait until it is imported to carry on with other business in dojo, or you're blocking other users that are using defectdojo. Or you give it so many CI uploads/imports that it starts blocking your pipelines.

This change should give conservative default (2 processes, 2 threads per process) to begin with.