### PR TITLE
Fix import error for Crashtest Security importer

### DIFF
--- a/dojo/tools/crashtest_security/parser.py
+++ b/dojo/tools/crashtest_security/parser.py
@@ -48,13 +48,21 @@ class CrashtestSecurityXmlParser(object):
             if failure is None:
                 continue
 
-            title = node.get('name').upper()
+            title = node.get('name')
+            # Remove enumeration from title
+            title = re.sub(r' \([0-9]*\)', '', title)
+
+            # Attache CVEs
             if "CVE" in title:
                 cve = re.findall(r'CVE-\d{4}-\d{4,7}', title)[0]
             else:
                 cve = None
             description = failure.get('message')
-            severity = failure.get('type')
+            severity = failure.get('type').capitalize()
+
+            # This denotes an error of the scanner and not a vulnerability
+            if severity == "Error":
+                continue
 
             find = Finding(title=title,
                            description=description,

--- a/dojo/tools/crashtest_security/parser.py
+++ b/dojo/tools/crashtest_security/parser.py
@@ -50,7 +50,7 @@ class CrashtestSecurityXmlParser(object):
 
             title = node.get('name')
             # Remove enumeration from title
-            title = re.sub(r' \([0-9]*\)', '', title)
+            title = re.sub(r' \([0-9]*\)$', '', title)
 
             # Attache CVEs
             if "CVE" in title:

--- a/dojo/tools/crashtest_security/parser.py
+++ b/dojo/tools/crashtest_security/parser.py
@@ -54,7 +54,7 @@ class CrashtestSecurityXmlParser(object):
 
             # Attache CVEs
             if "CVE" in title:
-                cve = re.findall(r'CVE-\d{4}-\d{4,7}', title)[0]
+                cve = re.findall(r'CVE-\d{4}-\d{4,10}', title)[0]
             else:
                 cve = None
             description = failure.get('message')


### PR DESCRIPTION
Due to a minor change in the output format, the importer crashes and produces a 500 server error.

A test file in the new format is provided here: https://github.com/DefectDojo/sample-scan-files/pull/45