### PR TITLE
Bugfix dashboard do not reraise e

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -645,7 +645,6 @@ def get_punchcard_data(findings, start_date, weeks):
 
     except Exception as e:
         logger.exception('Not showing punchcard graph due to exception gathering data', e)
-        raise(e)
         return None, None
 
 


### PR DESCRIPTION
There is a try..except around the dashboard punchcard code to help iron out corner cases.
The `raise(e)` in there was accidentally left from debugging, this PR removes it.