### PR TITLE
Read images as binaries. Fixes #1674

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1456,7 +1456,7 @@ def download_finding_pic(request, token):
     except:
         raise PermissionDenied
 
-    response = StreamingHttpResponse(FileIterWrapper(open(sizes[size].path)))
+    response = StreamingHttpResponse(FileIterWrapper(open(sizes[size].path, 'rb')))
     response['Content-Disposition'] = 'inline'
     mimetype, encoding = mimetypes.guess_type(sizes[size].name)
     response['Content-Type'] = mimetype


### PR DESCRIPTION
Images are binaries and should be read as such. 

The FileIterWrapper helper reads more than binaries, so we must set the B flag on the open function, not the IterWrapper when reading images.

Fixes #1674 and possibly #1633