### PR TITLE
Fortify Parser Overhaul

### DIFF
--- a/dojo/tools/fortify/DefaultReportDefinitionAllIssues.xml
+++ b/dojo/tools/fortify/DefaultReportDefinitionAllIssues.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ReportDefinition type="standard" ID="fortifySecurityReport">
+	<TemplateName>Fortify Security Report</TemplateName>
+	<TemplatePath></TemplatePath>
+	<LogoPath>/MF_logo.jpg</LogoPath>
+	<Footnote>Copyright 2018 Micro Focus or one of its affiliates.</Footnote>
+	<ReportSection enabled="true" optionalSubsections="false">
+		<Title>Executive Summary</Title>
+		<SubSection enabled="true">
+			<Title>Issues Overview</Title>
+			<Description>This section provides an overview of the issues uncovered during analysis. The report covers a summary of vulnerability categories discovered by the tool. The auditor should augment this section with higher-level conclusions derived from human review of the application (including architecture reviews,	black-box testing, compliance issues, etc.)</Description>
+			<Text>On $SCAN_DATE$, a source code review was performed over the $PROJECT_NAME$ code base. $SCAN_SUMMARY$ were scanned and reviewed for defects that could lead to potential security vulnerabilities. A total of $TOTAL_FINDINGS$ reviewed findings were uncovered during the analysis.</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Issue Summary by Fortify Priority Order</Title>
+			<Description>A table summarizing the number of issues found and the breakdown of issues in each Fortify Priority Level</Description>
+			<IssueListing limit="-1" listing="false">
+				<Refinement></Refinement>
+				<Chart chartType="table">
+					<Axis>Fortify Priority Order</Axis>
+				</Chart>
+			</IssueListing>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Recommendations and Conclusions</Title>
+			<Description>This section gives some high-level recommendations on remediating the issues discussed in the Issues Summary sub section. Recommendations will vary based on deployment scenarios, risk appetite, and existing mitigating strategies. The auditor should supplement the Fortify generic recommendations with specific information that takes into account the application specific variables.</Description>
+			<Text>The Issues Category section provides Fortify recommendations for addressing issues at a generic level.  The recommendations for specific fixes can be extrapolated from those generic recommendations by the development group.</Text>
+		</SubSection>
+	</ReportSection>
+	
+	<ReportSection enabled="true" optionalSubsections="true">
+		<Title>Project Summary</Title>
+		<SubSection enabled="true">
+			<Title>Code Base Summary</Title>
+			<Description>Summary of the Codebase that was analyzed</Description>
+			<Text>Code location: $SOURCE_BASE_PATH$
+Number of Files: $NUMBER_OF_FILES$
+Lines of Code: $LOC$
+Build Label: $PROJECT_BUILD_LABEL$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Scan Information</Title>
+			<Description>Details of the analysis</Description>
+			<Text>Scan time: $SCAN_TIME$
+SCA Engine version: $FORTIFY_SCA_VERSION$
+Machine Name: $SCAN_COMPUTER_ID$
+Username running scan: $SCAN_USER$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Results Certification</Title>
+			<Description>A full summary of the Results Certification for this project</Description>
+			<Text>$RESULTS_CERTIFICATION_SUMMARY$
+
+Details:
+
+$RESULTS_CERTIFICATION$</Text>
+		</SubSection>
+        <SubSection enabled="true">
+			<Title>Attack Surface</Title>
+			<Description>A full summary of the attack surface for this project</Description>
+			<Text>Attack Surface:
+$ATTACK_SURFACE$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Filter Set Summary</Title>
+			<Description>A brief summary of the filterset used to create this report</Description>
+			<Text>Current Enabled Filter Set:
+$FILTERSET_NAME$
+
+Filter Set Details:
+
+$FILTERSET_DETAILS$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Audit Guide Summary</Title>
+			<Description>Summary of the impact of the audit guide</Description>
+			<Text>$AUDIT_GUIDE_SUMMARY$</Text>
+		</SubSection>
+
+	</ReportSection>
+	<ReportSection enabled="true" optionalSubsections="true">
+		<Title>Results Outline</Title>
+		<SubSection enabled="true">
+			<Title>Overall number of results</Title>
+			<Description>Results count</Description>
+			<Text>The scan found $TOTAL_FINDINGS$ issues.</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Vulnerability Examples by Category</Title>
+			<Description>Results summary for critical and high priority issues.  Vulnerability examples are provided by category.</Description>
+			<IssueListing limit="-1" listing="true">
+				<Refinement></Refinement>
+				<Chart chartType="list">
+					<Axis>Category</Axis>
+				</Chart>
+			</IssueListing>
+		</SubSection>
+	</ReportSection>
+	<ReportSection enabled="false" optionalSubsections="true">
+		<Title>Detailed Project Summary</Title>
+		<SubSection enabled="true">
+			<Title>Files Scanned</Title>
+			<Description>A detailed listing of all scanned files.  Files are listed with paths relative to the Source Base Path</Description>
+			<Text>Code base location: $SOURCE_BASE_PATH$
+Files Scanned:
+$FILE_LISTING$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Reference Elements</Title>
+			<Description>A Listing of all libraries used for the translation phase of the analysis</Description>
+			<Text>Classpath:
+
+$CLASSPATH_LISTING$
+
+Libdirs:
+
+$LIBDIR_LISTING$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Rulepacks</Title>
+			<Description>A listing of all rulepacks used in the analysis</Description>
+			<Text>$RULEPACKS$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Properties</Title>
+			<Description>A complete listing of all properties set during analysis phase</Description>
+			<Text>$PROPERTIES$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Commandline Arguments</Title>
+			<Description>A listing of all arguments passed to SCA during the analysis phase</Description>
+			<Text>$COMMANDLINE_ARGS$</Text>
+		</SubSection>
+		<SubSection enabled="true">
+			<Title>Warnings</Title>
+			<Description>A listing of all warnings that occurred during the scan, during both translation and analysis phase</Description>
+			<Text>$WARNINGS$</Text>
+		</SubSection>
+	</ReportSection>
+
+	<ReportSection enabled="true" optionalSubsections="false">
+		<Title>Issue Count by Category</Title>
+		<SubSection enabled="true">
+			<Title>Issues By Category</Title>
+			<IssueListing limit="-1" listing="false">
+				<Refinement/>
+				<Chart chartType="table">
+					<Axis>Category</Axis>
+				</Chart>
+			</IssueListing>
+		</SubSection>
+	</ReportSection>
+	<ReportSection enabled="true" optionalSubsections="false">
+		<Title>Issue Breakdown by Analysis</Title>
+		<SubSection enabled="true">
+			<Title>Issue by Analysis</Title>
+			<IssueListing limit="-1" listing="false">
+				<Refinement/>
+				<Chart chartType="pie">
+					<Axis>Analysis</Axis>
+				</Chart>
+			</IssueListing>
+		</SubSection>
+	</ReportSection>
+	
+	
+	<ReportSection enabled="false" optionalSubsections="false">
+		<Title>New Issues</Title>
+
+		<SubSection enabled="true">
+			<Title>New Issues</Title>
+			<Description>A list of issues discovered since the previous analysis.</Description>
+			<Text>The following issues have been discovered since the last scan.</Text>
+			<IssueListing limit="-1" listing="false">
+				<Refinement></Refinement>
+				<Chart chartType="pie">
+					<Axis>New Issue</Axis>
+				</Chart>
+			</IssueListing>
+		</SubSection>
+	</ReportSection>
+
+</ReportDefinition>
+

--- a/dojo/tools/fortify/README.md
+++ b/dojo/tools/fortify/README.md
@@ -15,5 +15,3 @@ required XML:
 ```
 ./path/to/ReportGenerator -format xml -f /path/to/output.xml -source /path/to/downloaded/artifact.fpr -template DefaultReportDefinitionAllIssues.xml
 ```
-
-

--- a/dojo/tools/fortify/README.md
+++ b/dojo/tools/fortify/README.md
@@ -1,0 +1,19 @@
+# Usage
+To use this importer you will need an XML generated from a Fortify FPR. This guide assumes you 
+already have, or know how to acquire, an FPR file. Once you have the FPR file you will need
+use Fortify's ReportGenerator tool (located in the bin directory of your fortify install).
+```FORTIFY_INSTALL_ROOT/bin/ReportGenerator```
+
+### Getting All Issues
+By default, the Report Generator tool does _not_ display all issues, it will only display one
+per category. To get all issues, copy the DefaultReportDefinitionAllIssues.xml file from this
+directory to:  
+```FORTIFY_INSTALL_ROOT/Core/config/reports```
+
+Once this is complete, you can run the following command on your .fpr file to generate the
+required XML:
+```
+./path/to/ReportGenerator -format xml -f /path/to/output.xml -source /path/to/downloaded/artifact.fpr -template DefaultReportDefinitionAllIssues.xml
+```
+
+

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -12,8 +12,8 @@ class FortifyXMLParser(object):
     language_list = []
 
     def __init__(self, filename, test):
-        Fortifyscan = ElementTree.parse(filename)
-        root = Fortifyscan.getroot()
+        fortify_scan = ElementTree.parse(filename)
+        root = fortify_scan.getroot()
 
         # Get Date
         date_string = root.getchildren()[5].getchildren()[1].getchildren()[2].text
@@ -23,100 +23,61 @@ class FortifyXMLParser(object):
 
         # Get Language
         lang_string = root[8][4][2].text
-        lang_need_string = re.findall("^.*com.fortify.sca.Phase0HigherOrder.Languages.*$", lang_string, re.MULTILINE)
+        lang_need_string = re.findall("^.*com.fortify.sca.Phase0HigherOrder.Languages.*$",
+                                      lang_string, re.MULTILINE)
         lang_my_string = lang_need_string[0]
         language = lang_my_string.split('=')[1]
         if language not in self.language_list:
             self.language_list.append(language)
 
-        # Get Finding Details
-        dupes = dict()
-
+        # Get all issues
+        issues = []
         for ReportSection in root.findall('ReportSection'):
             if ReportSection.findtext('Title') == "Results Outline":
-                kingdom = ''
-                category = ''
-                mitigation = 'N/A'
-                impact = 'N/A'
-                references = ''
-                findingdetail = ''
-                title = ''
-                filename = ''
-                filepath = ''
-                linestart = ''
-                dupe_key = ''
-                filename = ''
-                linestart = ''
+                for issue in ReportSection.iter("Issue"):
+                    issues.append(issue)
 
-            for GroupingSection in ReportSection.iter('GroupingSection'):
-                for groupTitle in GroupingSection.iter('groupTitle'):
-                    grouptitle = groupTitle.text
-                cwe_id = grouptitle.split(' ')
-                if len(cwe_id) > 2:
-                    if cwe_id[2].isdigit():
-                        cwe_id = cwe_id[2]
-                    elif "," in cwe_id[2]:
-                        cwe_id = cwe_id[:1]
-                    else:
-                        cwe_id = 0
-                else:
-                    cwe_id = 0
+        # All issues obtained, create a map for reference
+        issue_map = {}
+        for issue in issues:
+            details = {}
+            details["Category"] = issue.find("Category").text
+            details["Folder"] = issue.find("Folder").text
+            details["Kingdom"] = issue.find("Kingdom").text
+            details["Abstract"] = issue.find("Abstract").text
+            details["Friority"] = issue.find("Friority").text
+            details["FileName"] = issue.find("Primary").find("FileName").text
+            details["FilePath"] = issue.find("Primary").find("FilePath").text
+            details["LineStart"] = issue.find("Primary").find("LineStart").text
+            details["Snippet"] = issue.find("Primary").find("Snippet").text
+            issue_map.update({issue.attrib['iid']: details})
+        # map created
 
-                for Friority in GroupingSection.iter('Friority'):
-                    sev = Friority.text
+        self.items = []
+        for issue_key, issue in issue_map.items():
+            self.items.append(Finding(
+                title=self.format_title(issue["Category"], issue["FileName"], issue["LineStart"]),
+                severity=issue["Friority"],
+                numerical_severity=Finding.get_numerical_severity(issue["Friority"]),
+                file_path=issue['FilePath'],
+                line_number=int(issue['LineStart']),
+                line=int(issue['LineStart']),
+                static_finding=True,
+                active=False,
+                verified=False,
+                test=test,
+                date=find_date,
+                description=self.format_description(issue["Abstract"],
+                                                    issue["FileName"],
+                                                    issue["Snippet"]),
+                unique_id_from_tool=issue_key
+            ))
 
-                for Category in GroupingSection.iter('Category'):
-                    category = Category.text
+    def format_title(self, category, filename, line_no):
+        return "{} - {}: {}".format(category, filename, line_no)
 
-                for Kingdom in GroupingSection.iter('Kingdom'):
-                    kingdom = Kingdom.text
+    def format_description(self, abstract, filename, snippet):
+        desc = "###Abstract:\n{}\n###Snippet:\n**File: {}**\n```\n{}\n```\n".format(
+                abstract, filename, snippet)
+        return desc
 
-                for LineStart in GroupingSection.iter('LineStart'):
-                    linestart = LineStart.text
-                    if linestart is not None:
-                        findingdetail += "**Line Start:**" + linestart + '\n'
-
-                for Snippet in GroupingSection.iter('Snippet'):
-                    snippet = Snippet.text
-                    if snippet is not None:
-                        findingdetail += "\n**Code:**\n'''\n" + snippet + "\n\n"
-
-                    for FileName in GroupingSection.iter('FileName'):
-                        filename = FileName.text
-                        if filename is not None:
-                            findingdetail += "**FileName:**" + filename + '\n'
-                    for FilePath in GroupingSection.iter('FilePath'):
-                        filepath = FilePath.text
-                        if filepath is not None:
-                            findingdetail += "**Filepath:**" + filepath + '\n'
-
-                    title = category + " " + kingdom
-                    if not isinstance(cwe_id, int):
-                        dupe_key = (title + sev + cwe_id)
-                    else:
-                        dupe_key = (title + sev + str(cwe_id))
-
-                    if dupe_key in dupes:
-                        find = dupes[dupe_key]
-                    else:
-                        dupes[dupe_key] = True
-                        find = Finding(title=title,
-                                        cwe=cwe_id,
-                                        test=test,
-                                        active=False,
-                                        verified=False,
-                                        description=findingdetail,
-                                        severity=sev,
-                                        numerical_severity=Finding.get_numerical_severity(sev),
-                                        mitigation=mitigation,
-                                        impact=impact,
-                                        references=references,
-                                        file_path=filepath,
-                                        line=linestart,
-                                        url='N/A',
-                                        date=find_date,
-                                        static_finding=True)
-                    dupes[dupe_key] = find
-                    findingdetail = ''
-
-        self.items = list(dupes.values())

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -95,7 +95,6 @@ class FortifyXMLParser(object):
                     mitigation=self.format_mitigation(issue, cat_meta),
                     unique_id_from_tool=issue_key
                 ))
-            else:
                 dupes.add(title)
 
     def format_title(self, category, filename, line_no):

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -30,54 +30,121 @@ class FortifyXMLParser(object):
         if language not in self.language_list:
             self.language_list.append(language)
 
+        # Get Category Information:
+        # Abstract, Explanation, Recommendation, Tips
+        cat_meta = {}
         # Get all issues
         issues = []
         for ReportSection in root.findall('ReportSection'):
             if ReportSection.findtext('Title') == "Results Outline":
+                # Get information on the vulnerability like the Abstract, Explanation,
+                # Recommendation, and Tips
+                for group in ReportSection.iter("GroupingSection"):
+                    title = group.findtext("groupTitle")
+                    maj_attr_summary = group.find("MajorAttributeSummary")
+                    if maj_attr_summary:
+                        meta_info = maj_attr_summary.findall("MetaInfo")
+                        cat_meta[title] = {x.findtext("Name"): x.findtext("Value")
+                                           for x in meta_info}
+                # Collect all issues
                 for issue in ReportSection.iter("Issue"):
                     issues.append(issue)
 
         # All issues obtained, create a map for reference
         issue_map = {}
         for issue in issues:
-            details = {}
-            details["Category"] = issue.find("Category").text
-            details["Folder"] = issue.find("Folder").text
-            details["Kingdom"] = issue.find("Kingdom").text
-            details["Abstract"] = issue.find("Abstract").text
-            details["Friority"] = issue.find("Friority").text
-            details["FileName"] = issue.find("Primary").find("FileName").text
-            details["FilePath"] = issue.find("Primary").find("FilePath").text
-            details["LineStart"] = issue.find("Primary").find("LineStart").text
-            details["Snippet"] = issue.find("Primary").find("Snippet").text
+            details = {
+                "Category": issue.find("Category").text,
+                "Folder": issue.find("Folder").text, "Kingdom": issue.find("Kingdom").text,
+                "Abstract": issue.find("Abstract").text,
+                "Friority": issue.find("Friority").text,
+                "FileName": issue.find("Primary").find("FileName").text,
+                "FilePath": issue.find("Primary").find("FilePath").text,
+                "LineStart": issue.find("Primary").find("LineStart").text,
+                "Snippet": issue.find("Primary").find("Snippet").text}
+
+            if issue.find("Source"):
+                source = {
+                    "FileName": issue.find("Source").find("FileName").text,
+                    "FilePath": issue.find("Source").find("FilePath").text,
+                    "LineStart": issue.find("Source").find("LineStart").text,
+                    "Snippet": issue.find("Source").find("Snippet").text}
+                details["Source"] = source
+
             issue_map.update({issue.attrib['iid']: details})
         # map created
 
         self.items = []
+        dupes = set()
         for issue_key, issue in issue_map.items():
-            self.items.append(Finding(
-                title=self.format_title(issue["Category"], issue["FileName"], issue["LineStart"]),
-                severity=issue["Friority"],
-                numerical_severity=Finding.get_numerical_severity(issue["Friority"]),
-                file_path=issue['FilePath'],
-                line_number=int(issue['LineStart']),
-                line=int(issue['LineStart']),
-                static_finding=True,
-                active=False,
-                verified=False,
-                test=test,
-                date=find_date,
-                description=self.format_description(issue["Abstract"],
-                                                    issue["FileName"],
-                                                    issue["Snippet"]),
-                unique_id_from_tool=issue_key
-            ))
+            title = self.format_title(issue["Category"], issue["FileName"], issue["LineStart"])
+            if title not in dupes:
+                self.items.append(Finding(
+                    title=title,
+                    severity=issue["Friority"],
+                    numerical_severity=Finding.get_numerical_severity(issue["Friority"]),
+                    file_path=issue['FilePath'],
+                    line_number=int(issue['LineStart']),
+                    line=int(issue['LineStart']),
+                    static_finding=True,
+                    active=False,
+                    verified=False,
+                    test=test,
+                    date=find_date,
+                    description=self.format_description(issue, cat_meta),
+                    mitigation=self.format_mitigation(issue, cat_meta),
+                    unique_id_from_tool=issue_key
+                ))
+            else:
+                dupes.add(title)
 
     def format_title(self, category, filename, line_no):
+        """
+        Builds the title much like it is represented in Fortify
+        :param category: Basically the title of the issue in the code
+        :param filename: File where it is found
+        :param line_no:  Line number of offending line
+        :return: str
+        """
         return "{} - {}: {}".format(category, filename, line_no)
 
-    def format_description(self, abstract, filename, snippet):
-        desc = "###Abstract:\n{}\n###Snippet:\n**File: {}**\n```\n{}\n```\n".format(
-                abstract, filename, snippet)
-        return desc
+    def format_mitigation(self, issue, meta_info) -> str:
+        """
+        Built from the meta_info of a category. All items of the same category will
+        have the same information in it
+        :param issue:  Issue dictionary
+        :param meta_info:  Meta_info dictionary
+        :return: str
+        """
+        mitigation = ""
+        recommendation = meta_info[issue["Category"]].get("Recommendations")
+        if recommendation:
+            mitigation += "###Recommendation:\n {}\n".format(recommendation)
 
+        tips = meta_info[issue["Category"]].get("Tips")
+        if tips:
+            mitigation += "###Tips:\n {}".format(tips)
+        return mitigation
+
+    def format_description(self, issue, meta_info) -> str:
+        """
+        Returns a formatted Description. This will contain information about the category,
+        snippet from the code, including the file and line number. If there is source information
+        it will also include that. Adds explanation of finding from the meta info
+        :param issue:       Issue Dictionary
+        :param meta_info:   Meta Dictionary
+        :return: str
+        """
+        desc = "##Catagory: {}\n".format(issue["Category"])
+        desc += "###Abstract:\n{}\n###Snippet:\n**File: {}: {}**\n```\n{}\n```\n".format(
+                issue["Abstract"], issue["FileName"], issue["LineStart"], issue["Snippet"])
+        explanation = meta_info[issue["Category"]].get("Explanation")
+        source = issue.get("Source")
+        if source:
+            desc += "##Source:\nThis snippet provides more context on the execution path that " \
+                    "leads to this finding. \n" \
+                    "####Snippet:\n**File: {}: {}**\n```\n{}\n```\n".format(
+                        source["FileName"], source["LineStart"], source["Snippet"])
+        if explanation:
+            desc += "##Explanation:\n {}".format(explanation)
+        return desc

--- a/dojo/unittests/scans/fortify/fortify_few_findings.xml
+++ b/dojo/unittests/scans/fortify/fortify_few_findings.xml
@@ -1,0 +1,1011 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ReportDefinition type="standard">
+    <TemplateName>Fortify Security Report</TemplateName>
+    <TemplatePath></TemplatePath>
+    <LogoPath>/HPE_logo.jpg</LogoPath>
+    <Footnote>Copyright 2017 Hewlett Packard Enterprise Development, L.P.</Footnote>
+    <UserName></UserName>
+    <ReportSection enabled="true" optionalSubsections="false">
+        <Title>Executive Summary</Title>
+        <SubSection enabled="true">
+            <Title>Issues Overview</Title>
+            <Description>This section provides an overview of the issues uncovered during analysis. The report covers a summary of vulnerability categories discovered by the tool. The auditor should augment this section with higher-level conclusions derived from human review of the application (including architecture reviews,	black-box testing, compliance issues, etc.)</Description>
+            <Text>On May 7, 2019, a source code review was performed over the redacted code base. 1,001 files, 3,110 LOC (Executable) were scanned and reviewed for defects that could lead to potential security vulnerabilities. A total of 8 reviewed findings were uncovered during the analysis.</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Issue Summary by Fortify Priority Order</Title>
+            <Description>A table summarizing the number of issues found and the breakdown of issues in each Fortify Priority Level</Description>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="table">
+                    <Axis>Fortify Priority Order</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="0">
+                        <groupTitle>Low</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="2">
+                        <groupTitle>High</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="0">
+                        <groupTitle>Medium</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="0">
+                        <groupTitle>Critical</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Recommendations and Conclusions</Title>
+            <Description>This section gives some high-level recommendations on remediating the issues discussed in the Issues Summary sub section. Recommendations will vary based on deployment scenarios, risk appetite, and existing mitigating strategies. The auditor should supplement the Fortify generic recommendations with specific information that takes into account the application specific variables.</Description>
+            <Text>The Issues Category section provides Fortify recommendations for addressing issues at a generic level.  The recommendations for specific fixes can be extrapolated from those generic recommendations by the development group.</Text>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="true">
+        <Title>Project Summary</Title>
+        <SubSection enabled="true">
+            <Title>Code Base Summary</Title>
+            <Description>Summary of the Codebase that was analyzed</Description>
+            <Text>Code location: /initialGitCloneRepos/on-demand-scans/pv0501
+Number of Files: 1001
+Lines of Code: 3110
+Build Label: &lt;No Build Label&gt;</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Scan Information</Title>
+            <Description>Details of the analysis</Description>
+            <Text>Scan time: 08:55
+SCA Engine version: 18.20.1046
+Machine Name: redacted
+Username running scan: redacted</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Results Certification</Title>
+            <Description>A full summary of the Results Certification for this project</Description>
+            <Text>Results Certification Valid
+
+Details:
+
+Results Signature:
+
+	SCA Analysis Results has Valid signature
+	
+
+Rules Signature:
+
+	There were no custom rules used in this scan</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Attack Surface</Title>
+            <Description>A full summary of the attack surface for this project</Description>
+            <Text>Attack Surface:
+File System:
+	null.null.open
+
+System Information:
+	null.null.null
+	java.lang.Throwable.getMessage
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Filter Set Summary</Title>
+            <Description>A brief summary of the filterset used to create this report</Description>
+            <Text>Current Enabled Filter Set:
+Security Auditor View
+
+Filter Set Details:
+
+Folder Filters:
+If [fortify priority order] contains critical Then set folder to Critical
+If [fortify priority order] contains high Then set folder to High
+If [fortify priority order] contains medium Then set folder to Medium
+If [fortify priority order] contains low Then set folder to Low</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Audit Guide Summary</Title>
+            <Description>Summary of the impact of the audit guide</Description>
+            <Text>Audit guide not enabled</Text>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="true">
+        <Title>Results Outline</Title>
+        <SubSection enabled="true">
+            <Title>Overall number of results</Title>
+            <Description>Results count</Description>
+            <Text>The scan found 8 issues.</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Vulnerability Examples by Category</Title>
+            <Description>Results summary for critical and high priority issues.  Vulnerability examples are provided by category.</Description>
+            <IssueListing listing="true" limit="1">
+                <Refinement>[fortify priority order]:critical OR [fortify priority order]:high</Refinement>
+                <Chart chartType="list">
+                    <Axis>Category</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="1">
+                        <groupTitle>Privilege Management: Unnecessary Permission</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The application fails to adhere to the principle of least privilege, which greatly amplifies the risk posed by other vulnerabilities.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>An application should only have the minimum permissions required for its proper execution. Extra permissions might deter users from installing the application. This permission might be unnecessary for this program.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Consider whether the application requires the requested permission in order to function properly. If it does not, you should remove the permission from the AndroidManifest.xml file. Do no over-permission the application by requesting more permissions than it really needs. This can lead to other malicious applications installed on the device taking advantage of such over-permissioned applications to adversely impact the user experience and the stored data. Additionally, extra permissions may unnecessarily discourage customers from installing your application.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="53C25D2FC6950554F16D3CEF9E41EF6F" ruleID="DA628366-FBE1-4D37-879F-7B8F53FF24C1">
+                            <Category>Privilege Management: Unnecessary Permission</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>The application fails to adhere to the principle of least privilege, which greatly amplifies the risk posed by other vulnerabilities.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>AndroidManifest.xml</FileName>
+<FilePath>app/build/intermediates/bundle_manifest/developDebug/processDevelopDebugManifest/bundle-manifest/AndroidManifest.xml</FilePath>
+<LineStart>11</LineStart>
+<Snippet>        android:targetSdkVersion="28" /&gt;
+
+    &lt;uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" /&gt;
+    &lt;uses-permission android:name="android.permission.INTERNET" /&gt;
+    &lt;uses-permission android:name="android.permission.READ_PHONE_STATE" /&gt;</Snippet>
+<TargetFunction>null()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Null Dereference</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method redacted() in redacted.java can crash the program by dereferencing a null pointer on line 28.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Null pointer exceptions usually occur when one or more of the programmer's assumptions is violated. A dereference-after-store error occurs when a program explicitly sets an object to null and dereferences it later. This error is often the result of a programmer initializing a variable to null when it is declared.
+
+
+Most null pointer issues result in general software reliability problems, but if attackers can intentionally trigger a null pointer dereference, they can use the resulting exception to bypass security logic or to cause the application to reveal debugging information that will be valuable in planning subsequent attacks.
+
+Example: In the following code, the programmer explicitly sets the variable foo to null. Later, the programmer dereferences foo before checking the object for a null value.
+
+
+Foo foo = null;
+...
+foo.setBar(val);
+...
+}
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Implement careful checks before dereferencing objects that might be null. When possible, abstract null checks into wrappers around code that manipulates resources to ensure that they are applied in all cases and to minimize the places where mistakes can occur.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>2</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="DCCBF8C4004DBEC817ACC013EB7D24EF" ruleID="B32F92AC-9605-0987-E73B-CCB28279AA24">
+                            <Category>Null Dereference</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method redacted() in redacted.java can crash the program by dereferencing a null pointer on line 28.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>AppModule_ProvidesApplicationContextFactory.java</FileName>
+<FilePath>app/build/generated/source/kapt/developDebug/com/redacted/redacted/redacted.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>
+  public static Context redacted(Application app) {
+    return Preconditions.checkNotNull(AppModule.providesApplicationContext(app), "Cannot return null from a non-@Nullable @Provides method");}
+}</Snippet>
+<TargetFunction>Dereferenced : providesApplicationContext(app)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="false" optionalSubsections="true">
+        <Title>Detailed Project Summary</Title>
+        <SubSection enabled="true">
+            <Title>Files Scanned</Title>
+            <Description>A detailed listing of all scanned files.  Files are listed with paths relative to the Source Base Path</Description>
+            <Text>Code base location: /redacted
+Files Scanned:
+redacted</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Reference Elements</Title>
+            <Description>A Listing of all libraries used for the translation phase of the analysis</Description>
+            <Text>Classpath:
+
+No classpath specified during translation
+
+Libdirs:
+
+No libdirs specified during translation</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Rulepacks</Title>
+            <Description>A listing of all rulepacks used in the analysis</Description>
+            <Text>Valid Rulepacks:
+
+Name: 		Fortify Secure Coding Rules, Extended, JavaScript
+Version: 	2018.4.0.0008
+ID: 				C4D1969E-B734-47D3-87D4-73962C1D32E2
+SKU: 			RUL13141
+
+Name: 		Fortify Secure Coding Rules, Core, Annotations
+Version: 	2018.4.0.0008
+ID: 				14EE50EB-FA1C-4AE8-8B59-39F952E21E3B
+SKU: 			RUL13078
+
+Name: 		Fortify Secure Coding Rules, Extended, JSP
+Version: 	2018.4.0.0008
+ID: 				00403342-15D0-48C9-8E67-4B1CFBDEFCD2
+SKU: 			RUL13026
+
+Name: 		Fortify Secure Coding Rules, Extended, Java
+Version: 	2018.4.0.0008
+ID: 				AAAC0B10-79E7-4FE5-9921-F4903A79D317
+SKU: 			RUL13007
+
+Name: 		Fortify Secure Coding Rules, Core, Android
+Version: 	2018.4.0.0008
+ID: 				FF9890E6-D119-4EE8-A591-83DCF4CA6952
+SKU: 			RUL13093
+
+Name: 		Fortify Secure Coding Rules, Extended, Configuration
+Version: 	2018.4.0.0008
+ID: 				CD6959FC-0C37-45BE-9637-BAA43C3A4D56
+SKU: 			RUL13005
+
+Name: 		Fortify Secure Coding Rules, Extended, Content
+Version: 	2018.4.0.0008
+ID: 				9C48678C-09B6-474D-B86D-97EE94D38F17
+SKU: 			RUL13067
+
+Name: 		Fortify Secure Coding Rules, Core, JavaScript
+Version: 	2018.4.0.0008
+ID: 				BD292C4E-4216-4DB8-96C7-9B607BFD9584
+SKU: 			RUL13059
+
+Name: 		Fortify Secure Coding Rules, Core, Java
+Version: 	2018.4.0.0008
+ID: 				06A6CC97-8C3F-4E73-9093-3E74C64A2AAF
+SKU: 			RUL13003
+
+Name: 		Fortify Secure Coding Rules, Core, Python
+Version: 	2018.4.0.0008
+ID: 				FD15CBE4-E059-4CBB-914E-546BDCEB422B
+SKU: 			RUL13083
+
+External Metadata:
+Version: 2018.4.0.0008
+
+Name: 		CWE
+ID: 				3ADB9EE4-5761-4289-8BD3-CBFCC593EBBC
+The Common Weakness Enumeration (CWE), co-sponsored and maintained by MITRE, is international in scope and free for public use. CWE provides a unified, measurable set of software weaknesses that is enabling more effective discussion, description, selection, and use of software security tools and services that can find these weaknesses in source code and operational systems as well as better understanding and management of software weaknesses related to architecture and design.
+
+Name: 		DISA CCI 2
+ID: 				7F037130-41E5-40F0-B653-7819A4B3E241
+The purpose of a Defense Information Systems Agency (DISA) Control Correlation Identifier (CCI) is to provide a standard identifier for policy based requirements which connect high-level policy expressions and low-level technical implementations. Associated with each CCI is a description for each of the singular, actionable, statements compromising an information assurance (IA) control or IA best practice. Using CCI allows high-level policy framework security requirements to be decomposed and explicitly associated with low-level implementations, thus enabling the assessment of related compliance assessment results spanning heterogeneous technologies. The current IA controls and best practices associated with each CCI, that are specified in NIST SP 800-53 Revision 4, can be viewed using the DISA STIG Viewer.  
+The following table summarizes the number of issues identified across the different CCIs broken down by Fortify Priority Order. The status of a CCI is considered "In Place" when there are no issues reported for a given CCI.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, CCI-003187 is not considered "In Place". Similarly, if the project is missing a Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, CCI-000366 and CCI-000256 are not considered "In Place".
+
+Name: 		FISMA
+ID: 				B40F9EE0-3824-4879-B9FE-7A789C89307C
+The Federal Information Processing Standard (FIPS) 200 document is part of the official series of publications, issued by the National Institute of Standards and Technology (NIST), relating to standards and guidelines adopted and promulgated under the provisions of the Federal Information Security Management Act (FISMA). Specifically, FIPS Publication 200 specifies the "Minimum Security Requirements for Federal Information and Information Systems."
+
+Name: 		GDPR
+ID: 				771C470C-9274-4580-8556-C12F5E4BEC51
+The EU General Data Protection Regulation (GDPR) replaces the Data Protection Directive 95/46/EC and was designed to harmonize data privacy laws across Europe, to protect and empower all EU citizens data privacy and to reshape the way organizations across the region approach data privacy. Going into effect on May 25, 2018, GDPR provides a framework for organizations on how to handle personal data.        According to GDPR regulation personal data "means any information relating to an identified or identifiable natural person ('data subject'); an identifiable natural person is one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person."      GDPR articles that pertain to application security and require businesses to protect personal data during design and development of its product and services are:
+
+   - Article 25, Data protection by design and by default - which requires "The controller shall implement appropriate technical and organisational measures for ensuring that, by default, only personal data which are necessary for each specific purpose of the processing are processed."
+   - Article 32, Security of processing - which requires businesses to protect its systems and applications "from accidental or unlawful destruction, loss, alteration, unauthorized disclosure of, or access to personal data".       This report may be used by organizations as a framework to help identify and protect personal data as it relates to application security.
+
+Name: 		MISRA C 2012
+ID: 				555A3A66-A0E1-47AF-910C-3F19A6FB2506
+Now in its third edition, the Motor Industry Software Reliability Association (MISRA) C Guidelines describe a subset of the C programming language in which there is reduced risk of introducing mistakes in critical systems. While the MISRA C Guidelines focus upon safety-related software development, a subset of the rules also reflect security properties. Fortify interprets the MISRA C Guidelines under the context of security and provides correlation of security vulnerabilty categories to the rules defined by MISRA. Fortify provides these security focused detection mechanism with the standard rulepacks, however, further support of the MISRA C Guidelines related to safety can be added through the use of custom rules. The results in this report can assist in the creation of a compliance matrix for MISRA.
+
+Name: 		MISRA C++ 2008
+ID: 				5D4B75A1-FC91-4B4B-BD4D-C81BBE9604FA
+The Motor Industry Software Reliability Association (MISRA) C++ Guidelines describe a subset of the C++ programming language in which there is reduced risk of introducing mistakes in critical systems. While the MISRA C++ Guidelines focus upon safety-related software development, a subset of the rules also reflect security properties. Fortify interprets the MISRA C++ Guidelines under the context of security and provides correlation of security vulnerabilty categories to the rules defined by MISRA. Fortify provides these security focused detection mechanism with the standard rulepacks, however, further support of the MISRA C++ Guidelines related to safety can be added through the use of custom rules. The results in this report can assist in the creation of a compliance matrix for MISRA.
+
+Name: 		NIST SP 800-53 Rev.4
+ID: 				1114583B-EA24-45BE-B7F8-B61201BACDD0
+NIST Special Publication 800-53 Revision 4 provides a list of security and privacy controls designed to protect federal organizations and information systems from security threats. The following table summarizes the number of issues identified across the different controls and broken down by Fortify Priority Order.
+
+Name: 		OWASP Mobile 2014
+ID: 				EEE3F9E7-28D6-4456-8761-3DA56C36F4EE
+The OWASP Mobile Top 10 Risks 2014 provides a powerful awareness document for mobile application security. The OWASP Mobile Top 10 represents a broad consensus about what the most critical mobile application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2004
+ID: 				771C470C-9274-4580-8556-C023E4D3ADB4
+The OWASP Top Ten 2004 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2007
+ID: 				1EB1EC0E-74E6-49A0-BCE5-E6603802987A
+The OWASP Top Ten 2007 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2010
+ID: 				FDCECA5E-C2A8-4BE8-BB26-76A8ECD0ED59
+The OWASP Top Ten 2010 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2013
+ID: 				1A2B4C7E-93B0-4502-878A-9BE40D2A25C4
+The OWASP Top Ten 2013 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2017
+ID: 				3C6ECB67-BBD9-4259-A8DB-B49328927248
+The OWASP Top Ten 2017 provides a powerful awareness document for web application security focused on informing the community about the consequences of the most common and most important web application security weaknesses. The OWASP Top Ten represents a broad agreement about what the most critical web application security flaws are with consensus being drawn from data collection and survey results. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		PCI 1.1
+ID: 				CBDB9D4D-FC20-4C04-AD58-575901CAB531
+The Payment Card Industry (PCI) Data Security Standard (DSS) 1.1 compliance standard describes 12 requirements which are organized into 6 logically related groups, which are "control objectives". PCI DSS requirements are applicable if Primary Account Number (PAN) is stored, processed, or transmitted by the system.
+
+Name: 		PCI 1.2
+ID: 				57940BDB-99F0-48BF-BF2E-CFC42BA035E5
+Payment Card Industry Data Security Standard Version 1.2 description
+
+Name: 		PCI 2.0
+ID: 				8970556D-7F9F-4EA7-8033-9DF39D68FF3E
+The PCI DSS 2.0 compliance standard, particularly sections 6.3, 6.5, and 6.6, references the OWASP Top 10 vulnerability categories as the core categories that must be tested for and remediated. The following table summarizes the number of issues identified across the different PCI DSS requirements and broken down by Fortify Priority Order.
+
+Name: 		PCI 3.0
+ID: 				E2FB0D38-0192-4F03-8E01-FE2A12680CA3
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.0. Fortify tests for 32 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.0 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		PCI 3.1
+ID: 				AC0D18CF-C1DA-47CF-9F1A-E8EC0A4A717E
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.1. Fortify tests for 31 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.1 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		PCI 3.2
+ID: 				4E8431F9-1BA1-41A8-BDBD-087D5826751A
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.2. Fortify tests for 31 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.2 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		PCI 3.2.1
+ID: 				EADE255F-6561-4EFE-AD31-2914F6BFA329
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.2.1. Fortify tests for 31 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.2.1 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		SANS Top 25 2009
+ID: 				939EF193-507A-44E2-ABB7-C00B2168B6D8
+The 2009 CWE/SANS Top 25 Programming Errors list the most significant programming errors that can lead to serious software vulnerabilities. They occur frequently, are often easy to find, and easy to exploit. They are dangerous because they will frequently allow attackers to completely take over the software, steal data, or prevent the software from working at all. The list is the result of collaboration between the SANS Institute, MITRE, and many top software security experts.
+
+Name: 		SANS Top 25 2010
+ID: 				72688795-4F7B-484C-88A6-D4757A6121CA
+SANS Top 25 2010 Most Dangerous Software Errors provides an enumeration of the most widespread and critical errors, categorized by Common Weakness Enumeration (CWE) identifiers, that lead to serious vulnerabilities in software (http://cwe.mitre.org/). These software errors are often easy to find and exploit. The inherent danger in these errors is that they can allow an attacker to completely take over the software, steal data, or prevent the software from working at all.
+
+Name: 		SANS Top 25 2011
+ID: 				92EB4481-1FD9-4165-8E16-F2DE6CB0BD63
+SANS Top 25 2011 Most Dangerous Software Errors provides an enumeration of the most widespread and critical errors, categorized by Common Weakness Enumeration (CWE) identifiers, that lead to serious vulnerabilities in software (http://cwe.mitre.org/). These software errors are often easy to find and exploit. The inherent danger in these errors is that they can allow an attacker to completely take over the software, steal data, or prevent the software from working at all.
+
+Name: 		STIG 3.1
+ID: 				F2FA57EA-5AAA-4DDE-90A5-480BE65CE7E7
+Security Technical Implementation Guide Version 3.1 description
+
+Name: 		STIG 3.10
+ID: 				788A87FE-C9F9-4533-9095-0379A9B35B12
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 3.4
+ID: 				58E2C21D-C70F-4314-8994-B859E24CF855
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.
+
+Name: 		STIG 3.5
+ID: 				DD18E81F-3507-41FA-9DFA-2A9A15B5479F
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt; &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.
+
+Name: 		STIG 3.6
+ID: 				000CA760-0FED-4374-8AA2-6FA3968A07B1
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 3.7
+ID: 				E69C07C0-81D8-4B04-9233-F3E74167C3D2
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 3.9
+ID: 				1A9D736B-2D4A-49D1-88CA-DF464B40D732
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 4.1
+ID: 				95227C50-A9E4-4C9D-A8AF-FD98ABAE1F3C
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.2
+ID: 				672C15F8-8822-4E05-8C9E-1A4BAAA7A373
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.3
+ID: 				A0B313F0-29BD-430B-9E34-6D10F1178506
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.4
+ID: 				ECEC5CA2-7ACA-4B70-BF44-3248B9C6F4F8
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.5
+ID: 				E6010E0A-7F71-4388-B8B7-EE9A02143474
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.6
+ID: 				EFB9B012-44D6-456D-B197-03D2FD7C7AD6
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.7
+ID: 				B04A1E01-F1C1-48D3-A827-0F70872182D7
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.8
+ID: 				E6805D9F-D5B5-4192-962C-46828FF68507
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID) which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing an Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		WASC 2.00
+ID: 				74f8081d-dd49-49da-880f-6830cebe9777
+The Web Application Security Consortium (WASC) was created as a cooperative effort to standardize, clarify, and organize the threats to the security of a web site. Version 2.00 of their Threat Classification outlines the attacks and weaknesses that can commonly lead to a website being compromised.
+
+Name: 		WASC 24 + 2
+ID: 				9DC61E7F-1A48-4711-BBFD-E9DFF537871F
+The Web Application Security Consortium (WASC) was created as a cooperative effort to standardize, clarify, and organize the threats to the security of a web site.
+
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Properties</Title>
+            <Description>A complete listing of all properties set during analysis phase</Description>
+            <Text>WinForms.CollectionMutationMonitor.Label=WinFormsDataSource
+awt.toolkit=sun.awt.X11.XToolkit
+com.fortify.AuthenticationKey=/home/redacted/.fortify/config/tools
+com.fortify.Core=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core
+com.fortify.InstallRoot=/opt/Fortify/Fortify_SCA_and_Apps_18.20
+com.fortify.InstallationUserName=redacted
+com.fortify.SCAExecutablePath=
+com.fortify.TotalPhysicalMemory=33565929472
+com.fortify.VS.RequireASPPrecompilation=true
+com.fortify.WorkingDirectory=/home/redacted/.fortify
+com.fortify.locale=en
+com.fortify.sca.AddImpliedMethods=true
+com.fortify.sca.AntCompilerClass=com.fortify.dev.ant.SCACompiler
+com.fortify.sca.AppendLogFile=true
+com.fortify.sca.BuildID=redacted
+com.fortify.sca.BundleControlflowIssues=true
+com.fortify.sca.BytecodePreview=true
+com.fortify.sca.CollectPerformanceData=true
+com.fortify.sca.CustomRulesDir=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/config/customrules
+com.fortify.sca.DaemonCompilers=com.fortify.sca.util.compilers.GppCompiler,com.fortify.sca.util.compilers.GccCompiler,com.fortify.sca.util.compilers.AppleGppCompiler,com.fortify.sca.util.compilers.AppleGccCompiler,com.fortify.sca.util.compilers.MicrosoftCompiler,com.fortify.sca.util.compilers.MicrosoftLinker,com.fortify.sca.util.compilers.LdCompiler,com.fortify.sca.util.compilers.ArUtil,com.fortify.sca.util.compilers.SunCCompiler,com.fortify.sca.util.compilers.SunCppCompiler,com.fortify.sca.util.compilers.IntelCompiler,com.fortify.sca.util.compilers.ExternalCppAdapter,com.fortify.sca.util.compilers.ClangCompiler
+com.fortify.sca.DeadCodeFilter=true
+com.fortify.sca.DeadCodeIgnoreTrivialPredicates=true
+com.fortify.sca.DefaultAnalyzers=semantic:dataflow:controlflow:nullptr:configuration:content:structural:buffer
+com.fortify.sca.DefaultFileTypes=java,rb,jsp,jspx,tag,tagx,tld,sql,cfm,php,phtml,ctp,pks,pkh,pkb,xml,config,Config,settings,properties,dll,exe,winmd,cs,vb,asax,ascx,ashx,asmx,aspx,master,Master,xaml,baml,cshtml,vbhtml,inc,asp,vbscript,js,ini,bas,cls,vbs,frm,ctl,html,htm,xsd,wsdd,xmi,py,cfml,cfc,abap,xhtml,cpx,xcfg,jsff,as,mxml,cbl,cscfg,csdef,wadcfg,wadcfgx,appxmanifest,wsdl,plist,bsp,ABAP,BSP,swift,page,trigger,scala,ts
+com.fortify.sca.DefaultJarsDirs=default_jars
+com.fortify.sca.DefaultRulesDir=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/config/rules
+com.fortify.sca.DisableDeadCodeElimination=false
+com.fortify.sca.DisableFunctionPointers=false
+com.fortify.sca.DisableGlobals=false
+com.fortify.sca.DisableInferredConstants=false
+com.fortify.sca.EnableInterproceduralConstantResolution=true
+com.fortify.sca.EnableNestedWrappers=true
+com.fortify.sca.EnableStructuralMatchCache=true
+com.fortify.sca.EnableWrapperDetection=true
+com.fortify.sca.FVDLDisableDescriptions=false
+com.fortify.sca.FVDLDisableProgramData=false
+com.fortify.sca.FVDLDisableSnippets=false
+com.fortify.sca.FVDLStylesheet=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/resources/sca/fvdl2html.xsl
+com.fortify.sca.IndirectCallGraphBuilders=WinFormsAdHocFunctionBuilder,VirtualCGBuilder,J2EEIndirectCGBuilder,JNICGBuilder,StoredProcedureResolver,JavaWSCGBuilder,StrutsCGBuilder,DotNetWSCGBuilder,SqlServerSPResolver,ASPCGBuilder,ScriptedCGBuilder,NewJspCustomTagCGBuilder,DotNetCABCGBuilder,StateInjectionCGBuilder,SqlServerSPResolver2,PHPLambdaResolver,JavaWebCGBuilder
+com.fortify.sca.JVMArgs=-XX:SoftRefLRUPolicyMSPerMB=3000 -Xmx30209336525 -Xss16M
+com.fortify.sca.JavaSourcepathSearch=true
+com.fortify.sca.JdkVersion=1.8
+com.fortify.sca.LauncherArgs=-autoheap
+com.fortify.sca.LogFileDir=/home/redacted/.fortify/sca18.2/log
+com.fortify.sca.LogFileExt=.log
+com.fortify.sca.LogFileName=sca.log
+com.fortify.sca.LogFileNameNoExt=sca
+com.fortify.sca.LogFilePath=/home/redacted/.fortify/sca18.2/log/sca.log
+com.fortify.sca.LogLevel=INFO
+com.fortify.sca.LowSeverityCutoff=1.0
+com.fortify.sca.MultithreadedAnalysis=true
+com.fortify.sca.NoNestedOutTagOutput=org.apache.taglibs.standard.tag.rt.core.RemoveTag,org.apache.taglibs.standard.tag.rt.core.SetTag
+com.fortify.sca.OldVbNetExcludeFileTypes=vb,asax,ascx,ashx,asmx,aspx,xaml,cshtml,vbhtml
+com.fortify.sca.PID=25975
+com.fortify.sca.Phase0HigherOrder.Languages=python,ruby,swift
+com.fortify.sca.Phase0HigherOrder.Level=1
+com.fortify.sca.PrintPerformanceDataAfterScan=false
+com.fortify.sca.ProjectRoot=/home/redacted/.fortify
+com.fortify.sca.ProjectRoot=/home/redacted/.fortify
+com.fortify.sca.RequireMapKeys=classrule
+com.fortify.sca.ResultsFile=redacted-results.fpr
+com.fortify.sca.SolverTimeout=15
+com.fortify.sca.SqlLanguage=PLSQL
+com.fortify.sca.SuppressLowSeverity=true
+com.fortify.sca.ThreadCount.NameTableLoading=1
+com.fortify.sca.TypeInferenceFunctionTimeout=60
+com.fortify.sca.TypeInferenceLanguages=javascript,typescript,python,ruby
+com.fortify.sca.TypeInferencePhase0Timeout=300
+com.fortify.sca.UnicodeInputFile=true
+com.fortify.sca.UniversalBlacklist=.*yyparse.*
+com.fortify.sca.alias.mode.csharp=fs
+com.fortify.sca.alias.mode.javascript=fi
+com.fortify.sca.alias.mode.swift=fi
+com.fortify.sca.alias.mode.typescript=fi
+com.fortify.sca.alias.mode.vb=fs
+com.fortify.sca.analyzer.controlflow.EnableLivenessOptimization=false
+com.fortify.sca.analyzer.controlflow.EnableMachineFiltering=false
+com.fortify.sca.analyzer.controlflow.EnableRefRuleOptimization=false
+com.fortify.sca.analyzer.controlflow.EnableTimeOut=true
+com.fortify.sca.compilers.ant=com.fortify.sca.util.compilers.AntAdapter
+com.fortify.sca.compilers.ar=com.fortify.sca.util.compilers.ArUtil
+com.fortify.sca.compilers.armcc=com.fortify.sca.util.compilers.ArmCcCompiler
+com.fortify.sca.compilers.armcpp=com.fortify.sca.util.compilers.ArmCppCompiler
+com.fortify.sca.compilers.c++=com.fortify.sca.util.compilers.GppCompiler
+com.fortify.sca.compilers.cc=com.fortify.sca.util.compilers.GccCompiler
+com.fortify.sca.compilers.clearmake=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.fortify=com.fortify.sca.util.compilers.FortifyCompiler
+com.fortify.sca.compilers.g++=com.fortify.sca.util.compilers.GppCompiler
+com.fortify.sca.compilers.g++-*=com.fortify.sca.util.compilers.GppCompiler
+com.fortify.sca.compilers.g++2*=com.fortify.sca.util.compilers.GppCompiler
+com.fortify.sca.compilers.g++3*=com.fortify.sca.util.compilers.GppCompiler
+com.fortify.sca.compilers.g++4*=com.fortify.sca.util.compilers.GppCompiler
+com.fortify.sca.compilers.gcc=com.fortify.sca.util.compilers.GccCompiler
+com.fortify.sca.compilers.gcc-*=com.fortify.sca.util.compilers.GccCompiler
+com.fortify.sca.compilers.gcc2*=com.fortify.sca.util.compilers.GccCompiler
+com.fortify.sca.compilers.gcc3*=com.fortify.sca.util.compilers.GccCompiler
+com.fortify.sca.compilers.gcc4*=com.fortify.sca.util.compilers.GccCompiler
+com.fortify.sca.compilers.gmake=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.gradle=com.fortify.sca.util.compilers.GradleAdapter
+com.fortify.sca.compilers.gradlew=com.fortify.sca.util.compilers.GradleAdapter
+com.fortify.sca.compilers.icc=com.fortify.sca.util.compilers.IntelCompiler
+com.fortify.sca.compilers.icpc=com.fortify.sca.util.compilers.IntelCompiler
+com.fortify.sca.compilers.jam=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.javac=com.fortify.sca.util.compilers.JavacCompiler
+com.fortify.sca.compilers.ld=com.fortify.sca.util.compilers.LdCompiler
+com.fortify.sca.compilers.make=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.mvn=com.fortify.sca.util.compilers.MavenAdapter
+com.fortify.sca.compilers.scalac=com.fortify.sca.util.compilers.ScalacCompiler
+com.fortify.sca.compilers.tcc=com.fortify.sca.util.compilers.ArmCcCompiler
+com.fortify.sca.compilers.tcpp=com.fortify.sca.util.compilers.ArmCppCompiler
+com.fortify.sca.compilers.touchless=com.fortify.sca.util.compilers.FortifyCompiler
+com.fortify.sca.cpfe.441.command=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/private-bin/sca/cpfe441.rfct
+com.fortify.sca.cpfe.command=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/private-bin/sca/cpfe48
+com.fortify.sca.cpfe.file.option=--gen_c_file_name
+com.fortify.sca.cpfe.options=--remove_unneeded_entities --suppress_vtbl -tused
+com.fortify.sca.cpfe.options=--remove_unneeded_entities --suppress_vtbl -tused
+com.fortify.sca.env.exesearchpath=/sbin:/bin:/usr/sbin:/usr/bin
+com.fortify.sca.fileextensions.ABAP=ABAP
+com.fortify.sca.fileextensions.BSP=ABAP
+com.fortify.sca.fileextensions.Config=XML
+com.fortify.sca.fileextensions.abap=ABAP
+com.fortify.sca.fileextensions.appxmanifest=XML
+com.fortify.sca.fileextensions.as=ACTIONSCRIPT
+com.fortify.sca.fileextensions.asp=ASP
+com.fortify.sca.fileextensions.bas=VB6
+com.fortify.sca.fileextensions.bsp=ABAP
+com.fortify.sca.fileextensions.cfc=CFML
+com.fortify.sca.fileextensions.cfm=CFML
+com.fortify.sca.fileextensions.cfml=CFML
+com.fortify.sca.fileextensions.cls=VB6
+com.fortify.sca.fileextensions.config=XML
+com.fortify.sca.fileextensions.cpx=XML
+com.fortify.sca.fileextensions.cscfg=XML
+com.fortify.sca.fileextensions.csdef=XML
+com.fortify.sca.fileextensions.ctl=VB6
+com.fortify.sca.fileextensions.ctp=PHP
+com.fortify.sca.fileextensions.erb=RUBY_ERB
+com.fortify.sca.fileextensions.faces=JSPX
+com.fortify.sca.fileextensions.frm=VB6
+com.fortify.sca.fileextensions.htm=HTML
+com.fortify.sca.fileextensions.html=HTML
+com.fortify.sca.fileextensions.ini=JAVA_PROPERTIES
+com.fortify.sca.fileextensions.java=JAVA
+com.fortify.sca.fileextensions.js=JAVASCRIPT
+com.fortify.sca.fileextensions.jsff=JSPX
+com.fortify.sca.fileextensions.jsp=JSP
+com.fortify.sca.fileextensions.jspx=JSPX
+com.fortify.sca.fileextensions.mxml=MXML
+com.fortify.sca.fileextensions.page=VISUAL_FORCE
+com.fortify.sca.fileextensions.php=PHP
+com.fortify.sca.fileextensions.phtml=PHP
+com.fortify.sca.fileextensions.pkb=PLSQL
+com.fortify.sca.fileextensions.pkh=PLSQL
+com.fortify.sca.fileextensions.pks=PLSQL
+com.fortify.sca.fileextensions.plist=XML
+com.fortify.sca.fileextensions.properties=JAVA_PROPERTIES
+com.fortify.sca.fileextensions.py=PYTHON
+com.fortify.sca.fileextensions.rb=RUBY
+com.fortify.sca.fileextensions.scala=SCALA
+com.fortify.sca.fileextensions.settings=XML
+com.fortify.sca.fileextensions.sql=SQL
+com.fortify.sca.fileextensions.swift=SWIFT
+com.fortify.sca.fileextensions.tag=JSP
+com.fortify.sca.fileextensions.tagx=JSP
+com.fortify.sca.fileextensions.tld=TLD
+com.fortify.sca.fileextensions.trigger=APEX_TRIGGER
+com.fortify.sca.fileextensions.ts=TYPESCRIPT
+com.fortify.sca.fileextensions.vbs=VBSCRIPT
+com.fortify.sca.fileextensions.vbscript=VBSCRIPT
+com.fortify.sca.fileextensions.wadcfg=XML
+com.fortify.sca.fileextensions.wadcfgx=XML
+com.fortify.sca.fileextensions.wsdd=XML
+com.fortify.sca.fileextensions.wsdl=XML
+com.fortify.sca.fileextensions.xcfg=XML
+com.fortify.sca.fileextensions.xhtml=JSPX
+com.fortify.sca.fileextensions.xmi=XML
+com.fortify.sca.fileextensions.xml=XML
+com.fortify.sca.fileextensions.xsd=XML
+com.fortify.sca.jsp.UseNativeParser=true
+com.fortify.sca.parser.python.ignore.module.1=test.badsyntax_future3
+com.fortify.sca.parser.python.ignore.module.2=test.badsyntax_future4
+com.fortify.sca.parser.python.ignore.module.3=test.badsyntax_future5
+com.fortify.sca.parser.python.ignore.module.4=test.badsyntax_future6
+com.fortify.sca.parser.python.ignore.module.5=test.badsyntax_future7
+com.fortify.sca.parser.python.ignore.module.6=test.badsyntax_future8
+com.fortify.sca.parser.python.ignore.module.7=test.badsyntax_future9
+com.fortify.sca.parser.python.ignore.module.8=test.badsyntax_nocaret
+com.fortify.sca.skip.libraries.AngularJS=angular.js,angular.min.js,angular-animate.js,angular-aria.js,angular_1_router.js,angular-cookies.js,angular-message-format.js,angular-messages.js,angular-mocks.js,angular-parse-ext.js,angular-resource.js,angular-route.js,angular-sanitize.js,angular-touch.js
+com.fortify.sca.skip.libraries.ES6=es6-shim.min.js,system-polyfills.js,shims_for_IE.js
+com.fortify.sca.skip.libraries.jQuery=jquery.js,jquery.min.js,jquery-migrate.js,jquery-migrate.min.js,jquery-ui.js,jquery-ui.min.js,jquery.mobile.js,jquery.mobile.min.js,jquery.color.js,jquery.color.min.js,jquery.color.svg-names.js,jquery.color.svg-names.min.js,jquery.color.plus-names.js,jquery.color.plus-names.min.js,jquery.tools.min.js
+com.fortify.sca.skip.libraries.javascript=bootstrap.js,bootstrap.min.js,typescript.js,typescriptServices.js
+com.fortify.sca.skip.libraries.typescript=typescript.d.ts,typescriptServices.d.ts
+com.fortify.search.defaultSyntaxVer=2
+com.sun.management.jmxremote=true
+file.encoding=UTF-8
+file.encoding.pkg=sun.io
+file.separator=/
+java.awt.graphicsenv=sun.awt.X11GraphicsEnvironment
+java.awt.headless=true
+java.awt.printerjob=sun.print.PSPrinterJob
+java.class.path=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/lib/exe/sca-exe.jar
+java.class.version=52.0
+java.endorsed.dirs=/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/endorsed
+java.ext.dirs=/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/ext:/usr/java/packages/lib/ext
+java.home=/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre
+java.io.tmpdir=/tmp
+java.library.path=/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib
+java.rmi.server.randomIDs=true
+java.runtime.name=OpenJDK Runtime Environment
+java.runtime.version=1.8.0_181-b02
+java.specification.name=Java Platform API Specification
+java.specification.vendor=Oracle Corporation
+java.specification.version=1.8
+java.vendor=Azul Systems, Inc.
+java.vendor.url=http://www.azulsystems.com/
+java.vendor.url.bug=http://www.azulsystems.com/support/
+java.version=1.8.0_181
+java.vm.info=mixed mode
+java.vm.name=OpenJDK 64-Bit Server VM
+java.vm.specification.name=Java Virtual Machine Specification
+java.vm.specification.vendor=Oracle Corporation
+java.vm.specification.version=1.8
+java.vm.vendor=Azul Systems, Inc.
+java.vm.version=25.181-b02
+line.separator=
+
+log4j.configurationFile=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/config/log4j2.xml
+log4j.isThreadContextMapInheritable=true
+max.file.path.length=255
+os.arch=amd64
+os.name=Linux
+os.version=3.10.0-957.1.3.el7.x86_64
+path.separator=:
+stderr.isatty=true
+stdout.isatty=true
+sun.arch.data.model=64
+sun.boot.class.path=/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/resources.jar:/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/rt.jar:/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/sunrsasign.jar:/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/jsse.jar:/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/jce.jar:/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/charsets.jar:/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/jfr.jar:/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/classes
+sun.boot.library.path=/opt/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/amd64
+sun.cpu.endian=little
+sun.cpu.isalist=
+sun.io.unicode.encoding=UnicodeLittle
+sun.java.command=sourceanalyzer -Djava.awt.headless=true -Dcom.sun.management.jmxremote=true -XX:SoftRefLRUPolicyMSPerMB=3000 -Dcom.fortify.sca.env.exesearchpath=/sbin:/bin:/usr/sbin:/usr/bin -Dcom.fortify.sca.ProjectRoot=/home/redacted/.fortify -Dstdout.isatty=true -Dstderr.isatty=true -Dcom.fortify.sca.PID=25975 -Xmx30209336525 -Dcom.fortify.TotalPhysicalMemory=33565929472 -Xss16M -Dcom.fortify.sca.JVMArgs=-XX:SoftRefLRUPolicyMSPerMB=3000 -Xmx30209336525 -Xss16M -Dcom.fortify.sca.LauncherArgs=-autoheap -Djava.class.path=/opt/Fortify/Fortify_SCA_and_Apps_18.20/Core/lib/exe/sca-exe.jar -b redacted -scan -f redacted-results.fpr
+sun.jnu.encoding=UTF-8
+sun.management.compiler=HotSpot 64-Bit Tiered Compilers
+sun.os.patch.level=unknown
+user.country=US
+user.dir=/initialGitCloneRepos/on-demand-scans
+user.home=/home/redacted
+user.language=en
+user.name=redacted
+user.timezone=America/New_York
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Commandline Arguments</Title>
+            <Description>A listing of all arguments passed to SCA during the analysis phase</Description>
+            <Text>-b
+redacted
+-scan
+-f
+redacted-results.fpr
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Warnings</Title>
+            <Description>A listing of all warnings that occurred during the scan, during both translation and analysis phase</Description>
+            <Text>[12003] Assuming Java source level to be 1.8 as it was not specified. Note that the default value may change in future versions.
+[1216] Unable to locate a class for import dagger.android.AndroidInjector
+[1216] Unable to locate a class for import android.content.Context
+[1216] Unable to locate a class for import dagger.internal.Factory
+[1216] Unable to locate a class for import android.os.StrictMode
+[1216] Unable to locate a class for import timber.log.Timber
+[1216] Unable to locate a class for import android.app.Activity
+[1216] Unable to locate a class for import dagger.android.DispatchingAndroidInjector
+[1216] Unable to locate a class for import android.content.BroadcastReceiver
+[1216] Unable to locate a class for import android.app.Fragment
+[1216] Unable to locate a class for import android.app.Service
+[1216] Unable to locate a class for import android.content.ContentProvider
+[1216] Unable to locate a class for import androidx.lifecycle.ViewModel
+[1216] Unable to locate a class for import com.google.errorprone.annotations.CanIgnoreReturnValue
+[1216] Unable to locate a class for import androidx.fragment.app.Fragment
+[1216] Unable to locate a class for import androidx.lifecycle.ViewModelProvider
+[1216] Unable to locate a class for import android.os.Bundle
+[1216] Unable to locate a class for import androidx.annotation.Nullable
+[1216] Unable to locate a class for import android.net.Uri
+[1216] Unable to locate a class for import android.content.Intent
+[1216] Unable to locate a class for import android.graphics.Bitmap
+[1216] Unable to locate a class for import android.graphics.YuvImage
+[1216] Unable to locate a class for import android.graphics.Rect
+[1216] Unable to locate a class for import android.graphics.Matrix
+[1216] Unable to locate a class for import android.graphics.Canvas
+[1216] Unable to locate a class for import android.annotation.SuppressLint
+[1216] Unable to locate a class for import com.google.android.gms.common.images.Size
+[1216] Unable to locate a class for import android.graphics.SurfaceTexture
+[1216] Unable to locate a class for import android.hardware.Camera.CameraInfo
+[1216] Unable to locate a class for import androidx.annotation.RequiresPermission
+[1216] Unable to locate a class for import android.view.WindowManager
+[1216] Unable to locate a class for import android.view.SurfaceView
+[1216] Unable to locate a class for import android.util.AttributeSet
+[1216] Unable to locate a class for import com.google.firebase.ml.common.FirebaseMLException
+[1216] Unable to locate a class for import androidx.sqlite.db.SupportSQLiteOpenHelper
+[1216] Unable to locate a class for import androidx.room.DatabaseConfiguration
+[1216] Unable to locate a class for import androidx.room.InvalidationTracker
+[1216] Unable to locate a class for import androidx.sqlite.db.SupportSQLiteDatabase
+[1216] Unable to locate a class for import androidx.room.util.TableInfo
+[1216] Unable to locate a class for import androidx.room.RoomDatabase
+[1216] Unable to locate a class for import io.reactivex.Single
+[1216] Unable to locate a class for import androidx.room.RoomSQLiteQuery
+[1216] Unable to locate a class for import androidx.sqlite.db.SupportSQLiteStatement
+[1216] Unable to locate a class for import android.database.Cursor
+[1216] Unable to locate a class for import androidx.room.EmptyResultSetException
+[1216] Unable to locate a class for import io.reactivex.Flowable
+[1216] Unable to locate a class for import dagger.Provides
+[1216] Unable to locate a class for import javax.inject.Singleton
+[1216] Unable to locate a class for import org.junit.runner.RunWith
+[1216] Unable to locate a class for import android.support.test.runner.AndroidJUnit4
+[1216] Unable to locate a class for import org.junit.Test
+[1216] Unable to locate a class for import com.squareup.moshi.JsonAdapter
+[1216] Unable to locate a class for import com.squareup.moshi.Moshi
+[1216] Unable to locate a class for import org.jetbrains.annotations.Nullable
+[1216] Unable to locate a class for import dagger.internal.Preconditions
+[1216] Unable to locate a class for import com.google.common.collect.ImmutableMap
+[1216] Unable to locate a class for import dagger.android.DispatchingAndroidInjector_Factory
+[1216] Unable to locate a class for import dagger.internal.InstanceFactory
+[1216] Unable to locate a class for import dagger.internal.DoubleCheck
+[1216] Unable to locate a class for import dagger.android.DaggerApplication_MembersInjector
+[1216] Unable to locate a class for import dagger.android.support.DaggerAppCompatActivity_MembersInjector
+[1216] Unable to locate a class for import dagger.android.support.DaggerFragment_MembersInjector
+[1216] Unable to locate a class for import android.graphics.ImageFormat
+[1216] Unable to locate a class for import android.graphics.BitmapFactory
+[1216] Unable to locate a class for import android.util.Log
+[1216] Unable to locate a class for import com.google.firebase.ml.vision.common.FirebaseVisionImageMetadata
+[1216] Unable to locate a class for import android.Manifest
+[1216] Unable to locate a class for import android.view.Surface
+[1216] Unable to locate a class for import android.content.res.Configuration
+[1216] Unable to locate a class for import com.google.android.gms.vision.CameraSource
+[1216] Unable to locate a class for import androidx.room.util.DBUtil
+[1216] Unable to locate a class for import androidx.room.RxRoom
+[1216] Unable to locate a class for import androidx.room.Room
+[1216] Unable to locate a class for import android.support.test.InstrumentationRegistry</Text>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="false">
+        <Title>Issue Count by Category</Title>
+        <SubSection enabled="true">
+            <Title>Issues By Category</Title>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="table">
+                    <Axis>Category</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="1">
+                        <groupTitle>Privilege Management: Unnecessary Permission</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Null Dereference</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="false">
+        <Title>Issue Breakdown by Analysis</Title>
+        <SubSection enabled="true">
+            <Title>Issue by Analysis</Title>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="pie">
+                    <Axis>Analysis</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="2">
+                        <groupTitle>&lt;none&gt;</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="false" optionalSubsections="false">
+        <Title>New Issues</Title>
+        <SubSection enabled="true">
+            <Title>New Issues</Title>
+            <Description>A list of issues discovered since the previous analysis.</Description>
+            <Text>The following issues have been discovered since the last scan.</Text>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="pie">
+                    <Axis>New Issue</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="2">
+                        <groupTitle>Issue New: May 7, 2019</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+</ReportDefinition>

--- a/dojo/unittests/scans/fortify/fortify_many_findings.xml
+++ b/dojo/unittests/scans/fortify/fortify_many_findings.xml
@@ -1,0 +1,11711 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<ReportDefinition type="standard">
+    <TemplateName>Fortify Security Report</TemplateName>
+    <TemplatePath></TemplatePath>
+    <LogoPath>/MF_logo.jpg</LogoPath>
+    <Footnote>Copyright 2018 Micro Focus or one of its affiliates.</Footnote>
+    <UserName></UserName>
+    <ReportSection enabled="true" optionalSubsections="false">
+        <Title>Executive Summary</Title>
+        <SubSection enabled="true">
+            <Title>Issues Overview</Title>
+            <Description>This section provides an overview of the issues uncovered during analysis. The report covers a summary of vulnerability categories discovered by the tool. The auditor should augment this section with higher-level conclusions derived from human review of the application (including architecture reviews,	black-box testing, compliance issues, etc.)</Description>
+            <Text>On Dec 17, 2019, a source code review was performed over the java-sec-code code base. 66 files, 1,037 LOC (Executable) were scanned and reviewed for defects that could lead to potential security vulnerabilities. A total of 334 reviewed findings were uncovered during the analysis.</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Issue Summary by Fortify Priority Order</Title>
+            <Description>A table summarizing the number of issues found and the breakdown of issues in each Fortify Priority Level</Description>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="table">
+                    <Axis>Fortify Priority Order</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="281">
+                        <groupTitle>Low</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="34">
+                        <groupTitle>High</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="13">
+                        <groupTitle>Critical</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Medium</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Recommendations and Conclusions</Title>
+            <Description>This section gives some high-level recommendations on remediating the issues discussed in the Issues Summary sub section. Recommendations will vary based on deployment scenarios, risk appetite, and existing mitigating strategies. The auditor should supplement the Fortify generic recommendations with specific information that takes into account the application specific variables.</Description>
+            <Text>The Issues Category section provides Fortify recommendations for addressing issues at a generic level.  The recommendations for specific fixes can be extrapolated from those generic recommendations by the development group.</Text>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="true">
+        <Title>Project Summary</Title>
+        <SubSection enabled="true">
+            <Title>Code Base Summary</Title>
+            <Description>Summary of the Codebase that was analyzed</Description>
+            <Text>Code location: /Users/apipia/git-repos/java-sec-code
+Number of Files: 66
+Lines of Code: 1037
+Build Label: &lt;No Build Label&gt;</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Scan Information</Title>
+            <Description>Details of the analysis</Description>
+            <Text>Scan time: 00:41
+SCA Engine version: 18.20.1071
+Machine Name: apipia2866
+Username running scan: apipia</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Results Certification</Title>
+            <Description>A full summary of the Results Certification for this project</Description>
+            <Text>Results Certification Valid
+
+Details:
+
+Results Signature:
+
+	SCA Analysis Results has Valid signature
+	
+
+Rules Signature:
+
+	There were no custom rules used in this scan</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Attack Surface</Title>
+            <Description>A full summary of the attack surface for this project</Description>
+            <Text>Attack Surface:
+Command Line Arguments:
+	org.joychou.Application.main
+	org.joychou.RMI.Client.main
+	org.joychou.RMI.Server.main
+	org.joychou.controller.Fastjson.main
+	org.joychou.controller.PathTraversal.main
+	org.joychou.controller.SpEL.main
+	org.joychou.controller.XStreamRce.main
+	org.joychou.controller.XXE.main
+	org.joychou.controller.othervulns.xlsxStreamerXXE.main
+	org.joychou.security.AntObjectInputStream.main
+
+File System:
+	java.io.FileInputStream.FileInputStream
+	java.nio.file.Files.readAllBytes
+
+Private Information:
+	null.null.null
+
+Serialized Data:
+	java.io.ObjectInputStream.readObject
+
+Stream:
+	java.io.InputStream.read
+
+System Information:
+	null.null.null
+	java.lang.System.getProperty
+
+Web:
+	javax.servlet.ServletRequest.getRemoteAddr
+	javax.servlet.http.HttpServletRequest.getMethod
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Filter Set Summary</Title>
+            <Description>A brief summary of the filterset used to create this report</Description>
+            <Text>Current Enabled Filter Set:
+Security Auditor View
+
+Filter Set Details:
+
+Folder Filters:
+If [fortify priority order] contains critical Then set folder to Critical
+If [fortify priority order] contains high Then set folder to High
+If [fortify priority order] contains medium Then set folder to Medium
+If [fortify priority order] contains low Then set folder to Low</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Audit Guide Summary</Title>
+            <Description>Summary of the impact of the audit guide</Description>
+            <Text>Audit guide not enabled</Text>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="true">
+        <Title>Results Outline</Title>
+        <SubSection enabled="true">
+            <Title>Overall number of results</Title>
+            <Description>Results count</Description>
+            <Text>The scan found 334 issues.</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Vulnerability Examples by Category</Title>
+            <Description>Results summary for critical and high priority issues.  Vulnerability examples are provided by category.</Description>
+            <IssueListing listing="true" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="list">
+                    <Axis>Category</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="64">
+                        <groupTitle>Poor Logging Practice: Use of a System Output Stream</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Example 1: The first Java program that a developer learns to write often looks like this:
+
+
+public class MyClass
+  public static void main(String[] args) {
+    System.out.println("hello world");
+  }
+}
+
+
+While most programmers go on to learn many nuances and subtleties about Java, a surprising number hang on to this first lesson and never give up on writing messages to standard output using System.out.println().
+
+The problem is that writing directly to standard output or standard error is often used as an unstructured form of logging. Structured logging facilities provide features like logging levels, uniform formatting, a logger identifier, timestamps, and, perhaps most critically, the ability to direct the log messages to the right place. When the use of system output streams is jumbled together with the code that uses loggers properly, the result is often a well-kept log that is missing critical information.
+
+Developers widely accept the need for structured logging, but many continue to use system output streams in their "pre-production" development. If the code you are reviewing is past the initial phases of development, use of System.out or System.err may indicate an oversight in the move to a structured logging system.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Use a Java logging facility rather than System.out or System.err.
+
+Example 2: For example, the "hello world" program above can be re-written using log4j like this:
+
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.BasicConfigurator;
+
+public class MyClass {
+  private final static Logger logger =
+            Logger.getLogger(MyClass.class);
+
+  public static void main(String[] args) {
+    BasicConfigurator.configure();
+    logger.info("hello world");
+  }
+}
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>64</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="820D451F97C84CA55430DC3DDB6AF97D" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>81</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="34947CE3B2ED6C912CE91A84F9ED323C" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>347</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="154A9997C6FA5A2A83640A883B45B74C" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>161</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            SAXParserFactory spf = SAXParserFactory.newInstance();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C2430BAB990BCCEEC16846BF6E07ABA6" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>277</LineStart>
+<Snippet>            return result.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="18C48FBE08EFCF39CF7E2D030574EDA9" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>83</LineStart>
+<Snippet>        }finally{
+            System.out.println("-----------------");
+            System.out.println("Connect database done.");
+        }
+        return result;</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F6A0F49DCD6F8C3459D3F2C130548AE5" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>181</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            Digester digester = new Digester();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="BED7D2A4F023A3EB7DD0331EAE308BEF" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>38</LineStart>
+<Snippet>            while ((tmpStr = inBr.readLine()) != null) {
+                lineStr += tmpStr + "\n";
+                System.out.println(tmpStr);
+            }
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="112230233D3B16EB85A839F86E406AB3" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>51</LineStart>
+<Snippet>
+            if(!con.isClosed())
+                System.out.println("Connecting to Database successfully.");
+
+            // sqli vuln code 漏洞代码</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8C3B4D0B35AAD054D9AF02D36823B56B" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>386</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            SAXParser saxParser = spf.newSAXParser();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="CB8220BB385B6183C2F68CC0DEA1DA47" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>238</LineStart>
+<Snippet>            }
+            sr.close();
+            System.out.println(buf.toString());
+            return buf.toString();
+        } catch (Exception e) {</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5FA97DF3E391FA1502565ABE81CDB418" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>66</LineStart>
+<Snippet>                String res_pwd = rs.getString("password");
+                result +=  res_name + ": " + res_pwd + "\n";
+                System.out.println(res_name + ": " + res_pwd);
+
+            }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="ACF87DB6FCD003B1E2D1B3C41026FB43" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>75</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            SAXBuilder builder = new SAXBuilder();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="686D9828FFB6309135E9ED396E2D85BB" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>393</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="83663581C60DC21DC3685B10E8169FAE" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>56</LineStart>
+<Snippet>             Statement statement = con.createStatement();
+             String sql = "select * from users where username = '" + username + "'";
+             System.out.println(sql);
+             ResultSet rs = statement.executeQuery(sql);
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="802D504B60A27E7B18F2A3B661D053A9" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>137</LineStart>
+<Snippet>        }finally{
+            System.out.println("-----------------");
+            System.out.println("Connect database done.");
+        }
+        return result;</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8EEE46C4F50457477E55A492C08714C0" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="09AD514469994949CC8E3BA7009130FA" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>125</LineStart>
+<Snippet>    public String url_bypass(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        System.out.println("url:  " + url);
+        URL u = new URL(url);
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0A6ACF435CB7624C5D33D0CBD5B976EF" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Fastjson.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Fastjson.java</FilePath>
+<LineStart>22</LineStart>
+<Snippet>    public static String Deserialize(@RequestBody String params) {
+        // 如果Content-Type不设置application/json格式，post数据会被url编码
+        System.out.println(params);
+        try {
+            // 将post提交的string转换为json</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="51511510376533B19CC6989262F99B1A" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>337</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="26D71FE82AD947A1A93218A620069008" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>151</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6C79F3AE530197FD8C59F84A0CF3082C" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>274</LineStart>
+<Snippet>            }
+            sr.close();
+            System.out.println(result.toString());
+            return result.toString();
+        } catch (Exception e) {</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="92E87A7B758483CE0735DD71B7AEEAB6" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Test.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Test.java</FilePath>
+<LineStart>19</LineStart>
+<Snippet>    private String Index(HttpServletResponse response, String empId) {
+
+        System.out.println(empId);
+        Cookie cookie = new Cookie("XSRF-TOKEN", "123");
+        cookie.setDomain("taobao.com");</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="B715790788252CB8FC853DC3204D8CC7" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Server.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Server.java</FilePath>
+<LineStart>23</LineStart>
+<Snippet>            Registry registry = LocateRegistry.getRegistry();
+            registry.bind("Hello", stub);
+            System.out.println("绑定1099端口成功");
+        } catch (Exception e) {
+            System.err.println("Server exception: " + e.toString());</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C90CAAFD51B7F367C4D8965FB0437DFF" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>90</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            SAXBuilder builder = new SAXBuilder();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8019D037A2DD894B5544132ADF02B5E8" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>376</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7EE3D0BA2FCC16826BF7301C07F036E1" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>120</LineStart>
+<Snippet>                String res_pwd = rs.getString("password");
+                result +=  res_name + ": " + res_pwd + "\n";
+                System.out.println(res_name + ": " + res_pwd);
+
+            }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="81CC906D2E8CDD2096ECB54DCA400080" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>AntObjectInputStream.java</FileName>
+<FilePath>src/main/java/org/joychou/security/AntObjectInputStream.java</FilePath>
+<LineStart>71</LineStart>
+<Snippet>        //恢复对象即反序列化
+        MyObject objectFromDisk = (MyObject)ois.readObject();
+        System.out.println(objectFromDisk.name);
+        ois.close();
+    }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E676F813924419AD83CC0F438924346E" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>53</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            XMLReader xmlReader = XMLReaderFactory.createXMLReader();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="3DCAD4262E7A3D51E5573329EC4BDFBB" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>143</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            SAXParserFactory spf = SAXParserFactory.newInstance();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7DF8C57C161B19F960C3012A37E976FD" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>241</LineStart>
+<Snippet>            return buf.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6FC585863549574E922768FC22512D4A" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XStreamRce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XStreamRce.java</FilePath>
+<LineStart>38</LineStart>
+<Snippet>        XStream xstream = new XStream(new DomDriver());
+        String xml = xstream.toXML(user); // Serialize
+        System.out.println(xml);
+
+        user = (User)xstream.fromXML(xml); // Deserialize</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C1CB632395FB249C834CC0F64EB764D5" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>134</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="DE8FF1E060DFDCC4954591A246259D8C" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>207</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="265CADDC4FDFB6925752532D1F358557" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>38</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+            XMLReader xmlReader = XMLReaderFactory.createXMLReader();
+            xmlReader.parse(new InputSource(new StringReader(xml_con)));  // parse xml</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0C87A877316424812466C97605971F53" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>301</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0F9DE3020F05EBC749E2F1E6E01A25E1" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XStreamRce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XStreamRce.java</FilePath>
+<LineStart>41</LineStart>
+<Snippet>
+        user = (User)xstream.fromXML(xml); // Deserialize
+        System.out.println(user.getId() + ": " + user.getUsername() );
+    }
+}</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="753F9BAF5F44EF8AF42953266B68A2F5" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>124</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            SAXReader reader = new SAXReader();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1DAF2AE9786701C7835903CCB9D09CE6" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>287</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D7791A68161DB83A40D8A934EFFA656E" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Server.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Server.java</FilePath>
+<LineStart>25</LineStart>
+<Snippet>            System.out.println("绑定1099端口成功");
+        } catch (Exception e) {
+            System.err.println("Server exception: " + e.toString());
+            e.printStackTrace();
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="3FF270CD83D8F921C7D9D68FC5E3F816" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>104</LineStart>
+<Snippet>
+            if(!con.isClosed())
+                System.out.println("Connecting to Database successfully.");
+
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6CC6447C3FB2E1922197C5D48EDA950C" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>PathTraversal.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/PathTraversal.java</FilePath>
+<LineStart>54</LineStart>
+<Snippet>    public static void main(String[] argv) throws IOException {
+        String aa = new String(Files.readAllBytes(Paths.get("pom.xml")), StandardCharsets.UTF_8);
+        System.out.println(aa);
+    }
+}</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E5B98FEA481F993471191C3F15819B5A" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>114</LineStart>
+<Snippet>            ResultSet rs = st.executeQuery();
+
+            System.out.println("-----------------");
+
+            while(rs.next()){</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F7C67DE755BBA95C1EB2165EA7B5C992" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>311</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="98E25EC64D58C3C4E1D7DE6085CC0EE0" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>329</LineStart>
+<Snippet>                    Node xxeNode = xxe.item(j);
+                    // 测试不能blind xxe，所以强行加了一个回显
+                    System.out.println("xxeNode: " + xxeNode.getNodeValue());
+                }
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5DA2F819D3379DD3C4CC6DD591ED67D4" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>197</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            Digester digester = new Digester();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="CA4ED0A2B9ECFD3AE67196006FC20BF2" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>65</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="698083CAE45D927E0EAB1C309F6CB8FD" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>108</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            SAXReader reader = new SAXReader();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="4B0B66BD536568D361331C221D2EEA7B" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Client.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Client.java</FilePath>
+<LineStart>15</LineStart>
+<Snippet>            Hello stub = (Hello) registry.lookup("Hello");
+            String response = stub.sayHello();
+            System.out.println("response: " + response);
+        } catch (Exception e) {
+            System.err.println("Client exception: " + e.toString());</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F6F57BF0E9333D84054F91D0478DC466" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>60</LineStart>
+<Snippet>
+
+            System.out.println("-----------------");
+
+            while(rs.next()){</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="EFBD7B47EBF4309E556B4A9A39ED774B" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>115</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F10385658E67EDC1638FF26263A9623F" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>111</LineStart>
+<Snippet>            PreparedStatement st = con.prepareStatement(sql);
+            st.setString(1, username);
+            System.out.println(st.toString());  // sql after prepare statement
+            ResultSet rs = st.executeQuery();
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0A1A231CE01A8F7F91DF7C805DA4733B" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>171</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D3C055C0A636D37E78557E73CA8F5FA1" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>218</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5055BC33E8C69CA3B0ACAA180731D59F" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>74</LineStart>
+<Snippet>
+        }catch (ClassNotFoundException e) {
+            System.out.println("Sorry,can`t find the Driver!");
+            e.printStackTrace();
+        }catch (SQLException e) {</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="65065488487D24E6C1EE06DC8B42EF9F" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>403</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            SAXParser saxParser = spf.newSAXParser();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F48BAA8D3C52E45CD2385187FE927CA9" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>251</LineStart>
+<Snippet>        try {
+            String xml_con = WebUtils.getRequestBody(request);
+            System.out.println(xml_con);
+
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E8DC450F54335079E40C2EA1B0DD5402" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>133</LineStart>
+<Snippet>
+        String host = u.getHost().toLowerCase();
+        System.out.println("host:  " + host);
+
+        // endsWith .</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1FC7C7E5AC52F7FE7F3EF842A7F031A3" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>188</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F6F57BF0E9333D84054F91D0478DC467" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>82</LineStart>
+<Snippet>
+        }finally{
+            System.out.println("-----------------");
+            System.out.println("Connect database done.");
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="300EAF0D4CC765CF77B389D8E4EF037E" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>128</LineStart>
+<Snippet>
+        }catch (ClassNotFoundException e) {
+            System.out.println("Sorry,can`t find the Driver!");
+            e.printStackTrace();
+        }catch (SQLException e) {</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="12F42494EE67DF00BD7F369286C4A25F" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Client.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Client.java</FilePath>
+<LineStart>17</LineStart>
+<Snippet>            System.out.println("response: " + response);
+        } catch (Exception e) {
+            System.err.println("Client exception: " + e.toString());
+            e.printStackTrace();
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E5B98FEA481F993471191C3F15819B5B" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>136</LineStart>
+<Snippet>
+        }finally{
+            System.out.println("-----------------");
+            System.out.println("Connect database done.");
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0EE17DC72161DEF9F25EF7E96B37D02E" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>413</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";
+        }</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="73EE6C2E1D6CA9DF0F999A8F7580D4DA" ruleID="F972FE42-6C15-47D2-BD5C-448166A574C2">
+                            <Category>Poor Logging Practice: Use of a System Output Stream</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Using println() rather than a dedicated logging facility makes it difficult to monitor the behavior of the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>368</LineStart>
+<Snippet>                    Node xxeNode = xxe.item(j);
+                    // 测试不能blind xxe，所以强行加了一个回显
+                    System.out.println("xxeNode: " + xxeNode.getNodeValue());
+                }
+</Snippet>
+<TargetFunction>FunctionCall: println()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="35">
+                        <groupTitle>Poor Style: Value Never Read</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method addCorsMappings() in CorsConfig.java never uses the value it assigns to the variable allowOrigins on line 20.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>This variable's value is not used. After the assignment, the variable is either assigned another value or goes out of scope.
+
+Example: The following code excerpt assigns to the variable r and then overwrites the value without using it.
+
+
+  r = getName();
+  r = getNewBuffer(buf);
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Remove unnecessary assignments in order to make the code easier to understand and maintain.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>35</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="D71F8C016FB2BBC16CCA6C065826C611" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method main() in Fastjson.java never uses the value it assigns to the variable object on line 37.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Fastjson.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Fastjson.java</FilePath>
+<LineStart>37</LineStart>
+<Snippet>        // Open calc in mac
+        String payload = "{\"@type\":\"com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl\", \"_bytecodes\": [\"yv66vgAAADEAOAoAAwAiBwA2BwAlBwAmAQAQc2VyaWFsVmVyc2lvblVJRAEAAUoBAA1Db25zdGFudFZhbHVlBa0gk/OR3e8+AQAGPGluaXQ+AQADKClWAQAEQ29kZQEAD0xpbmVOdW1iZXJUYWJsZQEAEkxvY2FsVmFyaWFibGVUYWJsZQEABHRoaXMBABNTdHViVHJhbnNsZXRQYXlsb2FkAQAMSW5uZXJDbGFzc2VzAQAzTG1lL2xpZ2h0bGVzcy9mYXN0anNvbi9HYWRnZXRzJFN0dWJUcmFuc2xldFBheWxvYWQ7AQAJdHJhbnNmb3JtAQByKExjb20vc3VuL29yZy9hcGFjaGUveGFsYW4vaW50ZXJuYWwveHNsdGMvRE9NO1tMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9zZXJpYWxpemVyL1NlcmlhbGl6YXRpb25IYW5kbGVyOylWAQAIZG9jdW1lbnQBAC1MY29tL3N1bi9vcmcvYXBhY2hlL3hhbGFuL2ludGVybmFsL3hzbHRjL0RPTTsBAAhoYW5kbGVycwEAQltMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9zZXJpYWxpemVyL1NlcmlhbGl6YXRpb25IYW5kbGVyOwEACkV4Y2VwdGlvbnMHACcBAKYoTGNvbS9zdW4vb3JnL2FwYWNoZS94YWxhbi9pbnRlcm5hbC94c2x0Yy9ET007TGNvbS9zdW4vb3JnL2FwYWNoZS94bWwvaW50ZXJuYWwvZHRtL0RUTUF4aXNJdGVyYXRvcjtMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9zZXJpYWxpemVyL1NlcmlhbGl6YXRpb25IYW5kbGVyOylWAQAIaXRlcmF0b3IBADVMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9kdG0vRFRNQXhpc0l0ZXJhdG9yOwEAB2hhbmRsZXIBAEFMY29tL3N1bi9vcmcvYXBhY2hlL3htbC9pbnRlcm5hbC9zZXJpYWxpemVyL1NlcmlhbGl6YXRpb25IYW5kbGVyOwEAClNvdXJjZUZpbGUBAAhFeHAuamF2YQwACgALBwAoAQAxbWUvbGlnaHRsZXNzL2Zhc3Rqc29uL0dhZGdldHMkU3R1YlRyYW5zbGV0UGF5bG9hZAEAQGNvbS9zdW4vb3JnL2FwYWNoZS94YWxhbi9pbnRlcm5hbC94c2x0Yy9ydW50aW1lL0Fic3RyYWN0VHJhbnNsZXQBABRqYXZhL2lvL1NlcmlhbGl6YWJsZQEAOWNvbS9zdW4vb3JnL2FwYWNoZS94YWxhbi9pbnRlcm5hbC94c2x0Yy9UcmFuc2xldEV4Y2VwdGlvbgEAHW1lL2xpZ2h0bGVzcy9mYXN0anNvbi9HYWRnZXRzAQAIPGNsaW5pdD4BABFqYXZhL2xhbmcvUnVudGltZQcAKgEACmdldFJ1bnRpbWUBABUoKUxqYXZhL2xhbmcvUnVudGltZTsMACwALQoAKwAuAQASb3BlbiAtYSBDYWxjdWxhdG9yCAAwAQAEZXhlYwEAJyhMamF2YS9sYW5nL1N0cmluZzspTGphdmEvbGFuZy9Qcm9jZXNzOwwAMgAzCgArADQBAA9saWdodGxlc3MvcHduZXIBABFMbGlnaHRsZXNzL3B3bmVyOwAhAAIAAwABAAQAAQAaAAUABgABAAcAAAACAAgABAABAAoACwABAAwAAAAvAAEAAQAAAAUqtwABsQAAAAIADQAAAAYAAQAAADwADgAAAAwAAQAAAAUADwA3AAAAAQATABQAAgAMAAAAPwAAAAMAAAABsQAAAAIADQAAAAYAAQAAAD8ADgAAACAAAwAAAAEADwA3AAAAAAABABUAFgABAAAAAQAXABgAAgAZAAAABAABABoAAQATABsAAgAMAAAASQAAAAQAAAABsQAAAAIADQAAAAYAAQAAAEIADgAAACoABAAAAAEADwA3AAAAAAABABUAFgABAAAAAQAcAB0AAgAAAAEAHgAfAAMAGQAAAAQAAQAaAAgAKQALAAEADAAAABsAAwACAAAAD6cAAwFMuAAvEjG2ADVXsQAAAAAAAgAgAAAAAgAhABEAAAAKAAEAAgAjABAACQ==\"], \"_name\": \"lightless\", \"_tfactory\": { }, \"_outputProperties\":{ }}";
+        JSONObject object = JSON.parseObject(payload, Feature.SupportNonPublicField);
+    }
+}</Snippet>
+<TargetFunction>VariableAccess: object</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F67B2847039F8816A1A525C9084BE251" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXReader() in XXE.java never uses the value it assigns to the variable reader on line 110.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>110</LineStart>
+<Snippet>            System.out.println(xml_con);
+
+            SAXReader reader = new SAXReader();
+            org.dom4j.Document document = reader.read(new InputSource(new StringReader(xml_con))); // cause xxe
+</Snippet>
+<TargetFunction>VariableAccess: reader</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="57293FCBD6A025B9DCF1618B06A74CA4" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method commonsHttpClient() in SSRF.java never uses the value it assigns to the variable client on line 210.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>210</LineStart>
+<Snippet>        }
+        // Create an instance of HttpClient.
+        HttpClient client = new HttpClient();
+
+        // Create a method instance.</Snippet>
+<TargetFunction>VariableAccess: client</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F536138921709B846E339B85EF137F1F" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method doFilter() in HttpFilter.java never uses the value it assigns to the variable matcher on line 43.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>HttpFilter.java</FileName>
+<FilePath>src/main/java/org/joychou/security/HttpFilter.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>
+        String refer = request.getHeader("referer");
+        PathMatcher matcher = new AntPathMatcher();
+        boolean isMatch = false;
+        for (String uri: WebConfig.getReferUris()) {</Snippet>
+<TargetFunction>VariableAccess: matcher</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="719B538AFE98F3339DEEB53838413EF2" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXReader_fix() in XXE.java never uses the value it assigns to the variable document on line 130.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>130</LineStart>
+<Snippet>            reader.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            reader.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            org.dom4j.Document document = reader.read(new InputSource(new StringReader(xml_con)));
+
+            return "ok";</Snippet>
+<TargetFunction>VariableAccess: document</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="EE22F323DC3FA46B579C97AA22159DC7" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method Deserialize() in Fastjson.java never uses the value it assigns to the variable ob on line 25.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Fastjson.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Fastjson.java</FilePath>
+<LineStart>25</LineStart>
+<Snippet>        try {
+            // 将post提交的string转换为json
+            JSONObject ob = JSON.parseObject(params);
+            return ob.get("name").toString();
+        }catch (Exception e){</Snippet>
+<TargetFunction>VariableAccess: ob</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="DADD456C285A07B44328C74899D97578" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method main() in SpEL.java never uses the value it assigns to the variable parser on line 33.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SpEL.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SpEL.java</FilePath>
+<LineStart>33</LineStart>
+<Snippet>
+    public static void main(String[] args)  {
+        ExpressionParser parser = new SpelExpressionParser();
+        String expression = "T(java.lang.Runtime).getRuntime().exec(\"open -a Calculator\")";
+        String result = parser.parseExpression(expression).getValue().toString();</Snippet>
+<TargetFunction>VariableAccess: parser</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="09B3E571F15BFD03DBD09D871AE50B7D" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ssrf_HttpClient() in SSRF.java never uses the value it assigns to the variable client on line 175.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>175</LineStart>
+<Snippet>
+        String url = request.getParameter("url");
+        CloseableHttpClient client = HttpClients.createDefault();
+        HttpGet httpGet = new HttpGet(url);
+        try {</Snippet>
+<TargetFunction>VariableAccess: client</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="B1D0BF654A4A727ECC3509C78EDDC9B4" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXBuilder() in XXE.java never uses the value it assigns to the variable document on line 78.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>78</LineStart>
+<Snippet>
+            SAXBuilder builder = new SAXBuilder();
+            org.jdom2.Document document = builder.build(new InputSource(new StringReader(xml_con)));  // cause xxe
+            return "ok";
+        } catch (Exception e) {</Snippet>
+<TargetFunction>VariableAccess: document</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="95125276E6B2A3660ABCC32653CCA395" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method rce() in SpEL.java never uses the value it assigns to the variable parser on line 26.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SpEL.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SpEL.java</FilePath>
+<LineStart>26</LineStart>
+<Snippet>    @RequestMapping("/spel/vul")
+    private static String rce(String expression) {
+        ExpressionParser parser = new SpelExpressionParser();
+        // fix method: SimpleEvaluationContext
+        String result = parser.parseExpression(expression).getValue().toString();</Snippet>
+<TargetFunction>VariableAccess: parser</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7D7DAC2457026975BAD56DF3C478827D" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXReader() in XXE.java never uses the value it assigns to the variable document on line 111.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>111</LineStart>
+<Snippet>
+            SAXReader reader = new SAXReader();
+            org.dom4j.Document document = reader.read(new InputSource(new StringReader(xml_con))); // cause xxe
+
+            return "ok";</Snippet>
+<TargetFunction>VariableAccess: document</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7F1F3E82B1894B135A9710364ED67849" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXBuilder_fix() in XXE.java never uses the value it assigns to the variable builder on line 92.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>92</LineStart>
+<Snippet>            System.out.println(xml_con);
+
+            SAXBuilder builder = new SAXBuilder();
+            builder.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            builder.setFeature("http://xml.org/sax/features/external-general-entities", false);</Snippet>
+<TargetFunction>VariableAccess: builder</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D0F95B7E00F0A4B21D14DA4DB68A63E2" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXReader_fix() in XXE.java never uses the value it assigns to the variable reader on line 126.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>126</LineStart>
+<Snippet>            System.out.println(xml_con);
+
+            SAXReader reader = new SAXReader();
+            reader.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            reader.setFeature("http://xml.org/sax/features/external-general-entities", false);</Snippet>
+<TargetFunction>VariableAccess: reader</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0964755FB3D134D8A7DCE3644B810534" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXBuilder_fix() in XXE.java never uses the value it assigns to the variable document on line 96.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>96</LineStart>
+<Snippet>            builder.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            builder.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            org.jdom2.Document document = builder.build(new InputSource(new StringReader(xml_con)));
+
+            return "ok";</Snippet>
+<TargetFunction>VariableAccess: document</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5D72DA1EB23CFEF327B7D0EBF54EB493" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method parseXml() in XStreamRce.java never uses the value it assigns to the variable xstream on line 26.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XStreamRce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XStreamRce.java</FilePath>
+<LineStart>26</LineStart>
+<Snippet>    public String parseXml(HttpServletRequest request) throws Exception{
+        String xml = WebUtils.getRequestBody(request);
+        XStream xstream = new XStream(new DomDriver());
+        xstream.fromXML(xml);
+        return "xstream";</Snippet>
+<TargetFunction>VariableAccess: xstream</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="823D7BAABF204DD980F520EDA91E6F0B" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method main() in XStreamRce.java never uses the value it assigns to the variable xstream on line 36.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XStreamRce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XStreamRce.java</FilePath>
+<LineStart>36</LineStart>
+<Snippet>        user.setUsername("admin");
+
+        XStream xstream = new XStream(new DomDriver());
+        String xml = xstream.toXML(user); // Serialize
+        System.out.println(xml);</Snippet>
+<TargetFunction>VariableAccess: xstream</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="88584570D2E2070E7F27F66FB60E2304" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ooxml_xxe() in ooxmlXXE.java never uses the value it assigns to the variable row on line 58.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>ooxmlXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java</FilePath>
+<LineStart>58</LineStart>
+<Snippet>        while (rows.hasNext())
+        {
+            row=(XSSFRow) rows.next();
+            Iterator cells = row.cellIterator();
+            while (cells.hasNext())</Snippet>
+<TargetFunction>VariableAccess: row</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="EF7AE5326D516472B5128FE2682DB48E" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ssrf_okhttp() in SSRF.java never uses the value it assigns to the variable ok_http on line 160.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>160</LineStart>
+<Snippet>        String url = request.getParameter("url");
+        OkHttpClient client = new OkHttpClient();
+        com.squareup.okhttp.Request ok_http = new com.squareup.okhttp.Request.Builder().url(url).build();
+        client.newCall(ok_http).execute();
+    }</Snippet>
+<TargetFunction>VariableAccess: ok_http</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="82FE831B678143E59ACDB7EDE8CD5CEA" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method main() in SpEL.java never uses the value it assigns to the variable result on line 35.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SpEL.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SpEL.java</FilePath>
+<LineStart>35</LineStart>
+<Snippet>        ExpressionParser parser = new SpelExpressionParser();
+        String expression = "T(java.lang.Runtime).getRuntime().exec(\"open -a Calculator\")";
+        String result = parser.parseExpression(expression).getValue().toString();
+    }
+}</Snippet>
+<TargetFunction>VariableAccess: result</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="9D1ED4F974F3B142C226D9C7830577A5" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_SAXBuilder() in XXE.java never uses the value it assigns to the variable builder on line 77.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>77</LineStart>
+<Snippet>            System.out.println(xml_con);
+
+            SAXBuilder builder = new SAXBuilder();
+            org.jdom2.Document document = builder.build(new InputSource(new StringReader(xml_con)));  // cause xxe
+            return "ok";</Snippet>
+<TargetFunction>VariableAccess: builder</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="67A315DB9353CCC14671838A277246A9" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ssrf_okhttp() in SSRF.java never uses the value it assigns to the variable client on line 159.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>159</LineStart>
+<Snippet>    public static void ssrf_okhttp(HttpServletRequest request) throws IOException {
+        String url = request.getParameter("url");
+        OkHttpClient client = new OkHttpClient();
+        com.squareup.okhttp.Request ok_http = new com.squareup.okhttp.Request.Builder().url(url).build();
+        client.newCall(ok_http).execute();</Snippet>
+<TargetFunction>VariableAccess: client</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="959F441C8A01385D819D525F15007054" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ooxml_xxe() in ooxmlXXE.java never uses the value it assigns to the variable cell on line 62.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>ooxmlXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java</FilePath>
+<LineStart>62</LineStart>
+<Snippet>            while (cells.hasNext())
+            {
+                cell=(XSSFCell) cells.next();
+
+                if (cell.getCellType() == XSSFCell.CELL_TYPE_STRING) {</Snippet>
+<TargetFunction>VariableAccess: cell</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="BFE25D122CDC2AE152B8897C7CB33028" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method main() in SpEL.java never uses the value it assigns to the variable expression on line 34.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SpEL.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SpEL.java</FilePath>
+<LineStart>34</LineStart>
+<Snippet>    public static void main(String[] args)  {
+        ExpressionParser parser = new SpelExpressionParser();
+        String expression = "T(java.lang.Runtime).getRuntime().exec(\"open -a Calculator\")";
+        String result = parser.parseExpression(expression).getValue().toString();
+    }</Snippet>
+<TargetFunction>VariableAccess: expression</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="BD9CE8A36054D77D9FBF8781E84DBB2D" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method addCorsMappings() in CorsConfig.java never uses the value it assigns to the variable allowOrigins on line 20.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CorsConfig.java</FileName>
+<FilePath>src/main/java/org/joychou/config/CorsConfig.java</FilePath>
+<LineStart>20</LineStart>
+<Snippet>            public void addCorsMappings(CorsRegistry registry) {
+                // 设置cors origin白名单。区分http和https，并且默认不会拦截同域请求。
+                String[] allowOrigins = {"http://test.joychou.org", "https://test.joychou.org"};
+
+                registry.addMapping("/cors/sec/webMvcConfigurer")</Snippet>
+<TargetFunction>VariableAccess: allowOrigins</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="B3548597BAA401359D586553AF4DBC0B" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method main() in xlsxStreamerXXE.java never uses the value it assigns to the variable wb on line 42.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>xlsxStreamerXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/xlsxStreamerXXE.java</FilePath>
+<LineStart>42</LineStart>
+<Snippet>
+    public static void main(String[] args) throws Exception {
+        Workbook wb = StreamingReader.builder().open((new FileInputStream("poc.xlsx")));
+    }
+}</Snippet>
+<TargetFunction>VariableAccess: wb</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="76768D6B79D22E3CC7F958957F4EDB97" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ssrf_okhttp() in SSRF.java never uses the value it assigns to the variable url on line 158.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>158</LineStart>
+<Snippet>    @ResponseBody
+    public static void ssrf_okhttp(HttpServletRequest request) throws IOException {
+        String url = request.getParameter("url");
+        OkHttpClient client = new OkHttpClient();
+        com.squareup.okhttp.Request ok_http = new com.squareup.okhttp.Request.Builder().url(url).build();</Snippet>
+<TargetFunction>VariableAccess: url</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6C8B21ECEF7492724953CF6B24562D20" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_Digester_fix() in XXE.java never uses the value it assigns to the variable digester on line 199.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>199</LineStart>
+<Snippet>            System.out.println(xml_con);
+
+            Digester digester = new Digester();
+            digester.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            digester.setFeature("http://xml.org/sax/features/external-general-entities", false);</Snippet>
+<TargetFunction>VariableAccess: digester</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="3E1BD618F6707E13F6D208AC45658037" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ooxml_xxe() in ooxmlXXE.java never uses the value it assigns to the variable wb on line 47.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>ooxmlXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java</FilePath>
+<LineStart>47</LineStart>
+<Snippet>    @ResponseBody
+    public String ooxml_xxe(MultipartFile file)throws IOException {
+        XSSFWorkbook wb = new XSSFWorkbook(file.getInputStream()); // xxe vuln
+
+        XSSFSheet sheet = wb.getSheetAt(0);</Snippet>
+<TargetFunction>VariableAccess: wb</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C5CDEAC89B6300E9764CC6CDF4F9110A" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ssrf_Request() in SSRF.java never uses the value it assigns to the variable url on line 92.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>92</LineStart>
+<Snippet>    {
+        try {
+            String url = request.getParameter("url");
+            return Request.Get(url).execute().returnContent().toString();
+        }catch(Exception e) {</Snippet>
+<TargetFunction>VariableAccess: url</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="BF67D7DC4B42909EDDD2EC41B7C95D48" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method isInnerIp() in SSRFChecker.java never uses the value it assigns to the variable utils on line 88.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>88</LineStart>
+<Snippet>
+        for (String subnet: blackSubnetlist) {
+            SubnetUtils utils = new SubnetUtils(subnet);
+            if (utils.getInfo().isInRange(strIP)) {
+                return true;</Snippet>
+<TargetFunction>VariableAccess: utils</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5C1672BC27D58E3640B42B4BD0B17048" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ssrf_HttpClient() in SSRF.java never uses the value it assigns to the variable httpResponse on line 178.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>178</LineStart>
+<Snippet>        HttpGet httpGet = new HttpGet(url);
+        try {
+            HttpResponse httpResponse = client.execute(httpGet); // send request
+            BufferedReader rd = new BufferedReader(new InputStreamReader(httpResponse.getEntity().getContent()));
+            StringBuffer result = new StringBuffer();</Snippet>
+<TargetFunction>VariableAccess: httpResponse</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="B60F095C48A991F70A2CF65CCA3ADA59" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xllx_streamer_xxe() in xlsxStreamerXXE.java never uses the value it assigns to the variable wb on line 37.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>xlsxStreamerXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/xlsxStreamerXXE.java</FilePath>
+<LineStart>37</LineStart>
+<Snippet>    @PostMapping("/readxlsx")
+    public void xllx_streamer_xxe(MultipartFile file)throws IOException {
+        Workbook wb = StreamingReader.builder().open(file.getInputStream());
+    }
+</Snippet>
+<TargetFunction>VariableAccess: wb</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="597B6E8B6B5960A6DBE37B01CF53D1EF" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_DocumentBuilder_fix() in XXE.java never uses the value it assigns to the variable document on line 296.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>296</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+            sr.close();
+</Snippet>
+<TargetFunction>VariableAccess: document</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="FEFD1A51840CD88B6138F440C8548B99" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method ooxml_xxe() in ooxmlXXE.java never uses the value it assigns to the variable sheet on line 49.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>ooxmlXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java</FilePath>
+<LineStart>49</LineStart>
+<Snippet>        XSSFWorkbook wb = new XSSFWorkbook(file.getInputStream()); // xxe vuln
+
+        XSSFSheet sheet = wb.getSheetAt(0);
+        XSSFRow row;
+        XSSFCell cell;</Snippet>
+<TargetFunction>VariableAccess: sheet</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="90EE145E161967A25A92320B3AE5F671" ruleID="B30AA17C-87EC-42CF-9160-CFDF122CE28E">
+                            <Category>Poor Style: Value Never Read</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method xxe_Digester() in XXE.java never uses the value it assigns to the variable digester on line 183.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>183</LineStart>
+<Snippet>            System.out.println(xml_con);
+
+            Digester digester = new Digester();
+            digester.parse(new StringReader(xml_con));  // parse xml
+</Snippet>
+<TargetFunction>VariableAccess: digester</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="34">
+                        <groupTitle>Poor Error Handling: Overly Broad Catch</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The catch block at Fastjson.java line 27 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Multiple catch blocks can get repetitive, but "condensing" catch blocks by catching a high-level class such as Exception can obscure exceptions that deserve special treatment or that should not be caught at this point in the program. Catching an overly broad exception essentially defeats the purpose of Java's typed exceptions, and can become particularly dangerous if the program grows and begins to throw new types of exceptions. The new exception types will not receive any attention.
+
+Example: The following code excerpt handles three types of exceptions in an identical fashion.
+
+
+  try {
+    doExchange();
+  }
+  catch (IOException e) {
+    logger.error("doExchange failed", e);
+  }
+  catch (InvocationTargetException e) {
+    logger.error("doExchange failed", e);
+  }
+  catch (SQLException e) {
+    logger.error("doExchange failed", e);
+  }
+
+
+At first blush, it may seem preferable to deal with these exceptions in a single catch block, as follows:
+
+
+  try {
+    doExchange();
+  }
+  catch (Exception e) {
+    logger.error("doExchange failed", e);
+  }
+
+
+However, if doExchange() is modified to throw a new type of exception that should be handled in some different kind of way, the broad catch block will prevent the compiler from pointing out the situation. Further, the new catch block will now also handle exceptions derived from RuntimeException such as ClassCastException, and NullPointerException, which is not the programmer's intent.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Do not catch broad exception classes such as Exception, Throwable, Error, or RuntimeException except at the very top level of the program or thread.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. The Fortify Secure Coding Rulepacks will not flag an overly broad catch block if the catch block in question immediately throws a new exception.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>34</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="D0987E83D4D8353C08759A8589A2B706" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRF.java line 257 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>257</LineStart>
+<Snippet>            }
+            ImageIO.read(u); // send request
+        } catch (Exception e) {
+            return e.toString();
+        }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="2C527D6B73507DF60A1E979582789B95" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRF.java line 129 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>129</LineStart>
+<Snippet>            }
+
+        }catch (Exception e) {
+            e.printStackTrace();
+        }finally {</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8DF4952AABD405B65544A1E9080B89CA" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 412 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>412</LineStart>
+<Snippet>            xmlReader.parse(new InputSource(new StringReader(xml_con)));
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1FFEF367E68FD4FACA612A5A3D6AF2F3" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 99 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>99</LineStart>
+<Snippet>
+            return "ok";
+        } catch (Exception e) {
+            return "except";
+        }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="92CE69164003072622D0168F063CF5D4" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 276 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>276</LineStart>
+<Snippet>            System.out.println(result.toString());
+            return result.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="71AED18BEB74B8988658FBC7B8691DB1" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 336 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>336</LineStart>
+<Snippet>            sr.close();
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="CBDBE296EB8E02E821434E5DD55C4634" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 375 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>375</LineStart>
+<Snippet>            sr.close();
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8AFDA71D62B8A31B71617EF2359B1593" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRFChecker.java line 50 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>50</LineStart>
+<Snippet>            } while (connection.getResponseCode() != HttpURLConnection.HTTP_OK);
+            connection.disconnect();
+        } catch (Exception e) {
+            return true;  // 如果异常了，认为是安全的，防止是超时导致的异常而验证不成功。
+        }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="BF406E27BFB15DC5AA4274C9BA55B83F" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRF.java line 94 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>94</LineStart>
+<Snippet>            String url = request.getParameter("url");
+            return Request.Get(url).execute().returnContent().toString();
+        }catch(Exception e) {
+            e.printStackTrace();
+            return "fail";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="898A5A331376914AF693AF7329FB7C5A" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 187 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>187</LineStart>
+<Snippet>
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C59E58F1216ED69E23999BC2EBEEC196" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRFChecker.java line 131 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>131</LineStart>
+<Snippet>            return u.getHost();
+
+        } catch (Exception e) {
+            return "";
+        }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="423FB798F5F02D32DAF490D97F4889F3" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SQLI.java line 78 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>78</LineStart>
+<Snippet>        }catch (SQLException e) {
+            e.printStackTrace();
+        }catch (Exception e) {
+            e.printStackTrace();
+</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8E6CC1AA955BB54A3AF6CA81730D04F1" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRF.java line 80 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>80</LineStart>
+<Snippet>            in.close();
+            return html.toString();
+        }catch(Exception e) {
+            e.printStackTrace();
+            return "fail";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="02EDDA1CC91AADF7C178189C1F46FC93" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRF.java line 55 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>55</LineStart>
+<Snippet>            in.close();
+            return html.toString();
+        }catch(Exception e) {
+            e.printStackTrace();
+            return "fail";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="B4FE4E80A064840B14963A9186D77365" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 206 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>206</LineStart>
+<Snippet>
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="AE4143CD49ED148E45550938AFF80EC1" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 392 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>392</LineStart>
+<Snippet>            xmlReader.parse(new InputSource(new StringReader(xml_con)));
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="9127A23CB2B4A49CDD7F93BB1AA4A00C" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 114 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>114</LineStart>
+<Snippet>
+            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6DE7A97C9E3C572D33675CAB5518AB40" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SecurityUtil.java line 100 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>100</LineStart>
+<Snippet>                logger.info("Unsupported encoding exception: " + filepath);
+                return null;
+            } catch (Exception e) {
+                logger.info(e.toString());
+                return null;</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D4C17CE03F7A12EB93DD36097DFEA8ED" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRFChecker.java line 111 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>111</LineStart>
+<Snippet>            return IpAddress.getHostAddress();
+        }
+        catch (Exception e) {
+            return "";
+        }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E178D1546F89A56514F7899D8B1A4C6A" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at Rce.java line 48 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>48</LineStart>
+<Snippet>            inBr.close();
+            in.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="278BBF0B78E19A095F446021C1E13D7E" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRF.java line 150 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>150</LineStart>
+<Snippet>            URL u = new URL(url);
+            ImageIO.read(u); // send request
+        } catch (Exception e) {
+        }
+    }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="022466070630B855921E7887D694B3D6" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 42 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>42</LineStart>
+<Snippet>            xmlReader.parse(new InputSource(new StringReader(xml_con)));  // parse xml
+            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E6B8D70B215BD3D399D35C8EE358B4E5" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 300 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>300</LineStart>
+<Snippet>
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="ECDBA24D3E2D97E659EE7768E50B53D3" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at Fastjson.java line 27 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Fastjson.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Fastjson.java</FilePath>
+<LineStart>27</LineStart>
+<Snippet>            JSONObject ob = JSON.parseObject(params);
+            return ob.get("name").toString();
+        }catch (Exception e){
+            e.printStackTrace();
+            return e.toString();</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1C1F7FDF088392A1A7729253A1EE73B3" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SecurityUtil.java line 42 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>42</LineStart>
+<Snippet>
+            return false;
+        } catch (Exception e) {
+            return false;
+        }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="68B6F55949C9C2747EA94B9BC2ABA36A" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 80 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>80</LineStart>
+<Snippet>            org.jdom2.Document document = builder.build(new InputSource(new StringReader(xml_con)));  // cause xxe
+            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8F3054CB1719D8D4CF74D597EA952B4B" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 170 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>170</LineStart>
+<Snippet>            parser.parse(new InputSource(new StringReader(xml_con)), new DefaultHandler());  // parse xml
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1BBE320E570E3D3B4170FFA956BE6FD6" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SQLI.java line 132 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>132</LineStart>
+<Snippet>        }catch (SQLException e) {
+            e.printStackTrace();
+        }catch (Exception e) {
+            e.printStackTrace();
+</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D3933BB50950E7DA2F2D9A952DB3C6E9" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 240 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>240</LineStart>
+<Snippet>            System.out.println(buf.toString());
+            return buf.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0AFF633E6B6AF0E1DAFE35EC1861776D" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 150 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>150</LineStart>
+<Snippet>
+            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="BA468F5A86560C6808802D8A93ACC368" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at SSRF.java line 186 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>186</LineStart>
+<Snippet>            }
+            return result.toString();
+        }catch (Exception e) {
+            e.printStackTrace();
+            return "fail";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="B674EF9AD0954409C60FB4E813645E65" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 133 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>133</LineStart>
+<Snippet>
+            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="80262E9C2A299FD180B45C44BC4E78C7" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at XXE.java line 64 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>64</LineStart>
+<Snippet>
+            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="2A2DC318150BDA22581D58B07A53B73C" ruleID="85E603E0-2933-4F38-851F-341604F75CB9">
+                            <Category>Poor Error Handling: Overly Broad Catch</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The catch block at URLRedirect.java line 70 handles a broad swath of exceptions,  potentially trapping dissimilar issues or problems that should not be dealt with at this point in the program.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>70</LineStart>
+<Snippet>        try{
+            rd.forward(request, response);
+        }catch (Exception e) {
+            e.printStackTrace();
+        }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="23">
+                        <groupTitle>Resource Injection</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>Attackers are able to control the resource identifier argument to URL() at SSRF.java line 44, which could enable them to access or modify otherwise protected system resources.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>A resource injection issue occurs when the following two conditions are met:
+
+1. An attacker is able to specify the identifier used to access a system resource.
+
+For example, an attacker may be able to specify a port number to be used to connect to a network resource.
+
+2. By specifying the resource, the attacker gains a capability that would not otherwise be permitted.
+
+For example, the program may give the attacker the ability to transmit sensitive information to a third-party server.
+
+
+
+Note: Resource injections involving resources stored on the file system are reported in a separate category named path manipulation. See the path manipulation description for further details of this vulnerability.
+
+Example 1: The following code uses a port number read from an HTTP request to create a socket.
+
+
+String remotePort = request.getParameter("remotePort");
+...
+ServerSocket srvr = new ServerSocket(remotePort);
+Socket skt = srvr.accept();
+...
+
+
+Some think that in the mobile world, classic web application vulnerabilities, such as resource injection, do not make sense -- why would the user attack themself? However, keep in mind that the essence of mobile platforms is applications that are downloaded from various sources and run alongside each other on the same device. The likelihood of running a piece of malware next to a banking application is high, which necessitates expanding the attack surface of mobile applications to include inter-process communication.
+
+Example 2: The following code uses a URL read from an Android intent to load the page in WebView.
+
+
+...
+	WebView webview = new WebView(this);
+	setContentView(webview);
+        String url = this.getIntent().getExtras().getString("url");
+	webview.loadUrl(url);
+...
+
+
+The kind of resource affected by user input indicates the kind of content that may be dangerous. For example, data containing special characters like period, slash, and backslash are risky when used in methods that interact with the file system. Similarly, data that contains URLs and URIs is risky for functions that create remote connections.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>The best way to prevent resource injection is with a level of indirection: create a list of legitimate resource names that a user is allowed to specify, and only allow the user to select from the list. With this approach the input provided by the user is never used directly to specify the resource name.
+
+In some situations this approach is impractical because the set of legitimate resource names is too large or too hard to keep track of. Programmers often resort to blacklisting in these situations. Blacklisting selectively rejects or escapes potentially dangerous characters before using the input. However, any such list of unsafe characters is likely to be incomplete and will almost certainly become out of date. A better approach is to create a whitelist of characters that are allowed to appear in the resource name and accept input composed exclusively of characters in the approved set.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. If the program is performing custom input validation you are satisfied with, use the Fortify Custom Rules Editor to create a cleanse rule for the validation routine.
+
+2. Implementation of an effective blacklist is notoriously difficult. One should be skeptical if validation logic requires blacklisting. Consider different types of input encoding and different sets of meta-characters that might have special meaning when interpreted by different operating systems, databases, or other resources. Determine whether or not the blacklist can be updated easily, correctly, and completely if these requirements ever change.
+
+3. A number of modern web frameworks provide mechanisms for performing validation of user input. Struts and Spring MVC are two examples. To highlight the unvalidated sources of input, the Fortify Secure Coding Rulepacks dynamically re-prioritize the issues reported by Fortify Static Code Analyzer by lowering their probability of exploit and providing pointers to the supporting evidence whenever the framework validation mechanism is in use. We refer to this feature as Context-Sensitive Ranking. To further assist the Fortify user with the auditing process, the Fortify Software Security Research group makes available the Data Validation project template that groups the issues into folders based on the validation mechanism applied to their source of input.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>23</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="47DD14CC31F10513043E6B67F0BFEEB4" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SecurityUtil.java line 28, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>        }
+        try {
+            URI uri = new URI(url);
+
+            if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>JSONP.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/jsonp/JSONP.java</FilePath>
+<LineStart>63</LineStart>
+<Snippet>    @RequestMapping(value = "/emptyReferer", produces = "application/javascript")
+    private String emptyReferer(HttpServletRequest request) {
+        String referer = request.getHeader("referer");
+
+        if (null != referer &amp;&amp; !SecurityUtil.checkURLbyEndsWith(referer, urlwhitelist)) {</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletRequest.getHeader()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="C52A7886E2EE7160DEB86AA2FDBD8D82" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at SSRF.java line 68, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>68</LineStart>
+<Snippet>        try {
+            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();
+            HttpURLConnection httpUrl = (HttpURLConnection)urlConnection;</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>67</LineStart>
+<Snippet>    {
+        try {
+            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="0BFF9046FD9A8E8C4C146AB5194C3452" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at URLWhiteList.java line 126, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>126</LineStart>
+<Snippet>        String url = request.getParameter("url");
+        System.out.println("url:  " + url);
+        URL u = new URL(url);
+
+        if (!u.getProtocol().startsWith("http") &amp;&amp; !u.getProtocol().startsWith("https")) {</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>124</LineStart>
+<Snippet>    @ResponseBody
+    public String url_bypass(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        System.out.println("url:  " + url);
+        URL u = new URL(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="DDF4198760F8740AE7856679B7EFE5C0" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at URLWhiteList.java line 187, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>187</LineStart>
+<Snippet>        String url = request.getParameter("url");
+
+        URI uri = new URI(url);
+        if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {
+            return "SecurityUtil is not http or https";</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>185</LineStart>
+<Snippet>    public String seccode2(HttpServletRequest request) throws Exception{
+        String whiteDomainlists[] = {"aaa.taobao.com", "ccc.bbb.taobao.com"};
+        String url = request.getParameter("url");
+
+        URI uri = new URI(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="153EB975C95075A891A722BB0F1B11DA" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at SSRFChecker.java line 33, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>33</LineStart>
+<Snippet>                }
+
+                connection = (HttpURLConnection) new URL(finalUrl).openConnection();
+                connection.setInstanceFollowRedirects(false);
+                connection.setUseCaches(false); // 设置为false，手动处理跳转，可以拿到每个跳转的URL</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>41</LineStart>
+<Snippet>                int responseCode = connection.getResponseCode(); // 发起网络请求
+                if (responseCode &gt;= 300 &amp;&amp; responseCode &lt;=307 &amp;&amp; responseCode != 304 &amp;&amp; responseCode != 306) {
+                    String redirectedUrl = connection.getHeaderField("Location");
+                    if (null == redirectedUrl)
+                        break;</Snippet>
+<TargetFunction>java.net.URLConnection.getHeaderField()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="0764E668F7E2C16ADB85B9AF4028DBB9" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SecurityUtil.java line 28, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>        }
+        try {
+            URI uri = new URI(url);
+
+            if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>83</LineStart>
+<Snippet>    @ResponseBody
+    public static void sendRedirect_seccode(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        String url = request.getParameter("url");
+        String urlwhitelist[] = {"joychou.org", "joychou.com"};
+        if (!SecurityUtil.checkURLbyEndsWith(url, urlwhitelist)) {</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="D8534AEDB91CD99B66CC17AFA634790A" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at SSRF.java line 252, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>252</LineStart>
+<Snippet>        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);
+            if (!SecurityUtil.checkSSRF(url)) {
+                return "SSRF check failed.";</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>250</LineStart>
+<Snippet>    @ResponseBody
+    public static String ssrf_ImageIO_safecode(HttpServletRequest request) {
+        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="62DA297E221EA8262FC722DD9A0D5A7A" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SSRFChecker.java line 124, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>124</LineStart>
+<Snippet>        try {
+            // 使用URI，而非URL，防止被绕过。
+            URI u = new URI(url);
+            if (!url.startsWith("http://") &amp;&amp; ! url.startsWith("https://")) {
+                return "";</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>250</LineStart>
+<Snippet>    @ResponseBody
+    public static String ssrf_ImageIO_safecode(HttpServletRequest request) {
+        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="725C769B7971578BC2A44B2C594CC371" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at URLWhiteList.java line 159, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>159</LineStart>
+<Snippet>        String url = request.getParameter("url");
+
+        URI uri = new URI(url);
+        if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {
+            return "SecurityUtil is not http or https";</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>157</LineStart>
+<Snippet>
+        String whiteDomainlists[] = {"taobao.com", "tmall.com"};
+        String url = request.getParameter("url");
+
+        URI uri = new URI(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="9630E3AFB4C507C693303A72CC33DBCA" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at SSRFChecker.java line 33, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>33</LineStart>
+<Snippet>                }
+
+                connection = (HttpURLConnection) new URL(finalUrl).openConnection();
+                connection.setInstanceFollowRedirects(false);
+                connection.setUseCaches(false); // 设置为false，手动处理跳转，可以拿到每个跳转的URL</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>250</LineStart>
+<Snippet>    @ResponseBody
+    public static String ssrf_ImageIO_safecode(HttpServletRequest request) {
+        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="947BD9FCD486E718A5A77C0E8844D20D" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at SSRF.java line 148, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>148</LineStart>
+<Snippet>        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);
+            ImageIO.read(u); // send request
+        } catch (Exception e) {</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>146</LineStart>
+<Snippet>    @ResponseBody
+    public static void ssrf_ImageIO(HttpServletRequest request) {
+        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="80671E26DA01B16AF200FE81A982BEE5" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at URLWhiteList.java line 59, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>59</LineStart>
+<Snippet>    public String contains(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost().toLowerCase();
+</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>58</LineStart>
+<Snippet>    @ResponseBody
+    public String contains(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost().toLowerCase();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="6B576C168C4108FB27050929095C55AB" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SecurityUtil.java line 28, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>        }
+        try {
+            URI uri = new URI(url);
+
+            if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>HttpFilter.java</FileName>
+<FilePath>src/main/java/org/joychou/security/HttpFilter.java</FilePath>
+<LineStart>42</LineStart>
+<Snippet>        HttpServletResponse response = (HttpServletResponse) res;
+
+        String refer = request.getHeader("referer");
+        PathMatcher matcher = new AntPathMatcher();
+        boolean isMatch = false;</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletRequest.getHeader()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="B56010300BD719CFF9EE597A7762CDBC" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at URLWhiteList.java line 39, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>39</LineStart>
+<Snippet>    public String endsWith(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost().toLowerCase();
+</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>38</LineStart>
+<Snippet>    @ResponseBody
+    public String endsWith(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost().toLowerCase();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="DCBF69036D1BEBDA3C9FC1B2D0B485CA" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at URLWhiteList.java line 80, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>80</LineStart>
+<Snippet>    public String regex(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost().toLowerCase();
+</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>79</LineStart>
+<Snippet>    @ResponseBody
+    public String regex(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost().toLowerCase();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="13811F7921B2517F3CB0F667BB821BEC" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at URLWhiteList.java line 217, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>217</LineStart>
+<Snippet>
+        String url = request.getParameter("url");
+        URI uri = new URI(url);
+
+        if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>216</LineStart>
+<Snippet>        whiteDomainlists.add("ccc.bbb.taobao.com");
+
+        String url = request.getParameter("url");
+        URI uri = new URI(url);
+</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="15850F9413A230EE04B0447D5F5A5A2A" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SecurityUtil.java line 28, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>        }
+        try {
+            URI uri = new URI(url);
+
+            if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>80</LineStart>
+<Snippet>    @RequestMapping("/sec/checkOrigin")
+    public String seccode(HttpServletRequest request, HttpServletResponse response) {
+        String origin = request.getHeader("Origin");
+
+        // 如果origin不为空并且origin不在白名单内，认定为不安全。</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletRequest.getHeader()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="16BAC71A37FC882F70AC34A21EC92AB1" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at SSRF.java line 120, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>120</LineStart>
+<Snippet>            response.setHeader("content-disposition", "attachment;fileName=" + downLoadImgFileName);
+
+            URL u = new URL(url);
+            int length;
+            byte[] bytes = new byte[1024];</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>114</LineStart>
+<Snippet>        InputStream inputStream = null;
+        OutputStream outputStream = null;
+        String url = request.getParameter("url");
+        try {
+            String downLoadImgFileName = Files.getNameWithoutExtension(url) + "." + Files.getFileExtension(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="D518F12F326685259DA010A6A0DBC4BB" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SecurityUtil.java line 28, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>        }
+        try {
+            URI uri = new URI(url);
+
+            if (!url.startsWith("http://") &amp;&amp; !url.startsWith("https://")) {</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>JSONP.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/jsonp/JSONP.java</FilePath>
+<LineStart>109</LineStart>
+<Snippet>    @RequestMapping(value = "/sec", produces = "application/javascript")
+    private String safecode(HttpServletRequest request) {
+        String referer = request.getHeader("referer");
+
+        if (!SecurityUtil.checkURLbyEndsWith(referer, urlwhitelist)) {</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletRequest.getHeader()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="00543A6FDB4AD24BA88904ACC68F4B87" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SSRFChecker.java line 124, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>124</LineStart>
+<Snippet>        try {
+            // 使用URI，而非URL，防止被绕过。
+            URI u = new URI(url);
+            if (!url.startsWith("http://") &amp;&amp; ! url.startsWith("https://")) {
+                return "";</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>203</LineStart>
+<Snippet>    public static String commonsHttpClient(HttpServletRequest request) {
+
+        String url = request.getParameter("url");
+
+        // Security check</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="F69061723BA7E11929C39E92A6E99606" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at SSRF.java line 44, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>44</LineStart>
+<Snippet>        try {
+            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();
+            BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream())); //send request</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>    {
+        try {
+            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="CC2BA2BF6D3CC375129FEB86AC6BBEC8" ruleID="2DEE27D8-C41F-48FC-8B40-FA60B403AEAE">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URL() at URLWhiteList.java line 102, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>102</LineStart>
+<Snippet>    public String indexOf(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost();
+        // If indexOf returns -1, it means that no string was found.</Snippet>
+<TargetFunction>java.net.URL.URL()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>101</LineStart>
+<Snippet>    @ResponseBody
+    public String indexOf(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);
+        String host = u.getHost();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="A743910CCC4B722F4F9115AB26EF31AF" ruleID="8F3B2393-5D1E-4860-A96F-0F6E0274923F">
+                            <Category>Resource Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Attackers are able to control the resource identifier argument to URI() at SSRFChecker.java line 124, which could enable them to access or modify otherwise protected system resources.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>124</LineStart>
+<Snippet>        try {
+            // 使用URI，而非URL，防止被绕过。
+            URI u = new URI(url);
+            if (!url.startsWith("http://") &amp;&amp; ! url.startsWith("https://")) {
+                return "";</Snippet>
+<TargetFunction>java.net.URI.URI()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>41</LineStart>
+<Snippet>                int responseCode = connection.getResponseCode(); // 发起网络请求
+                if (responseCode &gt;= 300 &amp;&amp; responseCode &lt;=307 &amp;&amp; responseCode != 304 &amp;&amp; responseCode != 306) {
+                    String redirectedUrl = connection.getHeaderField("Location");
+                    if (null == redirectedUrl)
+                        break;</Snippet>
+<TargetFunction>java.net.URLConnection.getHeaderField()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="18">
+                        <groupTitle>System Information Leak</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The function Deserialize() in Fastjson.java might reveal system data or debugging information by calling printStackTrace() on line 28. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>An information leak occurs when system data or debugging information leaves the program through an output stream or logging function.
+
+
+
+Example 1: The following code prints an exception to the standard error stream:
+
+
+try {
+    ...
+} catch (Exception e) {
+    e.printStackTrace();
+}
+
+
+Depending upon the system configuration, this information can be dumped to a console, written to a log file, or exposed to a remote user. For example, with scripting mechanisms it is trivial to redirect output information from "Standard error" or "Standard output" into a file or another program. Alternatively the system that the program runs on could have a remote logging mechanism such as a "syslog" server that will send the logs to a remote device. During development you will have no way of knowing where this information may end up being displayed.
+
+In some cases the error message tells the attacker precisely what sort of an attack the system is vulnerable to. For example, a database error message can reveal that the application is vulnerable to a SQL injection attack. Other error messages can reveal more oblique clues about the system. In the example above, the leaked information could imply information about the type of operating system, the applications installed on the system, and the amount of care that the administrators have put into configuring the program.
+
+Here is another scenario, specific to the mobile world. Most mobile devices now implement a Near-Field Communication (NFC) protocol for quickly sharing information between devices using radio communication. It works by bringing devices to close proximity or simply having them touch each other. Even though the communication range of NFC is limited to just a few centimeters, eavesdropping, data modification and various other types of attacks are possible, since NFC alone does not ensure secure communication.
+
+Example 2: The Android platform provides support for NFC. The following code creates a message that gets pushed to the other device within the range.
+
+...
+public static final String TAG = "NfcActivity";
+private static final String DATA_SPLITTER = "__:DATA:__";
+private static final String MIME_TYPE = "application/my.applications.mimetype";
+...
+public NdefMessage createNdefMessage(NfcEvent event) {
+    TelephonyManager tm = (TelephonyManager)Context.getSystemService(Context.TELEPHONY_SERVICE);
+    String VERSION = tm.getDeviceSoftwareVersion();
+    String text = TAG + DATA_SPLITTER + VERSION;
+    NdefRecord record = new NdefRecord(NdefRecord.TNF_MIME_MEDIA,
+            MIME_TYPE.getBytes(), new byte[0], text.getBytes());
+    NdefRecord[] records = { record };
+    NdefMessage msg = new NdefMessage(records);
+    return msg;
+}
+...
+
+
+NFC Data Exchange Format (NDEF) message contains typed data, a URI, or a custom application payload. If the message contains information about the application, such as its name, MIME type, or device software version, this information could be leaked to an eavesdropper. In the example above, Fortify Static Code Analyzer reports a System Information Leak vulnerability on the return statement.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Write error messages with security in mind. In production environments, turn off detailed error information in favor of brief messages. Restrict the generation and storage of detailed output that can help administrators and programmers diagnose problems. Be careful, debugging traces can sometimes appear in non-obvious places (embedded in comments in the HTML for an error page, for example).
+
+Even brief error messages that do not reveal stack traces or database dumps can potentially aid an attacker. For example, an "Access Denied" message can reveal that a file or user exists on the system.
+
+If you are concerned about leaking system data via NFC on an Android device, you could do one of the following three things. Either do not include system data in the messages pushed to other devices in range, or encrypt the payload of the message, or establish secure communication channel at a higher layer.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Do not rely on wrapper scripts, corporate IT policy, or quick-thinking system administrators to prevent system information leaks. Write software that is secure on its own.
+
+2. This category of vulnerability does not apply to all types of programs. For example, if your application executes on a client machine where system information is already available to an attacker, or if you print system information only to a trusted log file, you can use AuditGuide to filter out this category.
+
+3. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>18</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="5DCACDF11C1BC3216F0617FB1659953F" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function main() in Server.java might reveal system data or debugging information by calling printStackTrace() on line 26. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Server.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Server.java</FilePath>
+<LineStart>26</LineStart>
+<Snippet>        } catch (Exception e) {
+            System.err.println("Server exception: " + e.toString());
+            e.printStackTrace();
+        }
+    }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6B50EFA5957F12F0F1AD7E034C46491D" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function ssrf_openStream() in SSRF.java might reveal system data or debugging information by calling printStackTrace() on line 130. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>130</LineStart>
+<Snippet>
+        }catch (Exception e) {
+            e.printStackTrace();
+        }finally {
+            if (inputStream != null) {</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="9050DED05F8D4CC49286646B96D31186" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function jdbc_sqli_vul() in SQLI.java might reveal system data or debugging information by calling printStackTrace() on line 75. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>75</LineStart>
+<Snippet>        }catch (ClassNotFoundException e) {
+            System.out.println("Sorry,can`t find the Driver!");
+            e.printStackTrace();
+        }catch (SQLException e) {
+            e.printStackTrace();</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C17669C42A6AEFAD28897E3C2937D217" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function Deserialize() in Fastjson.java might reveal system data or debugging information by calling printStackTrace() on line 28. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Fastjson.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Fastjson.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>            return ob.get("name").toString();
+        }catch (Exception e){
+            e.printStackTrace();
+            return e.toString();
+        }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="152CFA0987C44EFC10C86B1EF8197A59" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function jdbc_sqli_sec() in SQLI.java might reveal system data or debugging information by calling printStackTrace() on line 129. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>129</LineStart>
+<Snippet>        }catch (ClassNotFoundException e) {
+            System.out.println("Sorry,can`t find the Driver!");
+            e.printStackTrace();
+        }catch (SQLException e) {
+            e.printStackTrace();</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7687598A12A246091A1EEB086DB2823B" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function uploadPicture() in FileUpload.java might reveal system data or debugging information by calling printStackTrace() on line 116. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>FileUpload.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/FileUpload.java</FilePath>
+<LineStart>116</LineStart>
+<Snippet>        } catch (IOException e) {
+            redirectAttributes.addFlashAttribute("message", "upload failed");
+            e.printStackTrace();
+            deleteFile(excelFile);
+            return "redirect:/file/status";</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D2110C74534A0EDB9D3059EC702981EE" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function ssrf_Request() in SSRF.java might reveal system data or debugging information by calling printStackTrace() on line 95. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>95</LineStart>
+<Snippet>            return Request.Get(url).execute().returnContent().toString();
+        }catch(Exception e) {
+            e.printStackTrace();
+            return "fail";
+        }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="678E70C238AE8402E7B44B1F84A7CB64" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function singleFileUpload() in FileUpload.java might reveal system data or debugging information by calling printStackTrace() on line 66. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>FileUpload.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/FileUpload.java</FilePath>
+<LineStart>66</LineStart>
+<Snippet>        } catch (IOException e) {
+            redirectAttributes.addFlashAttribute("message", "upload failed");
+            e.printStackTrace();
+            return "redirect:/file/status";
+        }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="71DBEE6D7AD81BC00843DE761FBBA2C7" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function ssrf_HttpClient() in SSRF.java might reveal system data or debugging information by calling printStackTrace() on line 187. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>187</LineStart>
+<Snippet>            return result.toString();
+        }catch (Exception e) {
+            e.printStackTrace();
+            return "fail";
+        }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="9050DED05F8D4CC49286646B96D31184" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function jdbc_sqli_vul() in SQLI.java might reveal system data or debugging information by calling printStackTrace() on line 79. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>79</LineStart>
+<Snippet>            e.printStackTrace();
+        }catch (Exception e) {
+            e.printStackTrace();
+
+        }finally{</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="147B6E9538D227EF90C0C1CDCF237D9C" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function ssrf_URLConnection() in SSRF.java might reveal system data or debugging information by calling printStackTrace() on line 56. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>56</LineStart>
+<Snippet>            return html.toString();
+        }catch(Exception e) {
+            e.printStackTrace();
+            return "fail";
+        }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="DFE67DA817AEB34FD529ABFEE4677257" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function forward() in URLRedirect.java might reveal system data or debugging information by calling printStackTrace() on line 71. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>71</LineStart>
+<Snippet>            rd.forward(request, response);
+        }catch (Exception e) {
+            e.printStackTrace();
+        }
+    }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="199FBA8F68E2AF0661EA2A2F15C8521C" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function main() in Client.java might reveal system data or debugging information by calling printStackTrace() on line 18. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Client.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Client.java</FilePath>
+<LineStart>18</LineStart>
+<Snippet>        } catch (Exception e) {
+            System.err.println("Client exception: " + e.toString());
+            e.printStackTrace();
+        }
+    }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="9050DED05F8D4CC49286646B96D31185" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function jdbc_sqli_vul() in SQLI.java might reveal system data or debugging information by calling printStackTrace() on line 77. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>77</LineStart>
+<Snippet>            e.printStackTrace();
+        }catch (SQLException e) {
+            e.printStackTrace();
+        }catch (Exception e) {
+            e.printStackTrace();</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="152CFA0987C44EFC10C86B1EF8197A58" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function jdbc_sqli_sec() in SQLI.java might reveal system data or debugging information by calling printStackTrace() on line 131. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>131</LineStart>
+<Snippet>            e.printStackTrace();
+        }catch (SQLException e) {
+            e.printStackTrace();
+        }catch (Exception e) {
+            e.printStackTrace();</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="152CFA0987C44EFC10C86B1EF8197A57" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function jdbc_sqli_sec() in SQLI.java might reveal system data or debugging information by calling printStackTrace() on line 133. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>133</LineStart>
+<Snippet>            e.printStackTrace();
+        }catch (Exception e) {
+            e.printStackTrace();
+
+        }finally{</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8DC95CA534C4B0878187709D24EB3B84" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function CommandExec() in Rce.java might reveal system data or debugging information by calling printStackTrace() on line 49. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>49</LineStart>
+<Snippet>            in.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "Except";
+        }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1E95C7186B1DDBB49283CE4F04D8A6C3" ruleID="FE4EADF2-7055-4C36-863E-5A01C4A0E1A4">
+                            <Category>System Information Leak</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function ssrf_httpURLConnection() in SSRF.java might reveal system data or debugging information by calling printStackTrace() on line 81. The information revealed by printStackTrace() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>81</LineStart>
+<Snippet>            return html.toString();
+        }catch(Exception e) {
+            e.printStackTrace();
+            return "fail";
+        }</Snippet>
+<TargetFunction>printStackTrace()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="18">
+                        <groupTitle>System Information Leak: Internal</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The function xxe_xmlReader() in XXE.java might reveal system data or debugging information by calling println() on line 43. The information revealed by println() could help an adversary form a plan of attack.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>An internal information leak occurs when system data or debugging information is sent to a local file, console, or screen via printing or logging.
+
+
+
+Example 1: The following code prints an exception to the standard error stream:
+
+
+try {
+    ...
+} catch (Exception e) {
+    e.printStackTrace();
+}
+
+
+Depending upon the system configuration, this information can be dumped to a console, written to a log file, or exposed to a user. In some cases the error message tells the attacker precisely what sort of an attack the system is vulnerable to. For example, a database error message can reveal that the application is vulnerable to a SQL injection attack. Other error messages can reveal more oblique clues about the system. In the example above, the leaked information could imply information about the type of operating system, the applications installed on the system, and the amount of care that the administrators have put into configuring the program.
+
+In the mobile world, information leaks are also a concern.
+
+Example 2: The code below logs the stack trace of a caught exception on the Android platform.
+
+...
+try {
+  ...
+} catch (Exception e) {
+    Log.e(TAG, Log.getStackTraceString(e));
+}
+...
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Write error messages with security in mind. In production environments, turn off detailed error information in favor of brief messages. Restrict the generation and storage of detailed output that can help administrators and programmers diagnose problems. Be careful, debugging traces can sometimes appear in non-obvious places (embedded in comments in the HTML for an error page, for example).
+
+Even brief error messages that do not reveal stack traces or database dumps can potentially aid an attacker. For example, an "Access Denied" message can reveal that a file or user exists on the system.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Do not rely on wrapper scripts, corporate IT policy, or quick-thinking system administrators to prevent system information leaks. Write software that is secure on its own.
+
+2. This category of vulnerability does not apply to all types of programs. For example, if your application executes on a client machine where system information is already available to an attacker, or if you print system information only to a trusted log file, you can use AuditGuide to filter out this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>18</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="19A415C36909DB7D946F06D589769E7A" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_Digester_fix() in XXE.java might reveal system data or debugging information by calling println() on line 207. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>207</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>207</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="41ED88077CCCFFED4078EC31775FB695" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_xmlReader() in XXE.java might reveal system data or debugging information by calling println() on line 43. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="FB41D99C0B195604898D718377D35A4F" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function DocumentBuilder() in XXE.java might reveal system data or debugging information by calling println() on line 277. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>277</LineStart>
+<Snippet>            return result.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>277</LineStart>
+<Snippet>            return result.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="592D0A59CB834B1ACC670334FCBFCABA" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function XMLReaderVul() in XXE.java might reveal system data or debugging information by calling println() on line 393. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>393</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>393</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="3D8327CC492A698082F3E9F1299DE232" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_xmlReader_fix() in XXE.java might reveal system data or debugging information by calling println() on line 65. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>65</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>65</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="B46207997D2F18095E31BB4572838E53" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function main() in Client.java might reveal system data or debugging information by calling println() on line 17. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Client.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Client.java</FilePath>
+<LineStart>17</LineStart>
+<Snippet>            System.out.println("response: " + response);
+        } catch (Exception e) {
+            System.err.println("Client exception: " + e.toString());
+            e.printStackTrace();
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>Client.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Client.java</FilePath>
+<LineStart>17</LineStart>
+<Snippet>            System.out.println("response: " + response);
+        } catch (Exception e) {
+            System.err.println("Client exception: " + e.toString());
+            e.printStackTrace();
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="68208BFB74495903C3E1D42E28611243" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_SAXBuilder() in XXE.java might reveal system data or debugging information by calling println() on line 81. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>81</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>81</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="74E3ADF9AA701A6CBC255886640CFCC2" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_SAXParser_fix() in XXE.java might reveal system data or debugging information by calling println() on line 171. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>171</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>171</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="7EDA88A775B1D6030F68453493CD7264" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_DocumentBuilder_fix() in XXE.java might reveal system data or debugging information by calling println() on line 301. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>301</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>301</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="FF6FF426A1E830BB60B19D067D529D56" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_xinclude_DocumentBuilder_fix() in XXE.java might reveal system data or debugging information by calling println() on line 376. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>376</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>376</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="491B080169537013A4359E3467D89C1D" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxeDocumentBuilderReturn() in XXE.java might reveal system data or debugging information by calling println() on line 241. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>241</LineStart>
+<Snippet>            return buf.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>241</LineStart>
+<Snippet>            return buf.toString();
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="F83CB727819BC7846CE32B39A7F6AA45" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function main() in Server.java might reveal system data or debugging information by calling println() on line 25. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Server.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Server.java</FilePath>
+<LineStart>25</LineStart>
+<Snippet>            System.out.println("绑定1099端口成功");
+        } catch (Exception e) {
+            System.err.println("Server exception: " + e.toString());
+            e.printStackTrace();
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>Server.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Server.java</FilePath>
+<LineStart>25</LineStart>
+<Snippet>            System.out.println("绑定1099端口成功");
+        } catch (Exception e) {
+            System.err.println("Server exception: " + e.toString());
+            e.printStackTrace();
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="D063EAC9DEB33FC8A5B31A0A3F6ECB20" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_xinclude_DocumentBuilder() in XXE.java might reveal system data or debugging information by calling println() on line 337. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>337</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>337</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="74301F42721151B2DBBF23EEFCF3C264" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_SAXParser() in XXE.java might reveal system data or debugging information by calling println() on line 151. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>151</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>151</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="F358D6C2FE61F8044CA6C0FE0159CE70" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_SAXReader() in XXE.java might reveal system data or debugging information by calling println() on line 115. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>115</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>115</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="27C64E129FDEB615A027A0758EEF6A8D" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function XMLReaderSec() in XXE.java might reveal system data or debugging information by calling println() on line 413. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>413</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>413</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e.toString());
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="CB72B283A23F01DE2B2947B50A278378" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_Digester() in XXE.java might reveal system data or debugging information by calling println() on line 188. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>188</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>188</LineStart>
+<Snippet>            return "test";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="06F3BF4B2F7909D79A49B17059901878" ruleID="DCA98C06-0D99-4EE0-ADA4-A4FA86FDE47A">
+                            <Category>System Information Leak: Internal</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The function xxe_SAXReader_fix() in XXE.java might reveal system data or debugging information by calling println() on line 134. The information revealed by println() could help an adversary form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>134</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>java.io.PrintStream.println()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>134</LineStart>
+<Snippet>            return "ok";
+        } catch (Exception e) {
+            System.out.println(e);
+            return "except";
+        }</Snippet>
+<TargetFunction>Read e()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="16">
+                        <groupTitle>Dead Code: Unused Method</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method vuln01() in Cookies.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>This method is never called or is only called from other dead code.
+
+Example 1: In the following class, the method doWork() can never be called.
+
+
+public class Dead {
+  private void doWork() {
+    System.out.println("doing work");
+  }
+  public static void main(String[] args) {
+    System.out.println("running Dead");
+  }
+}
+
+
+Example 2: In the following class, two private methods call each other, but since neither one is ever invoked from anywhere else, they are both dead code.
+
+
+public class DoubleDead {
+  private void doTweedledee() {
+    doTweedledumb();
+  }
+  private void doTweedledumb() {
+    doTweedledee();
+  }
+  public static void main(String[] args) {
+    System.out.println("running DoubleDead");
+  }
+}
+
+
+(In this case it is a good thing that the methods are dead: invoking either one would cause an infinite loop.)</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>A dead method may indicate a bug in dispatch code.
+
+Example 3: If method is flagged as dead named getWitch() in a class that also contains the following dispatch method, it may be because of a copy-and-paste error. The 'w' case should return getWitch() not getMummy().
+
+
+public ScaryThing getScaryThing(char st) {
+  switch(st) {
+    case 'm':
+      return getMummy();
+    case 'w':
+      return getMummy();
+    default:
+      return getBlob();
+  }
+}
+
+
+In general, you should repair or remove dead code. To repair dead code, execute the dead code directly or indirectly through a public method. Dead code causes additional complexity and maintenance burden without contributing to the functionality of the program.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. This issue may be a false positive if the program uses reflection to access private methods. (This is a non-standard practice. Private methods that are only invoked via reflection should be well documented.)</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>16</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="77DE042BE46A07FFEDC3B42CE582B1D1" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuln01() in Cookies.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Cookies.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Cookies.java</FilePath>
+<LineStart>19</LineStart>
+<Snippet>
+    @RequestMapping(value = "/vuln01")
+    private String vuln01(HttpServletRequest req) {
+        String nick = WebUtils.getCookieValueByName(req, NICK); // key code
+        return "Cookie nick: " + nick;</Snippet>
+<TargetFunction>Function: vuln01()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D7EFA86F4598834B93FD068286F95941" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuln04() in Cookies.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Cookies.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Cookies.java</FilePath>
+<LineStart>55</LineStart>
+<Snippet>
+    @RequestMapping(value = "/vuln04")
+    private String vuln04(HttpServletRequest req) {
+        String nick = null;
+        Cookie cookies[] = req.getCookies();</Snippet>
+<TargetFunction>Function: vuln04()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="BE25FE7C18DE0985AD5639AC60A09665" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method safecode() in JSONP.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>JSONP.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/jsonp/JSONP.java</FilePath>
+<LineStart>108</LineStart>
+<Snippet>     */
+    @RequestMapping(value = "/sec", produces = "application/javascript")
+    private String safecode(HttpServletRequest request) {
+        String referer = request.getHeader("referer");
+</Snippet>
+<TargetFunction>Function: safecode()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="69C2C8E473454DE8B96AC8C2F4A94054" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method crlf() in CRLFInjection.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>23</LineStart>
+<Snippet>    @RequestMapping("/safecode")
+    @ResponseBody
+    private static void crlf(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("test1", request.getParameter("test1"));
+        response.setHeader("test2", request.getParameter("test2"));</Snippet>
+<TargetFunction>Function: crlf()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C97D43C2E8075755A2C9603581EA2563" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method Index() in Test.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Test.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Test.java</FilePath>
+<LineStart>17</LineStart>
+<Snippet>    @RequestMapping(value = "/")
+    @ResponseBody
+    private String Index(HttpServletResponse response, String empId) {
+
+        System.out.println(empId);</Snippet>
+<TargetFunction>Function: Index()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="2FD86663C93B57A7F41002C38AED6F8C" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuls1() in CORS.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>27</LineStart>
+<Snippet>
+    @RequestMapping("/vuln/origin")
+    private static String vuls1(HttpServletRequest request, HttpServletResponse response) {
+        String origin = request.getHeader("origin");
+        response.setHeader("Access-Control-Allow-Origin", origin); // 设置Origin值为Header中获取到的</Snippet>
+<TargetFunction>Function: vuls1()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="48B0709151EBAD3C68603BAB9E312101" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuln03() in Cookies.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Cookies.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Cookies.java</FilePath>
+<LineStart>39</LineStart>
+<Snippet>
+    @RequestMapping(value = "/vuln03")
+    private String vuln03(HttpServletRequest req) {
+        String nick = null;
+        Cookie cookies[] = req.getCookies();</Snippet>
+<TargetFunction>Function: vuln03()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="581C028E654B6DD4428F9CC5333109CB" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method velocity() in SSTI.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSTI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSTI.java</FilePath>
+<LineStart>27</LineStart>
+<Snippet>     */
+    @GetMapping("/velocity")
+    private static void velocity(String template){
+        Velocity.init();
+</Snippet>
+<TargetFunction>Function: velocity()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6FCFFE3E1E46F8F5A6B00D723D55A6E6" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method rce() in SpEL.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SpEL.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SpEL.java</FilePath>
+<LineStart>25</LineStart>
+<Snippet>     */
+    @RequestMapping("/spel/vul")
+    private static String rce(String expression) {
+        ExpressionParser parser = new SpelExpressionParser();
+        // fix method: SimpleEvaluationContext</Snippet>
+<TargetFunction>Function: rce()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="82B7860272593B8F1F862D44066060FC" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method emptyReferer() in JSONP.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>JSONP.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/jsonp/JSONP.java</FilePath>
+<LineStart>62</LineStart>
+<Snippet>     */
+    @RequestMapping(value = "/emptyReferer", produces = "application/javascript")
+    private String emptyReferer(HttpServletRequest request) {
+        String referer = request.getHeader("referer");
+</Snippet>
+<TargetFunction>Function: emptyReferer()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C139B48A04A5A6BE85F58B2C3B18FF29" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuln02() in Cookies.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Cookies.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Cookies.java</FilePath>
+<LineStart>26</LineStart>
+<Snippet>
+    @RequestMapping(value = "/vuln02")
+    private String vuln02(HttpServletRequest req) {
+        String nick = null;
+        Cookie[] cookie = req.getCookies();</Snippet>
+<TargetFunction>Function: vuln02()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E3401B17B84537AB93258F825FC63896" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuln05() in Cookies.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Cookies.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Cookies.java</FilePath>
+<LineStart>71</LineStart>
+<Snippet>
+    @RequestMapping(value = "/vuln05")
+    private String vuln05(@CookieValue("nick") String nick) {
+        return "Cookie nick: " + nick;
+    }</Snippet>
+<TargetFunction>Function: vuln05()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="B68B79DA733467116DACF5C984DF92C6" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuln06() in Cookies.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Cookies.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Cookies.java</FilePath>
+<LineStart>77</LineStart>
+<Snippet>
+    @RequestMapping(value = "/vuln06")
+    private String vuln06(@CookieValue(value = "nick") String nick) {
+        return "Cookie nick: " + nick;
+    }</Snippet>
+<TargetFunction>Function: vuln06()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="47FB52B700A6519CF086F3649DD6D24C" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuls2() in CORS.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>35</LineStart>
+<Snippet>
+    @RequestMapping("/vuln/setHeader")
+    private static String vuls2(HttpServletResponse response) {
+        // 后端设置Access-Control-Allow-Origin为*的情况下，跨域的时候前端如果设置withCredentials为true会异常
+        response.setHeader("Access-Control-Allow-Origin", "*");</Snippet>
+<TargetFunction>Function: vuls2()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="07456D736D21773C8F54E6FA669408F5" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method vuls3() in CORS.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>44</LineStart>
+<Snippet>    @CrossOrigin("*")
+    @RequestMapping("/vuln/crossOrigin")
+    private static String vuls3(HttpServletResponse response) {
+        return info;
+    }</Snippet>
+<TargetFunction>Function: vuls3()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0ADEEA9D2B3C83A124A36282CAA42DB1" ruleID="6F84D4B0-3B7E-4463-A165-76135931D192">
+                            <Category>Dead Code: Unused Method</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The method referer() in JSONP.java is not reachable from any method outside the class. It is dead code. Dead code is defined as code that is never directly or indirectly executed by a public method.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>JSONP.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/jsonp/JSONP.java</FilePath>
+<LineStart>50</LineStart>
+<Snippet>     */
+    @RequestMapping(value = "/referer", produces = "application/javascript")
+    private String referer(HttpServletRequest request) {
+        String callback = request.getParameter("callback");
+        return callback + "(" + getUserInfo2JsonStr(request) + ")";</Snippet>
+<TargetFunction>Function: referer()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="13">
+                        <groupTitle>Poor Error Handling: Overly Broad Throws</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method uploadPicture() in FileUpload.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Declaring a method to throw Exception or Throwable makes it difficult for callers to do good error handling and error recovery. Java's exception mechanism is set up to make it easy for callers to anticipate what can go wrong and write code to handle each specific exceptional circumstance. Declaring that a method throws a generic form of exception defeats this system.
+
+Example: The following method throws three types of exceptions.
+
+
+public void doExchange()
+  throws IOException, InvocationTargetException,
+         SQLException {
+  ...
+}
+
+
+
+While it might seem tidier to write
+
+
+public void doExchange()
+  throws Exception {
+  ...
+}
+
+
+doing so hampers the caller's ability to understand and handle the exceptions that occur. Further, if a later revision of doExchange() introduces a new type of exception that should be treated differently than previous exceptions, there is no easy way to enforce this requirement.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Do not declare methods to throw Exception or Throwable. If the exceptions thrown by a method are not recoverable or should not generally be caught by the caller, consider throwing unchecked exceptions rather than checked exceptions. This can be accomplished by implementing exception classes that extend RuntimeException or Error instead of Exception, or add a try/catch wrapper in your method to convert checked exceptions to unchecked exceptions.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>13</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="5AF71872FDB2D4C68A8E10377535B47F" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method convert() in FileUpload.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>FileUpload.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/FileUpload.java</FilePath>
+<LineStart>145</LineStart>
+<Snippet>     * @return
+     */
+    private File convert(MultipartFile multiFile) throws Exception {
+        String fileName = multiFile.getOriginalFilename();
+        String suffix = fileName.substring(fileName.lastIndexOf("."));</Snippet>
+<TargetFunction>Function: convert()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="797AE1DF09E22C3B00E3021870931063" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method configureGlobal() in WebSecurityConfig.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>WebSecurityConfig.java</FileName>
+<FilePath>src/main/java/org/joychou/security/WebSecurityConfig.java</FilePath>
+<LineStart>101</LineStart>
+<Snippet>
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        auth
+                .inMemoryAuthentication()</Snippet>
+<TargetFunction>Function: configureGlobal()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C111D4FA8D07E4982CA501849B717B11" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method endsWith() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>37</LineStart>
+<Snippet>    @RequestMapping("/endswith")
+    @ResponseBody
+    public String endsWith(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);</Snippet>
+<TargetFunction>Function: endsWith()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7A6CEC06387E000FD01E568BB93AFF79" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method contains() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>57</LineStart>
+<Snippet>    @RequestMapping("/contains")
+    @ResponseBody
+    public String contains(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);</Snippet>
+<TargetFunction>Function: contains()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5D417AFE5D56BAA2644CAE3021D76C54" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method seccode3() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>209</LineStart>
+<Snippet>    @RequestMapping("/seccode3")
+    @ResponseBody
+    public String seccode3(HttpServletRequest request) throws Exception{
+
+        // Define muti-level host whitelist.</Snippet>
+<TargetFunction>Function: seccode3()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C2895DA2891DFD9EFC903357C3E276DC" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method url_bypass() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>123</LineStart>
+<Snippet>    @RequestMapping("/url_bypass")
+    @ResponseBody
+    public String url_bypass(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        System.out.println("url:  " + url);</Snippet>
+<TargetFunction>Function: url_bypass()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="2E755DB7FF51BAC79844724E672051C7" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method configure() in WebSecurityConfig.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>WebSecurityConfig.java</FileName>
+<FilePath>src/main/java/org/joychou/security/WebSecurityConfig.java</FilePath>
+<LineStart>57</LineStart>
+<Snippet>
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        // 默认token存在session里，用CookieCsrfTokenRepository改为token存在cookie里。
+        // 但存在后端多台服务器情况，session不能同步的问题，所以一般使用cookie模式。</Snippet>
+<TargetFunction>Function: configure()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6C3846B560D92A68CA1C3A4D102142FD" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method uploadPicture() in FileUpload.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>FileUpload.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/FileUpload.java</FilePath>
+<LineStart>75</LineStart>
+<Snippet>    // only upload picture
+    @PostMapping("/upload/picture")
+    public String uploadPicture(@RequestParam("file") MultipartFile multifile,
+                                   RedirectAttributes redirectAttributes) throws Exception{
+        if (multifile.isEmpty()) {</Snippet>
+<TargetFunction>Function: uploadPicture()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="DC5D95DFDDB326862F5A0ACFEB29D767" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method parseXml() in XStreamRce.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XStreamRce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XStreamRce.java</FilePath>
+<LineStart>24</LineStart>
+<Snippet>     */
+    @PostMapping("/xstream")
+    public String parseXml(HttpServletRequest request) throws Exception{
+        String xml = WebUtils.getRequestBody(request);
+        XStream xstream = new XStream(new DomDriver());</Snippet>
+<TargetFunction>Function: parseXml()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="CD05EE18D4C2A2293A863068288EE58E" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method seccode2() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>183</LineStart>
+<Snippet>    @RequestMapping("/seccode2")
+    @ResponseBody
+    public String seccode2(HttpServletRequest request) throws Exception{
+        String whiteDomainlists[] = {"aaa.taobao.com", "ccc.bbb.taobao.com"};
+        String url = request.getParameter("url");</Snippet>
+<TargetFunction>Function: seccode2()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="276D68303DF64090AB0861C24119483B" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method indexOf() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>100</LineStart>
+<Snippet>    @RequestMapping("/indexof")
+    @ResponseBody
+    public String indexOf(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);</Snippet>
+<TargetFunction>Function: indexOf()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="32C7FE340F9DA5298E656C8AA45677CA" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method regex() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>78</LineStart>
+<Snippet>    @RequestMapping("/regex")
+    @ResponseBody
+    public String regex(HttpServletRequest request) throws Exception{
+        String url = request.getParameter("url");
+        URL u = new URL(url);</Snippet>
+<TargetFunction>Function: regex()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="96AEB87E78DE2890785CDC21ED6C78A0" ruleID="572EA1F6-FC86-443E-B1A9-A227D5AD17CC">
+                            <Category>Poor Error Handling: Overly Broad Throws</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method seccode1() in URLWhiteList.java throws a generic exception making it harder for callers to do a good job of error handling and recovery.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>154</LineStart>
+<Snippet>    @RequestMapping("/seccode1")
+    @ResponseBody
+    public String seccode1(HttpServletRequest request) throws Exception{
+
+        String whiteDomainlists[] = {"taobao.com", "tmall.com"};</Snippet>
+<TargetFunction>Function: seccode1()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="10">
+                        <groupTitle>J2EE Bad Practices: Leftover Debug Code</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The class Application contains debug code, which can create unintended entry points in a deployed web application.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>A common development practice is to add "back door" code specifically designed for debugging or testing purposes that is not intended to be shipped or deployed with the application. When this sort of debug code is accidentally left in the application, the application is open to unintended modes of interaction. These back door entry points create security risks because they are not considered during design or testing and fall outside of the expected operating conditions of the application.
+
+The most common example of forgotten debug code is a main() method appearing in a web application. Although this is an acceptable practice during product development, classes that are part of a production J2EE application should not define a main().</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Remove debug code before deploying a production version of an application. Regardless of whether a direct security threat can be articulated, it is unlikely that there is a legitimate reason for such code to remain in the application after the early stages of development.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. The presence of a main() method may represent the tip of an iceberg. When you find a main(), look for other indications that developers were rushed or otherwise not able to conclude their efforts normally.
+
+2. If you are auditing a non-J2EE Java application, the J2EE Bad Practices category might not apply to your environment. If this is the case, you can use AuditGuide to suppress these issues.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>10</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="12F9A1CBBCC8C5277EF80945BDB01308" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class XXE contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>419</LineStart>
+<Snippet>
+
+    public static void main(String[] args) throws Exception {
+
+    }</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6DAF0D218A5181441F865BFEDC34D3AD" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class Client contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Client.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Client.java</FilePath>
+<LineStart>10</LineStart>
+<Snippet>    private Client() {}
+
+    public static void main(String[] args) {
+        try {
+            Registry registry = LocateRegistry.getRegistry("localhost");</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D2E7859F37DAADF26103EBF74799ACFB" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class XStreamRce contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XStreamRce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XStreamRce.java</FilePath>
+<LineStart>31</LineStart>
+<Snippet>    }
+
+    public static void main(String[] args) throws Exception {
+        User user = new User();
+        user.setId(0);</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="83E909A2C4DEEF9BC88780085DE580DF" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class AntObjectInputStream contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>AntObjectInputStream.java</FileName>
+<FilePath>src/main/java/org/joychou/security/AntObjectInputStream.java</FilePath>
+<LineStart>52</LineStart>
+<Snippet>    }
+
+    public static void main(String args[]) throws Exception{
+        // 定义myObj对象
+        MyObject myObj = new MyObject();</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="206BA27287169B588B4038B62147817E" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class Application contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Application.java</FileName>
+<FilePath>src/main/java/org/joychou/Application.java</FilePath>
+<LineStart>21</LineStart>
+<Snippet>    }
+
+    public static void main(String[] args) throws Exception {
+        SpringApplication.run(Application.class, args);
+    }</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="ABA6FB3B9A47FEED1E898FF41C46A8E4" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class SpEL contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SpEL.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SpEL.java</FilePath>
+<LineStart>32</LineStart>
+<Snippet>    }
+
+    public static void main(String[] args)  {
+        ExpressionParser parser = new SpelExpressionParser();
+        String expression = "T(java.lang.Runtime).getRuntime().exec(\"open -a Calculator\")";</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="D3BDB91AC7D56408CF8AE1E9C823BCAC" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class Fastjson contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Fastjson.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Fastjson.java</FilePath>
+<LineStart>33</LineStart>
+<Snippet>    }
+
+    public static void main(String[] args) {
+
+        // Open calc in mac</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F5EA14474F0CBFC9A4FBCA78E69552C2" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class xlsxStreamerXXE contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>xlsxStreamerXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/xlsxStreamerXXE.java</FilePath>
+<LineStart>41</LineStart>
+<Snippet>
+
+    public static void main(String[] args) throws Exception {
+        Workbook wb = StreamingReader.builder().open((new FileInputStream("poc.xlsx")));
+    }</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1C0E0433BDF69E088CF2631F0FF1E6B2" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class PathTraversal contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>PathTraversal.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/PathTraversal.java</FilePath>
+<LineStart>52</LineStart>
+<Snippet>    }
+
+    public static void main(String[] argv) throws IOException {
+        String aa = new String(Files.readAllBytes(Paths.get("pom.xml")), StandardCharsets.UTF_8);
+        System.out.println(aa);</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="3E900D38CEC28E16EACA4BC1BBD1E837" ruleID="625EEE1F-464F-42DC-85D6-269A637EF747">
+                            <Category>J2EE Bad Practices: Leftover Debug Code</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>The class Server contains debug code, which can create unintended entry points in a deployed web application.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Server.java</FileName>
+<FilePath>src/main/java/org/joychou/RMI/Server.java</FilePath>
+<LineStart>15</LineStart>
+<Snippet>    }
+
+    public static void main(String args[]) {
+
+        try {</Snippet>
+<TargetFunction>Function: main()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="7">
+                        <groupTitle>Denial of Service: StringBuilder</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The call to append() in SSRF.java on line 51 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Appending user-controlled data to a StringBuilder instance initialized with the default backing character array size (16) can cause the application to consume large amounts of heap memory while resizing the underlying array to fit user's data. Everytime new data is appended to a StringBuilder instance, it will try to fit it on its backing character array. If data does not fit, a new array will be created doubling the previous size while the old array will remain in the heap until it is garbage collected. This defect can be used to execute a Denial of Service (DoS) attack.
+
+Example 1: User-controlled data is appended to a StringBuilder instance initialized with the default constructor.
+
+    ...
+    StringBuilder sb = new StringBuilder();
+    sb.append(request.getParameter("foo"));
+    ...
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Initialize the StringBuilder with a size similar to the length of the expected data in order to reduce the number of times the backing array needs to be resized. Check the size of the data before appending it to a StringBuilder instance.
+
+Example 2: User-controlled data is appended to a StringBuilder instance initialized with the default constructor.
+
+    ...
+    private final int MAX_DATA = 128;
+    private final int EXPECTED_BUFFER_DATA = 1024;
+    StringBuilder sb = new StringBuilder(EXPECTED_BUFFER_DATA);
+    ...
+    String data = request.getParameter("foo");
+    if (data.length() &lt; MAX_DATA) sb.append(data);
+    ...
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>7</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="80F03E1942DEDF63873BF5A2B54A5FC5" ruleID="F2BD85B8-504E-4D52-967C-E00A043BAFAD">
+                            <Category>Denial of Service: StringBuilder</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to append() in SSRF.java on line 76 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>76</LineStart>
+<Snippet>
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }
+            in.close();</Snippet>
+<TargetFunction>java.lang.StringBuffer.append()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>75</LineStart>
+<Snippet>            StringBuffer html = new StringBuffer();
+
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }</Snippet>
+<TargetFunction>java.io.BufferedReader.readLine()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="B95293077051404DB63E1EAC72F6086E" ruleID="F2BD85B8-504E-4D52-967C-E00A043BAFAD">
+                            <Category>Denial of Service: StringBuilder</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to append() in XXE.java on line 269 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>269</LineStart>
+<Snippet>                    // 正常解析XML，需要判断是否是ELEMENT_NODE类型。否则会出现多余的的节点。
+                    if (child.item(j).getNodeType() == Node.ELEMENT_NODE) {
+                        result.append(node.getNodeName() + ": " + node.getFirstChild().getNodeValue() + "\n");
+                    }
+                }</Snippet>
+<TargetFunction>java.lang.StringBuffer.append()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="C3388893BFAB27FD15C4FD5AD3CB822C" ruleID="F2BD85B8-504E-4D52-967C-E00A043BAFAD">
+                            <Category>Denial of Service: StringBuilder</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to append() in SSRF.java on line 51 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>51</LineStart>
+<Snippet>
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }
+            in.close();</Snippet>
+<TargetFunction>java.lang.StringBuffer.append()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>50</LineStart>
+<Snippet>            StringBuffer html = new StringBuffer();
+
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }</Snippet>
+<TargetFunction>java.io.BufferedReader.readLine()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="FCB0E476FA519F1529F0244CD23FC996" ruleID="F2BD85B8-504E-4D52-967C-E00A043BAFAD">
+                            <Category>Denial of Service: StringBuilder</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to append() in SSRF.java on line 76 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>76</LineStart>
+<Snippet>
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }
+            in.close();</Snippet>
+<TargetFunction>java.lang.StringBuffer.append()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>71</LineStart>
+<Snippet>            URLConnection urlConnection = u.openConnection();
+            HttpURLConnection httpUrl = (HttpURLConnection)urlConnection;
+            BufferedReader in = new BufferedReader(new InputStreamReader(httpUrl.getInputStream())); //send request
+            String inputLine;
+            StringBuffer html = new StringBuffer();</Snippet>
+<TargetFunction>java.net.URLConnection.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="CF30980912E2C86F36C8C23B5219E108" ruleID="F2BD85B8-504E-4D52-967C-E00A043BAFAD">
+                            <Category>Denial of Service: StringBuilder</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to append() in SSRF.java on line 51 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>51</LineStart>
+<Snippet>
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }
+            in.close();</Snippet>
+<TargetFunction>java.lang.StringBuffer.append()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>46</LineStart>
+<Snippet>            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();
+            BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream())); //send request
+            String inputLine;
+            StringBuffer html = new StringBuffer();</Snippet>
+<TargetFunction>java.net.URLConnection.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="68C9C40A1DA8BD37FA04CBE232F729F8" ruleID="F2BD85B8-504E-4D52-967C-E00A043BAFAD">
+                            <Category>Denial of Service: StringBuilder</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to append() in SSRF.java on line 183 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>183</LineStart>
+<Snippet>            String line = "";
+            while ((line = rd.readLine()) != null) {
+                result.append(line);
+            }
+            return result.toString();</Snippet>
+<TargetFunction>java.lang.StringBuffer.append()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>182</LineStart>
+<Snippet>            StringBuffer result = new StringBuffer();
+            String line = "";
+            while ((line = rd.readLine()) != null) {
+                result.append(line);
+            }</Snippet>
+<TargetFunction>java.io.BufferedReader.readLine()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="9D68C5AFC19BA7DDA294DEB81CD4D052" ruleID="F2BD85B8-504E-4D52-967C-E00A043BAFAD">
+                            <Category>Denial of Service: StringBuilder</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to append() in XXE.java on line 234 appends untrusted data to a StringBuilder instance initialized with the default backing-array size (16). This can cause the JVM to over-consume heap memory space.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>234</LineStart>
+<Snippet>                for (int j = 0; j &lt; child.getLength(); j++) {
+                    Node node = child.item(j);
+                    buf.append(node.getNodeName() + ": " + node.getTextContent() + "\n");
+                }
+            }</Snippet>
+<TargetFunction>java.lang.StringBuffer.append()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="7">
+                        <groupTitle>Missing XML Validation</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method xxe_SAXParser() in XXE.java fails to enable validation before parsing XML on line 147, which gives an attacker the opportunity to supply malicious input.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Most successful attacks begin with a violation of the programmer's assumptions. By accepting an XML document without validating it against a DTD or XML schema, the programmer leaves a door open for attackers to provide unexpected, unreasonable, or malicious input. It is not possible for an XML parser to validate all aspects of a document's content; a parser cannot understand the complete semantics of the data. However, a parser can do a complete and thorough job of checking the document's structure and therefore guarantee to the code that processes the document that the content is well-formed.
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Always enable validation when you create an XML parser or parser factory. If enabling validation causes problems because the rules for defining a well-formed document are Byzantine or altogether unknown, chances are good that there are security errors nearby.
+
+Below are examples that demonstrate how to enable validation for the Xerces parsers (both DOM and SAX):
+
+
+org.apache.xerces.framework.XMLParser: parser.setValidation(true);
+org.apache.xerces.framework.XMLParser: parser.setValidationSchema(true);
+
+
+The following examples demonstrate how to enable validation for the SAX and DOM parser factories in the javax library.
+
+javax SAX parser factory:
+
+
+javax.xml.parsers.SAXParserFactory: factory.setValidating(true);
+javax.xml.parsers.SAXParserFactory: factory.setFeature("http://xml.org/sax/features/validation", true);
+
+
+javax DOM parser factory:
+
+
+javax.xml.parsers.DocumentBuilderFactory: factory.setValidating(true);
+
+
+The following examples demonstrate how to enable validation for individual parsers and XMLReaders in the javax library.
+
+Note: The Fortify Software Security Research group does not recommend enabling validation by this method. Instead, you should enable validation at the parser factory.
+
+javax SAX parser and reader:
+
+
+javax.xml.parsers.SAXParser: parser.setProperty("http://xml.org/sax/features/validation", new Boolean(true));
+org.xml.sax.XMLReader: reader.setFeature("http://xml.org/sax/features/validation", true);
+
+
+The following examples demonstrate how to set the XML return type for Apache Axis.
+
+Axis client Call:
+
+
+call.addParameter("testParam", org.apache.axis.Constants.XSD_STRING, javax.xml.rpc.ParameterMode.IN);
+call.setReturnType(org.apache.axis.Constants.XSD_STRING);
+String ret = (String) call.invoke( new Object[] { "Hello!" } );
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. The Fortify Secure Coding Rulepacks checks to ensure that javax parser factories enable validation before they are used to create parsers. By ensuring that the parser factory always creates validating parsers, there is less opportunity for error when creating and using a parser.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>7</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="FC8B62D0316FDD5788B788AAE4BC9BA8" ruleID="6205D59D-EEEC-42B0-9522-1FE15F05E302">
+                            <Category>Missing XML Validation</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method xxe_SAXParser_fix() in XXE.java fails to enable validation before parsing XML on line 168, which gives an attacker the opportunity to supply malicious input.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>168</LineStart>
+<Snippet>            spf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            SAXParser parser = spf.newSAXParser();
+            parser.parse(new InputSource(new StringReader(xml_con)), new DefaultHandler());  // parse xml
+            return "test";
+        } catch (Exception e) {</Snippet>
+<TargetFunction>parser.parse(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="0F26395B790E8135A5F3386A163235C3" ruleID="6205D59D-EEEC-42B0-9522-1FE15F05E302">
+                            <Category>Missing XML Validation</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method DocumentBuilder() in XXE.java fails to enable validation before parsing XML on line 257, which gives an attacker the opportunity to supply malicious input.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>257</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            // 遍历xml节点name和value</Snippet>
+<TargetFunction>db.parse(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="EBA62FFC59E75AD805B27949C029B2BC" ruleID="6205D59D-EEEC-42B0-9522-1FE15F05E302">
+                            <Category>Missing XML Validation</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method xxeDocumentBuilderReturn() in XXE.java fails to enable validation before parsing XML on line 224, which gives an attacker the opportunity to supply malicious input.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>224</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            // 遍历xml节点name和value</Snippet>
+<TargetFunction>db.parse(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="FBAB8429E630B076302C4DCB53CE71CF" ruleID="6205D59D-EEEC-42B0-9522-1FE15F05E302">
+                            <Category>Missing XML Validation</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method xxe_SAXParser() in XXE.java fails to enable validation before parsing XML on line 147, which gives an attacker the opportunity to supply malicious input.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>147</LineStart>
+<Snippet>            SAXParserFactory spf = SAXParserFactory.newInstance();
+            SAXParser parser = spf.newSAXParser();
+            parser.parse(new InputSource(new StringReader(xml_con)), new DefaultHandler());  // parse xml
+
+            return "test";</Snippet>
+<TargetFunction>parser.parse(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7F6AA97C7C98EDEB1FBAFA2C86392DD1" ruleID="6205D59D-EEEC-42B0-9522-1FE15F05E302">
+                            <Category>Missing XML Validation</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method xxe_DocumentBuilder_fix() in XXE.java fails to enable validation before parsing XML on line 296, which gives an attacker the opportunity to supply malicious input.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>296</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+            sr.close();
+</Snippet>
+<TargetFunction>db.parse(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="CC7A10CB180F0D3AC8A64175767A7C71" ruleID="6205D59D-EEEC-42B0-9522-1FE15F05E302">
+                            <Category>Missing XML Validation</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method xxe_xinclude_DocumentBuilder() in XXE.java fails to enable validation before parsing XML on line 319, which gives an attacker the opportunity to supply malicious input.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>319</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            NodeList rootNodeList = document.getChildNodes();</Snippet>
+<TargetFunction>db.parse(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="AAF7F7FE5113305AFC097D4AE4942EAD" ruleID="6205D59D-EEEC-42B0-9522-1FE15F05E302">
+                            <Category>Missing XML Validation</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method xxe_xinclude_DocumentBuilder_fix() in XXE.java fails to enable validation before parsing XML on line 358, which gives an attacker the opportunity to supply malicious input.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>358</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            NodeList rootNodeList = document.getChildNodes();</Snippet>
+<TargetFunction>db.parse(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Missing Check against Null</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method CommandExec() in Rce.java can dereference a null pointer on line 26 because it does not check the return value of getParameter(), which might return null.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Just about every serious attack on a software system begins with the violation of a programmer's assumptions. After the attack, the programmer's assumptions seem flimsy and poorly founded, but before an attack many programmers would defend their assumptions well past the end of their lunch break.
+
+Two dubious assumptions that are easy to spot in code are "this function call can never fail" and "it doesn't matter if this function call fails". When a programmer ignores the return value from a function, they implicitly state that they are operating under one of these assumptions.
+
+
+
+Example 1:  The following code does not check to see if the string returned by getParameter() is null before calling the member function compareTo(), potentially causing a null dereference.
+
+
+String itemName = request.getParameter(ITEM_NAME);
+	if (itemName.compareTo(IMPORTANT_ITEM)) {
+		...
+	}
+	...
+
+
+Example 2:. The following code shows a system property that is set to null and later dereferenced by a programmer who mistakenly assumes it will always be defined.
+
+
+System.clearProperty("os.name");
+...
+String os = System.getProperty("os.name");
+if (os.equalsIgnoreCase("Windows 95") )
+	System.out.println("Not supported");
+
+
+The traditional defense of this coding error is:
+
+"I know the requested value will always exist because.... If it does not exist, the program cannot perform the desired behavior so it doesn't matter whether I handle the error or simply allow the program to die dereferencing a null value."
+
+But attackers are skilled at finding unexpected paths through programs, particularly when exceptions are involved.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>If a function can return an error code or any other evidence of its success or failure, always check for the error condition, even if there is no obvious way for it to occur. In addition to preventing security errors, many initially mysterious bugs have eventually led back to a failed method call with an unchecked return value.
+
+Create an easy to use and standard way for dealing with failure in your application. If error handling is straightforward, programmers will be less inclined to omit it. One approach to standardized error handling is to write wrappers around commonly-used functions that check and handle error conditions without additional programmer intervention. When wrappers are implemented and adopted, the use of non-wrapped equivalents can be prohibited and enforced by using custom rules.
+
+Example 3: The following code implements a wrapper around getParameter() that checks the return value of getParameter() against null and uses a default value if the requested parameter is not defined.
+
+
+String safeGetParameter (HttpRequest request, String name)
+{
+    String value = request.getParameter(name);
+    if (value == null) {
+        return getDefaultValue(name)
+    }
+    return value;
+}
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Watch out for programmers who want to explain away this type of issue by saying "that can never happen because ...". Chances are good that they have developed their intuition about the way the system works by using their development workstation. If your software will eventually run under different operating systems, operating system versions, hardware configurations, or runtime environments, their intuition may not apply.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>6</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="5FDDB802547853EB91B5E9F74656E70C" ruleID="4280F38B-9FDB-454E-B495-89CF45CD51B7">
+                            <Category>Missing Check against Null</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The method ssrf_ImageIO_safecode() in SSRF.java can dereference a null pointer on line 253 because it does not check the return value of getParameter(), which might return null.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>250</LineStart>
+<Snippet>    @ResponseBody
+    public static String ssrf_ImageIO_safecode(HttpServletRequest request) {
+        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);</Snippet>
+<TargetFunction>url = getParameter(...) : ServletRequest.getParameter may return NULL()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="91FC194EA2638CE207E4D2665D20ED87" ruleID="4280F38B-9FDB-454E-B495-89CF45CD51B7">
+                            <Category>Missing Check against Null</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The method seccode1() in URLWhiteList.java can dereference a null pointer on line 160 because it does not check the return value of getParameter(), which might return null.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>157</LineStart>
+<Snippet>
+        String whiteDomainlists[] = {"taobao.com", "tmall.com"};
+        String url = request.getParameter("url");
+
+        URI uri = new URI(url);</Snippet>
+<TargetFunction>url = getParameter(...) : ServletRequest.getParameter may return NULL()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="FCA3A4C5E835F6B5FA45C48C95FE5B94" ruleID="4280F38B-9FDB-454E-B495-89CF45CD51B7">
+                            <Category>Missing Check against Null</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The method seccode3() in URLWhiteList.java can dereference a null pointer on line 219 because it does not check the return value of getParameter(), which might return null.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>216</LineStart>
+<Snippet>        whiteDomainlists.add("ccc.bbb.taobao.com");
+
+        String url = request.getParameter("url");
+        URI uri = new URI(url);
+</Snippet>
+<TargetFunction>url = getParameter(...) : ServletRequest.getParameter may return NULL()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="982A2EA0E356E54A1DA7E32A43C514FC" ruleID="4280F38B-9FDB-454E-B495-89CF45CD51B7">
+                            <Category>Missing Check against Null</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The method commonsHttpClient() in SSRF.java can dereference a null pointer on line 206 because it does not check the return value of getParameter(), which might return null.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>203</LineStart>
+<Snippet>    public static String commonsHttpClient(HttpServletRequest request) {
+
+        String url = request.getParameter("url");
+
+        // Security check</Snippet>
+<TargetFunction>url = getParameter(...) : ServletRequest.getParameter may return NULL()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="7D320B92FEC687FC4F8C5C2DC32C9344" ruleID="4280F38B-9FDB-454E-B495-89CF45CD51B7">
+                            <Category>Missing Check against Null</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The method CommandExec() in Rce.java can dereference a null pointer on line 26 because it does not check the return value of getParameter(), which might return null.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>26</LineStart>
+<Snippet>    @ResponseBody
+    public String CommandExec(HttpServletRequest request) {
+        String cmd = request.getParameter("cmd").toString();
+        Runtime run = Runtime.getRuntime();
+        String lineStr = "";</Snippet>
+<TargetFunction>getParameter(...) : ServletRequest.getParameter may return NULL()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="3F717786CBADBE196369C44ABA58E753" ruleID="4280F38B-9FDB-454E-B495-89CF45CD51B7">
+                            <Category>Missing Check against Null</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The method seccode2() in URLWhiteList.java can dereference a null pointer on line 188 because it does not check the return value of getParameter(), which might return null.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>185</LineStart>
+<Snippet>    public String seccode2(HttpServletRequest request) throws Exception{
+        String whiteDomainlists[] = {"aaa.taobao.com", "ccc.bbb.taobao.com"};
+        String url = request.getParameter("url");
+
+        URI uri = new URI(url);</Snippet>
+<TargetFunction>url = getParameter(...) : ServletRequest.getParameter may return NULL()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Portability Flaw: Locale Dependent Comparison</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The call to equals()  on line 93 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>When comparing data that may be locale-dependent, an appropriate locale should be specified.
+
+Example 1: The following example tries to perform validation to determine if user input includes a &lt;script&gt; tag.
+
+  ...
+  public String tagProcessor(String tag){
+    if (tag.toUpperCase().equals("SCRIPT")){
+      return null;
+    }
+    //does not contain SCRIPT tag, keep processing input
+    ...
+  }
+  ...
+
+
+The problem with the above code is that java.lang.String.toUpperCase() when used without a locale uses the rules of the default locale. Using the Turkish locale "title".toUpperCase() returns "T\u0130TLE", where "\u0130" is the "LATIN CAPITAL LETTER I WITH DOT ABOVE" character. This can lead to unexpected results, such as in Example 1 where this will prevent the word "script" from being caught by this validation, potentially leading to a Cross-Site Scripting vulnerability.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>To prevent this from occurring, always make sure to either specify the default locale, or specify the locale with APIs that accept them such as toUpperCase().
+
+Example 2: The following specifies the locale manually as an argument to toUpperCase().
+
+
+import java.util.Locale;
+  ...
+  public String tagProcessor(String tag){
+    if (tag.toUpperCase(Locale.ENGLISH).equals("SCRIPT")){
+      return null;
+    }
+    //does not contain SCRIPT tag, keep processing input
+    ...
+  }
+  ...
+
+
+Example 3: The following uses the function java.lang.String.equalsIgnoreCase() API to prevent this issue.
+
+
+  ...
+  public String tagProcessor(String tag){
+    if (tag.equalsIgnoreCase("SCRIPT")){
+      return null;
+    }
+    //does not contain SCRIPT tag, keep processing input
+    ...
+  }
+  ...
+
+
+This prevents the problem because equalsIgnoreCase() changes case similar to Character.toLowerCase() and Character.toUpperCase(). This involves creating temporary canonical forms of both strings using information from the UnicodeData file that is part of the Unicode Character Database maintained by the Unicode Consortium, and even though this may render them unreadable if they were to be read out, it makes comparison possible without being dependent upon locale.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. If SCA sees that java.util.Locale.setDefault() is called anywhere in the application, it will assume that the locale has been set accordingly and these issues will also not appear.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>6</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="0A018B16E8B7CC6D5E05715EB581715F" ruleID="D8E9ED3B-22EC-4CBA-98C8-7C67F73CCF4C">
+                            <Category>Portability Flaw: Locale Dependent Comparison</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The call to equals()  on line 93 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>FileUpload.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/FileUpload.java</FilePath>
+<LineStart>93</LineStart>
+<Snippet>        Boolean suffixFlag = false;
+        for (String white_suffix : picSuffixList) {
+            if (Suffix.toLowerCase().equals(white_suffix)) {
+                suffixFlag = true;
+                break;</Snippet>
+<TargetFunction>Suffix.toLowerCase().equals(...) : Comparison without checking locale()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="EAE70B9FA397C6A35ED1110C6B0052ED" ruleID="D8E9ED3B-22EC-4CBA-98C8-7C67F73CCF4C">
+                            <Category>Portability Flaw: Locale Dependent Comparison</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The call to equals()  on line 195 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>195</LineStart>
+<Snippet>        // equals
+        for (String domain: whiteDomainlists){
+            if (host.equals(domain)) {
+                return "Good url.";
+            }</Snippet>
+<TargetFunction>host.equals(...) : Comparison without checking locale()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="3BE8B2D4AB979C48DC8A4D487747B781" ruleID="D8E9ED3B-22EC-4CBA-98C8-7C67F73CCF4C">
+                            <Category>Portability Flaw: Locale Dependent Comparison</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The call to endsWith()  on line 137 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>137</LineStart>
+<Snippet>        // endsWith .
+        for (String domain: domainwhitelist){
+            if (host.endsWith("." + domain)) {
+                return "Good url.";
+            }</Snippet>
+<TargetFunction>host.endsWith(...) : Comparison without checking locale()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="3CF5A203199D0BD0129B7FF8AF658F4C" ruleID="D8E9ED3B-22EC-4CBA-98C8-7C67F73CCF4C">
+                            <Category>Portability Flaw: Locale Dependent Comparison</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The call to endsWith()  on line 43 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>
+        for (String domain: domainwhitelist){
+            if (host.endsWith(domain)) {
+                return "Good url.";
+            }</Snippet>
+<TargetFunction>host.endsWith(...) : Comparison without checking locale()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="C88EE7A76639E717863B5821160AB1C5" ruleID="D8E9ED3B-22EC-4CBA-98C8-7C67F73CCF4C">
+                            <Category>Portability Flaw: Locale Dependent Comparison</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The call to endsWith()  on line 36 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SecurityUtil.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SecurityUtil.java</FilePath>
+<LineStart>36</LineStart>
+<Snippet>            String host = uri.getHost().toLowerCase();
+            for (String whitelist: urlwhitelist){
+                if (host.endsWith("." + whitelist)) {
+                    return true;
+                }</Snippet>
+<TargetFunction>host.endsWith(...) : Comparison without checking locale()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="21B2D3996C7693DAC54DBF91EB4816D9" ruleID="D8E9ED3B-22EC-4CBA-98C8-7C67F73CCF4C">
+                            <Category>Portability Flaw: Locale Dependent Comparison</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The call to endsWith()  on line 168 causes portability problems because it has different locales which may lead to unexpected output. This may also circumvent custom validation routines.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>URLWhiteList.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLWhiteList.java</FilePath>
+<LineStart>168</LineStart>
+<Snippet>        // endsWith .
+        for (String domain: whiteDomainlists){
+            if (host.endsWith("." + domain)) {
+                return "Good url.";
+            }</Snippet>
+<TargetFunction>host.endsWith(...) : Comparison without checking locale()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Unreleased Resource: Database</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The function jdbc_sqli_vul() in SQLI.java sometimes fails to release a database resource allocated by getConnection() on line 48.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Resource leaks have at least two common causes:
+
+- Error conditions and other exceptional circumstances.
+
+- Confusion over which part of the program is responsible for releasing the resource.
+
+Most unreleased resource issues result in general software reliability problems. However, if an attacker can intentionally trigger a resource leak, the attacker may be able to launch a denial of service attack by depleting the resource pool.
+
+Example: Under normal conditions, the following code executes a database query, processes the results returned by the database, and closes the allocated statement object. But if an exception occurs while executing the SQL or processing the results, the statement object will not be closed. If this happens often enough, the database will run out of available cursors and not be able to execute any more SQL queries.
+
+  Statement stmt = conn.createStatement();
+  ResultSet rs = stmt.executeQuery(CXN_SQL);
+  harvestResults(rs);
+  stmt.close();
+
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>1. Never rely on finalize() to reclaim resources. In order for an object's finalize() method to be invoked, the garbage collector must determine that the object is eligible for garbage collection. Because the garbage collector is not required to run unless the JVM is low on memory, there is no guarantee that an object's finalize() method will be invoked in an expedient fashion. When the garbage collector finally does run, it may cause a large number of resources to be reclaimed in a short period of time, which can lead to "bursty" performance and lower overall system throughput. This effect becomes more pronounced as the load on the system increases.
+
+Finally, if it is possible for a resource reclamation operation to hang (if it requires communicating over a network to a database, for example), then the thread that is executing the finalize() method will hang.
+
+2. Release resources in a finally block. The code for the Example should be rewritten as follows:
+
+
+  public void execCxnSql(Connection conn) {
+    Statement stmt;
+    try {
+      stmt = conn.createStatement();
+      ResultSet rs = stmt.executeQuery(CXN_SQL);
+      ...
+    }
+    finally {
+      if (stmt != null) {
+        safeClose(stmt);
+      }
+    }
+}
+
+public static void safeClose(Statement stmt) {
+  if (stmt != null) {
+    try {
+      stmt.close();
+    } catch (SQLException e) {
+      log(e);
+    }
+  }
+}
+
+
+This solution uses a helper function to log the exceptions that might occur when trying to close the statement. Presumably this helper function will be reused whenever a statement needs to be closed.
+
+Also, the execCxnSql method does not initialize the stmt object to null. Instead, it checks to ensure that stmt is not null before calling safeClose(). Without the null check, the Java compiler reports that stmt might not be initialized. This choice takes advantage of Java's ability to detect uninitialized variables. If stmt is initialized to null in a more complex method, cases in which stmt is used without being initialized will not be detected by the compiler.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Be aware that closing a database connection may or may not automatically free other resources associated with the connection object. If the application uses connection pooling, it is best to explicitly close the other resources after the connection is closed. If the application is not using connection pooling, the other resources are automatically closed when the database connection is closed. In such a case, this vulnerability is invalid.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>6</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="8DFEC788F40C9C8BE6118FF5C1DEAA33" ruleID="789BB115-AAF5-4C03-BBC2-C4CFCC74C13A">
+                            <Category>Unreleased Resource: Database</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function jdbc_sqli_vul() in SQLI.java sometimes fails to release a database resource allocated by getConnection() on line 48.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>57</LineStart>
+<Snippet>             String sql = "select * from users where username = '" + username + "'";
+             System.out.println(sql);
+             ResultSet rs = statement.executeQuery(sql);
+
+</Snippet>
+<TargetFunction>rs = statement.executeQuery(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="2EF9DB8813CBC7D5F70E24313D11263F" ruleID="B7DFF4A8-9817-4418-A35B-E70D10DC825E">
+                            <Category>Unreleased Resource: Database</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function jdbc_sqli_vul() in SQLI.java sometimes fails to release a database resource allocated by getConnection() on line 48.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>48</LineStart>
+<Snippet>        try {
+            Class.forName(driver);
+            Connection con = DriverManager.getConnection(url, user, password);
+
+            if(!con.isClosed())</Snippet>
+<TargetFunction>con = getConnection(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="4F9E14E96FF5388281307E5902CA799D" ruleID="789BB115-AAF5-4C03-BBC2-C4CFCC74C13A">
+                            <Category>Unreleased Resource: Database</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function jdbc_sqli_sec() in SQLI.java sometimes fails to release a database resource allocated by getConnection() on line 101.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>112</LineStart>
+<Snippet>            st.setString(1, username);
+            System.out.println(st.toString());  // sql after prepare statement
+            ResultSet rs = st.executeQuery();
+
+            System.out.println("-----------------");</Snippet>
+<TargetFunction>rs = st.executeQuery()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="17EB747603A473CF938DB45381DDCD4F" ruleID="B7DFF4A8-9817-4418-A35B-E70D10DC825E">
+                            <Category>Unreleased Resource: Database</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function jdbc_sqli_sec() in SQLI.java sometimes fails to release a database resource allocated by getConnection() on line 101.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>101</LineStart>
+<Snippet>        try {
+            Class.forName(driver);
+            Connection con = DriverManager.getConnection(url, user, password);
+
+            if(!con.isClosed())</Snippet>
+<TargetFunction>con = getConnection(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="916D0F733F7811FDAC987EA99AE9E694" ruleID="EC71C442-6E66-45DF-9890-41A5156B1CD0">
+                            <Category>Unreleased Resource: Database</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function jdbc_sqli_sec() in SQLI.java sometimes fails to release a database resource allocated by getConnection() on line 101.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>109</LineStart>
+<Snippet>            // fix code
+            String sql = "select * from users where username = ?";
+            PreparedStatement st = con.prepareStatement(sql);
+            st.setString(1, username);
+            System.out.println(st.toString());  // sql after prepare statement</Snippet>
+<TargetFunction>st = con.prepareStatement(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="42650340402AE045E918038570774B4D" ruleID="EC71C442-6E66-45DF-9890-41A5156B1CD0">
+                            <Category>Unreleased Resource: Database</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function jdbc_sqli_vul() in SQLI.java sometimes fails to release a database resource allocated by getConnection() on line 48.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>54</LineStart>
+<Snippet>
+            // sqli vuln code 漏洞代码
+             Statement statement = con.createStatement();
+             String sql = "select * from users where username = '" + username + "'";
+             System.out.println(sql);</Snippet>
+<TargetFunction>statement = con.createStatement()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Unreleased Resource: Streams</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The function convert() in FileUpload.java sometimes fails to release a system resource allocated by FileOutputStream() on line 152.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>The program can potentially fail to release a system resource.
+
+Resource leaks have at least two common causes:
+
+- Error conditions and other exceptional circumstances.
+
+- Confusion over which part of the program is responsible for releasing the resource.
+
+Most unreleased resource issues result in general software reliability problems. However, if an attacker can intentionally trigger a resource leak, the attacker may be able to launch a denial of service attack by depleting the resource pool.
+
+Example: The following method never closes the file handle it opens. The finalize() method for FileInputStream eventually calls close(), but there is no guarantee as to how long it will take before the finalize() method will be invoked. In a busy environment, this can result in the JVM using up all of its file handles.
+
+private void processFile(String fName) throws FileNotFoundException, IOException {
+  FileInputStream fis = new FileInputStream(fName);
+  int sz;
+  byte[] byteArray = new byte[BLOCK_SIZE];
+  while ((sz = fis.read(byteArray)) != -1) {
+    processBytes(byteArray, sz);
+  }
+}
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>1. Never rely on finalize() to reclaim resources. In order for an object's finalize() method to be invoked, the garbage collector must determine that the object is eligible for garbage collection. Because the garbage collector is not required to run unless the JVM is low on memory, there is no guarantee that an object's finalize() method will be invoked in an expedient fashion. When the garbage collector finally does run, it may cause a large number of resources to be reclaimed in a short period of time, which can lead to "bursty" performance and lower overall system throughput. This effect becomes more pronounced as the load on the system increases.
+
+Finally, if it is possible for a resource reclamation operation to hang (if it requires communicating over a network to a database, for example), then the thread that is executing the finalize() method will hang.
+
+2. Release resources in a finally block. The code for the Example should be rewritten as follows:
+
+
+public void processFile(String fName) throws FileNotFoundException, IOException {
+  FileInputStream fis;
+  try {
+    fis = new FileInputStream(fName);
+    int sz;
+    byte[] byteArray = new byte[BLOCK_SIZE];
+    while ((sz = fis.read(byteArray)) != -1) {
+      processBytes(byteArray, sz);
+    }
+  }
+  finally {
+    if (fis != null) {
+      safeClose(fis);
+    }
+  }
+}
+
+public static void safeClose(FileInputStream fis) {
+  if (fis != null) {
+    try {
+      fis.close();
+    } catch (IOException e) {
+      log(e);
+    }
+  }
+}
+
+
+This solution uses a helper function to log the exceptions that might occur when trying to close the stream. Presumably this helper function will be reused whenever a stream needs to be closed.
+
+Also, the processFile method does not initialize the fis object to null. Instead, it checks to ensure that fis is not null before calling safeClose(). Without the null check, the Java compiler reports that fis might not be initialized. This choice takes advantage of Java's ability to detect uninitialized variables. If fis is initialized to null in a more complex method, cases in which fis is used without being initialized will not be detected by the compiler.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>6</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="F18A56B79F8ACA6C28DF23FC51D43C33" ruleID="74714BFC-EDF7-445B-8672-0996214D5845">
+                            <Category>Unreleased Resource: Streams</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function ssrf_URLConnection() in SSRF.java sometimes fails to release a system resource allocated by getInputStream() on line 46.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>46</LineStart>
+<Snippet>            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();
+            BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream())); //send request
+            String inputLine;
+            StringBuffer html = new StringBuffer();</Snippet>
+<TargetFunction>in = new BufferedReader(new java.io.InputStreamReader())</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F555F2FD6E95BD89C62881EF63D062C5" ruleID="74714BFC-EDF7-445B-8672-0996214D5845">
+                            <Category>Unreleased Resource: Streams</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function main() in AntObjectInputStream.java sometimes fails to release a system resource allocated by FileOutputStream() on line 58.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>AntObjectInputStream.java</FileName>
+<FilePath>src/main/java/org/joychou/security/AntObjectInputStream.java</FilePath>
+<LineStart>59</LineStart>
+<Snippet>        // 创建一个包含对象进行反序列化信息的/tmp/object数据文件
+        FileOutputStream fos = new FileOutputStream("/tmp/object");
+        ObjectOutputStream os = new ObjectOutputStream(fos);
+
+        // writeObject()方法将myObj对象写入/tmp/object文件</Snippet>
+<TargetFunction>os = new ObjectOutputStream(fos)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="680351B5D2D75E0BDFEDFE91408771B6" ruleID="74714BFC-EDF7-445B-8672-0996214D5845">
+                            <Category>Unreleased Resource: Streams</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function main() in AntObjectInputStream.java sometimes fails to release a system resource allocated by FileInputStream() on line 66.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>AntObjectInputStream.java</FileName>
+<FilePath>src/main/java/org/joychou/security/AntObjectInputStream.java</FilePath>
+<LineStart>67</LineStart>
+<Snippet>        // 从文件中反序列化obj对象
+        FileInputStream fis = new FileInputStream("/tmp/object");
+        AntObjectInputStream ois = new AntObjectInputStream(fis);  // AntObjectInputStream class
+
+        //恢复对象即反序列化</Snippet>
+<TargetFunction>ois = new AntObjectInputStream(fis)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="58131919F7B296B6A50B4C321B24DE3A" ruleID="74714BFC-EDF7-445B-8672-0996214D5845">
+                            <Category>Unreleased Resource: Streams</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function convert() in FileUpload.java sometimes fails to release a system resource allocated by FileOutputStream() on line 152.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>FileUpload.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/FileUpload.java</FilePath>
+<LineStart>152</LineStart>
+<Snippet>        File convFile = new File(UPLOADED_FOLDER + uuid + suffix);
+        convFile.createNewFile();
+        FileOutputStream fos = new FileOutputStream(convFile);
+        fos.write(multiFile.getBytes());
+        fos.close();</Snippet>
+<TargetFunction>fos = new FileOutputStream(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="A68FC2FD4958467757C2B687845AAFDA" ruleID="74714BFC-EDF7-445B-8672-0996214D5845">
+                            <Category>Unreleased Resource: Streams</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function main() in xlsxStreamerXXE.java sometimes fails to release a system resource allocated by FileInputStream() on line 42.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>xlsxStreamerXXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/othervulns/xlsxStreamerXXE.java</FilePath>
+<LineStart>42</LineStart>
+<Snippet>
+    public static void main(String[] args) throws Exception {
+        Workbook wb = StreamingReader.builder().open((new FileInputStream("poc.xlsx")));
+    }
+}</Snippet>
+<TargetFunction>new FileInputStream(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="037A7F81AACB1C80E7116E610B463F1B" ruleID="74714BFC-EDF7-445B-8672-0996214D5845">
+                            <Category>Unreleased Resource: Streams</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The function ssrf_httpURLConnection() in SSRF.java sometimes fails to release a system resource allocated by getInputStream() on line 71.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>71</LineStart>
+<Snippet>            URLConnection urlConnection = u.openConnection();
+            HttpURLConnection httpUrl = (HttpURLConnection)urlConnection;
+            BufferedReader in = new BufferedReader(new InputStreamReader(httpUrl.getInputStream())); //send request
+            String inputLine;
+            StringBuffer html = new StringBuffer();</Snippet>
+<TargetFunction>in = new BufferedReader(new java.io.InputStreamReader())</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>XML Entity Expansion Injection</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The XML parser configured in XXE.java:40 does not prevent nor limit Document Type Definition (DTD) entity resolution. This can expose the parser to an XML Entity Expansion injection.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>XML Entity Expansion injection also known as XML Bombs are Denial of Service (DoS) attacks that benefit from valid and well-formed XML blocks that expand exponentially until they exhaust the server allocated resources. XML allows to define custom entities which act as string substitution macros. By nesting recurrent entity resolutions, an attacker may easily crash the server resources.
+
+The following XML document shows an example of an XML Bomb.
+
+&lt;?xml version="1.0"?&gt;
+&lt;!DOCTYPE lolz [
+  &lt;!ENTITY lol "lol"&gt;
+  &lt;!ENTITY lol2 "&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;&amp;lol;"&gt;
+  &lt;!ENTITY lol3 "&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;&amp;lol2;"&gt;
+  &lt;!ENTITY lol4 "&amp;lol3;&amp;lol3;&amp;lol3;&amp;lol3;&amp;lol3;&amp;lol3;&amp;lol3;&amp;lol3;&amp;lol3;&amp;lol3;"&gt;
+  &lt;!ENTITY lol5 "&amp;lol4;&amp;lol4;&amp;lol4;&amp;lol4;&amp;lol4;&amp;lol4;&amp;lol4;&amp;lol4;&amp;lol4;&amp;lol4;"&gt;
+  &lt;!ENTITY lol6 "&amp;lol5;&amp;lol5;&amp;lol5;&amp;lol5;&amp;lol5;&amp;lol5;&amp;lol5;&amp;lol5;&amp;lol5;&amp;lol5;"&gt;
+  &lt;!ENTITY lol7 "&amp;lol6;&amp;lol6;&amp;lol6;&amp;lol6;&amp;lol6;&amp;lol6;&amp;lol6;&amp;lol6;&amp;lol6;&amp;lol6;"&gt;
+  &lt;!ENTITY lol8 "&amp;lol7;&amp;lol7;&amp;lol7;&amp;lol7;&amp;lol7;&amp;lol7;&amp;lol7;&amp;lol7;&amp;lol7;&amp;lol7;"&gt;
+  &lt;!ENTITY lol9 "&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;&amp;lol8;"&gt;
+]&gt;
+&lt;lolz&gt;&amp;lol9;&lt;/lolz&gt;
+
+
+This test could crash the server by expanding the small XML document into more than 3GB in memory.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>An XML parser should be configured securely so that it does not allow document type definition (DTD) custom entities as part of an incoming XML document.
+
+To avoid XML Entity Expansion injection the "secure-processing" property should be set for an XML factory, parser or reader:
+
+factory.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+
+
+In JAXP 1.3 and earlier versions, when the secure processing feature is on, default limitations are set for DOM and SAX parsers. These limits are:
+
+entityExpansionLimit = 64,000
+elementAttributeLimit = 10,000
+
+Since JAXP 1.4, the secure processing feature is turned on by default. In addition to the above limits, a new maxOccur limit is added to the validating parser. The limit is:
+
+maxOccur = 5,000
+
+
+If inline DOCTYPE declaration is not needed, it can be completely disabled with the following property:
+
+factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>6</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="382585D0196C92CD3A94AB640AE5549D" ruleID="67F8265E-C832-4376-83EF-3EA086DB961E">
+                            <Category>XML Entity Expansion Injection</Category>
+                            <Folder>Medium</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The XML parser configured in XXE.java:390 does not prevent nor limit Document Type Definition (DTD) entity resolution. This can expose the parser to an XML Entity Expansion injection.</Abstract>
+                            <Friority>Medium</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>390</LineStart>
+<Snippet>            SAXParser saxParser = spf.newSAXParser();
+            XMLReader xmlReader = saxParser.getXMLReader();
+            xmlReader.parse(new InputSource(new StringReader(xml_con)));
+            return "test";
+        } catch (Exception e) {</Snippet>
+<TargetFunction>org.xml.sax.XMLReader.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="8E9C70C4D51FB9AD1B92B5980A65F4C2" ruleID="1C2401A4-37A8-4B2E-9D0A-F03CB933D522">
+                            <Category>XML Entity Expansion Injection</Category>
+                            <Folder>Medium</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The XML parser configured in XXE.java:257 does not prevent nor limit Document Type Definition (DTD) entity resolution. This can expose the parser to an XML Entity Expansion injection.</Abstract>
+                            <Friority>Medium</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>257</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            // 遍历xml节点name和value</Snippet>
+<TargetFunction>javax.xml.parsers.DocumentBuilder.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="A2462122339E8A69C76644CFA292A262" ruleID="67F8265E-C832-4376-83EF-3EA086DB961E">
+                            <Category>XML Entity Expansion Injection</Category>
+                            <Folder>Medium</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The XML parser configured in XXE.java:40 does not prevent nor limit Document Type Definition (DTD) entity resolution. This can expose the parser to an XML Entity Expansion injection.</Abstract>
+                            <Friority>Medium</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>40</LineStart>
+<Snippet>            System.out.println(xml_con);
+            XMLReader xmlReader = XMLReaderFactory.createXMLReader();
+            xmlReader.parse(new InputSource(new StringReader(xml_con)));  // parse xml
+            return "ok";
+        } catch (Exception e) {</Snippet>
+<TargetFunction>org.xml.sax.XMLReader.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="FE1526C2F3321919087F4E2BFD58895A" ruleID="1C2401A4-37A8-4B2E-9D0A-F03CB933D522">
+                            <Category>XML Entity Expansion Injection</Category>
+                            <Folder>Medium</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The XML parser configured in XXE.java:319 does not prevent nor limit Document Type Definition (DTD) entity resolution. This can expose the parser to an XML Entity Expansion injection.</Abstract>
+                            <Friority>Medium</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>319</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            NodeList rootNodeList = document.getChildNodes();</Snippet>
+<TargetFunction>javax.xml.parsers.DocumentBuilder.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="0BFDF6FD73CC2364E2216201E363269A" ruleID="1C2401A4-37A8-4B2E-9D0A-F03CB933D522">
+                            <Category>XML Entity Expansion Injection</Category>
+                            <Folder>Medium</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The XML parser configured in XXE.java:224 does not prevent nor limit Document Type Definition (DTD) entity resolution. This can expose the parser to an XML Entity Expansion injection.</Abstract>
+                            <Friority>Medium</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>224</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            // 遍历xml节点name和value</Snippet>
+<TargetFunction>javax.xml.parsers.DocumentBuilder.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="B6847860EAFF14C35DBB735A2447524F" ruleID="1C2401A4-37A8-4B2E-9D0A-F03CB933D522">
+                            <Category>XML Entity Expansion Injection</Category>
+                            <Folder>Medium</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The XML parser configured in XXE.java:147 does not prevent nor limit Document Type Definition (DTD) entity resolution. This can expose the parser to an XML Entity Expansion injection.</Abstract>
+                            <Friority>Medium</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>147</LineStart>
+<Snippet>            SAXParserFactory spf = SAXParserFactory.newInstance();
+            SAXParser parser = spf.newSAXParser();
+            parser.parse(new InputSource(new StringReader(xml_con)), new DefaultHandler());  // parse xml
+
+            return "test";</Snippet>
+<TargetFunction>javax.xml.parsers.SAXParser.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>XML External Entity Injection</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>XML parser configured in XXE.java:40 does not prevent nor limit external entities resolution. This can expose the parser to an XML External Entities attack.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>XML External Entities attacks benefit from an XML feature to build documents dynamically at the time of processing. An XML entity allows inclusion of data dynamically from a given resource. External entities allow an XML document to include data from an external URI. Unless configured to do otherwise, external entities force the XML parser to access the resource specified by the URI, e.g., a file on the local machine or on a remote system. This behavior exposes the application to XML External Entity (XXE) attacks, which can be used to perform denial of service of the local system, gain unauthorized access to files on the local machine, scan remote machines, and perform denial of service of remote systems.
+
+The following XML document shows an example of an XXE attack.
+
+&lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
+ &lt;!DOCTYPE foo [
+  &lt;!ELEMENT foo ANY &gt;
+  &lt;!ENTITY xxe SYSTEM "file:///dev/random" &gt;]&gt;&lt;foo&gt;&amp;xxe;&lt;/foo&gt;
+
+
+This example could crash the server (on a UNIX system), if the XML parser attempts to substitute the entity with the contents of the /dev/random file.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>The XML unmarshaller should be configured securely so that it does not allow external entities as part of an incoming XML document.
+
+To avoid XXE injection do not use unmarshal methods that process an XML source directly as java.io.File, java.io.Reader or java.io.InputStream. Parse the document with a securely configured parser and use an unmarshal method that takes the secure parser as the XML source as shown in the following example:
+
+
+DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+DocumentBuilder db = dbf.newDocumentBuilder();
+Document document = db.parse(&lt;XML Source&gt;);
+Model model = (Model) u.unmarshal(document);
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>6</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="4CEEB930BE53ECE6B6A24BA1A652B031" ruleID="4B1396F4-255F-4952-BC09-B82ACB650FE8">
+                            <Category>XML External Entity Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>XML parser configured in XXE.java:319 does not prevent nor limit external entities resolution. This can expose the parser to an XML External Entities attack.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>319</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            NodeList rootNodeList = document.getChildNodes();</Snippet>
+<TargetFunction>javax.xml.parsers.DocumentBuilder.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="E52B57CC73A132A33E3A8D5CC8208BCD" ruleID="B1D6A836-C25A-4971-A9E8-6FCEBA60E3DB">
+                            <Category>XML External Entity Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>XML parser configured in XXE.java:40 does not prevent nor limit external entities resolution. This can expose the parser to an XML External Entities attack.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>40</LineStart>
+<Snippet>            System.out.println(xml_con);
+            XMLReader xmlReader = XMLReaderFactory.createXMLReader();
+            xmlReader.parse(new InputSource(new StringReader(xml_con)));  // parse xml
+            return "ok";
+        } catch (Exception e) {</Snippet>
+<TargetFunction>org.xml.sax.XMLReader.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="2AC212CE4DA77CA858E06AC216E166B4" ruleID="4B1396F4-255F-4952-BC09-B82ACB650FE8">
+                            <Category>XML External Entity Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>XML parser configured in XXE.java:147 does not prevent nor limit external entities resolution. This can expose the parser to an XML External Entities attack.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>147</LineStart>
+<Snippet>            SAXParserFactory spf = SAXParserFactory.newInstance();
+            SAXParser parser = spf.newSAXParser();
+            parser.parse(new InputSource(new StringReader(xml_con)), new DefaultHandler());  // parse xml
+
+            return "test";</Snippet>
+<TargetFunction>javax.xml.parsers.SAXParser.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="D1981A7FF50FCAAF079EDCA71B57803A" ruleID="4B1396F4-255F-4952-BC09-B82ACB650FE8">
+                            <Category>XML External Entity Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>XML parser configured in XXE.java:224 does not prevent nor limit external entities resolution. This can expose the parser to an XML External Entities attack.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>224</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            // 遍历xml节点name和value</Snippet>
+<TargetFunction>javax.xml.parsers.DocumentBuilder.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="91CF4A2C0441141618A7F01DEEEA3294" ruleID="4B1396F4-255F-4952-BC09-B82ACB650FE8">
+                            <Category>XML External Entity Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>XML parser configured in XXE.java:257 does not prevent nor limit external entities resolution. This can expose the parser to an XML External Entities attack.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>257</LineStart>
+<Snippet>            StringReader sr = new StringReader(xml_con);
+            InputSource is = new InputSource(sr);
+            Document document = db.parse(is);  // parse xml
+
+            // 遍历xml节点name和value</Snippet>
+<TargetFunction>javax.xml.parsers.DocumentBuilder.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="A446EF4E10DCEEA3B8421308B6ABD9B2" ruleID="B1D6A836-C25A-4971-A9E8-6FCEBA60E3DB">
+                            <Category>XML External Entity Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>XML parser configured in XXE.java:390 does not prevent nor limit external entities resolution. This can expose the parser to an XML External Entities attack.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>XXE.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XXE.java</FilePath>
+<LineStart>390</LineStart>
+<Snippet>            SAXParser saxParser = spf.newSAXParser();
+            XMLReader xmlReader = saxParser.getXMLReader();
+            xmlReader.parse(new InputSource(new StringReader(xml_con)));
+            return "test";
+        } catch (Exception e) {</Snippet>
+<TargetFunction>org.xml.sax.XMLReader.parse()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>WebUtils.java</FileName>
+<FilePath>src/main/java/org/joychou/util/WebUtils.java</FilePath>
+<LineStart>12</LineStart>
+<Snippet>    // Get request body.
+    public static String getRequestBody(HttpServletRequest request) throws IOException {
+        InputStream in = request.getInputStream();
+        return convertStreamToString(in);
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getInputStream()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="5">
+                        <groupTitle>Denial of Service</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The call to readLine() at Rce.java line 36 might allow an attacker to crash the program or otherwise make it unavailable to legitimate users.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Attackers may be able to deny service to legitimate users by flooding the application with requests, but flooding attacks can often be defused at the network layer. More problematic are bugs that allow an attacker to overload the application using a small number of requests. Such bugs allow the attacker to specify the quantity of system resources their requests will consume or the duration for which they will use them.
+
+Example 1: The following code allows a user to specify the amount of time for which a thread will sleep. By specifying a large number, an attacker may tie up the thread indefinitely. With a small number of requests, the attacker may deplete the application's thread pool.
+
+
+  int usrSleepTime = Integer.parseInt(usrInput);
+  Thread.sleep(usrSleepTime);
+
+
+Example 2: The following code reads a String from a zip file. Because it uses the readLine() method, it will read an unbounded amount of input. An attacker may take advantage of this code to cause an OutOfMemoryException or to consume a large amount of memory so that the program spends more time performing garbage collection or runs out of memory during some subsequent operation.
+
+
+  InputStream zipInput = zipFile.getInputStream(zipEntry);
+  Reader zipReader = new InputStreamReader(zipInput);
+  BufferedReader br = new BufferedReader(zipReader);
+  String line = br.readLine();
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Validate user input to ensure that it will not cause inappropriate resource utilization.
+
+Example 3: The following code allows a user to specify the amount of time for which a thread will sleep just as in Example 1, but only if the value is within reasonable bounds.
+
+  int usrSleepTime = Integer.parseInt(usrInput);
+  if (usrSleepTime &gt;= SLEEP_MIN &amp;&amp;
+      usrSleepTime &lt;= SLEEP_MAX) {
+    Thread.sleep(usrSleepTime);
+  } else {
+    throw new Exception("Invalid sleep duration");
+  }
+}
+
+
+Example 4: The following code reads a String from a zip file just as in Example 2, but the maximum string length it will read is MAX_STR_LEN characters.
+
+  InputStream zipInput = zipFile.getInputStream(zipEntry);
+  Reader zipReader = new InputStreamReader(zipInput);
+  BufferedReader br = new BufferedReader(zipReader);
+  StringBuffer sb = new StringBuffer();
+  int intC;
+  while ((intC = br.read()) != -1) {
+    char c = (char) intC;
+    if (c == '\n') {
+      break;
+    }
+    if (sb.length() &gt;= MAX_STR_LEN) {
+      throw new Exception("input too long");
+    }
+    sb.append(c);
+  }
+  String line = sb.toString();
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Denial of service can happen even if the quantity of system resources that will be consumed or the duration for which they will be used is not controlled by an attacker, or at least not directly. Instead, a programmer might choose unsafe constant values for specifying these parameters. The Fortify Secure Coding Rulepacks will report such cases as potential Denial of Services vulnerabilities.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>5</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="B2F908A5937AAAC269A914CAC70B9BA6" ruleID="24023E22-D6C7-4D5C-B049-38B7EFC8B408">
+                            <Category>Denial of Service</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to readLine() at Rce.java line 36 might allow an attacker to crash the program or otherwise make it unavailable to legitimate users.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>36</LineStart>
+<Snippet>            String tmpStr;
+
+            while ((tmpStr = inBr.readLine()) != null) {
+                lineStr += tmpStr + "\n";
+                System.out.println(tmpStr);</Snippet>
+<TargetFunction>readLine()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="6F36F4A3822DC15573C1AF7DCEC54BDA" ruleID="24023E22-D6C7-4D5C-B049-38B7EFC8B408">
+                            <Category>Denial of Service</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to readLine() at SSRF.java line 75 might allow an attacker to crash the program or otherwise make it unavailable to legitimate users.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>75</LineStart>
+<Snippet>            StringBuffer html = new StringBuffer();
+
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }</Snippet>
+<TargetFunction>readLine()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="653D0B20DA0ACE3A3DBA909634E8BF19" ruleID="5c0b56c2-93d3-48e6-b061-c89dbffb2628">
+                            <Category>Denial of Service</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to waitFor() at Rce.java line 41 might allow an attacker to crash the program or otherwise make it unavailable to legitimate users.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>41</LineStart>
+<Snippet>            }
+
+            if (p.waitFor() != 0) {
+                if (p.exitValue() == 1)
+                    return "command exec failed";</Snippet>
+<TargetFunction>waitFor()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5F823F6ACECE894E58D1729F1FD3B643" ruleID="24023E22-D6C7-4D5C-B049-38B7EFC8B408">
+                            <Category>Denial of Service</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to readLine() at SSRF.java line 50 might allow an attacker to crash the program or otherwise make it unavailable to legitimate users.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>50</LineStart>
+<Snippet>            StringBuffer html = new StringBuffer();
+
+            while ((inputLine = in.readLine()) != null) {
+                html.append(inputLine);
+            }</Snippet>
+<TargetFunction>readLine()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1B5E3E4E5BE3AB20C76DCFF9913E2B36" ruleID="24023E22-D6C7-4D5C-B049-38B7EFC8B408">
+                            <Category>Denial of Service</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The call to readLine() at SSRF.java line 182 might allow an attacker to crash the program or otherwise make it unavailable to legitimate users.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>182</LineStart>
+<Snippet>            StringBuffer result = new StringBuffer();
+            String line = "";
+            while ((line = rd.readLine()) != null) {
+                result.append(line);
+            }</Snippet>
+<TargetFunction>readLine()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="5">
+                        <groupTitle>Header Manipulation</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method vuls1() in CORS.java includes unvalidated data in an HTTP response header on line 29. This enables attacks such as cache-poisoning, cross-site scripting, cross-user defacement, page hijacking, cookie manipulation or open redirect.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Header Manipulation vulnerabilities occur when:
+
+1. Data enters a web application through an untrusted source, most frequently an HTTP request.
+
+
+2. The data is included in an HTTP response header sent to a web user without being validated.
+
+As with many software security vulnerabilities, Header Manipulation is a means to an end, not an end in itself. At its root, the vulnerability is straightforward: an attacker passes malicious data to a vulnerable application, and the application includes the data in an HTTP response header.
+
+One of the most common Header Manipulation attacks is HTTP Response Splitting. To mount a successful HTTP Response Splitting exploit, the application must allow input that contains CR (carriage return, also given by %0d or \r) and LF (line feed, also given by %0a or \n)characters into the header. These characters not only give attackers control of the remaining headers and body of the response the application intends to send, but also allows them to create additional responses entirely under their control.
+
+Many of today's modern application servers will prevent the injection of malicious characters into HTTP headers. For example, recent versions of Apache Tomcat will throw an IllegalArgumentException if you attempt to set a header with prohibited characters. If your application server prevents setting headers with new line characters, then your application is not vulnerable to HTTP Response Splitting. However, solely filtering for new line characters can leave an application vulnerable to Cookie Manipulation or Open Redirects, so care must still be taken when setting HTTP headers with user input.
+
+Example: The following code segment reads the name of the author of a weblog entry, author, from an HTTP request and sets it in a cookie header of an HTTP response.
+
+
+String author = request.getParameter(AUTHOR_PARAM);
+...
+Cookie cookie = new Cookie("author", author);
+     cookie.setMaxAge(cookieExpiration);
+     response.addCookie(cookie);
+
+
+Assuming a string consisting of standard alpha-numeric characters, such as "Jane Smith", is submitted in the request the HTTP response including this cookie might take the following form:
+
+
+HTTP/1.1 200 OK
+...
+Set-Cookie: author=Jane Smith
+...
+
+
+However, because the value of the cookie is formed of unvalidated user input the response will only maintain this form if the value submitted for AUTHOR_PARAM does not contain any CR and LF characters. If an attacker submits a malicious string, such as "Wiley Hacker\r\nHTTP/1.1 200 OK\r\n...", then the HTTP response would be split into two responses of the following form:
+
+
+HTTP/1.1 200 OK
+...
+Set-Cookie: author=Wiley Hacker
+
+HTTP/1.1 200 OK
+...
+
+
+Clearly, the second response is completely controlled by the attacker and can be constructed with any header and body content desired. The ability of attacker to construct arbitrary HTTP responses permits a variety of resulting attacks, including: cross-user defacement, web and browser cache poisoning, cross-site scripting and page hijacking.
+
+Cross-User Defacement: An attacker will be able to make a single request to a vulnerable server that will cause the server to create two responses, the second of which may be misinterpreted as a response to a different request, possibly one made by another user sharing the same TCP connection with the server. This can be accomplished by convincing the user to submit the malicious request themselves, or remotely in situations where the attacker and the user share a common TCP connection to the server, such as a shared proxy server. In the best case, an attacker may leverage this ability to convince users that the application has been hacked, causing users to lose confidence in the security of the application. In the worst case, an attacker may provide specially crafted content designed to mimic the behavior of the application but redirect private information, such as account numbers and passwords, back to the attacker.
+
+Cache Poisoning: The impact of a maliciously constructed response can be magnified if it is cached either by a web cache used by multiple users or even the browser cache of a single user. If a response is cached in a shared web cache, such as those commonly found in proxy servers, then all users of that cache will continue receive the malicious content until the cache entry is purged. Similarly, if the response is cached in the browser of an individual user, then that user will continue to receive the malicious content until the cache entry is purged, although only the user of the local browser instance will be affected.
+
+Cross-Site Scripting: Once attackers have control of the responses sent by an application, they have a choice of a variety of malicious content to provide users. Cross-site scripting is common form of attack where malicious JavaScript or other code included in a response is executed in the user's browser. The variety of attacks based on XSS is almost limitless, but they commonly include transmitting private data like cookies or other session information to the attacker, redirecting the victim to web content controlled by the attacker, or performing other malicious operations on the user's machine under the guise of the vulnerable site. The most common and dangerous attack vector against users of a vulnerable application uses JavaScript to transmit session and authentication information back to the attacker who can then take complete control of the victim's account.
+
+Page Hijacking: In addition to using a vulnerable application to send malicious content to a user, the same root vulnerability can also be leveraged to redirect sensitive content generated by the server and intended for the user to the attacker instead. By submitting a request that results in two responses, the intended response from the server and the response generated by the attacker, an attacker may cause an intermediate node, such as a shared proxy server, to misdirect a response generated by the server for the user to the attacker. Because the request made by the attacker generates two responses, the first is interpreted as a response to the attacker's request, while the second remains in limbo. When the user makes a legitimate request through the same TCP connection, the attacker's request is already waiting and is interpreted as a response to the victim's request. The attacker then sends a second request to the server, to which the proxy server responds with the server generated request intended for the victim, thereby compromising any sensitive information in the headers or body of the response intended for the victim.
+
+Cookie Manipulation: When combined with attacks like Cross-Site Request Forgery, attackers may change, add to, or even overwrite a legitimate user's cookies.
+
+Open Redirect: Allowing unvalidated input to control the URL used in a redirect can aid phishing attacks.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>The solution to Header Manipulation is to ensure that input validation occurs in the correct places and checks for the correct properties.
+
+Since Header Manipulation vulnerabilities occur when an application includes malicious data in its output, one logical approach is to validate data immediately before it leaves the application. However, because web applications often have complex and intricate code for generating responses dynamically, this method is prone to errors of omission (missing validation). An effective way to mitigate this risk is to also perform input validation for Header Manipulation.
+
+Web applications must validate their input to prevent other vulnerabilities, such as SQL injection, so augmenting an application's existing input validation mechanism to include checks for Header Manipulation is generally relatively easy. Despite its value, input validation for Header Manipulation does not take the place of rigorous output validation. An application may accept input through a shared data store or other trusted source, and that data store may accept input from a source that does not perform adequate input validation. Therefore, the application cannot implicitly rely on the safety of this or any other data. This means the best way to prevent Header Manipulation vulnerabilities is to validate everything that enters the application or leaves the application destined for the user.
+
+The most secure approach to validation for Header Manipulation is to create a whitelist of safe characters that are allowed to appear in HTTP response headers and accept input composed exclusively of characters in the approved set. For example, a valid name might only include alpha-numeric characters or an account number might only include digits 0-9.
+
+A more flexible, but less secure approach is known as blacklisting, which selectively rejects or escapes potentially dangerous characters before using the input. In order to form such a list, you first need to understand the set of characters that hold special meaning in HTTP response headers. Although the CR and LF characters are at the heart of an HTTP response splitting attack, other characters, such as ':' (colon) and '=' (equal), have special meaning in response headers as well.
+
+After you identify the correct points in an application to perform validation for Header Manipulation attacks and what special characters the validation should consider, the next challenge is to identify how your validation handles special characters. The application should reject any input destined to be included in HTTP response headers that contains special characters, particularly CR and LF, as invalid.
+
+Many application servers attempt to limit an application's exposure to HTTP response splitting vulnerabilities by providing implementations for the functions responsible for setting HTTP headers and cookies that perform validation for the characters essential to an HTTP response splitting attack. Do not rely on the server running your application to make it secure. When an application is developed there are no guarantees about what application servers it will run on during its lifetime. As standards and known exploits evolve, there are no guarantees that application servers will also stay in sync.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Many HttpServletRequest implementations return a URL-encoded string from getHeader(), will not cause a HTTP response splitting issue unless it is decoded first because the CR and LF characters will not carry a meta-meaning in their encoded form. However, this behavior is not specified in the J2EE standard and varies by implementation. Furthermore, even encoded user input returned from getHeader() can lead to other vulnerabilities, including open redirects and other HTTP header tampering.
+
+2. A number of modern web frameworks provide mechanisms for performing validation of user input. Struts and Spring MVC are two examples. To highlight the unvalidated sources of input, the Fortify Secure Coding Rulepacks dynamically re-prioritize the issues reported by Fortify Static Code Analyzer by lowering their probability of exploit and providing pointers to the supporting evidence whenever the framework validation mechanism is in use. We refer to this feature as Context-Sensitive Ranking. To further assist the Fortify user with the auditing process, the Fortify Software Security Research group makes available the Data Validation project template that groups the issues into folders based on the validation mechanism applied to their source of input.
+
+3. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>5</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="D768118AA94017414F5EEFF63E378085" ruleID="790A125E-5BFE-4931-A51A-29B7D5BECC93">
+                            <Category>Header Manipulation</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method vuls1() in CORS.java includes unvalidated data in an HTTP response header on line 29. This enables attacks such as cache-poisoning, cross-site scripting, cross-user defacement, page hijacking, cookie manipulation or open redirect.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>29</LineStart>
+<Snippet>    private static String vuls1(HttpServletRequest request, HttpServletResponse response) {
+        String origin = request.getHeader("origin");
+        response.setHeader("Access-Control-Allow-Origin", origin); // 设置Origin值为Header中获取到的
+        response.setHeader("Access-Control-Allow-Credentials", "true");  // cookie
+        return info;</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletResponse.setHeader()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>    @RequestMapping("/vuln/origin")
+    private static String vuls1(HttpServletRequest request, HttpServletResponse response) {
+        String origin = request.getHeader("origin");
+        response.setHeader("Access-Control-Allow-Origin", origin); // 设置Origin值为Header中获取到的
+        response.setHeader("Access-Control-Allow-Credentials", "true");  // cookie</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletRequest.getHeader()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="963C11C0BC25D041982147BE9AF38767" ruleID="790A125E-5BFE-4931-A51A-29B7D5BECC93">
+                            <Category>Header Manipulation</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method setHeader() in URLRedirect.java includes unvalidated data in an HTTP response header on line 44. This enables attacks such as cache-poisoning, cross-site scripting, cross-user defacement, page hijacking, cookie manipulation or open redirect.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>44</LineStart>
+<Snippet>        String url = request.getParameter("url");
+        response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY); // 301 redirect
+        response.setHeader("Location", url);
+    }
+</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletResponse.setHeader()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>42</LineStart>
+<Snippet>    @ResponseBody
+    public static void setHeader(HttpServletRequest request, HttpServletResponse response){
+        String url = request.getParameter("url");
+        response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY); // 301 redirect
+        response.setHeader("Location", url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="C915F4ED5027F6C60C606713902B3C0F" ruleID="790A125E-5BFE-4931-A51A-29B7D5BECC93">
+                            <Category>Header Manipulation</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method crlf() in CRLFInjection.java includes unvalidated data in an HTTP response header on line 25. This enables attacks such as cache-poisoning, cross-site scripting, cross-user defacement, page hijacking, cookie manipulation or open redirect.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>25</LineStart>
+<Snippet>    private static void crlf(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("test1", request.getParameter("test1"));
+        response.setHeader("test2", request.getParameter("test2"));
+        String author = request.getParameter("test3");
+        Cookie cookie = new Cookie("test3", author);</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletResponse.setHeader()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>25</LineStart>
+<Snippet>    private static void crlf(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("test1", request.getParameter("test1"));
+        response.setHeader("test2", request.getParameter("test2"));
+        String author = request.getParameter("test3");
+        Cookie cookie = new Cookie("test3", author);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="66F7B18A050FA23D22C53029030403F5" ruleID="790A125E-5BFE-4931-A51A-29B7D5BECC93">
+                            <Category>Header Manipulation</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method crlf() in CRLFInjection.java includes unvalidated data in an HTTP response header on line 24. This enables attacks such as cache-poisoning, cross-site scripting, cross-user defacement, page hijacking, cookie manipulation or open redirect.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>24</LineStart>
+<Snippet>    @ResponseBody
+    private static void crlf(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("test1", request.getParameter("test1"));
+        response.setHeader("test2", request.getParameter("test2"));
+        String author = request.getParameter("test3");</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletResponse.addHeader()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>24</LineStart>
+<Snippet>    @ResponseBody
+    private static void crlf(HttpServletRequest request, HttpServletResponse response) {
+        response.addHeader("test1", request.getParameter("test1"));
+        response.setHeader("test2", request.getParameter("test2"));
+        String author = request.getParameter("test3");</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="8DE20C41F00DA1D83D414956DF31E938" ruleID="790A125E-5BFE-4931-A51A-29B7D5BECC93">
+                            <Category>Header Manipulation</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method seccode() in CORS.java includes unvalidated data in an HTTP response header on line 87. This enables attacks such as cache-poisoning, cross-site scripting, cross-user defacement, page hijacking, cookie manipulation or open redirect.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>87</LineStart>
+<Snippet>            return "Origin is not safe.";
+        }
+        response.setHeader("Access-Control-Allow-Origin", origin);
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+        return JSONP.getUserInfo2JsonStr(request);</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletResponse.setHeader()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>80</LineStart>
+<Snippet>    @RequestMapping("/sec/checkOrigin")
+    public String seccode(HttpServletRequest request, HttpServletResponse response) {
+        String origin = request.getHeader("Origin");
+
+        // 如果origin不为空并且origin不在白名单内，认定为不安全。</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletRequest.getHeader()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="5">
+                        <groupTitle>Server-Side Request Forgery</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The function openConnection() on line 45 initiates a network connection to a third-party system using user-controlled data for resource URI. An attacker may leverage this vulnerability to send a request on behalf of the application server since the request will originate from the application server's internal IP address.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>A Server-Side Request Forgery occurs when an attacker may influence a network connection made by the application server. The network connection will originate from the application server's internal IP and an attacker will be able to use this connection to bypass network controls and scan or attack internal resources that are not otherwise exposed.
+
+
+
+Example: In the following example, an attacker will be able to control the URL the server is connecting to.
+
+
+String url = request.getParameter("url");
+CloseableHttpClient httpclient = HttpClients.createDefault();
+HttpGet httpGet = new HttpGet(url);
+CloseableHttpResponse response1 = httpclient.execute(httpGet);
+
+
+The attacker's ability to hijack the network connection will depend upon the specific part of the URI that can be controlled, and upon libraries used to establish the connection. For example, controlling the URI scheme will let the attacker use protocols different from http or https like:
+
+- up://
+- ldap://
+- jar://
+- gopher://
+- mailto://
+- ssh2://
+- telnet://
+- expect://
+
+An attacker will be able to leverage this hijacked network connection to perform the following attacks:
+
+- Port Scanning of intranet resources.
+- Bypass firewalls.
+- Attack vulnerable programs running on the application server or on the intranet.
+- Attack internal/external web applications using Injection attacks or CSRF.
+- Access local files using file:// scheme.
+- On Windows systems, file:// scheme and UNC paths can allow an attacker to scan and access internal shares.
+- Perform a DNS cache poisoning attack.
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Do not establish network connections based on user-controlled data and ensure that the request is being sent to the expected destination. If user data is necessary to build the destination URI, use a level of indirection: create a list of legitimate resource names that a user is allowed to specify, and only allow the user to select from the list. With this approach the input provided by the user is never used directly to specify the resource name.
+
+In some situations this approach is impractical because the set of legitimate resource names is too large or too hard to keep track of. Programmers often resort to blacklisting in these situations. Blacklisting selectively rejects or escapes potentially dangerous characters before using the input. However, any such list of unsafe characters is likely to be incomplete and will almost certainly become out of date. A better approach is to create a whitelist of characters that are allowed to appear in the resource name and accept input composed exclusively of characters in the approved set.
+
+Also, if required, make sure that the user input is only used to specify a resource on the target system but that the URI scheme, host, and port is controlled by the application. This way the damage that an attacker is able to do will be significantly reduced.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>5</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="9C0C3DC31A55A7523AA56452D9BD6703" ruleID="33DDCCB9-248C-46E8-BF4E-0A8DFA006946">
+                            <Category>Server-Side Request Forgery</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The function openConnection() on line 69 initiates a network connection to a third-party system using user-controlled data for resource URI. An attacker may leverage this vulnerability to send a request on behalf of the application server since the request will originate from the application server's internal IP address.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>69</LineStart>
+<Snippet>            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();
+            HttpURLConnection httpUrl = (HttpURLConnection)urlConnection;
+            BufferedReader in = new BufferedReader(new InputStreamReader(httpUrl.getInputStream())); //send request</Snippet>
+<TargetFunction>java.net.URL.openConnection()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>67</LineStart>
+<Snippet>    {
+        try {
+            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="F55081E2CEA2157875857B41E4E00D54" ruleID="33DDCCB9-248C-46E8-BF4E-0A8DFA006946">
+                            <Category>Server-Side Request Forgery</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The function openConnection() on line 45 initiates a network connection to a third-party system using user-controlled data for resource URI. An attacker may leverage this vulnerability to send a request on behalf of the application server since the request will originate from the application server's internal IP address.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>45</LineStart>
+<Snippet>            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();
+            BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream())); //send request
+            String inputLine;</Snippet>
+<TargetFunction>java.net.URL.openConnection()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>    {
+        try {
+            String url = request.getParameter("url");
+            URL u = new URL(url);
+            URLConnection urlConnection = u.openConnection();</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="76D5AB23C560F588218E45FD101EE65E" ruleID="33DDCCB9-248C-46E8-BF4E-0A8DFA006946">
+                            <Category>Server-Side Request Forgery</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The function openStream() on line 123 initiates a network connection to a third-party system using user-controlled data for resource URI. An attacker may leverage this vulnerability to send a request on behalf of the application server since the request will originate from the application server's internal IP address.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>123</LineStart>
+<Snippet>            int length;
+            byte[] bytes = new byte[1024];
+            inputStream = u.openStream(); // send request
+            outputStream = response.getOutputStream();
+            while ((length = inputStream.read(bytes)) &gt; 0) {</Snippet>
+<TargetFunction>java.net.URL.openStream()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>114</LineStart>
+<Snippet>        InputStream inputStream = null;
+        OutputStream outputStream = null;
+        String url = request.getParameter("url");
+        try {
+            String downLoadImgFileName = Files.getNameWithoutExtension(url) + "." + Files.getFileExtension(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="1C43E4D565888BD369D53C8E75199201" ruleID="33DDCCB9-248C-46E8-BF4E-0A8DFA006946">
+                            <Category>Server-Side Request Forgery</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The function openConnection() on line 33 initiates a network connection to a third-party system using user-controlled data for resource URI. An attacker may leverage this vulnerability to send a request on behalf of the application server since the request will originate from the application server's internal IP address.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>33</LineStart>
+<Snippet>                }
+
+                connection = (HttpURLConnection) new URL(finalUrl).openConnection();
+                connection.setInstanceFollowRedirects(false);
+                connection.setUseCaches(false); // 设置为false，手动处理跳转，可以拿到每个跳转的URL</Snippet>
+<TargetFunction>java.net.URL.openConnection()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>41</LineStart>
+<Snippet>                int responseCode = connection.getResponseCode(); // 发起网络请求
+                if (responseCode &gt;= 300 &amp;&amp; responseCode &lt;=307 &amp;&amp; responseCode != 304 &amp;&amp; responseCode != 306) {
+                    String redirectedUrl = connection.getHeaderField("Location");
+                    if (null == redirectedUrl)
+                        break;</Snippet>
+<TargetFunction>java.net.URLConnection.getHeaderField()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="4347DB64D4D2C245D13FE29EB51FA713" ruleID="33DDCCB9-248C-46E8-BF4E-0A8DFA006946">
+                            <Category>Server-Side Request Forgery</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The function openConnection() on line 33 initiates a network connection to a third-party system using user-controlled data for resource URI. An attacker may leverage this vulnerability to send a request on behalf of the application server since the request will originate from the application server's internal IP address.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>33</LineStart>
+<Snippet>                }
+
+                connection = (HttpURLConnection) new URL(finalUrl).openConnection();
+                connection.setInstanceFollowRedirects(false);
+                connection.setUseCaches(false); // 设置为false，手动处理跳转，可以拿到每个跳转的URL</Snippet>
+<TargetFunction>java.net.URL.openConnection()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>250</LineStart>
+<Snippet>    @ResponseBody
+    public static String ssrf_ImageIO_safecode(HttpServletRequest request) {
+        String url = request.getParameter("url");
+        try {
+            URL u = new URL(url);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Command Injection</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method codeInject() in CommandInject.java calls ProcessBuilder() to execute a command. This call might allow an attacker to inject malicious commands.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Command injection vulnerabilities take two forms:
+
+- An attacker can change the command that the program executes: the attacker explicitly controls what the command is.
+
+- An attacker can change the environment in which the command executes: the attacker implicitly controls what the command means.
+
+In this case, we are primarily concerned with the second scenario, the possibility that an attacker may be able to change the meaning of the command by changing an environment variable or by putting a malicious executable early in the search path. Command injection vulnerabilities of this type occur when:
+
+1. An attacker modifies an application's environment.
+
+2. The application executes a command without specifying an absolute path or verifying the binary being executed.
+
+3. By executing the command, the application gives an attacker a privilege or capability that the attacker would not otherwise have.
+
+Example: The following code is from a web application that allows users access to an interface through which they can update their password on the system. Part of the process for updating passwords in certain network environments is to run a make command in the /var/yp directory, the code for which is shown below.
+
+
+...
+System.Runtime.getRuntime().exec("make");
+...
+
+
+The problem here is that the program does not specify an absolute path for make and fails to clean its environment prior to executing the call to Runtime.exec(). If an attacker can modify the $PATH variable to point to a malicious binary called make and then execute the application in their environment, the malicious binary will be loaded instead of the one intended. Because of the nature of the application, it runs with the privileges necessary to perform system operations, which means the attacker's make will now be run with these privileges, possibly giving them complete control of the system.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>An attacker may indirectly control commands executed by a program by modifying the environment in which they are executed. The environment should not be trusted and precautions should be taken to prevent an attacker from using some manipulation of the environment to perform an attack. Whenever possible, commands should be controlled by the application and executed using an absolute path. In cases where the path is not known at compile time, such as for cross-platform applications, an absolute path should be constructed from trusted values during execution. Command values and paths read from configuration files or the environment should be sanity-checked against a set of invariants that define valid values.
+
+Other checks can sometimes be performed to detect if these sources may have been tampered with. For example, if a configuration file is world-writable, the program might refuse to run. In cases where information about the binary to be executed is known in advance, the program may perform checks to verify the identity of the binary. If a binary should always be owned by a particular user or have a particular set of access permissions assigned to it, these properties can be verified programmatically before the binary is executed.
+
+In the end it may be impossible for a program to fully protect itself from an imaginative attacker bent on controlling the commands the program executes. You should strive to identify and protect against every conceivable manipulation of input values and the environment. The goal should be to shut down as many attack vectors as possible.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. On Windows, the reported issue is not a concern if the command being executed is a Windows internal command. The internal commands do not reside on disk. Instead, they reside in COMMAND.COM, which loads into memory when the computer system is started. A list of internal commands includes: BREAK, CALL, CHCP, CHDIR(CD), CLS, COPY, CTTY, DATE, DEL(ERASE), DIR, ECHO, EXIT, FOR, GOTO, IF, MKDIR(MD), PATH, PAUSE, PROMPT, REM, RENAME(REN), RMDIR(RD), SET, SHIFT, TIME, TYPE, VER, VERIFY, VOL. For an up-to-date list of internal commands specific to your system, consult your system's documentation.
+
+2. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>4</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="9B25829B6E7512A353AE864EE4F27C70" ruleID="5760613C-9AF8-41EF-8431-66B6FBD4717A">
+                            <Category>Command Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method CommandExec() in Rce.java calls exec() with a command built from untrusted data. This call can cause the program to execute malicious commands on behalf of an attacker.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>31</LineStart>
+<Snippet>
+        try {
+            Process p = run.exec(cmd);
+            BufferedInputStream in = new BufferedInputStream(p.getInputStream());
+            BufferedReader inBr = new BufferedReader(new InputStreamReader(in));</Snippet>
+<TargetFunction>java.lang.Runtime.exec()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>Rce.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Rce.java</FilePath>
+<LineStart>26</LineStart>
+<Snippet>    @ResponseBody
+    public String CommandExec(HttpServletRequest request) {
+        String cmd = request.getParameter("cmd").toString();
+        Runtime run = Runtime.getRuntime();
+        String lineStr = "";</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="B7A063614438C8E81DA11EE440F55191" ruleID="C2388850-FF2A-494F-9E37-71DDDA3B7F61">
+                            <Category>Command Injection</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method codeInjectHost() in CommandInject.java calls ProcessBuilder() with a command built from untrusted data. This call can cause the program to execute malicious commands on behalf of an attacker.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>CommandInject.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CommandInject.java</FilePath>
+<LineStart>46</LineStart>
+<Snippet>        logger.info(host);
+        String[] cmdList = new String[]{"sh", "-c", "curl " + host};
+        ProcessBuilder builder = new ProcessBuilder(cmdList);
+        builder.redirectErrorStream(true);
+        Process process = builder.start();</Snippet>
+<TargetFunction>java.lang.ProcessBuilder.ProcessBuilder()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>CommandInject.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CommandInject.java</FilePath>
+<LineStart>43</LineStart>
+<Snippet>    public String codeInjectHost(HttpServletRequest request) throws IOException {
+
+        String host = request.getHeader("host");
+        logger.info(host);
+        String[] cmdList = new String[]{"sh", "-c", "curl " + host};</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletRequest.getHeader()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="ED8E9105168278A011382B0BC397289A" ruleID="0265B7FB-5F2E-4E66-AE21-FA180344A581">
+                            <Category>Command Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method codeInject() in CommandInject.java calls ProcessBuilder() to execute a command. This call might allow an attacker to inject malicious commands.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CommandInject.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CommandInject.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>
+        String[] cmdList = new String[]{"sh", "-c", "ls -la " + filepath};
+        ProcessBuilder builder = new ProcessBuilder(cmdList);
+        builder.redirectErrorStream(true);
+        Process process = builder.start();</Snippet>
+<TargetFunction>ProcessBuilder(0)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E0E1BE2D4D3CC14FAE3887DCD43CEB3E" ruleID="0265B7FB-5F2E-4E66-AE21-FA180344A581">
+                            <Category>Command Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method codeInjectSec() in CommandInject.java calls ProcessBuilder() to execute a command. This call might allow an attacker to inject malicious commands.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CommandInject.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CommandInject.java</FilePath>
+<LineStart>59</LineStart>
+<Snippet>        }
+        String[] cmdList = new String[]{"sh", "-c", "ls -la " + filterFilePath};
+        ProcessBuilder builder = new ProcessBuilder(cmdList);
+        builder.redirectErrorStream(true);
+        Process process = builder.start();</Snippet>
+<TargetFunction>ProcessBuilder(0)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Cookie Security: Cookie not Sent Over SSL</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>A cookie is created without the secure flag set to true.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Modern web browsers support a secure flag for each cookie. If the flag is set, the browser will only send the cookie over HTTPS. Sending cookies over an unencrypted channel can expose them to network sniffing attacks, so the secure flag helps keep a cookie's value confidential. This is especially important if the cookie contains private data or carries a session identifier.
+  
+
+Example 1: In the example below, a cookie added to the response without setting the secure flag.
+
+	Cookie cookie = new Cookie("emailCookie", email);
+	response.addCookie(cookie);
+
+
+If your application uses both HTTPS and HTTP but does not set the secure flag, cookies sent during an HTTPS request will also be sent during subsequent HTTP requests. Sniffing network traffic over unencrypted wireless connections is a trivial task for attackers, so sending cookies (especially those with session IDs) over HTTP can result in application compromise.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Set the Secure flag on all new cookies in order to instruct browsers not to send these cookies in the clear. Do this by calling setSecure(true).
+
+Example 2:
+
+	Cookie cookie = new Cookie("emailCookie", email);
+	cookie.setSecure(true);
+	response.addCookie(cookie);
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>4</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="8710DEE2B2B01410400FCEC5B7DD79DB" ruleID="AC87E716-8766-4F78-8851-86354C03A13B">
+                            <Category>Cookie Security: Cookie not Sent Over SSL</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>A cookie is created without the secure flag set to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Login.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Login.java</FilePath>
+<LineStart>42</LineStart>
+<Snippet>            cookie.setMaxAge(0);
+            cookie.setPath("/");
+            response.addCookie(cookie);
+        }
+</Snippet>
+<TargetFunction>addCookie(cookie)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="800DCDDD8EE8CAC227E8E3131407B508" ruleID="AC87E716-8766-4F78-8851-86354C03A13B">
+                            <Category>Cookie Security: Cookie not Sent Over SSL</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>A cookie is created without the secure flag set to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Test.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Test.java</FilePath>
+<LineStart>23</LineStart>
+<Snippet>        cookie.setDomain("taobao.com");
+        cookie.setMaxAge(-1); // forever time
+        response.addCookie(cookie);
+        return "success";
+    }</Snippet>
+<TargetFunction>addCookie(cookie)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5B1C2565C0DEE3D92A98FB47F475A1DF" ruleID="AC87E716-8766-4F78-8851-86354C03A13B">
+                            <Category>Cookie Security: Cookie not Sent Over SSL</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>A cookie is created without the secure flag set to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>28</LineStart>
+<Snippet>        String author = request.getParameter("test3");
+        Cookie cookie = new Cookie("test3", author);
+        response.addCookie(cookie);
+    }
+}</Snippet>
+<TargetFunction>addCookie(cookie)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="FA06C5D630DB1B517A6688082EE978D9" ruleID="AC87E716-8766-4F78-8851-86354C03A13B">
+                            <Category>Cookie Security: Cookie not Sent Over SSL</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>A cookie is created without the secure flag set to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XSS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XSS.java</FilePath>
+<LineStart>57</LineStart>
+<Snippet>    {
+        Cookie cookie = new Cookie("xss", xss);
+        response.addCookie(cookie);
+        return "Set param into cookie";
+    }</Snippet>
+<TargetFunction>addCookie(cookie)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Cookie Security: HTTPOnly not Set</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The program creates a cookie in CRLFInjection.java at line 27, but fails to set the HttpOnly flag to true.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>All major browsers support the HttpOnly cookie property that prevents client-side scripts from accessing the cookie. Cross-site scripting attacks often access cookies in an attempt to steal session identifiers or authentication tokens. Without HttpOnly enabled, attackers have easier access to user cookies.
+
+
+Example 1: The code in the example below creates a cookie without setting the HttpOnly property.
+
+javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie("emailCookie", email);
+// Missing a call to: cookie.setHttpOnly(true);
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Enable the HttpOnly property when you create cookies. Do this by calling, in the case of javax.servlet.http.Cookie, the setHttpOnly(boolean) method with the argument true.
+
+Example 2: The code in the example below creates the same cookie as the code in Example 1, but this time sets the HttpOnly parameter to true.
+
+javax.servlet.http.Cookie cookie = new javax.servlet.http.Cookie("emailCookie", email);
+cookie.setHttpOnly(true);
+
+
+Several mechanisms to bypass setting HttpOnly to true have been developed, and therefore it is not completely effective.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>4</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="A2715BEEE73E43EF0D8F0AD6E12DAD7D" ruleID="1733FB59-CC13-4E99-9638-3D45FEEE9BE1">
+                            <Category>Cookie Security: HTTPOnly not Set</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>The program creates a cookie in XSS.java at line 56, but fails to set the HttpOnly flag to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>XSS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/XSS.java</FilePath>
+<LineStart>56</LineStart>
+<Snippet>    public String store(String xss, HttpServletResponse response)
+    {
+        Cookie cookie = new Cookie("xss", xss);
+        response.addCookie(cookie);
+        return "Set param into cookie";</Snippet>
+<TargetFunction>cookie = new Cookie(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F2711F128EAAC1F02CA1BA5188BA474A" ruleID="1733FB59-CC13-4E99-9638-3D45FEEE9BE1">
+                            <Category>Cookie Security: HTTPOnly not Set</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>The program creates a cookie in CRLFInjection.java at line 27, but fails to set the HttpOnly flag to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>27</LineStart>
+<Snippet>        response.setHeader("test2", request.getParameter("test2"));
+        String author = request.getParameter("test3");
+        Cookie cookie = new Cookie("test3", author);
+        response.addCookie(cookie);
+    }</Snippet>
+<TargetFunction>cookie = new Cookie(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="1D9650CB4847175CB2A1F2B73FCCE30B" ruleID="1733FB59-CC13-4E99-9638-3D45FEEE9BE1">
+                            <Category>Cookie Security: HTTPOnly not Set</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>The program creates a cookie in Login.java at line 39, but fails to set the HttpOnly flag to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Login.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Login.java</FilePath>
+<LineStart>39</LineStart>
+<Snippet>        String[] deleteCookieKey = {"JSESSIONID", "remember-me"}; // delete cookie
+        for (String key : deleteCookieKey) {
+            Cookie cookie = new Cookie(key, null);
+            cookie.setMaxAge(0);
+            cookie.setPath("/");</Snippet>
+<TargetFunction>cookie = new Cookie(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E07D181F4A257666A1F1CC1F533F1C80" ruleID="1733FB59-CC13-4E99-9638-3D45FEEE9BE1">
+                            <Category>Cookie Security: HTTPOnly not Set</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>The program creates a cookie in Test.java at line 20, but fails to set the HttpOnly flag to true.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>Test.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Test.java</FilePath>
+<LineStart>20</LineStart>
+<Snippet>
+        System.out.println(empId);
+        Cookie cookie = new Cookie("XSRF-TOKEN", "123");
+        cookie.setDomain("taobao.com");
+        cookie.setMaxAge(-1); // forever time</Snippet>
+<TargetFunction>cookie = new Cookie(...)</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Password Management: Password in Comment</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>Storing passwords or password details in plain text anywhere in the system or system code may compromise system security in a way that cannot be easily remedied.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>It is never a good idea to hardcode a password. Storing password details within comments is equivalent to hardcoding passwords. Not only does it allow all of the project's developers to view the password, it also makes fixing the problem extremely difficult. After the code is in production, the password is now leaked to the outside world and cannot be protected or changed without patching the software. If the account protected by the password is compromised, the owners of the system must choose between security and availability.
+
+
+Example: The following comment specifies the default password to connect to a database:
+
+
+...
+// Default username for database connection is "scott"
+// Default password for database connection is "tiger"
+...
+
+
+This code will run successfully, but anyone who has access to it will have access to the password. After the program has shipped, there is likely no way to change the database user "scott" with a password of "tiger" unless the program is patched. An employee with access to this information can use it to break into the system.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Passwords should never be hardcoded and should generally be obfuscated and managed in an external source. Storing passwords in plain text anywhere on the system allows anyone with sufficient permissions to read and potentially misuse the password.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>4</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="DFA185DE70E02462E4FE76DDC886FDEA" ruleID="720E3A66-55AC-4D2D-8DB9-DC30E120A52F">
+                            <Category>Password Management: Password in Comment</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>Storing passwords or password details in plain text anywhere in the system or system code may compromise system security in a way that cannot be easily remedied.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CommandInject.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CommandInject.java</FilePath>
+<LineStart>18</LineStart>
+<Snippet>    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    /**
+     * http://localhost:8080/codeinject?filepath=/tmp;cat /etc/passwd
+     *</Snippet>
+<TargetFunction>Comment()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="4BDBE8744D086FD6E674AF6F35C193C9" ruleID="720E3A66-55AC-4D2D-8DB9-DC30E120A52F">
+                            <Category>Password Management: Password in Comment</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>Storing passwords or password details in plain text anywhere in the system or system code may compromise system security in a way that cannot be easily remedied.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CommandInject.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CommandInject.java</FilePath>
+<LineStart>34</LineStart>
+<Snippet>    }
+
+    /**
+     * Host Injection
+     * Host: hacked by joychou;cat /etc/passwd</Snippet>
+<TargetFunction>Comment()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="8A762BB71CF319864D50B1938D67986F" ruleID="720E3A66-55AC-4D2D-8DB9-DC30E120A52F">
+                            <Category>Password Management: Password in Comment</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>Storing passwords or password details in plain text anywhere in the system or system code may compromise system security in a way that cannot be easily remedied.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>101</LineStart>
+<Snippet>
+
+    /**
+     * Download the url file.
+     * http://localhost:8080/ssrf/openStream?url=file:///etc/passwd</Snippet>
+<TargetFunction>Comment()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="F6176D406F1E27FD482B856CF1CD8C64" ruleID="720E3A66-55AC-4D2D-8DB9-DC30E120A52F">
+                            <Category>Password Management: Password in Comment</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>Storing passwords or password details in plain text anywhere in the system or system code may compromise system security in a way that cannot be easily remedied.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>PathTraversal.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/PathTraversal.java</FilePath>
+<LineStart>21</LineStart>
+<Snippet>    protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    /**
+     * http://localhost:8080/path_traversal/vul?filepath=../../../../../etc/passwd
+     */</Snippet>
+<TargetFunction>Comment()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="2">
+                        <groupTitle>J2EE Bad Practices: getConnection()</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The J2EE standard forbids the direct management of connections.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>The J2EE standard requires that applications use the container's resource management facilities to obtain connections to resources.
+
+For example, a J2EE application should obtain a database connection as follows:
+
+
+ctx = new InitialContext();
+datasource = (DataSource)ctx.lookup(DB_DATASRC_REF);
+conn = datasource.getConnection();
+
+
+and should avoid obtaining a connection in this way:
+
+
+conn = DriverManager.getConnection(CONNECT_STRING);
+
+
+Every major web application container provides pooled database connection management as part of its resource management framework. Duplicating this functionality in an application is difficult and error prone, which is part of the reason it is forbidden under the J2EE standard.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Replace direct calls to DriverManager.getConnection() with a JNDI lookup of the appropriate connection factory, and obtain a connection from the connection factory.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Depending upon the complexity of resource management scheme in use, it may be difficult to identify specific errors in a proprietary connection management infrastructure. Instead of trying to hunt down the bugs, advocate migrating the application to a connection pool manager provided by the container.
+
+2. Beyond the more vanilla performance problems that are likely to be introduced, proprietary connection management often leads to password management mistakes. In applications that manage their own database connections it is not uncommon to find passwords hard-coded or stored in plain text configuration files because no alternative is readily available. Examples of this type of behavior should serve as added ammunition in your argument for moving to an application server managed connection pool.
+
+3. If you are auditing a non-J2EE Java application, the J2EE Bad Practices categories may not apply to your environment. If this is the case, you can use AuditGuide to suppress these issues.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>2</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="6A1C3AEE4D4225E5431268FF9A3DDB0C" ruleID="EDD8E0B5-D8F2-4F56-A20B-549E3880318B">
+                            <Category>J2EE Bad Practices: getConnection()</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The J2EE standard forbids the direct management of connections.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>101</LineStart>
+<Snippet>        try {
+            Class.forName(driver);
+            Connection con = DriverManager.getConnection(url, user, password);
+
+            if(!con.isClosed())</Snippet>
+<TargetFunction>getConnection()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="E58B8007751E245DAFE8F6A9C95C3907" ruleID="EDD8E0B5-D8F2-4F56-A20B-549E3880318B">
+                            <Category>J2EE Bad Practices: getConnection()</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The J2EE standard forbids the direct management of connections.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>48</LineStart>
+<Snippet>        try {
+            Class.forName(driver);
+            Connection con = DriverManager.getConnection(url, user, password);
+
+            if(!con.isClosed())</Snippet>
+<TargetFunction>getConnection()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="2">
+                        <groupTitle>Often Misused: Authentication</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The information returned by the call to getByName() is not trustworthy. Attackers may spoof DNS entries. Do not rely on DNS for security.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Many DNS servers are susceptible to spoofing attacks, so you should assume that your software will someday run in an environment with a compromised DNS server. If attackers are allowed to make DNS updates (sometimes called DNS cache poisoning), they can route your network traffic through their machines or make it appear as if their IP addresses are part of your domain. Do not base the security of your system on DNS names.
+
+
+Example: The following code uses a DNS lookup to determine whether an inbound request is from a trusted host. If an attacker can poison the DNS cache, they can gain trusted status.
+
+
+ String ip = request.getRemoteAddr();
+ InetAddress addr = InetAddress.getByName(ip);
+ if (addr.getCanonicalHostName().endsWith("trustme.com")) {
+ trusted = true;
+ }
+
+
+IP addresses are more reliable than DNS names, but they can also be spoofed. Attackers may easily forge the source IP address of the packets they send, but response packets will return to the forged IP address. To see the response packets, the attacker has to sniff the traffic between the victim machine and the forged IP address. In order to accomplish the required sniffing, attackers typically attempt to locate themselves on the same subnet as the victim machine. Attackers may be able to circumvent this requirement by using source routing, but source routing is disabled across much of the Internet today. In summary, IP address verification can be a useful part of an authentication scheme, but it should not be the single factor required for authentication.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>You can increase confidence in a domain name lookup if you check to make sure that the host's forward and backward DNS entries match. Attackers will not be able to spoof both the forward and the reverse DNS entries without controlling the nameservers for the target domain. This is not a foolproof approach however: attackers may be able to convince the domain registrar to turn over the domain to a malicious nameserver. Basing authentication on DNS entries is simply a risky proposition.
+
+While no authentication mechanism is foolproof, there are better alternatives than host-based authentication. Password systems offer decent security, but are susceptible to bad password choices, insecure password transmission, and bad password management. A cryptographic scheme like SSL is worth considering, but such schemes are often so complex that they bring with them the risk of significant implementation errors, and key material can always be stolen. In many situations, multi-factor authentication including a physical token offers the most security available at a reasonable price.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Check how the DNS information is being used. In addition to considering whether or not the program's authentication mechanisms can be defeated, consider how DNS spoofing can be used in a social engineering attack. For example, if attackers can make it appear that a posting came from an internal machine, can they gain credibility?</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>2</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="035A98EEFDA704C6B74256554C58483F" ruleID="C7D64877-9D39-40E0-9510-5B7051F6E778">
+                            <Category>Often Misused: Authentication</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The information returned by the call to getHostAddress() is not trustworthy. Attackers may spoof DNS entries. Do not rely on DNS for security.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>109</LineStart>
+<Snippet>        try {
+            InetAddress IpAddress = InetAddress.getByName(host); //  send dns request
+            return IpAddress.getHostAddress();
+        }
+        catch (Exception e) {</Snippet>
+<TargetFunction>getHostAddress()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                        <Issue iid="5C996EB1BAEF2A3292D98AFA29A4286B" ruleID="C7D64877-9D39-40E0-9510-5B7051F6E778">
+                            <Category>Often Misused: Authentication</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The information returned by the call to getByName() is not trustworthy. Attackers may spoof DNS entries. Do not rely on DNS for security.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>SSRFChecker.java</FileName>
+<FilePath>src/main/java/org/joychou/security/SSRFChecker.java</FilePath>
+<LineStart>108</LineStart>
+<Snippet>    private static String host2ip(String host) {
+        try {
+            InetAddress IpAddress = InetAddress.getByName(host); //  send dns request
+            return IpAddress.getHostAddress();
+        }</Snippet>
+<TargetFunction>getByName()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="2">
+                        <groupTitle>Open Redirect</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The file URLRedirect.java passes unvalidated data to an HTTP redirect function on line 55. Allowing unvalidated input to control the URL used in a redirect can aid phishing attacks.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Redirects allow web applications to direct users to different pages within the same application or to external sites. Applications utilize redirects to aid in site navigation and, in some cases, to track how users exit the site. Open redirect vulnerabilities occur when a web application redirects clients to any arbitrary URL that can be controlled by an attacker.
+
+Attackers may utilize open redirects to trick users into visiting a URL to a trusted site and redirecting them to a malicious site. By encoding the URL, an attacker is able to make it more difficult for end-users to notice the malicious destination of the redirect, even when it is passed as a URL parameter to the trusted site. Open redirects are often abused as part of phishing scams to harvest sensitive end-user data.
+
+
+
+Example 1: The following JSP code instructs the user's browser to open a URL parsed from the dest request parameter when a user clicks the link.
+
+
+    &lt;%
+        ...
+        String strDest = request.getParameter("dest");
+        pageContext.forward(strDest);
+        ...
+    %&gt;
+
+
+If a victim received an email instructing the user to follow a link to "http://trusted.example.com/ecommerce/redirect.asp?dest=www.wilyhacker.com", the user would likely click on the link believing they would be transferred to the trusted site. However, when the user clicks the link, the code above will redirect the browser to "http://www.wilyhacker.com".
+
+Many users have been educated to always inspect URLs they receive in emails to make sure the link specifies a trusted site they know. However, if the attacker Hex encoded the destination url as follows:
+"http://trusted.example.com/ecommerce/redirect.asp?dest=%77%69%6C%79%68%61%63%6B%65%72%2E%63%6F%6D"
+
+then even a savvy end-user may be fooled into following the link.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Unvalidated user input should not be allowed to control the destination URL in a redirect. Instead, use a level of indirection: create a list of legitimate URLs that users are allowed to specify and only allow users to select from the list. With this approach, input provided by users is never used directly to specify a URL for redirects.
+
+Example 2: The following code references an array populated with valid URLs. The link the user clicks passes in the array index that corresponds to the desired URL.
+
+
+    &lt;%
+        ...
+        try {
+            int strDest = Integer.parseInt(request.getParameter("dest"));
+            if((strDest &gt;= 0) &amp;&amp; (strDest &lt;= strURLArray.length -1 ))
+            {
+                strFinalURL = strURLArray[strDest];
+                pageContext.forward(strFinalURL);
+            }
+        }
+        catch (NumberFormatException nfe) {
+            // Handle exception
+            ...
+        }
+        ...
+    %&gt;
+
+
+In some situations this approach is impractical because the set of legitimate URLs is too large or too hard to keep track of. In such cases, use a similar approach to restrict the domains that users can be redirected to, which can at least prevent attackers from sending users to malicious external sites.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. A number of modern web frameworks provide mechanisms for performing validation of user input. Struts and Spring MVC are two examples. To highlight the unvalidated sources of input, the Fortify Secure Coding Rulepacks dynamically re-prioritize the issues reported by Fortify Static Code Analyzer by lowering their probability of exploit and providing pointers to the supporting evidence whenever the framework validation mechanism is in use. We refer to this feature as Context-Sensitive Ranking. To further assist the Fortify user with the auditing process, the Fortify Software Security Research group makes available the Data Validation project template that groups the issues into folders based on the validation mechanism applied to their source of input.
+
+2. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>2</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="0A9723E3CF568D89247C6C643D8435A8" ruleID="7B5AF271-BDC5-4ABE-A93A-316A14FA9028">
+                            <Category>Open Redirect</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The file URLRedirect.java passes unvalidated data to an HTTP redirect function on line 55. Allowing unvalidated input to control the URL used in a redirect can aid phishing attacks.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>55</LineStart>
+<Snippet>    public static void sendRedirect(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        String url = request.getParameter("url");
+        response.sendRedirect(url); // 302 redirect
+    }
+</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletResponse.sendRedirect()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>54</LineStart>
+<Snippet>    @ResponseBody
+    public static void sendRedirect(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        String url = request.getParameter("url");
+        response.sendRedirect(url); // 302 redirect
+    }</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                        <Issue iid="6B77CD5582830CE8BA20C9D69B5DB05C" ruleID="7B5AF271-BDC5-4ABE-A93A-316A14FA9028">
+                            <Category>Open Redirect</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The file URLRedirect.java passes unvalidated data to an HTTP redirect function on line 90. Allowing unvalidated input to control the URL used in a redirect can aid phishing attacks.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>90</LineStart>
+<Snippet>            return;
+        }
+        response.sendRedirect(url);
+    }
+}</Snippet>
+<TargetFunction>javax.servlet.http.HttpServletResponse.sendRedirect()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>83</LineStart>
+<Snippet>    @ResponseBody
+    public static void sendRedirect_seccode(HttpServletRequest request, HttpServletResponse response) throws IOException{
+        String url = request.getParameter("url");
+        String urlwhitelist[] = {"joychou.org", "joychou.com"};
+        if (!SecurityUtil.checkURLbyEndsWith(url, urlwhitelist)) {</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Build Misconfiguration: External Maven Dependency Repository</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>This maven build script relies on external sources, which could allow an attacker to insert malicious code into the final product or to take control of the build machine.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Several tools exist within the Java development world to aid in dependency management: both Apache Ant and Apache Maven build systems include functionality specifically designed to help manage dependencies and Apache Ivy is developed explicitly as a dependency manager. Although there are differences in their behavior, these tools share the common functionality that they automatically download external dependencies specified in the build process at build time. This makes it much easier for developer B to build software in the same manner as developer A. Developers just store dependency information in the build file, which means that each developer and build engineer has a consistent way to obtain dependencies, compile the code, and deploy without the dependency management hassles involved in manual dependency management. The following examples illustrate how Ivy, Ant and Maven can be used to manage external dependencies as part of a build process.
+
+Under Maven, instead of listing explicit URLs from which to retrieve the dependencies, developers specify the dependency names and versions and Maven relies on its underlying configuration to identify the server(s) from which to retrieve the dependencies. For commonly used components this saves the developer from having to researching dependency locations.
+
+Example 1: The following except from a Maven pom.xml file shows how a developer can specify multiple external dependencies using their name and version:
+
+
+&lt;dependencies&gt;
+  &lt;dependency&gt;
+    &lt;groupId&gt;commons-logging&lt;/groupId&gt;
+    &lt;artifactId&gt;commons-logging&lt;/artifactId&gt;
+    &lt;version&gt;1.1&lt;/version&gt;
+  &lt;/dependency&gt;
+  &lt;dependency&gt;
+    &lt;groupId&gt;javax.jms&lt;/groupId&gt;
+    &lt;artifactId&gt;jms&lt;/artifactId&gt;
+    &lt;version&gt;1.1&lt;/version&gt;
+  &lt;/dependency&gt;
+  ...
+&lt;/dependencies&gt;
+
+
+Two distinct types of attack scenarios affect these systems: An attacker could either compromise the server hosting the dependency or compromise the DNS server the build machine uses to redirect requests for hostname of the server hosting the dependency to a machine controlled by the attacker. Both scenarios result in the attacker gaining the ability to inject a malicious version of a dependency into a build running on an otherwise uncompromised machine.
+
+Regardless of the attack vector used to deliver the Trojan dependency, these scenarios share the common element that the build system blindly accepts the malicious binary and includes it in the build. Because the build system has no recourse for rejecting the malicious binary and existing security mechanisms, such as code review, typically focus on internally-developed code rather than external dependencies, this type of attack has a strong potential to go unnoticed as it spreads through the development environment and potentially into production.
+
+Although there is some risk of a compromised dependency being introduced into a manual build process, by the tendency of automated build systems to retrieve the dependency from an external source each time the build system is run in a new environment greatly increases the window of opportunity for an attacker. An attacker need only compromise the dependency server or the DNS server during one of the many times the dependency is retrieved in order to compromise the machine on which the build is occurring.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>The simplest solution is to refrain from adopting automated dependency management systems altogether. Managing dependencies manually eliminates the potential for unexpected behavior caused by the build system. Obviously, the an attacker could still mount one of the attacks described above to coincide with the manual retrieval of a dependency, but limiting the frequency with which the dependency must be retrieved significantly reduces the window of opportunity for an attacker. Finally, this solution forces the development organization to rely on what is ostensibly an antiquated build system. A system based on manual dependency management is often more difficult to use and maintain, and may be unacceptable in some software development environments.
+
+The second solution is a hybrid of the traditional manual dependency management approach and the fully automated solution that is popular today. The biggest advantage of the manual build process is the decreased window of attack, which can be achieved in a semi-automated system by replicating external dependency servers internally. Any build system that requires an external dependency can then point to the internal server using a hard-coded internal IP address to bypass the risk of DNS-based attacks. As new dependencies are added and new versions released, they can be downloaded once and included on the internal repository. This solution reduces the attack opportunities and allows the organization leverage existing internal network security infrastructure.
+
+To implement this solution using Maven, a project should have the IP address for an internal repository hard coded the pom.xml. Specifying the IP address in the pom.xml ensures the internal repository will be used by the corresponding build, but is tied to a specific project. Alternatively, the IP address can be specified in settings.xml, which makes the configuration easier to share across multiple projects.
+
+Example 2: The following Maven pom.xml demonstrates the use of an explicit internal IP address (the entries can also be used in settings.xml):
+
+
+&lt;project&gt;
+  ...
+  &lt;repositories&gt;
+    &lt;repository&gt;
+      &lt;releases&gt;
+        &lt;enabled&gt;true&lt;/enabled&gt;
+        &lt;updatePolicy&gt;always&lt;/updatePolicy&gt;
+        &lt;checksumPolicy&gt;warn&lt;/checksumPolicy&gt;
+      &lt;/releases&gt;
+      &lt;snapshots&gt;
+        &lt;enabled&gt;true&lt;/enabled&gt;
+        &lt;updatePolicy&gt;never&lt;/updatePolicy&gt;
+        &lt;checksumPolicy&gt;fail&lt;/checksumPolicy&gt;
+      &lt;/snapshots&gt;
+      &lt;id&gt;central&lt;/id&gt;
+      &lt;name&gt;Internal Repository&lt;/name&gt;
+      &lt;url&gt;http://172.16.1.13/maven2&lt;/url&gt;
+      &lt;layout&gt;default&lt;/layout&gt;
+    &lt;/repository&gt;
+  &lt;/repositories&gt;
+  &lt;pluginRepositories&gt;
+    ...
+  &lt;/pluginRepositories&gt;
+  ...
+&lt;/project&gt;
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="87E3EC5CC8154C006783CC461A6DDEEB" ruleID="FF57412F-DD28-44DE-8F4F-0AD39620768C">
+                            <Category>Build Misconfiguration: External Maven Dependency Repository</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Environment</Kingdom>
+                            <Abstract>This maven build script relies on external sources, which could allow an attacker to insert malicious code into the final product or to take control of the build machine.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>pom.xml</FileName>
+<FilePath>pom.xml</FilePath>
+<LineStart>4</LineStart>
+<Snippet>&lt;project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"&gt;
+    &lt;modelVersion&gt;4.0.0&lt;/modelVersion&gt;
+</Snippet>
+<TargetFunction>//project/repositories()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Code Correctness: Byte Array to String Conversion</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The call to String() on line 229 of SSRF.java converts a byte array into a String, which may lead to data loss.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>When data from a byte array is converted into a String, it is unspecified what will happen to any data that is outside of the applicable character set. This can lead to data being lost, or a decrease in the level of security when binary data is needed to ensure proper security measures are followed.
+
+Example 1: The following code converts data into a String in order to create a hash.
+
+
+  ...
+  FileInputStream fis = new FileInputStream(myFile);
+  byte[] byteArr = byte[BUFSIZE];
+  ...
+  int count = fis.read(byteArr);
+  ...
+  String fileString = new String(byteArr);
+  String fileSHA256Hex = DigestUtils.sha256Hex(fileString);
+  // use fileSHA256Hex to validate file
+  ...
+
+
+Assuming the size of the file is less than BUFSIZE, this works fine as long as the information in myFile is encoded the same as the default character set, however if it's using a different encoding, or is a binary file, it will lose information. This in turn will cause the resulting SHA hash to be less reliable, and could mean it's far easier to cause collisions, especially if any data outside of the default character set is represented by the same value, such as a question mark.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Generally speaking, a byte array potentially containing noncharacter data should never be converted into a String object as it may break functionality, but in some cases this can cause much larger security concerns. In a lot of cases there is no need to actually convert a byte array into a String, but if there is a specific reason to be able to create a String object from binary data, it must first be encoded in a way such that it will fit into the default character set.
+
+Example 2: The following uses a different variant of the API in Example 1 to prevent any validation problems.
+
+
+  ...
+  FileInputStream fis = new FileInputStream(myFile);
+  byte[] byteArr = byte[BUFSIZE];
+  ...
+  int count = fis.read(byteArr);
+  ...
+  byte[] fileSHA256 = DigestUtils.sha256(byteArr);
+  // use fileSHA256 to validate file, comparing hash byte-by-byte.
+  ...
+
+
+In this case, it is straightforward to rectify, since this API has overloaded variants including one that accepts a byte array, and this could be simplified even further by using another overloaded variant of DigestUtils.sha256() that accepts a FileInputStream object as its argument. Other scenarios may need careful consideration as to whether it's possible that the byte array could contain data outside of the character set, and further refactoring may be required.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="56B81EC767F37B2A615C2F9F23114941" ruleID="993CC475-24A5-4BBD-A008-67045CCA0ACB">
+                            <Category>Code Correctness: Byte Array to String Conversion</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The call to String() on line 229 of SSRF.java converts a byte array into a String, which may lead to data loss.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>229</LineStart>
+<Snippet>            // Read the response body.
+            byte[] resBody = method.getResponseBody();
+            return new String(resBody);
+
+        } catch (IOException e) {</Snippet>
+<TargetFunction>String()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Cookie Security: Overly Broad Path</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>A cookie with an overly broad path can be accessed through other applications on the same domain.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Developers often set cookies to be accessible from the root context path ("/"). This exposes the cookie to all web applications on the domain. Because cookies often carry sensitive information such as session identifiers, sharing cookies across applications can cause a vulnerability in one application to compromise another application.
+
+Example 1:
+Imagine you have a forum application deployed at http://communitypages.example.com/MyForum and the application sets a session ID cookie with path "/" when users log in to the forum.
+
+For example:
+
+  Cookie cookie = new Cookie("sessionID", sessionID);
+  cookie.setPath("/");
+
+
+Suppose an attacker creates another application at http://communitypages.example.com/EvilSite and posts a link to this site on the forum. When a user of the forum clicks this link, the browser will send the cookie set by /MyForum to the application running at /EvilSite. By stealing the session ID, the attacker can compromise the account of any forum user that browsed to /EvilSite.
+
+In addition to reading a cookie, it might be possible for attackers to perform a Cookie Poisoning attack by using /EvilSite to create its own overly broad cookie that overwrites the cookie from /MyForum.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Make sure to set cookie paths to be as restrictive as possible.
+
+Example 2: The following code shows how to set the cookie path to "/MyForum" for the example in the Explanation section.
+
+  Cookie cookie = new Cookie("sessionID", sessionID);
+  cookie.setPath("/MyForum");
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="B5F4115D294F19D542B1FC959F1F0433" ruleID="0FF9D3CC-9713-4478-AA74-8F78D7A55272">
+                            <Category>Cookie Security: Overly Broad Path</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>A cookie with an overly broad path can be accessed through other applications on the same domain.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>Login.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/Login.java</FilePath>
+<LineStart>41</LineStart>
+<Snippet>            Cookie cookie = new Cookie(key, null);
+            cookie.setMaxAge(0);
+            cookie.setPath("/");
+            response.addCookie(cookie);
+        }</Snippet>
+<TargetFunction>setPath()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Dead Code: Unused Field</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The field csrfExcludeUrl is never used.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>This field is never accessed, except perhaps by dead code. Dead code is defined as code that is never directly or indirectly executed by a public method. It is likely that the field is simply vestigial, but it is also possible that the unused field points out a bug.
+
+Example 1: The field named glue is not used in the following class. The author of the class has accidentally put quotes around the field name, transforming it into a string constant.
+
+
+public class Dead {
+
+  String glue;
+
+  public String getGlue() {
+    return "glue";
+  }
+
+}
+
+
+Example 2: The field named glue is used in the following class, but only from a method that is never called.
+
+
+public class Dead {
+
+  String glue;
+
+  private String getGlue() {
+    return glue;
+  }
+
+}
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>In general, you should repair or remove dead code. To repair dead code, execute the dead code directly or indirectly through a public method. Dead code causes additional complexity and maintenance burden without contributing to the functionality of the program.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="0653669F69E900A3F344EFAC7A1422E9" ruleID="3E7BCE41-4A79-49FF-8B8B-3F55F1F2DC5E">
+                            <Category>Dead Code: Unused Field</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Code Quality</Kingdom>
+                            <Abstract>The field csrfExcludeUrl is never used.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>WebSecurityConfig.java</FileName>
+<FilePath>src/main/java/org/joychou/security/WebSecurityConfig.java</FilePath>
+<LineStart>35</LineStart>
+<Snippet>
+    @Value("${joychou.security.csrf.exclude.url}")
+    private String[] csrfExcludeUrl;
+
+    @Value("${joychou.security.csrf.method}")</Snippet>
+<TargetFunction>Field: csrfExcludeUrl()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Dynamic Code Evaluation: Unsafe Deserialization</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>Deserializing user-controlled object streams at runtime can allow attackers to execute arbitrary code on the server, abuse application logic, and/or lead to denial of service.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Java serialization turns object graphs into byte streams containing the objects themselves and the necessary metadata to reconstruct them from the byte stream. Developers can create custom code to aid in the process of deserializing Java objects, where they may even replace the deserialized objects with different objects, or proxies. The customized deserialization process takes place during objects reconstruction before the objects are returned to the application and cast into expected types. By the time developers try to enforce an expected type, code may have already been executed.
+
+Custom deserialization routines are defined in the serializable classes which need to be present in the runtime classpath and cannot be injected by the attacker so the exploitability of these attacks depends on the classes available in the application environment. Unfortunately, common third party classes or even JDK classes can be abused to exhaust JVM resources, deploy malicious files, or run arbitrary code.
+
+Certain Spring service exporters use Java serialization behind the scenes at the transport layer. RMI, JMSInvoker and HTTPInvoker are examples of these services.
+
+Example 1: RMIServiceExporter exposing TestService methods.
+
+&lt;bean id="testService" class="example.TestServiceImpl"/&gt;
+&lt;bean class="org.springframework.remoting.rmi.RmiServiceExporter"&gt;
+    &lt;property name="serviceName" value="TestService"/&gt;
+    &lt;property name="service" ref="testService"/&gt;
+    &lt;property name="serviceInterface" value="example.TestService"/&gt;
+    &lt;property name="registryPort" value="1199"/&gt;
+&lt;/bean&gt;
+
+
+Example 2: JMSInvokerServiceExporter exposing TestService methods.
+
+&lt;bean id="testService" class="example.TestServiceImpl"/&gt;
+&lt;bean class="org.springframework.jms.remoting.JmsInvokerServiceExporter"&gt;
+        &lt;property name="serviceInterface" value="example.TestService"/&gt;
+        &lt;property name="service" ref="testService"/&gt;
+&lt;/bean&gt;
+
+
+Example 3: HTTPInvokerServiceExporter exposing TestService methods.
+
+&lt;bean id="testService" class="example.TestServiceImpl"/&gt;
+&lt;bean class="org.springframework.remoting.httpinvoker.HttpInvokerServiceExporter"&gt;
+        &lt;property name="serviceInterface" value="example.TestService"/&gt;
+        &lt;property name="service" ref="testService"/&gt;
+&lt;/bean&gt;
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>If possible, do not deserialize untrusted data without validating the contents of the object stream. In order to validate classes being deserialized, the look-ahead deserialization pattern should be used.
+
+The object stream will first contain the class description metadata and then the serialized bytes of their member fields. The Java serialization process allows developers to read the class description and decide whether to proceed with the deserialization of the object or abort it. In order to do so, it is necessary to subclass java.io.ObjectInputStream and provide a custom implementation of the resolveClass(ObjectStreamClass desc) method where class validation and verification should take place.
+
+While the ideal approach in this situation is to whitelist the expected classes, in some scenarios, this approach may not be practical. A blacklist approach is better for complex object graph structures. Keep in mind that although some classes to achieve code execution are publicly known, there may be others that are unknown or undisclosed, so a whitelist approach will always be the preferred approach. To avoid denial of service attacks, it is recommended that you override the resolveObject(Object obj) method in order to count how many objects are being deserialized and abort the deserialization when a threshold is surpassed.
+
+When deserialization takes place in library, or framework (e.g. when using JMX, RMI, JMS, HTTP Invokers) the above recommendation is not useful since it is beyond the developer's control. In those cases, you may want to make sure that these protocols meet the following requirements:
+
+- Not exposed publicly.
+- Use authentication.
+- Use integrity checks.
+- Use encryption.
+
+In addition, Fortify Runtime provides security controls to be enforced every time the application performs a deserialization from an ObjectInputStream, protecting both application code but also library and framework code from this type of attack.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="D7236F8B8ABBCCF2EAF387E376D72BAA" ruleID="550A858A-55E7-4358-B081-19D66E082EBD">
+                            <Category>Dynamic Code Evaluation: Unsafe Deserialization</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>Deserializing user-controlled object streams at runtime can allow attackers to execute arbitrary code on the server, abuse application logic, and/or lead to denial of service.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>pom.xml</FileName>
+<FilePath>pom.xml</FilePath>
+<LineStart>129</LineStart>
+<Snippet>        &lt;dependency&gt;
+            &lt;groupId&gt;org.springframework.boot&lt;/groupId&gt;
+            &lt;artifactId&gt;spring-boot-starter-actuator&lt;/artifactId&gt;
+        &lt;/dependency&gt;
+</Snippet>
+<TargetFunction>null()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>File Disclosure: J2EE</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>On line 67 of URLRedirect.java, the method forward() invokes a server side forward using a path built with unvalidated input. This could allow an attacker to download application binaries or view arbitrary files within protected directories.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>A file disclosure occur when:
+1. Data enters a program from an untrusted source.
+
+
+2. The data is used to dynamically construct a path.
+
+
+
+Example 1: The following code takes untrusted data and uses it to build a path which is used in a server side forward.
+
+
+...
+String returnURL = request.getParameter("returnURL");
+	RequestDispatcher rd = request.getRequestDispatcher(returnURL);
+	rd.forward();
+...
+
+
+Example 2: The following code takes untrusted data and uses it to build a path which is used in a server side forward.
+
+
+...
+	&lt;% String returnURL = request.getParameter("returnURL"); %&gt;
+	&lt;jsp:include page="&lt;%=returnURL%&gt;" /&gt;
+	...
+
+
+
+If an attacker provided a URL with the request parameter matching a sensitive file location, they would be able to view that file. For example, "http://www.yourcorp.com/webApp/logic?returnURL=WEB-INF/applicationContext.xml" would allow them to view the applicationContext.xml of the application.
+After the attacker had the applicationContext.xml, they could locate and download other configuration files referenced in the applicationContext.xml or even class or jar files. This would allow attackers to gain sensitive infomation about an application and target it for other types of attack.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Do not use untrusted data to direct requests to server-side resources. Instead, use a level of indirection between locations and paths.
+Instead of the following:
+
+&lt; a href="http://www.yourcorp.com/webApp/logic?nextPage=WEB-INF/signup.jsp"&gt;New Customer&lt;/a&gt;
+
+Use the following:
+
+&lt; a href="http://www.yourcorp.com/webApp/logic?nextPage=newCustomer"&gt;New Customer&lt;/a&gt;
+
+The server-side logic would have a map keyed by logical names to server-side paths such that the path stored under the key "newCustomer" would be "/WEB-INF/signup.jsp".</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="A9E6C9E82C5E5907753EEB14E98DF4E2" ruleID="66399BDF-8E0A-485E-A615-07C96D2632F9">
+                            <Category>File Disclosure: J2EE</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>On line 67 of URLRedirect.java, the method forward() invokes a server side forward using a path built with unvalidated input. This could allow an attacker to download application binaries or view arbitrary files within protected directories.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>67</LineStart>
+<Snippet>    public static void forward(HttpServletRequest request, HttpServletResponse response) {
+        String url = request.getParameter("url");
+        RequestDispatcher rd =request.getRequestDispatcher(url);
+        try{
+            rd.forward(request, response);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getRequestDispatcher()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>URLRedirect.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/URLRedirect.java</FilePath>
+<LineStart>66</LineStart>
+<Snippet>    @ResponseBody
+    public static void forward(HttpServletRequest request, HttpServletResponse response) {
+        String url = request.getParameter("url");
+        RequestDispatcher rd =request.getRequestDispatcher(url);
+        try{</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Header Manipulation: Cookies</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method crlf() in CRLFInjection.java includes unvalidated data in an HTTP cookie on line 27. This enables Cookie manipulation attacks and can lead to other HTTP Response header manipulation attacks like: cache-poisoning, cross-site scripting, cross-user defacement, page hijacking or open redirect.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Cookie Manipulation vulnerabilities occur when:
+
+1. Data enters a web application through an untrusted source, most frequently an HTTP request.
+
+2. The data is included in an HTTP cookie sent to a web user without being validated.
+
+As with many software security vulnerabilities, cookie manipulation is a means to an end, not an end in itself. At its root, the vulnerability is straightforward: an attacker passes malicious data to a vulnerable application, and the application includes the data in an HTTP cookie.
+
+Cookie Manipulation: When combined with attacks like Cross-Site Request Forgery, attackers may change, add to, or even overwrite a legitimate user's cookies.
+
+Being an HTTP Response header, Cookie manipulation attacks can also lead to other types of attacks like:
+
+HTTP Response Splitting:
+One of the most common Header Manipulation attacks is HTTP Response Splitting. To mount a successful HTTP Response Splitting exploit, the application must allow input that contains CR (carriage return, also given by %0d or \r) and LF (line feed, also given by %0a or \n)characters into the header. These characters not only give attackers control of the remaining headers and body of the response the application intends to send, but also allows them to create additional responses entirely under their control.
+
+Many of today's modern application servers will prevent the injection of malicious characters into HTTP headers. For example, recent versions of Apache Tomcat will throw an IllegalArgumentException if you attempt to set a header with prohibited characters. If your application server prevents setting headers with new line characters, then your application is not vulnerable to HTTP Response Splitting. However, solely filtering for new line characters can leave an application vulnerable to Cookie Manipulation or Open Redirects, so care must still be taken when setting HTTP headers with user input.
+
+Example 1: The following code segment reads the name of the author of a weblog entry, author, from an HTTP request and sets it in a cookie header of an HTTP response.
+
+
+String author = request.getParameter(AUTHOR_PARAM);
+...
+Cookie cookie = new Cookie("author", author);
+     cookie.setMaxAge(cookieExpiration);
+     response.addCookie(cookie);
+
+
+Assuming a string consisting of standard alpha-numeric characters, such as "Jane Smith", is submitted in the request the HTTP response including this cookie might take the following form:
+
+
+HTTP/1.1 200 OK
+...
+Set-Cookie: author=Jane Smith
+...
+
+
+However, because the value of the cookie is formed of unvalidated user input the response will only maintain this form if the value submitted for AUTHOR_PARAM does not contain any CR and LF characters. If an attacker submits a malicious string, such as "Wiley Hacker\r\nHTTP/1.1 200 OK\r\n...", then the HTTP response would be split into two responses of the following form:
+
+
+HTTP/1.1 200 OK
+...
+Set-Cookie: author=Wiley Hacker
+
+HTTP/1.1 200 OK
+...
+
+
+Clearly, the second response is completely controlled by the attacker and can be constructed with any header and body content desired. The ability of attacker to construct arbitrary HTTP responses permits a variety of resulting attacks, including: cross-user defacement, web and browser cache poisoning, cross-site scripting and page hijacking.
+
+Some think that in the mobile world, classic web application vulnerabilities, such as header and cookie manipulation, do not make sense -- why would the user attack themself? However, keep in mind that the essence of mobile platforms is applications that are downloaded from various sources and run alongside each other on the same device. The likelihood of running a piece of malware next to a banking application is high, which necessitates expanding the attack surface of mobile applications to include inter-process communication.
+
+Example 2: The following code adapts Example 1 to the Android platform.
+
+
+...
+        CookieManager webCookieManager = CookieManager.getInstance();
+        String author = this.getIntent().getExtras().getString(AUTHOR_PARAM);
+        String setCookie = "author=" + author + "; max-age=" + cookieExpiration;
+        webCookieManager.setCookie(url, setCookie);
+
+...
+
+
+Cross-User Defacement: An attacker will be able to make a single request to a vulnerable server that will cause the server to create two responses, the second of which may be misinterpreted as a response to a different request, possibly one made by another user sharing the same TCP connection with the server. This can be accomplished by convincing the user to submit the malicious request themselves, or remotely in situations where the attacker and the user share a common TCP connection to the server, such as a shared proxy server. In the best case, an attacker may leverage this ability to convince users that the application has been hacked, causing users to lose confidence in the security of the application. In the worst case, an attacker may provide specially crafted content designed to mimic the behavior of the application but redirect private information, such as account numbers and passwords, back to the attacker.
+
+Cache Poisoning: The impact of a maliciously constructed response can be magnified if it is cached either by a web cache used by multiple users or even the browser cache of a single user. If a response is cached in a shared web cache, such as those commonly found in proxy servers, then all users of that cache will continue receive the malicious content until the cache entry is purged. Similarly, if the response is cached in the browser of an individual user, then that user will continue to receive the malicious content until the cache entry is purged, although only the user of the local browser instance will be affected.
+
+Cross-Site Scripting: Once attackers have control of the responses sent by an application, they have a choice of a variety of malicious content to provide users. Cross-site scripting is common form of attack where malicious JavaScript or other code included in a response is executed in the user's browser. The variety of attacks based on XSS is almost limitless, but they commonly include transmitting private data like cookies or other session information to the attacker, redirecting the victim to web content controlled by the attacker, or performing other malicious operations on the user's machine under the guise of the vulnerable site. The most common and dangerous attack vector against users of a vulnerable application uses JavaScript to transmit session and authentication information back to the attacker who can then take complete control of the victim's account.
+
+Page Hijacking: In addition to using a vulnerable application to send malicious content to a user, the same root vulnerability can also be leveraged to redirect sensitive content generated by the server and intended for the user to the attacker instead. By submitting a request that results in two responses, the intended response from the server and the response generated by the attacker, an attacker may cause an intermediate node, such as a shared proxy server, to misdirect a response generated by the server for the user to the attacker. Because the request made by the attacker generates two responses, the first is interpreted as a response to the attacker's request, while the second remains in limbo. When the user makes a legitimate request through the same TCP connection, the attacker's request is already waiting and is interpreted as a response to the victim's request. The attacker then sends a second request to the server, to which the proxy server responds with the server generated request intended for the victim, thereby compromising any sensitive information in the headers or body of the response intended for the victim.
+
+Open Redirect: Allowing unvalidated input to control the URL used in a redirect can aid phishing attacks.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>The solution to cookie manipulation is to ensure that input validation occurs in the correct places and checks for the correct properties.
+
+Since Header Manipulation vulnerabilities like cookie manipulation occur when an application includes malicious data in its output, one logical approach is to validate data immediately before it leaves the application. However, because web applications often have complex and intricate code for generating responses dynamically, this method is prone to errors of omission (missing validation). An effective way to mitigate this risk is to also perform input validation for Header Manipulation.
+
+Web applications must validate their input to prevent other vulnerabilities, such as SQL injection, so augmenting an application's existing input validation mechanism to include checks for Header Manipulation is generally relatively easy. Despite its value, input validation for Header Manipulation does not take the place of rigorous output validation. An application may accept input through a shared data store or other trusted source, and that data store may accept input from a source that does not perform adequate input validation. Therefore, the application cannot implicitly rely on the safety of this or any other data. This means the best way to prevent Header Manipulation vulnerabilities is to validate everything that enters the application and leaves the application destined for the user.
+
+The most secure approach to validation for Header Manipulation is to create a whitelist of safe characters that are allowed to appear in HTTP response headers and accept input composed exclusively of characters in the approved set. For example, a valid name might only include alpha-numeric characters or an account number might only include digits 0-9.
+
+A more flexible, but less secure approach is known as blacklisting, which selectively rejects or escapes potentially dangerous characters before using the input. In order to form such a list, you first need to understand the set of characters that hold special meaning in HTTP response headers. Although the CR and LF characters are at the heart of an HTTP response splitting attack, other characters, such as ':' (colon) and '=' (equal), have special meaning in response headers as well.
+
+After you identify the correct points in an application to perform validation for Header Manipulation attacks and what special characters the validation should consider, the next challenge is to identify how your validation handles special characters. The application should reject any input destined to be included in HTTP response headers that contains special characters, particularly CR and LF, as invalid.
+
+Many application servers attempt to limit an application's exposure to HTTP response splitting vulnerabilities by providing implementations for the functions responsible for setting HTTP headers and cookies that perform validation for the characters essential to an HTTP response splitting attack. Do not rely on the server running your application to make it secure. When an application is developed there are no guarantees about what application servers it will run on during its lifetime. As standards and known exploits evolve, there are no guarantees that application servers will also stay in sync.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Many HttpServletRequest implementations return a URL-encoded string from getHeader(), will not cause a HTTP response splitting issue unless it is decoded first because the CR and LF characters will not carry a meta-meaning in their encoded form. However, this behavior is not specified in the J2EE standard and varies by implementation. Furthermore, even encoded user input returned from getHeader() can lead to other vulnerabilities, including open redirects and other HTTP header tampering.
+
+2. A number of modern web frameworks provide mechanisms for performing validation of user input. Struts and Spring MVC are two examples. To highlight the unvalidated sources of input, the Fortify Secure Coding Rulepacks dynamically re-prioritize the issues reported by Fortify Static Code Analyzer by lowering their probability of exploit and providing pointers to the supporting evidence whenever the framework validation mechanism is in use. We refer to this feature as Context-Sensitive Ranking. To further assist the Fortify user with the auditing process, the Fortify Software Security Research group makes available the Data Validation project template that groups the issues into folders based on the validation mechanism applied to their source of input.
+
+3. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="4A137F36F163C8934D4E8985978A7B6A" ruleID="F493EB79-7E64-4B7F-BCF4-41080CBF6508">
+                            <Category>Header Manipulation: Cookies</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>The method crlf() in CRLFInjection.java includes unvalidated data in an HTTP cookie on line 27. This enables Cookie manipulation attacks and can lead to other HTTP Response header manipulation attacks like: cache-poisoning, cross-site scripting, cross-user defacement, page hijacking or open redirect.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>27</LineStart>
+<Snippet>        response.setHeader("test2", request.getParameter("test2"));
+        String author = request.getParameter("test3");
+        Cookie cookie = new Cookie("test3", author);
+        response.addCookie(cookie);
+    }</Snippet>
+<TargetFunction>javax.servlet.http.Cookie.Cookie()</TargetFunction>
+                            </Primary>
+                            <Source>
+<FileName>CRLFInjection.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CRLFInjection.java</FilePath>
+<LineStart>26</LineStart>
+<Snippet>        response.addHeader("test1", request.getParameter("test1"));
+        response.setHeader("test2", request.getParameter("test2"));
+        String author = request.getParameter("test3");
+        Cookie cookie = new Cookie("test3", author);
+        response.addCookie(cookie);</Snippet>
+<TargetFunction>javax.servlet.ServletRequest.getParameter()</TargetFunction>
+                            </Source>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>HTML5: Overly Permissive CORS Policy</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>On line 37 of CORS.java the program defines an overly permissive Cross-Origin Resource Sharing (CORS) policy..</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Prior to HTML5, Web browsers enforced the Same Origin Policy which ensures that in order for JavaScript to access the contents of a Web page, both the JavaScript and the Web page must originate from the same domain. Without the Same Origin Policy, a malicious website could serve up JavaScript that loads sensitive information from other websites using a client's credentials, cull through it, and communicate it back to the attacker. HTML5 makes it possible for JavaScript to access data across domains if a new HTTP header called Access-Control-Allow-Origin is defined. With this header, a Web server defines which other domains are allowed to access its domain using cross-origin requests. However, caution should be taken when defining the header because an overly permissive CORS policy will allow a malicious application to communicate with the victim application in an inappropriate way, leading to spoofing, data theft, relay and other attacks.
+
+Example 1: Below is an example of using a wildcard to programmatically specify which domains the application is allowed to communicate with.
+
+
+  response.addHeader("Access-Control-Allow-Origin", "*");
+
+
+Using the * as the value of the Access-Control-Allow-Origin header indicates that the application's data is accessible to JavaScript running on any domain.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Do not use the * as the value of the Access-Control-Allow-Origin header. Instead, provide an explicit list of trusted domains.
+
+Example 2: The Access-Control-Allow-Origin header below specifies an explicit trusted domain.
+
+
+  response.addHeader("Access-Control-Allow-Origin", "www.trusted.com");
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="712D160F6C281C3BD9ACD63E01FC300D" ruleID="65B38B2D-0539-43F1-B052-1CB4C665C4E3">
+                            <Category>HTML5: Overly Permissive CORS Policy</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>On line 37 of CORS.java the program defines an overly permissive Cross-Origin Resource Sharing (CORS) policy..</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>CORS.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/CORS.java</FilePath>
+<LineStart>37</LineStart>
+<Snippet>    private static String vuls2(HttpServletResponse response) {
+        // 后端设置Access-Control-Allow-Origin为*的情况下，跨域的时候前端如果设置withCredentials为true会异常
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        return info;
+    }</Snippet>
+<TargetFunction>setHeader()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Password Management: Password in Configuration File</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>Storing a plain text password in a configuration file may result in a system compromise.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Storing a plain text password in a configuration file allows anyone who can read the file access to the password-protected resource. Developers sometimes believe that they cannot defend the application from someone who has access to the configuration, but this attitude makes an attacker's job easier. Good password management guidelines require that a password never be stored in plain text.
+
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>A password should never be stored in plain text. An administrator should be required to enter the password when the system starts. If that approach is impractical, a less secure but often adequate solution is to obfuscate the password and scatter the de-obfuscation material around the system so that an attacker has to obtain and correctly combine multiple system resources to decipher the password.
+
+Some third-party products claim the ability to manage passwords in a more secure way. For example, WebSphere Application Server 4.x uses a simple XOR encryption algorithm for obfuscating values, but be skeptical about such facilities. WebSphere and other application servers offer outdated and relatively weak encryption mechanisms that are insufficient for security-sensitive environments. For a secure solution the only viable option is a proprietary one.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Fortify Static Code Analyzer searches configuration files for common names used for password properties. Audit these issues by verifying that the flagged entry is used as a password and that the password entry contains plain text.
+
+2. If the entry in the configuration file is a default password, require that it be changed in addition to requiring that it be obfuscated in the configuration file.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="6BBA8F75C2B2A01DB2CEEA7F3A3ECB6F" ruleID="29C589A2-3796-4486-A12D-BCE05ADFFE11">
+                            <Category>Password Management: Password in Configuration File</Category>
+                            <Folder>High</Folder>
+                            <Kingdom>Environment</Kingdom>
+                            <Abstract>Storing a plain text password in a configuration file may result in a system compromise.</Abstract>
+                            <Friority>High</Friority>
+                            <Primary>
+<FileName>application.properties</FileName>
+<FilePath>src/main/resources/application.properties</FilePath>
+<LineStart>4</LineStart>
+<Snippet>spring.datasource.url=jdbc:mysql://localhost:3306/java_sec_code?AllowPublicKeyRetrieval=true&amp;useSSL=false&amp;serverTimezone=UTC
+spring.datasource.username=root
+spring.datasource.password=woshishujukumima
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+mybatis.mapper-locations=classpath:mapper/*.xml</Snippet>
+<TargetFunction>spring.datasource.password()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Poor Error Handling: Empty Catch Block</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method ssrf_ImageIO() in SSRF.java ignores an exception on line 150, which could cause the program to overlook unexpected states and conditions.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Just about every serious attack on a software system begins with the violation of a programmer's assumptions. After the attack, the programmer's assumptions seem flimsy and poorly founded, but before an attack many programmers would defend their assumptions well past the end of their lunch break.
+
+Two dubious assumptions that are easy to spot in code are "this method call can never fail" and "it doesn't matter if this call fails". When a programmer ignores an exception, they implicitly state that they are operating under one of these assumptions.
+
+Example 1: The following code excerpt ignores a rarely-thrown exception from doExchange().
+
+
+try {
+  doExchange();
+}
+catch (RareException e) {
+  // this can never happen
+}
+
+
+If a RareException were to ever be thrown, the program would continue to execute as though nothing unusual had occurred. The program records no evidence indicating the special situation, potentially frustrating any later attempt to explain the program's behavior.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>At a minimum, log the fact that the exception was thrown so that it will be possible to come back later and make sense of the resulting program behavior. Better yet, abort the current operation. If the exception is being ignored because the caller cannot properly handle it but the context makes it inconvenient or impossible for the caller to declare that it throws the exception itself, consider throwing a RuntimeException or an Error, both of which are unchecked exceptions. As of JDK 1.4, RuntimeException has a constructor that makes it easy to wrap another exception.
+
+Example 2: The code in Example 1 could be rewritten in the following way:
+
+
+try {
+  doExchange();
+}
+catch (RareException e) {
+  throw new RuntimeException("This can never happen", e);
+}
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. There are rare types of exceptions that can be discarded in some contexts. For instance, Thread.sleep() throws InterruptedException, and in many situations the program should behave the same way whether or not it was awoken prematurely.
+
+
+  try {
+    Thread.sleep(1000);
+  }
+  catch (InterruptedException e){
+    // The thread has been woken up prematurely, but its
+    // behavior should be the same either way.
+  }
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="96897A93752EA0D890DF22CFDB0677D0" ruleID="8843F319-8A22-4101-A378-C2B2F2597988">
+                            <Category>Poor Error Handling: Empty Catch Block</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>The method ssrf_ImageIO() in SSRF.java ignores an exception on line 150, which could cause the program to overlook unexpected states and conditions.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>150</LineStart>
+<Snippet>            URL u = new URL(url);
+            ImageIO.read(u); // send request
+        } catch (Exception e) {
+        }
+    }</Snippet>
+<TargetFunction>CatchBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Poor Error Handling: Throw Inside Finally</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>Using a throw statement inside a finally block breaks the logical progression through the try-catch-finally.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>In Java, finally blocks are always executed after their corresponding try-catch blocks and are often used to free allocated resources, such as file handles or database cursors. Throwing an exception in a finally block can bypass critical cleanup code since normal program execution will be disrupted.
+
+Example 1: In the following code, the call to stmt.close() is bypassed when the FileNotFoundException is thrown.
+
+public void processTransaction(Connection conn) throws FileNotFoundException
+{
+    FileInputStream fis = null;
+    Statement stmt = null;
+    try
+    {
+        stmt = conn.createStatement();
+        fis = new FileInputStream("badFile.txt");
+        ...
+    }
+    catch (FileNotFoundException fe)
+    {
+        log("File not found.");
+    }
+    catch (SQLException se)
+    {
+        //handle error
+    }
+    finally
+    {
+        if (fis == null)
+        {
+            throw new FileNotFoundException();
+        }
+
+        if (stmt != null)
+        {
+            try
+            {
+                stmt.close();
+            }
+            catch (SQLException e)
+            {
+                log(e);
+            }
+        }
+    }
+}
+
+This category is from the Cigital Java Rulepack. http://www.cigital.com/</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Never throw exceptions from within finally blocks. If you must re-throw an exception, do it inside a catch block so as not to interrupt the normal execution of the finally block.
+Example 2: The following code re-throws the FileNotFoundException in the catch block.
+
+public void processTransaction(Connection conn) throws FileNotFoundException
+{
+    FileInputStream fis = null;
+    Statement stmt = null;
+    try
+    {
+        stmt = conn.createStatement();
+        fis = new FileInputStream("badFile.txt");
+        ...
+    }
+    catch (FileNotFoundException fe)
+    {
+        log("File not found.");
+        throw fe;
+    }
+    catch (SQLException se)
+    {
+        //handle error
+    }
+    finally
+    {
+        if (fis != null)
+        {
+            try
+            {
+                fis.close();
+            }
+            catch (IOException ie)
+            {
+                log(ie);
+            }
+        }
+
+        if (stmt != null)
+        {
+            try
+            {
+                stmt.close();
+            }
+            catch (SQLException e)
+            {
+                log(e);
+            }
+        }
+    }
+}
+</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="8FD1831547692B82C4BDD46AD04B6CCE" ruleID="1F50410E-C148-415D-94A1-38D911C45919">
+                            <Category>Poor Error Handling: Throw Inside Finally</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Errors</Kingdom>
+                            <Abstract>Using a throw statement inside a finally block breaks the logical progression through the try-catch-finally.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SSRF.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SSRF.java</FilePath>
+<LineStart>131</LineStart>
+<Snippet>        }catch (Exception e) {
+            e.printStackTrace();
+        }finally {
+            if (inputStream != null) {
+                inputStream.close();</Snippet>
+<TargetFunction>FinallyBlock()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Spring Boot Misconfiguration: Actuator Endpoint Security Disabled</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The Spring Boot application uses Actuator endpoints requiring no authentication.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Spring Boot applications can be configured to deploy Actuators, which are REST endpoints that allow users to monitor different aspects of the application. There are different built-in Actuators which may expose sensitive data and are labeled as "sensitive". By default all sensitive HTTP endpoints are secured such that only users that have an ACTUATOR role may access them.
+
+This application is either disabling the authentication requirement for sensitive endpoints:
+
+Example 1:
+
+
+management.security.enabled=false
+
+
+Or marking sensitive endpoints as non-sensitive:
+
+Example 2:
+
+
+endpoints.health.sensitive=false
+
+
+Or a custom Actuator is set as non-sensitive:
+
+
+@Component
+public class CustomEndpoint implements Endpoint&lt;List&lt;String&gt;&gt; {
+
+    public String getId() {
+        return "customEndpoint";
+    }
+
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public boolean isSensitive() {
+        return false;
+    }
+
+    public List%lt;String&gt; invoke() {
+        // Custom logic to build the output
+        ...
+    }
+}
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>All endpoints exposing sensitive information or operations should be protected with the correct levels of authentication and authorization. It is always a good practice to require authentication even for internal servers as a security in-depth mechanism. Take into account that even in the case that the application is deployed internally, behind a firewall, an attacker may still be able to reach it using a Server-Side Request Forgery vulnerability found in a different application.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="28C3BD62094365FF63281680073A16F9" ruleID="C9C840C1-466D-494C-BD35-16BFDE247775">
+                            <Category>Spring Boot Misconfiguration: Actuator Endpoint Security Disabled</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Security Features</Kingdom>
+                            <Abstract>The Spring Boot application uses Actuator endpoints requiring no authentication.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>application.properties</FileName>
+<FilePath>src/main/resources/application.properties</FilePath>
+<LineStart>9</LineStart>
+<Snippet>
+# Spring Boot Actuator Vulnerable Config
+management.security.enabled=false
+# logging.config=classpath:logback-online.xml</Snippet>
+<TargetFunction>management.security.enabled()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>SQL Injection</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>On line 57 of SQLI.java, the method jdbc_sqli_vul() invokes a SQL query built using input potentially coming from an untrusted source. This call could allow an attacker to modify the statement's meaning or to execute arbitrary SQL commands.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>SQL injection errors occur when:
+
+1. Data enters a program from an untrusted source.
+
+In this case, Fortify Static Code Analyzer could not determine that the source of the data is trusted.
+
+2. The data is used to dynamically construct a SQL query.
+
+
+
+Example 1: The following code dynamically constructs and executes a SQL query that searches for items matching a specified name. The query restricts the items displayed to those where the owner matches the user name of the currently-authenticated user.
+
+
+...
+	String userName = ctx.getAuthenticatedUserName();
+	String itemName = request.getParameter("itemName");
+	String query = "SELECT * FROM items WHERE owner = '"
+				+ userName + "' AND itemname = '"
+				+ itemName + "'";
+	ResultSet rs = stmt.execute(query);
+...
+
+
+The query intends to execute the following code:
+
+
+	SELECT * FROM items
+	WHERE owner = &lt;userName&gt;
+	AND itemname = &lt;itemName&gt;;
+
+
+However, because the query is constructed dynamically by concatenating a constant base query string and a user input string, the query only behaves correctly if itemName does not contain a single-quote character. If an attacker with the user name wiley enters the string "name' OR 'a'='a" for itemName, then the query becomes the following:
+
+
+	SELECT * FROM items
+	WHERE owner = 'wiley'
+	AND itemname = 'name' OR 'a'='a';
+
+
+The addition of the OR 'a'='a' condition causes the where clause to always evaluate to true, so the query becomes logically equivalent to the much simpler query:
+
+
+	SELECT * FROM items;
+
+
+This simplification of the query allows the attacker to bypass the requirement that the query only return items owned by the authenticated user. The query now returns all entries stored in the items table, regardless of their specified owner.
+
+Example 2: This example examines the effects of a different malicious value passed to the query constructed and executed in Example 1. If an attacker with the user name wiley enters the string "name'; DELETE FROM items; --" for itemName, then the query becomes the following two queries:
+
+
+	SELECT * FROM items
+	WHERE owner = 'wiley'
+	AND itemname = 'name';
+
+	DELETE FROM items;
+
+	--'
+
+
+Many database servers, including Microsoft(R) SQL Server 2000, allow multiple SQL statements separated by semicolons to be executed at once. While this attack string results in an error on Oracle and other database servers that do not allow the batch-execution of statements separated by semicolons, on databases that do allow batch execution, this type of attack allows the attacker to execute arbitrary commands against the database.
+
+Notice the trailing pair of hyphens (--), which specifies to most database servers that the remainder of the statement is to be treated as a comment and not executed [4]. In this case the comment character serves to remove the trailing single-quote left over from the modified query. On a database where comments are not allowed to be used in this way, the general attack could still be made effective using a trick similar to the one used in Example 1. If an attacker enters the string "name'); DELETE FROM items; SELECT * FROM items WHERE 'a'='a", the following three valid statements will be created:
+
+
+	SELECT * FROM items
+	WHERE owner = 'wiley'
+	AND itemname = 'name';
+
+	DELETE FROM items;
+
+	SELECT * FROM items WHERE 'a'='a';
+
+
+Some think that in the mobile world, classic web application vulnerabilities, such as SQL injection, do not make sense -- why would the user attack themself? However, keep in mind that the essence of mobile platforms is applications that are downloaded from various sources and run alongside each other on the same device. The likelihood of running a piece of malware next to a banking application is high, which necessitates expanding the attack surface of mobile applications to include inter-process communication.
+
+Example 3: The following code adapts Example 1 to the Android platform.
+
+
+...
+        PasswordAuthentication pa = authenticator.getPasswordAuthentication();
+        String userName = pa.getUserName();
+        String itemName = this.getIntent().getExtras().getString("itemName");
+        String query = "SELECT * FROM items WHERE owner = '"
+                                + userName + "' AND itemname = '"
+                                + itemName + "'";
+        SQLiteDatabase db = this.openOrCreateDatabase("DB", MODE_PRIVATE, null);
+        Cursor c = db.rawQuery(query, null);
+...
+
+
+One traditional approach to preventing SQL injection attacks is to handle them as an input validation problem and either accept only characters from a whitelist of safe values or identify and escape a blacklist of potentially malicious values. Whitelisting can be a very effective means of enforcing strict input validation rules, but parameterized SQL statements require less maintenance and can offer more guarantees with respect to security. As is almost always the case, blacklisting is riddled with loopholes that make it ineffective at preventing SQL injection attacks. For example, attackers may:
+
+    - Target fields that are not quoted
+    - Find ways to bypass the need for certain escaped meta-characters
+    - Use stored procedures to hide the injected meta-characters
+
+Manually escaping characters in input to SQL queries can help, but it will not make your application secure from SQL injection attacks.
+
+Another solution commonly proposed for dealing with SQL injection attacks is to use stored procedures. Although stored procedures prevent some types of SQL injection attacks, they fail to protect against many others. Stored procedures typically help prevent SQL injection attacks by limiting the types of statements that can be passed to their parameters. However, there are many ways around the limitations and many interesting statements that can still be passed to stored procedures. Again, stored procedures can prevent some exploits, but they will not make your application secure against SQL injection attacks.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>The root cause of a SQL injection vulnerability is the ability of an attacker to change context in the SQL query, causing a value that the programmer intended to be interpreted as data to be interpreted as a command instead. When a SQL query is constructed, the programmer knows what should be interpreted as part of the command and what should be interpreted as data. Parameterized SQL statements can enforce this behavior by disallowing data-directed context changes and preventing nearly all SQL injection attacks. Parameterized SQL statements are constructed using strings of regular SQL, but when user-supplied data needs to be included, they create bind parameters, which are placeholders for data that is subsequently inserted. Bind parameters allow the program to explicitly specify to the database what should be treated as a command and what should be treated as data. When the program is ready to execute a statement, it specifies to the database the runtime values to use for the value of each of the bind parameters, without the risk of the data being interpreted as commands.
+
+Example 1 can be rewritten to use parameterized SQL statements (instead of concatenating user supplied strings) as follows:
+
+
+...
+	String userName = ctx.getAuthenticatedUserName();
+	String itemName = request.getParameter("itemName");
+	String query =
+        	"SELECT * FROM items WHERE itemname=? AND owner=?";
+	PreparedStatement stmt = conn.prepareStatement(query);
+	stmt.setString(1, itemName);
+	stmt.setString(2, userName);
+	ResultSet results = stmt.execute();
+...
+
+
+And here is an Android equivalent:
+
+
+...
+	PasswordAuthentication pa = authenticator.getPasswordAuthentication();
+	String userName = pa.getUserName();
+	String itemName = this.getIntent().getExtras().getString("itemName");
+	String query = "SELECT * FROM items WHERE itemname=? AND owner=?";
+	SQLiteDatabase db = this.openOrCreateDatabase("DB", MODE_PRIVATE, null);
+	Cursor c = db.rawQuery(query, new Object[]{itemName, userName});
+...
+
+
+More complicated scenarios, often found in report generation code, require that user input affect the command structure of the SQL statement, such as the addition of dynamic constraints in the WHERE clause. Do not use this requirement to justify concatenating user input into query strings. Prevent SQL injection attacks where user input must affect statement command structure with a level of indirection: create a set of legitimate strings that correspond to different elements you might include in a SQL statement. When constructing a statement, use input from the user to select from this set of application-controlled values.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. A common mistake is to use parameterized SQL statements that are constructed by concatenating user-controlled strings. Of course, this defeats the purpose of using parameterized SQL statements. If you are not certain that the strings used to form statements are constants controlled by the application, do not assume that they are safe because they are not being executed directly as SQL strings. Thoroughly investigate all uses of user-controlled strings in SQL statements and verify that none can be used to modify the meaning of the query.
+
+2. Data is untrustworthy if it originates from public non-final string fields of a class. These types of fields may be modified by an unknown source.
+
+3. Fortify RTA adds protection against this category.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="75F7C2653B299307602F32E891E25F36" ruleID="4B673A45-9AD5-4CBA-945B-11A3702CDF57">
+                            <Category>SQL Injection</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>On line 57 of SQLI.java, the method jdbc_sqli_vul() invokes a SQL query built using input potentially coming from an untrusted source. This call could allow an attacker to modify the statement's meaning or to execute arbitrary SQL commands.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>SQLI.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/SQLI.java</FilePath>
+<LineStart>57</LineStart>
+<Snippet>             String sql = "select * from users where username = '" + username + "'";
+             System.out.println(sql);
+             ResultSet rs = statement.executeQuery(sql);
+
+</Snippet>
+<TargetFunction>executeQuery()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>SQL Injection: MyBatis Mapper</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>On line 16 of UserMapper.xml, a SQL query is built using input potentially coming from an untrusted source. This call could allow an attacker to modify the statement's meaning or to execute arbitrary SQL commands.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>SQL injection errors occur when:
+
+1. Data enters a program from an untrusted source.
+
+2. The data is used to dynamically construct a SQL query.
+
+
+
+MyBatis Mapper XML files allow you to specify dynamic parameters in SQL statements and are typically defined by using the # characters, like this:
+
+
+    &lt;select id="getItems" parameterType="domain.company.MyParamClass" resultType="MyResultMap"&gt;
+        SELECT *
+        FROM items
+        WHERE owner = #{userName}
+    &lt;/select&gt;
+
+
+The # character with braces around the variable name indicate that MyBatis will create a parameterized query with the userName variable. However, MyBatis also allows you to concatenate variables directly to SQL statements using the $ character, opening the door for SQL injection.
+
+Example 1: The following code dynamically constructs and executes a SQL query that searches for items matching a specified name. The query restricts the items displayed to those where the owner matches the user name of the currently-authenticated user.
+
+
+    &lt;select id="getItems" parameterType="domain.company.MyParamClass" resultType="MyResultMap"&gt;
+        SELECT *
+        FROM items
+        WHERE owner = #{userName}
+        AND itemname = ${itemName}
+    &lt;/select&gt;
+
+
+However, because the query is constructed dynamically by concatenating a constant base query string and a user input string, the query only behaves correctly if itemName does not contain a single-quote character. If an attacker with the user name wiley enters the string "name' OR 'a'='a" for itemName, then the query becomes the following:
+
+
+    SELECT * FROM items
+    WHERE owner = 'wiley'
+    AND itemname = 'name' OR 'a'='a';
+
+
+The addition of the OR 'a'='a' condition causes the WHERE clause to always evaluate to true, so the query becomes logically equivalent to the much simpler query:
+
+
+    SELECT * FROM items;
+
+
+This simplification of the query allows the attacker to bypass the requirement that the query should only return items owned by the authenticated user. The query now returns all entries stored in the items table, regardless of their specified owner.
+
+Example 2: This example examines the effects of a different malicious value passed to the query constructed and executed in Example 1. If an attacker with the user name wiley enters the string "name'; DELETE FROM items; --" for itemName, then the query becomes the following two queries:
+
+
+    SELECT * FROM items
+    WHERE owner = 'wiley'
+    AND itemname = 'name';
+
+    DELETE FROM items;
+
+    --'
+
+
+Many database servers, including Microsoft(R) SQL Server 2000, allow multiple SQL statements separated by semicolons to be executed at once. While this attack string results in an error on Oracle and other database servers that do not allow the batch-execution of statements separated by semicolons, on databases that do allow batch execution, this type of attack allows the attacker to execute arbitrary commands against the database.
+
+Notice the trailing pair of hyphens (--), which specifies to most database servers that the remainder of the statement is to be treated as a comment and not executed [4]. In this case the comment character serves to remove the trailing single-quote left over from the modified query. On a database where comments are not allowed to be used in this way, the general attack could still be made effective using a trick similar to the one shown in Example 1. If an attacker enters the string "name'); DELETE FROM items; SELECT * FROM items WHERE 'a'='a", the following three valid statements will be created:
+
+
+    SELECT * FROM items
+    WHERE owner = 'wiley'
+    AND itemname = 'name';
+
+    DELETE FROM items;
+
+    SELECT * FROM items WHERE 'a'='a';
+
+
+One traditional approach to preventing SQL injection attacks is to handle them as an input validation problem and either accept only characters from a whitelist of safe values or identify and escape a blacklist of potentially malicious values. Whitelisting can be a very effective means of enforcing strict input validation rules, but parameterized SQL statements require less maintenance and can offer more guarantees with respect to security. As is almost always the case, blacklisting is riddled with loopholes that make it ineffective at preventing SQL injection attacks. For example, attackers may:
+
+    - Target fields that are not quoted
+    - Find ways to bypass the need for certain escaped meta-characters
+    - Use stored procedures to hide the injected meta-characters
+
+Manually escaping characters in input to SQL queries can help, but it will not guarantee that an application is secure against SQL injection attacks.
+
+Another solution commonly proposed for dealing with SQL injection attacks is to use stored procedures. Although stored procedures prevent some types of SQL injection attacks, they fail to protect against many others. Stored procedures typically help prevent SQL injection attacks by limiting the types of statements that can be passed to their parameters. However, there are many ways around the limitations and many interesting statements that can still be passed to stored procedures. Again, stored procedures can prevent some exploits, but they will not make your application secure against SQL injection attacks.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>The root cause of a SQL injection vulnerability is the ability of an attacker to change context in the SQL query, causing a value that the programmer intended to be interpreted as data to be interpreted as a command instead. When a SQL query is constructed, the programmer knows what should be interpreted as part of the command and what should be interpreted as data. Parameterized SQL statements can enforce this behavior by disallowing data-directed context changes and preventing nearly all SQL injection attacks. Parameterized SQL statements are constructed using strings of regular SQL, but where user-supplied data needs to be included, they include bind parameters, which are placeholders for data that is subsequently inserted. In other words, bind parameters allow the programmer to explicitly specify to the database what should be treated as a command and what should be treated as data. When the program is ready to execute a statement, it specifies to the database the runtime values to use for each of the bind parameters without the risk that the data will be interpreted as a modification to the command.
+
+Example 3: Example 1 can be rewritten to use parameterized SQL statements (instead of concatenating user supplied strings) as follows:
+
+
+    &lt;select id="getItems" parameterType="domain.company.MyParamClass" resultType="MyResultMap"&gt;
+        SELECT *
+        FROM items
+        WHERE owner = #{userName}
+        AND itemname = #{itemName}
+    &lt;/select&gt;
+
+
+More complicated scenarios, often found in report generation code, require that user input affect the structure of the SQL statement, for instance by adding a dynamic constraint in the WHERE clause. Do not use this requirement to justify concatenating user input to create a query string. MyBatis includes functionality to account for building dynamic queries within its XML schema, whilst still giving the ability to use parameterized queries [2].
+
+Example 4: Example 3 can be re-written as a dynamic query within the XML in order to first verify if itemName exists, whilst still using parameterized queries as such:
+
+
+    &lt;select id="getItems" parameterType="domain.company.MyParamClass" resultType="MyResultMap"&gt;
+        SELECT *
+        FROM items
+        WHERE owner = #{userName}
+        &lt;if test="itemName != null"&gt;
+            AND itemname = #{itemName}
+        &lt;/if&gt;
+    &lt;/select&gt;
+
+
+
+This way of creating dynamic queries prevents SQL injection due to keeping the security of parameterized queries, leaving it far safer and easier to maintain than string concatenation. If this is unavailable for any reason or insufficient, prevent SQL injection attacks where user input must affect command structure with a level of indirection: create a set of legitimate strings that correspond to different elements you might include in a SQL statement. When constructing a statement, use input from the user to select from this set of application-controlled values.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="26C3DA6786123DB37D2A1DAD1E62F748" ruleID="B217072F-6EB9-4E81-B7F6-F440B3F4B170">
+                            <Category>SQL Injection: MyBatis Mapper</Category>
+                            <Folder>Critical</Folder>
+                            <Kingdom>Input Validation and Representation</Kingdom>
+                            <Abstract>On line 16 of UserMapper.xml, a SQL query is built using input potentially coming from an untrusted source. This call could allow an attacker to modify the statement's meaning or to execute arbitrary SQL commands.</Abstract>
+                            <Friority>Critical</Friority>
+                            <Primary>
+<FileName>UserMapper.xml</FileName>
+<FilePath>src/main/resources/mapper/UserMapper.xml</FilePath>
+<LineStart>16</LineStart>
+<Snippet>    &lt;!--&lt;/select&gt;--&gt;
+
+    &lt;select id="findByUserNameVul2" parameterType="String" resultMap="User"&gt;
+        select * from users where username like '%${_parameter}%'
+    &lt;/select&gt;</Snippet>
+<TargetFunction>null()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>System Information Leak: Spring Boot Actuators Enabled</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>Enabling Spring Boot Actuators may reveal system data and debugging information which may help an adversary learn about the system and form a plan of attack.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>Spring Boot Actuators allow users to monitor and interact with the application. There are different built-in Actuators which expose system data and debugging information through HTTP endpoints, JMX or even by remote shell (SSH or Telnet). Attackers may benefit from this information to learn about the system and gather information that could be used to attack the application.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>Configure Actuators with security in mind. If the Actuator reveals sensitive data, it should be flagged as such so that unauthenticated users cannot access it.
+
+Example: The following property can be used to make all Actuator endpoints sensitive:
+
+
+endpoints.sensitive=true
+
+
+In production environments, turn off detailed error information in favor of brief messages. Restrict the generation and storage of detailed output that can help administrators and programmers diagnose problems.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="C4BBBB4F7D266DA85EA6B69B176F3625" ruleID="15EDD3AB-0EDB-4095-A0FD-B79BC549B5CC">
+                            <Category>System Information Leak: Spring Boot Actuators Enabled</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>Encapsulation</Kingdom>
+                            <Abstract>Enabling Spring Boot Actuators may reveal system data and debugging information which may help an adversary learn about the system and form a plan of attack.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>pom.xml</FileName>
+<FilePath>pom.xml</FilePath>
+<LineStart>129</LineStart>
+<Snippet>        &lt;dependency&gt;
+            &lt;groupId&gt;org.springframework.boot&lt;/groupId&gt;
+            &lt;artifactId&gt;spring-boot-starter-actuator&lt;/artifactId&gt;
+        &lt;/dependency&gt;
+</Snippet>
+<TargetFunction>null()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Unchecked Return Value</groupTitle>
+                        <MajorAttributeSummary>
+                            <MetaInfo>
+<Name>Abstract</Name>
+<Value>The method deleteFile() in FileUpload.java ignores the value returned by delete() on line 133, which could cause the program to overlook unexpected states and conditions.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Explanation</Name>
+<Value>It is not uncommon for Java programmers to misunderstand read() and related methods that are part of many java.io classes. Most errors and unusual events in Java result in an exception being thrown. (This is one of the advantages that Java has over languages like C: Exceptions make it easier for programmers to think about what can go wrong.) But the stream and reader classes do not consider it unusual or exceptional if only a small amount of data becomes available. These classes simply add the small amount of data to the return buffer, and set the return value to the number of bytes or characters read. There is no guarantee that the amount of data returned is equal to the amount of data requested.
+
+This behavior makes it important for programmers to examine the return value from read() and other IO methods to ensure that they receive the amount of data they expect.
+
+
+
+Example: The following code loops through a set of users, reading a private data file for each user. The programmer assumes that the files are always exactly 1 kilobyte in size and therefore ignores the return value from read(). If an attacker can create a smaller file, the program will recycle the remainder of the data from the previous user and handle it as though it belongs to the attacker.
+
+
+FileInputStream fis;
+byte[] byteArray = new byte[1024];
+for (Iterator i=users.iterator(); i.hasNext();) {
+    String userName = (String) i.next();
+    String pFileName = PFILE_ROOT + "/" + userName;
+    FileInputStream fis = new FileInputStream(pFileName);
+    fis.read(byteArray); // the file is always 1k bytes
+    fis.close();
+    processPFile(userName, byteArray);
+}
+</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Recommendations</Name>
+<Value>
+  FileInputStream fis;
+  byte[] byteArray = new byte[1024];
+  for (Iterator i=users.iterator(); i.hasNext();) {
+    String userName = (String) i.next();
+    String pFileName = PFILE_ROOT + "/" + userName;
+    fis = new FileInputStream(pFileName);
+    int bRead = 0;
+    while (bRead &lt; 1024) {
+        int rd = fis.read(byteArray, bRead, 1024 - bRead);
+        if (rd == -1) {
+          throw new IOException("file is unusually small");
+        }
+        bRead += rd;
+    }
+    // could add check to see if file is too large here
+    fis.close();
+    processPFile(userName, byteArray);
+  }
+
+
+Note: Because the fix for this problem is relatively complicated, you might be tempted to use a simpler approach, such as checking the size of the file before you begin reading. Such an approach would render the application vulnerable to a file system race condition, whereby an attacker could replace a well-formed file with a malicious file between the file size check and the call to read data from the file.</Value>
+                            </MetaInfo>
+                            <MetaInfo>
+<Name>Tips</Name>
+<Value>1. Watch out for programmers who want to explain away this type of issue by saying "that can never happen because ...". Chances are good that they have developed their intuition about the way the system works by using their development workstation. If your software will eventually run under different operating systems, operating system versions, hardware configurations, or runtime environments, their intuition may not apply.</Value>
+                            </MetaInfo>
+                            <AttributeValue>
+<Name>&lt;Unaudited&gt;</Name>
+<Count>1</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Not an Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Reliability Issue</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Bad Practice</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Suspicious</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                            <AttributeValue>
+<Name>Exploitable</Name>
+<Count>0</Count>
+                            </AttributeValue>
+                        </MajorAttributeSummary>
+                        <Issue iid="C14155C4B5665234265B19CAE6BF2A14" ruleID="DA3D93EF-F156-436B-BC4B-4BBFB3D1404B">
+                            <Category>Unchecked Return Value</Category>
+                            <Folder>Low</Folder>
+                            <Kingdom>API Abuse</Kingdom>
+                            <Abstract>The method deleteFile() in FileUpload.java ignores the value returned by delete() on line 133, which could cause the program to overlook unexpected states and conditions.</Abstract>
+                            <Friority>Low</Friority>
+                            <Primary>
+<FileName>FileUpload.java</FileName>
+<FilePath>src/main/java/org/joychou/controller/FileUpload.java</FilePath>
+<LineStart>133</LineStart>
+<Snippet>        for (File file : files) {
+            if (file.exists()) {
+                file.delete();
+            }
+        }</Snippet>
+<TargetFunction>delete()</TargetFunction>
+                            </Primary>
+                        </Issue>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="false" optionalSubsections="true">
+        <Title>Detailed Project Summary</Title>
+        <SubSection enabled="true">
+            <Title>Files Scanned</Title>
+            <Description>A detailed listing of all scanned files.  Files are listed with paths relative to the Source Base Path</Description>
+            <Text>Code base location: /Users/apipia/git-repos/java-sec-code
+Files Scanned:
+src/main/java/org/joychou/controller/URLRedirect.java		java	18 Lines	3 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/security/LoginFailureHandler.java		java	7 Lines	1.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/SQLI.java		java	64 Lines	5.4 KB	Dec 17, 2019 9:14:59 AM
+src/main/resources/templates/upload.html		html			Dec 17, 2019 9:14:59 AM
+src/main/resources/logback-online.xml		xml			Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/CORS.java		java	18 Lines	3.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/PathTraversal.java		java	15 Lines	1.8 KB	Dec 17, 2019 9:14:59 AM
+src/main/resources/create_db.sql		plsql	2 Lines		Dec 17, 2019 9:14:59 AM
+src/main/resources/templates/form.html		html			Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/security/WebSecurityConfig.java		java	24 Lines	4.6 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/CommandInject.java		java	21 Lines	2.2 KB	Dec 17, 2019 9:14:59 AM
+/Users/apipia/.fortify/sca18.2/build/java-sec-code/extracted/javascript/Users/apipia/git-repos/java-sec-code/src/main/resources/templates/index.html.js		secondary			Dec 17, 2019 9:28:49 AM
+src/main/resources/application.properties		java_properties		1.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/resources/templates/uploadPic.html		html			Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/security/SSRFChecker.java		java	45 Lines	4.5 KB	Dec 17, 2019 9:14:59 AM
+src/main/resources/templates/uploadStatus.html		html			Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/config/WebConfig.java		java	10 Lines	1.4 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/RMI/Client.java		java	9 Lines		Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/dao/User.java		java	8 Lines		Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/SSRF.java		java	93 Lines	8 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/Rce.java		java	19 Lines	1.5 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/SpEL.java		java	7 Lines	1.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/CSRF.java		java	3 Lines		Dec 17, 2019 9:14:59 AM
+src/main/resources/templates/xxe_upload.html		html			Dec 17, 2019 9:14:59 AM
+java-sec-code.xml		xml		95.6 KB	Dec 17, 2019 9:21:48 AM
+src/main/java/org/joychou/RMI/Hello.java		java			Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/security/CsrfAccessDeniedHandler.java		java	7 Lines	1.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/XSS.java		java	14 Lines	2.5 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/URLWhiteList.java		java	65 Lines	6.7 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/IPForge.java		java	7 Lines	1.4 KB	Dec 17, 2019 9:14:59 AM
+/Users/apipia/.fortify/sca18.2/build/java-sec-code/extracted/javascript/Users/apipia/git-repos/java-sec-code/src/main/resources/templates/uploadStatus.html.js		secondary			Dec 17, 2019 9:28:49 AM
+src/main/java/org/joychou/RMI/Server.java		java	12 Lines		Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/XStreamRce.java		java	13 Lines	1.3 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/Index.java		java	14 Lines	1.4 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java		java	17 Lines	2.4 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/security/LoginSuccessHandler.java		java	10 Lines	1.7 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/security/SecurityUtil.java		java	33 Lines	3.3 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/Application.java		java	3 Lines		Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/Test.java		java	7 Lines		Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/util/WebUtils.java		java	7 Lines		Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/config/CorsConfig.java		java	4 Lines	1 KB	Dec 17, 2019 9:14:59 AM
+pom.xml		xml		7.5 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/security/HttpFilter.java		java	16 Lines	2.6 KB	Dec 17, 2019 9:14:59 AM
+src/main/resources/mapper/UserMapper.xml		xml		1.1 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/Cookies.java		java	20 Lines	2.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/Fastjson.java		java	10 Lines	3.6 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/config/CorsConfig2.java		java		1.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/othervulns/xlsxStreamerXXE.java		java	4 Lines	1.2 KB	Dec 17, 2019 9:14:59 AM
+/Users/apipia/.fortify/sca18.2/build/java-sec-code/extracted/javascript/Users/apipia/git-repos/java-sec-code/src/main/resources/templates/upload.html.js		secondary			Dec 17, 2019 9:28:49 AM
+/Users/apipia/.fortify/sca18.2/build/java-sec-code/extracted/javascript/Users/apipia/git-repos/java-sec-code/src/main/resources/templates/xxe_upload.html.js		secondary			Dec 17, 2019 9:28:49 AM
+src/main/resources/templates/login.html		html		2.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/FileUpload.java		java	59 Lines	5.5 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/CRLFInjection.java		java	6 Lines		Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/imageConfig.java		java	3 Lines		Dec 17, 2019 9:14:59 AM
+/Users/apipia/.fortify/sca18.2/build/java-sec-code/extracted/javascript/Users/apipia/git-repos/java-sec-code/src/main/resources/templates/form.html.js		secondary			Dec 17, 2019 9:28:49 AM
+src/main/resources/templates/index.html		html		1 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/Deserialize.java		java	25 Lines	2.6 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/filter/SecCorsFilter.java		java	11 Lines	1.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/SSTI.java		java	8 Lines	1.2 KB	Dec 17, 2019 9:14:59 AM
+/Users/apipia/.fortify/sca18.2/build/java-sec-code/extracted/javascript/Users/apipia/git-repos/java-sec-code/src/main/resources/templates/uploadPic.html.js		secondary			Dec 17, 2019 9:28:49 AM
+src/main/java/org/joychou/security/AntObjectInputStream.java		java	20 Lines	2.8 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/jsonp/JSONP.java		java	24 Lines	4.3 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/mapper/UserMapper.java		java			Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/XXE.java		java	239 Lines	16.2 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/Login.java		java	15 Lines	1.7 KB	Dec 17, 2019 9:14:59 AM
+src/main/java/org/joychou/controller/jsonp/JSONPAdvice.java		java	1 Lines		Dec 17, 2019 9:14:59 AM</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Reference Elements</Title>
+            <Description>A Listing of all libraries used for the translation phase of the analysis</Description>
+            <Text>Classpath:
+
+No classpath specified during translation
+
+Libdirs:
+
+No libdirs specified during translation</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Rulepacks</Title>
+            <Description>A listing of all rulepacks used in the analysis</Description>
+            <Text>Valid Rulepacks:
+
+Name: 		Fortify Secure Coding Rules, Core, SQL
+Version: 	2019.1.0.0009
+ID: 				6494160B-E1DB-41F5-9840-2B1609EE7649
+SKU: 			RUL13004
+
+Name: 		Fortify Secure Coding Rules, Extended, Java
+Version: 	2019.1.0.0009
+ID: 				AAAC0B10-79E7-4FE5-9921-F4903A79D317
+SKU: 			RUL13007
+
+Name: 		Fortify Secure Coding Rules, Extended, SQL
+Version: 	2019.1.0.0009
+ID: 				4BC5B2FA-C209-4DBC-9C3E-1D3EEFAF135A
+SKU: 			RUL13025
+
+Name: 		Fortify Secure Coding Rules, Extended, JSP
+Version: 	2019.1.0.0009
+ID: 				00403342-15D0-48C9-8E67-4B1CFBDEFCD2
+SKU: 			RUL13026
+
+Name: 		Fortify Secure Coding Rules, Extended, JavaScript
+Version: 	2019.1.0.0009
+ID: 				C4D1969E-B734-47D3-87D4-73962C1D32E2
+SKU: 			RUL13141
+
+Name: 		Fortify Secure Coding Rules, Core, JavaScript
+Version: 	2019.1.0.0009
+ID: 				BD292C4E-4216-4DB8-96C7-9B607BFD9584
+SKU: 			RUL13059
+
+Name: 		Fortify Secure Coding Rules, Core, Android
+Version: 	2019.1.0.0009
+ID: 				FF9890E6-D119-4EE8-A591-83DCF4CA6952
+SKU: 			RUL13093
+
+Name: 		Fortify Secure Coding Rules, Extended, Content
+Version: 	2019.1.0.0009
+ID: 				9C48678C-09B6-474D-B86D-97EE94D38F17
+SKU: 			RUL13067
+
+Name: 		Fortify Secure Coding Rules, Extended, Configuration
+Version: 	2019.1.0.0009
+ID: 				CD6959FC-0C37-45BE-9637-BAA43C3A4D56
+SKU: 			RUL13005
+
+Name: 		Fortify Secure Coding Rules, Core, Annotations
+Version: 	2019.1.0.0009
+ID: 				14EE50EB-FA1C-4AE8-8B59-39F952E21E3B
+SKU: 			RUL13078
+
+Name: 		Fortify Secure Coding Rules, Core, Java
+Version: 	2019.1.0.0009
+ID: 				06A6CC97-8C3F-4E73-9093-3E74C64A2AAF
+SKU: 			RUL13003
+
+External Metadata:
+Version: 2019.1.0.0009
+
+Name: 		CWE
+ID: 				3ADB9EE4-5761-4289-8BD3-CBFCC593EBBC
+The Common Weakness Enumeration (CWE), co-sponsored and maintained by MITRE, is international in scope and free for public use. CWE provides a unified, measurable set of software weaknesses that is enabling more effective discussion, description, selection, and use of software security tools and services that can find these weaknesses in source code and operational systems as well as better understanding and management of software weaknesses related to architecture and design.
+
+Name: 		DISA CCI 2
+ID: 				7F037130-41E5-40F0-B653-7819A4B3E241
+The purpose of a Defense Information Systems Agency (DISA) Control Correlation Identifier (CCI) is to provide a standard identifier for policy based requirements which connect high-level policy expressions and low-level technical implementations. Associated with each CCI is a description for each of the singular, actionable, statements compromising an information assurance (IA) control or IA best practice. Using CCI allows high-level policy framework security requirements to be decomposed and explicitly associated with low-level implementations, thus enabling the assessment of related compliance assessment results spanning heterogeneous technologies. The current IA controls and best practices associated with each CCI, that are specified in NIST SP 800-53 Revision 4, can be viewed using the DISA STIG Viewer.  
+The following table summarizes the number of issues identified across the different CCIs broken down by Fortify Priority Order. The status of a CCI is considered "In Place" when there are no issues reported for a given CCI.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, CCI-003187 is not considered "In Place". Similarly, if the project is missing a Micro Focus Fortify WebInspect scan, or the scan contains any critical findings, CCI-000366 and CCI-000256 are not considered "In Place".
+
+Name: 		FISMA
+ID: 				B40F9EE0-3824-4879-B9FE-7A789C89307C
+The Federal Information Processing Standard (FIPS) 200 document is part of the official series of publications, issued by the National Institute of Standards and Technology (NIST), relating to standards and guidelines adopted and promulgated under the provisions of the Federal Information Security Management Act (FISMA). Specifically, FIPS Publication 200 specifies the "Minimum Security Requirements for Federal Information and Information Systems."
+
+Name: 		GDPR
+ID: 				771C470C-9274-4580-8556-C12F5E4BEC51
+The EU General Data Protection Regulation (GDPR) replaces the Data Protection Directive 95/46/EC and was designed to harmonize data privacy laws across Europe, to protect and empower all EU citizens data privacy and to reshape the way organizations across the region approach data privacy. Going into effect on May 25, 2018, GDPR provides a framework for organizations on how to handle personal data.        According to GDPR regulation personal data "means any information relating to an identified or identifiable natural person ('data subject'); an identifiable natural person is one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person."      GDPR articles that pertain to application security and require businesses to protect personal data during design and development of its product and services are:
+
+   - Article 25, Data protection by design and by default - which requires "The controller shall implement appropriate technical and organisational measures for ensuring that, by default, only personal data which are necessary for each specific purpose of the processing are processed."
+   - Article 32, Security of processing - which requires businesses to protect its systems and applications "from accidental or unlawful destruction, loss, alteration, unauthorized disclosure of, or access to personal data".       This report may be used by organizations as a framework to help identify and protect personal data as it relates to application security.
+
+Name: 		MISRA C 2012
+ID: 				555A3A66-A0E1-47AF-910C-3F19A6FB2506
+Now in its third edition, the Motor Industry Software Reliability Association (MISRA) C Guidelines describe a subset of the C programming language in which there is reduced risk of introducing mistakes in critical systems. While the MISRA C Guidelines focus upon safety-related software development, a subset of the rules also reflect security properties. Fortify interprets the MISRA C Guidelines under the context of security and provides correlation of security vulnerability  categories to the rules defined by MISRA. Fortify provides these security focused detection mechanism with the standard rulepacks, however, further support of the MISRA C Guidelines related to safety can be added through the use of custom rules. The results in this report can assist in the creation of a compliance matrix for MISRA.
+
+Name: 		MISRA C++ 2008
+ID: 				5D4B75A1-FC91-4B4B-BD4D-C81BBE9604FA
+The Motor Industry Software Reliability Association (MISRA) C++ Guidelines describe a subset of the C++ programming language in which there is reduced risk of introducing mistakes in critical systems. While the MISRA C++ Guidelines focus upon safety-related software development, a subset of the rules also reflect security properties. Fortify interprets the MISRA C++ Guidelines under the context of security and provides correlation of security vulnerability  categories to the rules defined by MISRA. Fortify provides these security focused detection mechanism with the standard rulepacks, however, further support of the MISRA C++ Guidelines related to safety can be added through the use of custom rules. The results in this report can assist in the creation of a compliance matrix for MISRA.
+
+Name: 		NIST SP 800-53 Rev.4
+ID: 				1114583B-EA24-45BE-B7F8-B61201BACDD0
+NIST Special Publication 800-53 Revision 4 provides a list of security and privacy controls designed to protect federal organizations and information systems from security threats. The following table summarizes the number of issues identified across the different controls and broken down by Fortify Priority Order.
+
+Name: 		OWASP Mobile 2014
+ID: 				EEE3F9E7-28D6-4456-8761-3DA56C36F4EE
+The OWASP Mobile Top 10 Risks 2014 provides a powerful awareness document for mobile application security. The OWASP Mobile Top 10 represents a broad consensus about what the most critical mobile application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2004
+ID: 				771C470C-9274-4580-8556-C023E4D3ADB4
+The OWASP Top Ten 2004 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2007
+ID: 				1EB1EC0E-74E6-49A0-BCE5-E6603802987A
+The OWASP Top Ten 2007 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2010
+ID: 				FDCECA5E-C2A8-4BE8-BB26-76A8ECD0ED59
+The OWASP Top Ten 2010 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2013
+ID: 				1A2B4C7E-93B0-4502-878A-9BE40D2A25C4
+The OWASP Top Ten 2013 provides a powerful awareness document for web application security. The OWASP Top Ten represents a broad consensus about what the most critical web application security flaws are. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		OWASP Top 10 2017
+ID: 				3C6ECB67-BBD9-4259-A8DB-B49328927248
+The OWASP Top Ten 2017 provides a powerful awareness document for web application security focused on informing the community about the consequences of the most common and most important web application security weaknesses. The OWASP Top Ten represents a broad agreement about what the most critical web application security flaws are with consensus being drawn from data collection and survey results. Project members include a variety of security experts from around the world who have shared their expertise to produce this list.
+
+Name: 		PCI 1.1
+ID: 				CBDB9D4D-FC20-4C04-AD58-575901CAB531
+The Payment Card Industry (PCI) Data Security Standard (DSS) 1.1 compliance standard describes 12 requirements which are organized into 6 logically related groups, which are "control objectives". PCI DSS requirements are applicable if Primary Account Number (PAN) is stored, processed, or transmitted by the system.
+
+Name: 		PCI 1.2
+ID: 				57940BDB-99F0-48BF-BF2E-CFC42BA035E5
+Payment Card Industry Data Security Standard Version 1.2 description
+
+Name: 		PCI 2.0
+ID: 				8970556D-7F9F-4EA7-8033-9DF39D68FF3E
+The PCI DSS 2.0 compliance standard, particularly sections 6.3, 6.5, and 6.6, references the OWASP Top 10 vulnerability categories as the core categories that must be tested for and remediated. The following table summarizes the number of issues identified across the different PCI DSS requirements and broken down by Fortify Priority Order.
+
+Name: 		PCI 3.0
+ID: 				E2FB0D38-0192-4F03-8E01-FE2A12680CA3
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.0. Fortify tests for 32 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.0 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		PCI 3.1
+ID: 				AC0D18CF-C1DA-47CF-9F1A-E8EC0A4A717E
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.1. Fortify tests for 31 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.1 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		PCI 3.2
+ID: 				4E8431F9-1BA1-41A8-BDBD-087D5826751A
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.2. Fortify tests for 31 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.2 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		PCI 3.2.1
+ID: 				EADE255F-6561-4EFE-AD31-2914F6BFA329
+The following is a summary of the application security portions of Payment Card Industry (PCI) Data Security Standard (DSS) v3.2.1. Fortify tests for 31 application security related requirements across sections 1, 2, 3, 4, 6, 7, 8, and 10 of PCI DSS and reports whether each requirement is In Place or Not In Place to indicate whether requirements are satisfied or not. This report is intended to measure the level of adherence the specific application(s) possess when compared to PCI DSS 3.2.1 compliance and is not intended to serve as a comprehensive Report on Compliance (ROC). The information contained in this report is targeted at project managers, security auditors, and compliance auditors.
+
+Name: 		SANS Top 25 2009
+ID: 				939EF193-507A-44E2-ABB7-C00B2168B6D8
+The 2009 CWE/SANS Top 25 Programming Errors list the most significant programming errors that can lead to serious software vulnerabilities. They occur frequently, are often easy to find, and easy to exploit. They are dangerous because they will frequently allow attackers to completely take over the software, steal data, or prevent the software from working at all. The list is the result of collaboration between the SANS Institute, MITRE, and many top software security experts.
+
+Name: 		SANS Top 25 2010
+ID: 				72688795-4F7B-484C-88A6-D4757A6121CA
+SANS Top 25 2010 Most Dangerous Software Errors provides an enumeration of the most widespread and critical errors, categorized by Common Weakness Enumeration (CWE) identifiers, that lead to serious vulnerabilities in software (http://cwe.mitre.org/). These software errors are often easy to find and exploit. The inherent danger in these errors is that they can allow an attacker to completely take over the software, steal data, or prevent the software from working at all.
+
+Name: 		SANS Top 25 2011
+ID: 				92EB4481-1FD9-4165-8E16-F2DE6CB0BD63
+SANS Top 25 2011 Most Dangerous Software Errors provides an enumeration of the most widespread and critical errors, categorized by Common Weakness Enumeration (CWE) identifiers, that lead to serious vulnerabilities in software (http://cwe.mitre.org/). These software errors are often easy to find and exploit. The inherent danger in these errors is that they can allow an attacker to completely take over the software, steal data, or prevent the software from working at all.
+
+Name: 		STIG 3.1
+ID: 				F2FA57EA-5AAA-4DDE-90A5-480BE65CE7E7
+Security Technical Implementation Guide Version 3.1 description
+
+Name: 		STIG 3.10
+ID: 				788A87FE-C9F9-4533-9095-0379A9B35B12
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 3.4
+ID: 				58E2C21D-C70F-4314-8994-B859E24CF855
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.
+
+Name: 		STIG 3.5
+ID: 				DD18E81F-3507-41FA-9DFA-2A9A15B5479F
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt; &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.
+
+Name: 		STIG 3.6
+ID: 				000CA760-0FED-4374-8AA2-6FA3968A07B1
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 3.7
+ID: 				E69C07C0-81D8-4B04-9233-F3E74167C3D2
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG identifies several severities with respect to vulnerabilities:
+    
+&lt;LI&gt;CAT I: allow an attacker immediate access into a machine, allow super user access, or bypass a firewall.&lt;/LI&gt; 
+&lt;LI&gt;CAT II: provide information that have a high potential of giving access to an intruder.&lt;/LI&gt; 
+&lt;LI&gt;CAT III: provide information that potentially could lead to compromise.&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 3.9
+ID: 				1A9D736B-2D4A-49D1-88CA-DF464B40D732
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APP&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APP5080: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APP5100: CAT II is not considered "In Place".
+
+Name: 		STIG 4.1
+ID: 				95227C50-A9E4-4C9D-A8AF-FD98ABAE1F3C
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.2
+ID: 				672C15F8-8822-4E05-8C9E-1A4BAAA7A373
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.3
+ID: 				A0B313F0-29BD-430B-9E34-6D10F1178506
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.4
+ID: 				ECEC5CA2-7ACA-4B70-BF44-3248B9C6F4F8
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.5
+ID: 				E6010E0A-7F71-4388-B8B7-EE9A02143474
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.6
+ID: 				EFB9B012-44D6-456D-B197-03D2FD7C7AD6
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.7
+ID: 				B04A1E01-F1C1-48D3-A827-0F70872182D7
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.8
+ID: 				E6805D9F-D5B5-4192-962C-46828FF68507
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		STIG 4.9
+ID: 				7B9F7B3B-07FC-4B61-99A1-70E3BB23A6A0
+Each requirement or recommendation identified by the Defense Information Systems Agency (DISA) STIG is represented by a STIG identifier (STIGID), which corresponds to a checklist item and a severity code [APSC-DV-&lt;I&gt;ID&lt;/I&gt;: CAT &lt;I&gt;SEV&lt;/I&gt;]. DISA STIG defines three severities with respect to vulnerabilities where their:
+    
+&lt;LI&gt;exploitation leads to direct and immediate loss of Confidentiality, Availability, or Integrity (CAT I).&lt;/LI&gt; 
+&lt;LI&gt;exploitation potentially results in loss of Confidentiality, Availability, or Integrity (CAT II).&lt;/LI&gt; 
+&lt;LI&gt;existence degrades protections against loss of Confidentiality, Availability, or Integrity (CAT III).&lt;/LI&gt;  &lt;/UL&gt;
+  
+The following table summarizes the number of issues identified across the different STIGIDs broken down by Fortify Priority Order. The status of a STIGID is considered "In Place" when there are no issues reported for a given STIGID.  
+
+If the project is missing a Fortify Static Code Analyzer (SCA) scan, or the scan contains findings that have not been fixed, hidden or suppressed, STIGID APSC-DV-003170: CAT II is not considered "In Place". Similarly, if the project is missing a Fortify WebInspect scan, or the scan contains any critical findings, STIGID APSC-DV-001460: CAT II and STIGID APSC-DV-002930: CAT II are not considered "In Place".
+
+Name: 		WASC 2.00
+ID: 				74f8081d-dd49-49da-880f-6830cebe9777
+The Web Application Security Consortium (WASC) was created as a cooperative effort to standardize, clarify, and organize the threats to the security of a web site. Version 2.00 of their Threat Classification outlines the attacks and weaknesses that can commonly lead to a website being compromised.
+
+Name: 		WASC 24 + 2
+ID: 				9DC61E7F-1A48-4711-BBFD-E9DFF537871F
+The Web Application Security Consortium (WASC) was created as a cooperative effort to standardize, clarify, and organize the threats to the security of a web site.
+
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Properties</Title>
+            <Description>A complete listing of all properties set during analysis phase</Description>
+            <Text>WinForms.CollectionMutationMonitor.Label=WinFormsDataSource
+awt.toolkit=sun.lwawt.macosx.LWCToolkit
+com.fortify.AuthenticationKey=/Users/apipia/.fortify/config/tools
+com.fortify.Core=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core
+com.fortify.InstallRoot=/Applications/Fortify/Fortify_SCA_and_Apps_18.20
+com.fortify.InstallationUserName=apipia
+com.fortify.SCAExecutablePath=
+com.fortify.TotalPhysicalMemory=17179869184
+com.fortify.VS.RequireASPPrecompilation=true
+com.fortify.WorkingDirectory=/Users/apipia/.fortify
+com.fortify.locale=en
+com.fortify.sca.AddImpliedMethods=true
+com.fortify.sca.AntCompilerClass=com.fortify.dev.ant.SCACompiler
+com.fortify.sca.AppendLogFile=true
+com.fortify.sca.BuildID=java-sec-code
+com.fortify.sca.BundleControlflowIssues=true
+com.fortify.sca.BytecodePreview=true
+com.fortify.sca.CollectPerformanceData=true
+com.fortify.sca.CustomRulesDir=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/config/customrules
+com.fortify.sca.DaemonCompilers=com.fortify.sca.util.compilers.GppCompiler,com.fortify.sca.util.compilers.GccCompiler,com.fortify.sca.util.compilers.AppleGppCompiler,com.fortify.sca.util.compilers.AppleGccCompiler,com.fortify.sca.util.compilers.MicrosoftCompiler,com.fortify.sca.util.compilers.MicrosoftLinker,com.fortify.sca.util.compilers.LdCompiler,com.fortify.sca.util.compilers.ArUtil,com.fortify.sca.util.compilers.SunCCompiler,com.fortify.sca.util.compilers.SunCppCompiler,com.fortify.sca.util.compilers.IntelCompiler,com.fortify.sca.util.compilers.ExternalCppAdapter,com.fortify.sca.util.compilers.ClangCompiler
+com.fortify.sca.DeadCodeFilter=true
+com.fortify.sca.DeadCodeIgnoreTrivialPredicates=true
+com.fortify.sca.DefaultAnalyzers=semantic:dataflow:controlflow:nullptr:configuration:content:structural:buffer
+com.fortify.sca.DefaultFileTypes=java,rb,jsp,jspx,tag,tagx,tld,sql,cfm,php,phtml,ctp,pks,pkh,pkb,xml,config,Config,settings,properties,dll,exe,winmd,cs,vb,asax,ascx,ashx,asmx,aspx,master,Master,xaml,baml,cshtml,vbhtml,inc,asp,vbscript,js,ini,bas,cls,vbs,frm,ctl,html,htm,xsd,wsdd,xmi,py,cfml,cfc,abap,xhtml,cpx,xcfg,jsff,as,mxml,cbl,cscfg,csdef,wadcfg,wadcfgx,appxmanifest,wsdl,plist,bsp,ABAP,BSP,swift,page,trigger,scala,ts
+com.fortify.sca.DefaultJarsDirs=default_jars
+com.fortify.sca.DefaultRulesDir=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/config/rules
+com.fortify.sca.DisableDeadCodeElimination=false
+com.fortify.sca.DisableFunctionPointers=false
+com.fortify.sca.DisableGlobals=false
+com.fortify.sca.DisableInferredConstants=false
+com.fortify.sca.EnableInterproceduralConstantResolution=true
+com.fortify.sca.EnableNestedWrappers=true
+com.fortify.sca.EnableStructuralMatchCache=true
+com.fortify.sca.EnableWrapperDetection=true
+com.fortify.sca.FVDLDisableDescriptions=false
+com.fortify.sca.FVDLDisableProgramData=false
+com.fortify.sca.FVDLDisableSnippets=false
+com.fortify.sca.FVDLStylesheet=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/resources/sca/fvdl2html.xsl
+com.fortify.sca.IndirectCallGraphBuilders=WinFormsAdHocFunctionBuilder,VirtualCGBuilder,J2EEIndirectCGBuilder,JNICGBuilder,StoredProcedureResolver,JavaWSCGBuilder,StrutsCGBuilder,DotNetWSCGBuilder,SqlServerSPResolver,ASPCGBuilder,ScriptedCGBuilder,NewJspCustomTagCGBuilder,DotNetCABCGBuilder,StateInjectionCGBuilder,SqlServerSPResolver2,PHPLambdaResolver,JavaWebCGBuilder
+com.fortify.sca.JVMArgs=-XX:SoftRefLRUPolicyMSPerMB=3000 -Xmx14745M -Xms400M -Xss24M
+com.fortify.sca.JavaSourcepathSearch=true
+com.fortify.sca.JdkVersion=1.8
+com.fortify.sca.LogFileDir=/Users/apipia/.fortify/sca18.2/log
+com.fortify.sca.LogFileExt=.log
+com.fortify.sca.LogFileName=sca.log
+com.fortify.sca.LogFileNameNoExt=sca
+com.fortify.sca.LogFilePath=/Users/apipia/.fortify/sca18.2/log/sca.log
+com.fortify.sca.LogLevel=INFO
+com.fortify.sca.LowSeverityCutoff=1.0
+com.fortify.sca.MultithreadedAnalysis=true
+com.fortify.sca.NoNestedOutTagOutput=org.apache.taglibs.standard.tag.rt.core.RemoveTag,org.apache.taglibs.standard.tag.rt.core.SetTag
+com.fortify.sca.OldVbNetExcludeFileTypes=vb,asax,ascx,ashx,asmx,aspx,xaml,cshtml,vbhtml
+com.fortify.sca.PID=46934
+com.fortify.sca.Phase0HigherOrder.Languages=python,ruby,swift
+com.fortify.sca.Phase0HigherOrder.Level=1
+com.fortify.sca.PrintPerformanceDataAfterScan=false
+com.fortify.sca.ProjectRoot=/Users/apipia/.fortify
+com.fortify.sca.ProjectRoot=/Users/apipia/.fortify
+com.fortify.sca.RequireMapKeys=classrule
+com.fortify.sca.ResultsFile=Fortifyjava-sec-code.fpr
+com.fortify.sca.SolverTimeout=15
+com.fortify.sca.SqlLanguage=PLSQL
+com.fortify.sca.SuppressLowSeverity=true
+com.fortify.sca.ThreadCount.NameTableLoading=1
+com.fortify.sca.TypeInferenceFunctionTimeout=60
+com.fortify.sca.TypeInferenceLanguages=javascript,typescript,python,ruby
+com.fortify.sca.TypeInferencePhase0Timeout=300
+com.fortify.sca.UnicodeInputFile=true
+com.fortify.sca.UniversalBlacklist=.*yyparse.*
+com.fortify.sca.alias.mode.csharp=fs
+com.fortify.sca.alias.mode.javascript=fi
+com.fortify.sca.alias.mode.swift=fi
+com.fortify.sca.alias.mode.typescript=fi
+com.fortify.sca.alias.mode.vb=fs
+com.fortify.sca.analyzer.controlflow.EnableLivenessOptimization=false
+com.fortify.sca.analyzer.controlflow.EnableMachineFiltering=false
+com.fortify.sca.analyzer.controlflow.EnableRefRuleOptimization=false
+com.fortify.sca.analyzer.controlflow.EnableTimeOut=true
+com.fortify.sca.clang.AcceptedParams=-arcmt-migrate-report-output+1,-compatibility_version+1,-current_version+1,-cxx-isystem+1,-D+1,-dependency-dot+1,-dependency-file+1,-F+1,-filelist+1,-flts-model+1,-fmodule-implementation-of+1,-framework+1,-gmodules,-idirafter+1,-iframework+1,-imacros+1,-imultilib+1,-include+1,-include-pch+1,-install_name+1,-iprefix+1,-iquote+1,-isystem+1,-ivfsoverlay+1,-iwithprefix+1,-iwithprefixbefore+1,-iwithsysroot+1,-I+1,-MF+1,-MMD,-MQ+1,-MT+1,-mllvm+1,-o+1,--serialize-diagnostics+1,-U+1,-undefined+1,-working-directory+1,-X*+1,-x+1
+com.fortify.sca.clang.SuppressedParams=--analyze,-e+1,-fapplication-extension,-fembed-bitcode,-fembed-bitcode-marker,-l*,-l+1,-L*,-L+1,-module-file-info+1,-mwatchos-version-min,--param+1,-w,-weak_framework+1,-Xanalyzer+1,-Xassembler+1,-Xlinker+1
+com.fortify.sca.compilers.ant=com.fortify.sca.util.compilers.AntAdapter
+com.fortify.sca.compilers.ar=com.fortify.sca.util.compilers.ArUtil
+com.fortify.sca.compilers.armcc=com.fortify.sca.util.compilers.ArmCcCompiler
+com.fortify.sca.compilers.armcpp=com.fortify.sca.util.compilers.ArmCppCompiler
+com.fortify.sca.compilers.c++=com.fortify.sca.util.compilers.AppleGppCompiler
+com.fortify.sca.compilers.cc=com.fortify.sca.util.compilers.AppleGccCompiler
+com.fortify.sca.compilers.clang=com.fortify.sca.util.compilers.ClangCompiler
+com.fortify.sca.compilers.clang++=com.fortify.sca.util.compilers.ClangCompiler
+com.fortify.sca.compilers.clearmake=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.fortify=com.fortify.sca.util.compilers.FortifyCompiler
+com.fortify.sca.compilers.g++=com.fortify.sca.util.compilers.AppleGppCompiler
+com.fortify.sca.compilers.g++-*=com.fortify.sca.util.compilers.AppleGppCompiler
+com.fortify.sca.compilers.g++2*=com.fortify.sca.util.compilers.AppleGppCompiler
+com.fortify.sca.compilers.g++3*=com.fortify.sca.util.compilers.AppleGppCompiler
+com.fortify.sca.compilers.g++4*=com.fortify.sca.util.compilers.AppleGppCompiler
+com.fortify.sca.compilers.gcc=com.fortify.sca.util.compilers.AppleGccCompiler
+com.fortify.sca.compilers.gcc-*=com.fortify.sca.util.compilers.AppleGccCompiler
+com.fortify.sca.compilers.gcc2*=com.fortify.sca.util.compilers.AppleGccCompiler
+com.fortify.sca.compilers.gcc3*=com.fortify.sca.util.compilers.AppleGccCompiler
+com.fortify.sca.compilers.gcc4*=com.fortify.sca.util.compilers.AppleGccCompiler
+com.fortify.sca.compilers.gmake=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.gradle=com.fortify.sca.util.compilers.GradleAdapter
+com.fortify.sca.compilers.gradlew=com.fortify.sca.util.compilers.GradleAdapter
+com.fortify.sca.compilers.icc=com.fortify.sca.util.compilers.IntelCompiler
+com.fortify.sca.compilers.icpc=com.fortify.sca.util.compilers.IntelCompiler
+com.fortify.sca.compilers.jam=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.javac=com.fortify.sca.util.compilers.JavacCompiler
+com.fortify.sca.compilers.ld=com.fortify.sca.util.compilers.LdCompiler
+com.fortify.sca.compilers.make=com.fortify.sca.util.compilers.TouchlessCompiler
+com.fortify.sca.compilers.mvn=com.fortify.sca.util.compilers.MavenAdapter
+com.fortify.sca.compilers.scalac=com.fortify.sca.util.compilers.ScalacCompiler
+com.fortify.sca.compilers.swift=com.fortify.sca.util.compilers.SwiftCompiler
+com.fortify.sca.compilers.swiftc=com.fortify.sca.util.compilers.SwiftCompiler
+com.fortify.sca.compilers.tcc=com.fortify.sca.util.compilers.ArmCcCompiler
+com.fortify.sca.compilers.tcpp=com.fortify.sca.util.compilers.ArmCppCompiler
+com.fortify.sca.compilers.touchless=com.fortify.sca.util.compilers.FortifyCompiler
+com.fortify.sca.compilers.xcodebuild=com.fortify.sca.util.compilers.XcodebuildScraper
+com.fortify.sca.cpfe.441.command=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/private-bin/sca/cpfe441.rfct
+com.fortify.sca.cpfe.command=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/private-bin/sca/cpfe48
+com.fortify.sca.cpfe.file.option=--gen_c_file_name
+com.fortify.sca.cpfe.options=--remove_unneeded_entities --suppress_vtbl -tused
+com.fortify.sca.cpfe.options=--remove_unneeded_entities --suppress_vtbl -tused
+com.fortify.sca.env.exesearchpath=/Library/Frameworks/Python.framework/Versions/3.5/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/VMware Fusion.app/Contents/Public:/Users/apipia/Library/Python/2.7/bin:/Users/apipia/Library/Python/3.7/bin:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/bin
+com.fortify.sca.fileextensions.ABAP=ABAP
+com.fortify.sca.fileextensions.BSP=ABAP
+com.fortify.sca.fileextensions.Config=XML
+com.fortify.sca.fileextensions.abap=ABAP
+com.fortify.sca.fileextensions.appxmanifest=XML
+com.fortify.sca.fileextensions.as=ACTIONSCRIPT
+com.fortify.sca.fileextensions.asp=ASP
+com.fortify.sca.fileextensions.bas=VB6
+com.fortify.sca.fileextensions.bsp=ABAP
+com.fortify.sca.fileextensions.cfc=CFML
+com.fortify.sca.fileextensions.cfm=CFML
+com.fortify.sca.fileextensions.cfml=CFML
+com.fortify.sca.fileextensions.cls=VB6
+com.fortify.sca.fileextensions.config=XML
+com.fortify.sca.fileextensions.cpx=XML
+com.fortify.sca.fileextensions.cscfg=XML
+com.fortify.sca.fileextensions.csdef=XML
+com.fortify.sca.fileextensions.ctl=VB6
+com.fortify.sca.fileextensions.ctp=PHP
+com.fortify.sca.fileextensions.erb=RUBY_ERB
+com.fortify.sca.fileextensions.faces=JSPX
+com.fortify.sca.fileextensions.frm=VB6
+com.fortify.sca.fileextensions.htm=HTML
+com.fortify.sca.fileextensions.html=HTML
+com.fortify.sca.fileextensions.ini=JAVA_PROPERTIES
+com.fortify.sca.fileextensions.java=JAVA
+com.fortify.sca.fileextensions.js=JAVASCRIPT
+com.fortify.sca.fileextensions.jsff=JSPX
+com.fortify.sca.fileextensions.jsp=JSP
+com.fortify.sca.fileextensions.jspx=JSPX
+com.fortify.sca.fileextensions.mxml=MXML
+com.fortify.sca.fileextensions.page=VISUAL_FORCE
+com.fortify.sca.fileextensions.php=PHP
+com.fortify.sca.fileextensions.phtml=PHP
+com.fortify.sca.fileextensions.pkb=PLSQL
+com.fortify.sca.fileextensions.pkh=PLSQL
+com.fortify.sca.fileextensions.pks=PLSQL
+com.fortify.sca.fileextensions.plist=XML
+com.fortify.sca.fileextensions.properties=JAVA_PROPERTIES
+com.fortify.sca.fileextensions.py=PYTHON
+com.fortify.sca.fileextensions.rb=RUBY
+com.fortify.sca.fileextensions.scala=SCALA
+com.fortify.sca.fileextensions.settings=XML
+com.fortify.sca.fileextensions.sql=SQL
+com.fortify.sca.fileextensions.swift=SWIFT
+com.fortify.sca.fileextensions.tag=JSP
+com.fortify.sca.fileextensions.tagx=JSP
+com.fortify.sca.fileextensions.tld=TLD
+com.fortify.sca.fileextensions.trigger=APEX_TRIGGER
+com.fortify.sca.fileextensions.ts=TYPESCRIPT
+com.fortify.sca.fileextensions.vbs=VBSCRIPT
+com.fortify.sca.fileextensions.vbscript=VBSCRIPT
+com.fortify.sca.fileextensions.wadcfg=XML
+com.fortify.sca.fileextensions.wadcfgx=XML
+com.fortify.sca.fileextensions.wsdd=XML
+com.fortify.sca.fileextensions.wsdl=XML
+com.fortify.sca.fileextensions.xcfg=XML
+com.fortify.sca.fileextensions.xhtml=JSPX
+com.fortify.sca.fileextensions.xmi=XML
+com.fortify.sca.fileextensions.xml=XML
+com.fortify.sca.fileextensions.xsd=XML
+com.fortify.sca.jsp.UseNativeParser=true
+com.fortify.sca.parser.python.ignore.module.1=test.badsyntax_future3
+com.fortify.sca.parser.python.ignore.module.2=test.badsyntax_future4
+com.fortify.sca.parser.python.ignore.module.3=test.badsyntax_future5
+com.fortify.sca.parser.python.ignore.module.4=test.badsyntax_future6
+com.fortify.sca.parser.python.ignore.module.5=test.badsyntax_future7
+com.fortify.sca.parser.python.ignore.module.6=test.badsyntax_future8
+com.fortify.sca.parser.python.ignore.module.7=test.badsyntax_future9
+com.fortify.sca.parser.python.ignore.module.8=test.badsyntax_nocaret
+com.fortify.sca.skip.libraries.AngularJS=angular.js,angular.min.js,angular-animate.js,angular-aria.js,angular_1_router.js,angular-cookies.js,angular-message-format.js,angular-messages.js,angular-mocks.js,angular-parse-ext.js,angular-resource.js,angular-route.js,angular-sanitize.js,angular-touch.js
+com.fortify.sca.skip.libraries.ES6=es6-shim.min.js,system-polyfills.js,shims_for_IE.js
+com.fortify.sca.skip.libraries.jQuery=jquery.js,jquery.min.js,jquery-migrate.js,jquery-migrate.min.js,jquery-ui.js,jquery-ui.min.js,jquery.mobile.js,jquery.mobile.min.js,jquery.color.js,jquery.color.min.js,jquery.color.svg-names.js,jquery.color.svg-names.min.js,jquery.color.plus-names.js,jquery.color.plus-names.min.js,jquery.tools.min.js
+com.fortify.sca.skip.libraries.javascript=bootstrap.js,bootstrap.min.js,typescript.js,typescriptServices.js
+com.fortify.sca.skip.libraries.typescript=typescript.d.ts,typescriptServices.d.ts
+com.fortify.sca.xcode.Overrides=GCC_PRECOMPILE_PREFIX_HEADER=NO,RUN_CLANG_STATIC_ANALYZER=NO
+com.fortify.search.defaultSyntaxVer=2
+file.encoding=UTF-8
+file.encoding.pkg=sun.io
+file.separator=/
+gopherProxySet=false
+java.awt.graphicsenv=sun.awt.CGraphicsEnvironment
+java.awt.headless=true
+java.awt.printerjob=sun.lwawt.macosx.CPrinterJob
+java.class.path=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/lib/exe/sca-exe.jar
+java.class.version=52.0
+java.endorsed.dirs=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/endorsed
+java.ext.dirs=/Users/apipia/Library/Java/Extensions:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java
+java.home=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre
+java.io.tmpdir=/var/folders/ht/4ysj286s7bs6mx1zn6d33c0hxt36fq/T/
+java.library.path=/Users/apipia/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:.
+java.runtime.name=OpenJDK Runtime Environment
+java.runtime.version=1.8.0_181-b02
+java.specification.name=Java Platform API Specification
+java.specification.vendor=Oracle Corporation
+java.specification.version=1.8
+java.vendor=Azul Systems, Inc.
+java.vendor.url=http://www.azulsystems.com/
+java.vendor.url.bug=http://www.azulsystems.com/support/
+java.version=1.8.0_181
+java.vm.info=mixed mode
+java.vm.name=OpenJDK 64-Bit Server VM
+java.vm.specification.name=Java Virtual Machine Specification
+java.vm.specification.vendor=Oracle Corporation
+java.vm.specification.version=1.8
+java.vm.vendor=Azul Systems, Inc.
+java.vm.version=25.181-b02
+line.separator=
+
+log4j.configurationFile=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/config/log4j2.xml
+log4j.isThreadContextMapInheritable=true
+max.file.path.length=255
+os.arch=x86_64
+os.name=Mac OS X
+os.version=10.14.6
+path.separator=:
+stderr.isatty=true
+stdout.isatty=true
+sun.arch.data.model=64
+sun.boot.class.path=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/resources.jar:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/rt.jar:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/sunrsasign.jar:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/jsse.jar:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/jce.jar:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/charsets.jar:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib/jfr.jar:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/classes
+sun.boot.library.path=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/jre/lib
+sun.cpu.endian=little
+sun.cpu.isalist=
+sun.io.unicode.encoding=UnicodeBig
+sun.java.command=sourceanalyzer -Djava.awt.headless=true -XX:SoftRefLRUPolicyMSPerMB=3000 -Dcom.fortify.sca.env.exesearchpath=/Library/Frameworks/Python.framework/Versions/3.5/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/VMware Fusion.app/Contents/Public:/Users/apipia/Library/Python/2.7/bin:/Users/apipia/Library/Python/3.7/bin:/Applications/Fortify/Fortify_SCA_and_Apps_18.20/bin -Dcom.fortify.sca.ProjectRoot=/Users/apipia/.fortify -Dstdout.isatty=true -Dstderr.isatty=true -Dcom.fortify.sca.PID=46934 -Xmx14745M -Xms400M -Xss24M -Dcom.fortify.TotalPhysicalMemory=17179869184 -Dcom.fortify.sca.JVMArgs=-XX:SoftRefLRUPolicyMSPerMB=3000 -Xmx14745M -Xms400M -Xss24M -Djava.class.path=/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/lib/exe/sca-exe.jar -b java-sec-code -scan -f Fortifyjava-sec-code.fpr
+sun.jnu.encoding=UTF-8
+sun.management.compiler=HotSpot 64-Bit Tiered Compilers
+sun.os.patch.level=unknown
+user.country=US
+user.dir=/Users/apipia/git-repos/java-sec-code
+user.home=/Users/apipia
+user.language=en
+user.name=apipia
+user.timezone=America/Los_Angeles
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Commandline Arguments</Title>
+            <Description>A listing of all arguments passed to SCA during the analysis phase</Description>
+            <Text>-b
+java-sec-code
+-scan
+-f
+Fortifyjava-sec-code.fpr
+</Text>
+        </SubSection>
+        <SubSection enabled="true">
+            <Title>Warnings</Title>
+            <Description>A listing of all warnings that occurred during the scan, during both translation and analysis phase</Description>
+            <Text>[1001] Unexpected exception while parsing file (javascript) /Users/apipia/git-repos/java-sec-code/src/main/resources/templates/login.html: Parse error at line 18, column 19.  Encountered: /
+[12019] The following references to Java functions could not be resolved. These functions may be part of classes that could not be found, or there may be a type error at the call site of the given function relative to the function declaration. Please ensure the Java source code can be compiled by a Java compiler. 
+	int.returnContent
+	org.apache.commons.httpclient.HttpClient.init^
+	org.springframework.web.multipart.MultipartFile.getBytes
+	com.squareup.okhttp.Request.Builder.url
+	timeBasedGenerator
+	int.generate
+	java.lang.String.init^
+	org.springframework.web.servlet.mvc.method.annotation.AbstractJsonpResponseBodyAdvice.init^
+	getCookie
+	org.springframework.security.web.savedrequest.SavedRequest.getRedirectUrl
+	org.apache.velocity.VelocityContext.init^
+	org.springframework.security.core.Authentication.getName
+	org.apache.http.client.methods.HttpGet.init^
+	org.springframework.web.cors.UrlBasedCorsConfigurationSource.registerCorsConfiguration
+	org.springframework.expression.ExpressionParser.parseExpression
+	org.apache.commons.digester3.Digester.setFeature
+	int.open
+	init
+	org.springframework.security.web.util.matcher.RequestMatcher.init^
+	org.springframework.web.multipart.MultipartFile.isEmpty
+	toJSONString
+	org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter.init^
+	int.getValue
+	int.failureHandler
+	org.jdom2.input.SAXBuilder.setFeature
+	com.alibaba.fastjson.JSONObject.get
+	org.apache.poi.xssf.usermodel.XSSFWorkbook.getSheetAt
+	org.springframework.security.web.csrf.CookieCsrfTokenRepository.init^
+	getLogger
+	com.thoughtworks.xstream.XStream.init^
+	org.springframework.web.cors.CorsConfiguration.setAllowCredentials
+	com.squareup.okhttp.Request.Builder.init^
+	org.apache.commons.digester3.Digester.parse
+	org.springframework.web.cors.CorsConfiguration.init^
+	int.loginPage
+	org.springframework.web.filter.CorsFilter.init^
+	com.squareup.okhttp.OkHttpClient.newCall
+	Get
+	org.apache.http.HttpResponse.getEntity
+	org.springframework.security.config.annotation.web.builders.HttpSecurity.exceptionHandling
+	evaluate
+	int.toString
+	org.springframework.web.multipart.MultipartFile.getOriginalFilename
+	org.jdom2.input.SAXBuilder.build
+	org.springframework.web.cors.CorsConfiguration.addAllowedOrigin
+	int.requireCsrfProtectionMatcher
+	org.springframework.security.config.annotation.web.builders.HttpSecurity.authorizeRequests
+	java.io.InputStreamReader.init^
+	org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler.logout
+	org.springframework.web.cors.CorsConfiguration.setAllowedMethods
+	int.allowedOrigins
+	org.apache.http.impl.client.CloseableHttpClient.execute
+	int.antMatchers
+	builder
+	int.execute
+	com.squareup.okhttp.OkHttpClient.init^
+	org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter.addResourceHandlers
+	org.apache.commons.net.util.SubnetUtils.init^
+	createDefault
+	int.logoutUrl
+	encodeBase64
+	com.thoughtworks.xstream.XStream.toXML
+	int.isInRange
+	org.apache.commons.httpclient.methods.GetMethod.setFollowRedirects
+	org.springframework.boot.builder.SpringApplicationBuilder.sources
+	getNameWithoutExtension
+	int.anyRequest
+	parseObject
+	org.springframework.expression.spel.standard.SpelExpressionParser.init^
+	org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry.addResourceHandler
+	int.formLogin
+	org.springframework.web.servlet.ModelAndView.addObject
+	org.springframework.security.web.savedrequest.HttpSessionRequestCache.getRequest
+	int.withUser
+	int.permitAll
+	org.springframework.util.AntPathMatcher.init^
+	org.springframework.util.PathMatcher.match
+	org.springframework.ui.Model.addAttribute
+	int.password
+	replace
+	run
+	org.apache.commons.httpclient.methods.GetMethod.getStatusLine
+	org.apache.poi.xssf.usermodel.XSSFCell.getCellType
+	isNotBlank
+	org.apache.poi.xssf.usermodel.XSSFCell.getStringCellValue
+	org.apache.velocity.VelocityContext.put
+	com.thoughtworks.xstream.XStream.fromXML
+	org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder.inMemoryAuthentication
+	info
+	int.csrfTokenRepository
+	org.apache.commons.httpclient.methods.GetMethod.init^
+	int.allowCredentials
+	org.apache.poi.xssf.usermodel.XSSFCell.getNumericCellValue
+	getFileExtension
+	org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler.init^
+	org.apache.commons.httpclient.HttpClient.executeMethod
+	org.apache.poi.xssf.usermodel.XSSFRow.cellIterator
+	org.springframework.web.cors.UrlBasedCorsConfigurationSource.init^
+	int.authenticated
+	int.rememberMe
+	int.allowedMethods
+	com.thoughtworks.xstream.io.xml.DomDriver.init^
+	org.apache.commons.net.util.SubnetUtils.getInfo
+	org.springframework.web.servlet.config.annotation.CorsRegistry.addMapping
+	int.and
+	int.successHandler
+	org.jdom2.input.SAXBuilder.init^
+	org.springframework.web.cors.CorsConfiguration.setAllowedOrigins
+	isBlank
+	org.apache.poi.xssf.usermodel.XSSFSheet.rowIterator
+	org.dom4j.io.SAXReader.init^
+	org.springframework.web.servlet.ModelAndView.init^
+	org.springframework.web.servlet.view.json.MappingJackson2JsonView.init^
+	int.getAuthentication
+	org.springframework.web.cors.CorsConfiguration.addAllowedHeader
+	javax.servlet.http.HttpServletResponse.setContentType
+	int.ignoringAntMatchers
+	org.springframework.web.servlet.mvc.support.RedirectAttributes.addFlashAttribute
+	getServerInfo
+	int.roles
+	org.springframework.security.config.annotation.web.builders.HttpSecurity.cors
+	org.apache.commons.httpclient.methods.GetMethod.releaseConnection
+	org.springframework.security.web.savedrequest.HttpSessionRequestCache.init^
+	org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter.init^
+	org.apache.poi.xssf.usermodel.XSSFWorkbook.init^
+	org.dom4j.io.SAXReader.read
+	org.dom4j.io.SAXReader.setFeature
+	org.apache.commons.digester3.Digester.init^
+	int.build
+	int.logout
+	int.accessDeniedHandler
+	org.apache.commons.httpclient.methods.GetMethod.getResponseBody
+	org.springframework.web.cors.CorsConfiguration.addAllowedMethod
+	org.springframework.boot.web.support.SpringBootServletInitializer.init^
+	org.springframework.web.multipart.MultipartFile.getInputStream
+	java.util.Map&lt;java.lang.String, java.lang.String&gt;.put
+	int.addResourceLocations
+	getContext
+	int.getContent
+	org.springframework.security.config.annotation.web.builders.HttpSecurity.csrf
+
+[1202] Unable to resolve symbol 'SpringApplication' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/Application.java:22:9)
+[1202] Unable to resolve symbol 'LoggerFactory' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/CommandInject.java:16:37)
+[1202] Unable to resolve symbol 'JSON' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Fastjson.java:25:29)
+[1202] Unable to resolve symbol 'RequestMethod' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Fastjson.java:18:69)
+[1202] Unable to resolve symbol 'Feature' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Fastjson.java:37:63)
+[1202] Unable to resolve symbol 'Generators' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/FileUpload.java:148:21)
+[1202] Unable to resolve symbol 'StringUtils' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/IPForge.java:37:13)
+[1202] Unable to resolve symbol 'ServerInfo' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Index.java:30:33)
+[1202] Unable to resolve symbol 'SecurityContextHolder' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Login.java:32:31)
+[1202] Unable to resolve symbol 'Base64' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/PathTraversal.java:46:32)
+[1202] Unable to resolve symbol 'Request' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSRF.java:93:20)
+[1202] Unable to resolve symbol 'Files' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSRF.java:116:42)
+[1202] Unable to resolve symbol 'HttpClients' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSRF.java:175:38)
+[1202] Unable to resolve symbol 'HttpStatus' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSRF.java:223:43)
+[1202] Unable to resolve symbol 'Velocity' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSTI.java:28:9)
+[1202] Unable to resolve symbol 'MediaType' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/jsonp/JSONP.java:81:61)
+[1202] Unable to resolve symbol 'XSSFCell' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java:64:52)
+[1202] Unable to resolve symbol 'StreamingReader' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/othervulns/xlsxStreamerXXE.java:37:23)
+[1202] Unable to resolve symbol 'Ordered' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/filter/SecCorsFilter.java:15:16)
+[1202] Unable to resolve symbol 'org' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/util/WebUtils.java:23:54)
+[12022] The class "javax.servlet.Filter" could not be found on the classpath, but it was found in the JAR file provided by Fortify in "/Applications/Fortify/Fortify_SCA_and_Apps_18.20/Core/default_jars/javax.servlet-api-3.0.1.jar" as a convenience. To ensure consistent translation behavior add the JAR file that contains "javax.servlet.Filter" to the classpath given to the translation step. Refer to the documentation about "default JARs" in the SCA User Guide for more information.
+[1211] Unable to resolve type 'RequestParam' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SQLI.java:44:34)
+[1211] Unable to resolve type 'RequestMapping' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SQLI.java:43:6)
+[1211] Unable to resolve type 'GetMapping' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SQLI.java:148:6)
+[1211] Unable to resolve type 'RestController' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SQLI.java:21:2)
+[1211] Unable to resolve type 'com.squareup.okhttp.Request' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSRF.java:160:9)
+[1211] Unable to resolve type 'com.squareup.okhttp.Request.Builder' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSRF.java:160:47)
+[1211] Unable to resolve type 'org.jdom2.Document' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/XXE.java:78:13)
+[1211] Unable to resolve type 'org.dom4j.Document' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/XXE.java:111:13)
+[1211] Unable to resolve type 'PostMapping' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/XXE.java:382:6)
+[1213] Unable to resolve field 'POST' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Fastjson.java:18:69)
+[1213] Unable to resolve field 'SupportNonPublicField' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Fastjson.java:37:63)
+[1213] Unable to resolve field 'VERSION' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/Index.java:35:40)
+[1213] Unable to resolve field 'SC_OK' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/SSRF.java:223:43)
+[1213] Unable to resolve field 'APPLICATION_JSON_VALUE' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/jsonp/JSONP.java:81:61)
+[1213] Unable to resolve field 'CELL_TYPE_STRING' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java:64:52)
+[1213] Unable to resolve field 'CELL_TYPE_NUMERIC' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/controller/othervulns/ooxmlXXE.java:66:58)
+[1213] Unable to resolve field 'HIGHEST_PRECEDENCE' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/filter/SecCorsFilter.java:15:16)
+[1213] Unable to resolve field 'TEXT_HTML_VALUE' at (/Users/apipia/git-repos/java-sec-code/src/main/java/org/joychou/security/CsrfAccessDeniedHandler.java:31:43)
+[1216] Unable to locate a class for import org.springframework.boot.web.support.SpringBootServletInitializer
+[1216] Unable to locate a class for import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
+[1216] Unable to locate a class for import org.springframework.web.servlet.mvc.method.annotation.AbstractJsonpResponseBodyAdvice
+[1216] Unable to locate a class for import org.springframework.web.filter.CorsFilter
+[1216] Unable to locate a class for import org.springframework.security.web.access.AccessDeniedHandler
+[1216] Unable to locate a class for import org.springframework.security.web.authentication.AuthenticationFailureHandler
+[1216] Unable to locate a class for import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+[1216] Unable to locate a class for import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+[1216] Unable to locate a class for import org.springframework.security.web.util.matcher.RequestMatcher
+[1216] Unable to locate a class for import org.springframework.boot.web.servlet.ServletComponentScan
+[1216] Unable to locate a class for import org.springframework.boot.autoconfigure.SpringBootApplication
+[1216] Unable to locate a class for import org.springframework.boot.builder.SpringApplicationBuilder
+[1216] Unable to locate a class for import org.springframework.context.annotation.Configuration
+[1216] Unable to locate a class for import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+[1216] Unable to locate a class for import org.springframework.context.annotation.Bean
+[1216] Unable to locate a class for import org.springframework.web.servlet.config.annotation.CorsRegistry
+[1216] Unable to locate a class for import org.springframework.stereotype.Component
+[1216] Unable to locate a class for import org.springframework.beans.factory.annotation.Value
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.RestController
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.RequestMapping
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.CrossOrigin
+[1216] Unable to locate a class for import org.springframework.security.web.csrf.CsrfToken
+[1216] Unable to locate a class for import org.springframework.stereotype.Controller
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.ResponseBody
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.GetMapping
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.PostMapping
+[1216] Unable to locate a class for import org.slf4j.Logger
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.CookieValue
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.RequestBody
+[1216] Unable to locate a class for import com.alibaba.fastjson.JSONObject
+[1216] Unable to locate a class for import org.springframework.web.multipart.MultipartFile
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.RequestParam
+[1216] Unable to locate a class for import org.springframework.web.servlet.mvc.support.RedirectAttributes
+[1216] Unable to locate a class for import org.springframework.ui.Model
+[1216] Unable to locate a class for import org.springframework.security.core.Authentication
+[1216] Unable to locate a class for import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler
+[1216] Unable to locate a class for import org.springframework.beans.factory.annotation.Autowired
+[1216] Unable to locate a class for import com.squareup.okhttp.OkHttpClient
+[1216] Unable to locate a class for import org.apache.http.impl.client.CloseableHttpClient
+[1216] Unable to locate a class for import org.apache.http.client.methods.HttpGet
+[1216] Unable to locate a class for import org.apache.http.HttpResponse
+[1216] Unable to locate a class for import org.apache.commons.httpclient.HttpClient
+[1216] Unable to locate a class for import org.apache.commons.httpclient.methods.GetMethod
+[1216] Unable to locate a class for import org.apache.velocity.VelocityContext
+[1216] Unable to locate a class for import org.springframework.expression.ExpressionParser
+[1216] Unable to locate a class for import org.springframework.expression.spel.standard.SpelExpressionParser
+[1216] Unable to locate a class for import com.thoughtworks.xstream.XStream
+[1216] Unable to locate a class for import com.thoughtworks.xstream.io.xml.DomDriver
+[1216] Unable to locate a class for import org.jdom2.input.SAXBuilder
+[1216] Unable to locate a class for import org.dom4j.io.SAXReader
+[1216] Unable to locate a class for import org.apache.commons.digester3.Digester
+[1216] Unable to locate a class for import org.springframework.web.servlet.ModelAndView
+[1216] Unable to locate a class for import org.springframework.web.servlet.view.json.MappingJackson2JsonView
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.ControllerAdvice
+[1216] Unable to locate a class for import org.apache.poi.xssf.usermodel.XSSFWorkbook
+[1216] Unable to locate a class for import org.apache.poi.xssf.usermodel.XSSFSheet
+[1216] Unable to locate a class for import org.apache.poi.xssf.usermodel.XSSFRow
+[1216] Unable to locate a class for import org.apache.poi.xssf.usermodel.XSSFCell
+[1216] Unable to locate a class for import org.apache.poi.ss.usermodel.Workbook
+[1216] Unable to locate a class for import org.springframework.core.annotation.Order
+[1216] Unable to locate a class for import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+[1216] Unable to locate a class for import org.springframework.web.cors.CorsConfiguration
+[1216] Unable to locate a class for import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
+[1216] Unable to locate a class for import org.apache.ibatis.annotations.Mapper
+[1216] Unable to locate a class for import org.apache.ibatis.annotations.Param
+[1216] Unable to locate a class for import org.apache.ibatis.annotations.Select
+[1216] Unable to locate a class for import org.springframework.security.access.AccessDeniedException
+[1216] Unable to locate a class for import org.springframework.util.PathMatcher
+[1216] Unable to locate a class for import org.springframework.util.AntPathMatcher
+[1216] Unable to locate a class for import org.springframework.security.core.AuthenticationException
+[1216] Unable to locate a class for import org.springframework.security.web.savedrequest.SavedRequest
+[1216] Unable to locate a class for import org.springframework.security.web.savedrequest.HttpSessionRequestCache
+[1216] Unable to locate a class for import org.apache.commons.net.util.SubnetUtils
+[1216] Unable to locate a class for import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+[1216] Unable to locate a class for import org.springframework.security.config.annotation.web.builders.HttpSecurity
+[1216] Unable to locate a class for import org.springframework.security.web.csrf.CookieCsrfTokenRepository
+[1216] Unable to locate a class for import org.springframework.web.cors.CorsConfigurationSource
+[1216] Unable to locate a class for import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+[1216] Unable to locate a class for import org.springframework.boot.SpringApplication
+[1216] Unable to locate a class for import org.slf4j.LoggerFactory
+[1216] Unable to locate a class for import com.alibaba.fastjson.JSON
+[1216] Unable to locate a class for import org.springframework.web.bind.annotation.RequestMethod
+[1216] Unable to locate a class for import com.alibaba.fastjson.parser.Feature
+[1216] Unable to locate a class for import com.fasterxml.uuid.Generators
+[1216] Unable to locate a class for import org.apache.commons.lang.StringUtils
+[1216] Unable to locate a class for import org.apache.catalina.util.ServerInfo
+[1216] Unable to locate a class for import org.springframework.security.core.context.SecurityContextHolder
+[1216] Unable to locate a class for import org.apache.commons.codec.binary.Base64
+[1216] Unable to locate a class for import org.apache.http.client.fluent.Request
+[1216] Unable to locate a class for import com.google.common.io.Files
+[1216] Unable to locate a class for import org.apache.http.impl.client.HttpClients
+[1216] Unable to locate a class for import org.apache.http.HttpStatus
+[1216] Unable to locate a class for import org.apache.velocity.app.Velocity
+[1216] Unable to locate a class for import org.springframework.http.MediaType
+[1216] Unable to locate a class for import com.monitorjbl.xlsx.StreamingReader
+[1216] Unable to locate a class for import org.springframework.core.Ordered
+[236] Your license does not allow access to Fortify SCA for Python</Text>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="false">
+        <Title>Issue Count by Category</Title>
+        <SubSection enabled="true">
+            <Title>Issues By Category</Title>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="table">
+                    <Axis>Category</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="64">
+                        <groupTitle>Poor Logging Practice: Use of a System Output Stream</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="35">
+                        <groupTitle>Poor Style: Value Never Read</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="34">
+                        <groupTitle>Poor Error Handling: Overly Broad Catch</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="23">
+                        <groupTitle>Resource Injection</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="18">
+                        <groupTitle>System Information Leak</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="18">
+                        <groupTitle>System Information Leak: Internal</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="16">
+                        <groupTitle>Dead Code: Unused Method</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="13">
+                        <groupTitle>Poor Error Handling: Overly Broad Throws</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="10">
+                        <groupTitle>J2EE Bad Practices: Leftover Debug Code</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="7">
+                        <groupTitle>Denial of Service: StringBuilder</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="7">
+                        <groupTitle>Missing XML Validation</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Missing Check against Null</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Portability Flaw: Locale Dependent Comparison</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Unreleased Resource: Database</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>Unreleased Resource: Streams</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>XML Entity Expansion Injection</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="6">
+                        <groupTitle>XML External Entity Injection</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="5">
+                        <groupTitle>Denial of Service</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="5">
+                        <groupTitle>Header Manipulation</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="5">
+                        <groupTitle>Server-Side Request Forgery</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Command Injection</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Cookie Security: Cookie not Sent Over SSL</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Cookie Security: HTTPOnly not Set</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="4">
+                        <groupTitle>Password Management: Password in Comment</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="2">
+                        <groupTitle>J2EE Bad Practices: getConnection()</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="2">
+                        <groupTitle>Often Misused: Authentication</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="2">
+                        <groupTitle>Open Redirect</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Build Misconfiguration: External Maven Dependency Repository</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Code Correctness: Byte Array to String Conversion</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Cookie Security: Overly Broad Path</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Dead Code: Unused Field</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Dynamic Code Evaluation: Unsafe Deserialization</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>File Disclosure: J2EE</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Header Manipulation: Cookies</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>HTML5: Overly Permissive CORS Policy</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Password Management: Password in Configuration File</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Poor Error Handling: Empty Catch Block</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Poor Error Handling: Throw Inside Finally</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Spring Boot Misconfiguration: Actuator Endpoint Security Disabled</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>SQL Injection</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>SQL Injection: MyBatis Mapper</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>System Information Leak: Spring Boot Actuators Enabled</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="1">
+                        <groupTitle>Unchecked Return Value</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="true" optionalSubsections="false">
+        <Title>Issue Breakdown by Analysis</Title>
+        <SubSection enabled="true">
+            <Title>Issue by Analysis</Title>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="pie">
+                    <Axis>Analysis</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="334">
+                        <groupTitle>&lt;none&gt;</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+    <ReportSection enabled="false" optionalSubsections="false">
+        <Title>New Issues</Title>
+        <SubSection enabled="true">
+            <Title>New Issues</Title>
+            <Description>A list of issues discovered since the previous analysis.</Description>
+            <Text>The following issues have been discovered since the last scan.</Text>
+            <IssueListing listing="false" limit="-1">
+                <Refinement></Refinement>
+                <Chart chartType="pie">
+                    <Axis>New Issue</Axis>
+                    <MajorAttribute>Analysis</MajorAttribute>
+                    <GroupingSection count="4">
+                        <groupTitle>Issue Updated: Dec 17, 2019</groupTitle>
+                    </GroupingSection>
+                    <GroupingSection count="330">
+                        <groupTitle>Issue New: Dec 17, 2019</groupTitle>
+                    </GroupingSection>
+                </Chart>
+            </IssueListing>
+        </SubSection>
+    </ReportSection>
+</ReportDefinition>

--- a/dojo/unittests/test_fortify_parser.py
+++ b/dojo/unittests/test_fortify_parser.py
@@ -8,7 +8,7 @@ class TestFortifyParser(TestCase):
     def test_fortify_many_findings(self):
         testfile = "dojo/unittests/scans/fortify/fortify_many_findings.xml"
         parser = FortifyXMLParser(testfile, Test())
-        self.assertEqual(334, len(parser.items))
+        self.assertEqual(324, len(parser.items))
 
     def test_fortify_few_findings(self):
         testfile = "dojo/unittests/scans/fortify/fortify_few_findings.xml"

--- a/dojo/unittests/test_fortify_parser.py
+++ b/dojo/unittests/test_fortify_parser.py
@@ -1,17 +1,16 @@
 from django.test import TestCase
 from dojo.tools.fortify.parser import FortifyXMLParser
 from dojo.models import Test
-from pathlib import Path
 
 
 class TestFortifyParser(TestCase):
 
     def test_fortify_many_findings(self):
-        testfile = Path("dojo/unittests/scans/fortify/fortify_many_findings.xml")
+        testfile = "dojo/unittests/scans/fortify/fortify_many_findings.xml"
         parser = FortifyXMLParser(testfile, Test())
         self.assertEqual(334, len(parser.items))
 
     def test_fortify_few_findings(self):
-        testfile = Path("dojo/unittests/scans/fortify/fortify_few_findings.xml")
+        testfile = "dojo/unittests/scans/fortify/fortify_few_findings.xml"
         parser = FortifyXMLParser(testfile, Test())
         self.assertEqual(2, len(parser.items))

--- a/dojo/unittests/test_fortify_parser.py
+++ b/dojo/unittests/test_fortify_parser.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+from dojo.tools.fortify.parser import FortifyXMLParser
+from dojo.models import Test
+from pathlib import Path
+
+
+class TestFortifyParser(TestCase):
+
+    def test_fortify_many_findings(self):
+        testfile = Path("dojo/unittests/scans/fortify/fortify_many_findings.xml")
+        parser = FortifyXMLParser(testfile, Test())
+        self.assertEqual(334, len(parser.items))
+
+    def test_fortify_few_findings(self):
+        testfile = Path("dojo/unittests/scans/fortify/fortify_few_findings.xml")
+        parser = FortifyXMLParser(testfile, Test())
+        self.assertEqual(2, len(parser.items))


### PR DESCRIPTION
# Changes
Fortify parser now contains the following information:
1. Abstract details (short definition)
2. Explanation (of finding)
3. Snippet
4. Source details (if available)
5. Mitigation with Recommendation and Tips (if available)

Fortify parser now also creates a single Finding from each issue in the XML (rather than trying to collect them all into buckets)

# Screenshots
![findings_list](https://user-images.githubusercontent.com/17787069/71032964-48336880-20cb-11ea-85b6-6940118a5b30.png)
List of Findings

![finding_details](https://user-images.githubusercontent.com/17787069/71032979-53869400-20cb-11ea-87a1-3a8694b5056d.png)
Details of a finding

![desc_explanation](https://user-images.githubusercontent.com/17787069/71032985-584b4800-20cb-11ea-9eee-86898f913509.png)
Description containing an Explanation

![mitigation](https://user-images.githubusercontent.com/17787069/71032994-5d0ffc00-20cb-11ea-8b10-4235f4ad9cf1.png)
Mitigation information for a finding

# Testing
I used [this](https://github.com/JoyChou93/java-sec-code) code to create an FPR with Fortify, generated the XML and uploaded it for a total of 324 Findings. (334 were created, 10 were removed for deduplication, which I verified and am satisfied with). The XML is also added to the repo for unit tests, but I'll include it here:
[java-sec-code.txt](https://github.com/DefectDojo/django-DefectDojo/files/3975415/java-sec-code.txt)

# Notes
There are some details in the README located in the dojo/tools/fortify folder that provide information on how to generate an XML from an FPR with _all issues_. I have even included the XML for the ReportGenerator that one can use to with ReportGeneration to get all issues. Shout-out to @dougmorato for help with that.
