### PR TITLE
Social-auth: Fix call-back URLs

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -69,7 +69,7 @@ env = environ.Env(
     DD_SECRET_KEY=(str, '.'),
     DD_CREDENTIAL_AES_256_KEY=(str, '.'),
     DD_DATA_UPLOAD_MAX_MEMORY_SIZE=(int, 8388608),  # Max post size set to 8mb
-    DD_SOCIAL_AUTH_TRAILING_SLASH=(bool, False),
+    DD_SOCIAL_AUTH_TRAILING_SLASH=(bool, True),
     DD_SOCIAL_AUTH_AUTH0_OAUTH2_ENABLED=(bool, False),
     DD_SOCIAL_AUTH_AUTH0_KEY=(str, ''),
     DD_SOCIAL_AUTH_AUTH0_SECRET=(str, ''),
@@ -333,12 +333,8 @@ LOGIN_EXEMPT_URLS = (
     r'^%sreports/cover$' % URL_PREFIX,
     r'^%sfinding/image/(?P<token>[^/]+)$' % URL_PREFIX,
     r'^%sapi/v2/' % URL_PREFIX,
-    r'complete/auth0-oauth2/',
-    r'complete/google-oauth2/',
-    r'complete/okta-oauth2/',
-    r'complete/gitlab-oauth2/',
+    r'complete/',
     r'empty_survey/([\d]+)/answer'
-    r'complete/azuread-tenant-oauth2/',
 )
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This commit fixes an issue where the trailing slash of callbacks URLs is removed
(DD_SOCIAL_AUTH_TRAILING_SLASH=(bool, False) and makes the login process fail as
it differs from the LOGIN_EXEMPT_URLS URLs that are allowing URLs with the trailing
slash.

This commit also generalizes the allowed call-back URLs to ```complete/``` instead
of cherry-picking the different IdPs. I'll simplify the process to add new IdPs
in the future.

Last but not least this commit also revert what has been introduced into #PR 2079
where DD_SOCIAL_AUTH_TRAILING_SLASH was set to False. I understand now that it was
bad idea to do that as it modifies the call-back URL that is sent to the IdP by
removing the trailing slash, it'll probably break existing social-auth deployments
as the allowed-call-back-url will need to be adapted IdP-side.

Linked to issue https://github.com/DefectDojo/django-DefectDojo/issues/2122

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [ x Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
