### PR TITLE
yamllint satisfaction

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,7 +15,7 @@ categories:
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    labels: 
+    labels:
       - 'dependencies'
       - 'maintenance'
   - title: '🚩 Requires settings change'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Despite web yaml validators saying it was valid, yamllint didn't... and it seems release-drafter is no longer working after the last mods.

So fixing a couple things that yamllint complained about:

```
$ yamllint .github/release-drafter.yml 
.github/release-drafter.yml
  1:1       warning  missing document start "---"  (document-start)
  17:12     error    trailing spaces  (trailing-spaces)
```

```
$ yamllint .github/workflows/release-drafter.yml 
.github/workflows/release-drafter.yml
  1:1       warning  missing document start "---"  (document-start)
  3:1       warning  truthy value should be one of [false, true]  (truthy)
  16:11     warning  comment not indented like content  (comments-indentation)
  16:81     error    line too long (101 > 80 characters)  (line-length)
```

This PR removes errors found by yamllint and eventually some warnings, and will hopefully make release-drafter work again.

To be noted that release-drafter is completely silent about errors...