### PR TITLE
Checkmarx set false positive status

### DIFF
--- a/dojo/tools/checkmarx/parser.py
+++ b/dojo/tools/checkmarx/parser.py
@@ -107,6 +107,7 @@ class CheckmarxXMLParser(object):
                            test=self.test,
                            active=False,
                            verified=False,
+                           false_p=result.get('FalsePositive') == "True",
                            # Concatenates the query information with this specific finding information
                            description=findingdetail + '-----\n' + description,
                            severity=sev,
@@ -155,6 +156,7 @@ class CheckmarxXMLParser(object):
         paths = result.findall('Path')
         if(len(paths)) > 1:
             logger.warning("Checkmarx scan: more than one path found: " + str(len(paths)) + ". Only the last one will be used")
+
         for path in paths:
             sourceFilename = ''
             sinkFilename = ''
@@ -182,6 +184,7 @@ class CheckmarxXMLParser(object):
                        test=self.test,
                        active=False,
                        verified=False,
+                       false_p=result.get('FalsePositive') == "True",
                        description=findingdetail,
                        severity=sev,
                        numerical_severity=Finding.get_numerical_severity(sev),

--- a/dojo/unittests/scans/checkmarx/single_finding_false_positive.xml
+++ b/dojo/unittests/scans/checkmarx/single_finding_false_positive.xml
@@ -1,0 +1,159 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CxXMLResults InitiatorName="Initiator Name" Owner="domain\user" ScanId="1000227" ProjectId="121" ProjectName="Webgoat" TeamFullPathOnReportDate="team\full\path" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121" ScanStart="Sunday, February 25, 2018 11:35:52 AM" Preset="Checkmarx Default" ScanTime="00h:07m:13s" LinesOfCodeScanned="92054" FilesScanned="480" ReportCreationTime="Sunday, April 21, 2019 10:30:08 PM" Team="team_name" CheckmarxVersion="8.6.0 HF1" ScanComments="" ScanType="Full" SourceOrigin="LocalPath" Visibility="Public">
+  <Query id="595" categories="PCI DSS v3.2;PCI DSS (3.2) - 6.5.7 - Cross-site scripting (XSS),OWASP Top 10 2013;A3-Cross-Site Scripting (XSS),FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-15 Information Output Filtering (P0),OWASP Top 10 2017;A7-Cross-Site Scripting (XSS)" cweId="79" name="Stored_XSS" group="Java_High_Risk" Severity="High" Language="Java" LanguageHash="0125540914009541" LanguageChangeDate="2018-02-12T00:00:00.0000000" SeverityIndex="3" QueryPath="Java\Cx\Java High Risk\Stored XSS Version:2" QueryVersionCode="56163505">
+    <Result NodeId="10002270028" FileName="WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java" Status="New" Line="39" Column="59" FalsePositive="True" Severity="High" AssignToUser="" state="0" Remark="" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121&amp;pathid=28" SeverityIndex="3">
+      <Path ResultId="1000227" PathId="28" SimilarityId="1574221060">
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>39</Line>
+          <Column>59</Column>
+          <NodeId>1</NodeId>
+          <Name>executeQuery</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>39</Number>
+              <Code>                ResultSet results = statement.executeQuery(query);</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>39</Line>
+          <Column>27</Column>
+          <NodeId>2</NodeId>
+          <Name>results</Name>
+          <Type></Type>
+          <Length>7</Length>
+          <Snippet>
+            <Line>
+              <Number>39</Number>
+              <Code>                ResultSet results = statement.executeQuery(query);</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>46</Line>
+          <Column>28</Column>
+          <NodeId>3</NodeId>
+          <Name>results</Name>
+          <Type></Type>
+          <Length>7</Length>
+          <Snippet>
+            <Line>
+              <Number>46</Number>
+              <Code>                    while (results.next()) {</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>47</Line>
+          <Column>34</Column>
+          <NodeId>4</NodeId>
+          <Name>results</Name>
+          <Type></Type>
+          <Length>7</Length>
+          <Snippet>
+            <Line>
+              <Number>47</Number>
+              <Code>                        int id = results.getInt(0);</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>53</Line>
+          <Column>64</Column>
+          <NodeId>5</NodeId>
+          <Name>getString</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>53</Number>
+              <Code>                        userMap.put("cookie", results.getString(5));</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>53</Line>
+          <Column>36</Column>
+          <NodeId>6</NodeId>
+          <Name>put</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>53</Number>
+              <Code>                        userMap.put("cookie", results.getString(5));</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>54</Line>
+          <Column>25</Column>
+          <NodeId>7</NodeId>
+          <Name>userMap</Name>
+          <Type></Type>
+          <Length>7</Length>
+          <Snippet>
+            <Line>
+              <Number>54</Number>
+              <Code>                        userMap.put("loginCOunt",Integer.toString(results.getInt(6)));</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>55</Line>
+          <Column>44</Column>
+          <NodeId>8</NodeId>
+          <Name>userMap</Name>
+          <Type></Type>
+          <Length>7</Length>
+          <Snippet>
+            <Line>
+              <Number>55</Number>
+              <Code>                        allUsersMap.put(id,userMap);</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>55</Line>
+          <Column>40</Column>
+          <NodeId>9</NodeId>
+          <Name>put</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>55</Number>
+              <Code>                        allUsersMap.put(id,userMap);</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/missing-function-ac/src/main/java/org/owasp/webgoat/plugin/Users.java</FileName>
+          <Line>58</Line>
+          <Column>28</Column>
+          <NodeId>10</NodeId>
+          <Name>allUsersMap</Name>
+          <Type></Type>
+          <Length>11</Length>
+          <Snippet>
+            <Line>
+              <Number>58</Number>
+              <Code>                    return allUsersMap;</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+      </Path>
+    </Result>
+  </Query>
+</CxXMLResults>

--- a/dojo/unittests/test_checkmarx_parser.py
+++ b/dojo/unittests/test_checkmarx_parser.py
@@ -150,7 +150,6 @@ class TestCheckmarxParser(TestCase):
         self.assertEqual(str, type(item.line))
         self.assertEqual("58", item.line)
         # Added field for detailed scanner
-        item = self.parser.items[0]
         self.assertEqual(str, type(item.unique_id_from_tool))
         self.assertEqual("28", item.unique_id_from_tool)
         self.assertEqual(str, type(item.sast_source_object))
@@ -175,6 +174,8 @@ class TestCheckmarxParser(TestCase):
         self.assertEqual(False, item.active)
         self.assertEqual(bool, type(item.verified))
         self.assertEqual(False, item.verified)
+        self.assertEqual(bool, type(item.false_p))
+        self.assertEqual(False, item.false_p)
         self.assertEqual(str, type(item.severity))
         self.assertEqual("High", item.severity)
         self.assertEqual(str, type(item.numerical_severity))
@@ -192,6 +193,34 @@ class TestCheckmarxParser(TestCase):
         self.assertEqual(datetime.datetime(2018, 2, 25, 11, 35, 52), item.date)
         self.assertEqual(bool, type(item.static_finding))
         self.assertEqual(True, item.static_finding)
+
+# ----------------------------------------------------------------------------
+# single finding false positive
+# ----------------------------------------------------------------------------
+    def test_file_name_aggregated_parse_file_with_false_positive_is_false_positive(self):
+        my_file_handle, product, engagement, test = self.init("dojo/unittests/scans/checkmarx/single_finding_false_positive.xml")
+        self.parser = CheckmarxXMLParser(my_file_handle, test)
+        self.teardown(my_file_handle)
+        # Verifications common to both parsers
+        self.check_parse_file_with_false_positive_is_false_positive(self.parser)
+
+    def test_detailed_parse_file_with_false_positive_is_false_positive(self):
+        my_file_handle, product, engagement, test = self.init("dojo/unittests/scans/checkmarx/single_finding_false_positive.xml")
+        self.parser = CheckmarxXMLParser(my_file_handle, test, 'detailed')
+        self.teardown(my_file_handle)
+        # Verifications common to both parsers
+        self.check_parse_file_with_false_positive_is_false_positive(self.parser)
+
+    def check_parse_file_with_false_positive_is_false_positive(self, parser):
+        self.assertEqual(1, len(self.parser.items))
+        # check content
+        item = self.parser.items[0]
+        self.assertEqual(bool, type(item.active))
+        self.assertEqual(False, item.active)
+        self.assertEqual(bool, type(item.verified))
+        self.assertEqual(False, item.verified)
+        self.assertEqual(bool, type(item.false_p))
+        self.assertEqual(True, item.false_p)
 
 # ----------------------------------------------------------------------------
 # multiple_findings : source filename = sink filename.
@@ -367,6 +396,8 @@ class TestCheckmarxParser(TestCase):
         self.assertEqual(False, item.active)
         self.assertEqual(bool, type(item.verified))
         self.assertEqual(False, item.verified)
+        self.assertEqual(bool, type(item.false_p))
+        self.assertEqual(False, item.false_p)
         self.assertEqual(str, type(item.severity))
         self.assertEqual("High", item.severity)
         self.assertEqual(str, type(item.numerical_severity))
@@ -506,6 +537,8 @@ class TestCheckmarxParser(TestCase):
         self.assertEqual(False, item.active)
         self.assertEqual(bool, type(item.verified))
         self.assertEqual(False, item.verified)
+        self.assertEqual(bool, type(item.false_p))
+        self.assertEqual(False, item.false_p)
         self.assertEqual(str, type(item.severity))
         self.assertEqual("High", item.severity)
         self.assertEqual(str, type(item.numerical_severity))


### PR DESCRIPTION
Imports checkmarx vuln with false positive status when found as such in checkmarx report
In WIP because I have based this branch on https://github.com/DefectDojo/django-DefectDojo/pull/1665 where checkmarx parser was modified a lot. 
It's actually just a couple of lines of code in checkmarx parser.py for this PR

Note that ticking "active" / "verified" in the GUI may lead to status such as: 
active, verified, false positive

this is because active and verified when ticked in the GUI overwrites what is done by the parser. 

