### PR TITLE
findings_list: add tooltips for engagement name and test title

### DIFF
--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -302,7 +302,7 @@
                                   {% endif %}
                                 </td>
                                 <td>
-                                     {{ finding.get_found_by }}
+                                  <a target="#" data-toggle="tooltip" data-placement="bottom" title="Test: {{ finding.test }}">{{ finding.get_found_by }}</a>
                                 </td>
                                 <td>{% if finding.under_review %}Under Review, {% endif %}{{ finding.status }}{% if finding.duplicate_finding.id %}, <a href="{% url 'view_finding' finding.duplicate_finding.id%}" data-toggle="tooltip" data-placement="top" title="{{ finding.duplicate_finding.title }}, {{ finding.duplicate_finding.created }}">Original</a>
                                   {% endif %}
@@ -340,7 +340,7 @@
                                 {% if show_product_column and product_tab is None %}
                                 <td><a
                                         href="{% url 'view_product' finding.test.engagement.product.id %}"
-                                        title="{{ finding.test.engagement.product }}">{{ finding.test.engagement.product }}</a>
+                                        title="{{ finding.test.engagement }}" alt="{{ finding.test.engagement.product }}">{{ finding.test.engagement.product }}</a>
                                 </td>
                                 {% endif %}
                             </tr>


### PR DESCRIPTION
When viewing a list of findings currently it's hard to see in which engagement a finding is.
When you're using deduplication_on_engagement you will (can) have multiple identical findings in different engagements. I added a tooltip to show the engagement name with the product (as there's not really enough to add another text column).

I also added a tooltip with the specific test title to the foundby value, this can be beneficial again in some scenario's.