### PR TITLE
Added exception catching, error message, and redirect

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -555,7 +555,14 @@ def import_scan_results(request, eid=None, pid=None):
                     new_f.cred_id = cred_user.cred_id
                     new_f.save()
 
-            parser = import_parser_factory(file, t, active, verified)
+            try:
+                parser = import_parser_factory(file, t, active, verified)
+            except Exception as e:
+                messages.add_message(request,
+                                     messages.ERROR,
+                                     "Error importing scan results: {}".format(str(e)),
+                                     extra_tags='alert-danger')
+                return HttpResponseRedirect(reverse('import_scan_results', args=(eid,)))
 
             try:
                 for item in parser.items:

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -36,6 +36,7 @@ from dojo.tasks import update_epic_task, add_epic_task
 from functools import reduce
 
 logger = logging.getLogger(__name__)
+parse_logger = logging.getLogger('dojo')
 
 
 @user_passes_test(lambda u: u.is_staff)
@@ -560,8 +561,11 @@ def import_scan_results(request, eid=None, pid=None):
             except Exception as e:
                 messages.add_message(request,
                                      messages.ERROR,
-                                     "Error importing scan results: {}".format(str(e)),
+                                     "An error has occurred in the parser, please see error "
+                                     "log for details.",
                                      extra_tags='alert-danger')
+                parse_logger.exception(e)
+                parse_logger.error("Error in parser: {}".format(str(e)))
                 return HttpResponseRedirect(reverse('import_scan_results', args=(eid,)))
 
             try:

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -32,7 +32,7 @@ from dojo.tasks import add_issue_task, update_issue_task
 from functools import reduce
 
 logger = logging.getLogger(__name__)
-
+parse_logger = logging.getLogger('dojo')
 
 def view_test(request, tid):
     test = Test.objects.get(id=tid)
@@ -603,8 +603,11 @@ def re_import_scan_results(request, tid):
             except Exception as e:
                 messages.add_message(request,
                                      messages.ERROR,
-                                     "Error importing scan results: {}".format(str(e)),
+                                     "An error has occurred in the parser, please see error "
+                                     "log for details.",
                                      extra_tags='alert-danger')
+                parse_logger.exception(e)
+                parse_logger.error("Error in parser: {}".format(str(e)))
                 return HttpResponseRedirect(reverse('re_import_scan_results', args=(t.id,)))
 
             try:

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -600,6 +600,12 @@ def re_import_scan_results(request, tid):
                 parser = import_parser_factory(file, t, active, verified)
             except ValueError:
                 raise Http404()
+            except Exception as e:
+                messages.add_message(request,
+                                     messages.ERROR,
+                                     "Error importing scan results: {}".format(str(e)),
+                                     extra_tags='alert-danger')
+                return HttpResponseRedirect(reverse('re_import_scan_results', args=(t.id,)))
 
             try:
                 items = parser.items


### PR DESCRIPTION
Was getting pretty annoyed by the **500 Internal Server Error** message when there are exceptions in the parser logic. 

Not sure if this is the _most correct_ way to solve the problem but I gave it a shot.
Reloads the page with an error message that I pull straight from the exception. Up to the coder of the parser logic to make sure the error message is useful. (i.e. Key error message are pretty useless by themselves)

I just print the exception message in the error, could change this to have less information (just something like "there were errors importing scan results" without specifying the errors)

Following screenshot was generated by adding to the hackerone parser:
`raise Exception("Raising an exception in the parser for error testing.")`
![image](https://user-images.githubusercontent.com/17787069/72628887-1e58a600-3904-11ea-995b-b4e77ed26a1e.png)
