### PR TITLE
integration tests fixes and improvements

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -29,7 +29,7 @@ from dojo.signals import dedupe_signal
 
 from dojo.models import Finding, Engagement, Finding_Template, Product, JIRA_PKey, JIRA_Issue, \
     Dojo_User, User, Alerts, System_Settings, Notifications, UserContactInfo, Endpoint, Benchmark_Type, \
-    Language_Type, Languages, Rule, Finding, Test_Type
+    Language_Type, Languages, Rule, Test_Type
 from asteval import Interpreter
 from requests.auth import HTTPBasicAuth
 import logging
@@ -111,6 +111,8 @@ def sync_dedupe(sender, *args, **kwargs):
         else:
             deduplicationLogger.debug("no configuration per parser found; using legacy algorithm")
             deduplicate_legacy(new_finding)
+    else:
+        deduplicationLogger.debug("skipping dedupe because it's disabled in system settings get()")
 
 
 def deduplicate_legacy(new_finding):

--- a/tests/Engagement_unit_test.py
+++ b/tests/Engagement_unit_test.py
@@ -10,7 +10,7 @@ class EngagementTest(BaseTestCase):
 
     def test_add_new_engagement(self):
         driver = self.login_page()
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         driver.find_element_by_class_name("pull-left").click()
         driver.find_element_by_link_text("Add New Engagement").click()
         driver.find_element_by_id("id_name").send_keys("test engagement")
@@ -24,7 +24,7 @@ class EngagementTest(BaseTestCase):
 
     def test_edit_created_new_engagement(self):
         driver = self.login_page()
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         driver.find_element_by_class_name("pull-left").click()
         driver.find_element_by_link_text("View Engagements").click()
         driver.find_element_by_link_text("test engagement").click()
@@ -39,7 +39,7 @@ class EngagementTest(BaseTestCase):
 
     def test_close_new_engagement(self):
         driver = self.login_page()
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         driver.find_element_by_class_name("pull-left").click()
         driver.find_element_by_link_text("View Engagements").click()
         driver.find_element_by_link_text("edited test engagement").click()
@@ -50,7 +50,7 @@ class EngagementTest(BaseTestCase):
 
     def test_delete_new_closed_engagement(self):
         driver = self.login_page()
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         driver.find_element_by_class_name("pull-left").click()
         driver.find_element_by_link_text('View Engagements').click()
         driver.find_element_by_link_text("edited test engagement").click()
@@ -62,7 +62,9 @@ class EngagementTest(BaseTestCase):
 
     def test_new_ci_cd_engagement(self):
         driver = self.login_page()
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
+        # wait for product_wrapper div as datatables javascript modifies the DOM on page load.
+        driver.find_element_by_id('products_wrapper')
         driver.find_element_by_link_text('QA Test').click()
         driver.find_element_by_xpath("//a[@class='dropdown-toggle active']//span[@class='hidden-xs']").click()
         driver.find_element_by_link_text('Add New CI/CD Engagement').click()

--- a/tests/Import_scanner_unit_test.py
+++ b/tests/Import_scanner_unit_test.py
@@ -197,7 +197,7 @@ class ScannerTest(BaseTestCase):
 
     def test_engagement_import_scan_result(self):
         driver = self.login_page()
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         driver.find_element_by_class_name("pull-left").click()
         driver.find_element_by_link_text("Add New Engagement").click()
         driver.find_element_by_id("id_name").send_keys('Scan type mapping')
@@ -246,7 +246,7 @@ class ScannerTest(BaseTestCase):
             if len(cases) == 0:
                 failed_tests += [test.upper() + ': No test cases']
             for case in cases:
-                driver.get(self.base_url + "product")
+                self.goto_product_overview(driver)
                 driver.find_element_by_class_name("pull-left").click()
                 driver.find_element_by_link_text("Add New Engagement").click()
                 driver.find_element_by_id("id_name").send_keys(test + ' - ' + case)

--- a/tests/Product_unit_test.py
+++ b/tests/Product_unit_test.py
@@ -4,7 +4,8 @@ import unittest
 import re
 import sys
 import time
-from base_test_class import BaseTestCase
+from base_test_class import BaseTestCase, on_exception_html_source_logger
+from selenium.webdriver.common.by import By
 
 
 class WaitForPageLoad(object):
@@ -32,10 +33,14 @@ class WaitForPageLoad(object):
 
 class ProductTest(BaseTestCase):
 
+    @on_exception_html_source_logger
     def test_create_product(self):
+        # make sure no left overs from previous runs are left behind
+        self.delete_product_if_exists()
+
         driver = self.login_page()
         # Navigate to the product page
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         # "Click" the dropdown button to see options
         driver.find_element_by_id("dropdownMenu1").click()
         # "Click" the add prodcut button
@@ -58,20 +63,22 @@ class ProductTest(BaseTestCase):
         self.assertTrue(re.search(r'Product added successfully', productTxt) or
             re.search(r'Product with this Name already exists.', productTxt))
 
+    @on_exception_html_source_logger
     def test_list_products(self):
         driver = self.login_page()
         # Navigate to the product page
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         # list products which will make sure there are no javascript errors such as before in https://github.com/DefectDojo/django-DefectDojo/issues/2050
 
     # For product consistency sake, We won't be editting the product title
     # instead We can edit the product description
+    @on_exception_html_source_logger
     def test_edit_product_description(self):
         # Login to the site. Password will have to be modified
         # to match an admin password in your own container
         driver = self.login_page()
         # Navigate to the product page
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the dropdown option
@@ -88,12 +95,13 @@ class ProductTest(BaseTestCase):
         self.assertTrue(re.search(r'Product updated successfully', productTxt) or
             re.search(r'Product with this Name already exists.', productTxt))
 
+    @on_exception_html_source_logger
     def test_add_product_engagement(self):
         # Test To Add Engagement To product
         # login to site, password set to fetch from environ
         driver = self.login_page()
-        # Navigate to Product page
-        driver.get(self.base_url + "product")
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the dropdown option
@@ -125,12 +133,13 @@ class ProductTest(BaseTestCase):
         # Assert of the query to dtermine status of failure
         self.assertTrue(re.search(r'Engagement added successfully', productTxt))
 
+    @on_exception_html_source_logger
     def test_add_product_finding(self):
         # Test To Add Finding To product
         # login to site, password set to fetch from environ
         driver = self.login_page()
-        # Navigate to Product page
-        driver.get(self.base_url + "product")
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # Click on the 'Finding dropdown button'
@@ -166,12 +175,13 @@ class ProductTest(BaseTestCase):
         # Assert to the query to dtermine status of failure
         self.assertTrue(re.search(r'App Vulnerable to XSS', productTxt))
 
+    @on_exception_html_source_logger
     def test_add_product_endpoints(self):
         # Test To Add Endpoints To product
         # login to site, password set to fetch from environ
         driver = self.login_page()
-        # Navigate to Product page
-        driver.get(self.base_url + "product")
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # Click on the 'Endpoints' dropdown button
@@ -189,12 +199,13 @@ class ProductTest(BaseTestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Endpoint added successfully', productTxt))
 
+    @on_exception_html_source_logger
     def test_add_product_custom_field(self):
         # Test To Add Custom Fields To product
         # login to site, password set to fetch from environ
         driver = self.login_page()
-        # Navigate to Product page
-        driver.get(self.base_url + "product")
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the dropdown option
@@ -217,12 +228,13 @@ class ProductTest(BaseTestCase):
         self.assertTrue(re.search(r'Metadata added successfully', productTxt) or
             re.search(r'A metadata entry with the same name exists already for this object.', productTxt))
 
+    @on_exception_html_source_logger
     def test_edit_product_custom_field(self):
         # Test To Edit Product Custom Fields
         # login to site, password set to fetch from environ
         driver = self.login_page()
-        # Navigate to Product page
-        driver.get(self.base_url + "product")
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the dropdown option
@@ -241,12 +253,13 @@ class ProductTest(BaseTestCase):
         self.assertTrue(re.search(r'Metadata edited successfully', productTxt) or
             re.search(r'A metadata entry with the same name exists already for this object.', productTxt))
 
+    @on_exception_html_source_logger
     def test_add_product_tracking_files(self):
         # Test To Add tracking files To product
         # login to site, password set to fetch from environ
         driver = self.login_page()
-        # Navigate to Product page
-        driver.get(self.base_url + "product")
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the dropdown option
@@ -267,12 +280,13 @@ class ProductTest(BaseTestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Added Tracked File to a Product', productTxt))
 
+    @on_exception_html_source_logger
     def test_edit_product_tracking_files(self):
         # Test To Edit Product Tracking Files
         # login to site, password set to fetch from environ
         driver = self.login_page()
-        # Navigate to Product page
-        driver.get(self.base_url + "product")
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select and click on the particular product to edit
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the dropdown option
@@ -292,12 +306,22 @@ class ProductTest(BaseTestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(re.search(r'Tool Product Configuration Successfully Updated', productTxt))
 
-    def test_delete_product(self):
-        # Login to the site. Password will have to be modified
-        # to match an admin password in your own container
+    @on_exception_html_source_logger
+    def delete_product_if_exists(self):
         driver = self.login_page()
         # Navigate to the product page
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
+        # Select the specific product to delete
+        qa_products = driver.find_elements(By.LINK_TEXT, "QA Test")
+
+        if len(qa_products) > 0:
+            self.test_delete_product()
+
+    @on_exception_html_source_logger
+    def test_delete_product(self):
+        driver = self.login_page()
+        # Navigate to the product page
+        self.goto_product_overview(driver)
         # Select the specific product to delete
         driver.find_element_by_link_text("QA Test").click()
         # Click the drop down menu

--- a/tests/Test_unit_test.py
+++ b/tests/Test_unit_test.py
@@ -47,7 +47,9 @@ class TestUnitTest(BaseTestCase):
         # Username and password will be gotten from environ
         driver = self.login_page()
         # Navigate to the Product page to select the product we created earlier
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
+        # wait for product_wrapper div as datatables javascript modifies the DOM on page load.
+        driver.find_element_by_id('products_wrapper')
         # Select and click on the particular product to create test for
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the dropdown option

--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -38,7 +38,7 @@ class DedupeTest(BaseTestCase):
                     dupe_count += 1
 
             if (dupe_count != expected_number_of_duplicates):
-                print("duplicate count mismatch, let's wait a bit for the celery dedupe task to finish and try again (15s)")
+                print("duplicate count mismatch, let's wait a bit for the celery dedupe task to finish and try again (5s)")
             else:
                 break
 

--- a/tests/ibm_appscan_test.py
+++ b/tests/ibm_appscan_test.py
@@ -17,7 +17,9 @@ class IBMAppScanTest(BaseTestCase):
         # Username and password will be gotten from environ
         driver = self.login_page()
         # Navigate to the Endpoint page
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
+        # wait for product_wrapper div as datatables javascript modifies the DOM on page load.
+        driver.find_element_by_id('products_wrapper')
         driver.find_element_by_link_text("QA Test").click()
         # "Click" the Finding Drop down
         driver.find_element_by_partial_link_text("Findings").click()

--- a/tests/local-integration-tests.bat
+++ b/tests/local-integration-tests.bat
@@ -10,6 +10,10 @@ echo "Running Product integration tests"
 python tests/Product_unit_test.py
 if %ERRORLEVEL% NEQ 0 GOTO END
 
+echo "Running Dedupe integration tests"
+python tests/dedupe_unit_test.py
+if %ERRORLEVEL% NEQ 0 GOTO END
+
 echo "Running Endpoint integration tests"
 python tests/Endpoint_unit_test.py
 if %ERRORLEVEL% NEQ 0 GOTO END
@@ -44,10 +48,6 @@ if %ERRORLEVEL% NEQ 0 GOTO END
 
 echo "Running Check Status test"
 python tests/check_status.py
-if %ERRORLEVEL% NEQ 0 GOTO END
-
-echo "Running Dedupe integration tests"
-python tests/dedupe_unit_test.py
 if %ERRORLEVEL% NEQ 0 GOTO END
 
 REM REM  The below tests are commented out because they are still an unstable work in progress

--- a/tests/local-integration-tests.sh
+++ b/tests/local-integration-tests.sh
@@ -23,6 +23,14 @@ else
     echo "Error: Product integration test failed"; exit 1
 fi
 
+echo "Running Dedupe integration tests"
+if python3 tests/dedupe_unit_test.py ; then
+    echo "Success: Dedupe integration tests passed"
+else
+    docker-compose logs uwsgi --tail=all
+    echo "Error: Dedupe integration test failed"; exit 1
+fi
+
 echo "Running Endpoint integration tests"
 if python3 tests/Endpoint_unit_test.py ; then
     echo "Success: Endpoint integration tests passed"
@@ -93,14 +101,6 @@ if python3 tests/check_status.py ; then
 else
     docker-compose logs uwsgi --tail=all
     echo "Error: Check status tests failed"; exit 1
-fi
-
-echo "Running Dedupe integration tests"
-if python3 tests/dedupe_unit_test.py ; then
-    echo "Success: Dedupe integration tests passed"
-else
-    docker-compose logs uwsgi --tail=all
-    echo "Error: Dedupe integration test failed"; exit 1
 fi
 
 # The below tests are commented out because they are still an unstable work in progress

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -16,7 +16,7 @@ class DojoTests(BaseTestCase):
 
     def test_create_product(self):
         driver = self.login_page()
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         driver.find_element_by_id("dropdownMenu1").click()
         driver.find_element_by_link_text("Add Product").click()
         driver.find_element_by_id("id_name").clear()
@@ -31,7 +31,7 @@ class DojoTests(BaseTestCase):
     def test_engagement(self):
         driver = self.login_page()
         driver = self.driver
-        driver.get(self.base_url + "product")
+        self.goto_product_overview(driver)
         driver.find_element_by_link_text("Product List").click()
         driver.find_element_by_xpath("//table[@id='products']/tbody/tr[1]/td[5]/a").click()
 

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -2,11 +2,6 @@
 
 umask 0002
 
-echo "Waiting for services to start"
-docker-compose up -d
-# wait for containers to start from images and services to become available
-sleep 100 # giving long enough time
-
 ## Installing Google Chrome browser
 sudo apt-get install -y gdebi && \
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
@@ -23,120 +18,143 @@ python3 -m pip install selenium requests --user || exit 1
 # Exporting Username and password to env for access by automation scripts
 CONTAINER_NAME=django-defectdojo_initializer_1
 echo "export DD_ADMIN_USER=admin" >> ~/.profile && \
-    container_id=(`docker ps -a --filter name=${CONTAINER_NAME}.* | awk 'FNR == 2 {print $1}'`) && \
+    container_id=(`docker ps -a --filter name=${CONTAINER_NAME}.* | awk 'FNR ==2 {print $1}'`) && \
     docker logs $container_id 2>&1 | grep "Admin password:"| cut -c17- | (read passwordss; echo "export DD_ADMIN_PASSWORD=$passwordss" >> ~/.profile) && \
     source ~/.profile
 
 # All available Unittest Scripts are activated below
-# If successful, A success message is printed and the script continues
-# If any script is unsuccessful a failure message is printed and the test script
+# If successsful, A successs message is printed and the script continues
+# If any script is unsuccesssful a failure message is printed and the test script
 # Exits with status code of 1
 
 export DD_BASE_URL='http://localhost:8080/'
 
-echo "Running Product type integration tests"
-if python3 tests/Product_type_unit_test.py ; then
-    echo "Success: Product type integration tests passed"
-else
+function fail() {
+    echo "Error: $1 test failed"
     docker-compose logs --tail="all" uwsgi
-    echo "Error: Product type integration test failed."; exit 1
+    exit 1    
+}
+
+function success() {
+    echo "Succes: $1 test passed"
+}
+
+test="Product type integration tests"
+echo "Running: $test"
+if python3 tests/Product_type_unit_test.py ; then
+    success $test
+else
+    fail $test
 fi
 
-echo "Running Product integration tests"
+test="Product integration tests"
+echo "Running: $test"
 if python3 tests/Product_unit_test.py ; then 
-    echo "Success: Product integration tests passed"
+    success $test
 else
-    echo "Error: Product integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Endpoint integration tests"
+test="Endpoint integration tests"
+echo "Running: $test"
 if python3 tests/Endpoint_unit_test.py ; then
-    echo "Success: Endpoint integration tests passed"
+    success $test
 else
-    echo "Error: Endpoint integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Engagement integration tests"
+test="Engagement integration tests"
+echo "Running: $test"
 if python3 tests/Engagement_unit_test.py ; then
-    echo "Success: Engagement integration tests passed"
+    success $test
 else
-    echo "Error: Engagement integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Environment integration tests"
+test="Environment integration tests"
+echo "Running: $test"
 if python3 tests/Environment_unit_test.py ; then 
-    echo "Success: Environment integration tests passed"
+    success $test
 else
-    echo "Error: Environment integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Finding integration tests"
+test="Finding integration tests"
+echo "Running: $test"
 if python3 tests/Finding_unit_test.py ; then
-    echo "Success: Finding integration tests passed"
+    success $test
 else
-    echo "Error: Finding integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Test integration tests"
+test="Test integration tests"
+echo "Running: $test"
 if python3 tests/Test_unit_test.py ; then
-    echo "Success: Test integration tests passed"
+    success $test
 else
-    echo "Error: Test integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running User integration tests"
+test=echo "User integration tests"
+echo "Running: $test"
 if python3 tests/User_unit_test.py ; then
-    echo "Success: User integration tests passed"
+    success $test
 else
-    echo "Error: User integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Ibm Appscan integration test"
+test="Ibm Appscan integration test"
+echo "Running: $test"
 if python3 tests/ibm_appscan_test.py ; then
-    echo "Success: Ibm AppScan integration tests passed"
+    success $test
 else
-    echo "Error: Ibm AppScan integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Smoke integration test"
+test="Smoke integration test"
+echo "Running: $test"
 if python3 tests/smoke_test.py ; then
-    echo "Success: Smoke integration tests passed"
+    success $test
 else
-    echo "Error: Smoke integration test failed"; exit 1
+    fail $test
 fi
 
-echo "Running Check Status test"
+test="Check Status test"
+echo "Running: $test"
 if python3 tests/check_status.py ; then
-    echo "Success: check status tests passed"
+    success $test
 else
-    echo "Error: Check status tests failed"; exit 1
+    fail $test
 fi
 
-echo "Running Dedupe integration tests"
+test="Dedupe integration tests"
+echo "Running: $test"
 if python3 tests/dedupe_unit_test.py ; then
-    echo "Success: Dedupe integration tests passed"
+    success $test
 else
-    echo "Error: Dedupe integration test failed"; exit 1
+    fail $test
 fi
+
+
 
 # The below tests are commented out because they are still an unstable work in progress
 ## Once Ready they can be uncommented.
 
-# echo "Running Import Scanner integration test"
+# echo "Import Scanner integration test"
 # if python3 tests/Import_scanner_unit_test.py ; then
 #     echo "Success: Import Scanner integration tests passed" 
 # else
 #     echo "Error: Import Scanner integration test failed"; exit 1
 # fi
 
-# echo "Running Check Status UI integration test"
+# echo "Check Status UI integration test"
 # if python3 tests/check_status_ui.py ; then
 #     echo "Success: Check Status UI tests passed"
 # else
 #     echo "Error: Check Status UI test failed"; exit 1
 # fi
 
-# echo "Running Zap integration test"
+# echo "Zap integration test"
 # if python3 tests/zap.py ; then
 #     echo "Success: zap integration tests passed"
 # else

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -217,6 +217,12 @@ echo "Running test ${TEST}"
       # make sure you remember to change back to 'release' before making a PR
       source ./docker/setEnv.sh release
       docker-compose build
+
+      echo "Waiting for services to start"
+      docker-compose up -d
+      # wait for containers to start from images and services to become available
+      sleep 100 # giving long enough time
+
       source ./travis/integration_test-script.sh
       ;;
     snyk)


### PR DESCRIPTION
Integration tests were failing randomly in Travis. Turns our this was not Travis' fault, but our own code.

This PR fixes two main problems with Defect Dojo / Integration tests.

- Dedupe tests failing. This was caused by a corner cases being affected by #1953. The cache there is local per worker, so if you have multiple workers, you can have stale system settings for at most 30s. This is usualy OK, but in integration tests it's an issue. This PR contains a workaround, proper fix to follow based on #2164

- `StaleElementReferenceException` by Selenium. This was caused by #1586. After the page is loaded, the datatables javascript applies itself to the DOM and changes it. It wraps itself around the original products table causing the element that selenium just found to go stale. This is a bit of a race condition, explaining why it sometimes works. Fixed by waiting for the datatables element being present in the DOM.

Improvements:

- Check if an import was successful. This makes sure the test fails when the import was not succesful. And also it makes sure the test waits until the import has finished before importing the next scan!

- Increase wait time for background dedupe. Could be that it's just very slow.

- Delete existing QA Product that could be left behind by previous failing tests. Shouldn't happen inside travis, but you never know and it also helps when running local integration tests on an existing database.

- Display logs if integration tests fail.

- Remove some old commented code

- Add some comments here and there to explain tests

Reverted changes from earlier version of this PR:

-  Make dedupe synchronous so it doesn't rely on celery in the background
might be useful to actually let celery perform dedupe.