### PR TITLE
release-drafter to work with dev branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$NEXT_PATCH_VERSION 🌈'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: '$NEXT_PATCH_VERSION 🌈'
+tag-template: '$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 New scanners'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,7 @@ categories:
     labels:
       - 'feature'
       - 'enhancement'
+      - 'performance'
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
@@ -17,6 +18,9 @@ categories:
     labels: 
       - 'dependencies'
       - 'maintenance'
+  - title: '🚩 Requires settings change'
+    labels:
+      - 'settings_changes'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - dev
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
+      - master
       - dev
 
 jobs:


### PR DESCRIPTION
Changing the release-drafter to add `dev` branch on top of `master`, given our flow, to get the more granular merge info.