### PR TITLE
Fix dedupe for dynamic parsers: fix addition of endpoints in hash_cod…

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1382,7 +1382,9 @@ class Finding(models.Model):
                     deduplicationLogger.debug(hashcodeField + ' : ' + str(getattr(self, hashcodeField)))
                 else:
                     # For endpoints, need to compute the field
-                    fields_to_hash = fields_to_hash + self.get_endpoints()
+                    myEndpoints = self.get_endpoints()
+                    fields_to_hash = fields_to_hash + myEndpoints
+                    deduplicationLogger.debug(hashcodeField + ' : ' + myEndpoints)
             deduplicationLogger.debug("compute_hash_code - fields_to_hash = " + fields_to_hash)
             return self.hash_fields(fields_to_hash)
         else:
@@ -1393,6 +1395,7 @@ class Finding(models.Model):
         fields_to_hash = self.title + str(self.cwe) + str(self.line) + str(self.file_path) + self.description
         if self.dynamic_finding:
             fields_to_hash = fields_to_hash + self.get_endpoints()
+        deduplicationLogger.debug("compute_hash_code_legacy - fields_to_hash = " + fields_to_hash)
         return self.hash_fields(fields_to_hash)
 
     # Get endpoints from self.unsaved_endpoints
@@ -1400,9 +1403,11 @@ class Finding(models.Model):
     def get_endpoints(self):
         endpoint_str = ''
         if len(self.unsaved_endpoints) > 0 and self.id is None:
+            deduplicationLogger.debug("get_endpoints: there are unsaved_endpoints and self.id is None")
             for e in self.unsaved_endpoints:
                 endpoint_str += str(e.host_with_port)
         else:
+            deduplicationLogger.debug("get_endpoints: there aren't unsaved_endpoints or self.id is not None. endpoints count: " + str(self.endpoints.count()))
             for e in self.endpoints.all():
                 endpoint_str += str(e.host_with_port)
         return endpoint_str
@@ -1566,31 +1571,39 @@ class Finding(models.Model):
         return long_desc
 
     def save(self, dedupe_option=True, false_history=False, rules_option=True, issue_updater_option=True, *args, **kwargs):
-        logger.debug("Saving finding of id " + str(self.id))
         # Make changes to the finding before it's saved to add a CWE template
         new_finding = False
         if self.pk is None:
+            # We enter here during the first call from serializers.py
+            logger.debug("Saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is None)")
             false_history = True
             from dojo.utils import apply_cwe_to_template
             self = apply_cwe_to_template(self)
+            # calling django.db.models superclass save method
             super(Finding, self).save(*args, **kwargs)
         else:
+            # We enter here during the second call from serializers.py
+            logger.debug("Saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is not None)")
+            # calling django.db.models superclass save method
             super(Finding, self).save(*args, **kwargs)
 
             # Run async the tool issue update to update original issue with Defect Dojo updates
             if issue_updater_option:
                 from dojo.tasks import async_tool_issue_updater
                 async_tool_issue_updater.delay(self)
-
         if (self.file_path is not None) and (self.endpoints.count() == 0):
             self.static_finding = True
             self.dynamic_finding = False
         elif (self.file_path is not None):
             self.static_finding = True
 
-        # Compute hash code before dedupe
-        if (self.hash_code is None):
-            self.hash_code = self.compute_hash_code()
+        # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
+        # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
+        if(dedupe_option):
+            if (self.hash_code is not None):
+                deduplicationLogger.debug("Hash_code already computed for finding")
+            else:
+                self.hash_code = self.compute_hash_code()
         self.found_by.add(self.test.test_type)
 
         if rules_option:

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -564,7 +564,9 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
     'NPM Audit Scan': ['title', 'severity'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cve + file_path + severity
-    'Whitesource Scan': ['title', 'severity', 'description']
+    'Whitesource Scan': ['title', 'severity', 'description'],
+    'ZAP Scan': ['cwe', 'endpoints', 'severity'],
+    'Qualys Scan': ['title', 'endpoints', 'severity']
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
@@ -575,7 +577,9 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'SonarQube Scan': False,
     'Dependency Check Scan': True,
     'NPM Audit Scan': True,
-    'Whitesource Scan': True
+    'Whitesource Scan': True,
+    'ZAP Scan': False,
+    'Qualys Scan': True
 }
 
 # List of fields that are known to be usable in hash_code computation)
@@ -607,7 +611,9 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'SonarQube Scan': DEDUPE_ALGO_HASH_CODE,
     'Dependency Check Scan': DEDUPE_ALGO_HASH_CODE,
     'NPM Audit Scan': DEDUPE_ALGO_HASH_CODE,
-    'Whitesource Scan': DEDUPE_ALGO_HASH_CODE
+    'Whitesource Scan': DEDUPE_ALGO_HASH_CODE,
+    'ZAP Scan': DEDUPE_ALGO_HASH_CODE,
+    'Qualys Scan': DEDUPE_ALGO_HASH_CODE
 }
 
 
@@ -658,10 +664,9 @@ LOGGING = {
         },
         'dojo': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': False,
         },
-        # Can be very verbose when many findings exist
         'dojo.specific-loggers.deduplication': {
             'handlers': ['console'],
             'level': 'INFO',


### PR DESCRIPTION
- Fix dedupe for dynamic parsers: fix addition of endpoints in hash_code computation.
- Add deduplication configuration for ZAP and Qualys
- Set dojo logger to INFO (instead of debug). 

I have noticed that the dynamic parsers such as ZAP and qualys weren't working correctly: they failed to include the endpoints in the hash_code because when the hash_code was computed, the endpoints weren't already built (both in legacy dedupe algo and using the new configurable dedupe)
I'm pretty sure this used to work some time ago but it probably broke at some point. 

By the way i found many calls to "save" when uploading reports. I'm no django expert but if we persist to the bdd each time a "save" is called, there is probably a major performance gain to be done here: 
- finding.save is called twice by serializer.py
- inside of finding.save, django.db.models.save is called twice too
so that's 4 calls to the db I guess for each finding. it may be why importing findings takes so much time. we may be talking x2 or x3 performance gain if we could save just once or twice instead of 4.

I have added a couple of debug logs there (switch back dojo logger to debug in order to see them)


