### PR TITLE
make finding images work in docker dev and ptvsd setup

### DIFF
--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -5,6 +5,8 @@ services:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-uwsgi-dev.sh']
     volumes:
       - '.:/app:z'
+      - './media:/app/media/finding_images'
+      - './media/CACHE:/app/media/CACHE'
     environment:
       DD_DEBUG: 'True'
   celeryworker:
@@ -19,6 +21,8 @@ services:
   nginx:
     volumes:
       - './dojo/static/dojo:/usr/share/nginx/html/static/dojo'
+      - './media:/usr/share/nginx/html/media'
+      - './media/CACHE:/usr/share/nginx/html/media/CACHE'
   mysql:
     ports:
       - target: 3306

--- a/docker-compose.override.ptvsd.yml
+++ b/docker-compose.override.ptvsd.yml
@@ -5,6 +5,8 @@ services:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-uwsgi-ptvsd.sh']
     volumes:
       - '.:/app:z'
+      - './media:/app/media/finding_images'
+      - './media/CACHE:/app/media/CACHE'      
     environment:
       DD_DEBUG: 'True'
     ports:
@@ -18,6 +20,8 @@ services:
   nginx:
     volumes:
       - './dojo/static/dojo:/usr/share/nginx/html/static/dojo'
+      - './media:/usr/share/nginx/html/media'
+      - './media/CACHE:/usr/share/nginx/html/media/CACHE'      
   mysql:
     ports:
       - target: 3306

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -25,6 +25,9 @@ http {
     location /static {
       alias /usr/share/nginx/html/static;
     }
+    location /media {
+        alias /usr/share/nginx/html/media;
+    }
     location / {
       include /run/uwsgi_pass;
       include /etc/nginx/wsgi_params;


### PR DESCRIPTION
Partial fix for #2045, makes finding images work in docker development setup.

Making it work in release mode will have to wait until @devGregA has finalized the migration to AppVeyor.