### PR TITLE
Apply Template to Finding: Fix merge options for tags

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1353,6 +1353,7 @@ def choose_finding_template_options(request, tid, fid):
         'product_tab': product_tab,
         'template': template,
         'form': form,
+        'finding_tags': [tag.name for tag in finding.tags.all()],
     })
 
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1016,8 +1016,9 @@ class ApplyFindingTemplateForm(forms.Form):
                                      "Choose from the list or add new tags.  Press TAB key to add.")
 
     def __init__(self, template=None, *args, **kwargs):
-        tags = Tag.objects.usage_for_model(Finding_Template)
-        t = [(tag.name, tag.name) for tag in tags]
+        # django-tagging apparently can not filter for multiple models at once
+        tags = Tag.objects.usage_for_model(Finding_Template) + Tag.objects.usage_for_model(Finding)
+        t = sorted({(tag.name, tag.name) for tag in tags})
         super(ApplyFindingTemplateForm, self).__init__(*args, **kwargs)
         self.fields['tags'].widget.choices = t
         self.template = template

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -80,6 +80,7 @@
                     ]
                 });
                 mde.render();
+                elem.mde = mde;
             });
         });
 

--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -1,3 +1,4 @@
+{% load as_json %}
 {% load event_tags %}
 {% load get_attribute %}
 {% if form.non_field_errors %}
@@ -21,10 +22,14 @@
     <div class="form-group{% if field.errors %} has-error{% endif %}">
         <label class="col-sm-2 control-label">{{ field.label }} Option</label>
         <div class="col-sm-10 {{ classes.value }}">
-            <select class="form-control" data-field-value="{{ field.value }}" data-template-value="{{ template_value }}" onchange="(function(t){ var field = document.forms['apply_template']['{{ field.name }}']; var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=t.getAttribute('data-field-value'); break; case 'replace': fieldValue= t.getAttribute('data-template-value'); break; case 'combine': fieldValue= t.getAttribute('data-field-value').concat('\r\n').concat(t.getAttribute('data-template-value')); break;  } field.mde === undefined ? field.value = fieldValue : field.mde.value(fieldValue); })(this)">
+            {% if field.name == 'tags' %}
+                <select class="form-control" data-field-value="{{ finding_tags|as_json }}" data-template-value="{{ field.value|as_json }}" onchange="(function(t){ var field = document.forms['apply_template']['{{ field.name }}']; var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=JSON.parse(t.getAttribute('data-field-value')); break; case 'replace': fieldValue= JSON.parse(t.getAttribute('data-template-value')); break; case 'combine': fieldValue= JSON.parse(t.getAttribute('data-field-value')).concat(JSON.parse(t.getAttribute('data-template-value'))); break;  } $(field).val(fieldValue); $('#id_tags').trigger('chosen:updated'); })(this)">
+            {% else %}
+                <select class="form-control" data-field-value="{{ field.value }}" data-template-value="{{ template_value }}" onchange="(function(t){ var field = document.forms['apply_template']['{{ field.name }}']; var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=t.getAttribute('data-field-value'); break; case 'replace': fieldValue= t.getAttribute('data-template-value'); break; case 'combine': fieldValue= t.getAttribute('data-field-value').concat('\r\n').concat(t.getAttribute('data-template-value')); break;  } field.mde === undefined ? field.value = fieldValue : field.mde.value(fieldValue); })(this)">
+            {% endif %}
                 <option value="Keep">Keep</option>
                 <option value="Replace">Replace</option>
-                {% if field|is_text %}
+                {% if field|is_text or field.name == 'tags' %}
                     <option value="Combine">Combine</option>
                 {% endif %}
             </select>

--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -21,7 +21,7 @@
     <div class="form-group{% if field.errors %} has-error{% endif %}">
         <label class="col-sm-2 control-label">{{ field.label }} Option</label>
         <div class="col-sm-10 {{ classes.value }}">
-            <select class="form-control" data-field-value="{{ field.value }}" data-template-value="{{ template_value }}" onchange="(function(t){ var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=t.getAttribute('data-field-value'); break; case 'replace': fieldValue= t.getAttribute('data-template-value'); break; case 'combine': fieldValue= t.getAttribute('data-field-value').concat('\r\n').concat(t.getAttribute('data-template-value')); break;  } document.forms['apply_template']['{{ field.name }}'].value = fieldValue; })(this)">
+            <select class="form-control" data-field-value="{{ field.value }}" data-template-value="{{ template_value }}" onchange="(function(t){ var field = document.forms['apply_template']['{{ field.name }}']; var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=t.getAttribute('data-field-value'); break; case 'replace': fieldValue= t.getAttribute('data-template-value'); break; case 'combine': fieldValue= t.getAttribute('data-field-value').concat('\r\n').concat(t.getAttribute('data-template-value')); break;  } field.mde === undefined ? field.value = fieldValue : field.mde.value(fieldValue); })(this)">
                 <option value="Keep">Keep</option>
                 <option value="Replace">Replace</option>
                 {% if field|is_text %}

--- a/dojo/templatetags/as_json.py
+++ b/dojo/templatetags/as_json.py
@@ -1,0 +1,8 @@
+import json
+from django import template
+register = template.Library()
+
+
+@register.filter
+def as_json(value):
+    return json.dumps(value)


### PR DESCRIPTION
This fixes the merge options for the tags attribute. The following problems are solved:

1) The form's data value for the tags is overwritten in the view, thus the template had no
    way of determining the actual Finding's tag value. The view now explicitly passes these
    on to the template.
2) The template value in the `onchange` handler was not handled properly, as it was a
   QuerySet: The `data-template-value` field contained the `__repr__` value of the
   queryset (i.e., `<QuerySet ...>`) rather than the tag names.
3) The (ugly) inline `onchange` handler for the select was not handling the case of a
   multi-select properly. This is fixed now with a dedicated handler for the tag field.
4) The available tags in the `ApplyFindingTemplateForm` were missing those tags that
   are only used within `Finding`s, but not within any `Finding_Template`s. This adds
   a workaround to list these tags as well.

Additionally, this allows to use the `Combine` option for tags as well.


**Note:** This pull request is based on #1819.

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] This fixes a bug
- [x] This does not change any models
- [x] This fixes a bug