### PR TITLE
Added unique_id_from_tool for "to mitigate" logic for Checkmarx

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -762,6 +762,13 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         severity=sev,
                         numerical_severity=Finding.get_numerical_severity(sev),
                         description=item.description).all()
+                elif scan_type == 'Checkmarx Scan detailed':
+                    findings = Finding.objects.filter(
+                        title=item.title,
+                        test=test,
+                        severity=sev,
+                        unique_id_from_tool=item.unique_id_from_tool,
+                        numerical_severity=Finding.get_numerical_severity(sev)).all()
                 else:
                     findings = Finding.objects.filter(
                         title=item.title,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -636,6 +636,13 @@ def re_import_scan_results(request, tid):
                                                       numerical_severity=Finding.get_numerical_severity(sev),
                                                       description=item.description
                                                       )
+                    elif scan_type == 'Checkmarx scan detailed':
+                        find = Finding.objects.filter(title=item.title,
+                                                      test__id=t.id,
+                                                      severity=sev,
+                                                      unique_id_from_tool=item.unique_id_from_tool,
+                                                      numerical_severity=Finding.get_numerical_severity(sev),
+                                                      )
                     else:
                         find = Finding.objects.filter(title=item.title,
                                                       test__id=t.id,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -636,7 +636,7 @@ def re_import_scan_results(request, tid):
                                                       numerical_severity=Finding.get_numerical_severity(sev),
                                                       description=item.description
                                                       )
-                    elif scan_type == 'Checkmarx scan detailed':
+                    elif scan_type == 'Checkmarx Scan detailed':
                         find = Finding.objects.filter(title=item.title,
                                                       test__id=t.id,
                                                       severity=sev,


### PR DESCRIPTION

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

To tag a finding as "Mitigated" for scan_type "Checkmarx Scan detailed" the current logic does not have "unique_id_from_tool" as a distinct identifier. Adding the unique_id_from_tool correctly identifies the previous mitigated finding during re-import of scan.