### PR TITLE
use local dates for tests and engagement start/end dates

### DIFF
--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -57,10 +57,10 @@
                                 </tr>
                                 <tr>
                                     <td>
-                                        {{ engagement.target_start }}
+                                        {{ engagement.target_start|date}}
                                     </td>
                                     <td>
-                                        {{ engagement.target_end }}
+                                        {{ engagement.target_end|date}}
                                     </td>
                                     <td>
                                         {{ engagement.status }}

--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -227,7 +227,7 @@
                                       {% endfor %}
                                   </sup>
                                 </td>
-                                <td>{{ engagement.object.target_start }} - {{ engagement.object.target_end }}</td>
+                                <td>{{ engagement.object.target_start|date }} - {{ engagement.object.target_end|date }}</td>
                                 <td>{{ engagement.object.status }}</td>
                             </tr>
                         {% endfor %}
@@ -277,7 +277,7 @@
                                       {% endfor %}
                                   </sup>
                                 </td>
-                                <td>{{ test.object.engagement.target_start }} - {{ test.object.engagement.target_end }}</td>
+                                <td>{{ test.object.engagement.target_start|date }} - {{ test.object.engagement.target_end|date }}</td>
                                 <td>{{ test.object.engagement.status }}</td>
                             </tr>
                         {% endfor %}

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -63,10 +63,10 @@
                                         {{ test.engagement }}
                                     </td>
                                     <td>
-                                        {{ test.target_start }}
+                                        {{ test.target_start|date }}
                                     </td>
                                     <td>
-                                        {{ test.target_end }}
+                                        {{ test.target_end|date }}
                                     </td>
                                     <td>
                                         {{ test.percent_complete }}%


### PR DESCRIPTION
Following #1835 I found some more places where target_start and target_end for engagement/test where not localized before being displayed.

In theory I think we might have to apply the "|date" filter everywhere also where finding.date, note.date etc is being used. However for now I think the test/engagement dates are the most sensitive to a "1 day off issue", so I fixed those first and will leave the rest as-is for now.