### PR TITLE
[apiv2] Enable POST endpoint to create a note

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -641,6 +641,7 @@ class ReImportScanView(mixins.CreateModelMixin,
 class NotesViewSet(mixins.ListModelMixin,
                    mixins.RetrieveModelMixin,
                    mixins.UpdateModelMixin,
+                   mixins.CreateModelMixin,
                    viewsets.GenericViewSet):
     serializer_class = serializers.NoteSerializer
     queryset = Notes.objects.all()


### PR DESCRIPTION
In order to satisfy some automation needs, I need to create note from the API. So there goes a new POST endpoint to create a note, which would be orphaned at creation.

The idea is to then associate that note to a finding through code.

Looking for feedback on this.
