### PR TITLE
Make Similar findings play nice with dedupe on engagement

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2121,6 +2121,11 @@ def get_missing_mandatory_notetypes(finding):
 def mark_finding_duplicate(request, original_id, duplicate_id):
     original = get_object_or_404(Finding, id=original_id)
     duplicate = get_object_or_404(Finding, id=duplicate_id)
+
+    if original.test.engagement != duplicate.test.engagement:
+        if original.test.engagement.deduplication_on_engagement or duplicate.test.engagement.deduplication_on_engagement:
+            raise ValueError('Marking finding {} as duplicate of {} failed as they are not in the same engagement and deduplication_on_engagement is enabled for at least one of them')
+
     duplicate.duplicate = True
     duplicate.active = False
     duplicate.verified = False

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1326,7 +1326,13 @@ class Finding(models.Model):
 
     @property
     def similar_findings(self):
-        filtered = Finding.objects.filter(test__engagement__product=self.test.engagement.product)
+        filtered = Finding.objects.all()
+
+        if self.test.engagement.deduplication_on_engagement:
+            filtered = filtered.filter(test__engagement=self.test.engagement)
+        else:
+            filtered = filtered.filter(test__engagement__product=self.test.engagement.product)
+
         if self.cve:
             filtered = filtered.filter(cve=self.cve)
         if self.cwe:
@@ -1335,6 +1341,7 @@ class Finding(models.Model):
             filtered = filtered.filter(file_path=self.file_path)
         if self.line:
             filtered = filtered.filter(line=self.line)
+
         return filtered.exclude(pk=self.pk)[:10]
 
     def compute_hash_code(self):


### PR DESCRIPTION
Currently similar findings doesn't respect the deduplication_on_engagement flag and allows users to mark findings from other engagements as duplicate. When you have dedeuplication removal turned on this will remove the duplicate issue which is probably not what the users want in this scenario.

This PR makes sure the similar finding view only returns findings within the same engagement iff deduplication_on_engagement is turned on.

And it prevents the marking as duplicate from happening alltogether by adding some checks to the lower level code.