### PR TITLE
Fix test notes not appearing in report + cosmetic improvement

### DIFF
--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -145,7 +145,7 @@
         <div class="row">
             <div class="col-lg-12">
                 {% if include_finding_notes %}
-                    {% with notes=find.notes.all|get_public_notes %}
+                    {% with notes=test.notes.all|get_public_notes %}
                         {% if notes.count > 0 %}
                             <h3>Test Notes</h3>
                             {% for note in notes reversed %}

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -147,10 +147,43 @@
                 {% if include_finding_notes %}
                     {% with notes=test.notes.all|get_public_notes %}
                         {% if notes.count > 0 %}
-                            <h3>Test Notes</h3>
-                            {% for note in notes reversed %}
-                                    <p>{{ note.author }} - {{ note.date }} - {{ note }}</p>
-                            {% endfor %}
+                            <h3> Test Notes </h3>
+                            <table id="notes" class="tablesorter-bootstrap table table-condensed table-striped">
+                                <thead>
+                                <tr>
+                                    <th>User</th>
+                                    <th>Date</th>
+                                    {% with notes_with_type=notes|get_notetype_notes_count %}
+                                        {% if notes_with_type > 0 %}
+                                            <th>Note Type</th>
+                                        {% endif %}
+                                        <th>Note</th>
+                                        </tr>
+                                        </thead>
+                                        <tbody>
+                                        {% for note in notes reversed %}
+                                            <tr>
+                                                <td>
+                                                    {{ note.author.username }}
+                                                </td>
+                                                <td>
+                                                    {{ note.date }}
+                                                </td>
+                                                {% if notes_with_type > 0 %}
+                                                    <td>
+                                                        {% if note.note_type != None %}
+                                                            {{ note.note_type }}
+                                                        {% endif %}
+                                                    </td>
+                                                {% endif %}
+                                                <td>
+                                                    {{ note|linebreaks }}
+                                                </td>
+                                            </tr>
+                                        {% endfor %}
+                                        </tbody>
+                                    {% endwith %}
+                            </table>
                         {% endif %}
                     {% endwith %}
                 {% endif %}


### PR DESCRIPTION
Just a quick little typo fix.

Issue:
When generating an HTML report for a Test, test notes were not appearing.

Cause:
Typo - was looking at find.notes rather than test.notes

