### PR TITLE
Kubernetes 1.16 / helm3 improvements

### DIFF
--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -23,18 +23,60 @@ cd django-DefectDojo
 
 minikube start
 minikube addons enable ingress
+```
+Helm <= v2
+```zsh
 helm init
 helm repo update
+```
+
+Helm >= v3
+```zsh
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
+```
+Then pull the dependent charts:
+```zsh
 helm dependency update ./helm/defectdojo
 ```
 
-Now, install the helm chart into minikube:
+Now, install the helm chart into minikube.
+
+If you have setup an ingress controller: 
+```zsh
+DJANGO_INGRESS_ENABLED=true
+```
+else: 
+```zsh
+DJANGO_INGRESS_ENABLED=false
+```
+
+If you have configured TLS: 
+```zsh
+DJANGO_INGRESS_ACTIVATE_TLS=true
+```
+else: 
+```zsh
+DJANGO_INGRESS_ACTIVATE_TLS=false
+```
+
+Helm <= v2:
 
 ```zsh
 helm install \
   ./helm/defectdojo \
   --name=defectdojo \
-  --set django.ingress.enabled=false
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS}
+
+```
+
+Helm >= v3:
+
+```zsh
+helm install \
+  defectdojo \
+  ./helm/defectdojo \
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS}
 ```
 
 It usually takes up to a minute for the services to startup and the
@@ -75,14 +117,22 @@ Log in with username admin and the password from the previous command.
 ### Minikube with locally built containers
 
 If testing containers locally, then set the imagePullPolicy to Never,
-which ensures containers are not pulled from Docker hub.
-
+which ensures containers are not pulled from Docker hub
+(helm 2) :
 ```zsh
 helm install \
   ./helm/defectdojo \
   --name=defectdojo \
-  --set django.ingress.enabled=false \
-  --set imagePullPolicy=Never
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS},imagePullPolicy=Never
+```
+
+### Installing from a private registry
+If you have stored your images in a private registry, you can install defectdojo chart with (helm 3). 
+
+- First create a secret named "defectdojoregistrykey" based on the credentials that can pull from the registry: see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+- Then install the chart with:
+```zsh
+helm install  defectdojo ./helm/defectdojo/ --set repositoryPrefix=<myregistry.com/path>,imagePullSecrets=defectdojoregistrykey,django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS}
 ```
 
 ### Build Images Locally
@@ -91,6 +141,30 @@ helm install \
 # Build images
 docker build -t defectdojo/defectdojo-django -f Dockerfile.django .
 docker build -t defectdojo/defectdojo-nginx -f Dockerfile.nginx .
+```
+
+```zsh
+# Build images behind proxy
+docker build --build-arg http_proxy=http://myproxy.com:8080 --build-arg https_proxy=http://myproxy.com:8080 -t defectdojo/defectdojo-django -f Dockerfile.django .
+docker build --build-arg http_proxy=http://myproxy.com:8080 --build-arg https_proxy=http://myproxy.com:8080 -t defectdojo/defectdojo-nginx -f Dockerfile.nginx .
+```
+
+### Upgrade the chart
+If you want to change kubernetes configuration of use an updated docker image (evolution of defectDojo code), upgrade the application:
+```
+helm upgrade  defectdojo ./helm/defectdojo/
+```
+
+### Re-install the chart
+In case of issue or in any other situation where you need to re-install the chart, you can do it and re-use the same secrets (note that this will create a new database; more information below): 
+
+```zsh
+# helm 3
+helm uninstall defectdojo
+helm install \
+  defectdojo \
+  ./helm/defectdojo \
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS},createSecret=false,createRabbitMqSecret=false,createMysqlSecret=false,createRedisSecret=false
 ```
 
 ## Kubernetes Production
@@ -164,7 +238,7 @@ helm test defectdojo --cleanup
 # Navigate to <https://defectdojo.default.minikube.local>.
 ```
 
-TODO: The MySQL volumes aren't persistent across `helm delete` operations. To
+TODO: The MySQL volumes aren't persistent across `helm uninstall` operations. To
 make them persistent, you need to add an annotation to the persistent volume
 claim:
 
@@ -190,6 +264,8 @@ kubectl logs $(kubectl get pod --selector=defectdojo.org/component=${POD} \
 # Open a shell in a specific pod
 kubectl exec -it $(kubectl get pod --selector=defectdojo.org/component=${POD} \
   -o jsonpath="{.items[0].metadata.name}") -- /bin/bash
+# Or: 
+kubectl exec defectdojo-django-<xxx-xxx> -c uwsgi -it /bin/sh
 
 # Open a Python shell in a specific pod
 kubectl exec -it $(kubectl get pod --selector=defectdojo.org/component=${POD} \
@@ -197,8 +273,18 @@ kubectl exec -it $(kubectl get pod --selector=defectdojo.org/component=${POD} \
 ```
 
 ### Clean up Kubernetes
-
+Helm <= v2
 ```zsh
 # Uninstall Helm chart
 helm delete defectdojo --purge
+```
+
+Helm >= v3
+```
+helm uninstall defectdojo
+```
+
+In case of failure, you can manually remove all resources:
+```
+kubectl delete statefulset.apps/defectdojo-rabbitmq deployment.apps/defectdojo-django deployment.apps/defectdojo-celery-worker deployment.apps/defectdojo-celery-beat deployment.apps/defectdojo-mysql deployment.apps/defectdojo-celery job.batch/defectdojo-initializer
 ```

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -66,7 +66,8 @@ Helm <= v2:
 helm install \
   ./helm/defectdojo \
   --name=defectdojo \
-  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS}
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED} \
+  --set django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS}
 
 ```
 
@@ -76,7 +77,8 @@ Helm >= v3:
 helm install \
   defectdojo \
   ./helm/defectdojo \
-  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS}
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED} \
+  --set django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS}
 ```
 
 It usually takes up to a minute for the services to startup and the
@@ -123,7 +125,9 @@ which ensures containers are not pulled from Docker hub
 helm install \
   ./helm/defectdojo \
   --name=defectdojo \
-  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS},imagePullPolicy=Never
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED} \
+  --set django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS} \
+  --set imagePullPolicy=Never
 ```
 
 ### Installing from a private registry
@@ -164,7 +168,14 @@ helm uninstall defectdojo
 helm install \
   defectdojo \
   ./helm/defectdojo \
-  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED},django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS},createSecret=false,createRabbitMqSecret=false,createMysqlSecret=false,createRedisSecret=false
+  --set django.ingress.enabled=${DJANGO_INGRESS_ENABLED} \
+  --set django.ingress.activateTLS=${DJANGO_INGRESS_ACTIVATE_TLS} \
+  --set createSecret=false \
+  --set createRabbitMqSecret=false \
+  --set createRedisSecret=false \
+  --set createMysqlSecret=false \
+  --set createPostgresqlSecret=false
+
 ```
 
 ## Kubernetes Production

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -160,7 +160,9 @@ helm upgrade  defectdojo ./helm/defectdojo/
 ```
 
 ### Re-install the chart
-In case of issue or in any other situation where you need to re-install the chart, you can do it and re-use the same secrets (note that this will create a new database; more information below): 
+In case of issue or in any other situation where you need to re-install the chart, you can do it and re-use the same secrets.
+
+**Note that when using mysql, this will create a new database, while with postgresql you'll keep the same database (more information below)**
 
 ```zsh
 # helm 3

--- a/KUBERNETES.md
+++ b/KUBERNETES.md
@@ -297,7 +297,8 @@ Helm >= v3
 helm uninstall defectdojo
 ```
 
-In case of failure, you can manually remove all resources:
+To remove persistent objects not removed by uninstall (this will remove any database):  
 ```
-kubectl delete statefulset.apps/defectdojo-rabbitmq deployment.apps/defectdojo-django deployment.apps/defectdojo-celery-worker deployment.apps/defectdojo-celery-beat deployment.apps/defectdojo-mysql deployment.apps/defectdojo-celery job.batch/defectdojo-initializer
+kubectl delete secrets defectdojo defectdojo-redis-specific defectdojo-rabbitmq-specific defectdojo-postgresql-specific defectdojo-mysql-specific
+kubectl delete pvc data-defectdojo-rabbitmq-0 data-defectdojo-postgresql-0
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For detailed documentation you can visit
 [Read the Docs](https://defectdojo.readthedocs.io/).
 
 ## Supported Installation Options
-
+* [Kubernetes](KUBERNETES.md)
 * [Setup.bash](https://github.com/DefectDojo/django-DefectDojo/blob/dev/setup/README.MD)
 * [Docker](DOCKER.md)
 

--- a/docker/entrypoint-uwsgi-ptvsd.sh
+++ b/docker/entrypoint-uwsgi-ptvsd.sh
@@ -18,6 +18,4 @@ exec uwsgi \
   --wsgi dojo.wsgi:application \
   --py-autoreload 1 \
   --enable-threads --lazy-apps --honour-stdin \
-  --processes 2 \
-  --threads 2
   

--- a/docker/entrypoint-uwsgi-ptvsd.sh
+++ b/docker/entrypoint-uwsgi-ptvsd.sh
@@ -17,5 +17,4 @@ exec uwsgi \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
   --py-autoreload 1 \
-  --enable-threads --lazy-apps --honour-stdin \
-  
+  --enable-threads --lazy-apps --honour-stdin

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: defectdojo
-version: 0.1.0
+version: 1.0.0
 icon: https://www.defectdojo.org/img/favicon.ico

--- a/helm/defectdojo/requirements.lock
+++ b/helm/defectdojo/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: mysql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 0.15.0
+  version: 1.6.2
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 3.11.7
+  version: 8.1.2
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.3.1
+  version: 6.16.0
 - name: redis
   repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.1.4
-digest: sha256:efc2c8d717d0bd0fbc6fceca36390af3ad590d66fd8ef7b496633a93c0b502ab
-generated: 2019-03-08T15:00:39.862499+01:00
+  version: 10.3.1
+digest: sha256:52c9799f9de0a7befb954001bb59d3f600989609e48b8b7f57f5ffbe880b1cc8
+generated: "2020-01-14T22:58:39.389199081+01:00"

--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
   - name: mysql
-    version: 1.5.0
+    version: 1.6.2
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: mysql.enabled
   - name: postgresql
-    version: 7.7.2
+    version: 8.1.2
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
   - name: rabbitmq
-    version: 6.14.1
+    version: 6.16.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq.enabled
   - name: redis
-    version: 10.2.1
+    version: 10.3.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: redis.enabled

--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
   - name: mysql
-    version: 0.15.0
+    version: 1.5.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: mysql.enabled
   - name: postgresql
-    version: 3.11.7
+    version: 7.7.2
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
   - name: rabbitmq
-    version: 4.3.1
+    version: 6.14.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq.enabled
   - name: redis
-    version: 6.1.4
+    version: 10.2.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: redis.enabled

--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -53,3 +53,23 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  Builds the repository names for use with local or private registries
+*/}}
+{{- define "celery.repository" -}}
+{{- printf "%s" .Values.repositoryPrefix -}}/defectdojo-django
+{{- end -}}
+
+{{- define "django.nginx.repository" -}}
+{{- printf "%s" .Values.repositoryPrefix -}}/defectdojo-nginx
+{{- end -}}
+
+{{- define "django.uwsgi.repository" -}}
+{{- printf "%s" .Values.repositoryPrefix -}}/defectdojo-django
+{{- end -}}
+
+{{- define "initializer.repository" -}}
+{{- printf "%s" .Values.repositoryPrefix -}}/defectdojo-django
+{{- end -}}
+

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -49,8 +49,11 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              key: postgres-password
+              # use postgresql chart secret
+              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
               # Use mysql chart secret
               # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -24,31 +24,33 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
-        - name: celery
-          image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: ['/entrypoint-celery-beat.sh']
-          envFrom:
-            - configMapRef:
-                name: {{ $fullName }}
-          env:
-            - name: DD_CELERY_BROKER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.celery.broker }}
-                  key: {{ .Values.celery.broker }}-password
-            - name: DD_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-                  key: postgres-password
-                  {{- else if eq .Values.database "mysql" }}
-                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-                  key: mysql-password
-                  {{- end }}
-          resources:
-            {{- toYaml .Values.celery.beat.resources | nindent 12 }}
+      - command:
+        - /entrypoint-celery-beat.sh
+        name: celery
+        image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        envFrom:
+        - configMapRef:
+            name: {{ $fullName }}
+        env:
+        - name: DD_CELERY_BROKER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $fullName }}-{{ .Values.celery.broker }}
+              key: {{ .Values.celery.broker }}-password
+        - name: DD_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if eq .Values.database "postgresql" }}
+              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgres-password
+              {{- else if eq .Values.database "mysql" }}
+              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              key: mysql-password
+              {{- end }}
+        resources:
+          {{- toYaml .Values.celery.beat.resources | nindent 10 }}
+# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.celery.beat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -23,11 +23,15 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       containers:
       - command:
         - /entrypoint-celery-beat.sh
         name: celery
-        image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
+        image: "{{ template "celery.repository" . }}:{{ .Values.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         envFrom:
         - configMapRef:
@@ -36,7 +40,10 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use broker chart secret
+              # name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use secret handled outside of the chart
+              name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
         - name: DD_DATABASE_PASSWORD
           valueFrom:
@@ -45,12 +52,14 @@ spec:
               name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
               key: postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use mysql chart secret
+              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
               key: mysql-password
               {{- end }}
         resources:
           {{- toYaml .Values.celery.beat.resources | nindent 10 }}
-# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.celery.beat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/celery-deployment.yaml
+++ b/helm/defectdojo/templates/celery-deployment.yaml
@@ -47,8 +47,11 @@ spec:
             valueFrom:
               secretKeyRef:
                 {{- if eq .Values.database "postgresql" }}
-                name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-                key: postgres-password
+                # use postgresql chart secret
+                # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+                # Use secret handled outside of the chart
+                name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+                key: postgresql-password
                 {{- else if eq .Values.database "mysql" }}
                 # Use mysql chart secret
                 # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/celery-deployment.yaml
+++ b/helm/defectdojo/templates/celery-deployment.yaml
@@ -28,26 +28,27 @@ spec:
           image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           envFrom:
-            - configMapRef:
-                name: {{ $fullName }}
+          - configMapRef:
+              name: {{ $fullName }}
           env:
-            - name: DD_CELERY_BROKER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.celery.broker }}
-                  key: {{ .Values.celery.broker }}-password
-            - name: DD_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-                  key: postgres-password
-                  {{- else if eq .Values.database "mysql" }}
-                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-                  key: mysql-password
-                  {{- end }}   
+          - name: DD_CELERY_BROKER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ $fullName }}-{{ .Values.celery.broker }}
+                key: {{ .Values.celery.broker }}-password
+          - name: DD_DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                {{- if eq .Values.database "postgresql" }}
+                name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+                key: postgres-password
+                {{- else if eq .Values.database "mysql" }}
+                name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                key: mysql-password
+                {{- end }}   
           resources:
             {{- toYaml .Values.celery.resources | nindent 12 }}
+# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.celery.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/celery-deployment.yaml
+++ b/helm/defectdojo/templates/celery-deployment.yaml
@@ -23,9 +23,13 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       containers:
         - name: celery
-          image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
+          image: "{{ template "celery.repository" . }}:{{ .Values.tag }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           envFrom:
           - configMapRef:
@@ -34,7 +38,10 @@ spec:
           - name: DD_CELERY_BROKER_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: {{ $fullName }}-{{ .Values.celery.broker }}
+                # Use broker chart secret
+                # name: {{ $fullName }}-{{ .Values.celery.broker }}
+                # Use secret handled outside of the chart
+                name: defectdojo-{{ .Values.celery.broker }}-specific
                 key: {{ .Values.celery.broker }}-password
           - name: DD_DATABASE_PASSWORD
             valueFrom:
@@ -43,12 +50,14 @@ spec:
                 name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
                 key: postgres-password
                 {{- else if eq .Values.database "mysql" }}
-                name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                # Use mysql chart secret
+                # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+                # Use secret handled outside of the chart
+                name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
                 key: mysql-password
                 {{- end }}   
           resources:
             {{- toYaml .Values.celery.resources | nindent 12 }}
-# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.celery.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -48,8 +48,11 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              key: postgres-password
+              # use postgresql chart secret
+              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
               # Use mysql chart secret
               # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -24,31 +24,32 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
-        - name: celery
-          image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: ['/entrypoint-celery-worker.sh']
-          envFrom:
-            - configMapRef:
-                name: {{ $fullName }}
-          env:
-            - name: DD_CELERY_BROKER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.celery.broker }}
-                  key: {{ .Values.celery.broker }}-password
-            - name: DD_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-                  key: postgres-password
-                  {{- else if eq .Values.database "mysql" }}
-                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-                  key: mysql-password
-                  {{- end }}   
-          resources:
-            {{- toYaml .Values.celery.worker.resources | nindent 12 }}
+      - name: celery
+        image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command: ['/entrypoint-celery-worker.sh']
+        envFrom:
+        - configMapRef:
+            name: {{ $fullName }}
+        env:
+        - name: DD_CELERY_BROKER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $fullName }}-{{ .Values.celery.broker }}
+              key: {{ .Values.celery.broker }}-password
+        - name: DD_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if eq .Values.database "postgresql" }}
+              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgres-password
+              {{- else if eq .Values.database "mysql" }}
+              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              key: mysql-password
+              {{- end }}   
+        resources:
+          {{- toYaml .Values.celery.worker.resources | nindent 10 }}
+# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.celery.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -23,9 +23,13 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       containers:
       - name: celery
-        image: "{{ .Values.celery.repository }}:{{ .Values.tag }}"
+        image: "{{ template "celery.repository" . }}:{{ .Values.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command: ['/entrypoint-celery-worker.sh']
         envFrom:
@@ -35,7 +39,10 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use broker chart secret
+              # name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use secret handled outside of the chart
+              name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
         - name: DD_DATABASE_PASSWORD
           valueFrom:
@@ -44,12 +51,14 @@ spec:
               name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
               key: postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use mysql chart secret
+              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
               key: mysql-password
               {{- end }}   
         resources:
           {{- toYaml .Values.celery.worker.resources | nindent 10 }}
-# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.celery.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -23,12 +23,16 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       volumes:
       - name: run
         emptyDir: {}
       containers:
       - name: uwsgi
-        image: '{{ .Values.django.uwsgi.repository }}:{{ .Values.tag }}'
+        image: '{{ template "django.uwsgi.repository" . }}:{{ .Values.tag }}'
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         volumeMounts:
         - name: run
@@ -40,7 +44,10 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use broker chart secret
+              # name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use secret handled outside of the chart
+              name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
         - name: DD_DATABASE_PASSWORD
           valueFrom:
@@ -49,13 +56,16 @@ spec:
               name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
               key: postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use mysql chart secret
+              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
               key: mysql-password
               {{- end }}   
         resources:
           {{- toYaml .Values.django.uwsgi.resources | nindent 10 }}
       - name: nginx
-        image: '{{ .Values.django.nginx.repository }}:{{ .Values.tag }}'
+        image: '{{ template "django.nginx.repository" . }}:{{ .Values.tag }}'
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         volumeMounts:
         - name: run
@@ -89,7 +99,6 @@ spec:
           failureThreshold: 12
         resources:
           {{- toYaml .Values.django.nginx.resources | nindent 10 }}
-# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -24,71 +24,72 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       volumes:
-        - name: run
-          emptyDir: {}
+      - name: run
+        emptyDir: {}
       containers:
-        - name: uwsgi
-          image: '{{ .Values.django.uwsgi.repository }}:{{ .Values.tag }}'
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          volumeMounts:
-            - name: run
-              mountPath: /run
-          envFrom:
-            - configMapRef:
-                name: {{ $fullName }}
-          env:
-            - name: DD_CELERY_BROKER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $fullName }}-{{ .Values.celery.broker }}
-                  key: {{ .Values.celery.broker }}-password
-            - name: DD_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-                  key: postgres-password
-                  {{- else if eq .Values.database "mysql" }}
-                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-                  key: mysql-password
-                  {{- end }}   
-          resources:
-            {{- toYaml .Values.django.uwsgi.resources | nindent 12 }}
-        - name: nginx
-          image: '{{ .Values.django.nginx.repository }}:{{ .Values.tag }}'
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          volumeMounts:
-            - name: run
-              mountPath: /run
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          envFrom:
-            - configMapRef:
-                name: {{ $fullName }}
-          livenessProbe:
-            httpGet:
-              path: /
-              port: http
-              httpHeaders:
-                - name: Host
-                  value: {{ .Values.host }}
-            initialDelaySeconds: 120
-            periodSeconds: 10
-            failureThreshold: 6
-          readinessProbe:
-            httpGet:
-              path: /
-              port: http
-              httpHeaders:
-                - name: Host
-                  value: {{ .Values.host }}
-            initialDelaySeconds: 120
-            periodSeconds: 10
-            failureThreshold: 12
-          resources:
-            {{- toYaml .Values.django.nginx.resources | nindent 12 }}
+      - name: uwsgi
+        image: '{{ .Values.django.uwsgi.repository }}:{{ .Values.tag }}'
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        envFrom:
+        - configMapRef:
+            name: {{ $fullName }}
+        env:
+        - name: DD_CELERY_BROKER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ $fullName }}-{{ .Values.celery.broker }}
+              key: {{ .Values.celery.broker }}-password
+        - name: DD_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if eq .Values.database "postgresql" }}
+              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgres-password
+              {{- else if eq .Values.database "mysql" }}
+              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              key: mysql-password
+              {{- end }}   
+        resources:
+          {{- toYaml .Values.django.uwsgi.resources | nindent 10 }}
+      - name: nginx
+        image: '{{ .Values.django.nginx.repository }}:{{ .Values.tag }}'
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: {{ $fullName }}
+        livenessProbe:
+          httpGet:
+            path: /
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.host }}
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          failureThreshold: 6
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.host }}
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          failureThreshold: 12
+        resources:
+          {{- toYaml .Values.django.nginx.resources | nindent 10 }}
+# conversion to kubernetes v1.16 not tested for the below lines
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -53,8 +53,11 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              key: postgres-password
+              # use postgresql chart secret
+              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
               # Use mysql chart secret
               # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -15,12 +15,14 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
+{{- if .Values.django.ingress.activateTLS -}}
   tls:
   - hosts:
       - {{ .Values.host }}
   {{- if .Values.django.ingress.secretName }}
     secretName: {{ .Values.django.ingress.secretName }}
   {{- end }}
+{{- end }}
   rules:
   - host: {{ .Values.host }}
     http:

--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -15,10 +15,10 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- if .Values.django.ingress.activateTLS -}}
+{{- if .Values.django.ingress.activateTLS }}
   tls:
   - hosts:
-      - {{ .Values.host }}
+    - {{ .Values.host }}
   {{- if .Values.django.ingress.secretName }}
     secretName: {{ .Values.django.ingress.secretName }}
   {{- end }}

--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -16,17 +16,17 @@ metadata:
 {{- end }}
 spec:
   tls:
-    - hosts:
-        - {{ .Values.host }}
-    {{- if .Values.django.ingress.secretName }}
-      secretName: {{ .Values.django.ingress.secretName }}
-    {{- end }}
+  - hosts:
+      - {{ .Values.host }}
+  {{- if .Values.django.ingress.secretName }}
+    secretName: {{ .Values.django.ingress.secretName }}
+  {{- end }}
   rules:
-    - host: {{ .Values.host }}
-      http:
-        paths:
-          - path: /
-            backend:
-              serviceName: {{ $fullName }}-django
-              servicePort: http
+  - host: {{ .Values.host }}
+    http:
+      paths:
+        - path: /
+          backend:
+            serviceName: {{ $fullName }}-django
+            servicePort: http
 {{- end }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -19,27 +19,28 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       containers:
-        - name: initializer
-          image: "{{ .Values.initializer.repository }}:{{ .Values.tag }}"
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
-          command: ['/entrypoint-initializer.sh']
-          envFrom:
-            - configMapRef:
-                name: {{ $fullName }}
-            - secretRef:
-                name: {{ $fullName }}
-          env:
-            - name: DD_DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  {{- if eq .Values.database "postgresql" }}
-                  name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-                  key: postgres-password
-                  {{- else if eq .Values.database "mysql" }}
-                  name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-                  key: mysql-password
-                  {{- end }}   
-          resources:
-            {{- toYaml .Values.initializer.resources | nindent 12 }}
+      - name: initializer
+        image: "{{ .Values.initializer.repository }}:{{ .Values.tag }}"
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        command:
+          - /entrypoint-initializer.sh
+        envFrom:
+        - configMapRef:
+            name: {{ $fullName }}
+        - secretRef:
+            name: {{ $fullName }}
+        env:
+        - name: DD_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if eq .Values.database "postgresql" }}
+              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgres-password
+              {{- else if eq .Values.database "mysql" }}
+              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              key: mysql-password
+              {{- end }}   
+        resources:
+          {{- toYaml .Values.initializer.resources | nindent 10 }}
       restartPolicy: Never
   backoffLimit: 1

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -38,8 +38,11 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              key: postgres-password
+              # use postgresql chart secret
+              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
               # Use mysql chart secret
               # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -18,9 +18,13 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecrets }}
+      {{- end }}
       containers:
       - name: initializer
-        image: "{{ .Values.initializer.repository }}:{{ .Values.tag }}"
+        image: "{{ template "initializer.repository" . }}:{{ .Values.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
           - /entrypoint-initializer.sh
@@ -37,9 +41,12 @@ spec:
               name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
               key: postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{- if .Values.mysql.enabled }} {{ template "mysql.fullname" .}} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use mysql chart secret
+              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
               key: mysql-password
-              {{- end }}   
+              {{- end }}
         resources:
           {{- toYaml .Values.initializer.resources | nindent 10 }}
       restartPolicy: Never

--- a/helm/defectdojo/templates/secret-mysql.yaml
+++ b/helm/defectdojo/templates/secret-mysql.yaml
@@ -1,9 +1,8 @@
-{{- if .Values.createSecret -}}
-{{- $fullName := include "defectdojo.fullname" . -}}
+{{- if .Values.createMysqlSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $fullName }}
+  name: defectdojo-mysql-specific
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -13,7 +12,7 @@ metadata:
     helm.sh/resource-policy: keep
 type: Opaque
 data:
-  DD_ADMIN_PASSWORD: {{ randAlphaNum 22 | b64enc | quote }}
-  DD_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
-  DD_CREDENTIAL_AES_256_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
+  mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
+
 {{- end }}

--- a/helm/defectdojo/templates/secret-postgresql.yaml
+++ b/helm/defectdojo/templates/secret-postgresql.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.createPostgresqlSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: defectdojo-postgresql-specific
+  labels:
+    app.kubernetes.io/name: {{ include "defectdojo.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "defectdojo.chart" . }}
+  annotations:
+    helm.sh/resource-policy: keep
+type: Opaque
+data:
+  postgresql-password : {{ randAlphaNum 10 | b64enc | quote }}
+
+{{- end }}

--- a/helm/defectdojo/templates/secret-rabbitmq.yaml
+++ b/helm/defectdojo/templates/secret-rabbitmq.yaml
@@ -1,9 +1,8 @@
-{{- if .Values.createSecret -}}
-{{- $fullName := include "defectdojo.fullname" . -}}
+{{- if .Values.createRabbitMqSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $fullName }}
+  name: defectdojo-rabbitmq-specific
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -13,7 +12,6 @@ metadata:
     helm.sh/resource-policy: keep
 type: Opaque
 data:
-  DD_ADMIN_PASSWORD: {{ randAlphaNum 22 | b64enc | quote }}
-  DD_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
-  DD_CREDENTIAL_AES_256_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
+  rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
 {{- end }}

--- a/helm/defectdojo/templates/secret-redis.yaml
+++ b/helm/defectdojo/templates/secret-redis.yaml
@@ -1,9 +1,8 @@
-{{- if .Values.createSecret -}}
-{{- $fullName := include "defectdojo.fullname" . -}}
+{{- if .Values.createRedisSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $fullName }}
+  name: defectdojo-redis-specific
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -13,7 +12,5 @@ metadata:
     helm.sh/resource-policy: keep
 type: Opaque
 data:
-  DD_ADMIN_PASSWORD: {{ randAlphaNum 22 | b64enc | quote }}
-  DD_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
-  DD_CREDENTIAL_AES_256_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  redis-password: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}

--- a/helm/defectdojo/templates/secret.yaml
+++ b/helm/defectdojo/templates/secret.yaml
@@ -16,4 +16,5 @@ data:
   DD_ADMIN_PASSWORD: {{ randAlphaNum 22 | b64enc | quote }}
   DD_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
   DD_CREDENTIAL_AES_256_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  mysql-password : {{ randAlphaNum 32 | b64enc | quote }}
 {{- end }}

--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -38,8 +38,11 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              key: postgres-password
+              # use postgresql chart secret
+              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
               # Use mysql chart secret
               # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}

--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -11,9 +11,13 @@ metadata:
   annotations:
     helm.sh/hook: test-success
 spec:
+  {{- if .Values.imagePullSecrets }}
+  imagePullSecrets:
+  - name: {{ .Values.imagePullSecrets }}
+  {{- end }}
   containers:
     - name: unit-tests
-      image: '{{ .Values.django.uwsgi.repository }}:{{ .Values.tag }}'
+      image: '{{ .Values.repositoryPrefix }}/defectdojo-django:{{ .Values.tag }}'
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       command: ['/entrypoint-unit-tests.sh']
       envFrom:
@@ -25,13 +29,25 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use broker chart secret
+              # name: {{ $fullName }}-{{ .Values.celery.broker }}
+              # Use secret handled outside of the chart
+              name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ $fullName }}-{{ .Values.database }}
+              {{- if eq .Values.database "postgresql" }}
+              name: {{- if .Values.postgresql.enabled }} {{ template "postgresql.fullname" .}} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              key: postgres-password
+              {{- else if eq .Values.database "mysql" }}
+              # Use mysql chart secret
+              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              # Use secret handled outside of the chart
+              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              key: mysql-password
+              {{- end }}
               key: {{ if eq .Values.database "postgresql" }}{{ .Values.database }}-password{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.database }}-root-password{{ end }}
         - name: DD_DEBUG
-          value: 'on'
+          value: 'True'
   restartPolicy: Never

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -83,7 +83,7 @@ initializer:
       memory: 128Mi
 
 mysql:
-  enabled: true
+  enabled: false
   mysqlUser: defectdojo
   existingSecret: defectdojo-mysql-specific
   mysqlDatabase: defectdojo
@@ -97,7 +97,7 @@ mysql:
   # mysqlPasswordSecret: ""  
 
 postgresql:
-  enabled: false
+  enabled: true
   postgresqlUsername: defectdojo
   postgresqlDatabase: defectdojo
   existingSecret: defectdojo-postgresql-specific

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -13,7 +13,7 @@ createPostgresqlSecret: true
 ## Configuration value to select database type
 ## Option to use "postgresql" or "mysql" database type, by default "postgresql" is chosen
 ## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select
-database: mysql
+database: postgresql
 host: defectdojo.default.minikube.local
 imagePullPolicy: Always
 # Where to pull the defectDojo images from. Defaults to "defectdojo/*" repositories on hub.docker.com

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -1,12 +1,23 @@
 ---
 # Global settings
+# create defectdojo specific secret
 createSecret: true
+# create rabbitmq secret outside of rabbitmq chart
+createRabbitMqSecret: true
+# create redis secret outside of redis chart
+createRedisSecret: true
+# create mysql secret outside of mysql chart
+createMysqlSecret: true
 ## Configuration value to select database type
 ## Option to use "postgresql" or "mysql" database type, by default "postgresql" is chosen
 ## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select
 database: mysql
 host: defectdojo.default.minikube.local
 imagePullPolicy: Always
+# Where to pull the defectDojo images from. Defaults to "defectdojo/*" repositories on hub.docker.com
+repositoryPrefix: defectdojo
+# When using a private registry, name of the secret that holds the registry secret (eg deploy token from gitlab-ci project)
+# imagePullSecrets: defectdojoregistrykey
 tag: latest
 
 admin:
@@ -18,7 +29,6 @@ admin:
 # Components
 celery:
   broker: rabbitmq
-  repository: defectdojo/defectdojo-django
   logLevel: DEBUG
   beat:
     affinity: {}
@@ -30,7 +40,6 @@ celery:
     tolerations: []
   worker:
     affinity: {}
-    repository: defectdojo/defectdojo-django
     logLevel: DEBUG
     nodeSelector: {}
     replicas: 1
@@ -44,11 +53,12 @@ django:
   affinity: {}
   ingress:
     enabled: true
+    activateTLS: true
     secretName: defectdojo-tls
     annotations:
-      kubernetes.io/ingress.class: nginx
+      # Restricts the type of ingress controller that can interact with our chart (nginx, traefik, ...)
+      #kubernetes.io/ingress.class: nginx
   nginx:
-    repository: defectdojo/defectdojo-nginx
     resources:
       requests:
         cpu: 100m
@@ -57,7 +67,6 @@ django:
   replicas: 1
   tolerations: []
   uwsgi:
-    repository: defectdojo/defectdojo-django
     resources:
       requests:
         cpu: 100m
@@ -65,7 +74,6 @@ django:
 
 initializer:
   run: true
-  repository: defectdojo/defectdojo-django
   keepSeconds: 60
   resources:
     requests:
@@ -75,6 +83,7 @@ initializer:
 mysql:
   enabled: true
   mysqlUser: defectdojo
+  existingSecret: defectdojo-mysql-specific
   mysqlDatabase: defectdojo
   service:
     port: 3306  
@@ -106,8 +115,13 @@ postgresql:
 rabbitmq:
   enabled: true
   replicas: 1
+  rabbitmq:
+    existingPasswordSecret: defectdojo-rabbitmq-specific
+    existingErlangSecret: defectdojo-rabbitmq-specific
 
 redis:
   enabled: false
+  existingSecret: defectdojo-redis-specific
   cluster:
     slaveCount: 1
+

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -8,6 +8,8 @@ createRabbitMqSecret: true
 createRedisSecret: true
 # create mysql secret outside of mysql chart
 createMysqlSecret: true
+# create postgresql secret outside of postgresql chart
+createPostgresqlSecret: true
 ## Configuration value to select database type
 ## Option to use "postgresql" or "mysql" database type, by default "postgresql" is chosen
 ## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select
@@ -98,8 +100,9 @@ postgresql:
   enabled: false
   postgresqlUsername: defectdojo
   postgresqlDatabase: defectdojo
+  existingSecret: defectdojo-postgresql-specific
   persistence:
-    enabled: false
+    enabled: true
   replication:
     enabled: false
   service:


### PR DESCRIPTION
Various fixes and improvments for kubernetes: 
- Fixed yaml identations
- Convert to kubernetes 1.16 using "kubectl convert". This probably didn't change much but this is the first thing I tried when nothing was working for me :) . I have kept the changes which is basically a bit of identation and formating changes; it's more standard this way I guess because it's how kubernetes "natively" idents yaml. 
- add option "django.ingress.activateTLS" : before having this option, if you hadn't setup TLS, the application wasn't working (HTTP 404). Now we have a first step without TLS with a working application. (I haven't tested TLS yet)
- comment out nginx ingress controller annotation: due to this annotation, the application could only work with nginx controller (example: with traefik, HTTP 404 with error "backend not found" when debug is activated). For most users, this annotation is not required because it's only required when you have several ingress controllers. A possible improvment would be to make it configurable in values.yaml
- handle secrets outside of the dependent charts: I had issues with the rabbitmq chart, because when things are not working and you re-install the carts, due to (or thanks to) the statefulset, the first password generated is the correct one and after re-installing, the secret would get populated with a wrong password. By handling secrets outside of the dependent chart and by adding options to re-create or not the secrets, it's easier to handle the lifecycle of the secrets: we can keep the same secret when re-installing so that it still holds the correct value. 
- bump up dependencies (otherwise it wasn't working for kubernetes 1.16)
- bump up chart versions
- fix documentation for use with helm 3
- fix hot reloading in ptvsd env (not related to kubernetes by it had to be done)
