### PR TITLE
dedupe: also log background tasks and management tasks

### DIFF
--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -3,9 +3,12 @@ from pytz import timezone
 
 from dojo.models import Finding
 from dojo.utils import get_system_setting
-from dojo.utils import sync_dedupe
+import logging
 
 locale = timezone(get_system_setting('time_zone'))
+
+logger = logging.getLogger(__name__)
+deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 """
 Author: Aaron Weaver
@@ -19,7 +22,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         findings = Finding.objects.all()
-        print("######## Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
+        logger.info("######## Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
+        deduplicationLogger.info("######## Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
         for finding in findings:
             finding.hash_code = finding.compute_hash_code()
             finding.save()
+        logger.info("######## Done Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
+        deduplicationLogger.info("######## Done Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -291,6 +291,7 @@ def async_update_findings_from_source_issues(*args, **kwargs):
 
 @app.task(bind=True)
 def async_dupe_delete(*args, **kwargs):
+    logger.info("delete excess duplicates")
     deduplicationLogger.info("delete excess duplicates")
     system_settings = System_Settings.objects.get()
     if system_settings.delete_dupulicates:


### PR DESCRIPTION
To have a complete view in the dedupe log, this PR makes sure also background tasks and management tasks are logging to the `deduplicationLoigger`.