### PR TITLE
Fixing endpoint pop-up in add_findings.html  

### DIFF
--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -58,6 +58,7 @@
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
+    <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 
     <script type="application/javascript">
         $ = django.jQuery;


### PR DESCRIPTION
The browser should create a new window / pop-up if a user wants to add an endpoint to a newly created finding. However, jQuery crashs with a Deferred exception and the browser doesn't create a new window:
```
jquery.min.js:2 jQuery.Deferred exception: Cannot read property 'document' of null TypeError: Cannot read property 'document' of null
    at HTMLDocument.<anonymous> (http://localhost:8080/endpoints/1/add?_popup:141:25)
    at l (http://localhost:8080/static/jquery/dist/jquery.min.js:2:29375)
    at c (http://localhost:8080/static/jquery/dist/jquery.min.js:2:29677) undefined
```
After adding the `RelatedObjectLookups.js`, the pop-up will be created.