### PR TITLE
Backport nodejs fix

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -23,16 +23,22 @@ RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 FROM build AS collectstatic
 
 USER root
+ENV \
+  # This will point yarn to whatever version of node you decide to use
+  # due to the use of nodejs instead of node name in some distros
+  node="nodejs"
 RUN \
   apt-get -y update && \
   apt-get -y install apt-transport-https ca-certificates && \
   curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-  echo "deb https://deb.nodesource.com/node_11.x stretch main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  echo "deb https://nightly.yarnpkg.com/debian/ nightly main" | tee /etc/apt/sources.list.d/yarn.list && \
   apt-get -y update && \
   apt-get -y install nodejs && \
+  echo "$(node --version)" && \
   apt-get -y install --no-install-recommends yarn && \
+  echo "$(yarn --version)" && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
   true


### PR DESCRIPTION
Based off `1.5.4` tag, created this `1.5.4.1` to be clean and not force-push.

Should also be tagged `1.5.4.1` upon merge and released.