### PR TITLE
Fix bug with deduplication in qualys findings

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1318,7 +1318,14 @@ class Finding(models.Model):
         return filtered.exclude(pk=self.pk)
 
     def compute_hash_code(self):
-        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + self.description
+        hash_string = self.title + str(self.cwe) + str(self.line) + str(self.file_path)
+        # additional check to exclude unwanted information from description for the duplicate detection, e.g. dates, times_found, ...
+        end_position = self.description.find("================")
+        if end_position > -1:
+            hash_string += self.description[:end_position]
+        else:
+            hash_string += self.description
+
         if self.dynamic_finding:
             endpoint_str = ''
             if len(self.unsaved_endpoints) > 0 and self.id is None:

--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -141,6 +141,7 @@ def issue_r(raw_row, vuln):
                                                    htmltext("QID: " + str(_gid)),
                                                    htmltext("Port: " + str(_port)),
                                                    htmltext("Result Evidence: " + _result),
+                                                   htmltext("================"),
                                                    htmltext("First Found: " + _first_found),
                                                    htmltext("Last Found: " + _last_found),
                                                    htmltext("Times Found: " + _times_found),


### PR DESCRIPTION
Qualys findings contains information like dates or times found. When using deduplication the hash should not include this information. To archive this we using a separator.

Has someone has a better idea to solve this bug or is this solution fine?

On behalf of DB Systel GmbH

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.