### PR TITLE
performance gains by prefetching in more places

### DIFF
--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -13,3 +13,10 @@ def globalize_oauth_vars(request):
 def bind_system_settings(request):
     from dojo.models import System_Settings
     return {'system_settings': System_Settings.objects.get()}
+
+
+def bind_alert_count(request):
+    from dojo.models import Alerts
+    if not request.user.is_authenticated:
+        return {}
+    return {'alert_count': Alerts.objects.filter(user_id=request.user).count()}

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -95,21 +95,19 @@ def engagement(request):
 
 @user_passes_test(lambda u: u.is_staff)
 def engagements_all(request):
+
+    products_with_engagements = Product.objects.filter(~Q(engagement=None)).distinct()
     filtered = EngagementFilter(
         request.GET,
-        queryset=Product.objects.filter(
-            ~Q(engagement=None),
-        ).distinct())
+        queryset=products_with_engagements.prefetch_related('engagement_set', 'prod_type', 'engagement_set__lead',
+                                                            'engagement_set__test_set__lead', 'engagement_set__test_set__test_type'))
+
     prods = get_page_items(request, filtered.qs, 25)
     name_words = [
-        product.name for product in Product.objects.filter(
-            ~Q(engagement=None),
-        ).distinct()
+        product.name for product in products_with_engagements.only('name')
     ]
     eng_words = [
-        engagement.name for product in Product.objects.filter(
-            ~Q(engagement=None),
-        ).distinct() for engagement in product.engagement_set.all()
+        engagement.name for engagement in Engagement.objects.filter(active=True)
     ]
 
     add_breadcrumb(

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -581,7 +581,6 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
-        prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
     return prefetched_findings
 
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -42,6 +42,7 @@ from dojo.utils import get_page_items, add_breadcrumb, FileIterWrapper, process_
 
 from dojo.tasks import add_issue_task, update_issue_task, add_comment_task
 from django.template.defaultfilters import pluralize
+from django.db.models.query import QuerySet
 
 
 logger = logging.getLogger(__name__)
@@ -571,14 +572,16 @@ def open_findings(request, pid=None, eid=None, view=None):
 
 def prefetch_for_findings(findings):
     prefetched_findings = findings
-    prefetched_findings = prefetched_findings.select_related('reporter')
-    prefetched_findings = prefetched_findings.select_related('jira_issue')
-    prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
-    prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
-    prefetched_findings = prefetched_findings.prefetch_related('found_by')
-    prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
-    # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
-    prefetched_findings = prefetched_findings.prefetch_related('notes')
+    if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_findings = prefetched_findings.select_related('reporter')
+        prefetched_findings = prefetched_findings.select_related('jira_issue')
+        prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
+        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
+        prefetched_findings = prefetched_findings.prefetch_related('found_by')
+        prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
+        # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
+        prefetched_findings = prefetched_findings.prefetch_related('notes')
+        prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
     return prefetched_findings
 
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -132,6 +132,9 @@ def verified_findings(request, pid=None, eid=None, view=None):
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
     if jira_config:
         jira_config = jira_config.conf_id
+
+    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
+
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,
@@ -233,6 +236,9 @@ def out_of_scope_findings(request, pid=None, eid=None, view=None):
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
     if jira_config:
         jira_config = jira_config.conf_id
+
+    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
+
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,
@@ -334,6 +340,9 @@ def false_positive_findings(request, pid=None, eid=None, view=None):
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
     if jira_config:
         jira_config = jira_config.conf_id
+
+    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
+
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,
@@ -435,6 +444,9 @@ def inactive_findings(request, pid=None, eid=None, view=None):
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
     if jira_config:
         jira_config = jira_config.conf_id
+
+    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
+
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,
@@ -539,7 +551,7 @@ def open_findings(request, pid=None, eid=None, view=None):
     if jira_config:
         jira_config = jira_config.conf_id
 
-    paged_findings.object_list = prefetch_for_open_findings(paged_findings.object_list)
+    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
 
     return render(
         request, 'dojo/findings_list.html', {
@@ -557,9 +569,11 @@ def open_findings(request, pid=None, eid=None, view=None):
         })
 
 
-def prefetch_for_open_findings(findings):
+def prefetch_for_findings(findings):
     prefetched_findings = findings
+    prefetched_findings = prefetched_findings.select_related('reporter')
     prefetched_findings = prefetched_findings.select_related('jira_issue')
+    prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
     prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
     prefetched_findings = prefetched_findings.prefetch_related('found_by')
     prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
@@ -590,7 +604,9 @@ def accepted_findings(request, pid=None):
 
     product_tab = None
     if pid:
-        product_tab = Product_Tab(pid, title="Closed Findings", tab="findings")
+        product_tab = Product_Tab(pid, title="Accepted Findings", tab="findings")
+
+    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
 
     return render(
         request, 'dojo/findings_list.html', {
@@ -612,11 +628,13 @@ def closed_findings(request, pid=None):
     ]
 
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings.qs, 25)
+    paged_findings = get_page_items(request, findings.qs.order_by('-mitigated'), 25)
 
     product_tab = None
     if pid:
         product_tab = Product_Tab(pid, title="Closed Findings", tab="findings")
+
+    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
 
     return render(
         request, 'dojo/findings_list.html', {

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -88,7 +88,6 @@ def prefetch_for_product(prods):
                 finding__verified=True,
                 finding__mitigated__isnull=True)
         prefetched_prods = prefetched_prods.prefetch_related(Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
-        prefetched_prods = prefetched_prods.prefetch_related('tagged_items__tag')
 
     return prefetched_prods
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -29,6 +29,7 @@ from dojo.tasks import add_epic_task, add_issue_task
 from tagging.models import Tag
 from tagging.utils import get_tag_list
 from django.db.models import Prefetch
+from django.db.models.query import QuerySet
 
 logger = logging.getLogger(__name__)
 
@@ -74,17 +75,21 @@ def product(request):
 
 
 def prefetch_for_product(prods):
-    prefetched_prods = prods.select_related('technical_contact').select_related('product_manager').select_related('prod_type').select_related('team_manager')
-    prefetched_prods = prefetched_prods.annotate(active_engagement_count=Count('engagement__id', filter=Q(engagement__active=True)))
-    prefetched_prods = prefetched_prods.annotate(closed_engagement_count=Count('engagement__id', filter=Q(engagement__active=False)))
-    prefetched_prods = prefetched_prods.annotate(last_engagement_date=Max('engagement__target_start'))
-    prefetched_prods = prefetched_prods.annotate(active_finding_count=Count('engagement__test__finding__id', filter=Q(engagement__test__finding__active=True)))
-    prefetched_prods = prefetched_prods.prefetch_related(Prefetch('jira_pkey_set', queryset=JIRA_PKey.objects.all().select_related('conf'), to_attr='jira_confs'))
-    active_endpoint_query = Endpoint.objects.filter(
-            finding__active=True,
-            finding__verified=True,
-            finding__mitigated__isnull=True)
-    prefetched_prods = prefetched_prods.prefetch_related(Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
+    prefetched_prods = prods
+    if isinstance(prods, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_prods = prefetched_prods.select_related('technical_contact').select_related('product_manager').select_related('prod_type').select_related('team_manager')
+        prefetched_prods = prefetched_prods.annotate(active_engagement_count=Count('engagement__id', filter=Q(engagement__active=True)))
+        prefetched_prods = prefetched_prods.annotate(closed_engagement_count=Count('engagement__id', filter=Q(engagement__active=False)))
+        prefetched_prods = prefetched_prods.annotate(last_engagement_date=Max('engagement__target_start'))
+        prefetched_prods = prefetched_prods.annotate(active_finding_count=Count('engagement__test__finding__id', filter=Q(engagement__test__finding__active=True)))
+        prefetched_prods = prefetched_prods.prefetch_related(Prefetch('jira_pkey_set', queryset=JIRA_PKey.objects.all().select_related('conf'), to_attr='jira_confs'))
+        active_endpoint_query = Endpoint.objects.filter(
+                finding__active=True,
+                finding__verified=True,
+                finding__mitigated__isnull=True)
+        prefetched_prods = prefetched_prods.prefetch_related(Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
+        prefetched_prods = prefetched_prods.prefetch_related('tagged_items__tag')
+
     return prefetched_prods
 
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -79,7 +79,7 @@ def prefetch_for_product(prods):
     prefetched_prods = prefetched_prods.annotate(closed_engagement_count=Count('engagement__id', filter=Q(engagement__active=False)))
     prefetched_prods = prefetched_prods.annotate(last_engagement_date=Max('engagement__target_start'))
     prefetched_prods = prefetched_prods.annotate(active_finding_count=Count('engagement__test__finding__id', filter=Q(engagement__test__finding__active=True)))
-    prefetched_prods = prefetched_prods.prefetch_related(Prefetch('jira_pkey_set', queryset=JIRA_PKey.objects.all(), to_attr='jira_confs'))
+    prefetched_prods = prefetched_prods.prefetch_related(Prefetch('jira_pkey_set', queryset=JIRA_PKey.objects.all().select_related('conf'), to_attr='jira_confs'))
     active_endpoint_query = Endpoint.objects.filter(
             finding__active=True,
             finding__verified=True,

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -44,7 +44,7 @@ def product_type(request):
 
 def prefetch_for_product_type(prod_types):
     prefetch_prod_types = prod_types
-    
+
     if isinstance(prefetch_prod_types, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
         active_findings_query = Q(prod_type__engagement__test__finding__active=True,
                                 prod_type__engagement__test__finding__mitigated__isnull=True,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -446,7 +446,7 @@ TEMPLATES = [
                 'social_django.context_processors.backends',
                 'social_django.context_processors.login_redirect',
                 'dojo.context_processors.globalize_oauth_vars',
-                'dojo.context_processors.bind_system_settings',
+                'dojo.context_processors.bind_alert_count',
             ],
         },
     },

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -89,9 +89,9 @@
                     <!-- /input-group -->
                 </li>
                 <li class="dropdown">
-                    <a class="dropdown-toggle dropdown-toggle-h{% alert_count %}" data-toggle="dropdown" href="#" aria-expanded="false" aria-label="{% alert_count %} Alerts">
+                    <a class="dropdown-toggle dropdown-toggle-h{{ alert_count }}" data-toggle="dropdown" href="#" aria-expanded="false" aria-label="{{ alert_count }} Alerts">
                         <i class="fa fa-bell fa-fw"></i>
-                        <span id="alert_count" class="badge badge-count badge-count{% alert_count %}">{% alert_count %}</span>
+                        <span id="alert_count" class="badge badge-count badge-count{{ alert_count }}">{{ alert_count }}</span>
                         <i class="fa fa-caret-down"></i>
                     </a>
                     <ul class="dropdown-menu dropdown-alerts">

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -81,9 +81,9 @@
                     </div>
                 </div>
                 {% if request.user.is_superuser %}
-                    <a href="{% url 'closed_findings' %}?mitigated=2&o=numerical_severity">
+                    <a href="{% url 'closed_findings' %}?mitigated=2&o=-mitigated">
                 {% else %}
-                    <a href="{% url 'closed_findings' %}?mitigated=2&mitigated_by={{ request.user.id }}&o=numerical_severity">
+                    <a href="{% url 'closed_findings' %}?mitigated=2&mitigated_by={{ request.user.id }}&o=-mitigated">
                 {% endif %}
                     <div class="panel-footer">
                         <span class="pull-left">View Finding Details</span>

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -127,7 +127,11 @@
                             <th class="nowrap">{% dojo_sort request 'Severity' 'numerical_severity' 'asc' %}</th>
                             <th class="nowrap">{% dojo_sort request 'Name' 'title' %}</th>
                             <th>CWE</th>
+                            {% if filter_name == 'Closed' %}
+                            <th class="nowrap">{% dojo_sort request 'Closed Date' 'mitigated'%}</th>
+                            {% else %}
                             <th class="nowrap">{% dojo_sort request 'Date' 'date'%}</th>
+                            {% endif %}
                             <th class="nowrap">Age</th>
                             {% if system_settings.enable_finding_sla %}
                             <th>SLA</th>
@@ -290,7 +294,11 @@
                                   </a>
                                 {% endif %}
                                 </td>
+                                {% if filter_name == 'Closed' %}
+                                <td class="nowrap">{{ finding.mitigated|date }}</td>
+                                {% else %}
                                 <td class="nowrap">{{ finding.date }}</td>
+                                {% endif %}
                                 <td>{{ finding.age }}</td>
                                 {% if system_settings.enable_finding_sla %}
                                 <td>

--- a/dojo/templatetags/navigation_tags.py
+++ b/dojo/templatetags/navigation_tags.py
@@ -2,15 +2,9 @@ from django import template
 from django.utils.safestring import mark_safe as safe
 from django.utils.html import escape
 
-from dojo.models import Product_Type, Alerts
+from dojo.models import Product_Type
 
 register = template.Library()
-
-
-@register.simple_tag(takes_context=True)
-def alert_count(context):
-    count = Alerts.objects.filter(user_id=context['request'].user).count()
-    return count if count > 0 else 0
 
 
 @register.simple_tag(takes_context=True)

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -38,6 +38,7 @@ echo "Running Product type integration tests"
 if python3 tests/Product_type_unit_test.py ; then
     echo "Success: Product type integration tests passed"
 else
+    docker-compose logs --tail="all" uwsgi
     echo "Error: Product type integration test failed."; exit 1
 fi
 

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -195,6 +195,7 @@ echo "Running test ${TEST}"
       CR=$(curl -s -m 10 -I http://localhost:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
       if [ "$CR" != 200 ]; then
         echo "ERROR: cannot display login screen; got HTTP code $CR"
+        docker-compose logs  --tail="all" uwsgi
         exit 1
       fi
       echo "Docker compose container status"


### PR DESCRIPTION
Similar to #1899 prefetching most date up front to reduce queries and increase performance.
Includes some small cosmetic changes and no longer performs 5 queries per page to display the alert count.

- prefetch related data when displaying active / all engagements
- prefetch related data when displaying list of findings
- prefetch related data when displaying search results
- add check for old codepaths to only prefetch when possible
- order recently closed findings by descending closed (mitigated) date
- cache alert counts while rendering pages/templates -> needs a change to `settings.py`.
