### PR TITLE
kubernetes: fix node selectors; add limits

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -108,7 +108,7 @@ spec:
           failureThreshold: 12
         resources:
           {{- toYaml .Values.django.nginx.resources | nindent 10 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.django.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -53,4 +53,8 @@ spec:
         resources:
           {{- toYaml .Values.initializer.resources | nindent 10 }}
       restartPolicy: Never
+      {{- with .Values.initializer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 1

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -42,6 +42,9 @@ celery:
       requests:
         cpu: 100m
         memory: 128Mi
+      limits:
+        cpu: 2000m
+        memory: 256Mi
     tolerations: []
   worker:
     affinity: {}
@@ -52,6 +55,9 @@ celery:
       requests:
         cpu: 100m
         memory: 128Mi
+      limits:
+        cpu: 2000m
+        memory: 256Mi
     tolerations: []
 
 django:
@@ -68,6 +74,9 @@ django:
       requests:
         cpu: 100m
         memory: 128Mi
+      limits:
+        cpu: 2000m
+        memory: 256Mi
   nodeSelector: {}
   replicas: 1
   tolerations: []
@@ -76,14 +85,21 @@ django:
       requests:
         cpu: 100m
         memory: 128Mi
+      limits:
+        cpu: 2000m
+        memory: 512Mi
 
 initializer:
   run: true
   keepSeconds: 60
+  nodeSelector: {}
   resources:
     requests:
       cpu: 100m
       memory: 128Mi
+    limits:
+      cpu: 2000m
+      memory: 256Mi
 
 mysql:
   enabled: false


### PR DESCRIPTION
- add a nodeselector in the initializer job
- fix nodeSelector in django deployment (was at the root, should be under django as in values.yaml)
- add limits