### PR TITLE
fix uwsgi typo in initializer log

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -27,7 +27,7 @@ if [ ! -z "$ADMIN_EXISTS" ]
 then
     echo "Admin password: Initialization detected that the admin user ${DD_ADMIN_USER} already exists in your database."
     echo "If you don't remember the ${DD_ADMIN_USER} password, you can create a new superuser with:"
-    echo "$ docker-compose exec uswgi /bin/bash -c 'python manage.py createsuperuser'"
+    echo "$ docker-compose exec uwsgi /bin/bash -c 'python manage.py createsuperuser'"
     exit
 fi
 


### PR DESCRIPTION
Won't work as well in a copy-paste situation.