### PR TITLE
Cicd improvements: reupload mitigation, overdue

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -7,7 +7,7 @@ from dojo.models import Product, Engagement, Test, Finding, \
 from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools import requires_file
 from dojo.tools.factory import import_parser_factory
-from dojo.utils import create_notification
+from dojo.utils import create_notification, max_safe
 from django.urls import reverse
 from tagging.models import Tag
 from django.core.validators import URLValidator, validate_ipv46_address
@@ -536,6 +536,7 @@ class ScanSerializer(serializers.ModelSerializer):
 
 class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     scan_date = serializers.DateField(default=datetime.date.today)
+
     minimum_severity = serializers.ChoiceField(
         choices=SEVERITY_CHOICES,
         default='Info')
@@ -567,6 +568,11 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         endpoint_to_add = data['endpoint_to_add']
         environment, created = Development_Environment.objects.get_or_create(
             name='Development')
+        scan_date = data['scan_date']
+        scan_date_time = datetime.datetime.combine(scan_date, timezone.now().time())
+        if settings.USE_TZ:
+            scan_date_time = timezone.make_aware(scan_date_time, timezone.get_default_timezone())
+
         test = Test(
             engagement=data['engagement'],
             lead=data['lead'],
@@ -583,6 +589,13 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         test.save()
         # return the id of the created test, can't find a better way because this is not a ModelSerializer....
         self.fields['test'] = serializers.IntegerField(read_only=True, default=test.id)
+
+        test.engagement.updated = max_safe([scan_date_time, test.engagement.updated])
+
+        if test.engagement.engagement_type == 'CI/CD':
+            test.engagement.target_end = max_safe([scan_date, test.engagement.target_end])
+
+        test.engagement.save()
 
         if 'tags' in data:
             test.tags = ' '.join(data['tags'])
@@ -743,6 +756,9 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         endpoint_to_add = data['endpoint_to_add']
         min_sev = data['minimum_severity']
         scan_date = data['scan_date']
+        scan_date_time = datetime.datetime.combine(scan_date, timezone.now().time())
+        if settings.USE_TZ:
+            scan_date_time = timezone.make_aware(scan_date_time, timezone.get_default_timezone())
         verified = data['verified']
         active = data['active']
 
@@ -789,8 +805,9 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
 
                 if findings:
                     finding = findings[0]
-                    if finding.mitigated:
+                    if finding.mitigated or finding.is_Mitigated:
                         finding.mitigated = None
+                        finding.is_Mitigated = False
                         finding.mitigated_by = None
                         finding.active = True
                         finding.verified = verified
@@ -852,21 +869,27 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
 
             to_mitigate = set(original_items) - set(new_items)
             for finding in to_mitigate:
-                finding.mitigated = datetime.datetime.combine(
-                    scan_date,
-                    timezone.now().time())
-                if settings.USE_TZ:
-                    finding.mitigated = timezone.make_aware(
-                        finding.mitigated,
-                        timezone.get_default_timezone())
-                finding.mitigated_by = self.context['request'].user
-                finding.active = False
-                finding.save()
-                note = Notes(entry="Mitigated by %s re-upload." % scan_type,
-                             author=self.context['request'].user)
-                note.save()
-                finding.notes.add(note)
-                mitigated_count += 1
+                if not finding.mitigated or not finding.is_Mitigated:
+                    finding.mitigated = scan_date_time
+                    finding.is_Mitigated = True
+                    finding.mitigated_by = self.context['request'].user
+                    finding.active = False
+                    finding.save()
+                    note = Notes(entry="Mitigated by %s re-upload." % scan_type,
+                                author=self.context['request'].user)
+                    note.save()
+                    finding.notes.add(note)
+                    mitigated_count += 1
+
+            test.updated = max_safe([scan_date_time, test.updated])
+            test.engagement.updated = max_safe([scan_date_time, test.engagement.updated])
+
+            if test.engagement.engagement_type == 'CI/CD':
+                test.target_end = max_safe([scan_date_time, test.target_end])
+                test.engagement.target_end = max_safe([scan_date, test.engagement.target_end])
+
+            test.save()
+            test.engagement.save()
 
         except SyntaxError:
             raise Exception("Parser SyntaxError")

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -29,6 +29,7 @@ from django.core.cache import cache
 from dojo.tag.prefetching_tag_descriptor import PrefetchingTagDescriptor
 from django.contrib.contenttypes.fields import GenericRelation
 from tagging.models import TaggedItem
+from dateutil.relativedelta import relativedelta
 
 fmt = getattr(settings, 'LOG_FORMAT', None)
 lvl = getattr(settings, 'LOG_LEVEL', logging.DEBUG)
@@ -960,6 +961,19 @@ class Engagement(models.Model):
 
     class Meta:
         ordering = ['-target_start']
+
+    def is_overdue(self):
+        if self.engagement_type == 'CI/CD':
+            overdue_grace_days = 10
+        else:
+            overdue_grace_days = 0
+
+        max_end_date = timezone.now() - relativedelta(days=overdue_grace_days)
+
+        if self.target_end < max_end_date.date():
+            return True
+
+        return False
 
     def __unicode__(self):
         return "Engagement: %s (%s)" % (self.name if self.name else '',

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -52,7 +52,7 @@
                                         {% if e.active %}
 						<div class="lineContainer">
 							<a  style="display: inline" class="eng_link" href="{% url 'view_engagement' e.id %}">
-                                                {% if e.name %}{{ e.name }} {% endif %}{{ e.target_start }}</a>
+                                                {% if e.name %}{{ e.name }} {% endif %}{{ e.target_start|date }} - {{ e.target_end|date }}</a>
                                                 <sup>
                                                     {% for tag in e.tags %}
                                                          <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
@@ -64,9 +64,9 @@
                                                         |
                                                         {%  for test in e.test_set.all %}
 								{% if test.lead %}
-                                                                <a href="{% url 'view_test' test.id %}"> {{ test }}: {{ test.lead.first_name }} </a> |
+                                                                <a href="{% url 'view_test' test.id %}"> {{ test }}: {{ test.lead.first_name }} ({{ test.updated|date}})</a> |
 								{% else %}
-                                                                <a href="{% url 'view_test' test.id %}"> {{ test }} </a> |
+                                                                <a href="{% url 'view_test' test.id %}"> {{ test }} ({{ test.updated|date}})</a> |
 								{% endif %}
                                                         {% endfor %}
 						</div>

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -168,12 +168,14 @@
                     { "data": "tests" , render: function (data, type, row) {
                             return type === 'export' ? getDojoExportValueFromTag(data, 'a') :  data;
                     }},
-                    { "data": "action", render: function (data, type, row) {
-                            return type === 'export' ?  "" :  data;
-                    }},
+                    {% if user.is_staff %}
+                        { "data": "action", render: function (data, type, row) {
+                                return type === 'export' ?  "" :  data;
+                        }},
+                    {% endif %}
                 ],
                 "columnDefs": [
-                    { "orderable": false, "targets": [8] }
+                    { "orderable": false, "targets": [0] }
                 ],
                 dom: 'Bfrtip',
                 paging: false,

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
+{% load display_tags %}
 {% block content %}
     <div class="row" xmlns="http://www.w3.org/1999/html">
         <div class="col-md-12">
@@ -25,11 +26,10 @@
                         <thead>
                         <tr>
                             <th>Product</th>
-                            <th>Tags</th>
                             <th>Product Type</th>
                             <th>Engagement Name</th>
                             <th>Status</th>
-                            <th>Target Start</th>
+                            <th>Period</th>
                             <th>Lead</th>
                             <th>Tests</th>
                             {% if user.is_staff %}
@@ -44,17 +44,13 @@
                                 <tr>
 
                                     <td class="prod_name"><a href="{% url 'view_product' p.id %}">{{ p.name }}</a>
-                                    </td>
-                                    <!-- Tags column -->
-                                    <td>
                                         <sup>
                                             {% for tag in p.tags %}
-                                                <a title="Search {{ tag }}" class="tag-label tag-color"
-                                                   href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
+                                            <a title="Search {{ tag }}" class="tag-label tag-color"
+                                            href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
                                             {% endfor %}
                                         </sup>
                                     </td>
-                                    <!-- End of Tags Column -->
                                     <td class="prod_name">
                                         <a href="{% url 'product_type_metrics' p.prod_type.id %}">{{ p.prod_type.name }}</a>
                                     </td>
@@ -72,13 +68,16 @@
                                         <br>
                                     </td>
                                     <td> {{ e.status }} </td>
-                                    <td> {{ e.target_start }} </td>
+                                    <td> {{ e.target_start|date }} - {{ e.target_end|date }} 
+                                        {% if e.is_overdue %}<sup><div class="tag-label warning-color">{{ e.target_end|overdue }} overdue</div></sup>
+                                        {% endif %}
+                                    </td>
                                     <td> {{ e.lead.first_name }}</td>
                                     <td> {% for test in e.test_set.all %}
                                         {% if test.lead %}
-                                            <a href="{% url 'view_test' test.id %}"> {{ test }}: {{ test.lead.first_name }} </a>
+                                            <a href="{% url 'view_test' test.id %}"> {{ test }}: {{ test.lead.first_name }} ({{ test.updated|date}})</a>
                                         {% else %}
-                                            <a href="{% url 'view_test' test.id %}"> {{ test }} </a>
+                                            <a href="{% url 'view_test' test.id %}"> {{ test }} ({{ test.updated|date}})</a>
                                         {% endif %}
                                         <br>
                                     {% endfor %}

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -150,9 +150,6 @@
                     { "data": "product" , render: function (data, type, row) {
                             return type === 'export' ? getDojoExportValueFromTag(data, 'a') :  data;
                     }},
-                    { "data": "tags" , render: function (data, type, row) {
-                            return type === 'export' ?  getDojoExportValueFromTag(data, 'a') :  data;
-                    }},
                     { "data": "product_type" , render: function (data, type, row) {
                             return type === 'export' ? getDojoExportValueFromTag(data, 'a') :  data;
                     }},

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -132,7 +132,7 @@
                     </td>
                     <td class="nowrap">{{ eng.target_start|datediff_time:eng.target_end }}
                       {% if status == "open" %}
-                        {% if eng.target_end|overdue %}
+                        {% if eng.is_overdue %}
                         <sup>
                           <div class="tag-label warning-color">
                             {{ eng.target_end|overdue }} overdue
@@ -165,7 +165,7 @@
                           {% for test in eng.test_set.all %}
                                <li>
                                  <a class="" href="{% url 'view_test' test.id %}">
-                                   <i class="fa fa-list-alt"></i> {{test}}, {{test.created}}
+                                   <i class="fa fa-list-alt"></i> {{test}}, {{test.updated}}
                                </li>
                             {% endfor %}
                         </ul>

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -511,7 +511,7 @@
           <tr>
             <td><strong>Length</strong></td>
             <td>{{ eng.target_start|datediff_time:eng.target_end }}
-              {% if eng.target_end|overdue and eng.status != 'Completed'%}
+              {% if eng.is_overdue and eng.status != 'Completed'%}
               <sup>
                 <div class="tag-label warning-color">
                   {{ eng.target_end|overdue }} overdue

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -663,7 +663,7 @@ def re_import_scan_results(request, tid):
                     if len(finding) == 1:
                         finding = finding[0]
                         if finding.mitigated or finding.is_Mitigated:
-							# it was once fixed, but now back
+                            # it was once fixed, but now back
                             finding.mitigated = None
                             finding.is_Mitigated = False
                             finding.mitigated_by = None

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2067,3 +2067,7 @@ def truncate_with_dots(the_string, max_length_including_dots):
     if not the_string:
         return the_string
     return (the_string[:max_length_including_dots - 3] + '...' if len(the_string) > max_length_including_dots else the_string)
+
+
+def max_safe(list):
+    return max(i for i in list if i is not None)

--- a/tests/Engagement_unit_test.py
+++ b/tests/Engagement_unit_test.py
@@ -8,6 +8,14 @@ from Product_unit_test import ProductTest
 
 class EngagementTest(BaseTestCase):
 
+    def test_list_active_engagements(self):
+        driver = self.login_page()
+        self.goto_active_engagements_overview(driver)
+
+    def test_list_all_engagements(self):
+        driver = self.login_page()
+        self.goto_all_engagements_overview(driver)
+
     def test_add_new_engagement(self):
         driver = self.login_page()
         self.goto_product_overview(driver)

--- a/tests/Test_unit_test.py
+++ b/tests/Test_unit_test.py
@@ -13,7 +13,9 @@ class TestUnitTest(BaseTestCase):
         # Login to the site.
         driver = self.login_page()
 
-        driver.get(self.base_url + "engagements_all")
+        # goto engagemnent list (and wait for javascript to load)
+        self.goto_all_engagements_overview(driver)
+
         # Select a previously created engagement title
         driver.find_element_by_partial_link_text("Ad Hoc Engagement").click()
 

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -80,7 +80,11 @@ class BaseTestCase(unittest.TestCase):
         WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, "products_wrapper")))
 
     def goto_active_engagements_overview(self, driver):
-        return self.goto_engagements_internal(driver, 'engagement')
+        # return self.goto_engagements_internal(driver, 'engagement')
+        # engagement overview doesn't seem to have the datatables yet modifying the DOM
+        # https://github.com/DefectDojo/django-DefectDojo/issues/2173
+        driver.get(self.base_url + 'engagement')
+        return driver
 
     def goto_all_engagements_overview(self, driver):
         return self.goto_engagements_internal(driver, 'engagements_all')

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -118,12 +118,13 @@ class BaseTestCase(unittest.TestCase):
             accepted_javascript_messages = r'((zoom\-in\.cur.*)|(images\/finding_images\/.*))404\ \(Not\ Found\)'
 
             if (entry['level'] == 'SEVERE'):
-                print(self.driver.current_url)  # TODO actually this seems to be the previous url
+                # print(self.driver.current_url)  # TODO actually this seems to be the previous url
                 # self.driver.save_screenshot("C:\\Data\\django-DefectDojo\\tests\\javascript-errors.png")
                 # with open("C:\\Data\\django-DefectDojo\\tests\\javascript-errors.html", "w") as f:
                 #    f.write(self.driver.page_source)
 
-                print(entry)
+                print('There was a SEVERE javascript error in the console, please check all steps fromt the current test to see where it happens')
+                print('Currently there is no way to find out at which url the error happened.')
                 if self.accept_javascript_errors:
                     print('WARNING: skipping SEVERE javascript error because accept_javascript_errors is True!')
                 elif re.search(accepted_javascript_messages, entry['message']):

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -79,6 +79,26 @@ class BaseTestCase(unittest.TestCase):
         # wait for product_wrapper div as datatables javascript modifies the DOM on page load.
         WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, "products_wrapper")))
 
+    def goto_active_engagements_overview(self, driver):
+        return self.goto_engagements_internal(driver, 'engagement')
+
+    def goto_all_engagements_overview(self, driver):
+        return self.goto_engagements_internal(driver, 'engagements_all')
+
+    def goto_engagements_internal(self, driver, rel_url):
+        driver.get(self.base_url + rel_url)
+        body = driver.find_element_by_tag_name("BODY").text
+        # print('BODY:')
+        # print(body)
+        # print('re.search:', re.search(r'No products found', body))
+
+        if re.search(r'No engagements found', body):
+            return driver
+
+        # wait for engagements_wrapper div as datatables javascript modifies the DOM on page load.
+        WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.ID, "engagements_wrapper")))
+        return driver
+
     def is_alert_present(self):
         try:
             self.driver.switch_to_alert()

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -123,6 +123,7 @@ class BaseTestCase(unittest.TestCase):
                 # with open("C:\\Data\\django-DefectDojo\\tests\\javascript-errors.html", "w") as f:
                 #    f.write(self.driver.page_source)
 
+                print(entry)
                 print('There was a SEVERE javascript error in the console, please check all steps fromt the current test to see where it happens')
                 print('Currently there is no way to find out at which url the error happened.')
                 if self.accept_javascript_errors:

--- a/tests/local-integration-tests.bat
+++ b/tests/local-integration-tests.bat
@@ -2,33 +2,29 @@ set DD_ADMIN_USER=admin
 set DD_ADMIN_PASSWORD=admin
 set DD_BASE_URL=http://localhost:8080/
 
-echo "Running Product type integration tests"
-python tests/Product_type_unit_test.py
-if %ERRORLEVEL% NEQ 0 GOTO END
+REM echo "Running Product type integration tests"
+REM python tests/Product_type_unit_test.py
+REM if %ERRORLEVEL% NEQ 0 GOTO END
 
-echo "Running Product integration tests"
-python tests/Product_unit_test.py
-if %ERRORLEVEL% NEQ 0 GOTO END
+REM echo "Running Dedupe integration tests"
+REM python tests/dedupe_unit_test.py
+REM if %ERRORLEVEL% NEQ 0 GOTO END
 
-echo "Running Dedupe integration tests"
-python tests/dedupe_unit_test.py
-if %ERRORLEVEL% NEQ 0 GOTO END
+REM echo "Running Endpoint integration tests"
+REM python tests/Endpoint_unit_test.py
+REM if %ERRORLEVEL% NEQ 0 GOTO END
 
-echo "Running Endpoint integration tests"
-python tests/Endpoint_unit_test.py
-if %ERRORLEVEL% NEQ 0 GOTO END
+REM echo "Running Engagement integration tests"
+REM python tests/Engagement_unit_test.py
+REM if %ERRORLEVEL% NEQ 0 GOTO END
 
-echo "Running Engagement integration tests"
-python tests/Engagement_unit_test.py
-if %ERRORLEVEL% NEQ 0 GOTO END
+REM echo "Running Environment integration tests"
+REM python tests/Environment_unit_test.py 
+REM if %ERRORLEVEL% NEQ 0 GOTO END
 
-echo "Running Environment integration tests"
-python tests/Environment_unit_test.py 
-if %ERRORLEVEL% NEQ 0 GOTO END
-
-echo "Running Finding integration tests"
-python tests/Finding_unit_test.py
-if %ERRORLEVEL% NEQ 0 GOTO END
+REM echo "Running Finding integration tests"
+REM python tests/Finding_unit_test.py
+REM if %ERRORLEVEL% NEQ 0 GOTO END
 
 echo "Running Test integration tests"
 python tests/Test_unit_test.py
@@ -48,6 +44,10 @@ if %ERRORLEVEL% NEQ 0 GOTO END
 
 echo "Running Check Status test"
 python tests/check_status.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Product integration tests"
+python tests/Product_unit_test.py
 if %ERRORLEVEL% NEQ 0 GOTO END
 
 REM REM  The below tests are commented out because they are still an unstable work in progress


### PR DESCRIPTION
Some CI/CD related improvements I implemented during due to due usage:

- (fix) #1926 Mitigate only once on reuploads
- show overdue also in list of active/all engagements
- ci/cd:
  - set target_end to to the date of the latest scan import
  - use 10 day grace period before ci/cd engagement becomes overdue

The idea is that for CI/CD engagement a target_end usually doesn't make sense. By updating the target_end whenever a scan is uploaded it becomes nicely apparent which engagements are scanned regularly. We have a policy that every project(or branch) should be scanned at least weakly, so a 10 day grace period fits nicely with that.
