### PR TITLE
product list: add missing quotes around asc for table sorter

### DIFF
--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -330,7 +330,7 @@
                     { "data": "contacts" },
                     { "data": "product_type" },
                 ],
-                order: [1, asc],
+                order: [1, "asc"],
                 "columnDefs": [
                     { "orderable": false, "targets": [0] }
                 ],


### PR DESCRIPTION
quotes were missing around "asc" on the product list page resulting in javascript errors.