### PR TITLE
unittests: check for existence of system_settings db record

### DIFF
--- a/dojo/unittests/test_system_settings.py
+++ b/dojo/unittests/test_system_settings.py
@@ -5,7 +5,12 @@ from dojo.models import System_Settings
 class TestSystemSettings(TestCase):
 
     def test_system_settings_update(self):
-        system_settings = System_Settings.objects.get()
+        try:
+            # although the unittests are run after initial data has been loaded, for some reason in travis sometimes the settings aren't present
+            system_settings = System_Settings.objects.get()
+        except System_Settings.DoesNotExistDoesNotExist:
+            system_settings = System_Settings()
+
         system_settings.enable_jira = True
         system_settings.save()
         system_settings = System_Settings.objects.get()


### PR DESCRIPTION
Lately we have seen a lot of `DoestNotExist` exceptions on `System_Settings` in the travis builds (causing failures). Usually this was after migrations failed with Travis saying some table alreadys exists, even though it should have been starting with an empty db.

Today however I saw a build failing which did have no migration errors, only this error on `System_Settings`. So just to be sure it's not the cause of the failures, I've added a try-except block around it. Similar to what is done in `get_system_setting` in `utils.py`.
