### PR TITLE
Product/Product Type: Filter count for active findings

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -376,6 +376,7 @@ class Product_Type(models.Model):
 
     def findings_count(self):
         return Finding.objects.filter(mitigated__isnull=True,
+                                      active=True,
                                       verified=True,
                                       false_p=False,
                                       duplicate=False,
@@ -577,6 +578,7 @@ class Product(models.Model):
     @property
     def findings_count(self):
         return Finding.objects.filter(mitigated__isnull=True,
+                                      active=True,
                                       verified=True,
                                       false_p=False,
                                       duplicate=False,


### PR DESCRIPTION
As all occurrences of the value of `findings_count` link to the list
of *open* findings, this commit changes the count to only include
active issues. Otherwise, the value has a discrepancy between the
shown number of findings and the actual length of the list when
following the link.

(Generally speaking, this should be changed to use `annotate` rather than retrieve the value from the database for every row of the table as it is currently done)

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant
- [x] This is not a new feature
- [x] No model changes
- [x] This is not a new feature.