### PR TITLE
Move similar finding below actual finding main info

### DIFF
--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -292,78 +292,6 @@
             </table>
         </div>
     </div>
-    {% with findings=finding.similar_findings %}
-        {% if findings %}
-            <div class="panel panel-default">
-                <div class="panel-heading">
-                    <h4>Similar Findings<span class="pull-right"><a data-toggle="collapse" href="#similar_findings"><i class="glyphicon glyphicon-chevron-up"></i></a></span></h4>
-                </div>
-                <div id="similar_findings" class="panel-body collapse in">
-                    <table class="table table-striped table-hover centered">
-                        <tr>
-                            <th>Finding</th>
-                            <th>Status</th>
-                            <th>Tags</th>
-                            <th>Test</th>
-                            <th>Engagement</th>
-                            <th>Version</th>
-                            <th>CVE</th>
-                            <th>File</th>
-                            <th>Deduplicate?</th>
-                        </tr>
-                        {% for similar in findings %}
-                            <tr>
-                                <td>
-                                    <a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ similar.title }}" href="{% url 'view_finding' similar.id %}">{{ similar.date }}</a>
-                                    {% with similar.notes.count as note_count %}
-                                        ({{ note_count }} note{{ note_count|pluralize }})
-                                    {% endwith %}
-                                </td>
-                                <td>{{ similar.status }}{% if similar.duplicate_finding_id %}, <a href="{% url 'view_finding' similar.duplicate_finding_id %}">Original</a> {% endif %}</td>
-                                <td>
-                                    {% if similar.tags %}
-                                        <small>
-                                            {% for tag in similar.tags %}
-                                                <a title="Search {{ tag }}" class="tag-label tag-color"
-                                                   href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
-                                            {% endfor %}
-                                        </small>
-                                    {% endif %}
-                                </td>
-                                <td><a href="{% url 'view_test' similar.test_id %}">{{ similar.test.test_type.name }}</a></td>
-                                <td><a href="{% url 'view_engagement' similar.test.engagement_id %}">{{ similar.test.engagement.name }}</a></td>
-                                <td>{{ similar.test.engagement.version }}</td>
-                                <td>{{ similar.cve }}</td>
-                                <td>{{ similar.file_path }}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}</td>
-                                <td>
-                                    {% if similar.duplicate %}
-                                        <form method="post"
-                                              action="{% url 'reset_finding_duplicate_status' similar.id %}">
-                                            {% csrf_token %}
-                                            <input type="submit" value="Reset duplicate status"/>
-                                        </form>
-                                    {% elif finding.duplicate_finding_id != similar.id %}
-                                        <form method="post"
-                                              action="{% url 'mark_finding_duplicate' original_id=similar.id duplicate_id=finding.id %}">
-                                            {% csrf_token %}
-                                            <input type="submit" value="Use as original"/>
-                                        </form>
-                                        <form method="post"
-                                              action="{% url 'mark_finding_duplicate' duplicate_id=similar.id original_id=finding.id %}">
-                                            {% csrf_token %}
-                                            <input type="submit" value="Mark as duplicate"/>
-                                        </form>
-                                    {% else %}
-                                        <i>N/A</i>
-                                    {% endif %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </table>
-                </div>
-            </div>
-        {% endif %}
-    {% endwith %}
     {% if finding.static_finding or finding.line > 0 %}
         {% if finding.sast_source_object or finding.sast_sink_object or finding.sast_source_file_path or finding.sast_source_line > 0 %}
         {# For tools that give information on both source (start) and sink (end) of the attack vector #}
@@ -517,6 +445,78 @@
             </div>
         </div>
     {% endif %}
+    {% with findings=finding.similar_findings %}
+        {% if findings %}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4>Similar Findings<span class="pull-right"><a data-toggle="collapse" href="#similar_findings"><i class="glyphicon glyphicon-chevron-up"></i></a></span></h4>
+                </div>
+                <div id="similar_findings" class="panel-body collapse in">
+                    <table class="table table-striped table-hover centered">
+                        <tr>
+                            <th>Finding</th>
+                            <th>Status</th>
+                            <th>Tags</th>
+                            <th>Test</th>
+                            <th>Engagement</th>
+                            <th>Version</th>
+                            <th>CVE</th>
+                            <th>File</th>
+                            <th>Deduplicate?</th>
+                        </tr>
+                        {% for similar in findings %}
+                            <tr>
+                                <td>
+                                    <a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ similar.title }}" href="{% url 'view_finding' similar.id %}">{{ similar.date }}</a>
+                                    {% with similar.notes.count as note_count %}
+                                        ({{ note_count }} note{{ note_count|pluralize }})
+                                    {% endwith %}
+                                </td>
+                                <td>{{ similar.status }}{% if similar.duplicate_finding_id %}, <a href="{% url 'view_finding' similar.duplicate_finding_id %}">Original</a> {% endif %}</td>
+                                <td>
+                                    {% if similar.tags %}
+                                        <small>
+                                            {% for tag in similar.tags %}
+                                                <a title="Search {{ tag }}" class="tag-label tag-color"
+                                                   href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
+                                            {% endfor %}
+                                        </small>
+                                    {% endif %}
+                                </td>
+                                <td><a href="{% url 'view_test' similar.test_id %}">{{ similar.test.test_type.name }}</a></td>
+                                <td><a href="{% url 'view_engagement' similar.test.engagement_id %}">{{ similar.test.engagement.name }}</a></td>
+                                <td>{{ similar.test.engagement.version }}</td>
+                                <td>{{ similar.cve }}</td>
+                                <td>{{ similar.file_path }}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}</td>
+                                <td>
+                                    {% if similar.duplicate %}
+                                        <form method="post"
+                                              action="{% url 'reset_finding_duplicate_status' similar.id %}">
+                                            {% csrf_token %}
+                                            <input type="submit" value="Reset duplicate status"/>
+                                        </form>
+                                    {% elif finding.duplicate_finding_id != similar.id %}
+                                        <form method="post"
+                                              action="{% url 'mark_finding_duplicate' original_id=similar.id duplicate_id=finding.id %}">
+                                            {% csrf_token %}
+                                            <input type="submit" value="Use as original"/>
+                                        </form>
+                                        <form method="post"
+                                              action="{% url 'mark_finding_duplicate' duplicate_id=similar.id original_id=finding.id %}">
+                                            {% csrf_token %}
+                                            <input type="submit" value="Mark as duplicate"/>
+                                        </form>
+                                    {% else %}
+                                        <i>N/A</i>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+        {% endif %}
+    {% endwith %}
 
     {% with endpoints=finding.endpoints.all|get_vulnerable_endpoints %}
         {% if endpoints %}


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When viewing findings which have "similars", the similar takes a big amount of place.
And if the finding has "extra" info, such as components, or I imagine endpoint info and such, you have to scroll down or minimize the "similar finding" block, which is aggravating.

This moves the "similar findings" block below these.

![image](https://user-images.githubusercontent.com/5468769/78009239-03ad9f00-7341-11ea-9484-ed7a0aede228.png)
