### PR TITLE
Add component name and version for JFrog scans

### DIFF
--- a/dojo/tools/jfrogxray/parser.py
+++ b/dojo/tools/jfrogxray/parser.py
@@ -95,6 +95,8 @@ def get_item(vulnerability, test):
         title = vulnerability['id'] + " - " + str(cve) + " - " + vulnerability['component']
     else:
         title = str(cve) + " - " + vulnerability['component']
+    component_name = vulnerability['component']
+    component_version = vulnerability['source_comp_id'][len(vulnerability['source_id'])+1:]
 
     # create the finding object
     finding = Finding(
@@ -105,6 +107,8 @@ def get_item(vulnerability, test):
         severity=severity,
         description=(vulnerability['summary'] + "\n\n" + extra_desc).strip(),
         mitigation=mitigation,
+        component_name=component_name,
+        component_version=component_version,
         file_path=vulnerability.get('source_comp_id'),
         severity_justification="CVSS v3 base score: {}\nCVSS v2 base score: {}".format(cvss_v3, cvss_v2),
         static_finding=True,

--- a/dojo/tools/jfrogxray/parser.py
+++ b/dojo/tools/jfrogxray/parser.py
@@ -95,8 +95,8 @@ def get_item(vulnerability, test):
         title = vulnerability['id'] + " - " + str(cve) + " - " + vulnerability['component']
     else:
         title = str(cve) + " - " + vulnerability['component']
-    component_name = vulnerability['component']
-    component_version = vulnerability['source_comp_id'][len(vulnerability['source_id'])+1:]
+    component_name = vulnerability.get('component')
+    component_version = vulnerability.get('source_comp_id')[len(vulnerability.get('source_id', '')) + 1:]
 
     # create the finding object
     finding = Finding(

--- a/dojo/unittests/test_jfrogxray_parser.py
+++ b/dojo/unittests/test_jfrogxray_parser.py
@@ -9,6 +9,9 @@ class TestJfrogXrayJSONParser(TestCase):
         parser = XrayJSONParser(testfile, Test())
         testfile.close()
         self.assertEqual(1, len(parser.items))
+        item = parser.items[0]
+        self.assertEquals('debian:stretch:libx11', item.component_name)
+        self.assertEquals('2:1.6.4-3', item.component_version)
 
     def test_parse_file_with_many_vulns(self):
         testfile = open("dojo/unittests/scans/jfrogxray/many_vulns.json")


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
