### PR TITLE
Removing threading from ptvsd entrypoint

### DIFF
--- a/docker/entrypoint-uwsgi-ptvsd.sh
+++ b/docker/entrypoint-uwsgi-ptvsd.sh
@@ -17,4 +17,4 @@ exec uwsgi \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
   --py-autoreload 1 \
-  --lazy-apps --honour-stdin
+  --enable-threads --lazy-apps --honour-stdin

--- a/docker/entrypoint-uwsgi-ptvsd.sh
+++ b/docker/entrypoint-uwsgi-ptvsd.sh
@@ -17,7 +17,4 @@ exec uwsgi \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
   --py-autoreload 1 \
-  --enable-threads --lazy-apps --honour-stdin \
-  --processes 2 \
-  --threads 2
-  
+  --lazy-apps --honour-stdin


### PR DESCRIPTION
Running ptvsd with threads and potentially multi-processes will mess with you soon or later.

If you're debugging something anyways, you probably do not need multiple threads, but rather will like to have 100% of your breakpoints work or hot-reload to be super fast.

fyi @ptrovatelli 