### PR TITLE
Updated php parser to report on warnings even with no errors

### DIFF
--- a/dojo/tools/php_security_audit_v2/parser.py
+++ b/dojo/tools/php_security_audit_v2/parser.py
@@ -13,7 +13,9 @@ class PhpSecurityAuditV2(object):
         dupes = dict()
 
         for filepath, report in list(data["files"].items()):
-            if report["errors"] > 0:
+            errors = report.get("errors") or 0
+            warns = report.get("warnings") or 0
+            if errors + warns > 0:
                 for issue in report["messages"]:
                     title = issue["source"]
 


### PR DESCRIPTION
Reference to **Issue #1701** 
Simple fix to check for errors + warnings rather than just errors > 0.

Using provided json file:
[phpcs_security_audit.txt](https://github.com/DefectDojo/django-DefectDojo/files/3965604/phpcs_security_audit.txt)

Originally 18 findings were created, after the update there are 19. 
Missing finding was a finding that contained only a warning. 
Internal.LineEndings.Mixed