### PR TITLE
bugfix: include verified findings in product metrics on product detai…

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -94,7 +94,6 @@ def view_product(request, pid):
 
     open_findings = Finding.objects.filter(test__engagement__product=prod,
                                                 false_p=False,
-                                                verified=False,
                                                 active=True,
                                                 duplicate=False,
                                                 out_of_scope=False).order_by('numerical_severity').values('severity').annotate(count=Count('severity'))


### PR DESCRIPTION
(quick)fixes #1875

There are more places where I think findings are only included in metrics when they are NOT verified. This sounds counter intuitive to me, but I would like to check with the other developers / owners what the idea of this verified field was before changing a lot of queries.
I do think it makes sense to change this one query here because the product details page is probably used a lot and currently never shows any findings, unless you mark them as NOT verified.