### PR TITLE
Revert import scan to original permission checks

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
-from rest_framework.permissions import DjangoModelPermissions, IsAdminUser
+from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from django_filters.rest_framework import DjangoFilterBackend
@@ -23,6 +23,7 @@ from datetime import datetime
 from dojo.utils import get_period_counts_legacy
 from dojo.api_v2 import serializers, permissions
 from django.db.models import Count, Q
+
 
 class EndPointViewSet(mixins.ListModelMixin,
                       mixins.RetrieveModelMixin,
@@ -614,7 +615,6 @@ class ImportScanView(mixins.CreateModelMixin,
     serializer_class = serializers.ImportScanSerializer
     parser_classes = [MultiPartParser]
     queryset = Test.objects.all()
-    permission_classes = [IsAdminUser]
 
 
 class ReImportScanView(mixins.CreateModelMixin,


### PR DESCRIPTION
Fixes https://github.com/DefectDojo/django-DefectDojo/issues/1977

While we may decide to do something more later on is a different discussion, but we should revert this back to what it was. See related issue for more info.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
