### PR TITLE
owasp_dependency_checker: truncate too long cve fields

### DIFF
--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -30,7 +30,7 @@ class DependencyCheckParser(object):
         description = self.get_field_value(vulnerability, 'description')
 
         title = '{0} | {1}'.format(filename, name)
-        cve = name
+        cve = name[:28]
         # Use CWE-1035 as fallback
         cwe = 1035  # Vulnerable Third Party Component
         if cwe_field:


### PR DESCRIPTION
Since ff9057cf9e80d5508d6a6a9774b6aa77dae99817 my owasp dependency checker imports are failing because the CVE field has been limited to 20 characters.
This makes sense, but apparently the owap dependency checker parser uses the "name" field as CVE and sometimes it doesn't contain a valid CVE value but a textual description of the vulnerability.
i.e. when there is no CVE for this vulnerability I presume.
Options considered:
- Keep as-is: let imports fail. Not an option because it happens all the time
- Truncate: simplest for now, but while typing this I realize it might lead to strange CVE values

Possible improvement: check if the value matches regex, if not, do not set CVE.

At least it's working again now and we can gain some experience with the kind of values we see in the name/cve field