### PR TITLE
Anchore parser fix to consider package_path

### DIFF
--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -50,7 +50,9 @@ class AnchoreEngineScanParser(object):
 
             references = item['url']
 
-            dupe_key = data['imageDigest'] + "|" + item['feed'] + "|" + item['feed_group'] + "|" + item['package'] + '|' + item['vuln']
+            dupe_key = data['imageDigest'] + '|' + item['feed'] + '|' + item['feed_group'] \
+                + '|' + item['package_name'] + '|' + item['package_version'] + '|' \
+                + '|' + item['package_path'] + '|' + item['vuln']
 
             if dupe_key in dupes:
                 find = dupes[dupe_key]

--- a/dojo/unittests/scans/anchore/many_vulns.json
+++ b/dojo/unittests/scans/anchore/many_vulns.json
@@ -281,8 +281,100 @@
             "severity": "Critical",
             "url": "https://whatever-tracker-/tracker/CVE-9999-0000",
             "vuln": "CVE-9999-0000"
+        },
+        {
+            "feed": "vulndb",
+            "feed_group": "vulndb:vulnerabilities",
+            "fix": "1.18",
+            "nvd_data": [],
+            "package": "jersey-1.13",
+            "package_cpe": "cpe:/a:-:jersey:1.13:-:-",
+            "package_cpe23": "cpe:2.3:a:-:jersey:1.13:-:-:-:-:-:-:-",
+            "package_name": "jersey",
+            "package_path": "/usr/share/myapp/myapp.war:sources/jersey-apache-client-1.13-sources-jar/jersey-apache-client-1.13-sources.jar",
+            "package_type": "java",
+            "package_version": "1.13",
+            "severity": "Medium",
+            "url": "http://dev-anchore-engine-api:8228/v1/query/vulnerabilities?id=VULNDB-103881",
+            "vendor_data": [
+                {
+                    "cvss_v2": {
+                        "base_score": 5.0,
+                        "exploitability_score": 10.0,
+                        "impact_score": 2.9
+                    },
+                    "cvss_v3": {
+                        "base_score": -1.0,
+                        "exploitability_score": -1.0,
+                        "impact_score": -1.0
+                    },
+                    "id": "VULNDB-103881"
+                }
+            ],
+            "vuln": "VULNDB-103881"
+        },
+        {
+            "feed": "vulndb",
+            "feed_group": "vulndb:vulnerabilities",
+            "fix": "1.18",
+            "nvd_data": [],
+            "package": "jersey-1.13",
+            "package_cpe": "cpe:/a:-:jersey:1.13:-:-",
+            "package_cpe23": "cpe:2.3:a:-:jersey:1.13:-:-:-:-:-:-:-",
+            "package_name": "jersey",
+            "package_path": "/usr/share/myapp/myapp.war:sources/jersey-client-1.13-sources-jar/jersey-client-1.13-sources.jar",
+            "package_type": "java",
+            "package_version": "1.13",
+            "severity": "Medium",
+            "url": "http://dev-anchore-engine-api:8228/v1/query/vulnerabilities?id=VULNDB-103881",
+            "vendor_data": [
+                {
+                    "cvss_v2": {
+                        "base_score": 5.0,
+                        "exploitability_score": 10.0,
+                        "impact_score": 2.9
+                    },
+                    "cvss_v3": {
+                        "base_score": -1.0,
+                        "exploitability_score": -1.0,
+                        "impact_score": -1.0
+                    },
+                    "id": "VULNDB-103881"
+                }
+            ],
+            "vuln": "VULNDB-103881"
+        },
+        {
+            "feed": "vulndb",
+            "feed_group": "vulndb:vulnerabilities",
+            "fix": "1.18",
+            "nvd_data": [],
+            "package": "jersey-1.13",
+            "package_cpe": "cpe:/a:-:jersey:1.13:-:-",
+            "package_cpe23": "cpe:2.3:a:-:jersey:1.13:-:-:-:-:-:-:-",
+            "package_name": "jersey",
+            "package_path": "/usr/share/myapp/myapp.war:sources/jersey-core-1.13-sources-jar/jersey-core-1.13-sources.jar",
+            "package_type": "java",
+            "package_version": "1.13",
+            "severity": "Medium",
+            "url": "http://dev-anchore-engine-api:8228/v1/query/vulnerabilities?id=VULNDB-103881",
+            "vendor_data": [
+                {
+                    "cvss_v2": {
+                        "base_score": 5.0,
+                        "exploitability_score": 10.0,
+                        "impact_score": 2.9
+                    },
+                    "cvss_v3": {
+                        "base_score": -1.0,
+                        "exploitability_score": -1.0,
+                        "impact_score": -1.0
+                    },
+                    "id": "VULNDB-103881"
+                }
+            ],
+            "vuln": "VULNDB-103881"
         }
-
 ],
     "vulnerability_type": "os"
 }

--- a/dojo/unittests/test_anchore_parser.py
+++ b/dojo/unittests/test_anchore_parser.py
@@ -19,4 +19,4 @@ class TestAnchoreEngineParser(TestCase):
         testfile = open("dojo/unittests/scans/anchore/many_vulns.json")
         parser = AnchoreEngineScanParser(testfile, Test())
         testfile.close()
-        self.assertEqual(20, len(parser.items))
+        self.assertEqual(23, len(parser.items))


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

The anchore parser has a `dupe_key` variable made up of certain vuln characteristics, to directly avoid re-importing findings inside the parser.

However, inconsistencies creeped in as the `package_path` filled for java vulnerabilities was not taken into account. That led to not all findings being imported because of it and have incomplete report.

The unittest has been amended with concrete examples. 

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
