### PR TITLE
Move image hash away from finding desc to references

### DIFF
--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -33,7 +33,6 @@ class AnchoreEngineScanParser(object):
                 cve = item['vuln']
 
             # Finding details information
-            findingdetail += 'Image hash: ' + data['imageDigest'] + '\n\n'
             findingdetail += 'Package: ' + item['package'] + '\n\n'
             findingdetail += 'Package path: ' + item['package_path'] + '\n\n'
             findingdetail += 'Package type: ' + item['package_type'] + '\n\n'
@@ -48,7 +47,8 @@ class AnchoreEngineScanParser(object):
             mitigation += "Upgrade to " + item['package_name'] + ' ' + item['fix'] + '\n'
             mitigation += "URL: " + item['url'] + '\n'
 
-            references = item['url']
+            references = 'Image hash: ' + data['imageDigest'] + '\n\n'
+            references += item['url']
 
             dupe_key = data['imageDigest'] + "|" + item['feed'] + "|" + item['feed_group'] + "|" + item['package'] + '|' + item['vuln']
 


### PR DESCRIPTION
While setting up @ptrovatelli 's awesome dedup-per-parser configuration on Anchore, I noticed that dedupe didn't work as expected because of the description's inclusion of "imageDigest" (shows as "Image hash" in the UI). E.g., say you scan 10 docker images that share the same baseline, you can't dedup across them if you include `imageDigest` in the description and despite the fact the findings are indeed the same.

This PR simply moves that information to references.

Therefore, if setting up dedup-per-parser on Anchore, the `description` field can be used. If you want to keep the previous behavior for dedup, you could simply add `references` field to the dedup configuration fields.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.