### PR TITLE
dev: chg: use Helm named repositories. Closes #1728

### DIFF
--- a/helm/defectdojo/requirements.lock
+++ b/helm/defectdojo/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: mysql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://kubernetes-charts.storage.googleapis.com
   version: 1.6.2
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://kubernetes-charts.storage.googleapis.com
   version: 8.1.2
 - name: rabbitmq
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://kubernetes-charts.storage.googleapis.com
   version: 6.16.0
 - name: redis
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://kubernetes-charts.storage.googleapis.com
   version: 10.3.1
-digest: sha256:52c9799f9de0a7befb954001bb59d3f600989609e48b8b7f57f5ffbe880b1cc8
-generated: "2020-01-14T22:58:39.389199081+01:00"
+digest: sha256:10b3095a1ece96e42add9b258ca0856e10fd7aeb7d4601f66630a3830f64630d
+generated: "2020-02-11T20:10:45.198726226Z"

--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
   - name: mysql
     version: 1.6.2
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: "@stable"
     condition: mysql.enabled
   - name: postgresql
     version: 8.1.2
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: "@stable"
     condition: postgresql.enabled
   - name: rabbitmq
     version: 6.16.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: "@stable"
     condition: rabbitmq.enabled
   - name: redis
     version: 10.3.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: "@stable"
     condition: redis.enabled


### PR DESCRIPTION
This allows the use of Helm named repositories and uses caching layers
or other repositories managers like Nexus, Artifactory, S3 buckets...

Signed-off-by: Carlos Juan Gómez Peñalver <carlosjuangp@gmail.com>

------

**Note: DefectDojo is now on Python3 and Django 2.2.1 Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/dd_migrations folder.
- [x] Add applicable tests to the unit tests.