### PR TITLE
drf_yasg for api documentation

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import detail_route, action
+from rest_framework.parsers import MultiPartParser
 from django_filters.rest_framework import DjangoFilterBackend
 
 from dojo.engagement.services import close_engagement, reopen_engagement
@@ -611,12 +612,14 @@ class UsersViewSet(mixins.ListModelMixin,
 class ImportScanView(mixins.CreateModelMixin,
                      viewsets.GenericViewSet):
     serializer_class = serializers.ImportScanSerializer
+    parser_classes = [MultiPartParser]
     queryset = Test.objects.all()
 
 
 class ReImportScanView(mixins.CreateModelMixin,
                        viewsets.GenericViewSet):
     serializer_class = serializers.ReImportScanSerializer
+    parser_classes = [MultiPartParser]
     queryset = Test.objects.all()
 
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -463,6 +463,7 @@ INSTALLED_APPS = (
     # 'axes'
     'django_celery_results',
     'social_django',
+    'drf_yasg',
 )
 
 # ------------------------------------------------------------------------------

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -2,11 +2,13 @@ from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
-from rest_framework_swagger.views import get_swagger_view
 from tastypie.api import Api
 from tastypie_swagger.views import SwaggerView, ResourcesView, SchemaView
 from rest_framework.routers import DefaultRouter
 from rest_framework.authtoken import views as tokenviews
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
 from django.http import HttpResponse
 from defectDojo_engagement_survey.urls import urlpatterns as survey_urls
 
@@ -150,7 +152,17 @@ swagger_urls = [
     url(r'^schema/$', SchemaView.as_view(), name='schema'),
 ]
 
-schema_view = get_swagger_view(title='Defect Dojo API v2')
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Defect Dojo API",
+        default_version='v2',
+        description="To use the API you need be authorized.",
+    ),
+    # if public=False, includes only endpoints the current user has access to
+    public=True,
+    # The API of a OpenSource project should be public accessible
+    permission_classes=(permissions.AllowAny),
+)
 
 urlpatterns = [
     #  tastypie api
@@ -169,7 +181,7 @@ urlpatterns = [
         name='action_history'),
     url(r'^%s' % get_system_setting('url_prefix'), include(ur)),
     url(r'^api/v2/api-token-auth/', tokenviews.obtain_auth_token),
-    url(r'^api/v2/doc/', schema_view, name="api_v2_schema"),
+    url(r'^api/v2/doc/', schema_view.with_ui('swagger', cache_timeout=0), name='api_v2_schema'),
     url(r'^robots.txt', lambda x: HttpResponse("User-Agent: *\nDisallow: /", content_type="text/plain"), name="robots_file"),
 ]
 

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -161,7 +161,7 @@ schema_view = get_schema_view(
     # if public=False, includes only endpoints the current user has access to
     public=True,
     # The API of a OpenSource project should be public accessible
-    permission_classes=(permissions.AllowAny),
+    permission_classes=[permissions.AllowAny],
 )
 
 urlpatterns = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,4 @@ ptvsd>=4.2.7
 google-api-python-client==1.7.11
 google-auth==1.6.3
 google-auth-oauthlib==0.3.0
+drf_yasg==1.17.0


### PR DESCRIPTION
Using drf_yasg for the generation of swagger documentations allowed to use api generator like openapi-generator (https://github.com/OpenAPITools/openapi-generator). In first tests it worked very well and I am currently working on a api wrapper in python, generated by openapi-generator. 

Furthermore the api documentation contains much more details, e.g. return types. 

On behalf of DB Systel GmbH

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.