### PR TITLE
Npm audit add file path and configure dedupe fields

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -566,7 +566,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'Dependency Check Scan': ['cve', 'file_path'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
-    'NPM Audit Scan': ['title', 'severity'],
+    'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cve + file_path + severity
     'Whitesource Scan': ['title', 'severity', 'description'],
     'ZAP Scan': ['cwe', 'endpoints', 'severity'],

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -56,6 +56,7 @@ def get_item(item_node, test):
     finding = Finding(title=item_node['title'] + " - " + "(" + item_node['module_name'] + ", " + item_node['vulnerable_versions'] + ")",
                       test=test,
                       severity=severity,
+                      file_path=item_node['module_name'],
                       description=item_node['overview'] + "\n Vulnerable Module: " +
                       item_node['module_name'] + "\n Vulnerable Versions: " +
                       str(item_node['vulnerable_versions']) + "\n Patched Version: " +
@@ -63,6 +64,7 @@ def get_item(item_node, test):
                       str(item_node['cwe']) + "\n Access: " +
                       str(item_node['access']),
                       cwe=item_node['cwe'][4:],
+                      cve=item_node['cves'][0] if (len(item_node['cves']) > 0) else None,
                       mitigation=item_node['recommendation'],
                       references=item_node['url'],
                       active=False,

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -53,14 +53,19 @@ def get_item(item_node, test):
     else:
         severity = 'Info'
 
+    paths = ''
+    for finding in item_node['findings']:
+        paths += "\n  - " + str(finding['version']) + ":" + str(','.join(finding['paths']))
+
     finding = Finding(title=item_node['title'] + " - " + "(" + item_node['module_name'] + ", " + item_node['vulnerable_versions'] + ")",
                       test=test,
                       severity=severity,
-                      file_path=item_node['module_name'],
+                      file_path=item_node['findings'][0]['paths'][0],
                       description=item_node['overview'] + "\n Vulnerable Module: " +
                       item_node['module_name'] + "\n Vulnerable Versions: " +
                       str(item_node['vulnerable_versions']) + "\n Patched Version: " +
-                      str(item_node['patched_versions']) + "\n Vulnerable Path: " + str(item_node['findings'][0]['paths']) + "\n CWE: " +
+                      str(item_node['patched_versions']) + "\n Vulnerable Paths: " +
+                      str(paths) + "\n CWE: " +
                       str(item_node['cwe']) + "\n Access: " +
                       str(item_node['access']),
                       cwe=item_node['cwe'][4:],


### PR DESCRIPTION
the module name in the npm audit report can be used as filepath, and the cve field will also be populated.

specified filepath + cve + cwe as extra fields for dedupe