### PR TITLE
Limit number of similar findings displayed to 10

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1335,7 +1335,7 @@ class Finding(models.Model):
             filtered = filtered.filter(file_path=self.file_path)
         if self.line:
             filtered = filtered.filter(line=self.line)
-        return filtered.exclude(pk=self.pk)
+        return filtered.exclude(pk=self.pk)[:10]
 
     def compute_hash_code(self):
         if hasattr(settings, 'HASHCODE_FIELDS_PER_SCANNER') and hasattr(settings, 'HASHCODE_ALLOWS_NULL_CWE') and hasattr(settings, 'HASHCODE_ALLOWED_FIELDS'):


### PR DESCRIPTION
This addresses an issue from #1628 when a finding with no CVE, CWE, file
path, or line number would list all findings from the same product which
can potentially grow unbounded.

@madchap @jeffret-b

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] ~If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.~
- [ ] ~Model changes must include the necessary migrations in the dojo/dd_migrations folder.~
- [ ] ~Add applicable tests to the unit tests.~