### PR TITLE
Updated Requirements.yaml for Helm 3 install

### DIFF
--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
   - name: mysql
-    version: 0.15.0
+    version: 1.6.2
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: mysql.enabled
   - name: postgresql
-    version: 3.11.7
+    version: 8.6.4
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: postgresql.enabled
   - name: rabbitmq
-    version: 4.3.1
+    version: 6.18.2
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq.enabled
   - name: redis
-    version: 6.1.4
+    version: 10.5.7
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: redis.enabled


### PR DESCRIPTION
New Releases of each have been updated. Helm installs should now work without complaint.

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [ ] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
