### PR TITLE
Finding:  Fix unbound variable error in `edit_template`

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1676,7 +1676,6 @@ def edit_template(request, tid):
     template = get_object_or_404(Finding_Template, id=tid)
     form = FindingTemplateForm(instance=template)
 
-    apply_message = ""
     if request.method == 'POST':
         form = FindingTemplateForm(request.POST, instance=template)
         if form.is_valid():
@@ -1687,6 +1686,8 @@ def edit_template(request, tid):
             count = apply_cwe_mitigation(form.cleaned_data["apply_to_findings"], template)
             if count > 0:
                 apply_message = " and " + str(count) + " " + pluralize(count, 'finding,findings') + " "
+            else:
+                apply_message = ""
 
             tags = request.POST.getlist('tags')
             t = ", ".join('"{0}"'.format(w) for w in tags)
@@ -1703,9 +1704,8 @@ def edit_template(request, tid):
                 messages.ERROR,
                 'Template form has error, please revise and try again.',
                 extra_tags='alert-danger')
-    else:
-        count = apply_cwe_mitigation(True, template, False)
 
+    count = apply_cwe_mitigation(True, template, False)
     form.initial['tags'] = [tag.name for tag in template.tags]
     add_breadcrumb(title="Edit Template", top_level=False, request=request)
     return render(request, 'dojo/add_template.html', {


### PR DESCRIPTION
This errors occurs in case of a save request with an invalid form:

    Internal Server Error: /template/XXX/edit
    Traceback (most recent call last):
      [...]
      File "./dojo/finding/views.py", line 1242, in edit_template
        'count': count,
    UnboundLocalError: local variable 'count' referenced before assignment
