### PR TITLE
Integration test: Assert absence of javascript errors

### DIFF
--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -330,7 +330,7 @@
                     { "data": "contacts" },
                     { "data": "product_type" },
                 ],
-                order: [1, asc],
+                order: [1, "asc"],
                 "columnDefs": [
                     { "orderable": false, "targets": [0] }
                 ],

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -62,6 +62,7 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Images updated successfully', productTxt))
+        # TODO fix javascript error because images are not working inside docker/travis, accept for now: https://github.com/DefectDojo/django-DefectDojo/issues/2045
         self.accept_javascript_errors = True
 
     def test_mark_finding_for_review(self):
@@ -134,6 +135,7 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Images updated successfully', productTxt))
+        # TODO fix javascript error because images are not working inside docker/travis, accept for now: https://github.com/DefectDojo/django-DefectDojo/issues/2045
         self.accept_javascript_errors = True
 
     def test_close_finding(self):
@@ -191,6 +193,8 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'App Vulnerable to XSS', productTxt))
+        # TODO fix javascript error because images are not working inside docker/travis, accept for now: https://github.com/DefectDojo/django-DefectDojo/issues/2045
+        self.accept_javascript_errors = True
 
     def test_delete_finding_template(self):
         driver = self.login_page()

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -62,6 +62,7 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Images updated successfully', productTxt))
+        self.accept_javascript_errors = True
 
     def test_mark_finding_for_review(self):
         # login to site, password set to fetch from environ
@@ -133,6 +134,7 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Images updated successfully', productTxt))
+        self.accept_javascript_errors = True
 
     def test_close_finding(self):
         driver = self.login_page()
@@ -260,13 +262,13 @@ def suite():
     suite.addTest(FindingTest('test_list_finding'))
     suite.addTest(FindingTest('test_edit_finding'))
     suite.addTest(FindingTest('test_add_image'))
+    suite.addTest(FindingTest('test_delete_image'))
     suite.addTest(FindingTest('test_mark_finding_for_review'))
     suite.addTest(FindingTest('test_clear_review_from_finding'))
     suite.addTest(FindingTest('test_close_finding'))
     suite.addTest(FindingTest('test_make_finding_a_template'))
     suite.addTest(FindingTest('test_apply_template_to_a_finding'))
     suite.addTest(FindingTest('test_import_scan_result'))
-    suite.addTest(FindingTest('test_delete_image'))
     suite.addTest(FindingTest('test_delete_finding'))
     suite.addTest(FindingTest('test_delete_finding_template'))
     suite.addTest(ProductTest('test_delete_product'))

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -12,6 +12,31 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 class FindingTest(BaseTestCase):
 
+    def test_list_finding(self):
+        # bulk edit dropdown menu
+        driver = self.login_page()
+        driver.get(self.base_url + "finding")
+
+        driver.find_element_by_id("select_all").click()
+
+        driver.find_element_by_id("dropdownMenu2").click()
+
+        bulk_edit_menu = driver.find_element_by_id("bulk_edit_menu")
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_active").is_enabled(), False)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_verified").is_enabled(), False)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_false_p").is_enabled(), False)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_out_of_scope").is_enabled(), False)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_is_Mitigated").is_enabled(), False)
+
+        driver.find_element_by_id("id_bulk_status").click()
+
+        bulk_edit_menu = driver.find_element_by_id("bulk_edit_menu")
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_active").is_enabled(), True)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_verified").is_enabled(), True)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_false_p").is_enabled(), True)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_out_of_scope").is_enabled(), True)
+        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_is_Mitigated").is_enabled(), True)
+
     def test_edit_finding(self):
         # The Name of the Finding created by test_add_product_finding => 'App Vulnerable to XSS'
         # Test To Add Finding To product

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -62,8 +62,6 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Images updated successfully', productTxt))
-        # TODO fix javascript error because images are not working inside docker/travis, accept for now: https://github.com/DefectDojo/django-DefectDojo/issues/2045
-        self.accept_javascript_errors = True
 
     def test_mark_finding_for_review(self):
         # login to site, password set to fetch from environ
@@ -135,8 +133,6 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Images updated successfully', productTxt))
-        # TODO fix javascript error because images are not working inside docker/travis, accept for now: https://github.com/DefectDojo/django-DefectDojo/issues/2045
-        self.accept_javascript_errors = True
 
     def test_close_finding(self):
         driver = self.login_page()
@@ -193,8 +189,6 @@ class FindingTest(BaseTestCase):
         productTxt = driver.find_element_by_tag_name("BODY").text
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'App Vulnerable to XSS', productTxt))
-        # TODO fix javascript error because images are not working inside docker/travis, accept for now: https://github.com/DefectDojo/django-DefectDojo/issues/2045
-        self.accept_javascript_errors = True
 
     def test_delete_finding_template(self):
         driver = self.login_page()

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -12,48 +12,6 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 class FindingTest(BaseTestCase):
 
-    def login_page(self):
-        # Make a member reference to the driver
-        driver = self.driver
-        # Navigate to the login page
-        driver.get(self.base_url + "login")
-        # Good practice to clear the entry before typing
-        driver.find_element_by_id("id_username").clear()
-        # These credentials will be used by Travis when testing new PRs
-        # They will not work when testing on your own build
-        # Be sure to change them before submitting a PR
-        driver.find_element_by_id("id_username").send_keys(os.environ['DD_ADMIN_USER'])
-        driver.find_element_by_id("id_password").clear()
-        driver.find_element_by_id("id_password").send_keys(os.environ['DD_ADMIN_PASSWORD'])
-        # "Click" the but the login button
-        driver.find_element_by_css_selector("button.btn.btn-success").click()
-        return driver
-
-    def test_list_finding(self):
-        # bulk edit dropdown menu
-        driver = self.login_page()
-        driver.get(self.base_url + "finding")
-
-        driver.find_element_by_id("select_all").click()
-
-        driver.find_element_by_id("dropdownMenu2").click()
-
-        bulk_edit_menu = driver.find_element_by_id("bulk_edit_menu")
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_active").is_enabled(), False)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_verified").is_enabled(), False)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_false_p").is_enabled(), False)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_out_of_scope").is_enabled(), False)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_is_Mitigated").is_enabled(), False)
-
-        driver.find_element_by_id("id_bulk_status").click()
-
-        bulk_edit_menu = driver.find_element_by_id("bulk_edit_menu")
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_active").is_enabled(), True)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_verified").is_enabled(), True)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_false_p").is_enabled(), True)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_out_of_scope").is_enabled(), True)
-        self.assertEqual(bulk_edit_menu.find_element_by_id("id_bulk_is_Mitigated").is_enabled(), True)
-
     def test_edit_finding(self):
         # The Name of the Finding created by test_add_product_finding => 'App Vulnerable to XSS'
         # Test To Add Finding To product

--- a/tests/Product_unit_test.py
+++ b/tests/Product_unit_test.py
@@ -297,19 +297,27 @@ class ProductTest(BaseTestCase):
     def test_delete_product(self):
         # Login to the site. Password will have to be modified
         # to match an admin password in your own container
+        print('1:', self.driver.get_log('browser'))
         driver = self.login_page()
         # Navigate to the product page
         driver.get(self.base_url + "product")
+        print('2:', self.driver.get_log('browser'))
+
         # Select the specific product to delete
         driver.find_element_by_link_text("QA Test").click()
         # Click the drop down menu
+        print('3:', self.driver.get_log('browser'))
         driver.find_element_by_id('dropdownMenu1').click()
         # "Click" the Delete option
+        print('4:', self.driver.get_log('browser'))
         driver.find_element_by_link_text("Delete").click()
         # "Click" the delete button to complete the transaction
+        print('5:', self.driver.get_log('browser'))
         driver.find_element_by_css_selector("button.btn.btn-danger").click()
+        print('6:', self.driver.get_log('browser'))
         # Query the site to determine if the product has been added
         productTxt = driver.find_element_by_tag_name("BODY").text
+        print('7:', self.driver.get_log('browser'))
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Product and relationships removed.', productTxt))
 

--- a/tests/Product_unit_test.py
+++ b/tests/Product_unit_test.py
@@ -33,14 +33,6 @@ class WaitForPageLoad(object):
 class ProductTest(BaseTestCase):
 
     def test_create_product(self):
-        # try:
-        #     # sometimes the product is left behind from previous test run
-        #     self.test_delete_product()
-        # except:
-        #     print('failed to delete possible existing product, assuming it was already gone')
-
-        # Login to the site. Password will have to be modified
-        # to match an admin password in your own container
         driver = self.login_page()
         # Navigate to the product page
         driver.get(self.base_url + "product")
@@ -297,28 +289,20 @@ class ProductTest(BaseTestCase):
     def test_delete_product(self):
         # Login to the site. Password will have to be modified
         # to match an admin password in your own container
-        print('1:', self.driver.get_log('browser'))
         driver = self.login_page()
         # Navigate to the product page
         driver.get(self.base_url + "product")
-        print('2:', self.driver.get_log('browser'))
-
         # Select the specific product to delete
         driver.find_element_by_link_text("QA Test").click()
         # Click the drop down menu
-        print('3:', self.driver.get_log('browser'))
         driver.find_element_by_id('dropdownMenu1').click()
         # "Click" the Delete option
-        print('4:', self.driver.get_log('browser'))
         driver.find_element_by_link_text("Delete").click()
         # "Click" the delete button to complete the transaction
-        print('5:', self.driver.get_log('browser'))
         driver.find_element_by_css_selector("button.btn.btn-danger").click()
-        print('6:', self.driver.get_log('browser'))
         # Query the site to determine if the product has been added
         productTxt = driver.find_element_by_tag_name("BODY").text
-        print('7:', self.driver.get_log('browser'))
-        # Assert ot the query to dtermine status of failure
+        # Assert ot the query to determine status of failure
         self.assertTrue(re.search(r'Product and relationships removed.', productTxt))
 
 

--- a/tests/Product_unit_test.py
+++ b/tests/Product_unit_test.py
@@ -58,6 +58,12 @@ class ProductTest(BaseTestCase):
         self.assertTrue(re.search(r'Product added successfully', productTxt) or
             re.search(r'Product with this Name already exists.', productTxt))
 
+    def test_list_products(self):
+        driver = self.login_page()
+        # Navigate to the product page
+        driver.get(self.base_url + "product")
+        # list products which will make sure there are no javascript errors such as before in https://github.com/DefectDojo/django-DefectDojo/issues/2050
+
     # For product consistency sake, We won't be editting the product title
     # instead We can edit the product description
     def test_edit_product_description(self):
@@ -319,6 +325,7 @@ def suite():
     suite.addTest(ProductTest('test_edit_product_custom_field'))
     suite.addTest(ProductTest('test_add_product_tracking_files'))
     suite.addTest(ProductTest('test_edit_product_tracking_files'))
+    suite.addTest(ProductTest('test_list_products'))
     suite.addTest(ProductTest('test_delete_product'))
     return suite
 

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -19,8 +19,8 @@ class BaseTestCase(unittest.TestCase):
             dd_driver_options = Options()
 
             # headless means no UI, if you want to see what is happening remove headless. Adding detach will leave the window open after the test
-            # dd_driver_options.add_argument("--headless")
-            dd_driver_options.add_experimental_option("detach", True)
+            dd_driver_options.add_argument("--headless")
+            # dd_driver_options.add_experimental_option("detach", True)
 
             # the next 2 maybe needed in some scenario's for example on WSL or other headless situations
             # dd_driver_options.add_argument("--no-sandbox")
@@ -94,6 +94,9 @@ class BaseTestCase(unittest.TestCase):
         {'level': 'SEVERE', 'message': 'http://localhost:8080/product/type/4/edit 563:16 "error"', 'source': 'console-api', 'timestamp': 1583952828410}
         """
         for entry in self.driver.get_log('browser'):
+            if (entry['level'] == 'SEVERE'):
+                print(self.driver.current_url)
+                print(entry)
             self.assertNotEqual(entry['level'], 'SEVERE')
 
     def tearDown(self):

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -44,9 +44,9 @@ class BaseTestCase(unittest.TestCase):
         # # change path of chromedriver according to which directory you have chromedriver.
         # cls.options = Options()
         # cls.options.add_argument("--headless")
-        # # cls.options.add_experimental_option("detach", True)
-        # # cls.options.add_argument("--no-sandbox")
-        # # cls.options.add_argument("--disable-dev-shm-usage")
+        # cls.options.add_experimental_option("detach", True)
+        # cls.options.add_argument("--no-sandbox")
+        # cls.options.add_argument("--disable-dev-shm-usage")
         # cls.driver = webdriver.Chrome('chromedriver', chrome_options=cls.options)
         # cls.driver.implicitly_wait(30)
         cls.base_url = os.environ['DD_BASE_URL']
@@ -95,7 +95,7 @@ class BaseTestCase(unittest.TestCase):
         """
         for entry in self.driver.get_log('browser'):
             if (entry['level'] == 'SEVERE'):
-                print(self.driver.current_url)
+                print(self.driver.current_url)  # TODO actually this seems to be the previous url
                 print(entry)
             self.assertNotEqual(entry['level'], 'SEVERE')
 

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -19,8 +19,8 @@ class BaseTestCase(unittest.TestCase):
             dd_driver_options = Options()
 
             # headless means no UI, if you want to see what is happening remove headless. Adding detach will leave the window open after the test
-            dd_driver_options.add_argument("--headless")
-            # dd_driver_options.add_experimental_option("detach", True)
+            # dd_driver_options.add_argument("--headless")
+            dd_driver_options.add_experimental_option("detach", True)
 
             # the next 2 maybe needed in some scenario's for example on WSL or other headless situations
             # dd_driver_options.add_argument("--no-sandbox")

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -31,11 +31,11 @@ class BaseTestCase(unittest.TestCase):
             # dd_driver_options.add_argument("--start-maximized")
 
             # some extra logging can be turned on if you want to query the browser javascripe console in your tests
-            # desired = webdriver.DesiredCapabilities.CHROME
-            # desired['loggingPrefs'] = {'browser': 'ALL'}
+            desired = webdriver.DesiredCapabilities.CHROME
+            desired['goog:loggingPrefs'] = {'browser': 'ALL'}
 
             # change path of chromedriver according to which directory you have chromedriver.
-            dd_driver = webdriver.Chrome('chromedriver', chrome_options=dd_driver_options)
+            dd_driver = webdriver.Chrome('chromedriver', chrome_options=dd_driver_options, desired_capabilities=desired)
             dd_driver.implicitly_wait(30)
 
         cls.driver = dd_driver
@@ -85,7 +85,20 @@ class BaseTestCase(unittest.TestCase):
         finally:
             self.accept_next_alert = True
 
+    def assertNoConsoleErrors(self):
+        """
+        Sample output for levels (i.e. errors are SEVERE)
+        {'level': 'DEBUG', 'message': 'http://localhost:8080/product/type/4/edit 560:12 "debug"', 'source': 'console-api', 'timestamp': 1583952828410}
+        {'level': 'INFO', 'message': 'http://localhost:8080/product/type/4/edit 561:16 "info"', 'source': 'console-api', 'timestamp': 1583952828410}
+        {'level': 'WARNING', 'message': 'http://localhost:8080/product/type/4/edit 562:16 "warning"', 'source': 'console-api', 'timestamp': 1583952828410}
+        {'level': 'SEVERE', 'message': 'http://localhost:8080/product/type/4/edit 563:16 "error"', 'source': 'console-api', 'timestamp': 1583952828410}
+        """
+        for entry in self.driver.get_log('browser'):
+            self.assertNotEqual(entry['level'], 'SEVERE')
+
     def tearDown(self):
+        self.assertNoConsoleErrors()
+
         self.assertEqual([], self.verificationErrors)
 
     @classmethod

--- a/tests/local-integration-tests.bat
+++ b/tests/local-integration-tests.bat
@@ -76,4 +76,8 @@ REM REM fi
 
 echo "Done Running all configured integration tests."
 
+<<<<<<< HEAD
 :END
+=======
+:END
+>>>>>>> simplify and speedup integration tests

--- a/tests/local-integration-tests.bat
+++ b/tests/local-integration-tests.bat
@@ -50,8 +50,8 @@ echo "Running Dedupe integration tests"
 python tests/dedupe_unit_test.py
 if %ERRORLEVEL% NEQ 0 GOTO END
 
-REM  The below tests are commented out because they are still an unstable work in progress
-REM Once Ready they can be uncommented.
+REM REM  The below tests are commented out because they are still an unstable work in progress
+REM REM Once Ready they can be uncommented.
 
 REM REM echo "Running Import Scanner integration test"
 REM REM python tests/Import_scanner_unit_test.py
@@ -74,10 +74,6 @@ REM REM else
 REM REM     echo "Error: Zap integration test failed"; exit 1
 REM REM fi
 
-echo "Done Running all configured integration tests."
+REM echo "Done Running all configured integration tests."
 
-<<<<<<< HEAD
 :END
-=======
-:END
->>>>>>> simplify and speedup integration tests


### PR DESCRIPTION
We have seen about 7 PRs / issues around javascript erros lately. These are now all fixed, but we should check for javascript errors in the integration tests.

(EDIT Actually found another one using this PR: #2095)

This PR adds those checks. At the end of every test (so each method), there is a check to see if there are no javascript errors.

This can be checked earlier manually by calling `self.assertNoConsoleErrors()`.

Currently the docker build used by Travis doesn't support images for findings, so these errors are ignored.

- removed superfluous login_page method
- add settings for logging for javascript console
- move delete_image earlier so the javascript errors disappear again
- add test_list_products to make sure product list is free of javascript errors
- add WebdriverOnlyNewLogFacade that only returns new log entries since last time it was called
