### PR TITLE
Adding a parser from Harbor vulnerability API

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -563,6 +563,13 @@
         },
         "model": "dojo.test_type",
         "pk": 172
-    }
+    },
+	{
+		"fields": {
+			"name": "Harbor Vulnerability"
+		},
+		"model": "dojo.test_type",
+		"pk": 173
+	}
 ]
 

--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -566,10 +566,9 @@
     },
 	{
 		"fields": {
-			"name": "Harbor Vulnerability"
+			"name": "Harbor Vulnerability Scan"
 		},
 		"model": "dojo.test_type",
 		"pk": 173
 	}
 ]
-

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -367,7 +367,8 @@ class ImportScanForm(forms.Form):
                          ("Burp Enterprise Scan", "Burp Enterprise Scan"),
                          ("DSOP Scan", "DSOP Scan"),
                          ("Trivy Scan", "Trivy Scan"),
-                         ("Anchore Enterprise Policy Check", "Anchore Enterprise Policy Check"))
+                         ("Anchore Enterprise Policy Check", "Anchore Enterprise Policy Check"),
+                         ("Harbor Vulnerability", "Harbor Vulnerability"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
     scan_date = forms.DateTimeField(

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -368,7 +368,7 @@ class ImportScanForm(forms.Form):
                          ("DSOP Scan", "DSOP Scan"),
                          ("Trivy Scan", "Trivy Scan"),
                          ("Anchore Enterprise Policy Check", "Anchore Enterprise Policy Check"),
-                         ("Harbor Vulnerability", "Harbor Vulnerability"))
+                         ("Harbor Vulnerability Scan", "Harbor Vulnerability Scan"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
     scan_date = forms.DateTimeField(

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -60,7 +60,7 @@
 	<li><b>Gosec Scanner </b> - Import Gosec Scanner findings in JSON format.</li>
 	<li><b>HackerOne Cases</b> - Import HackerOne cases findings in JSON format.</li>
 	<li><b>Hadolint Dockerfile check </b> - Import Hadolint Dockerfile check findings in JSON format.</li>
-	<li><b>Harbor Vulnerability </b> - Import vulnerabilities from Harbor API.</li>
+	<li><b>Harbor Vulnerability Scan </b> - Import vulnerabilities from Harbor API.</li>
 	<li><b>JFrogXray Scan </b> - Import Xray findings in JSON format.</li>
 	<li><b>Kiuwan Scanner</b> - Import Kiuwan Scan in CSV format. Export as CSV Results on Kiuwan.</li>
 	<li><b>Microfocus Webinspect Scanner</b> - Import XML report</li>

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -60,6 +60,7 @@
 	<li><b>Gosec Scanner </b> - Import Gosec Scanner findings in JSON format.</li>
 	<li><b>HackerOne Cases</b> - Import HackerOne cases findings in JSON format.</li>
 	<li><b>Hadolint Dockerfile check </b> - Import Hadolint Dockerfile check findings in JSON format.</li>
+	<li><b>Harbor Vulnerability </b> - Import vulnerabilities from Harbor API.</li>
 	<li><b>JFrogXray Scan </b> - Import Xray findings in JSON format.</li>
 	<li><b>Kiuwan Scanner</b> - Import Kiuwan Scan in CSV format. Export as CSV Results on Kiuwan.</li>
 	<li><b>Microfocus Webinspect Scanner</b> - Import XML report</li>

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -74,6 +74,7 @@ from dojo.tools.trivy.parser import TrivyParser
 from dojo.tools.outpost24.parser import Outpost24Parser
 from dojo.tools.burp_enterprise.parser import BurpEnterpriseHtmlParser
 from dojo.tools.anchore_enterprise.parser import AnchoreEnterprisePolicyCheckParser
+from dojo.tools.harbor_vulnerability.parser import HarborVulnerabilityParser
 
 
 
@@ -242,6 +243,8 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
         parser = DsopParser(file, test)
     elif scan_type == 'Anchore Enterprise Policy Check':
         parser = AnchoreEnterprisePolicyCheckParser(file, test)
+    elif scan_type == 'Harbor Vulnerability':
+        parser = HarborVulnerabilityParser(file, test)
     else:
         raise ValueError('Unknown Test Type')
 

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -77,7 +77,6 @@ from dojo.tools.anchore_enterprise.parser import AnchoreEnterprisePolicyCheckPar
 from dojo.tools.harbor_vulnerability.parser import HarborVulnerabilityParser
 
 
-
 __author__ = 'Jay Paz'
 
 

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -242,7 +242,7 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
         parser = DsopParser(file, test)
     elif scan_type == 'Anchore Enterprise Policy Check':
         parser = AnchoreEnterprisePolicyCheckParser(file, test)
-    elif scan_type == 'Harbor Vulnerability':
+    elif scan_type == 'Harbor Vulnerability Scan':
         parser = HarborVulnerabilityParser(file, test)
     else:
         raise ValueError('Unknown Test Type')

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -23,10 +23,8 @@ class HarborVulnerabilityParser(object):
         # When doing dictionary, we can detect duplications
         dupes = dict()
 
-        vulnerability = data[
-            "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
-        ]["vulnerabilities"]
-
+        # To be compatible with update in version
+        vulnerability = data[data.keys()[0]]["vulnerabilities"]
         if vulnerability is None:
             return
 

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -2,13 +2,17 @@ import json
 from dojo.models import Finding
 
 
-class HarborVulnerability(object):
+class HarborVulnerabilityParser(object):
 
     """
     Read JSON data from Harbor compatible format and import it to DefectDojo
     """
 
     def __init__(self, filename, test):
+
+        self.items = ()
+        if filename is None:
+            return
 
         tree = filename.read()
         try:
@@ -19,9 +23,14 @@ class HarborVulnerability(object):
         # When doing dictionary, we can detect duplications
         dupes = dict()
 
-        for item in data[
+        vulnerability = data[
             "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
-        ]["vulnerabilities"]:
+        ]["vulnerabilities"]
+
+        if vulnerability is None:
+            return
+
+        for item in vulnerability:
 
             # Default = empty string
             title = ""

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -10,7 +10,7 @@ class HarborVulnerabilityParser(object):
 
     def __init__(self, filename, test):
 
-        self.items = ()
+        self.items = []
         if filename is None:
             return
 

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -1,0 +1,83 @@
+import json
+from dojo.models import Finding
+
+
+class HarborVulnerability(object):
+
+    """
+    Read JSON data from Harbor compatible format and import it to DefectDojo
+    """
+
+    def __init__(self, filename, test):
+
+        tree = filename.read()
+        try:
+            data = json.loads(str(tree, "utf-8"))
+        except:
+            data = json.loads(tree)
+
+        # When doing dictionary, we can detect duplications
+        dupes = dict()
+
+        for item in data[
+            "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0"
+        ]["vulnerabilities"]:
+
+            # Default = empty string
+            title = ""
+            sev = ""
+            findingdetail = ""
+            mitigation = ""
+            impact = ""
+            references = ""
+            static_finding = True
+
+            # Trying to add all possible details
+            title = "{} - {} ({})".format(item["id"], item["package"], item["version"])
+            sev = transpose_severity(item["severity"])
+            findingdetail += item["description"]
+
+            if item["fix_version"]:
+                mitigation += "Upgrade {} to version {}\n\n".format(
+                    item["package"], item["version"]
+                )
+
+            if len(item["links"]) > 0:
+                for l in item["links"]:
+                    references += "{}\n".format(l)
+                mitigation += "Reference: {}".format(item["links"][0])
+
+            dupe_key = title
+
+            if dupe_key in dupes:
+                find = dupes[dupe_key]
+            else:
+                dupes[dupe_key] = True
+
+                find = Finding(
+                    title=title,
+                    test=test,
+                    active=False,
+                    verified=False,
+                    description=findingdetail,
+                    severity=sev,
+                    numerical_severity=Finding.get_numerical_severity(sev),
+                    mitigation=mitigation,
+                    impact=impact,
+                    references=references,
+                    file_path=filename,
+                    url="N/A",
+                    static_finding=True,
+                )
+
+                dupes[dupe_key] = find
+                findingdetail = ""
+
+        self.items = list(dupes.values())
+
+
+def transpose_severity(severity):
+    if (severity == "Negligible") or (severity == "Unknown"):
+        return "Informational"
+    else:
+        return severity.title()

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -24,12 +24,16 @@ class HarborVulnerabilityParser(object):
         dupes = dict()
 
         # To be compatible with update in version
-        vulnerability = data[data.keys()[0]]["vulnerabilities"]
+        try:
+            vulnerability = data[data.keys()[0]]["vulnerabilities"]
+        except KeyError:
+            return
+
+        # Early exit if empty
         if vulnerability is None:
             return
 
         for item in vulnerability:
-
             # Default = empty string
             title = ""
             sev = ""

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -25,8 +25,8 @@ class HarborVulnerabilityParser(object):
 
         # To be compatible with update in version
         try:
-            vulnerability = data[data.keys()[0]]["vulnerabilities"]
-        except KeyError:
+            vulnerability = data[next(iter(data.keys()))]["vulnerabilities"]
+        except (KeyError, StopIteration):
             return
 
         # Early exit if empty

--- a/dojo/unittests/scans/harbor_vulnerability/harbor-0-vuln.json
+++ b/dojo/unittests/scans/harbor_vulnerability/harbor-0-vuln.json
@@ -1,6 +1,6 @@
 {
     "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
-        "generated_at": "2020-03-04T02:51:42.448665594Z",
+        "generated_at": "2020-01-01T00:00:00.000000000Z",
         "scanner": {
             "name": "Clair",
             "vendor": "CoreOS",

--- a/dojo/unittests/scans/harbor_vulnerability/harbor-1-vuln.json
+++ b/dojo/unittests/scans/harbor_vulnerability/harbor-1-vuln.json
@@ -1,0 +1,24 @@
+{
+    "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
+        "generated_at": "2020-01-01T00:00:00.000000000Z",
+        "scanner": {
+            "name": "Clair",
+            "vendor": "CoreOS",
+            "version": "2.x"
+        },
+        "severity": "None",
+        "vulnerabilities": [
+            {
+                "id": "CVE-YYYY-NNN",
+                "package": "package",
+                "version": "exploitable-version",
+                "fix_version": "unexploitable-version",
+                "severity": "Negligible",
+                "description": "This is a sample description for sample description from Harbor API.",
+                "links": [
+                    "https://github.com/goharbor/harbor"
+                ]
+            }
+        ]
+    }
+}

--- a/dojo/unittests/scans/harbor_vulnerability/harbor-5-vuln.json
+++ b/dojo/unittests/scans/harbor_vulnerability/harbor-5-vuln.json
@@ -1,0 +1,68 @@
+{
+    "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
+        "generated_at": "2020-01-01T00:00:00.000000000Z",
+        "scanner": {
+            "name": "Clair",
+            "vendor": "CoreOS",
+            "version": "2.x"
+        },
+        "severity": "Critical",
+        "vulnerabilities": [
+            {
+                "id": "CVE-YYYY-001",
+                "package": "package-1",
+                "version": "exploitable-version-1",
+                "fix_version": "unexploitable-version-1",
+                "severity": "Negligible",
+                "description": "This is a sample description for sample description from Harbor API.",
+                "links": [
+                    "https://github.com/goharbor/harbor"
+                ]
+            },
+            {
+                "id": "CVE-YYYY-002",
+                "package": "package-2",
+                "version": "exploitable-version-2",
+                "fix_version": "unexploitable-version-2",
+                "severity": "High",
+                "description": "This is a sample description for sample description from Harbor API.",
+                "links": [
+                    "https://github.com/goharbor/harbor"
+                ]
+            },
+            {
+                "id": "CVE-YYYY-003",
+                "package": "package-3",
+                "version": "exploitable-version-3",
+                "fix_version": "unexploitable-version-3",
+                "severity": "High",
+                "description": "This is a sample description for sample description from Harbor API.",
+                "links": [
+                    "https://github.com/goharbor/harbor"
+                ]
+            },
+            {
+                "id": "CVE-YYYY-004",
+                "package": "package-4",
+                "version": "exploitable-version-4",
+                "fix_version": "unexploitable-version-4",
+                "severity": "Critical",
+                "description": "This is a sample description for sample description from Harbor API.",
+                "links": [
+                    "https://github.com/goharbor/harbor"
+                ]
+            },
+            {
+                "id": "CVE-YYYY-005",
+                "package": "package-5",
+                "version": "exploitable-version-5",
+                "fix_version": "unexploitable-version-5",
+                "severity": "Critical",
+                "description": "This is a sample description for sample description from Harbor API.",
+                "links": [
+                    "https://github.com/goharbor/harbor"
+                ]
+            }
+        ]
+    }
+}

--- a/dojo/unittests/scans/harbor_vulnerability/harbor_0_vuln.json
+++ b/dojo/unittests/scans/harbor_vulnerability/harbor_0_vuln.json
@@ -1,0 +1,12 @@
+{
+    "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
+        "generated_at": "2020-03-04T02:51:42.448665594Z",
+        "scanner": {
+            "name": "Clair",
+            "vendor": "CoreOS",
+            "version": "2.x"
+        },
+        "severity": "None",
+        "vulnerabilities": null
+    }
+}

--- a/dojo/unittests/test_harbor_vulnerability.py
+++ b/dojo/unittests/test_harbor_vulnerability.py
@@ -2,10 +2,8 @@ from django.test import TestCase
 from dojo.models import Test
 from dojo.tools.harbor_vulnerability.parser import HarborVulnerabilityParser
 
-import os.path
 
 class TestHarborVulnerabilityParser(TestCase):
-
     def test_parse_without_file_has_no_findings(self):
         parser = HarborVulnerabilityParser(None, Test())
         self.assertEqual(0, len(parser.items))
@@ -24,8 +22,13 @@ class TestHarborVulnerabilityParser(TestCase):
 
         findings = parser.items[0]
         self.assertEqual(findings.title, "CVE-YYYY-NNN - package (exploitable-version)")
-        self.assertEqual(findings.description, "This is a sample description for sample description from Harbor API.")
-        self.assertEqual(findings.severity, "Informational")  # Negligible is translated to Informational
+        self.assertEqual(
+            findings.description,
+            "This is a sample description for sample description from Harbor API.",
+        )
+        self.assertEqual(
+            findings.severity, "Informational"
+        )  # Negligible is translated to Informational
 
     # Sample with Multiple Test
     def test_parse_file_with_multiple_vuln_has_multiple_findings(self):

--- a/dojo/unittests/test_harbor_vulnerability.py
+++ b/dojo/unittests/test_harbor_vulnerability.py
@@ -1,0 +1,16 @@
+from django.test import TestCase
+from dojo.models import Test
+from dojo.tools.harbor_vulnerability.parser import HarborVulnerabilityParser
+
+import os.path
+
+class TestHarborVulnerabilityParser(TestCase):
+
+    def test_parse_without_file_has_no_findings(self):
+        parser = HarborVulnerabilityParser(None, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_file_with_no_vuln_has_no_findings(self):
+        testfile = open("dojo/unittests/scans/harbor_vulnerability/harbor_0_vuln.json")
+        parser = HarborVulnerabilityParser(testfile, Test())
+        self.assertEqual(0, len(parser.items))

--- a/dojo/unittests/test_harbor_vulnerability.py
+++ b/dojo/unittests/test_harbor_vulnerability.py
@@ -11,6 +11,24 @@ class TestHarborVulnerabilityParser(TestCase):
         self.assertEqual(0, len(parser.items))
 
     def test_parse_file_with_no_vuln_has_no_findings(self):
-        testfile = open("dojo/unittests/scans/harbor_vulnerability/harbor_0_vuln.json")
+        testfile = open("dojo/unittests/scans/harbor_vulnerability/harbor-0-vuln.json")
         parser = HarborVulnerabilityParser(testfile, Test())
         self.assertEqual(0, len(parser.items))
+
+    # Sample with One Test
+    # + also verify data with one test
+    def test_parse_file_with_one_vuln_has_one_findings(self):
+        testfile = open("dojo/unittests/scans/harbor_vulnerability/harbor-1-vuln.json")
+        parser = HarborVulnerabilityParser(testfile, Test())
+        self.assertEqual(1, len(parser.items))
+
+        findings = parser.items[0]
+        self.assertEqual(findings.title, "CVE-YYYY-NNN - package (exploitable-version)")
+        self.assertEqual(findings.description, "This is a sample description for sample description from Harbor API.")
+        self.assertEqual(findings.severity, "Informational")  # Negligible is translated to Informational
+
+    # Sample with Multiple Test
+    def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
+        testfile = open("dojo/unittests/scans/harbor_vulnerability/harbor-5-vuln.json")
+        parser = HarborVulnerabilityParser(testfile, Test())
+        self.assertEqual(5, len(parser.items))


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement

---

Harbor (https://github.com/goharbor/harbor) has the ability to scan all containers and itself acts as a bridge between the scanner and the image. We wanted to utilise that function from Harbor.

I've added a documentation PR on Harbor integration per following link
https://github.com/DefectDojo/Documentation/pull/79