### PR TITLE
[apiv2] Add capability to query by finding_id on the jira_finding_mapping endpoint

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -324,7 +324,7 @@ class JiraIssuesViewSet(mixins.ListModelMixin,
     serializer_class = serializers.JIRAIssueSerializer
     queryset = JIRA_Issue.objects.all()
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('id', 'jira_id', 'jira_key')
+    filter_fields = ('id', 'jira_id', 'jira_key', 'finding_id')
 
 
 class JiraViewSet(mixins.ListModelMixin,


### PR DESCRIPTION
In order to re-create an existing association, we must know the finding_id to find, then delete and (re)create. (The patch method does not work due to the unique database constraint on finding_id).

This basically allows to `GET` the association with the finding_id alone.