### PR TITLE
Apply template to Finding: Fix merge options for markdown text fields

### DIFF
--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -80,6 +80,7 @@
                     ]
                 });
                 mde.render();
+                elem.mde = mde;
             });
         });
 

--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -21,7 +21,7 @@
     <div class="form-group{% if field.errors %} has-error{% endif %}">
         <label class="col-sm-2 control-label">{{ field.label }} Option</label>
         <div class="col-sm-10 {{ classes.value }}">
-            <select class="form-control" data-field-value="{{ field.value }}" data-template-value="{{ template_value }}" onchange="(function(t){ var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=t.getAttribute('data-field-value'); break; case 'replace': fieldValue= t.getAttribute('data-template-value'); break; case 'combine': fieldValue= t.getAttribute('data-field-value').concat('\r\n').concat(t.getAttribute('data-template-value')); break;  } document.forms['apply_template']['{{ field.name }}'].value = fieldValue; })(this)">
+            <select class="form-control" data-field-value="{{ field.value }}" data-template-value="{{ template_value }}" onchange="(function(t){ var field = document.forms['apply_template']['{{ field.name }}']; var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=t.getAttribute('data-field-value'); break; case 'replace': fieldValue= t.getAttribute('data-template-value'); break; case 'combine': fieldValue= t.getAttribute('data-field-value').concat('\r\n').concat(t.getAttribute('data-template-value')); break;  } field.mde === undefined ? field.value = fieldValue : field.mde.value(fieldValue); })(this)">
                 <option value="Keep">Keep</option>
                 <option value="Replace">Replace</option>
                 {% if field|is_text %}


### PR DESCRIPTION
The markdown rich text fields used in the apply template to finding view
shadow the underlying textareas. Thus, the update of the textarea's value
has no effect.
This commit stores the MDE JavaScript objects on the the field's DOM
object. The change of the contents is now performed on the MDE elements
using their designated method rather than directly on the textarea
element.

- [x] Your code is flake8 compliant (no change within the Python code; the JS code has not been compliant to any reasonable style guides before ...)
- [x] Your code is python 3.5 compliant
- [x] This fixes a bug
- [x] There are no model changes
- [x] This fixes a bug