### PR TITLE
Updated datatable because the endpoint popup didnt work. 

### DIFF
--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -583,6 +583,9 @@
 
             // Mapping of table columns to objects for proper cleanup and data formatting
             var dojoTable = $('#open_findings').DataTable({
+                drawCallback: function(){
+                    $('.has-popover').popover({'trigger':'hover'});
+                },
                 "columns": [
                     { "data": "checkbox", render: function (data, type, row) {
                             return type === 'export' ?  "" :  data;


### PR DESCRIPTION

Updated datatable because the endpoint popup didnt work. The hover-trigger was missing

This affected the "open Findings" View. Basically the trigger was not set in the data-tables, but as far as I know the only location for endpoints in datatables was in the "open findings" view, which uses the findings_listtemplate

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [ ] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.