### PR TITLE
Adding SimilarityID and PathID concatenation as unique_id_from_tool for Checkmarx Parser

### DIFF
--- a/dojo/tools/checkmarx/parser.py
+++ b/dojo/tools/checkmarx/parser.py
@@ -164,7 +164,9 @@ class CheckmarxXMLParser(object):
             sinkLineNumber = None
             sourceObject = ''
             sinkObject = ''
-            pathId = path.get('PathId')
+            similarityId = str(path.get("SimilarityId"))
+            path_id = str(path.get("PathId"))
+            pathId = similarityId+path_id
             findingdetail = '{}-----\n'.format(findingdetail)
             # Loop over function calls / assignments in the data flow graph
             for pathnode in path.findall('PathNode'):

--- a/dojo/tools/checkmarx/parser.py
+++ b/dojo/tools/checkmarx/parser.py
@@ -166,7 +166,7 @@ class CheckmarxXMLParser(object):
             sinkObject = ''
             similarityId = str(path.get("SimilarityId"))
             path_id = str(path.get("PathId"))
-            pathId = similarityId+path_id
+            pathId = similarityId + path_id
             findingdetail = '{}-----\n'.format(findingdetail)
             # Loop over function calls / assignments in the data flow graph
             for pathnode in path.findall('PathNode'):

--- a/dojo/unittests/test_checkmarx_parser.py
+++ b/dojo/unittests/test_checkmarx_parser.py
@@ -151,7 +151,8 @@ class TestCheckmarxParser(TestCase):
         self.assertEqual("58", item.line)
         # Added field for detailed scanner
         self.assertEqual(str, type(item.unique_id_from_tool))
-        self.assertEqual("28", item.unique_id_from_tool)
+        # unique_id_from_tool update from PathId to SimilarityId+PathId
+        self.assertEqual("157422106028", item.unique_id_from_tool)
         self.assertEqual(str, type(item.sast_source_object))
         self.assertEqual("executeQuery", item.sast_source_object)
         self.assertEqual(str, type(item.sast_sink_object))


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Per Checkmarx Support, SimilariyID+PathID should be used to identify unique findings.
I am using the dev branch to add this change as it has the latest rework from https://github.com/DefectDojo/django-DefectDojo/pull/1665 

Please do let me know if I am missing something :)

Thanks,
SD
