### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coverage==4.5.3
 defusedxml==0.6.0
 django_celery_results==1.1.1
 django-auditlog==0.4.5
-git+https://github.com/DefectDojo/django-custom-field.git@master#egg=django-custom-field
+git+https://github.com/DefectDojo/django-custom-field.git@v3.0
 django-dbbackup>=3.2.0
 django-environ==0.4.5
 django-filter==2.0.0
@@ -19,7 +19,7 @@ django-rest-swagger==2.1.2
 django-slack==5.13.0
 django-tagging==0.4.6
 django-taggit-serializer==0.1.7
-git+https://github.com/DefectDojo/django-tastypie-swagger@master#egg=django-tastypie-swagger
+git+https://github.com/DefectDojo/django-tastypie-swagger.git@1.0
 django-tastypie==0.14.2
 django-watson==1.5.2
 Django==2.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coverage==4.5.3
 defusedxml==0.6.0
 django_celery_results==1.1.1
 django-auditlog==0.4.5
-git+https://github.com/DefectDojo/django-custom-field.git@v3.0
+git+https://github.com/DefectDojo/django-custom-field.git@4e095dd9119858e90fd21560e5618c6347e4ef1b#egg=django-custom-field
 django-dbbackup>=3.2.0
 django-environ==0.4.5
 django-filter==2.0.0
@@ -19,7 +19,7 @@ django-rest-swagger==2.1.2
 django-slack==5.13.0
 django-tagging==0.4.6
 django-taggit-serializer==0.1.7
-git+https://github.com/DefectDojo/django-tastypie-swagger.git@v1.0
+git+https://github.com/DefectDojo/django-tastypie-swagger.git@c7c5629480dc20cadd3015490a01bd8e70393c36#egg=django-tastypie-swagger
 django-tastypie==0.14.2
 django-watson==1.5.2
 Django==2.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coverage==4.5.3
 defusedxml==0.6.0
 django_celery_results==1.1.1
 django-auditlog==0.4.5
-git+https://github.com/Maffooch/django-custom-field.git@master#egg=django-custom-field
+git+https://github.com/DefectDojo/django-custom-field.git@master#egg=django-custom-field
 django-dbbackup>=3.2.0
 django-environ==0.4.5
 django-filter==2.0.0
@@ -19,7 +19,7 @@ django-rest-swagger==2.1.2
 django-slack==5.13.0
 django-tagging==0.4.6
 django-taggit-serializer==0.1.7
-git+https://github.com/Maffooch/django-tastypie-swagger@master#egg=django-tastypie-swagger
+git+https://github.com/DefectDojo/django-tastypie-swagger@master#egg=django-tastypie-swagger
 django-tastypie==0.14.2
 django-watson==1.5.2
 Django==2.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-rest-swagger==2.1.2
 django-slack==5.13.0
 django-tagging==0.4.6
 django-taggit-serializer==0.1.7
-git+https://github.com/DefectDojo/django-tastypie-swagger.git@1.0
+git+https://github.com/DefectDojo/django-tastypie-swagger.git@v1.0
 django-tastypie==0.14.2
 django-watson==1.5.2
 Django==2.2.4


### PR DESCRIPTION
**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Ownership of Django-custom-fields and Django-tastypyswagger has now changed to DefectDojo. Updates to corresponding install bases are necessary.

Update in dev takes place in #1713

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.