### PR TITLE
similar findings: add tooltip to show title

### DIFF
--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -314,7 +314,7 @@
                         {% for similar in findings %}
                             <tr>
                                 <td>
-                                    <a href="{% url 'view_finding' similar.id %}">{{ similar.date }}</a>
+                                    <a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ similar.title }}" href="{% url 'view_finding' similar.id %}">{{ similar.date }}</a>
                                     {% with similar.notes.count as note_count %}
                                         ({{ note_count }} note{{ note_count|pluralize }})
                                     {% endwith %}


### PR DESCRIPTION
The list with similar findings doesn't show the title, so you need to open each similar findings to check out what it is (providing that cwe is equal or empty and cve is equal or empty and filepath is equal or empty). This happens a lot with the npm audit scan as it doesn't have most of these fields.

This small change adds a tooltip to the finding (date) to make it easier to compare. There's no room to add the full title.

![image](https://user-images.githubusercontent.com/4426050/73124911-1e5e4300-3fa1-11ea-9dca-56890c522bc1.png)
