### PR TITLE
fix #2048 handle None value for CWE in apply finding template

### DIFF
--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -18,7 +18,7 @@
 {% endfor %}
 
 {% for field in form.visible_fields %}
-    {% with template_value=template|get_attribute:field.name %}
+    {% with template_value=template|get_attribute:field.name|default_if_none:'' %}
     <div class="form-group{% if field.errors %} has-error{% endif %}">
         <label class="col-sm-2 control-label">{{ field.label }} Option</label>
         <div class="col-sm-10 {{ classes.value }}">


### PR DESCRIPTION
Fixes #2048, handle None (empty) value for CWE properly when applying a finding template to a finding.