### PR TITLE
Only run async tool issue updated when applicable

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2060,8 +2060,8 @@ def finding_bulk_update_all(request, pid=None):
                             prev_prod = finding.test.engagement.product.id
 
                 for finding in finds:
-                    from dojo.tasks import async_tool_issue_updater
-                    async_tool_issue_updater.delay(finding)
+                    from dojo.tools import tool_issue_updater
+                    tool_issue_updater.async_tool_issue_update(finding)
 
                     if JIRA_PKey.objects.filter(product=finding.test.engagement.product).count() == 0:
                         log_jira_alert('Finding cannot be pushed to jira as there is no jira configuration for this product.', finding)

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1589,8 +1589,8 @@ class Finding(models.Model):
 
             # Run async the tool issue update to update original issue with Defect Dojo updates
             if issue_updater_option:
-                    from dojo.tools import tool_issue_updater
-                    tool_issue_updater.async_tool_issue_update(self)
+                from dojo.tools import tool_issue_updater
+                tool_issue_updater.async_tool_issue_update(self)
         if (self.file_path is not None) and (self.endpoints.count() == 0):
             self.static_finding = True
             self.dynamic_finding = False

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1589,8 +1589,8 @@ class Finding(models.Model):
 
             # Run async the tool issue update to update original issue with Defect Dojo updates
             if issue_updater_option:
-                from dojo.tasks import async_tool_issue_updater
-                async_tool_issue_updater.delay(self)
+                    from dojo.tools import tool_issue_updater
+                    tool_issue_updater.async_tool_issue_update(self)
         if (self.file_path is not None) and (self.endpoints.count() == 0):
             self.static_finding = True
             self.dynamic_finding = False

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -549,7 +549,7 @@ def finding_bulk_update(request, tid):
                 for finding in finds:
                     from dojo.tools import tool_issue_updater
                     tool_issue_updater.async_tool_issue_update(finding)
-                    
+
                     if JIRA_PKey.objects.filter(product=finding.test.engagement.product).count() == 0:
                         log_jira_alert('Finding cannot be pushed to jira as there is no jira configuration for this product.', finding)
                     else:

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -547,9 +547,9 @@ def finding_bulk_update(request, tid):
                     calculate_grade(test.engagement.product)
 
                 for finding in finds:
-                    from dojo.tasks import async_tool_issue_updater
-                    async_tool_issue_updater.delay(finding)
-
+                    from dojo.tools import tool_issue_updater
+                    tool_issue_updater.async_tool_issue_update(finding)
+                    
                     if JIRA_PKey.objects.filter(product=finding.test.engagement.product).count() == 0:
                         log_jira_alert('Finding cannot be pushed to jira as there is no jira configuration for this product.', finding)
                     else:

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -1,8 +1,8 @@
 from dojo.tools import SCAN_SONARQUBE_API
-from dojo.tasks import async_tool_issue_updater
 
 def async_tool_issue_update(finding, *args, **kwargs):
     if is_tool_issue_updater_needed(finding):
+        from dojo.tasks import async_tool_issue_updater
         async_tool_issue_updater.delay(finding)
 
 

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -1,5 +1,6 @@
 from dojo.tools import SCAN_SONARQUBE_API
 
+
 def async_tool_issue_update(finding, *args, **kwargs):
     if is_tool_issue_updater_needed(finding):
         from dojo.tasks import async_tool_issue_updater

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -1,4 +1,14 @@
 from dojo.tools import SCAN_SONARQUBE_API
+from dojo.tasks import async_tool_issue_updater
+
+def async_tool_issue_update(finding, *args, **kwargs):
+    if is_tool_issue_updater_needed(finding):
+        async_tool_issue_updater.delay(finding)
+
+
+def is_tool_issue_updater_needed(finding, *args, **kwargs):
+    test_type = finding.test.test_type
+    return test_type.name == SCAN_SONARQUBE_API
 
 
 def tool_issue_updater(finding, *args, **kwargs):


### PR DESCRIPTION
Since the sonarqube (api) integration, every update to an issue or every issue created, triggers the creation of an async celery task to update the original issue in sonarqube.
This makes sense for issues that were imported from sonarqube. But not for all other issues. In CI/CD environment this leads to lots and lots of celery tasks that basically do nothing but generate overhead :)
So I wrapped the async tool update code in a function that only creates the async task if applicable.
For now this only applies to imports from sonarcube. 

The original functions do not refer to "sonarqube updater" but a more generic "tool_issue_updater". So maybe it was designed to be a mechanism for other tools in the future?
As I didn't want to change much to this, I just created a simple wrapper function.

@twsagarcia let me know if my change breaks anything