### PR TITLE
Add endpoints to scan

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -528,6 +528,9 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     verified = serializers.BooleanField(default=True)
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
+    endpoint_to_add = serializers.PrimaryKeyRelatedField(queryset=Endpoint.objects.all(),
+                                                         required=False,
+                                                         default=None)
     test_type = serializers.CharField(required=False)
     file = serializers.FileField(required=False)
     engagement = serializers.PrimaryKeyRelatedField(
@@ -546,6 +549,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         verified = data['verified']
         test_type, created = Test_Type.objects.get_or_create(
             name=data.get('test_type', data['scan_type']))
+        endpoint_to_add = data['endpoint_to_add']
         environment, created = Development_Environment.objects.get_or_create(
             name='Development')
         test = Test(
@@ -624,6 +628,9 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         product=test.engagement.product)
 
                     item.endpoints.add(ep)
+
+                if endpoint_to_add:
+                    item.endpoints.add(endpoint_to_add)
 
                 if item.unsaved_tags is not None:
                     item.tags = item.unsaved_tags
@@ -704,6 +711,9 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
     verified = serializers.BooleanField(default=True)
     scan_type = serializers.ChoiceField(
         choices=ImportScanForm.SCAN_TYPE_CHOICES)
+    endpoint_to_add = serializers.PrimaryKeyRelatedField(queryset=Endpoint.objects.all(),
+                                                          default=None,
+                                                          required=False)
     tags = TagListSerializerField(required=False)
     file = serializers.FileField(required=False)
     test = serializers.PrimaryKeyRelatedField(
@@ -713,6 +723,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         data = self.validated_data
         test = data['test']
         scan_type = data['scan_type']
+        endpoint_to_add = data['endpoint_to_add']
         min_sev = data['minimum_severity']
         scan_date = data['scan_date']
         verified = data['verified']
@@ -815,7 +826,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                             fragment=endpoint.fragment,
                             product=test.engagement.product)
                         finding.endpoints.add(ep)
-
+                    if endpoint_to_add:
+                        finding.endpoints.add(endpoint_to_add)
                     if item.unsaved_tags:
                         finding.tags = item.unsaved_tags
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -714,7 +714,6 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
     endpoint_to_add = serializers.PrimaryKeyRelatedField(queryset=Endpoint.objects.all(),
                                                           default=None,
                                                           required=False)
-    tags = TagListSerializerField(required=False)
     file = serializers.FileField(required=False)
     test = serializers.PrimaryKeyRelatedField(
         queryset=Test.objects.all())

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -619,6 +619,17 @@ def import_scan_results(request, eid=None, pid=None):
                             product=t.engagement.product)
 
                         item.endpoints.add(ep)
+                    for endpoint in form.cleaned_data['endpoints']:
+                        ep, created = Endpoint.objects.get_or_create(
+                            protocol=endpoint.protocol,
+                            host=endpoint.host,
+                            path=endpoint.path,
+                            query=endpoint.query,
+                            fragment=endpoint.fragment,
+                            product=t.engagement.product)
+
+                        item.endpoints.add(ep)
+
                     item.save(false_history=True)
 
                     if item.unsaved_tags is not None:
@@ -660,7 +671,7 @@ def import_scan_results(request, eid=None, pid=None):
         prod_id = pid
         custom_breadcrumb = {"", ""}
         product_tab = Product_Tab(prod_id, title=title, tab="findings")
-
+    form.fields['endpoints'].queryset = Endpoint.objects.filter(product__id=product_tab.product.id)
     return render(request, 'dojo/import_scan_results.html', {
         'form': form,
         'product_tab': product_tab,

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -373,6 +373,8 @@ class ImportScanForm(forms.Form):
     active = forms.BooleanField(help_text="Select if these findings are currently active.", required=False)
     verified = forms.BooleanField(help_text="Select if these findings have been verified.", required=False)
     scan_type = forms.ChoiceField(required=True, choices=SORTED_SCAN_TYPE_CHOICES)
+    endpoints = forms.ModelMultipleChoiceField(Endpoint.objects, required=False, label='Systems / Endpoints',
+                                               widget=MultipleSelectWithPopPlusMinus(attrs={'size': '5'}))
     tags = forms.CharField(widget=forms.SelectMultiple(choices=[]),
                            required=False,
                            help_text="Add tags that help describe this scan.  "
@@ -420,6 +422,8 @@ class ReImportScanForm(forms.Form):
                                          choices=SEVERITY_CHOICES[0:4])
     active = forms.BooleanField(help_text="Select if these findings are currently active.", required=False)
     verified = forms.BooleanField(help_text="Select if these findings have been verified.", required=False)
+    endpoints = forms.ModelMultipleChoiceField(Endpoint.objects, required=False, label='Systems / Endpoints',
+                                               widget=MultipleSelectWithPopPlusMinus(attrs={'size': '5'}))
     tags = forms.CharField(widget=forms.SelectMultiple(choices=[]),
                            required=False,
                            help_text="Add tags that help describe this scan.  "

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -106,8 +106,17 @@
     </div>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
-    <script type="application/javascript">
+	<script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+	<script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
+	<script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+	<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
+	<script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
+	<script type="application/javascript">
+	$ = django.jQuery;
+	$.hotkeys.options.filterInputAcceptingElements = false;
+	$.hotkeys.options.filterTextInputs = false;
+	$('#add_id_endpoints').attr('href', '/endpoints/{{ product_tab.product.id }}/add?_popup');
+
 	$(function () {
 
 	    $('#id_tags').chosen({

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -694,6 +694,14 @@ def re_import_scan_results(request, tid):
                                                                          fragment=endpoint.fragment,
                                                                          product=t.engagement.product)
                             find.endpoints.add(ep)
+                        for endpoint in form.cleaned_data['endpoints']:
+                            ep, created = Endpoint.objects.get_or_create(protocol=endpoint.protocol,
+                                                                         host=endpoint.host,
+                                                                         path=endpoint.path,
+                                                                         query=endpoint.query,
+                                                                         fragment=endpoint.fragment,
+                                                                         product=t.engagement.product)
+                            find.endpoints.add(ep)
 
                         if item.unsaved_tags is not None:
                             find.tags = item.unsaved_tags
@@ -747,6 +755,7 @@ def re_import_scan_results(request, tid):
 
     product_tab = Product_Tab(engagement.product.id, title="Re-upload a %s" % scan_type, tab="engagements")
     product_tab.setEngagement(engagement)
+    form.fields['endpoints'].queryset = Endpoint.objects.filter(product__id=product_tab.product.id)
     return render(request,
                   'dojo/import_scan_results.html',
                   {'form': form,


### PR DESCRIPTION
Option to manually add endpoints to scans

In some cases it is helpful to have the opportunity to manually add endpoints to scans. One example is a clair scan which you want to map to a specific server.

on behalf of DB Systel GmbH

---

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.