### PR TITLE
Prefetch tags and more to remove 1+N queries problem

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -91,13 +91,20 @@ class TagListSerializerField(serializers.ListField):
     def to_representation(self, value):
         if not isinstance(value, TagList):
             if not isinstance(value, list):
+                # this will trigger when a queryset is found...
                 if self.order_by:
                     tags = value.all().order_by(*self.order_by)
                 else:
                     tags = value.all()
                 value = [tag.name for tag in tags]
+            elif len(value) > 0 and isinstance(value[0], Tag):
+                # .. but sometimes the queryset already has been converted into a list, i.e. by prefetch_related
+                tags = value
+                value = [tag.name for tag in tags]
+                if self.order_by:
+                    # the only possible ordering is by name, so we order after creating the list
+                    value = sorted(value)
             value = TagList(value, pretty_print=self.pretty_print)
-
         return value
 
 
@@ -188,6 +195,7 @@ class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
     def get_findings_list(self, obj):
         return obj.open_findings_list()
 
+
 class ProductTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product_Type
@@ -239,6 +247,7 @@ class EndpointSerializer(TaggitSerializer, serializers.ModelSerializer):
         fields = '__all__'
 
     def validate(self, data):
+        # print('EndpointSerialize.validate')
         port_re = "(:[0-9]{1,5}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}" \
                   "|655[0-2][0-9]|6553[0-5])"
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -35,6 +35,7 @@ from dojo.utils import get_page_items, add_breadcrumb, handle_uploaded_threat, \
     FileIterWrapper, get_cal_event, message, get_system_setting, create_notification, Product_Tab
 from dojo.tasks import update_epic_task, add_epic_task
 from functools import reduce
+from django.db.models.query import QuerySet
 
 logger = logging.getLogger(__name__)
 parse_logger = logging.getLogger('dojo')
@@ -85,6 +86,8 @@ def engagement(request):
         top_level=not len(request.GET),
         request=request)
 
+    prods.object_list = prefetch_for_products_with_engagments(prods.object_list)
+
     return render(
         request, 'dojo/engagement.html', {
             'products': prods,
@@ -116,6 +119,8 @@ def engagements_all(request):
         top_level=not len(request.GET),
         request=request)
 
+    prods.object_list = prefetch_for_products_with_engagments(prods.object_list)
+
     return render(
         request, 'dojo/engagements_all.html', {
             'products': prods,
@@ -123,6 +128,14 @@ def engagements_all(request):
             'name_words': sorted(set(name_words)),
             'eng_words': sorted(set(eng_words)),
         })
+
+
+def prefetch_for_products_with_engagments(products_with_engagements):
+    if isinstance(products_with_engagements, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        return products_with_engagements.prefetch_related('tagged_items__tag',
+            'engagement_set__tagged_items__tag',
+            'engagement_set__test_set__tagged_items__tag')
+    return products_with_engagements
 
 
 @user_passes_test(lambda u: u.is_staff)

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1391,7 +1391,7 @@ def choose_finding_template_options(request, tid, fid):
         'product_tab': product_tab,
         'template': template,
         'form': form,
-        'finding_tags': [tag.name for tag in finding.tags.all()],
+        'finding_tags': [tag.name for tag in finding.tags],
     })
 
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -581,6 +581,7 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
+        prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
     return prefetched_findings
 
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -26,6 +26,9 @@ from django import forms
 from django.utils.translation import gettext as _
 from dojo.signals import dedupe_signal
 from django.core.cache import cache
+from dojo.tag.prefetching_tag_descriptor import PrefetchingTagDescriptor
+from django.contrib.contenttypes.fields import GenericRelation
+from tagging.models import TaggedItem
 
 fmt = getattr(settings, 'LOG_FORMAT', None)
 lvl = getattr(settings, 'LOG_LEVEL', logging.DEBUG)
@@ -597,6 +600,9 @@ class Product(models.Model):
     internet_accessible = models.BooleanField(default=False, help_text=_('Specify if the application is accessible from the public internet.'))
     regulations = models.ManyToManyField(Regulation, blank=True)
 
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
+
     def __unicode__(self):
         return self.name
 
@@ -935,6 +941,9 @@ class Engagement(models.Model):
     orchestration_engine = models.ForeignKey(Tool_Configuration, verbose_name="Orchestration Engine", help_text="Orchestration service responsible for CI/CD test", null=True, blank=True, related_name='orchestration', on_delete=models.CASCADE)
     deduplication_on_engagement = models.BooleanField(default=False)
 
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
+
     class Meta:
         ordering = ['-target_start']
 
@@ -991,6 +1000,9 @@ class Endpoint(models.Model):
     endpoint_params = models.ManyToManyField(Endpoint_Params, blank=True,
                                              editable=False)
     remediated = models.BooleanField(default=False, blank=True)
+
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
 
     class Meta:
         ordering = ['product', 'protocol', 'host', 'path', 'query', 'fragment']
@@ -1199,6 +1211,9 @@ class Test(models.Model):
     updated = models.DateTimeField(auto_now=True, null=True)
     created = models.DateTimeField(auto_now_add=True, null=True)
 
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
+
     def test_type_name(self):
         return self.test_type.name
 
@@ -1361,6 +1376,9 @@ class Finding(models.Model):
     nb_occurences = models.IntegerField(null=True, blank=True,
                                verbose_name="Number of occurences",
                                help_text="Number of occurences in the source tool when several vulnerabilites were found and aggregated by the scanner")
+
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
 
     SEVERITIES = {'Info': 4, 'Low': 3, 'Medium': 2,
                   'High': 1, 'Critical': 0}
@@ -1826,6 +1844,9 @@ class Finding_Template(models.Model):
     numerical_severity = models.CharField(max_length=4, null=True, blank=True, editable=False)
     template_match = models.BooleanField(default=False, verbose_name='Template Match Enabled', help_text="Enables this template for matching remediation advice. Match will be applied to all active, verified findings by CWE.")
     template_match_title = models.BooleanField(default=False, verbose_name='Match Template by Title and CWE', help_text="Matches by title text (contains search) and CWE.")
+
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
 
     SEVERITIES = {'Info': 4, 'Low': 3, 'Medium': 2,
                   'High': 1, 'Critical': 0}
@@ -2301,6 +2322,9 @@ class App_Analysis(models.Model):
     website_found = models.URLField(max_length=400, null=True, blank=True)
     created = models.DateTimeField(null=False, editable=False, default=now)
 
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
+
     def __unicode__(self):
         return self.name + " | " + self.product.name
 
@@ -2330,6 +2354,9 @@ class Objects(models.Model):
                                 null=True, blank=True)
     review_status = models.ForeignKey(Objects_Review, on_delete=models.CASCADE)
     created = models.DateTimeField(null=False, editable=False, default=now)
+
+    # used for prefetching tags because django-tagging doesn't support that out of the box
+    tagged_items = GenericRelation(TaggedItem)
 
     def __unicode__(self):
         name = None
@@ -2642,6 +2669,9 @@ tag_register(Endpoint)
 tag_register(Finding_Template)
 tag_register(App_Analysis)
 tag_register(Objects)
+
+# Patch to support prefetching
+PrefetchingTagDescriptor.patch()
 
 # Benchmarks
 admin.site.register(Benchmark_Type)

--- a/dojo/object/parser.py
+++ b/dojo/object/parser.py
@@ -77,7 +77,7 @@ def import_object_eng(request, engagement, json_data):
             object.save()
             found_object = object
             if file_type == "path":
-                for tag in found_object.tags.all():
+                for tag in found_object.tags:
                     Tag.objects.update_tags(object, tag.name)
 
         full_url = None

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -87,6 +87,7 @@ def prefetch_for_product(prods):
                 finding__active=True,
                 finding__mitigated__isnull=True)
         prefetched_prods = prefetched_prods.prefetch_related(Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
+        prefetched_prods = prefetched_prods.prefetch_related('tagged_items__tag')
 
     return prefetched_prods
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -99,7 +99,8 @@ def iso_to_gregorian(iso_year, iso_week, iso_day):
 
 
 def view_product(request, pid):
-    prod = get_object_or_404(Product, id=pid)
+    prod_query = Product.objects.all().select_related('product_manager', 'technical_contact', 'team_manager')
+    prod = get_object_or_404(prod_query, id=pid)
     auth = request.user.is_staff or request.user in prod.authorized_users.all()
     if not auth:
         # will render 403

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -99,7 +99,7 @@ def iso_to_gregorian(iso_year, iso_week, iso_day):
 
 
 def view_product(request, pid):
-    prod_query = Product.objects.all().select_related('product_manager', 'technical_contact', 'team_manager')
+    prod_query = Product.objects.all().select_related('product_manager', 'technical_contact', 'team_manager').prefetch_related('authorized_users')
     prod = get_object_or_404(prod_query, id=pid)
     auth = request.user.is_staff or request.user in prod.authorized_users.all()
     if not auth:

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -449,10 +449,13 @@ def view_engagements(request, pid, engagement_type="Interactive"):
 
 
 def prefetch_for_view_engagements(engs):
-    prefetched_engs = engs.prefetch_related('test_set')
-    prefetched_engs = prefetched_engs.annotate(count_findings_all=Count('test__finding__id'))
-    prefetched_engs = prefetched_engs.annotate(count_findings_open=Count('test__finding__id', filter=Q(test__finding__active=True)))
-    prefetched_engs = prefetched_engs.annotate(count_findings_duplicate=Count('test__finding__id', filter=Q(test__finding__duplicate=True)))
+    prefetched_engs = engs
+    if isinstance(engs, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_engs = prefetched_engs.prefetch_related('test_set')
+        prefetched_engs = prefetched_engs.annotate(count_findings_all=Count('test__finding__id'))
+        prefetched_engs = prefetched_engs.annotate(count_findings_open=Count('test__finding__id', filter=Q(test__finding__active=True)))
+        prefetched_engs = prefetched_engs.annotate(count_findings_duplicate=Count('test__finding__id', filter=Q(test__finding__duplicate=True)))
+        prefetched_engs = prefetched_engs.prefetch_related('tagged_items__tag')
     return prefetched_engs
 
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -454,6 +454,7 @@ def prefetch_for_view_engagements(engs):
     if isinstance(engs, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
         prefetched_engs = prefetched_engs.select_related('lead')
         prefetched_engs = prefetched_engs.prefetch_related('test_set')
+        prefetched_engs = prefetched_engs.prefetch_related('test_set__test_type')  # test.name uses test_type
         prefetched_engs = prefetched_engs.annotate(count_findings_all=Count('test__finding__id'))
         prefetched_engs = prefetched_engs.annotate(count_findings_open=Count('test__finding__id', filter=Q(test__finding__active=True)))
         prefetched_engs = prefetched_engs.annotate(count_findings_duplicate=Count('test__finding__id', filter=Q(test__finding__duplicate=True)))

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -452,6 +452,7 @@ def view_engagements(request, pid, engagement_type="Interactive"):
 def prefetch_for_view_engagements(engs):
     prefetched_engs = engs
     if isinstance(engs, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_engs = prefetched_engs.select_related('lead')
         prefetched_engs = prefetched_engs.prefetch_related('test_set')
         prefetched_engs = prefetched_engs.annotate(count_findings_all=Count('test__finding__id'))
         prefetched_engs = prefetched_engs.annotate(count_findings_open=Count('test__finding__id', filter=Q(test__finding__active=True)))

--- a/dojo/search/views.py
+++ b/dojo/search/views.py
@@ -136,19 +136,20 @@ def simple_search(request):
                             product__authorized_users__in=[request.user]), tags)
 
             if findings:
-                findings = findings.prefetch_related('object', 'object__test', 'object__test__engagement', 'object__test__engagement__product', 'object__risk_acceptance_set', 'object__test__test_type')
+                findings = findings.prefetch_related('object', 'object__test', 'object__test__engagement', 'object__test__engagement__product',
+                 'object__risk_acceptance_set', 'object__test__test_type', 'object__tagged_items__tag', 'object__test__engagement__product__tagged_items__tag')
 
             if engagements:
-                engagements = engagements.prefetch_related('object', 'object__product')
+                engagements = engagements.prefetch_related('object', 'object__product', 'object__product__tagged_items__tag', 'object__tagged_items__tag')
 
             if products:
-                products = products.prefetch_related('object')
+                products = products.prefetch_related('object', 'object__tagged_items__tag')
 
             if tests:
-                tests = tests.prefetch_related('object', 'object__engagement', 'object__engagement__product', 'object__test_type')
+                tests = tests.prefetch_related('object', 'object__engagement', 'object__engagement__product', 'object__test_type', 'object__engagement__tagged_items__tag')
 
             if languages:
-                languages = languages.prefetch_related('object', 'object__product')
+                languages = languages.prefetch_related('object', 'object__product', 'object__product__tagged_items__tag')
 
         else:
             form = SimpleSearchForm()

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -499,7 +499,7 @@ INSTALLED_APPS = (
     'rest_framework.authtoken',
     'rest_framework_swagger',
     'dbbackup',
-    'taggit_serializer',
+    # 'taggit_serializer',
     # 'axes'
     'django_celery_results',
     'social_django',

--- a/dojo/tag/prefetching_tag_descriptor.py
+++ b/dojo/tag/prefetching_tag_descriptor.py
@@ -1,0 +1,17 @@
+from tagging.managers import TagDescriptor
+
+
+class PrefetchingTagDescriptor(object):
+
+    def get_with_prefetch(self, instance, owner):
+        if instance:
+            # print('returning prefetched tags')
+            if hasattr(instance, 'tagged_items'):
+                return [ti.tag for ti in list(instance.tagged_items.all())]
+
+        return self.__old__get__(instance, owner)
+
+    def patch():
+        print('patching TagDescriptor')
+        TagDescriptor.__old__get__ = TagDescriptor.__get__
+        TagDescriptor.__get__ = PrefetchingTagDescriptor.get_with_prefetch

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
+{% load display_tags %}
 {% block content %}
     <div class="row">
         <div class="col-md-12">

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -52,6 +52,13 @@
 						<div class="lineContainer">
 							<a  style="display: inline" class="eng_link" href="{% url 'view_engagement' e.id %}">
                                                 {% if e.name %}{{ e.name }} {% endif %}{{ e.target_start }}</a>
+                                                <sup>
+                                                    {% for tag in e.tags %}
+                                                         <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
+                                                     {% endfor %}
+                                                </sup>                                                
+                                                {% if e.is_overdue %}<sup><div class="tag-label warning-color">{{ e.target_end|overdue }} overdue</div></sup>
+                                                {% endif %}                                                
 							| Lead: {{ e.lead.first_name }}
                                                         |
                                                         {%  for test in e.test_set.all %}
@@ -62,11 +69,7 @@
 								{% endif %}
                                                         {% endfor %}
 						</div>
-                                                <sup>
-                                                 {% for tag in e.tags %}
-                                                      <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
-                                                  {% endfor %}
-                                                </sup>
+
                                         {% endif %}
                                     {% endfor %}
                                 </td>

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -61,8 +61,15 @@
                                     <td>
                                         <a style="display: inline" class="eng_link"
                                            href="{% url 'view_engagement' e.id %}">
-                                            {% if e.name %}{{ e.name }} {% endif %}<br>
+                                            {% if e.name %}{{ e.name }} {% endif %}
                                         </a>
+                                        <sup>
+                                            {% for tag in e.tags %}
+                                            <a title="Search {{ tag }}" class="tag-label tag-color"
+                                            href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
+                                            {% endfor %}
+                                        </sup>
+                                        <br>
                                     </td>
                                     <td> {{ e.status }} </td>
                                     <td> {{ e.target_start }} </td>
@@ -75,12 +82,7 @@
                                         {% endif %}
                                         <br>
                                     {% endfor %}
-                                        <sup>
-                                            {% for tag in e.tags %}
-                                                <a title="Search {{ tag }}" class="tag-label tag-color"
-                                                   href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
-                                            {% endfor %}
-                                        </sup></td>
+                                    </td>
                                     {% if user.is_staff %}
                                         <td>
                                             <a class="btn btn-sm btn-success" href="{% url 'new_eng_for_prod' p.id %}">

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -12,7 +12,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.urls import reverse
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.shortcuts import render, get_object_or_404
 from django.views.decorators.cache import cache_page
@@ -33,6 +33,7 @@ from functools import reduce
 
 logger = logging.getLogger(__name__)
 parse_logger = logging.getLogger('dojo')
+
 
 def view_test(request, tid):
     test = get_object_or_404(Test, pk=tid)
@@ -69,7 +70,7 @@ def view_test(request, tid):
     else:
         form = NoteForm()
 
-    fpage = get_page_items(request, findings.qs, 25)
+    fpage = get_page_items(request, prefetch_for_findings(findings.qs), 25)
     sfpage = get_page_items(request, stub_findings, 25)
     show_re_upload = any(test.test_type.name in code for code in ImportScanForm.SCAN_TYPE_CHOICES)
 
@@ -133,6 +134,17 @@ def view_test(request, tid):
                    'show_export': google_sheets_enabled,
                    'sheet_url': sheet_url
                    })
+
+
+def prefetch_for_findings(findings):
+    prefetched_findings = findings
+    if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_findings = prefetched_findings.select_related('reporter')
+        prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
+        # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
+        prefetched_findings = prefetched_findings.prefetch_related('notes')
+        prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
+    return prefetched_findings
 
 
 @user_passes_test(lambda u: u.is_staff)

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -143,6 +143,7 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
+        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
     return prefetched_findings
 

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -1,7 +1,7 @@
 from dojo.models import Product, Engagement, Test, Finding, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
-    Finding_Template
+    Finding_Template, App_Analysis
 
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
@@ -42,6 +42,11 @@ class BaseClass():
 
         @skipIfNotSubclass('ListModelMixin')
         def test_list(self):
+            
+            if hasattr(self.endpoint_model, 'tags') and self.payload:
+                # create a new instance first to make sure there's at least 1 instance with tags set by payload to trigger tag handling code
+                response = self.client.post(self.url, self.payload)
+
             response = self.client.get(self.url, format='json')
             self.assertEqual(200, response.status_code)
 
@@ -93,6 +98,7 @@ class EndpointTest(BaseClass.RESTEndpointTest):
             'query': 'test=true',
             'fragment': 'test-1',
             'product': 1,
+            "tags": ["mytag", "yourtag"]
         }
         self.update_fields = {'protocol': 'ftp'}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -263,7 +269,7 @@ class ProductTest(BaseClass.RESTEndpointTest):
             "prod_type": 1,
             "name": "Test Product",
             "description": "test product",
-            "tags": ["mytag"]
+            "tags": ["mytag", "yourtag"]
         }
         self.update_fields = {'prod_type': 2}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -335,6 +341,7 @@ class TestsTest(BaseClass.RESTEndpointTest):
             "target_end": "2017-01-12T00:00",
             "percent_complete": 0,
             "lead": 2,
+            "tags": []
         }
         self.update_fields = {'percent_complete': 100}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
@@ -482,6 +489,7 @@ class ImportScanTest(BaseClass.RESTEndpointTest):
             "file": open('tests/zap_sample.xml'),
             "engagement": 1,
             "lead": 2,
+            "tags": ["'ci/cd, api"]
         }
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -1,7 +1,7 @@
 from dojo.models import Product, Engagement, Test, Finding, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
-    Finding_Template, App_Analysis
+    Finding_Template
 
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
@@ -42,7 +42,7 @@ class BaseClass():
 
         @skipIfNotSubclass('ListModelMixin')
         def test_list(self):
-            
+
             if hasattr(self.endpoint_model, 'tags') and self.payload:
                 # create a new instance first to make sure there's at least 1 instance with tags set by payload to trigger tag handling code
                 response = self.client.post(self.url, self.payload)

--- a/dojo/unittests/test_taggit_tags.py
+++ b/dojo/unittests/test_taggit_tags.py
@@ -1,0 +1,67 @@
+from django.test import TestCase
+from dojo.models import Product, Engagement, Test, Finding, \
+    JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
+    User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
+    Finding_Template, App_Analysis
+
+from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
+    FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
+    JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
+    ScansViewSet, StubFindingsViewSet, TestsViewSet, \
+    ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
+    UsersViewSet, ImportScanView
+
+
+class TaggitTests(TestCase):
+    fixtures = ['dojo_testdata.json']
+
+    def setUp(self, *args, **kwargs):
+        pass
+
+    def test_tags_prefetching(self):
+        print('\nadding tags')
+        for product in Product.objects.all():
+            product.tags = self.add_tags(product.tags, ['product_' + str(product.id)])
+            product.save()
+            for eng in product.engagement_set.all():
+                eng.tags = self.add_tags(eng.tags, ['eng_' + str(eng.id), 'product_' + str(product.id)])
+                eng.save()
+                for test in eng.test_set.all():
+                    test.tags = self.add_tags(test.tags, ['test_' + str(test.id), 'eng_' + str(eng.id), 'product_' + str(product.id)])
+                    test.save()
+
+        # print('testing tags for correctness without prefetching')
+        self.check_tags(Product.objects.all())
+
+        # print('testing tags for correctness with prefetching')
+        self.check_tags(Product.objects.all().prefetch_related('tagged_items__tag'))
+
+        # print('testing tags for correctness with nested prefetching')
+        self.check_tags(Product.objects.all().prefetch_related('tagged_items__tag', 'engagement_set__tagged_items__tag'))
+
+
+    def add_tags(self, curr_tags, extra_tags):
+            print(curr_tags)
+            for tag in extra_tags:
+                curr_tags.append(tag)
+            return ", ".join(curr_tags)
+
+    def check_tags(self, queryset):
+        for product in queryset:
+            # print(product.name + ": " + str(product.tags))
+            self.assertEqual(len(product.tags), 1)
+            self.assertEqual(product.tags[0].name, 'product_' + str(product.id))
+            for eng in product.engagement_set.all():
+                # print("         :" + eng.name + ": " + str(eng.tags))
+                self.assertEqual(len(eng.tags), 2)
+                self.assertEqual('product_' + str(product.id) in [tag.name for tag in product.tags], True)
+                self.assertEqual('eng_' + str(eng.id) in [tag.name for tag in eng.tags], True)
+                self.assertEqual('eng_' + str(eng.id + 1) in [tag.name for tag in eng.tags], False)
+                for test in eng.test_set.all():
+                    # print("         :" + eng.name + ": " + test.test_type.name + ": " + str(test.tags))
+                    self.assertEqual(len(test.tags), 3)
+                    self.assertEqual('product_' + str(product.id) in [tag.name for tag in product.tags], True)
+                    self.assertEqual('eng_' + str(eng.id) in [tag.name for tag in eng.tags], True)
+                    self.assertEqual('eng_' + str(eng.id + 1) in [tag.name for tag in eng.tags], False)
+                    self.assertEqual('test_' + str(test.id) in [tag.name for tag in test.tags], True)
+                    self.assertEqual('test_' + str(test.id + 1) in [tag.name for tag in test.tags], False)

--- a/dojo/unittests/test_taggit_tags.py
+++ b/dojo/unittests/test_taggit_tags.py
@@ -1,15 +1,5 @@
 from django.test import TestCase
-from dojo.models import Product, Engagement, Test, Finding, \
-    JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
-    User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
-    Finding_Template, App_Analysis
-
-from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
-    FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
-    JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
-    ScansViewSet, StubFindingsViewSet, TestsViewSet, \
-    ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView
+from dojo.models import Product
 
 
 class TaggitTests(TestCase):
@@ -39,12 +29,10 @@ class TaggitTests(TestCase):
         # print('testing tags for correctness with nested prefetching')
         self.check_tags(Product.objects.all().prefetch_related('tagged_items__tag', 'engagement_set__tagged_items__tag'))
 
-
     def add_tags(self, curr_tags, extra_tags):
-            print(curr_tags)
-            for tag in extra_tags:
-                curr_tags.append(tag)
-            return ", ".join(curr_tags)
+        for tag in extra_tags:
+            curr_tags.append(tag)
+        return ", ".join(curr_tags)
 
     def check_tags(self, queryset):
         for product in queryset:

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -32,8 +32,9 @@ from dojo.models import Finding, Engagement, Finding_Template, Product, JIRA_PKe
     Language_Type, Languages, Rule
 from asteval import Interpreter
 from requests.auth import HTTPBasicAuth
-
 import logging
+
+
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ django-polymorphic==2.1.2
 django-rest-swagger==2.2.0
 django-slack==5.14.3
 django-tagging==0.5.0
-django-taggit-serializer==0.1.7
 git+https://github.com/DefectDojo/django-tastypie-swagger.git@c7c5629480dc20cadd3015490a01bd8e70393c36#egg=django-tastypie-swagger
 django-tastypie==0.14.2
 django-watson==1.5.3

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'Markdown==3.2.1',
         'pandas>=0.22.0',
         'django-dbbackup>=3.2.0',
-        'django-taggit-serializer==0.1.7',
         'whitenoise==4.1.4',
         'django-environ==0.4.5',
         'titlecase'


### PR DESCRIPTION
This solves part of #1812.

When Defect Dojo displays a list of findings / products / engagements it performs an additional query for each row in the table. This query retrieves the tags for 1 row at a time. So a list of 25 products results in 25 database queries. The active engagements page even has more queries, 25 for the products and then an additional one for each engagement. In my instance this resulted in 100+ only to retrieve tags. This PR resolves that in line with best practices around Django ORM. 

So we can keep using the current taggit library and we don't have to do a complex migration right-away.

Changes made:
- Add a `GenericRelation` from models that can be tagged. This is needed to be able to find tags with a model instance.
- Patch the `TagDescriptor` coming with `django.taggit` as the original one has hardcoded database queries bypassing ORM features such as prefetching
- Remove `taggit_serializer` module from `settings.dist.py`. This was no longer in use as the contents from that module have been copied into the DD codebase long ago.
- Added (basic) unit test to cover the prefetching logic
- Updating rexisting `test_rest_framework` unit test to make sure tagging logic is triggered when retrieving models.
- Prefetch tags for product list, engagement list, finding list, search results, view_product, view_eng_list and some small places mised in #1955 
- BUGFIX: Display tags in the correct column in engagement list.

