### PR TITLE
No staff for new social logins

### DIFF
--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -52,4 +52,4 @@ def social_uid(backend, details, response, *args, **kwargs):
 
 def modify_permissions(backend, uid, user=None, social=None, *args, **kwargs):
     if kwargs.get('is_new'):
-        user.is_staff = True
+        user.is_staff = False


### PR DESCRIPTION
Today, any new social login user gets `staff` permissions, meaning in the current state, gets access to all of defectdojo's data. This is definitely not great for confidentiality of information.

This simple change I guess is the only thing needed to just have the new user as a regular user with no right, which would then trigger a better out-of-band workflow to request just the necessary access to defectdojo.

Provides a workaround for #1697 

@Maffooch I saw the blame pointing to you there.. would you agree?