### PR TITLE
cache system_settings v2

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -52,11 +52,11 @@ User.objects.create_superuser(
 )
 EOD
 
+  python3 manage.py loaddata system_settings
   python3 manage.py loaddata initial_banner_conf
   python3 manage.py loaddata product_type
   python3 manage.py loaddata test_type
   python3 manage.py loaddata development_environment
-  python3 manage.py loaddata system_settings
   python3 manage.py loaddata benchmark_type
   python3 manage.py loaddata benchmark_category
   python3 manage.py loaddata benchmark_requirement

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -2,7 +2,11 @@ from django.http import HttpResponseRedirect
 from django.conf import settings
 from django.utils.http import urlquote
 from re import compile
+import logging
+from threading import local
+from django.db import models
 
+logger = logging.getLogger(__name__)
 
 EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
 if hasattr(settings, 'LOGIN_EXEMPT_URLS'):
@@ -21,6 +25,7 @@ class LoginRequiredMiddleware:
     """
 
     def __init__(self, get_response):
+
         self.get_response = get_response
 
     def __call__(self, request):
@@ -41,3 +46,71 @@ class LoginRequiredMiddleware:
 
         response = self.get_response(request)
         return response
+
+
+class DojoSytemSettingsMiddleware(object):
+    _thread_local = local()
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        # avoid circular imports
+        from dojo.models import System_Settings
+        models.signals.post_save.connect(self.cleanup, sender=System_Settings)
+
+    def __call__(self, request):
+        self.load()
+        response = self.get_response(request)
+        self.cleanup()
+        return response
+
+    def process_exception(self, request, exception):
+        logger.debug('cleaning up during exception')
+        self.cleanup()
+
+    @classmethod
+    def get_system_settings(cls):
+        if hasattr(cls._thread_local, 'system_settings'):
+            return cls._thread_local.system_settings
+
+        return None
+
+    @classmethod
+    def cleanup(cls, *args, **kwargs):
+        logger.debug('removing thread local system_settings')
+        if hasattr(cls._thread_local, 'system_settings'):
+            del cls._thread_local.system_settings
+
+    @classmethod
+    def load(cls):
+        from dojo.models import System_Settings
+        system_settings = System_Settings.objects.get(no_cache=True)
+        cls._thread_local.system_settings = system_settings
+        return system_settings
+
+
+class System_Settings_Manager(models.Manager):
+
+    def get_from_db(self, *args, **kwargs):
+        # logger.debug('resfreshing system_settings from db')
+        try:
+            from_db = super(System_Settings_Manager, self).get(*args, **kwargs)
+        except:
+            from dojo.models import System_Settings
+            # this mimics the existing code that was in filters.py and utils.py.
+            # cases I have seen triggering this is for example manage.py collectstatic inside a docker build where mysql is not available
+            # logger.debug('unable to get system_settings from database, constructing (new) default instance. Exception was:', exc_info=True)
+            return System_Settings()
+        return from_db
+
+    def get(self, no_cache=False, *args, **kwargs):
+        if no_cache:
+            # logger.debug('no_cache specified or cached value found, loading system settings from db')
+            return self.get_from_db(*args, **kwargs)
+
+        from_cache = DojoSytemSettingsMiddleware.get_system_settings()
+
+        if not from_cache:
+            # logger.debug('no cached value found, loading system settings from db')
+            return self.get_from_db(*args, **kwargs)
+
+        return from_cache

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1741,13 +1741,10 @@ class Finding(models.Model):
                 from dojo.tasks import async_dedupe
                 try:
                     if self.reporter.usercontactinfo.block_execution:
-                        logger.debug('triggering signal for sync dedupe')
                         dedupe_signal.send(sender=self.__class__, new_finding=self)
                     else:
-                        logger.debug('triggering async dedupe')
                         async_dedupe.delay(self, *args, **kwargs)
                 except:
-                    logger.debug('triggering async dedupe except')
                     async_dedupe.delay(self, *args, **kwargs)
                     pass
             else:

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -508,6 +508,7 @@ INSTALLED_APPS = (
 DJANGO_MIDDLEWARE_CLASSES = [
     # 'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.common.CommonMiddleware',
+    'dojo.middleware.DojoSytemSettingsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.security.SecurityMiddleware',
@@ -704,8 +705,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'verbose': {
-            'format': '[%(asctime)s] %(levelname)s '
-                      '[%(name)s:%(lineno)d] %(message)s',
+            'format': '[%(asctime)s] %(levelname)s [%(name)s:%(lineno)d] %(message)s',
             'datefmt': '%d/%b/%Y %H:%M:%S',
         },
         'simple': {

--- a/dojo/system_settings/views.py
+++ b/dojo/system_settings/views.py
@@ -16,10 +16,7 @@ logger = logging.getLogger(__name__)
 
 @user_passes_test(lambda u: u.is_superuser)
 def system_settings(request):
-    try:
-        system_settings_obj = System_Settings.objects.get(no_cache=True)
-    except:
-        system_settings_obj = System_Settings()
+    system_settings_obj = System_Settings.objects.get(no_cache=True)
 
     # Celery needs to be set with the setting: CELERY_RESULT_BACKEND = 'db+sqlite:///dojo.celeryresults.sqlite'
     if hasattr(settings, 'CELERY_RESULT_BACKEND'):

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -273,7 +273,7 @@ def add_comment_task(find, note):
 
 @app.task(name='async_dedupe')
 def async_dedupe(new_finding, *args, **kwargs):
-    deduplicationLogger.debug("running deduplication")
+    deduplicationLogger.debug("running async deduplication")
     dedupe_signal.send(sender=new_finding.__class__, new_finding=new_finding)
 
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1731,11 +1731,7 @@ def prepare_for_view(encrypted_value):
 
 
 def get_system_setting(setting):
-    try:
-        system_settings = System_Settings.objects.get()
-    except:
-        system_settings = System_Settings()
-
+    system_settings = System_Settings.objects.get()
     return getattr(system_settings, setting, None)
 
 

--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -57,8 +57,6 @@ class DedupeTest(BaseTestCase):
             driver.find_element_by_xpath('//*[@id="id_enable_deduplication"]').click()
             # save settings
             driver.find_element_by_css_selector("input.btn.btn-primary").click()
-            # Temporary fix for the caching issue, see https://github.com/DefectDojo/django-DefectDojo/issues/2164
-            time.sleep(30)
             # check if it's enabled after reload
             driver.get(self.base_url + 'system_settings')
             self.assertTrue(driver.find_element_by_id('id_enable_deduplication').is_selected())


### PR DESCRIPTION
fixes #2164 and properly fixes the workaround from #2160 

This is an improved caching of system settings. The one in #1954 was using the django cache.
This works fine under normal use, but when using multiple workers even the limited ttl of 30s is too much.

This PR introduces a middleware to cache the system_settings during a single request.
It uses a threadlocal, which should be used with care. In this case it's reliable because the middleware 
always cleans up the threadlocal at the end of the request.
Anythin that is not a request (celery tasks) will not use the middleware, so are not affected and will always 
query the database.

Alternatives considered:
- Use an external query caching tool such as Redis. 
This can still be used, but I didn't want to introduces more 
components/containers to be installed/documented/supported.

- Use a dependency injection framework such as django-injector. 
This would require changes to almost any view class and also introduces a completely new concept.

- Use an existing library that does something with caching or storing the request.
I tried https://github.com/benrobster/django-threadlocals, but this doesn't clean up after the request and doesn't handle exceptions.
I tried https://github.com/t-evans/django-threadlocalrequest, but this is 7 years old.

- Use query cache based on django cache
I am using https://github.com/noripyt/django-cachalot and it works fine. But the cache is local to each worker, so would suffer from the same issue as #2160.

So I ended up writing a middleware myself, it's quite simple but feedback is welcome.
I left some debug logging as comments which can easily be enabled if needed.
I'm missing the TRACE log level ;-)