### PR TITLE
Add plantuml github action + use major version for RD

### DIFF
--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -12,12 +12,12 @@ jobs:
     env:
       UML_FILES: ".puml"
     steps:
-      - name: Checkout Source 
+      - name: Checkout Source
         uses: actions/checkout@v1
       - name: Generate SVG Diagrams
         uses: cloudbees/plantuml-github-action@master
         with:
-            args: -v -tsvg $UML_FILES
+          args: -v -tsvg $UML_FILES
       - name: Get changed UML files
         id: getfile
         run: |
@@ -28,12 +28,12 @@ jobs:
       - name: Generate PNG Diagrams
         uses: cloudbees/plantuml-github-action@master
         with:
-            args: -v -tpng $UML_FILES
+          args: -v -tpng $UML_FILES
       - name: Push Local Changes
-        uses:  stefanzweifel/git-auto-commit-action@v4.1.2 
-        with: 
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
           commit_user_name: "PlantUML_bot"
           commit_user_email: "noreply@defectdojo.org"
           commit_author: "PlantUML Bot <noreply@defectdojo.org>"
-          commit_message: "Generate SVG and PNG images for PlantUML diagrams" 
+          commit_message: "Generate SVG and PNG images for PlantUML diagrams"
           branch: ${{ github.head_ref }}

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -1,0 +1,39 @@
+name: Generate PlantUML Diagrams
+on:
+  push:
+    paths:
+      - '**.puml'
+    branches:
+      - master
+      - dev
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      UML_FILES: ".puml"
+    steps:
+      - name: Checkout Source 
+        uses: actions/checkout@v1
+      - name: Generate SVG Diagrams
+        uses: cloudbees/plantuml-github-action@master
+        with:
+            args: -v -tsvg $UML_FILES
+      - name: Get changed UML files
+        id: getfile
+        run: |
+          echo "::set-output name=files::$(git diff-tree -r --no-commit-id --name-only ${{ github.sha }} | grep ${{ env.UML_FILES }} | xargs)"
+      - name: UML files considered echo output
+        run: |
+          echo ${{ steps.getfile.outputs.files }}
+      - name: Generate PNG Diagrams
+        uses: cloudbees/plantuml-github-action@master
+        with:
+            args: -v -tpng $UML_FILES
+      - name: Push Local Changes
+        uses:  stefanzweifel/git-auto-commit-action@v4.1.2 
+        with: 
+          commit_user_name: "PlantUML_bot"
+          commit_user_email: "noreply@defectdojo.org"
+          commit_author: "PlantUML Bot <noreply@defectdojo.org>"
+          commit_message: "Generate SVG and PNG images for PlantUML diagrams" 
+          branch: ${{ github.head_ref }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.6.1
+      - uses: release-drafter/release-drafter@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Upon a PR merging, will auto-generate the png and svg output for a given .puml file (plantUML), like the ones we are introducing through PR #2003 