### PR TITLE
Amend swagger doc to have the proper serializer displayed

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -7,6 +7,7 @@ from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_yasg.utils import swagger_auto_schema
 
 from dojo.engagement.services import close_engagement, reopen_engagement
 from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \
@@ -235,6 +236,7 @@ class FindingViewSet(mixins.ListModelMixin,
         return Response(serialized_notes,
                 status=status.HTTP_200_OK)
 
+    @swagger_auto_schema(request_body=serializers.NoteSerializer)
     @action(detail=True, methods=["patch"])
     def remove_note(self, request, pk=None):
         """Remove Note From Finding Note"""


### PR DESCRIPTION
Fixes #2118

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)

There would be probably more to fix, but now that there is an example, it may be easier for those who notice -- including myself :)
