### PR TITLE
Added CVE Reference to imported findings from clair

### DIFF
--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -54,6 +54,7 @@ def get_item(item_node, test):
                       str(item_node['vulnerability']),
                       mitigation=item_node['fixedby'],
                       references=item_node['link'],
+                      cve=item_node['vulnerability'],
                       active=False,
                       verified=False,
                       false_p=False,


### PR DESCRIPTION
Currently the CVE Reference is not added to the created findings when importing Clair Results to DefectDojo