### PR TITLE
remove dependency pygments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,6 @@ pdfkit==0.6.1
 Pillow==7.0.0  # required by django-imagekit
 psycopg2-binary==2.8.4
 cryptography==2.8
-pygments==2.5.2
 python-dateutil==2.8.1
 python-nmap==0.6.1
 pytz==2019.3


### PR DESCRIPTION
Pygments is never used in the code. Related to https://github.com/DefectDojo/django-DefectDojo/pull/2004.

On behalf of DB Systel GmbH
