### PR TITLE
Apply Template to Finding: Use replace as default option for tags

### DIFF
--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -23,7 +23,7 @@
         <div class="col-sm-10 {{ classes.value }}">
             <select class="form-control" data-field-value="{{ field.value }}" data-template-value="{{ template_value }}" onchange="(function(t){ var fieldValue = ''; switch(t.value.toLowerCase()){ case 'keep': fieldValue=t.getAttribute('data-field-value'); break; case 'replace': fieldValue= t.getAttribute('data-template-value'); break; case 'combine': fieldValue= t.getAttribute('data-field-value').concat('\r\n').concat(t.getAttribute('data-template-value')); break;  } document.forms['apply_template']['{{ field.name }}'].value = fieldValue; })(this)">
                 <option value="Keep">Keep</option>
-                <option value="Replace">Replace</option>
+                <option value="Replace"{% if field.name == 'tags' %} selected{% endif %}>Replace</option>
                 {% if field|is_text %}
                     <option value="Combine">Combine</option>
                 {% endif %}


### PR DESCRIPTION
As `replace` is the default action taken for tags, this makes the select allowing
to choose the option select `replace` by default. Therefore, it is no longer
necessary to change the value twice if one wants to choose `keep`.
(Previously, "Keep" as first option was selected even though "Replace" was the action performed by default)

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] This is a fix/enhancement of an existing feature.
- [x] This does not change the models.
- [x] No logic is changed.