### PR TITLE
Added CVE Reference to imported findings from clair

### DIFF
--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -54,6 +54,7 @@ def get_item(item_node, test):
                       str(item_node['vulnerability']),
                       mitigation=item_node['fixedby'],
                       references=item_node['link'],
+                      cve=item_node['vulnerability'],
                       active=False,
                       verified=False,
                       false_p=False,


### PR DESCRIPTION
Currently CVE References are not added to Findings when those are imported from clair reports.

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [y] Your code is flake8 compliant 
- [y] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [y] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.