### PR TITLE
docker initializer: do not give a new non-working passwd if admin present in DB

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -9,8 +9,6 @@ then
 fi
 echo "Initializing."
 
-echo "Admin user: ${DD_ADMIN_USER}"
-
 echo -n "Waiting for database to be reachable "
 until echo "select 1;" | python3 manage.py dbshell > /dev/null
 do
@@ -22,6 +20,7 @@ echo
 python3 manage.py makemigrations dojo
 python3 manage.py migrate
 
+echo "Admin user: ${DD_ADMIN_USER}"
 ADMIN_EXISTS=$(echo "SELECT * from auth_user;" | python manage.py dbshell | grep admin)
 # Abort if the admin user already exists, instead of giving a new fake password that won't work
 if [ ! -z "$ADMIN_EXISTS" ]

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -21,7 +21,7 @@ python3 manage.py makemigrations dojo
 python3 manage.py migrate
 
 echo "Admin user: ${DD_ADMIN_USER}"
-ADMIN_EXISTS=$(echo "SELECT * from auth_user;" | python manage.py dbshell | grep admin)
+ADMIN_EXISTS=$(echo "SELECT * from auth_user;" | python manage.py dbshell | grep "${DD_ADMIN_USER}")
 # Abort if the admin user already exists, instead of giving a new fake password that won't work
 if [ ! -z "$ADMIN_EXISTS" ]
 then

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -25,8 +25,8 @@ ADMIN_EXISTS=$(echo "SELECT * from auth_user;" | python manage.py dbshell | grep
 # Abort if the admin user already exists, instead of giving a new fake password that won't work
 if [ ! -z "$ADMIN_EXISTS" ]
 then
-    echo "Initialization detected that the admin user ${DD_ADMIN_USER} already exists in your database."
-    echo "If you don't remember the password, you can create a new superuser with:"
+    echo "Admin password: Initialization detected that the admin user ${DD_ADMIN_USER} already exists in your database."
+    echo "If you don't remember the ${DD_ADMIN_USER} password, you can create a new superuser with:"
     echo "$ docker-compose exec uswgi /bin/bash -c 'python manage.py createsuperuser'"
     exit
 fi

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -26,7 +26,7 @@ ADMIN_EXISTS=$(echo "SELECT * from auth_user;" | python manage.py dbshell | grep
 if [ ! -z "$ADMIN_EXISTS" ]
 then
     echo "Initialization detected that the admin user ${DD_ADMIN_USER} already exists in your database."
-    echo "If you don't remember the password for, you can create a new superuser with:"
+    echo "If you don't remember the password, you can create a new superuser with:"
     echo "$ docker-compose exec uswgi /bin/bash -c 'python manage.py createsuperuser'"
     exit
 fi


### PR DESCRIPTION
Make sure to not give a new non-working admin passwd if present in DB, and print the command to create a new superuser in case the user cannot remember.