### PR TITLE
Fix PHP Symfony Security Checker import and dedupe

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -571,6 +571,9 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Whitesource Scan': ['title', 'severity', 'description'],
     'ZAP Scan': ['cwe', 'endpoints', 'severity'],
     'Qualys Scan': ['title', 'endpoints', 'severity']
+    'PHP Symfony Security Check': ['title', 'cve'],
+    # for backwards compatibility because someone decided to rename this scanner:
+    'Symfony Security Check': ['title', 'cve'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -618,7 +618,9 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Whitesource Scan': DEDUPE_ALGO_HASH_CODE,
     'ZAP Scan': DEDUPE_ALGO_HASH_CODE,
     'Qualys Scan': DEDUPE_ALGO_HASH_CODE,
-    'PHP Symfony Security Check': DEDUPE_ALGO_HASH_CODE
+    'PHP Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
+    # for backwards compatibility because someone decided to rename this scanner:
+    'Symfony Security Check': DEDUPE_ALGO_HASH_CODE
 }
 
 # ------------------------------------------------------------------------------

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -570,7 +570,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # possible improvment: in the scanner put the library name into file_path, then dedup on cve + file_path + severity
     'Whitesource Scan': ['title', 'severity', 'description'],
     'ZAP Scan': ['cwe', 'endpoints', 'severity'],
-    'Qualys Scan': ['title', 'endpoints', 'severity']
+    'Qualys Scan': ['title', 'endpoints', 'severity'],
     'PHP Symfony Security Check': ['title', 'cve'],
     # for backwards compatibility because someone decided to rename this scanner:
     'Symfony Security Check': ['title', 'cve'],

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -617,7 +617,8 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'NPM Audit Scan': DEDUPE_ALGO_HASH_CODE,
     'Whitesource Scan': DEDUPE_ALGO_HASH_CODE,
     'ZAP Scan': DEDUPE_ALGO_HASH_CODE,
-    'Qualys Scan': DEDUPE_ALGO_HASH_CODE
+    'Qualys Scan': DEDUPE_ALGO_HASH_CODE,
+    'PHP Symfony Security Check': DEDUPE_ALGO_HASH_CODE
 }
 
 # ------------------------------------------------------------------------------

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -291,7 +291,7 @@ def async_update_findings_from_source_issues(*args, **kwargs):
 
 @app.task(bind=True)
 def async_dupe_delete(*args, **kwargs):
-    logger.info("delete excess duplicates")
+    deduplicationLogger.info("delete excess duplicates")
     system_settings = System_Settings.objects.get()
     if system_settings.delete_dupulicates:
         dupe_max = system_settings.max_dupes
@@ -304,6 +304,7 @@ def async_dupe_delete(*args, **kwargs):
                     .filter(duplicate=True).order_by('date')
             dupe_count = len(duplicate_list) - dupe_max
             for finding in duplicate_list:
+                deduplicationLogger.debug('deleting finding {}:{} ({}))'.format(finding.id, finding.title, finding.hash_code))
                 finding.delete()
                 dupe_count = dupe_count - 1
                 if dupe_count == 0:

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -124,7 +124,7 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
         parser = NspParser(file, test)
     elif scan_type == 'NPM Audit Scan':
         parser = NpmAuditParser(file, test)
-    elif scan_type == 'Symfony Security Check':
+    elif scan_type == 'PHP Symfony Security Check':
         parser = PhpSymfonySecurityCheckParser(file, test)
     elif scan_type == 'Generic Findings Import':
         parser = GenericFindingUploadCsvParser(file, test, active, verified)

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -63,6 +63,7 @@ def get_item(dependency_name, dependency_version, advisory, test):
                       out_of_scope=False,
                       mitigated=None,
                       impact="No impact provided",
+                      static_finding=True,
                       dynamic_finding=False)
 
     return finding

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -62,6 +62,7 @@ def get_item(dependency_name, dependency_version, advisory, test):
                       duplicate=False,
                       out_of_scope=False,
                       mitigated=None,
-                      impact="No impact provided")
+                      impact="No impact provided",
+                      dynamic_finding=False)
 
     return finding


### PR DESCRIPTION
Importing PHP Symfony Security Checker seems to be broken for a long time as the scan_type became out of sync in factory.py in 86f2de355c2cc80ce44ad8b437aa87d8afce89d4 (at least in APIv2)

This small commit changes the id/key in factory.py to match with those in test_type.json etc.