### PR TITLE
TLS Improvments

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -198,18 +198,19 @@ docker-compose down --volumes
 ```
 
 # Run with docker using https
+## use your own  Credentials
 To secure the application by https, follow those steps
 *  Generate a private key without password
 *  Generate a CSR (Certificate Signing Request)
 *  Have the CSR signed by a certificate authority
 *  Place the private key and the certificate under the nginx folder
-*  Replace nginx/nginx.conf by nginx/nginx_TLS.conf
-*  In nginx.conf, update that part: 
+*  copy your secrets into: 
 ```
         server_name                 your.servername.com;
-        ssl_certificate             /yourCertificate.cer;
-        ssl_certificate_key         /yourPrivateKey.key;
+        ssl_certificate             /etc/nginx/ssl/nginx.crt
+        ssl_certificate_key        /etc/nginx/ssl/nginx.key;
 ```
+*set the GENERATE_TLS_CERTIFICATE != True in the docker-compose.override.https.yml
 * Protect your private key from other users: 
 ```
 chmod 400 nginx/*.key
@@ -218,6 +219,15 @@ chmod 400 nginx/*.key
 
 ```docker build  -t defectdojo/defectdojo-nginx -f Dockerfile.nginx .```
 
+* Run defectDojo with: 
+```
+rm -f docker-compose.override.yml
+ln -s docker-compose.override.https.yml docker-compose.override.yml
+docker-compose up
+```
+
+## create Credentials on the fly
+* you can generate a Certificate on the fly (without valid domainname etc.)
 
 * Run defectDojo with: 
 ```
@@ -226,7 +236,7 @@ ln -s docker-compose.override.https.yml docker-compose.override.yml
 docker-compose up
 ```
 
-The default https port is 8083.
+The default https port is 8443.
 
 To change the port:
 - update `nginx.conf`

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -215,9 +215,6 @@ To secure the application by https, follow those steps
 ```
 chmod 400 nginx/*.key
 ```
-* Rebuild the nginx image in order to place the private key and the certificate where nginx will find them (under / in the nginx container):
-
-```docker build  -t defectdojo/defectdojo-nginx -f Dockerfile.nginx .```
 
 * Run defectDojo with: 
 ```

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -72,8 +72,8 @@ ENV \
   DD_UWSGI_PASS="uwsgi_server" \
   DD_UWSGI_HOST="uwsgi" \
   DD_UWSGI_PORT="3031" \
-  GENERATE_TLS_CERTIFICATE="true" \
-  USE_TLS="false"
+  GENERATE_TLS_CERTIFICATE="False" \
+  USE_TLS="False"
 USER 1001
 EXPOSE 8080
 ENTRYPOINT ["/entrypoint-nginx.sh"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -57,17 +57,18 @@ RUN \
 
 FROM nginx:1.17.7@sha256:89a42c3ba15f09a3fbe39856bddacdf9e94cd03df7403cad4fc105088e268fc9
 COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
-COPY wsgi_params nginx/nginx.conf /etc/nginx/
-COPY docker/entrypoint-nginx.sh nginx/*.cer nginx/*.key /
+COPY wsgi_params nginx/nginx.conf nginx/nginx_TLS.conf /etc/nginx/
+COPY docker/entrypoint-nginx.sh /
 RUN \
   chmod -R g=u /var/cache/nginx && \
   chmod -R g=u /var/run && \
-  if [ -f /*.key -o -f /*.cer ]; then chown 1001 /*.key /*.cer; fi && \
   true
 ENV \
   DD_UWSGI_PASS="uwsgi_server" \
   DD_UWSGI_HOST="uwsgi" \
-  DD_UWSGI_PORT="3031"
+  DD_UWSGI_PORT="3031" \
+  GENERATE_TLS_CERTIFICATE="true" \
+  USE_TLS="false"
 USER 1001
 EXPOSE 8080
 ENTRYPOINT ["/entrypoint-nginx.sh"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -60,8 +60,13 @@ COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf nginx/nginx_TLS.conf /etc/nginx/
 COPY docker/entrypoint-nginx.sh /
 RUN \
+  apt-get -y update && \
+  apt-get -y install openssl && \
+  apt-get clean && \
   chmod -R g=u /var/cache/nginx && \
   chmod -R g=u /var/run && \
+  mkdir -p /etc/nginx/ssl && \
+  chown 1001 /etc/nginx/ssl/ &&\
   true
 ENV \
   DD_UWSGI_PASS="uwsgi_server" \

--- a/docker-compose.override.https.yml
+++ b/docker-compose.override.https.yml
@@ -2,9 +2,12 @@
 version: '3.7'
 services:
   nginx:
+    environment:
+      USE_TLS: 'True'
+      GENERATE_TLS_CERTIFICATE: 'True'
     ports:
-      - target: ${DD_PORT:-8083}
-        published: ${DD_PORT:-8083}
+      - target: ${DD_PORT:-8443}
+        published: ${DD_PORT:-8443}
         protocol: tcp
         mode: host
   uwsgi:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
         published: ${DD_PORT:-8080}
         protocol: tcp
         mode: host
+      - target: ${DD_PORT:-8443}
+        published: ${DD_PORT:-8443}
+        protocol: tcp
+        mode: host
   uwsgi:
     build: 
       context: ./

--- a/docker/entrypoint-nginx.sh
+++ b/docker/entrypoint-nginx.sh
@@ -1,7 +1,23 @@
 #!/bin/sh
 
 umask 0002
-
+if [${GENERATE_TLS_CERTIFICATE} == true]
+then
+  openssl req  \
+      -x509 \
+      -nodes \
+      -days 365 \
+      -newkey rsa:4096 \
+      -keyout /etc/nginx/ssl/nginx.key \
+      -out /etc/nginx/ssl/nginx.crt \
+      -subj "/C=DE/ST=City/L=City/O=Global Security/OU=IT Department/CN=nginx"
+  chown 1001 /etc/nginx/ssl/nginx.key /etc/nginx/ssl/nginx.crt
+fi
 echo "uwsgi_pass ${DD_UWSGI_PASS};" > /run/uwsgi_pass
 echo "server ${DD_UWSGI_HOST}:${DD_UWSGI_PORT};" > /run/uwsgi_server
-exec nginx -g "daemon off;"
+if [${USE_TLS} == true]
+then
+  exec nginx -c /etc/nginx/nginx_TLS.conf -g "daemon off;"
+else
+  exec nginx -g "daemon off;"
+fi

--- a/docker/entrypoint-nginx.sh
+++ b/docker/entrypoint-nginx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 umask 0002
-if [ "${GENERATE_TLS_CERTIFICATE}" == "true" ]
+if [ "${GENERATE_TLS_CERTIFICATE}" == "True" ]
 then
   openssl req  \
       -x509 \
@@ -15,7 +15,7 @@ then
 fi
 echo "uwsgi_pass ${DD_UWSGI_PASS};" > /run/uwsgi_pass
 echo "server ${DD_UWSGI_HOST}:${DD_UWSGI_PORT};" > /run/uwsgi_server
-if [ "${USE_TLS}" == "true" ]
+if [ "${USE_TLS}" == "True" ]
 then
   exec nginx -c /etc/nginx/nginx_TLS.conf -g "daemon off;"
 else

--- a/docker/entrypoint-nginx.sh
+++ b/docker/entrypoint-nginx.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 umask 0002
-if [${GENERATE_TLS_CERTIFICATE} == true]
+if [ "${GENERATE_TLS_CERTIFICATE}" == "true" ]
 then
   openssl req  \
       -x509 \
@@ -11,11 +11,11 @@ then
       -keyout /etc/nginx/ssl/nginx.key \
       -out /etc/nginx/ssl/nginx.crt \
       -subj "/C=DE/ST=City/L=City/O=Global Security/OU=IT Department/CN=nginx"
-  chown 1001 /etc/nginx/ssl/nginx.key /etc/nginx/ssl/nginx.crt
+
 fi
 echo "uwsgi_pass ${DD_UWSGI_PASS};" > /run/uwsgi_pass
 echo "server ${DD_UWSGI_HOST}:${DD_UWSGI_PORT};" > /run/uwsgi_server
-if [${USE_TLS} == true]
+if [ "${USE_TLS}" == "true" ]
 then
   exec nginx -c /etc/nginx/nginx_TLS.conf -g "daemon off;"
 else

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -34,9 +34,10 @@ http {
         ssl_certificate             /etc/nginx/ssl/nginx.crt;
         ssl_certificate_key         /etc/nginx/ssl/nginx.key;
         ssl_session_cache           builtin:1000  shared:SSL:10m;
+        # ciphers from https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1d&guideline=5.4
         ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-        ssl_prefer_server_ciphers on;
+        ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256;
+        ssl_prefer_server_ciphers off;
 
         location = /50x.html {
             root                    /usr/share/nginx/html;

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -28,7 +28,7 @@ http {
     }
 
     server {
-        server_tokens               off
+        server_tokens               off;
         listen                      8443 ssl;
         server_name                 your.servername.com;
         ssl_certificate             /etc/nginx/ssl/nginx.crt;

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -34,7 +34,7 @@ http {
         ssl_certificate             /etc/nginx/ssl/nginx.crt;
         ssl_certificate_key         /etc/nginx/ssl/nginx.key;
         ssl_session_cache           builtin:1000  shared:SSL:10m;
-        ssl_protocols TLSv1.2;
+        ssl_protocols TLSv1.2 TLSv1.3;
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
         ssl_prefer_server_ciphers on;
 

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -23,19 +23,20 @@ http {
     server {
         listen                      8080;
         location / {
-            return                 301 https://$host$request_uri:8083;
+            return                 301 https://$host$request_uri:8443;
         }
     }
 
     server {
-        listen                      8083 ssl;
+        server_tokens               off
+        listen                      8443 ssl;
         server_name                 your.servername.com;
-        ssl_certificate             /yourCertificate.cer;
-        ssl_certificate_key         /yourPrivateKey.key;
+        ssl_certificate             /etc/nginx/ssl/nginx.crt;
+        ssl_certificate_key         /etc/nginx/ssl/nginx.key;
         ssl_session_cache           builtin:1000  shared:SSL:10m;
-        ssl_protocols               TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers                 HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
-        ssl_prefer_server_ciphers   on;
+        ssl_protocols TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+        ssl_prefer_server_ciphers on;
 
         location = /50x.html {
             root                    /usr/share/nginx/html;


### PR DESCRIPTION
Generate TLS Certificate

The Nginx generates a TLS Certificate on every start if there is the environment variable is not set. You can add your own cetrificate by mounting it to /etc/nginx/ssl/ and setting GENERATE_TLS_CERTIFICATE to false. You can activate the TLS configuration fo nginx with the environment variable USE_TLS.

From my point of view it is an security issue that the certificate is inlcuded during the docker build step. It should be added at the runtime not at buildtime.

Hardening on the TLS Configuration of nginx.

On behalf of DB Systel GmbH

----


**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ x] Your code is flake8 compliant 
- [ x] Your code is python 3.5 compliant
- [ x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [ ] Add applicable tests to the unit tests.
