### PR TITLE
performance: cache system_settings in views

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -92,8 +92,10 @@ class Regulation(models.Model):
 class SystemSettingsManager(models.Manager):
     CACHE_KEY = 'defect_dojo_cache.system_settings'
 
-    def get(self, *args, **kwargs):
+    def get(self, no_cache=False, *args, **kwargs):
         # cache only 30s because django default cache backend is local per process
+        if no_cache:
+            return super(SystemSettingsManager, self).get(*args, **kwargs)
         return cache.get_or_set(self.CACHE_KEY, lambda: super(SystemSettingsManager, self).get(*args, **kwargs), timeout=30)
 
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -24,6 +24,7 @@ from multiselectfield import MultiSelectField
 from django import forms
 from django.utils.translation import gettext as _
 from dojo.signals import dedupe_signal
+from django.core.cache import cache
 
 fmt = getattr(settings, 'LOG_FORMAT', None)
 lvl = getattr(settings, 'LOG_LEVEL', logging.DEBUG)
@@ -86,6 +87,14 @@ class Regulation(models.Model):
 
     def __str__(self):
         return self.acronym + ' (' + self.jurisdiction + ')'
+
+
+class SystemSettingsManager(models.Manager):
+    CACHE_KEY = 'defect_dojo_cache.system_settings'
+
+    def get(self, *args, **kwargs):
+        # cache only 30s because django default cache backend is local per process
+        return cache.get_or_set(self.CACHE_KEY, lambda: super(SystemSettingsManager, self).get(*args, **kwargs), timeout=30)
 
 
 class System_Settings(models.Model):
@@ -244,6 +253,12 @@ class System_Settings(models.Model):
     column_widths = models.CharField(max_length=1500, blank=True)
     drive_folder_ID = models.CharField(max_length=100, blank=True)
     enable_google_sheets = models.BooleanField(default=False, null=True, blank=True)
+
+    objects = SystemSettingsManager()
+
+    def save(self, *args, **kwargs):
+        cache.delete(SystemSettingsManager.CACHE_KEY)
+        super(System_Settings, self).save(*args, **kwargs)
 
 
 class SystemSettingsFormAdmin(forms.ModelForm):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -257,8 +257,8 @@ class System_Settings(models.Model):
     objects = SystemSettingsManager()
 
     def save(self, *args, **kwargs):
-        cache.delete(SystemSettingsManager.CACHE_KEY)
         super(System_Settings, self).save(*args, **kwargs)
+        cache.delete(SystemSettingsManager.CACHE_KEY)
 
 
 class SystemSettingsFormAdmin(forms.ModelForm):

--- a/dojo/system_settings/views.py
+++ b/dojo/system_settings/views.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 @user_passes_test(lambda u: u.is_superuser)
 def system_settings(request):
     try:
-        system_settings_obj = System_Settings.objects.get()
+        system_settings_obj = System_Settings.objects.get(no_cache=True)
     except:
         system_settings_obj = System_Settings()
 

--- a/dojo/unittests/test_system_settings.py
+++ b/dojo/unittests/test_system_settings.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from dojo.models import System_Settings
+
+
+class TestSystemSettings(TestCase):
+
+    def test_system_settings_update(self):
+        system_settings = System_Settings.objects.get()
+        system_settings.enable_jira = True
+        system_settings.save()
+        system_settings = System_Settings.objects.get()
+        self.assertEquals(system_settings.enable_jira, True)
+
+        system_settings.enable_jira = False
+        system_settings.save()
+        system_settings = System_Settings.objects.get()
+        self.assertEquals(system_settings.enable_jira, False)
+
+        system_settings.enable_jira = True
+        system_settings.save()
+        system_settings = System_Settings.objects.get(no_cache=True)
+        self.assertEquals(system_settings.enable_jira, True)


### PR DESCRIPTION
The codebase is using lots of `System_Settings.objects.get()` calls to read the system settings. This results in lots of database queries. Sometimes over a 100 queries just to render one page.

Alternatives considered:

1. Rewrite all occurrences into something like `get_system_settings()` to abstract away from the implementation of system settings as a model
2. Use threadlocals in some way
3. Use a full blown Redis ORM cache or similar

Although option 3 provides many benefits, it's also an extra step/hurdle/maintenance burden. Also having 100s of queries for a single will page will never lead to optimal results.

So I opted for option 4:

4. Sneaky caching of System_Settings model
Basically it's a fully supported features of Django ORM to use custom managers for your model. For example to all kinds of things with optimizing queries or whatever. Most ORM caching frameworks such as `cachalot` use these as well. Here we just use it to store the `System_Settings` model instance in the default django cache backend. And we clear the cache when changes are saved to `System_Settings`. The default cache backend is local within a process. So if you have multiple (uwsgi) processes, this will lead to stale data in the cache. Hence a 30s timeout. 
Each request will now lead to at most 1 database queries to retrieve `System_Settings`.

You can test this for example by enabling/disabling JIRA in system settings. It will show/hide the two extra JIRA columns on the open findings page (or any page showing a list of findings).