### PR TITLE
Disable heroku install for now as an error is generated 

### DIFF
--- a/travis/before-install.sh
+++ b/travis/before-install.sh
@@ -14,5 +14,5 @@ sudo npm install -g snyk
 
 
 # Install Deployment
-sudo curl https://cli-assets.heroku.com/install-ubuntu.sh | sh
-
+# Disabled because it breaks the build currently due to an error. It's not used currently.
+# sudo curl https://cli-assets.heroku.com/install-ubuntu.sh | sh


### PR DESCRIPTION
Disable for now as the error below breaks everything Travis.
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1232  100  1232    0     0   6508      0 --:--:-- --:--:-- --:--:--  6518
This script requires superuser access to install apt packages.
You will be prompted for your password by sudo.
+ dpkg -s apt-transport-https
+ echo deb https://cli-assets.heroku.com/apt ./
+ dpkg -s heroku-toolbelt
+ true
+ curl https://cli-assets.heroku.com/apt/release.key+ apt-key add -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   952  100   952    0     0   4643      0 --:--:-- --:--:-- --:--:--  4643
gpg: invalid armor header: mQENBF5ymugBCAD+hcFN+HTB67wvXGUFiW+3BFtjtuBp8QMewamt87gl7jJnmB9h\n
```