### PR TITLE
dashboard: use aggregate to populate severity pie chart

### DIFF
--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -71,8 +71,8 @@ def dashboard(request):
     # make sure all keys are present
     sev_counts = {'Critical': 0,
                   'High': 0,
-                  'Medium': 0,	
-                  'Low': 0,	
+                  'Medium': 0,
+                  'Low': 0,
                   'Info': 0}
 
     for s in severities:

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -12,6 +12,7 @@ from django.shortcuts import render
 from django.utils import timezone
 
 from dojo.models import Finding, Engagement, Risk_Acceptance
+from django.db.models import Count
 from dojo.utils import add_breadcrumb, get_punchcard_data
 
 from defectDojo_engagement_survey.models import Answered_Survey
@@ -64,15 +65,13 @@ def dashboard(request):
         findings = Finding.objects.filter(reporter=request.user,
                                           verified=True, duplicate=False)
 
-    sev_counts = {'Critical': 0,
-                  'High': 0,
-                  'Medium': 0,
-                  'Low': 0,
-                  'Info': 0}
-
-    for finding in findings:
-        if finding.severity:
-            sev_counts[finding.severity.capitalize()] += 1
+    # order_by is needed due to ordering being present in Meta of Finding
+    severities = findings.values('severity').annotate(count=Count('severity')).order_by()
+  
+    sev_counts = {}
+    for s in severities:
+        logger.error(s)
+        sev_counts[s['severity']] = s['count']
 
     by_month = list()
 

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -67,7 +67,7 @@ def dashboard(request):
 
     # order_by is needed due to ordering being present in Meta of Finding
     severities = findings.values('severity').annotate(count=Count('severity')).order_by()
-  
+
     sev_counts = {}
     for s in severities:
         logger.error(s)

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -68,7 +68,13 @@ def dashboard(request):
     # order_by is needed due to ordering being present in Meta of Finding
     severities = findings.values('severity').annotate(count=Count('severity')).order_by()
 
-    sev_counts = {}
+    # make sure all keys are present
+    sev_counts = {'Critical': 0,
+                  'High': 0,
+                  'Medium': 0,	
+                  'Low': 0,	
+                  'Info': 0}
+
     for s in severities:
         logger.error(s)
         sev_counts[s['severity']] = s['count']


### PR DESCRIPTION
As I have over 10000 findings in my instance, I'm getting nice visibility of the bottlenecks in Defect Dojo.

The dashboard is showing a pie chart with all-time severity count. It populates this by retrieving ALL findings from the database and let some django code count the severities (no comment).

I've rewritten this to use an aggregate in the queryset.

There's more to be optimized in the dashboard statistics, but the weekend is almost over.
