### PR TITLE
Cut the URL elements to the maximum size they can actually have accor…

### DIFF
--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -85,10 +85,10 @@ class ZapXmlParser(object):
                 for i in item.items:
                     parts = urlparse(i['uri'])
                     find.unsaved_endpoints.append(Endpoint(protocol=parts.scheme,
-                                                           host=parts.netloc,
-                                                           path=parts.path,
-                                                           query=parts.query,
-                                                           fragment=parts.fragment,
+                                                           host=parts.netloc[:500],
+                                                           path=parts.path[:500],
+                                                           query=parts.query[:1000],
+                                                           fragment=parts.fragment[:500],
                                                            product=test.engagement.product))
                 items.append(find)
         return items


### PR DESCRIPTION
When the endpoint URL is very big, the parser fails with: 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.5/site-packages/django/db/backends/mysql/base.py", line 71, in execute
    return self.cursor.execute(query, args)
  File "/usr/local/lib/python3.5/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/usr/local/lib/python3.5/site-packages/MySQLdb/cursors.py", line 312, in _query
    db.query(q)
  File "/usr/local/lib/python3.5/site-packages/MySQLdb/connections.py", line 224, in query
    _mysql.connection.query(self, query)
MySQLdb._exceptions.DataError: (1406, "Data too long for column 'query' at row 1")
```

this cuts the size of the field to the actual field length in the DB
