### PR TITLE
phpcs_security_audit_v2 fix on inclusion of the warnings along with e…

### DIFF
--- a/dojo/tools/hadolint/parser.py
+++ b/dojo/tools/hadolint/parser.py
@@ -13,8 +13,10 @@ class HadolintParser(object):
             self.items = []
 
     def parse_json(self, json_output):
+        json_output = json_output.read()
+
         try:
-            tree = json.load(json_output)
+            tree = json.loads(json_output.decode('utf-8').strip())
         except:
             raise Exception("Invalid format")
 

--- a/dojo/tools/php_security_audit_v2/parser.py
+++ b/dojo/tools/php_security_audit_v2/parser.py
@@ -13,7 +13,8 @@ class PhpSecurityAuditV2(object):
         dupes = dict()
 
         for filepath, report in list(data["files"].items()):
-            if report["errors"] > 0:
+            # This change below will include in report warnings and errors.
+            if ( report["errors"]  or report["warnings"] ) > 0:
                 for issue in report["messages"]:
                     title = issue["source"]
 


### PR DESCRIPTION
Small fix to phpcs_security_audit_v2 plugin to include warnings alongside errors in the report.

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.