### PR TITLE
cache alert_count within request scope

### DIFF
--- a/dojo/templatetags/navigation_tags.py
+++ b/dojo/templatetags/navigation_tags.py
@@ -9,7 +9,11 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def alert_count(context):
-    count = Alerts.objects.filter(user_id=context['request'].user).count()
+    count = context.get('dojo_alert_count', None)
+    if count is None:
+        count = Alerts.objects.filter(user_id=context['request'].user).count()
+        context['dojo_alert_count'] = count
+      
     return count if count > 0 else 0
 
 


### PR DESCRIPTION
Current dev branch doesn't cache alert_count when rendering pages. So each http requests results in multiple queries to get the alert count. Although not always very heavy, it makes no sense to do ~5 queries per page in each request.

I don't know everything about django, so couldn't find an easy way to cache this value without too many changes. This PR is to get some feedback.

I know most of you probably don't care about these small queries, but I'd like to see if they can be avoided. In large instances you can have lots of alerts so they can be 10ms each resulting in a 50ms delay for each page.