### PR TITLE
integration tests: disable those without benefit for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: xenial
 language: minimal
 services:
-  - docker
+  # - docker
 env:
   global:
     - K8S_VERSION=v1.13.4
@@ -10,20 +10,20 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
   matrix:
     - BROKER=rabbitmq DATABASE=mysql
-    - BROKER=rabbitmq DATABASE=postgresql
-    - BROKER=redis DATABASE=mysql
-    - BROKER=redis DATABASE=postgresql
+    # - BROKER=rabbitmq DATABASE=postgresql
+    # - BROKER=redis DATABASE=mysql
+    # - BROKER=redis DATABASE=postgresql
     - TEST=flake8
-    - TEST=snyk
-    - TEST=docker
+    # - TEST=snyk
+    # - TEST=docker
     - TEST=integration_tests
 matrix: 
-  allow_failures:
-    - env: TEST=snyk
+  # allow_failures:
+  #   - env: TEST=snyk
 jobs:
-  include:  
-    - stage: deploy
-      env: TEST=deploy
+  # include:  
+  #   - stage: deploy
+  #     env: TEST=deploy
 before_install: ['./travis/before-install.sh']
 before_script: ['./travis/before-script.sh']
 script: ['./travis/script.sh']

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -112,12 +112,13 @@ else
     echo "Error: Check status tests failed"; exit 1
 fi
 
-echo "Running Dedupe integration tests"
-if python3 tests/dedupe_unit_test.py ; then
-    echo "Success: Dedupe integration tests passed"
-else
-    echo "Error: Dedupe integration test failed"; exit 1
-fi
+# disable due to too many failures in travis, see #2160
+# echo "Running Dedupe integration tests"
+# if python3 tests/dedupe_unit_test.py ; then
+#     echo "Success: Dedupe integration tests passed"
+# else
+#     echo "Error: Dedupe integration test failed"; exit 1
+# fi
 
 # The below tests are commented out because they are still an unstable work in progress
 ## Once Ready they can be uncommented.


### PR DESCRIPTION
EDIT: In the mean time I think #2160 actually fixes a lot of issues, so let's see what that brings us before killing of some tests. 

This disables some parts of our Travis test suite:

- dedupe_unit test. As seen in #2160 there are so many failures without any reason, could even be a bug in the code. For now we disable this as it is frustrating PR owners with too many unrelated failures.

- BROKERs. Only keep rabbitmq+mysql. Building the other 3 brokers is not of real benefit, increases built time and chances for errors/timeouts.

- snyk. Not working and ignored anyway.

- docker. No real benefit as it's just a build/run. The exact same containers are built (and run) by the integration_test step.