### PR TITLE
travis: reorder tests to prioritize important tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,14 @@ env:
     - HELM_VERSION=v2.13.0
     - CHANGE_MINIKUBE_NONE_USER=true
   matrix:
+    - TEST=flake8
+    - TEST=integration_tests
+    - TEST=docker
     - BROKER=rabbitmq DATABASE=mysql
     - BROKER=rabbitmq DATABASE=postgresql
     - BROKER=redis DATABASE=mysql
     - BROKER=redis DATABASE=postgresql
-    - TEST=flake8
     - TEST=snyk
-    - TEST=docker
-    - TEST=integration_tests
 matrix: 
   allow_failures:
     - env: TEST=snyk


### PR DESCRIPTION
In my experience the two most important Travis steps are the integration tests and flake8. Always good fun to let it build for 40 minutes only to see that you have left 1 space at the end of some line.

This PR reorders the travis build matrix to have these two tests on top so they execute first.