### PR TITLE
Allow staff users to delete notes

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -912,7 +912,7 @@ class AddNewNoteOptionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Notes
-        fields = ['entry', 'private', 'note_type']
+        fields = ['entry', 'private']
 
 
 class FindingToFindingImagesSerializer(serializers.Serializer):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -912,7 +912,7 @@ class AddNewNoteOptionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Notes
-        fields = ['entry', 'private']
+        fields = ['entry', 'private', 'note_type']
 
 
 class FindingToFindingImagesSerializer(serializers.Serializer):

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -203,13 +203,12 @@ class FindingViewSet(mixins.ListModelMixin,
             if new_note.is_valid():
                 entry = new_note.validated_data['entry']
                 private = new_note.validated_data['private']
-                note_type = new_note.validated_data['note_type']
             else:
                 return Response(new_note.errors,
                     status=status.HTTP_400_BAD_REQUEST)
 
             author = request.user
-            note = Notes(entry=entry, author=author, private=private, note_type=note_type)
+            note = Notes(entry=entry, author=author, private=private)
             note.save()
             finding.notes.add(note)
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -247,7 +247,7 @@ class FindingViewSet(mixins.ListModelMixin,
         else:
             return Response({"error": "('note_id') parameter missing"},
                 status=status.HTTP_400_BAD_REQUEST)
-        if note.author.username == request.user.username or request.user.is_superuser:
+        if note.author.username == request.user.username or request.user.is_staff:
             finding.notes.remove(note)
             note.delete()
         else:

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -195,7 +195,7 @@ class FindingViewSet(mixins.ListModelMixin,
         serialized_tags = serializers.TagSerializer({"tags": tags})
         return Response(serialized_tags.data)
 
-    @action(detail=True, methods=["get", "post"])
+    @action(detail=True, methods=["get", "post", "patch"])
     def notes(self, request, pk=None):
         finding = get_object_or_404(Finding.objects, id=pk)
         if request.method == 'POST':
@@ -203,12 +203,13 @@ class FindingViewSet(mixins.ListModelMixin,
             if new_note.is_valid():
                 entry = new_note.validated_data['entry']
                 private = new_note.validated_data['private']
+                note_type = new_note.validated_data['note_type']
             else:
                 return Response(new_note.errors,
                     status=status.HTTP_400_BAD_REQUEST)
 
             author = request.user
-            note = Notes(entry=entry, author=author, private=private)
+            note = Notes(entry=entry, author=author, private=private, note_type=note_type)
             note.save()
             finding.notes.add(note)
 
@@ -234,7 +235,7 @@ class FindingViewSet(mixins.ListModelMixin,
         return Response(serialized_notes,
                 status=status.HTTP_200_OK)
 
-    @action(detail=True, methods=["put", "patch"])
+    @action(detail=True, methods=["patch"])
     def remove_note(self, request, pk=None):
         """Remove Note From Finding Note"""
         finding = get_object_or_404(Finding.objects, id=pk)
@@ -247,7 +248,7 @@ class FindingViewSet(mixins.ListModelMixin,
         else:
             return Response({"error": "('note_id') parameter missing"},
                 status=status.HTTP_400_BAD_REQUEST)
-        if note.author.username == request.user.username:
+        if note.author.username == request.user.username or request.user.is_superuser:
             finding.notes.remove(note)
             note.delete()
         else:

--- a/dojo/notes/views.py
+++ b/dojo/notes/views.py
@@ -33,7 +33,7 @@ def delete_issue(request, id, page, objid):
         reverse_url = "view_finding"
     form = DeleteNoteForm(request.POST, instance=note)
 
-    if page is None or str(request.user) != note.author.username and not request.user.is_superuser:
+    if page is None or str(request.user) != note.author.username and not request.user.is_staff:
         raise PermissionDenied
 
     if form.is_valid():


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

This PR grants superuser users the ability to delete notes from the API, and also make the `patch` endpoint work to remove a note from a finding.

When wanting to remove a note from a finding with the same user from the UI or from the APIv2, the APIv2 forbid me to delete if not the same user, something we don't have from the UI.

Also, the `patch` or `put` methods were actually forbidden (error 405), even though specified on the `remove_note` endpoint, it had to be specified also on the `notes` to work.

Since both seemed to achieve the same thing, I removed the `put` method.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
