### PR TITLE
Fix import error for Crashtest Security importer for skipped scans

### DIFF
--- a/dojo/tools/crashtest_security/parser.py
+++ b/dojo/tools/crashtest_security/parser.py
@@ -64,6 +64,10 @@ class CrashtestSecurityXmlParser(object):
             if severity == "Error":
                 continue
 
+            # This denotes a skipped scan and not a vulnerability
+            if severity == "Skipped":
+                continue
+
             find = Finding(title=title,
                            description=description,
                            test=test,


### PR DESCRIPTION
I just noticed another crash during the import of a Crashtest Security Scan file, in the case that the scan contains any skipped test case.

This PR fixes prevents this crash by adding a check for skipped tests.
