### PR TITLE
simplify and speedup integration tests

### DIFF
--- a/tests/Endpoint_unit_test.py
+++ b/tests/Endpoint_unit_test.py
@@ -1,58 +1,12 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 import unittest
 import re
 import sys
-import os
+from base_test_class import BaseTestCase
+from Product_unit_test import ProductTest
 
 
-# first thing first. We have to create product, just to make sure there is atleast 1 product available
-# to assign endpoints to when creating or editing any.
-# importing Product_unit_test as a module
-# set relative path
-dir_path = os.path.dirname(os.path.realpath(__file__))
-try:  # First Try for python 3
-    import importlib.util
-    product_unit_test_module = importlib.util.spec_from_file_location("Product_unit_test",
-        os.path.join(dir_path, 'Product_unit_test.py'))  # using ',' allows python to determine the type of separator to use.
-    product_unit_test = importlib.util.module_from_spec(product_unit_test_module)
-    product_unit_test_module.loader.exec_module(product_unit_test)
-except:  # This will work for python2 if above fails
-    import imp
-    product_unit_test = imp.load_source('Product_unit_test',
-        os.path.join(dir_path, 'Product_unit_test.py'))
-
-
-class EndpointTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        # Make a member reference to the driver
-        driver = self.driver
-        # Navigate to the login page
-        driver.get(self.base_url + "login")
-        # Good practice to clear the entry before typing
-        driver.find_element_by_id("id_username").clear()
-        # These credentials will be used by Travis when testing new PRs
-        # They will not work when testing on your own build
-        # Be sure to change them before submitting a PR
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        # "Click" the but the login button
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class EndpointTest(BaseTestCase):
 
     def test_create_endpoint(self):
         # Login to the site.
@@ -122,24 +76,21 @@ class EndpointTest(unittest.TestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Endpoint and relationships removed.', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
     # Add each test the the suite to be run
     # success and failure is output by the test
-    suite.addTest(product_unit_test.ProductTest('test_create_product'))
+    suite.addTest(ProductTest('test_create_product'))
     suite.addTest(EndpointTest('test_create_endpoint'))
     suite.addTest(EndpointTest('test_edit_endpoint'))
     suite.addTest(EndpointTest('test_delete_endpoint'))
-    suite.addTest(product_unit_test.ProductTest('test_delete_product'))
+    suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Engagement_unit_test.py
+++ b/tests/Engagement_unit_test.py
@@ -1,47 +1,12 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 import unittest
 import re
 import sys
-import os
+from base_test_class import BaseTestCase
+from Product_unit_test import ProductTest
 
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-try:  # First Try for python 3
-    import importlib.util
-    product_unit_test_module = importlib.util.spec_from_file_location("Product_unit_test",
-        os.path.join(dir_path, 'Product_unit_test.py'))  # using ',' allows python to determine the type of separator to use.
-    product_unit_test = importlib.util.module_from_spec(product_unit_test_module)
-    product_unit_test_module.loader.exec_module(product_unit_test)
-except:  # This will work for python2 if above fails
-    import imp
-    product_unit_test = imp.load_source('Product_unit_test',
-        os.path.join(dir_path, 'Product_unit_test.py'))
-
-
-class EngagementTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        driver.find_element_by_id("id_username").clear()
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class EngagementTest(BaseTestCase):
 
     def test_add_new_engagement(self):
         driver = self.login_page()
@@ -108,24 +73,21 @@ class EngagementTest(unittest.TestCase):
         EngagementTXT = driver.find_element_by_tag_name("BODY").text
         self.assertTrue(re.search(r'Engagement added successfully.', EngagementTXT))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(product_unit_test.ProductTest('test_create_product'))
+    suite.addTest(ProductTest('test_create_product'))
     suite.addTest(EngagementTest('test_add_new_engagement'))
     suite.addTest(EngagementTest('test_edit_created_new_engagement'))
     suite.addTest(EngagementTest('test_close_new_engagement'))
     suite.addTest(EngagementTest('test_delete_new_closed_engagement'))
     suite.addTest(EngagementTest('test_new_ci_cd_engagement'))
-    suite.addTest(product_unit_test.ProductTest('test_delete_product'))
+    suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Environment_unit_test.py
+++ b/tests/Environment_unit_test.py
@@ -1,24 +1,11 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 import unittest
 import re
 import sys
 import os
+from base_test_class import BaseTestCase
 
 
-class EnvironmentTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
+class EnvironmentTest(BaseTestCase):
 
     def login_page(self):
         driver = self.driver
@@ -59,10 +46,6 @@ class EnvironmentTest(unittest.TestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         self.assertTrue(re.search(r'Environment deleted successfully.', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
@@ -73,6 +56,7 @@ def suite():
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -1,38 +1,16 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.keys import Keys
 import unittest
 import re
 import sys
 import os
+from base_test_class import BaseTestCase
+from Product_unit_test import ProductTest, WaitForPageLoad
 
-# importing Product_unit_test as a module
-# set relative path
 dir_path = os.path.dirname(os.path.realpath(__file__))
-try:  # First Try for python 3
-    import importlib.util
-    product_unit_test_module = importlib.util.spec_from_file_location("Product_unit_test",
-        os.path.join(dir_path, 'Product_unit_test.py'))  # using ',' allows python to determine the type of separator to use.
-    product_unit_test = importlib.util.module_from_spec(product_unit_test_module)
-    product_unit_test_module.loader.exec_module(product_unit_test)
-except:  # This will work for python2 if above fails
-    import imp
-    product_unit_test = imp.load_source('Product_unit_test',
-        os.path.join(dir_path, 'Product_unit_test.py'))
 
 
-class FindingTest(unittest.TestCase):
-    def setUp(self):
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
+class FindingTest(BaseTestCase):
 
     def login_page(self):
         # Make a member reference to the driver
@@ -95,7 +73,7 @@ class FindingTest(unittest.TestCase):
         image_path = os.path.join(dir_path, 'finding_image.png')
         driver.find_element_by_id("id_form-0-image").send_keys(image_path)
         # Save uploaded image
-        with product_unit_test.WaitForPageLoad(driver, timeout=50):
+        with WaitForPageLoad(driver, timeout=50):
             driver.find_element_by_css_selector("button.btn.btn-success").click()
         # Query the site to determine if the finding has been added
         productTxt = driver.find_element_by_tag_name("BODY").text
@@ -260,7 +238,7 @@ class FindingTest(unittest.TestCase):
         file_path = os.path.join(dir_path, 'zap_sample.xml')
         driver.find_element_by_name("file").send_keys(file_path)
         # Click Submit button
-        with product_unit_test.WaitForPageLoad(driver, timeout=50):
+        with WaitForPageLoad(driver, timeout=50):
             driver.find_elements_by_css_selector("button.btn.btn-primary")[1].click()
         # Query the site to determine if the finding has been added
         productTxt = driver.find_element_by_tag_name("BODY").text
@@ -289,17 +267,13 @@ class FindingTest(unittest.TestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Finding deleted successfully', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
     # Add each test the the suite to be run
     # success and failure is output by the test
-    suite.addTest(product_unit_test.ProductTest('test_create_product'))
-    suite.addTest(product_unit_test.ProductTest('test_add_product_finding'))
+    suite.addTest(ProductTest('test_create_product'))
+    suite.addTest(ProductTest('test_add_product_finding'))
     suite.addTest(FindingTest('test_edit_finding'))
     suite.addTest(FindingTest('test_add_image'))
     suite.addTest(FindingTest('test_mark_finding_for_review'))
@@ -311,11 +285,12 @@ def suite():
     suite.addTest(FindingTest('test_delete_image'))
     suite.addTest(FindingTest('test_delete_finding'))
     suite.addTest(FindingTest('test_delete_finding_template'))
-    suite.addTest(product_unit_test.ProductTest('test_delete_product'))
+    suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Import_scanner_unit_test.py
+++ b/tests/Import_scanner_unit_test.py
@@ -1,5 +1,3 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 import unittest
 import re
@@ -7,36 +5,13 @@ import sys
 import os
 import git
 import shutil
-
-# first thing first. We have to create product, just to make sure there is atleast 1 product available
-# to assign endpoints to when creating or editing any.
-# importing Product_unit_test as a module
-# set relative path
-dir_path = os.path.dirname(os.path.realpath(__file__))
-try:  # First Try for python 3
-    import importlib.util
-    product_unit_test_module = importlib.util.spec_from_file_location("Product_unit_test",
-        os.path.join(dir_path, 'Product_unit_test.py'))  # using ',' allows python to determine the type of separator to use.
-    product_unit_test = importlib.util.module_from_spec(product_unit_test_module)
-    product_unit_test_module.loader.exec_module(product_unit_test)
-except:  # This will work for python2 if above fails
-    import imp
-    product_unit_test = imp.load_source('Product_unit_test',
-        os.path.join(dir_path, 'Product_unit_test.py'))
+from base_test_class import BaseTestCase
+from Product_unit_test import ProductTest
 
 
-class ScannerTest(unittest.TestCase):
+class ScannerTest(BaseTestCase):
     def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
+        super().setUp(self)
         self.repo_path = dir_path + '/scans'
         if os.path.isdir(self.repo_path):
             shutil.rmtree(self.repo_path)
@@ -49,16 +24,6 @@ class ScannerTest(unittest.TestCase):
         tests = sorted(os.listdir(self.repo_path))
         self.tools = [i for i in tools if i not in self.remove_items]
         self.tests = [i for i in tests if i not in self.remove_items]
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        driver.find_element_by_id("id_username").clear()
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
 
     def test_check_test_file(self):
         missing_tests = ['MISSING TEST FOLDER']
@@ -317,8 +282,7 @@ class ScannerTest(unittest.TestCase):
         assert len(failed_tests) == 0
 
     def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
+        super().tearDown(self)
         shutil.rmtree(self.repo_path)
 
 
@@ -329,13 +293,14 @@ def suite():
     suite.addTest(ScannerTest('test_check_for_fixtures'))
     suite.addTest(ScannerTest('test_check_for_forms'))
     suite.addTest(ScannerTest('test_check_for_options'))
-    suite.addTest(product_unit_test.ProductTest('test_create_product'))
+    suite.addTest(ProductTest('test_create_product'))
     suite.addTest(ScannerTest('test_engagement_import_scan_result'))
-    suite.addTest(product_unit_test.ProductTest('test_delete_product'))
+    suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Note_type_unit_test.py
+++ b/tests/Note_type_unit_test.py
@@ -1,34 +1,10 @@
-from selenium import webdriver
 import unittest
 import re
 import sys
-import os
+from base_test_class import BaseTestCase
 
 
-class NoteTypeTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_experimental_option("detach", True)
-
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        driver.find_element_by_id("id_username").clear()
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class NoteTypeTest(BaseTestCase):
 
     def test_create_note_type(self):
         driver = self.login_page()
@@ -70,10 +46,6 @@ class NoteTypeTest(unittest.TestCase):
         NoteTypeTxt = driver.find_element_by_tag_name("BODY").text
         self.assertTrue(re.search(r'Note type Enabled successfully.', NoteTypeTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
@@ -85,6 +57,7 @@ def suite():
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Product_type_unit_test.py
+++ b/tests/Product_type_unit_test.py
@@ -1,35 +1,10 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 import unittest
 import re
 import sys
-import os
+from base_test_class import BaseTestCase
 
 
-class ProductTypeTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_experimental_option("detach", True)
-
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        driver.find_element_by_id("id_username").clear()
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class ProductTypeTest(BaseTestCase):
 
     def test_create_product_type(self):
         print("\n\nDebug Print Log: testing 'create product type' \n")
@@ -65,10 +40,6 @@ class ProductTypeTest(unittest.TestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         self.assertTrue(re.search(r'Product type Deleted successfully.', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
@@ -79,6 +50,7 @@ def suite():
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Product_unit_test.py
+++ b/tests/Product_unit_test.py
@@ -1,12 +1,10 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.keys import Keys
 import unittest
 import re
 import sys
-import os
 import time
+from base_test_class import BaseTestCase
 
 
 class WaitForPageLoad(object):
@@ -32,38 +30,15 @@ class WaitForPageLoad(object):
         )
 
 
-class ProductTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_experimental_option("detach", True)
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        # Make a member reference to the driver
-        driver = self.driver
-        # Navigate to the login page
-        driver.get(self.base_url + "login")
-        # Good practice to clear the entry before typing
-        driver.find_element_by_id("id_username").clear()
-        # Set the user to an admin account
-        # os.environ['DD_ADMIN_USER']
-        driver.find_element_by_id("id_username").clear()
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        # "Click" the but the login button
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class ProductTest(BaseTestCase):
 
     def test_create_product(self):
+        # try:
+        #     # sometimes the product is left behind from previous test run
+        #     self.test_delete_product()
+        # except:
+        #     print('failed to delete possible existing product, assuming it was already gone')
+
         # Login to the site. Password will have to be modified
         # to match an admin password in your own container
         driver = self.login_page()
@@ -338,10 +313,6 @@ class ProductTest(unittest.TestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Product and relationships removed.', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
@@ -361,6 +332,7 @@ def suite():
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/Test_unit_test.py
+++ b/tests/Test_unit_test.py
@@ -1,58 +1,12 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 import unittest
 import re
 import sys
-import os
+from base_test_class import BaseTestCase
+from Product_unit_test import ProductTest
 
 
-# first thing first. We have to create product, just to make sure there is atleast 1 product available
-# to assign endpoints to when creating or editing any.
-# importing Product_unit_test as a module
-# set relative path
-dir_path = os.path.dirname(os.path.realpath(__file__))
-try:  # First Try for python 3
-    import importlib.util
-    product_unit_test_module = importlib.util.spec_from_file_location("Product_unit_test",
-        os.path.join(dir_path, 'Product_unit_test.py'))  # using ',' allows python to determine the type of separator to use.
-    product_unit_test = importlib.util.module_from_spec(product_unit_test_module)
-    product_unit_test_module.loader.exec_module(product_unit_test)
-except:  # This will work for python2 if above fails
-    import imp
-    product_unit_test = imp.load_source('Product_unit_test',
-        os.path.join(dir_path, 'Product_unit_test.py'))
-
-
-class TestUnitTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        # Make a member reference to the driver
-        driver = self.driver
-        # Navigate to the login page
-        driver.get(self.base_url + "login")
-        # Good practice to clear the entry before typing
-        driver.find_element_by_id("id_username").clear()
-        # These credentials will be used by Travis when testing new PRs
-        # They will not work when testing on your own build
-        # Be sure to change them before submitting a PR
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        # "Click" the but the login button
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class TestUnitTest(BaseTestCase):
 
     def test_create_test(self):
         # To create test for a product
@@ -167,25 +121,22 @@ class TestUnitTest(unittest.TestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Test and relationships removed.', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
     # Add each test the the suite to be run
     # success and failure is output by the test
-    suite.addTest(product_unit_test.ProductTest('test_create_product'))
+    suite.addTest(ProductTest('test_create_product'))
     suite.addTest(TestUnitTest('test_create_test'))
     suite.addTest(TestUnitTest('test_edit_test'))
     # suite.addTest(TestUnitTest('test_add_note'))
     # suite.addTest(TestUnitTest('test_delete_test'))
-    suite.addTest(product_unit_test.ProductTest('test_delete_product'))
+    suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/User_unit_test.py
+++ b/tests/User_unit_test.py
@@ -1,41 +1,11 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 # from selenium.webdriver.support.ui import Select
 import unittest
 import re
 import sys
-import os
+from base_test_class import BaseTestCase
 
 
-class UserTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        # Make a member reference to the driver
-        driver = self.driver
-        # Navigate to the login page
-        driver.get(self.base_url + "login")
-        # Good practice to clear the entry before typing
-        driver.find_element_by_id("id_username").clear()
-        # These credentials will be used by Travis when testing new PRs
-        # They will not work when testing on your own build
-        # Be sure to change them before submitting a PR
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        # "Click" the but the login button
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class UserTest(BaseTestCase):
 
     def test_create_user(self):
         # Login to the site.
@@ -125,10 +95,6 @@ class UserTest(unittest.TestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'User and relationships removed.', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
@@ -141,6 +107,7 @@ def suite():
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -1,0 +1,98 @@
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+import unittest
+import os
+
+dd_driver = None
+dd_driver_options = None
+
+
+class BaseTestCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        global dd_driver
+        if not dd_driver:
+            # setupModule and tearDownModule are not working in our scenario, so for now we use setupClass and a global variable
+            # global variables are dirty, but in unit tests scenario's like these they are acceptable
+            print('launching browser for: ', cls.__name__)
+            global dd_driver_options
+            dd_driver_options = Options()
+
+            # headless means no UI, if you want to see what is happening remove headless. Adding detach will leave the window open after the test
+            dd_driver_options.add_argument("--headless")
+            # dd_driver_options.add_experimental_option("detach", True)
+
+            # the next 2 maybe needed in some scenario's for example on WSL or other headless situations
+            # dd_driver_options.add_argument("--no-sandbox")
+            # dd_driver_options.add_argument("--disable-dev-shm-usage")
+
+            # start maximized or at least with sufficient with because datatables will hide certain controls when the screen is too narrow
+            dd_driver_options.add_argument("--window-size=1280,768")
+            # dd_driver_options.add_argument("--start-maximized")
+
+            # some extra logging can be turned on if you want to query the browser javascripe console in your tests
+            # desired = webdriver.DesiredCapabilities.CHROME
+            # desired['loggingPrefs'] = {'browser': 'ALL'}
+
+            # change path of chromedriver according to which directory you have chromedriver.
+            dd_driver = webdriver.Chrome('chromedriver', chrome_options=dd_driver_options)
+            dd_driver.implicitly_wait(30)
+
+        cls.driver = dd_driver
+
+        # print('launching browser for: ', cls.__name__)
+        # # change path of chromedriver according to which directory you have chromedriver.
+        # cls.options = Options()
+        # cls.options.add_argument("--headless")
+        # # cls.options.add_experimental_option("detach", True)
+        # # cls.options.add_argument("--no-sandbox")
+        # # cls.options.add_argument("--disable-dev-shm-usage")
+        # cls.driver = webdriver.Chrome('chromedriver', chrome_options=cls.options)
+        # cls.driver.implicitly_wait(30)
+        cls.base_url = os.environ['DD_BASE_URL']
+
+    def setUp(self):
+        self.verificationErrors = []
+        self.accept_next_alert = True
+        # clear browser console logs?
+
+    def login_page(self):
+        driver = self.driver
+        driver.get(self.base_url + "login")
+        driver.find_element_by_id("id_username").clear()
+        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
+        driver.find_element_by_id("id_password").clear()
+        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
+        driver.find_element_by_css_selector("button.btn.btn-success").click()
+        return driver
+
+    def is_alert_present(self):
+        try:
+            self.driver.switch_to_alert()
+        except NoAlertPresentException as e:
+            return False
+        return True
+
+    def close_alert_and_get_its_text(self):
+        try:
+            alert = self.driver.switch_to_alert()
+            alert_text = alert.text
+            if self.accept_next_alert:
+                alert.accept()
+            else:
+                alert.dismiss()
+            return alert_text
+        finally:
+            self.accept_next_alert = True
+
+    def tearDown(self):
+        self.assertEqual([], self.verificationErrors)
+
+    @classmethod
+    def tearDownDriver(cls):
+        print('tearDownDriver: ', cls.__name__)
+        global dd_driver
+        if dd_driver:
+            if not dd_driver_options.experimental_options or not dd_driver_options.experimental_options['detach']:
+                print('closing browser')
+                dd_driver.quit()

--- a/tests/check_status.py
+++ b/tests/check_status.py
@@ -5,36 +5,10 @@ import time
 import unittest
 import sys
 import requests
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.common.exceptions import NoAlertPresentException
-from selenium.common.exceptions import NoSuchElementException
+from base_test_class import BaseTestCase
 
 
-class Login(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        cred_user_elem = driver.find_element_by_id("id_username")
-        cred_user_elem.clear()
-        cred_user_elem.send_keys(os.environ['DD_ADMIN_USER'])
-        cred_pass_elem = driver.find_element_by_id("id_password")
-        cred_pass_elem.clear()
-        cred_pass_elem.send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class Login(BaseTestCase):
 
     def get_api_key(self):
         driver = self.login_page()
@@ -82,36 +56,6 @@ class Login(unittest.TestCase):
         r = requests.get(api_url, headers=headers, verify=False)
         self.assertEqual(r.status_code, 200)
 
-    def is_element_present(self, how, what):
-        try:
-            self.driver.find_element(by=how, value=what)
-        except NoSuchElementException as e:
-            return False
-        return True
-
-    def is_alert_present(self):
-        try:
-            self.driver.switch_to_alert()
-        except NoAlertPresentException as e:
-            return False
-        return True
-
-    def close_alert_and_get_its_text(self):
-        try:
-            alert = self.driver.switch_to_alert()
-            alert_text = alert.text
-            if self.accept_next_alert:
-                alert.accept()
-            else:
-                alert.dismiss()
-            return alert_text
-        finally:
-            self.accept_next_alert = True
-
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
@@ -121,6 +65,7 @@ def suite():
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/check_status_ui.py
+++ b/tests/check_status_ui.py
@@ -1,35 +1,9 @@
 # -*- coding: utf-8 -*-
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.common.exceptions import NoSuchElementException
-from selenium.common.exceptions import NoAlertPresentException
-import unittest
-import os
 import requests
+from base_test_class import BaseTestCase
 
 
-class Login(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        driver.find_element_by_id("id_username").clear()
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
-
+class Login(BaseTestCase):
     def test_engagement_status(self):
         driver = self.login_page()
         cookies = driver.get_cookies()
@@ -150,36 +124,9 @@ class Login(unittest.TestCase):
         r = s.get(url)
         self.assertEqual(r.status_code, 200)
 
-    def is_element_present(self, how, what):
-        try:
-            self.driver.find_element(by=how, value=what)
-        except NoSuchElementException as e:
-            return False
-        return True
-
-    def is_alert_present(self):
-        try:
-            self.driver.switch_to_alert()
-        except NoAlertPresentException as e:
-            return False
-        return True
-
-    def close_alert_and_get_its_text(self):
-        try:
-            alert = self.driver.switch_to_alert()
-            alert_text = alert.text
-            if self.accept_next_alert:
-                alert.accept()
-            else:
-                alert.dismiss()
-            return alert_text
-        finally:
-            self.accept_next_alert = True
-
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 if __name__ == "__main__":
-    unittest.main()
+    try:
+        unittest.main(verbosity=2)
+    finally:
+        BaseTestCase.tearDownDriver()

--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -1,5 +1,3 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -8,51 +6,19 @@ import unittest
 import re
 import sys
 import os
+from base_test_class import BaseTestCase
+from Product_unit_test import ProductTest
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-try:  # First Try for python 3
-    import importlib.util
-    product_unit_test_module = importlib.util.spec_from_file_location("Product_unit_test",
-        os.path.join(dir_path, 'Product_unit_test.py'))  # using ',' allows python to determine the type of separator to use.
-    product_unit_test = importlib.util.module_from_spec(product_unit_test_module)
-    product_unit_test_module.loader.exec_module(product_unit_test)
-except:  # This will work for python2 if above fails
-    import imp
-    product_unit_test = imp.load_source('Product_unit_test',
-        os.path.join(dir_path, 'Product_unit_test.py'))
 
 
-class DedupeTest(unittest.TestCase):
+class DedupeTest(BaseTestCase):
     # --------------------------------------------------------------------------------------------------------
     # Initialization
     # --------------------------------------------------------------------------------------------------------
     def setUp(self):
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_experimental_option("detach", True)
-        self.options.add_argument("--window-size=1280,768")
-        # self.options.add_argument("--no-sandbox")
-
-        desired = webdriver.DesiredCapabilities.CHROME
-        desired['loggingPrefs'] = {'browser': 'ALL'}
-
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options, desired_capabilities=desired)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
+        super().setUp()
         self.relative_path = dir_path = os.path.dirname(os.path.realpath(__file__))
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        driver.find_element_by_id("id_username").clear()
-        # os.environ['DD_ADMIN_USER']
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
 
     def check_nb_duplicates(self, expected_number_of_duplicates):
         print("checking duplicates...")
@@ -411,14 +377,10 @@ class DedupeTest(unittest.TestCase):
     def test_check_cross_status(self):
         self.check_nb_duplicates(1)
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(product_unit_test.ProductTest('test_create_product'))
+    suite.addTest(ProductTest('test_create_product'))
     suite.addTest(DedupeTest('test_enable_deduplication'))
     # Test same scanners - same engagement - static - dedupe
     suite.addTest(DedupeTest('test_delete_findings'))
@@ -446,11 +408,12 @@ def suite():
     suite.addTest(DedupeTest('test_import_cross_test'))
     suite.addTest(DedupeTest('test_check_cross_status'))
     # Clean up
-    suite.addTest(product_unit_test.ProductTest('test_delete_product'))
+    suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/ibm_appscan_test.py
+++ b/tests/ibm_appscan_test.py
@@ -1,57 +1,16 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 import unittest
 import re
 import sys
 import os
+from base_test_class import BaseTestCase
+from Product_unit_test import ProductTest
 
-# importing Product_unit_test as a module
-# set relative path
+
 dir_path = os.path.dirname(os.path.realpath(__file__))
-try:  # First Try for python 3
-    import importlib.util
-
-    product_unit_test_module = importlib.util.spec_from_file_location("Product_unit_test",
-                                                                      os.path.join(dir_path,
-                                                                                   'Product_unit_test.py'))  # using ',' allows python to determine the type of separator to use.
-    product_unit_test = importlib.util.module_from_spec(product_unit_test_module)
-    product_unit_test_module.loader.exec_module(product_unit_test)
-except:  # This will work for python2 if above fails
-    import imp
-    product_unit_test = imp.load_source('Product_unit_test',
-                                        os.path.join(dir_path, 'Product_unit_test.py'))
 
 
-class IBMAppScanTest(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        # Make a member reference to the driver
-        driver = self.driver
-        # Navigate to the login page
-        driver.get(self.base_url + "login")
-        # Good practice to clear the entry before typing
-        driver.find_element_by_id("id_username").clear()
-        # These credentials will be used by Travis when testing new PRs
-        # They will not work when testing on your own build
-        # Be sure to change them before submitting a PR
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        # "Click" the but the login button
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class IBMAppScanTest(BaseTestCase):
 
     def test_import_ibm_app_scan_result(self):
         # Login to the site.
@@ -76,22 +35,19 @@ class IBMAppScanTest(unittest.TestCase):
         # Assert the query to determine status or failure
         self.assertTrue(re.search(r'IBM AppScan DAST processed, a total of 27 findings were processed', productTxt))
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
     # Add each test the the suite to be run
     # success and failure is output by the test
-    suite.addTest(product_unit_test.ProductTest('test_create_product'))
+    suite.addTest(ProductTest('test_create_product'))
     suite.addTest(IBMAppScanTest('test_import_ibm_app_scan_result'))
-    suite.addTest(product_unit_test.ProductTest('test_delete_product'))
+    suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)

--- a/tests/local-integration-tests.bat
+++ b/tests/local-integration-tests.bat
@@ -1,0 +1,79 @@
+set DD_ADMIN_USER=admin
+set DD_ADMIN_PASSWORD=admin
+set DD_BASE_URL=http://localhost:8080/
+
+echo "Running Product type integration tests"
+python tests/Product_type_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Product integration tests"
+python tests/Product_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Endpoint integration tests"
+python tests/Endpoint_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Engagement integration tests"
+python tests/Engagement_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Environment integration tests"
+python tests/Environment_unit_test.py 
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Finding integration tests"
+python tests/Finding_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Test integration tests"
+python tests/Test_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running User integration tests"
+python tests/User_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Ibm Appscan integration test"
+python tests/ibm_appscan_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Smoke integration test"
+python tests/smoke_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Check Status test"
+python tests/check_status.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+echo "Running Dedupe integration tests"
+python tests/dedupe_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
+REM  The below tests are commented out because they are still an unstable work in progress
+REM Once Ready they can be uncommented.
+
+REM REM echo "Running Import Scanner integration test"
+REM REM python tests/Import_scanner_unit_test.py
+REM REM     echo "Success: Import Scanner integration tests passed" 
+REM REM else
+REM REM     echo "Error: Import Scanner integration test failed"; exit 1
+REM REM fi
+
+REM REM echo "Running Check Status UI integration test"
+REM REM python tests/check_status_ui.py
+REM REM     echo "Success: Check Status UI tests passed"
+REM REM else
+REM REM     echo "Error: Check Status UI test failed"; exit 1
+REM REM fi
+
+REM REM echo "Running Zap integration test"
+REM REM python tests/zap.py
+REM REM     echo "Success: zap integration tests passed"
+REM REM else
+REM REM     echo "Error: Zap integration test failed"; exit 1
+REM REM fi
+
+echo "Done Running all configured integration tests."
+
+:END

--- a/tests/local-integration-tests.sh
+++ b/tests/local-integration-tests.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+export DD_BASE_URL='http://localhost:8080/'
+
+# All available Unittest Scripts are activated below
+# If successful, A success message is printed and the script continues
+# If any script is unsuccessful a failure message is printed and the test script
+# Exits with status code of 1
+
+echo "Running Product type integration tests"
+if python3 tests/Product_type_unit_test.py ; then
+    echo "Success: Product type integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Product type integration test failed."; exit 1
+fi
+
+echo "Running Product integration tests"
+if python3 tests/Product_unit_test.py ; then 
+    echo "Success: Product integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Product integration test failed"; exit 1
+fi
+
+echo "Running Endpoint integration tests"
+if python3 tests/Endpoint_unit_test.py ; then
+    echo "Success: Endpoint integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Endpoint integration test failed"; exit 1
+fi
+
+echo "Running Engagement integration tests"
+if python3 tests/Engagement_unit_test.py ; then
+    echo "Success: Engagement integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Engagement integration test failed"; exit 1
+fi
+
+echo "Running Environment integration tests"
+if python3 tests/Environment_unit_test.py ; then 
+    echo "Success: Environment integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Environment integration test failed"; exit 1
+fi
+
+echo "Running Finding integration tests"
+if python3 tests/Finding_unit_test.py ; then
+    echo "Success: Finding integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Finding integration test failed"; exit 1
+fi
+
+echo "Running Test integration tests"
+if python3 tests/Test_unit_test.py ; then
+    echo "Success: Test integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Test integration test failed"; exit 1
+fi
+
+echo "Running User integration tests"
+if python3 tests/User_unit_test.py ; then
+    echo "Success: User integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: User integration test failed"; exit 1
+fi
+
+echo "Running Ibm Appscan integration test"
+if python3 tests/ibm_appscan_test.py ; then
+    echo "Success: Ibm AppScan integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Ibm AppScan integration test failed"; exit 1
+fi
+
+echo "Running Smoke integration test"
+if python3 tests/smoke_test.py ; then
+    echo "Success: Smoke integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Smoke integration test failed"; exit 1
+fi
+
+echo "Running Check Status test"
+if python3 tests/check_status.py ; then
+    echo "Success: check status tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Check status tests failed"; exit 1
+fi
+
+echo "Running Dedupe integration tests"
+if python3 tests/dedupe_unit_test.py ; then
+    echo "Success: Dedupe integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Dedupe integration test failed"; exit 1
+fi
+
+# The below tests are commented out because they are still an unstable work in progress
+## Once Ready they can be uncommented.
+
+# echo "Running Import Scanner integration test"
+# if python3 tests/Import_scanner_unit_test.py ; then
+#     echo "Success: Import Scanner integration tests passed" 
+# else
+#     echo "Error: Import Scanner integration test failed"; exit 1
+# fi
+
+# echo "Running Check Status UI integration test"
+# if python3 tests/check_status_ui.py ; then
+#     echo "Success: Check Status UI tests passed"
+# else
+#     echo "Error: Check Status UI test failed"; exit 1
+# fi
+
+# echo "Running Zap integration test"
+# if python3 tests/zap.py ; then
+#     echo "Success: zap integration tests passed"
+# else
+#     echo "Error: Zap integration test failed"; exit 1
+# fi
+
+exec echo "Done Running all configured integration tests."

--- a/tests/local-unit-tests.sh
+++ b/tests/local-unit-tests.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./manage.py test dojo.unittests --noinput --failfast --debug-mode -v 2 --keepdb
+

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -1,36 +1,13 @@
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import Select
 from selenium.common.exceptions import NoSuchElementException
 from selenium.common.exceptions import NoAlertPresentException
 import unittest
 import re
-import os
 import sys
+from base_test_class import BaseTestCase
 
 
-class DojoTests(unittest.TestCase):
-    def setUp(self):
-        # change path of chromedriver according to which directory you have chromedriver.
-        self.options = Options()
-        self.options.add_argument("--headless")
-        # self.options.add_argument("--no-sandbox")
-        # self.options.add_argument("--disable-dev-shm-usage")
-        self.driver = webdriver.Chrome('chromedriver', chrome_options=self.options)
-        self.driver.implicitly_wait(30)
-        self.base_url = os.environ['DD_BASE_URL']
-        self.verificationErrors = []
-        self.accept_next_alert = True
-
-    def login_page(self):
-        driver = self.driver
-        driver.get(self.base_url + "login")
-        driver.find_element_by_id("id_username").clear()
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
+class DojoTests(BaseTestCase):
 
     def test_login(self):
         driver = self.login_page()
@@ -121,10 +98,6 @@ class DojoTests(unittest.TestCase):
         finally:
             self.accept_next_alert = True
 
-    def tearDown(self):
-        self.driver.quit()
-        self.assertEqual([], self.verificationErrors)
-
 
 def suite():
     suite = unittest.TestSuite()
@@ -133,6 +106,7 @@ def suite():
 
 
 if __name__ == "__main__":
-    runner = unittest.TextTestRunner(descriptions=True, failfast=True)
+    runner = unittest.TextTestRunner(descriptions=True, failfast=True, verbosity=2)
     ret = not runner.run(suite()).wasSuccessful()
+    BaseTestCase.tearDownDriver()
     sys.exit(ret)


### PR DESCRIPTION
During #2002 I ran into the fact that Integration tests are quite slow.
(and we also see this in Travis that sometimes the test gets killed because it takes too long)

This PR does *not* change the test coverage, it just improves the way they are structured and run:

- Extract duplicated (setUp) code into `BaseTestCase`
- Reuse browser session to save lots of time
- Import between testcases in a normale way
- Add some comments on how to initialize webdriver for local tests, visible browser window, etc
- Add some `local-xxxx` scripts to facilitate how to start the tests locally
- Set verbosity in testrunnen. (Let the integration tests log what they are doing as sometimes it's not clear in Travis which tests have been run / skipped / commented out)

This looks like a big PR, but that is only because so much duplicated code was removed / extracted.

In theory we could create 1 python script that runs all the TestSuites in one go and reuse the browser for all of them. But I didn't want to change too much in this PR.

