### PR TITLE
fix some queries so that open include active verified and not verified

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -85,7 +85,6 @@ def prefetch_for_product(prods):
         prefetched_prods = prefetched_prods.prefetch_related(Prefetch('jira_pkey_set', queryset=JIRA_PKey.objects.all().select_related('conf'), to_attr='jira_confs'))
         active_endpoint_query = Endpoint.objects.filter(
                 finding__active=True,
-                finding__verified=True,
                 finding__mitigated__isnull=True)
         prefetched_prods = prefetched_prods.prefetch_related(Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
 
@@ -207,6 +206,7 @@ def view_product_metrics(request, pid):
     verified_findings = Finding.objects.filter(test__engagement__product=prod,
                                                date__range=[start_date, end_date],
                                                false_p=False,
+                                               active=True,
                                                verified=True,
                                                duplicate=False,
                                                out_of_scope=False).order_by("date")
@@ -226,7 +226,6 @@ def view_product_metrics(request, pid):
                                            duplicate=False,
                                            out_of_scope=False,
                                            active=True,
-                                           verified=False,
                                            mitigated__isnull=True)
 
     inactive_findings = Finding.objects.filter(test__engagement__product=prod,
@@ -261,7 +260,6 @@ def view_product_metrics(request, pid):
     open_vulnerabilities = Finding.objects.filter(
         test__engagement__product=prod,
         false_p=False,
-        verified=False,
         duplicate=False,
         out_of_scope=False,
         active=True,
@@ -685,8 +683,7 @@ def all_product_findings(request, pid):
     result = ProductFindingFilter(
         request.GET,
         queryset=Finding.objects.filter(test__engagement__product=p,
-                                        active=True,
-                                        verified=True))
+                                        active=True))
     page = get_page_items(request, result.qs, 25)
 
     add_breadcrumb(title="Open findings", top_level=False, request=request)


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Should fix https://github.com/DefectDojo/django-DefectDojo/issues/2013, even though after re-reading it, I think this PR is going to mostly be some type of cleanup.

Finding open view

![image](https://user-images.githubusercontent.com/5468769/76319665-d476b580-62df-11ea-939e-ea7025d53384.png)

Product open finding view

![image](https://user-images.githubusercontent.com/5468769/76319731-ed7f6680-62df-11ea-8ee8-b92b327922ec.png)

Both queries go to https://github.com/DefectDojo/django-DefectDojo/blob/dev/dojo/finding/views.py#L467 per the urls.py.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
