### PR TITLE
system settings test: fix copy-paste error

### DIFF
--- a/dojo/unittests/test_system_settings.py
+++ b/dojo/unittests/test_system_settings.py
@@ -8,7 +8,7 @@ class TestSystemSettings(TestCase):
         try:
             # although the unittests are run after initial data has been loaded, for some reason in travis sometimes the settings aren't present
             system_settings = System_Settings.objects.get()
-        except System_Settings.DoesNotExistDoesNotExist:
+        except System_Settings.DoesNotExist:
             system_settings = System_Settings()
 
         system_settings.enable_jira = True


### PR DESCRIPTION
I don't know what went wrong with my own tests, then travis, then 2 approvers, but obviously my PR #2105 contains a syntax error. this PR fixes it

Good thing is that the exception is being triggered, which might mean this PR will help travis become more successful.

```
======================================================================
ERROR: test_system_settings_update (dojo.unittests.test_system_settings.TestSystemSettings)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/app/dojo/unittests/test_system_settings.py", line 10, in test_system_settings_update
    system_settings = System_Settings.objects.get()
  File "/app/dojo/models.py", line 104, in get
    return cache.get_or_set(self.CACHE_KEY, lambda: super(SystemSettingsManager, self).get(*args, **kwargs), timeout=30)
  File "/usr/local/lib/python3.5/site-packages/django/core/cache/backends/base.py", line 167, in get_or_set
    default = default()
  File "/app/dojo/models.py", line 104, in <lambda>
    return cache.get_or_set(self.CACHE_KEY, lambda: super(SystemSettingsManager, self).get(*args, **kwargs), timeout=30)
  File "/usr/local/lib/python3.5/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/django/db/models/query.py", line 408, in get
    self.model._meta.object_name
dojo.models.System_Settings.DoesNotExist: System_Settings matching query does not exist.
```