### PR TITLE
only show dupes dropdown if there are dupes, fixes #2006

### DIFF
--- a/dojo/templates/dojo/edit_findings.html
+++ b/dojo/templates/dojo/edit_findings.html
@@ -145,6 +145,8 @@
             });
         });
 
+
+        {% if dupes %}
         window.onload = function() {
             var menu = document.getElementById("dupe_choice").parentElement.parentElement
             var dupe_box = document.getElementById("id_duplicate").parentElement.parentElement.parentElement.parentElement
@@ -156,7 +158,7 @@
                 menu.setAttribute("class", "form-group hidden");
             }
         };
-
+        
         $("#id_duplicate").change(function () {
             var menu = document.getElementById("dupe_choice").parentElement.parentElement
             var dupe_box = document.getElementById("id_duplicate").parentElement.parentElement.parentElement.parentElement
@@ -167,8 +169,9 @@
             else {
                 menu.setAttribute("class", "form-group hidden");
             }
-
+            
         });
+        {% endif %}
 
         $("#add_finding").submit(function () {
             var isFormValid = true;


### PR DESCRIPTION
fixes javascript error in #2006. the javascript is trying to manipulate elements that are not in the html if there are no dupes. this PR prevents that.