### PR TITLE
dependency checkers: provide better defaults for static/dynamic field

### DIFF
--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -199,7 +199,6 @@ class DependencyTrackParser(object):
             static_finding=True,
             dynamic_finding=False)
 
-
     def __init__(self, file, test):
         # Start with an empty list of findings
         self.items = []

--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -195,7 +195,10 @@ class DependencyTrackParser(object):
             description=vulnerability_description,
             severity=vulnerability_severity,
             numerical_severity=Finding.get_numerical_severity(vulnerability_severity),
-            false_p=is_false_positive)
+            false_p=is_false_positive,
+            static_finding=True,
+            dynamic_finding=False)
+
 
     def __init__(self, file, test):
         # Start with an empty list of findings

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -71,6 +71,8 @@ def get_item(item_node, test):
                       duplicate=False,
                       out_of_scope=False,
                       mitigated=None,
-                      impact="No impact provided")
+                      impact="No impact provided",
+                      static_finding=True,
+                      dynamic_finding=False)
 
     return finding

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -62,6 +62,8 @@ def get_item(dependency_name, dependency_version, advisory, test):
                       duplicate=False,
                       out_of_scope=False,
                       mitigated=None,
-                      impact="No impact provided")
+                      impact="No impact provided",
+                      static_finding=True,
+                      dynamic_finding=False)
 
     return finding


### PR DESCRIPTION
I am observing some findings marked as dynamic even though they are imported from the OWASP Dependency Checker / Track scans. Third party dependencies should be treated as static, so a good start is to mark them as static in the parser/import.