### PR TITLE
[Helm] Fix resources indentation. Closes #1663

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -40,6 +40,6 @@ spec:
                   key: mysql-password
                   {{- end }}   
           resources:
-            {{- toYaml .Values.initializer.resources | nindent 10 }}
+            {{- toYaml .Values.initializer.resources | nindent 12 }}
       restartPolicy: Never
   backoffLimit: 1


### PR DESCRIPTION
- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.

This only fails when resources are defined for the initializer container/pod
```
initializer:
  resources:
    limits:
      cpu: 1
```

Instructions to reproduce

Download Helm (I used [Helm 3.0.2](https://github.com/helm/helm/releases/tag/v3.0.2))
```
$ cd django-DefectDojo
$ helm add stable https://kubernetes-charts.storage.googleapis.com/
$ helm depency update ./helm/defectdojo
$ helm depency build ./helm/defectdojo
$ helm template --set initializer.resources.limits.cpu=1 -n defect-dojo defect-dojo ./helm/defectdojo
```

Scroll until you find
```
# Source: defectdojo/templates/initializer-job.yaml
...
````

Note:
Looks like the `requirements.lock` file is outdated. Would you like me to add this change to the PR or raise a new PR for it?
```
diff --git a/helm/defectdojo/requirements.lock b/helm/defectdojo/requirements.lock
index 2465554d..09029639 100644
--- a/helm/defectdojo/requirements.lock
+++ b/helm/defectdojo/requirements.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
   version: 6.1.4
-digest: sha256:efc2c8d717d0bd0fbc6fceca36390af3ad590d66fd8ef7b496633a93c0b502ab
-generated: 2019-03-08T15:00:39.862499+01:00
+digest: sha256:3f1841bbf842240768ccec54380dad99315635cdec2e2362ce118ae2e85f5271
+generated: "2019-12-28T10:46:28.704899258Z"
```