### PR TITLE
Fix middlewares

### DIFF
--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -24,8 +24,6 @@ class LoginRequiredMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        response = self.get_response(request)
-
         assert hasattr(request, 'user'), "The Login Required middleware\
  requires authentication middleware to be installed. Edit your\
  MIDDLEWARE_CLASSES setting to insert\
@@ -40,4 +38,6 @@ class LoginRequiredMiddleware:
                 else:
                     fullURL = "%s?next=%s" % (settings.LOGIN_URL, urlquote(request.get_full_path()))
                 return HttpResponseRedirect(fullURL)
+
+        response = self.get_response(request)
         return response

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -1,8 +1,6 @@
 from django.http import HttpResponseRedirect
 from django.conf import settings
-from django.utils import timezone
 from django.utils.http import urlquote
-from dojo.utils import get_system_setting
 from re import compile
 
 
@@ -42,18 +40,4 @@ class LoginRequiredMiddleware:
                 else:
                     fullURL = "%s?next=%s" % (settings.LOGIN_URL, urlquote(request.get_full_path()))
                 return HttpResponseRedirect(fullURL)
-        return response
-
-
-class TimezoneMiddleware:
-    """
-    Middleware that checks the configured timezone to use in each request
-    """
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        response = self.get_response(request)
-        timezone.activate(get_system_setting('time_zone'))
         return response

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -519,7 +519,6 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'dojo.middleware.LoginRequiredMiddleware',
-    'dojo.middleware.TimezoneMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'watson.middleware.SearchContextMiddleware',
     'auditlog.middleware.AuditlogMiddleware',


### PR DESCRIPTION
Hey there,

I noticed that both middlewares execute their custom logic only *after* the request is handled.

Wrt the `LoginRequiredMiddleware`, this allows unauthenticated users to execute requests even if the request URL is not on the whitelist `settings.LOGIN_EXEMPT_URLS`.  The unauthenticated user cannot see the result of the request, though.

EDIT: As suggested by @valentijnscholten, this PR removes the timezone middlware.

Best,
Felix