### PR TITLE
copycat release-drafter config on dev branch

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: 'v$NEXT_PATCH_VERSION 🌈'
-tag-template: 'v$NEXT_PATCH_VERSION'
+name-template: '$NEXT_PATCH_VERSION 🌈'
+tag-template: '$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 New scanners'
     labels:
@@ -8,17 +8,20 @@ categories:
     labels:
       - 'feature'
       - 'enhancement'
+      - 'performance'
   - title: '🐛 Bug Fixes'
     labels:
       - 'fix'
       - 'bugfix'
       - 'bug'
   - title: '🧰 Maintenance'
-    labels: 
+    labels:
       - 'dependencies'
       - 'maintenance'
+  - title: '🚩 Requires settings change'
+    labels:
+      - 'settings_changes'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## Changes
-
   $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,15 +5,12 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - master
+      - dev
 
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v5.6.1
-        # with:
-          # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-          # config-name: my-config.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Opened a ticket in the release-drafter gh as well..

Until then, would like to push the exact same config in `dev` that what is on `master`. It would be odd to have to replicate the config in all branches and not just the default one as their page and comments seems to hint at, but since `dev` PRs are getting drafted and not `dev`'s, I guess it does not hurt to try.