### PR TITLE
add required middleware to set actor_id in auditlog entries

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -503,6 +503,7 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'dojo.middleware.LoginRequiredMiddleware',
     'dojo.middleware.TimezoneMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
+    'auditlog.middleware.AuditlogMiddleware',
 ]
 
 MIDDLEWARE = DJANGO_MIDDLEWARE_CLASSES


### PR DESCRIPTION
fixes #2064 
a middleware is needed to make sure the auditlog post_save signals know the actor of the action

https://django-auditlog.readthedocs.io/en/latest/usage.html#actors