### PR TITLE
Dependabot config - target_branch

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,4 +12,5 @@ update_configs:
 
   - package_manager: "docker"
     directory: "/"
+    target_branch: "dev"
     update_schedule: "weekly"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,5 @@
 version: 1
 update_configs:
-  # Keep package.json (& lockfiles) up to date as soon as
-  # new versions are published to the npm registry
   - package_manager: "python"
     directory: "/"
     target_branch: "dev"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date as soon as
+  # new versions are published to the npm registry
+  - package_manager: "python"
+    directory: "/"
+    target_branch: "dev"
+    update_schedule: "live"
+
+  - package_manager: "javascript"
+    directory: "/"
+    target_branch: "dev"
+    update_schedule: "live"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,3 +9,7 @@ update_configs:
     directory: "/"
     target_branch: "dev"
     update_schedule: "live"
+
+  - package_manager: "docker"
+    directory: "/"
+    update_schedule: "weekly"


### PR DESCRIPTION
Addresses #1678 

Dependabot should issue PR against `dev` and not `master`.

This config would normally work for python and yarn dependencies.