### PR TITLE
adding multi-procs and threads by default

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -13,4 +13,7 @@ exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
+  --enable-threads \
+  --processes 2 \
+  --threads 2 \
   --py-autoreload 1

--- a/docker/entrypoint-uwsgi-ptvsd.sh
+++ b/docker/entrypoint-uwsgi-ptvsd.sh
@@ -17,5 +17,7 @@ exec uwsgi \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
   --py-autoreload 1 \
-  --enable-threads --lazy-apps --honour-stdin
+  --enable-threads --lazy-apps --honour-stdin \
+  --processes 2 \
+  --threads 2
   

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -5,4 +5,7 @@ umask 0002
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
+  --enable-threads \
+  --processes 2 \
+  --threads 2 \
   --wsgi dojo.wsgi:application


### PR DESCRIPTION
Adding multi process and multi-thread by default to avoid blocking.
Otherwise, you may just be watching an import for 5 minutes and not do anything else.
