### PR TITLE
Minor whitesource cvss3 fix

### DIFF
--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -38,7 +38,13 @@ class WhitesourceJSONParser(object):
 
             cve = node.get('name')
             title = cve + " | " + lib_name
-            severity = node.get('severity').lower().capitalize()
+            # cvss2 by default in CLI, but cvss3 in UI. Adapting to have homogeneous behavior.
+            if 'cvss3_severity' in node:
+                cvss_sev = node.get('cvss3_severity')
+            else:
+                cvss_sev = node.get('severity')
+            severity = cvss_sev.lower().capitalize()
+
             cvss3_score = node.get('cvss3_score', "N/A")
             cvss3_vector = node.get('scoreMetadataVector', "N/A")
             severity_justification = "CVSS v3 score: {} ({})".format(cvss3_score, cvss3_vector)


### PR DESCRIPTION
Minor fix to take cvss3 by default, to make cli and UI give the same results.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.