### PR TITLE
show local dates for tests target_start and target_end

### DIFF
--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -293,7 +293,7 @@
                                        </li>
                                    </ul>
                                 </td>
-                                <td>{{ test.target_start|local_date }} - {{ test.target_end|local_date }}</td>
+                                <td>{{ test.target_start|date }} - {{ test.target_end|date }}</td>
                                 <td>
                                   {% if test.lead.get_full_name and test.lead.get_full_name.strip %}
                                       {{ test.lead.get_full_name }}

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -293,7 +293,7 @@
                                        </li>
                                    </ul>
                                 </td>
-                                <td>{{ test.target_start.date }} - {{ test.target_end.date }}</td>
+                                <td>{{ test.target_start|local_date }} - {{ test.target_end|local_date }}</td>
                                 <td>
                                   {% if test.lead.get_full_name and test.lead.get_full_name.strip %}
                                       {{ test.lead.get_full_name }}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -120,7 +120,7 @@
                             <b><i>Unknown</i></b>
                         {% endif %}
                     </td>
-                    <td>{{ test.target_start|local_date }} - {{ test.target_end|local_date }}</td>
+                    <td>{{ test.target_start|date }} - {{ test.target_end|date }}</td>
                     {% if test.percent_complete > 0 %}
                         <td>
                             <div class="progress">

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -120,7 +120,7 @@
                             <b><i>Unknown</i></b>
                         {% endif %}
                     </td>
-                    <td>{{ test.target_start.date }} - {{ test.target_end.date }}</td>
+                    <td>{{ test.target_start|local_date }} - {{ test.target_end|local_date }}</td>
                     {% if test.percent_complete > 0 %}
                         <td>
                             <div class="progress">

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -769,3 +769,9 @@ def get_severity_count(id, table):
     display_counts = ", ".join([str(item) for item in display_counts])
 
     return display_counts
+
+@register.filter(name='local_date')
+def local_date(the_date):
+    the_local_date = the_date.astimezone(timezone.get_current_timezone())
+    return the_local_date.strftime("%b %d, %Y")
+

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -769,9 +769,3 @@ def get_severity_count(id, table):
     display_counts = ", ".join([str(item) for item in display_counts])
 
     return display_counts
-
-
-@register.filter(name='local_date')
-def local_date(the_date):
-    the_local_date = the_date.astimezone(timezone.get_current_timezone())
-    return the_local_date.strftime("%b %d, %Y")

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -770,8 +770,8 @@ def get_severity_count(id, table):
 
     return display_counts
 
+
 @register.filter(name='local_date')
 def local_date(the_date):
     the_local_date = the_date.astimezone(timezone.get_current_timezone())
     return the_local_date.strftime("%b %d, %Y")
-


### PR DESCRIPTION
Currently the list of tests in an engagement and also the view tests page shows the target_start and target_end date without localizing them.

I'm in CET and this means tests will be 1 day off always. On import the datetime is set to UTC in the database. This works fine for datetimes, which are localized correctly by django.
But when shortening them to the date part only, it fails.

i.e. target_start = 'Feb 01, 2020' on import, results in 2020-01-31 23:00:00 in the database, which is shown on screen as 'Jan 31, 2020' (instead of 'Feb 01, 2020').

~~I don't know why this is and found lots and lots of (stack overflow) posts around the same issues.~~

~~In the end I just created a filter that helps us to localize the date.~~

Fixes #970