### PR TITLE
Pushing dependabot config to master

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,17 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    target_branch: "dev"
+    update_schedule: "live"
+
+  - package_manager: "javascript"
+    directory: "/"
+    target_branch: "dev"
+    update_schedule: "live"
+
+  - package_manager: "docker"
+    directory: "/"
+    target_branch: "dev"
+    update_schedule: "weekly"
+


### PR DESCRIPTION
Pushing dependabot config to master (default) branch, so that it actually takes effect.