### PR TITLE
Fixing re-import finding date logic

### DIFF
--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -649,7 +649,8 @@ def re_import_scan_results(request, tid):
                         new_items.append(find.id)
                     else:
                         item.test = t
-                        item.date = scan_date
+                        if item.date == timezone.now().date():
+                            item.date = t.target_start
                         item.reporter = request.user
                         item.last_reviewed = timezone.now()
                         item.last_reviewed_by = request.user


### PR DESCRIPTION
updated code to set date to target start if date is the default date of 'today'

Date setting behavior will be the same for new findings on re-import as well as new findings on initial import.

Bug: #1855