### PR TITLE
Add GitLab SAST parser

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -573,7 +573,7 @@
 	},
 	{
 		"fields": {
-		    "name": "Gitleaks Scan"
+			"name": "Gitleaks Scan"
 		},
 		"model": "dojo.test_type",
 		"pk": 174
@@ -584,5 +584,12 @@
 		},
 		"model": "dojo.test_type",
 		"pk": 175
+	},
+	{
+		"fields": {
+			"name": "GitLab SAST Report"
+		},
+		"model": "dojo.test_type",
+		"pk": 176
 	}
 ]

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -374,7 +374,8 @@ class ImportScanForm(forms.Form):
                          ("Anchore Enterprise Policy Check", "Anchore Enterprise Policy Check"),
                          ("Gitleaks Scan", "Gitleaks Scan"),
                          ("Choctaw Hog Scan", "Choctaw Hog Scan"),
-                         ("Harbor Vulnerability Scan", "Harbor Vulnerability Scan"))
+                         ("Harbor Vulnerability Scan", "Harbor Vulnerability Scan"),
+                         ("GitLab SAST Report", "GitLab SAST Report"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
     scan_date = forms.DateTimeField(

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -63,6 +63,7 @@
 	<li><b>Fortify</b> - Import Findings from XML file format.</li>
 
 	<li><b>Generic Findings Import</b> - Import Generic findings in CSV format.</li>
+	<li><b>GitLab SAST Report</b> - Import GitLab SAST Report vulnerabilities in JSON format.</li>
 	<li><b>Gitleaks Scan </b> - Import Gitleaks Scan findings in JSON format.</li>
 	<li><b>Gosec Scanner </b> - Import Gosec Scanner findings in JSON format.</li>
 	<li><b>HackerOne Cases</b> - Import HackerOne cases findings in JSON format.</li>

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -77,6 +77,9 @@ from dojo.tools.anchore_enterprise.parser import AnchoreEnterprisePolicyCheckPar
 from dojo.tools.gitleaks.parser import GitleaksJSONParser
 from dojo.tools.harbor_vulnerability.parser import HarborVulnerabilityParser
 from dojo.tools.choctaw_hog.parser import ChoctawhogParser
+from dojo.tools.gitlab_sast.parser import GitlabSastReportParser
+
+
 
 
 __author__ = 'Jay Paz'
@@ -250,6 +253,8 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
         parser = HarborVulnerabilityParser(file, test)
     elif scan_type == 'Choctaw Hog Scan':
         parser = ChoctawhogParser(file, test)
+    elif scan_type == 'GitLab SAST Report':
+        parser = GitlabSastReportParser(file, test)
     else:
         raise ValueError('Unknown Test Type')
 

--- a/dojo/tools/gitlab_sast/parser.py
+++ b/dojo/tools/gitlab_sast/parser.py
@@ -1,0 +1,139 @@
+import json
+from dojo.models import Finding
+
+
+class GitlabSastReportParser(object):
+    def __init__(self, json_output, test):
+        self.items = []
+
+        if json_output is None:
+            return
+
+        tree = self.parse_json(json_output)
+        if tree:
+            self.items = [data for data in self.get_items(tree, test)]
+
+    def parse_json(self, json_output):
+        try:
+            data = json_output.read()
+            try:
+                tree = json.loads(str(data, 'utf-8'))
+            except:
+                tree = json.loads(data)
+        except:
+            raise Exception("Invalid format")
+
+        return tree
+
+    def get_items(self, tree, test):
+        items = {}
+
+        for node in tree['vulnerabilities']:
+            item = get_item(node, test)
+            if item:
+                items[item.unique_id_from_tool] = item
+
+        return list(items.values())
+
+
+def get_item(vuln, test):
+    if vuln['category'] != 'sast':
+        # For SAST reports, value must always be "sast"
+        return None
+
+    unique_id_from_tool = None
+    if 'id' in vuln:
+        unique_id_from_tool = vuln['id']
+    else:
+        # If the new unique id is not provided, fall back to deprecated "cve" fingerprint (old version)
+        unique_id_from_tool = vuln['cve']
+
+    title = ''
+    if 'name' in vuln:
+        title = vuln['name']
+    elif 'message' in vuln:
+        title = vuln['message']
+    elif 'description' in vuln:
+        title = vuln['description']
+    else:
+        # All other fields are optional, if none of them has a value, fall back on the unique id
+        title = unique_id_from_tool
+
+    description = 'Scanner: {}\n'.format(vuln['scanner']['name'])
+    if 'message' in vuln:
+        description += '{}\n'.format(vuln['message'])
+    if 'description' in vuln:
+        description += '{}\n'.format(vuln['description'])
+
+    location = vuln['location']
+    file_path = location['file'] if 'file' in location else None
+    sourcefile = location['file'] if 'file' in location else None
+
+    line = location['start_line'] if 'start_line' in location else None
+    if 'end_line' in location:
+        line = location['end_line']
+
+    sast_source_line = location['start_line'] if 'start_line' in location else None
+
+    sast_object = None
+    if 'class' in location and 'method' in location:
+        sast_object = '{}#{}'.format(location['class'], location['method'])
+    elif 'class' in location:
+        sast_object = location['class']
+    elif 'method' in location:
+        sast_object = location['method']
+
+    severity = vuln['severity']
+    if severity == 'Undefined' or severity == 'Unknown':
+        # Severity can be "Undefined" or "Unknown" in SAST report
+        # In that case we set it as Info and specify the initial severity in the title
+        title = '[{} severity] {}'.format(severity, title)
+        severity = 'Info'
+    numerical_severity = Finding.get_numerical_severity(severity)
+    scanner_confidence = Finding.get_number_severity(vuln['confidence'])
+
+    mitigation = ''
+    if 'solution' in vuln:
+        mitigation = vuln['solution']
+
+    cwe = None
+    cve = None
+    references = ''
+    if 'identifiers' in vuln:
+        for identifier in vuln['identifiers']:
+            if identifier['type'].lower() == 'cwe':
+                cwe = identifier['value']
+            elif identifier['type'].lower() == 'cve':
+                cve = identifier['value']
+            else:
+                references += 'Identifier type: {}\n'.format(identifier['type'])
+                references += 'Name: {}\n'.format(identifier['name'])
+                references += 'Value: {}\n'.format(identifier['value'])
+                if 'url' in identifier:
+                    references += 'URL: {}\n'.format(identifier['url'])
+                references += '\n'
+
+    finding = Finding(title=title,
+                      test=test,
+                      active=False,
+                      verified=False,
+                      description=description,
+                      severity=severity,
+                      numerical_severity=numerical_severity,
+                      scanner_confidence=scanner_confidence,
+                      mitigation=mitigation,
+                      unique_id_from_tool=unique_id_from_tool,
+                      references=references,
+                      file_path=file_path,
+                      sourcefile=sourcefile,
+                      line=line,
+                      sast_source_object=sast_object,
+                      sast_sink_object=sast_object,
+                      sast_source_file_path=file_path,
+                      sast_source_line=sast_source_line,
+                      cwe=cwe,
+                      cve=cve,
+                      static_finding=True,
+                      dynamic_finding=False)
+
+    return finding

--- a/dojo/unittests/scans/gitlab_sast/gl-sast-report-0-vuln.json
+++ b/dojo/unittests/scans/gitlab_sast/gl-sast-report-0-vuln.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.3",
+  "vulnerabilities": [],
+  "remediations": []
+}

--- a/dojo/unittests/scans/gitlab_sast/gl-sast-report-1-vuln.json
+++ b/dojo/unittests/scans/gitlab_sast/gl-sast-report-1-vuln.json
@@ -1,0 +1,34 @@
+{
+  "version": "2.3",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "docker-compose.override.unit_tests.yml:4dd25cfea7294af80c58a87f764286ce21ec612e78ae7a208c0a92887870963b:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "docker-compose.override.unit_tests.yml",
+        "start_line": 19,
+        "end_line": 19,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    }
+  ],
+  "remediations": []
+}

--- a/dojo/unittests/scans/gitlab_sast/gl-sast-report-many-vuln.json
+++ b/dojo/unittests/scans/gitlab_sast/gl-sast-report-many-vuln.json
@@ -1,0 +1,13006 @@
+{
+  "version": "2.3",
+  "vulnerabilities": [
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "docker-compose.override.unit_tests.yml:4dd25cfea7294af80c58a87f764286ce21ec612e78ae7a208c0a92887870963b:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "docker-compose.override.unit_tests.yml",
+        "start_line": 19,
+        "end_line": 19,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "docker-compose.yml:f118b746c89ea593e3d99a34330b35a9a46270e71dd253f0c9ff29507d3601fe:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "docker-compose.yml",
+        "start_line": 27,
+        "end_line": 27,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "PKCS8 key",
+      "message": "PKCS8 key",
+      "description": "PKCS8 private key detected; please remove and revoke it if this is a leak.",
+      "cve": "docker/key.pem:3021d90eb9437b2d8f30e8363695c4418b5e5f1870801b5c317e9398ee0f572d:PKCS8",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "gitleaks",
+        "name": "Gitleaks"
+      },
+      "location": {
+        "file": "docker/key.pem",
+        "start_line": 1,
+        "end_line": 52,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "gitleaks_rule_id",
+          "name": "Gitleaks rule ID PKCS8",
+          "value": "PKCS8"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "dojo/settings/settings.dist.py:ac48da3029b35c40a4126d516386d226bbe00c27f9d6b44834458c29ef9d8779:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "dojo/settings/settings.dist.py",
+        "start_line": 155,
+        "end_line": 155,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-6-findings.html:918c6716cd1d9901f678ac3aaf725ccb381ae66f63c84d3f2001e083743b4971:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-6-findings.html",
+        "start_line": 2590,
+        "end_line": 2590,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-no-finding.html:918c6716cd1d9901f678ac3aaf725ccb381ae66f63c84d3f2001e083743b4971:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-no-finding.html",
+        "start_line": 29890,
+        "end_line": 29890,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html:918c6716cd1d9901f678ac3aaf725ccb381ae66f63c84d3f2001e083743b4971:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html",
+        "start_line": 359,
+        "end_line": 359,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-single-finding.html:918c6716cd1d9901f678ac3aaf725ccb381ae66f63c84d3f2001e083743b4971:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-single-finding.html",
+        "start_line": 2539,
+        "end_line": 2539,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html:918c6716cd1d9901f678ac3aaf725ccb381ae66f63c84d3f2001e083743b4971:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html",
+        "start_line": 359,
+        "end_line": 359,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "entrypoint_scripts/os/linux.sh:4d29e6f03b929e137462e9e8691ff7e7463048983b6ba57fb760aae13c11a75b:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "entrypoint_scripts/os/linux.sh",
+        "start_line": 136,
+        "end_line": 136,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "entrypoint_scripts/run/startup-docker.bash:32f21f0a91c39a44f0da1c77143262107220fe53230553d0acfc5f21e09127df:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "entrypoint_scripts/run/startup-docker.bash",
+        "start_line": 13,
+        "end_line": 13,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "setup/scripts/common/dojo-shared-resources.sh:cd35d0621aa5b6223a812bc618cda3c037c81973ad3285070f1ac62c7fd04b1f:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "setup/scripts/common/dojo-shared-resources.sh",
+        "start_line": 493,
+        "end_line": 493,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Password in URL",
+      "message": "Password in URL",
+      "description": "Password in URL detected; please remove and revoke it if this is a leak.",
+      "cve": "setup/scripts/os/linux.sh:4d29e6f03b929e137462e9e8691ff7e7463048983b6ba57fb760aae13c11a75b:Password in URL",
+      "severity": "Critical",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "trufflehog",
+        "name": "TruffleHog"
+      },
+      "location": {
+        "file": "setup/scripts/os/linux.sh",
+        "start_line": 282,
+        "end_line": 282,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "trufflehog_rule_id",
+          "name": "TruffleHog rule ID Password in URL",
+          "value": "Password in URL"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Requests call with verify=False disabling SSL certificate checks, security issue.",
+      "cve": "tests/check_status.py:b75a5383b20ff7998b549669f81157bb6a63ec522d4f63306a262a7ee971ef50:B501",
+      "severity": "High",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/check_status.py",
+        "start_line": 61,
+        "end_line": 61,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B501",
+          "value": "B501",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b501_request_with_no_cert_validation.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Requests call with verify=False disabling SSL certificate checks, security issue.",
+      "cve": "tests/check_status.py:c8197e0544a456059ce0a2351c220a09095cec8f353771255682a54a14fb182c:B501",
+      "severity": "High",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/check_status.py",
+        "start_line": 70,
+        "end_line": 70,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B501",
+          "value": "B501",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b501_request_with_no_cert_validation.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Requests call with verify=False disabling SSL certificate checks, security issue.",
+      "cve": "tests/check_status.py:c8197e0544a456059ce0a2351c220a09095cec8f353771255682a54a14fb182c:B501",
+      "severity": "High",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/check_status.py",
+        "start_line": 79,
+        "end_line": 79,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B501",
+          "value": "B501",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b501_request_with_no_cert_validation.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Requests call with verify=False disabling SSL certificate checks, security issue.",
+      "cve": "tests/check_status.py:c8197e0544a456059ce0a2351c220a09095cec8f353771255682a54a14fb182c:B501",
+      "severity": "High",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/check_status.py",
+        "start_line": 51,
+        "end_line": 51,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B501",
+          "value": "B501",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b501_request_with_no_cert_validation.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/finding/views.py:1a36ff64cacd4285dd7cf6eb408304de6885feba5761b1754de34259dfc983f8:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/finding/views.py",
+        "start_line": 1293,
+        "end_line": 1295,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/finding/views.py:1a36ff64cacd4285dd7cf6eb408304de6885feba5761b1754de34259dfc983f8:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/finding/views.py",
+        "start_line": 1293,
+        "end_line": 1295,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/forms.py:30697c2b83aa3f80d65bc3a8e90fce40b00d1909d11aa2461e6150d221af2c5e:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 122,
+        "end_line": 122,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/forms.py:30697c2b83aa3f80d65bc3a8e90fce40b00d1909d11aa2461e6150d221af2c5e:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 122,
+        "end_line": 122,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/forms.py:a0090bb4aff12faf70e10e7b9a7237bc1c9dfc0318970659651a92fd20b828c9:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 58,
+        "end_line": 58,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/forms.py:a0090bb4aff12faf70e10e7b9a7237bc1c9dfc0318970659651a92fd20b828c9:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 50,
+        "end_line": 50,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/forms.py:a0090bb4aff12faf70e10e7b9a7237bc1c9dfc0318970659651a92fd20b828c9:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 42,
+        "end_line": 42,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/forms.py:a0090bb4aff12faf70e10e7b9a7237bc1c9dfc0318970659651a92fd20b828c9:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 50,
+        "end_line": 50,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/forms.py:a0090bb4aff12faf70e10e7b9a7237bc1c9dfc0318970659651a92fd20b828c9:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 42,
+        "end_line": 42,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/forms.py:a0090bb4aff12faf70e10e7b9a7237bc1c9dfc0318970659651a92fd20b828c9:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/forms.py",
+        "start_line": 58,
+        "end_line": 58,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of possibly insecure function - consider using safer ast.literal_eval.",
+      "cve": "dojo/google_sheet/views.py:3179111f4a512eb1bce4d1849a63a4f44c60ba701a7a1cd0867d9b701deb911e:B307",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/google_sheet/views.py",
+        "start_line": 788,
+        "end_line": 788,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B307",
+          "value": "B307"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of possibly insecure function - consider using safer ast.literal_eval.",
+      "cve": "dojo/google_sheet/views.py:a58bd7716041e6ee1c32bc8be9bc66f87601c075f021de22b29eb8bd6b82ee2b:B307",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/google_sheet/views.py",
+        "start_line": 786,
+        "end_line": 786,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B307",
+          "value": "B307"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:036a2fcffa4cad42c948dab73377334e3df3a8664bed0f34cfb217d3739c5bdd:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 181,
+        "end_line": 181,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:036a2fcffa4cad42c948dab73377334e3df3a8664bed0f34cfb217d3739c5bdd:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 204,
+        "end_line": 204,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:036a2fcffa4cad42c948dab73377334e3df3a8664bed0f34cfb217d3739c5bdd:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 163,
+        "end_line": 163,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:1777dbb9d46e7f34a15f6f79678bc2951f92a2a218721c0e6ce1819f47fbc771:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 374,
+        "end_line": 374,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:1777dbb9d46e7f34a15f6f79678bc2951f92a2a218721c0e6ce1819f47fbc771:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 295,
+        "end_line": 295,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:1777dbb9d46e7f34a15f6f79678bc2951f92a2a218721c0e6ce1819f47fbc771:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 295,
+        "end_line": 295,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:1777dbb9d46e7f34a15f6f79678bc2951f92a2a218721c0e6ce1819f47fbc771:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 374,
+        "end_line": 374,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:180f6c3138ca70881e3f966a7f50c995ac06762132106acf5baf6029fbb6ef87:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 139,
+        "end_line": 139,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:22c625c4b5195514ed916b531e05d03183859070f7c90ac74adf080032e4284a:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 160,
+        "end_line": 160,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:24efac74b9185d9613acb0862a7dacdbcf9fe5702675a48d27656f6fd1e65caf:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 384,
+        "end_line": 384,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:24efac74b9185d9613acb0862a7dacdbcf9fe5702675a48d27656f6fd1e65caf:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 316,
+        "end_line": 316,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:24efac74b9185d9613acb0862a7dacdbcf9fe5702675a48d27656f6fd1e65caf:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 384,
+        "end_line": 384,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:24efac74b9185d9613acb0862a7dacdbcf9fe5702675a48d27656f6fd1e65caf:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 316,
+        "end_line": 316,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:2aeb539f51f9dbafa0f7c397f5bf5b3c568132af9d5d260d72bd9567eec9f3d6:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 228,
+        "end_line": 228,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:2aeb539f51f9dbafa0f7c397f5bf5b3c568132af9d5d260d72bd9567eec9f3d6:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 228,
+        "end_line": 228,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:3952aadd50072f2f4f87233cdee91d09075522b1097850d7b2d7be4fe7ca4d8b:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 145,
+        "end_line": 148,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:3952aadd50072f2f4f87233cdee91d09075522b1097850d7b2d7be4fe7ca4d8b:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 145,
+        "end_line": 148,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:3a19db702835df97699dba14514d491897110cc440183b72e448e54844bf6172:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 239,
+        "end_line": 239,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:3a19db702835df97699dba14514d491897110cc440183b72e448e54844bf6172:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 239,
+        "end_line": 239,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:96af52918a417777a4fcc830be862544ad4b29d4db9d36ab9507aef7d255a2b6:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 233,
+        "end_line": 233,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:96af52918a417777a4fcc830be862544ad4b29d4db9d36ab9507aef7d255a2b6:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 233,
+        "end_line": 233,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:d40780ead5af790dc78de5d21af7d853a565a33012dfaacd2718fad55e632dce:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 215,
+        "end_line": 215,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:d40780ead5af790dc78de5d21af7d853a565a33012dfaacd2718fad55e632dce:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 193,
+        "end_line": 193,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:d40780ead5af790dc78de5d21af7d853a565a33012dfaacd2718fad55e632dce:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 193,
+        "end_line": 193,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:d40780ead5af790dc78de5d21af7d853a565a33012dfaacd2718fad55e632dce:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 215,
+        "end_line": 215,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:e183821e1294de2c84f8608fc24af8bae0f2bf199520f6848b36948682f8df82:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 305,
+        "end_line": 305,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:e183821e1294de2c84f8608fc24af8bae0f2bf199520f6848b36948682f8df82:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 365,
+        "end_line": 365,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:e183821e1294de2c84f8608fc24af8bae0f2bf199520f6848b36948682f8df82:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 365,
+        "end_line": 365,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:e183821e1294de2c84f8608fc24af8bae0f2bf199520f6848b36948682f8df82:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 305,
+        "end_line": 305,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:ea4c6ab95275b82f672fe021f7acf64df297d15274c8bf5faffde8600ca92f1b:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 142,
+        "end_line": 142,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/reports/widgets.py:fd09529cdd2dccb3553e2faa9d6f5468b0d874e131be03a280c72d19843b8d7f:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 170,
+        "end_line": 170,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/reports/widgets.py:fd09529cdd2dccb3553e2faa9d6f5468b0d874e131be03a280c72d19843b8d7f:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/reports/widgets.py",
+        "start_line": 170,
+        "end_line": 170,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:0d30f007e501126c5fe9c88c0d0e38c6cc86eb04596f959dbf1b983c3c602acb:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 566,
+        "end_line": 566,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:0d30f007e501126c5fe9c88c0d0e38c6cc86eb04596f959dbf1b983c3c602acb:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 566,
+        "end_line": 566,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:0f311263567a8a02c5c8ac3c670e58b329c73e61d05accc52905838cb3631633:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 618,
+        "end_line": 618,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:0f311263567a8a02c5c8ac3c670e58b329c73e61d05accc52905838cb3631633:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 618,
+        "end_line": 618,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:0f9b1254dd27c226bbcb1844593e4c00335b4dd1c581cb78c4d96ef48d8c933b:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 626,
+        "end_line": 626,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:0f9b1254dd27c226bbcb1844593e4c00335b4dd1c581cb78c4d96ef48d8c933b:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 626,
+        "end_line": 626,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:122989ed5997ffdb34c840bb23d98b4169d2cc1f28d7975d6074ea5a9ba6555b:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 624,
+        "end_line": 624,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:122989ed5997ffdb34c840bb23d98b4169d2cc1f28d7975d6074ea5a9ba6555b:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 624,
+        "end_line": 624,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:1232e36a125a80f7a0026464a727b30d65b781178b035695f7b3e45a2857c57d:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 570,
+        "end_line": 570,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:1232e36a125a80f7a0026464a727b30d65b781178b035695f7b3e45a2857c57d:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 570,
+        "end_line": 570,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:1b5d1acdb6ede987d7a341e2c79e09ca9d79a2bc68ede5e05d19e005fc0874b4:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 620,
+        "end_line": 620,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:1b5d1acdb6ede987d7a341e2c79e09ca9d79a2bc68ede5e05d19e005fc0874b4:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 620,
+        "end_line": 620,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:27c175394c9e8e6a172c47c86981ef93c4224e0abfa7c62e31a0ff0a9749fca7:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 604,
+        "end_line": 604,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:27c175394c9e8e6a172c47c86981ef93c4224e0abfa7c62e31a0ff0a9749fca7:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 604,
+        "end_line": 604,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:2c6421ab3d61d072bb103297b37db1fa2ecce7028d71e976f6ff1d5bd10eb8ee:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 622,
+        "end_line": 622,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:2c6421ab3d61d072bb103297b37db1fa2ecce7028d71e976f6ff1d5bd10eb8ee:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 622,
+        "end_line": 622,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:2ef7cedb22cdfbf69d3531f9aad7e1553b6d1bcfa5d65543d304ddd4083ff79e:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 608,
+        "end_line": 608,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:2ef7cedb22cdfbf69d3531f9aad7e1553b6d1bcfa5d65543d304ddd4083ff79e:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 608,
+        "end_line": 608,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:41f621be7e6b2d8321b928f81fb20a92f2bbcc8a904fac9431da37bc8cd567bd:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 606,
+        "end_line": 606,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:41f621be7e6b2d8321b928f81fb20a92f2bbcc8a904fac9431da37bc8cd567bd:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 606,
+        "end_line": 606,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:443c2db185d3cb20727cfc61ac46870f3f71c37a1fe7c3b62081a44ec6ffe8cd:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 596,
+        "end_line": 596,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:443c2db185d3cb20727cfc61ac46870f3f71c37a1fe7c3b62081a44ec6ffe8cd:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 596,
+        "end_line": 596,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:5790a486535a0410f29f0a5aad559e38e99490ef408cf62957fdfd561414fbfa:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 135,
+        "end_line": 135,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:5790a486535a0410f29f0a5aad559e38e99490ef408cf62957fdfd561414fbfa:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 135,
+        "end_line": 135,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:64e8d0dc13933001e5c46adc5c9a5f2ff4adb709b184b191bc62a96e5d36bb48:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 108,
+        "end_line": 108,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:64e8d0dc13933001e5c46adc5c9a5f2ff4adb709b184b191bc62a96e5d36bb48:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 108,
+        "end_line": 108,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:84623a8efe67663d5136a6024c9732a72188b8372a07de66e5c4609fafc5851a:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 588,
+        "end_line": 588,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:84623a8efe67663d5136a6024c9732a72188b8372a07de66e5c4609fafc5851a:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 588,
+        "end_line": 588,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:8d1b7b342ae3a851cc81f019566c59865c337048f544f45189b33c787664bb6e:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 564,
+        "end_line": 564,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:8d1b7b342ae3a851cc81f019566c59865c337048f544f45189b33c787664bb6e:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 564,
+        "end_line": 564,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:966faebd1155aa824a0d229514ee2ad0c82cdd061035f3cded93730331c58d7c:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 572,
+        "end_line": 572,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:966faebd1155aa824a0d229514ee2ad0c82cdd061035f3cded93730331c58d7c:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 572,
+        "end_line": 572,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:97df1a3d77959fcae6426514e1c53cbcebc65448ddbbe989fbc402489bb8f8b7:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 634,
+        "end_line": 634,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:97df1a3d77959fcae6426514e1c53cbcebc65448ddbbe989fbc402489bb8f8b7:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 634,
+        "end_line": 634,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:9c779cbf390307832a61784029abf2614b822c696d06d876aef39fc8c606af46:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 590,
+        "end_line": 590,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:9c779cbf390307832a61784029abf2614b822c696d06d876aef39fc8c606af46:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 590,
+        "end_line": 590,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:a0d1cd338707f1d259784c40577dff57578fb4e6b8882e8a9091a6f7530fbbdf:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 616,
+        "end_line": 616,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:a0d1cd338707f1d259784c40577dff57578fb4e6b8882e8a9091a6f7530fbbdf:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 616,
+        "end_line": 616,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:c17fee716e095b80cdbd7d54a52de7b16aa8fdac7dc988a9f5c9704d0ea917ce:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 594,
+        "end_line": 594,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:c17fee716e095b80cdbd7d54a52de7b16aa8fdac7dc988a9f5c9704d0ea917ce:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 594,
+        "end_line": 594,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:c4c57127d0c3d1964e4c99e1e9f973ef95d7891f621d83e3620efbf9dc12d441:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 592,
+        "end_line": 592,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:c4c57127d0c3d1964e4c99e1e9f973ef95d7891f621d83e3620efbf9dc12d441:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 592,
+        "end_line": 592,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:cc7ec564aec514b3b53c574fded8aa38f63f03087fe54fc1d59d490a682abfff:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 60,
+        "end_line": 60,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:cc7ec564aec514b3b53c574fded8aa38f63f03087fe54fc1d59d490a682abfff:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 60,
+        "end_line": 60,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:e29c477f99e8f3c200f373b50ed5e5df1030389f41322c3ffffc85a6fdef5d19:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 562,
+        "end_line": 562,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:e29c477f99e8f3c200f373b50ed5e5df1030389f41322c3ffffc85a6fdef5d19:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 562,
+        "end_line": 562,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:e7812e2b73f1bd44ff588dbf3ace6114635688bf2c1c380e6889b3cacdd1ba4d:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 337,
+        "end_line": 337,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:e7812e2b73f1bd44ff588dbf3ace6114635688bf2c1c380e6889b3cacdd1ba4d:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 337,
+        "end_line": 337,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:e8f95b1755393ef559183fb5027b402377fe8bdd371e3526a58b3cd2f1dac90f:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 642,
+        "end_line": 642,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:e8f95b1755393ef559183fb5027b402377fe8bdd371e3526a58b3cd2f1dac90f:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 642,
+        "end_line": 642,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:f249142c577065fc7b2249852f7db81d8c00cf3827c1adcab72bf8cda3abaf77:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 568,
+        "end_line": 568,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/display_tags.py:f249142c577065fc7b2249852f7db81d8c00cf3827c1adcab72bf8cda3abaf77:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 568,
+        "end_line": 568,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/display_tags.py:fdde08c891bf6d63b6698dd5291857f417464cde2cf2a8f6f1781ab66b26b6a7:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 443,
+        "end_line": 443,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/navigation_tags.py:459a3afaf3f411633787691308be69132eb7150eadaa69c557f32e2d9f50c261:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/navigation_tags.py",
+        "start_line": 134,
+        "end_line": 134,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/navigation_tags.py:8c80a09327a61007c74f10b737ddcf11cc6977819d852ecc8a551fa4ad17bdaf:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/navigation_tags.py",
+        "start_line": 139,
+        "end_line": 139,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/navigation_tags.py:aeaab78b80d46c804e7fd0237c0b0272ae6e7fa1a6b87355908f619a27d79c3e:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/navigation_tags.py",
+        "start_line": 29,
+        "end_line": 29,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/navigation_tags.py:aeaab78b80d46c804e7fd0237c0b0272ae6e7fa1a6b87355908f619a27d79c3e:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/navigation_tags.py",
+        "start_line": 29,
+        "end_line": 29,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of mark_safe() may expose cross-site scripting vulnerabilities and should be reviewed.",
+      "cve": "dojo/templatetags/navigation_tags.py:f80b5bb842ed18247cfa3a639c71b9d249feb116e6c008588ab1e72b98cd1681:B308",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/navigation_tags.py",
+        "start_line": 77,
+        "end_line": 77,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B308",
+          "value": "B308"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Potential XSS on mark_safe function.",
+      "cve": "dojo/templatetags/navigation_tags.py:f80b5bb842ed18247cfa3a639c71b9d249feb116e6c008588ab1e72b98cd1681:B703",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/navigation_tags.py",
+        "start_line": 77,
+        "end_line": 77,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B703",
+          "value": "B703"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.",
+      "cve": "dojo/tools/acunetix/parser_helper.py:5624b9f257743c82ff40294c9a7660bb22731d7964a67a456200a713f03d34b4:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/acunetix/parser_helper.py",
+        "start_line": 24,
+        "end_line": 24,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/blackduck/parser.py:0103fabc08063f8578c7c57649e94b36171f79f5a8913fb7db684100eeeff624:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/blackduck/parser.py",
+        "start_line": 36,
+        "end_line": 37,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/bundler_audit/parser.py:1e8afbcd739b24028c1d2f46748066ffc7552104461abed802ad9712541d2763:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/bundler_audit/parser.py",
+        "start_line": 48,
+        "end_line": 48,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.",
+      "cve": "dojo/tools/burp/parser.py:0c5fb6e0c48e4d929a0c216acb4269ab8a3d4ba31e1b84f5182bb1871b61cfb7:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/burp/parser.py",
+        "start_line": 63,
+        "end_line": 63,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.fromstring to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.fromstring with its defusedxml equivalent function.",
+      "cve": "dojo/tools/burp/parser.py:c793da06d0684b9744e5b2db1897581024e40511b62c5799c1248a70b85ccb53:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/burp/parser.py",
+        "start_line": 70,
+        "end_line": 70,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/cobalt/parser.py:49b5550cea992e995fec56fc3656c028626cf23ed78f453f9dd3f8f8bb708335:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/cobalt/parser.py",
+        "start_line": 46,
+        "end_line": 46,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Possible binding to all interfaces.",
+      "cve": "dojo/tools/contrast/parser.py:201f2506423a7509b04958cb52cecef9b76c5643365c46e26eb78d38d4a13900:B104",
+      "severity": "Medium",
+      "confidence": "Medium",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/contrast/parser.py",
+        "start_line": 91,
+        "end_line": 91,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B104",
+          "value": "B104",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b104_hardcoded_bind_all_interfaces.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/contrast/parser.py:7e86a0ba581c320828d653b03fe5c75f220a7345ae706dd9fc125086224c08cb:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/contrast/parser.py",
+        "start_line": 33,
+        "end_line": 33,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/dawnscanner/parser.py:c25465d01d23706a581396e93a724f0f0b50df2d4030f3e1d59e72c1128f492a:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/dawnscanner/parser.py",
+        "start_line": 43,
+        "end_line": 43,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/dependency_check/parser.py:54c33ace789fc3d44625228b7ad4a9cfc8d27e85cca1d02660317b0e4f6af0ab:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/dependency_check/parser.py",
+        "start_line": 125,
+        "end_line": 125,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/generic/parser.py:0999f0165c8838b46df99da5f883da57e40cc8ed8eebecf31615b186f9a1154a:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/generic/parser.py",
+        "start_line": 338,
+        "end_line": 338,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/h1/parser.py:8024e53a017c99ccb251d2f70bcc3e60a033fd9f55306686de975d1b01b9bbec:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/h1/parser.py",
+        "start_line": 59,
+        "end_line": 59,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/ibm_app/parser.py:0acada6e436d14c9e6d62a4a0719a3e3684e2b4622ded796f5f5f5d4cbd61989:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/ibm_app/parser.py",
+        "start_line": 80,
+        "end_line": 80,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/immuniweb/parser.py:3cc6f6b411d3d6e162efb7a9bc710b473a689638a05b161eb40c7b0084af8ffc:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/immuniweb/parser.py",
+        "start_line": 62,
+        "end_line": 62,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/kiuwan/parser.py:4d04066e6857ecc8e5f5f428a7c4419817177ad950d1028b4e531bbf485cd487:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/kiuwan/parser.py",
+        "start_line": 83,
+        "end_line": 83,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/microfocus_webinspect/parser.py:eea6ab266612ed97736103a4bd4d62004e68889d509ac2ae3546ab47f8e9b7cf:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/microfocus_webinspect/parser.py",
+        "start_line": 70,
+        "end_line": 70,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/mozilla_observatory/parser.py:227fad54cd6a22727423321a2f00a1d9f2773da56236922b288a775b6ff614ed:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/mozilla_observatory/parser.py",
+        "start_line": 47,
+        "end_line": 47,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/nikto/parser.py:802632239706a7812580910732e8f09df3e34955060283397faf9dc3279b1889:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/nikto/parser.py",
+        "start_line": 59,
+        "end_line": 59,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.",
+      "cve": "dojo/tools/nmap/parser.py:1d5dab23203edfe47cc3bb1516af3aeb54a4e54b16793d4dea24432250c3fe6a:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/nmap/parser.py",
+        "start_line": 16,
+        "end_line": 16,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/openscap/parser.py:78ad2547f504d29e462b82784e77b8313397e91eac6645ea84d7d5e7ed934c15:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/openscap/parser.py",
+        "start_line": 64,
+        "end_line": 64,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/openvas_csv/parser.py:63bb9ca2bdadf712d2ff3a5dd39345e99873fe8ab0748cdb93b8c2dbad69d534:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/openvas_csv/parser.py",
+        "start_line": 339,
+        "end_line": 339,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.",
+      "cve": "dojo/tools/qualys/parser.py:f4d36e5f17394f2eb1e261e90df78aa9a04db3ae7880bcc619c7ae838ac48d5a:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/qualys/parser.py",
+        "start_line": 212,
+        "end_line": 212,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.",
+      "cve": "dojo/tools/qualys_webapp/parser.py:4bc8bc8a3ea378ff4ae121c5a307efac025f3e590dda3550ab5aea1adf6da36e:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/qualys_webapp/parser.py",
+        "start_line": 144,
+        "end_line": 144,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/retirejs/parser.py:75c8b1f94d79f55f50bc0defb71d386049cf6bb89fac6f411613fb2d86eea1ed:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/retirejs/parser.py",
+        "start_line": 45,
+        "end_line": 45,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Audit url open for permitted schemes. Allowing use of file:/ or custom schemes is often unexpected.",
+      "cve": "dojo/tools/safety/parser.py:d31826e17ae93489b9744de869d4e407304fe51f4c25fe5a1a272fd1bc14670c:B310",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/safety/parser.py",
+        "start_line": 11,
+        "end_line": 11,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B310",
+          "value": "B310"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/skf/parser.py:6169d2559920d062dbbe2717cb462c4ad8b82cf558ba16abe317d45302d1b568:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/skf/parser.py",
+        "start_line": 135,
+        "end_line": 135,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.",
+      "cve": "dojo/tools/sonarqube/parser.py:19e9efc69a6b9013834977fd3f953646857a13369fb321ce42c04e30f9534672:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/sonarqube/parser.py",
+        "start_line": 14,
+        "end_line": 14,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.fromstring to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.fromstring with its defusedxml equivalent function.",
+      "cve": "dojo/tools/sonarqube_api/importer.py:dbe06ea0c7925d869fb9f24e452be6ced16e56aa414d3e7e81820ddaf46c94cc:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/sonarqube_api/importer.py",
+        "start_line": 159,
+        "end_line": 159,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/sslscan/parser.py:d07e3f666f367b2d3bfdfff63549e8f999c7070f9eba408a3aabee18876eb60c:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/sslscan/parser.py",
+        "start_line": 52,
+        "end_line": 52,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/sslyze/parser.py:d07e3f666f367b2d3bfdfff63549e8f999c7070f9eba408a3aabee18876eb60c:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/sslyze/parser.py",
+        "start_line": 101,
+        "end_line": 101,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/testssl/parser.py:d07e3f666f367b2d3bfdfff63549e8f999c7070f9eba408a3aabee18876eb60c:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/testssl/parser.py",
+        "start_line": 57,
+        "end_line": 57,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/trufflehog/parser.py:eb8a35b1e8d290d29090630f165593a7507a4f8a6ac4e857ea5d38962b0ec340:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/trufflehog/parser.py",
+        "start_line": 40,
+        "end_line": 40,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/trustwave/parser.py:bd260e0162a79501cc8b2ef81745123d36363fc2d74c1b0cea4f07adfa530253:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/trustwave/parser.py",
+        "start_line": 178,
+        "end_line": 178,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/vcg/parser.py:ea3547b9aedbf2dd59d30565d48e05f1e1d663b4f25439b6d95d27eb68505d63:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/vcg/parser.py",
+        "start_line": 172,
+        "end_line": 172,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/vcg/parser.py:ea3547b9aedbf2dd59d30565d48e05f1e1d663b4f25439b6d95d27eb68505d63:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/vcg/parser.py",
+        "start_line": 112,
+        "end_line": 112,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/wapiti/parser.py:eea6ab266612ed97736103a4bd4d62004e68889d509ac2ae3546ab47f8e9b7cf:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/wapiti/parser.py",
+        "start_line": 63,
+        "end_line": 63,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/whitesource/parser.py:52cbbccfd7b77010f6c50b6ece5cc13b2ba7257ab48b8b35bba8757149365b47:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/whitesource/parser.py",
+        "start_line": 85,
+        "end_line": 85,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of insecure MD2, MD4, MD5, or SHA1 hash function.",
+      "cve": "dojo/tools/wpscan/parser.py:bc6b119fd1d8a48a663fb350ce9936813d44148315817875658848c0606b9d62:B303",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/wpscan/parser.py",
+        "start_line": 54,
+        "end_line": 54,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B303",
+          "value": "B303"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Possible binding to all interfaces.",
+      "cve": "dojo/wsgi.py:8f83be41ce233ffdd3ba538f5cf8dcbc594351800eea73148308f607f57ee863:B104",
+      "severity": "Medium",
+      "confidence": "Medium",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/wsgi.py",
+        "start_line": 53,
+        "end_line": 53,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B104",
+          "value": "B104",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b104_hardcoded_bind_all_interfaces.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with its defusedxml equivalent function.",
+      "cve": "tests/validate_acunetix_scan_xml.py:5624b9f257743c82ff40294c9a7660bb22731d7964a67a456200a713f03d34b4:B320",
+      "severity": "Medium",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/validate_acunetix_scan_xml.py",
+        "start_line": 15,
+        "end_line": 15,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B320",
+          "value": "B320"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/benchmark/views.py:c988492d15a140a3b200ee45ef43f60934d984d5b90b035d160b2df9cdbf500d:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/benchmark/views.py",
+        "start_line": 26,
+        "end_line": 26,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/cred/views.py:bca9484e5547f64d3a0cc1a228028b87eaa866bfa32ed0e6f01e695d40348a24:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/cred/views.py",
+        "start_line": 602,
+        "end_line": 602,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/finding/views.py:ea88e3621f293029f0be0a07923f647c3f31929cac53117009219c0da3cb486e:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/finding/views.py",
+        "start_line": 1097,
+        "end_line": 1097,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/google_sheet/views.py:0d99d8da76a3f9f531a267e26ee81770b4e4cf9b69f329ed72738dee376e6a2e:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/google_sheet/views.py",
+        "start_line": 402,
+        "end_line": 402,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/google_sheet/views.py:7f3ea599070d54d4357e3c0a97a717ee2a63de9a0f56c489e7ce1e61555b155f:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/google_sheet/views.py",
+        "start_line": 312,
+        "end_line": 312,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "cve": "dojo/middleware.py:134dadbf05483a5ef25ece4de17484c6d7ee52b1954640def46dcd811e987bf6:B101",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/middleware.py",
+        "start_line": 31,
+        "end_line": 36,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B101",
+          "value": "B101",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Possible hardcoded password: 'Pass'",
+      "cve": "dojo/models.py:4728303944c6bbf8b9fa2df9f108f60d3ed619f32dd5484f6f70e23feee8f594:B105",
+      "severity": "Low",
+      "confidence": "Medium",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/models.py",
+        "start_line": 1822,
+        "end_line": 1822,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B105",
+          "value": "B105",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b105_hardcoded_password_string.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Possible hardcoded password: 'Fail'",
+      "cve": "dojo/models.py:b8547f6af0a7532068fd37deb8dc2c5b5e721ca91d52960b63a8f57344c4747b:B105",
+      "severity": "Low",
+      "confidence": "Medium",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/models.py",
+        "start_line": 1824,
+        "end_line": 1824,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B105",
+          "value": "B105",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b105_hardcoded_password_string.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Possible hardcoded password: 'POST'",
+      "cve": "dojo/okta.py:ed0865cc9fe7680777b1dc5425c2122ff86a77b4e35553e741e6c5c952c1d833:B105",
+      "severity": "Low",
+      "confidence": "Medium",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/okta.py",
+        "start_line": 69,
+        "end_line": 69,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B105",
+          "value": "B105",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b105_hardcoded_password_string.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Possible hardcoded password: 'POST'",
+      "cve": "dojo/okta.py:f5dca5b0a23106e19e0b7cc47bda0a13e1f5b37bac4a9cd9420874e290c9088d:B105",
+      "severity": "Low",
+      "confidence": "Medium",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/okta.py",
+        "start_line": 36,
+        "end_line": 36,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B105",
+          "value": "B105",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b105_hardcoded_password_string.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/product/views.py:cf996664718e6b84aaa94f5e80ee016f29ffed64e074662d8a1d8267f0c77598:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/product/views.py",
+        "start_line": 564,
+        "end_line": 564,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Standard pseudo-random generators are not suitable for security/cryptographic purposes.",
+      "cve": "dojo/templatetags/display_tags.py:1ae99eae2ca3d9ad9478620b191075ca9fcb52db25824784b4a41ad03228c268:B311",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 408,
+        "end_line": 408,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B311",
+          "value": "B311"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/templatetags/display_tags.py:1b7f212d248d62df8555cc93aea885b9f08e9546cd6e561610a322bb8c4e6042:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 302,
+        "end_line": 302,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/templatetags/display_tags.py:54c2ed9b789ed5da2d7a7f450cb6b96d836c21c17c852670bfac29544e6d4c3a:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 506,
+        "end_line": 506,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Standard pseudo-random generators are not suitable for security/cryptographic purposes.",
+      "cve": "dojo/templatetags/display_tags.py:f8fd75c0acde92adece2cd6186bde8494a4e1ca816ddaebffdf0377eeb63242c:B311",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/templatetags/display_tags.py",
+        "start_line": 380,
+        "end_line": 380,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B311",
+          "value": "B311"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using XMLSyntaxError to parse untrusted XML data is known to be vulnerable to XML attacks. Replace XMLSyntaxError with the equivalent defusedxml package.",
+      "cve": "dojo/tools/acunetix/parser_helper.py:d9c198cb448ea07d896bca670d26bbb050841a3420f3626498387815191b3203:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/acunetix/parser_helper.py",
+        "start_line": 3,
+        "end_line": 3,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace etree with the equivalent defusedxml package.",
+      "cve": "dojo/tools/acunetix/parser_helper.py:df5fc3aac40e61145ad26a493655beb7ce8f1da45cb950aa4d510a638c89c340:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/acunetix/parser_helper.py",
+        "start_line": 2,
+        "end_line": 2,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace etree with the equivalent defusedxml package.",
+      "cve": "dojo/tools/burp/parser.py:94a935dd00fd2a2ebdc42d605a46cb7f5f7fa43c3c2734534b4f4e0f75701f2b:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/burp/parser.py",
+        "start_line": 12,
+        "end_line": 12,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/kiuwan/parser.py:b644f1fec7a87fe4373190f8ebb8bbe7e7ebc669ca61c51dba06f61e0708a7e5:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/kiuwan/parser.py",
+        "start_line": 74,
+        "end_line": 74,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/microfocus_webinspect/parser.py:2ada57343510b672d4d963454207d279aec27e78a0582b311df3df29fb76a4f0:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/microfocus_webinspect/parser.py",
+        "start_line": 117,
+        "end_line": 117,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using lxml.etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree with the equivalent defusedxml package.",
+      "cve": "dojo/tools/nmap/parser.py:bce553e3b09674e6a6125fb3a0cdcc621572e34ba7c1264dc3f6813c15d49be3:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/nmap/parser.py",
+        "start_line": 2,
+        "end_line": 2,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/openscap/parser.py:2ada57343510b672d4d963454207d279aec27e78a0582b311df3df29fb76a4f0:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/openscap/parser.py",
+        "start_line": 120,
+        "end_line": 120,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/openscap/parser.py:58e6a7cb38a5b6cddfb0df163d35a6b1156e367e418ad22a2401e62015b384d7:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/openscap/parser.py",
+        "start_line": 55,
+        "end_line": 55,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace etree with the equivalent defusedxml package.",
+      "cve": "dojo/tools/qualys/parser.py:d4df7250950bfaaeb5d748ac0d79d837651eeb1e6f16e0c537dbadc27a428174:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/qualys/parser.py",
+        "start_line": 18,
+        "end_line": 18,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace etree with the equivalent defusedxml package.",
+      "cve": "dojo/tools/qualys_webapp/parser.py:d4df7250950bfaaeb5d748ac0d79d837651eeb1e6f16e0c537dbadc27a428174:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/qualys_webapp/parser.py",
+        "start_line": 13,
+        "end_line": 13,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace etree with the equivalent defusedxml package.",
+      "cve": "dojo/tools/sonarqube/parser.py:4f6a24a1086d429277287a8574e24b193f3638406e58e9a80e7d68eebb91024f:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/sonarqube/parser.py",
+        "start_line": 1,
+        "end_line": 1,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace etree with the equivalent defusedxml package.",
+      "cve": "dojo/tools/sonarqube_api/importer.py:678f945f5af5f7299602ceb5390e50042ebd7cb63f2418b546fd7871b8d58645:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/sonarqube_api/importer.py",
+        "start_line": 4,
+        "end_line": 4,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/testssl/parser.py:2ada57343510b672d4d963454207d279aec27e78a0582b311df3df29fb76a4f0:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/testssl/parser.py",
+        "start_line": 98,
+        "end_line": 98,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/wapiti/parser.py:2ada57343510b672d4d963454207d279aec27e78a0582b311df3df29fb76a4f0:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/wapiti/parser.py",
+        "start_line": 111,
+        "end_line": 111,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/wpscan/parser.py:9eefa5df69d920528497986083a686694f36618af3df510e67f574575e268077:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/wpscan/parser.py",
+        "start_line": 27,
+        "end_line": 27,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "dojo/tools/zap/parser.py:2c7efcf155541cf48317870607f8537f7a7da8f370001716cad6b18b031731d4:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/tools/zap/parser.py",
+        "start_line": 154,
+        "end_line": 154,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Standard pseudo-random generators are not suitable for security/cryptographic purposes.",
+      "cve": "dojo/unittests/test_api_v1.py:2c944926db291952b7cca0ec9c28a004abb5ce5ccbcc054a1b077b8e745f8766:B311",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "dojo/unittests/test_api_v1.py",
+        "start_line": 28,
+        "end_line": 28,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B311",
+          "value": "B311"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Try, Except, Pass detected.",
+      "cve": "tests/Import_scanner_unit_test.py:0115b13a8c1742ecfce96e34469ff9906e5387b1934b2e4a3d51fdd4eb7aea0a:B110",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/Import_scanner_unit_test.py",
+        "start_line": 271,
+        "end_line": 271,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B110",
+          "value": "B110",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b110_try_except_pass.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "cve": "tests/Import_scanner_unit_test.py:23f1fc4b4c60fb3616d5bbe78930e8f2ceb581d4272ea8a8f9bf73c7ac982403:B101",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/Import_scanner_unit_test.py",
+        "start_line": 150,
+        "end_line": 150,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B101",
+          "value": "B101",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "cve": "tests/Import_scanner_unit_test.py:5a098258f5abaff5e93231ba498f693ffcec0a983952e3320f6aea33d23c2f23:B101",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/Import_scanner_unit_test.py",
+        "start_line": 314,
+        "end_line": 314,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B101",
+          "value": "B101",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "cve": "tests/Import_scanner_unit_test.py:646cbbbdfb6b839a4b412ce958d1622f2096e7870843a18b6e360ac9e028fa9c:B101",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/Import_scanner_unit_test.py",
+        "start_line": 82,
+        "end_line": 82,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B101",
+          "value": "B101",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "cve": "tests/Import_scanner_unit_test.py:bdcd5dcb9e6e49f8ab0ead80ce7ae5e6245eee6bcb1ce82138c5d06be06a15f3:B101",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/Import_scanner_unit_test.py",
+        "start_line": 228,
+        "end_line": 228,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B101",
+          "value": "B101",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "cve": "tests/Import_scanner_unit_test.py:e34fd58a8455d9fde85a5035b4aa68d5b730344f73ca68514595967ea6559d63:B101",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/Import_scanner_unit_test.py",
+        "start_line": 188,
+        "end_line": 188,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B101",
+          "value": "B101",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.",
+      "cve": "tests/Import_scanner_unit_test.py:e6772c9a7cf3b0092303fc9ff187667c94830dca2219af89b84a7cb4013fde98:B101",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/Import_scanner_unit_test.py",
+        "start_line": 112,
+        "end_line": 112,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B101",
+          "value": "B101",
+          "url": "https://docs.openstack.org/bandit/latest/plugins/b101_assert_used.html"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using XMLSyntaxError to parse untrusted XML data is known to be vulnerable to XML attacks. Replace XMLSyntaxError with the equivalent defusedxml package.",
+      "cve": "tests/validate_acunetix_scan_xml.py:c0563421814d4b3b21adec4248397d3ec2a5490a615e31732e235a32ada8236b:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/validate_acunetix_scan_xml.py",
+        "start_line": 2,
+        "end_line": 2,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "message": "Using etree to parse untrusted XML data is known to be vulnerable to XML attacks. Replace etree with the equivalent defusedxml package.",
+      "cve": "tests/validate_acunetix_scan_xml.py:c0563421814d4b3b21adec4248397d3ec2a5490a615e31732e235a32ada8236b:B410",
+      "severity": "Low",
+      "confidence": "High",
+      "scanner": {
+        "id": "bandit",
+        "name": "Bandit"
+      },
+      "location": {
+        "file": "tests/validate_acunetix_scan_xml.py",
+        "start_line": 1,
+        "end_line": 1,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "bandit_test_id",
+          "name": "Bandit Test ID B410",
+          "value": "B410"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Found fs.openSync with non literal argument at index 0",
+      "message": "Found fs.openSync with non literal argument at index 0",
+      "description": "A variable is present in the filename argument of fs calls, this might allow an attacker to access anything on your system.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-non-literal-fs-filename",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 29,
+        "end_line": 29,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-non-literal-fs-filename",
+          "value": "security/detect-non-literal-fs-filename",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-fs-filename"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Found fs.open with non literal argument at index 0",
+      "message": "Found fs.open with non literal argument at index 0",
+      "description": "A variable is present in the filename argument of fs calls, this might allow an attacker to access anything on your system.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-non-literal-fs-filename",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 349,
+        "end_line": 349,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-non-literal-fs-filename",
+          "value": "security/detect-non-literal-fs-filename",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-fs-filename"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Found non-literal argument to RegExp Constructor",
+      "message": "Found non-literal argument to RegExp Constructor",
+      "description": "RegExp() called with a variable, this might allow an attacker to DOS your application with a long-running regular expression.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-non-literal-regexp",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 351,
+        "end_line": 351,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-non-literal-regexp",
+          "value": "security/detect-non-literal-regexp",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-regexp"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Found non-literal argument to RegExp Constructor",
+      "message": "Found non-literal argument to RegExp Constructor",
+      "description": "RegExp() called with a variable, this might allow an attacker to DOS your application with a long-running regular expression.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-non-literal-regexp",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 29,
+        "end_line": 29,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-non-literal-regexp",
+          "value": "security/detect-non-literal-regexp",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-non-literal-regexp"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 62,
+        "end_line": 62,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 58,
+        "end_line": 58,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 59,
+        "end_line": 59,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 60,
+        "end_line": 60,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 61,
+        "end_line": 61,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 57,
+        "end_line": 57,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 63,
+        "end_line": 63,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 65,
+        "end_line": 65,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 66,
+        "end_line": 66,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 67,
+        "end_line": 67,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 68,
+        "end_line": 68,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 71,
+        "end_line": 71,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 72,
+        "end_line": 72,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 73,
+        "end_line": 73,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 74,
+        "end_line": 74,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 77,
+        "end_line": 77,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 79,
+        "end_line": 79,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 81,
+        "end_line": 81,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 82,
+        "end_line": 82,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 83,
+        "end_line": 83,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 84,
+        "end_line": 84,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 87,
+        "end_line": 87,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 88,
+        "end_line": 88,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 89,
+        "end_line": 89,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 90,
+        "end_line": 90,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 96,
+        "end_line": 96,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 97,
+        "end_line": 97,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 98,
+        "end_line": 98,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 56,
+        "end_line": 56,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 100,
+        "end_line": 100,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 101,
+        "end_line": 101,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 102,
+        "end_line": 102,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 103,
+        "end_line": 103,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 104,
+        "end_line": 104,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 105,
+        "end_line": 105,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 106,
+        "end_line": 106,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 674,
+        "end_line": 674,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 107,
+        "end_line": 107,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 108,
+        "end_line": 108,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 109,
+        "end_line": 109,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 110,
+        "end_line": 110,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 111,
+        "end_line": 111,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 112,
+        "end_line": 112,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 113,
+        "end_line": 113,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 114,
+        "end_line": 114,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 115,
+        "end_line": 115,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 116,
+        "end_line": 116,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 117,
+        "end_line": 117,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 122,
+        "end_line": 122,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 123,
+        "end_line": 123,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 129,
+        "end_line": 129,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 130,
+        "end_line": 130,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 131,
+        "end_line": 131,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 133,
+        "end_line": 133,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 134,
+        "end_line": 134,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 135,
+        "end_line": 135,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 136,
+        "end_line": 136,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 137,
+        "end_line": 137,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 138,
+        "end_line": 138,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 139,
+        "end_line": 139,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 140,
+        "end_line": 140,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 142,
+        "end_line": 142,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 143,
+        "end_line": 143,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 144,
+        "end_line": 144,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 147,
+        "end_line": 147,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 148,
+        "end_line": 148,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 149,
+        "end_line": 149,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 150,
+        "end_line": 150,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 151,
+        "end_line": 151,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 152,
+        "end_line": 152,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 153,
+        "end_line": 153,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 154,
+        "end_line": 154,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 155,
+        "end_line": 155,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 158,
+        "end_line": 158,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 159,
+        "end_line": 159,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 161,
+        "end_line": 161,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 163,
+        "end_line": 163,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 164,
+        "end_line": 164,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 165,
+        "end_line": 165,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 167,
+        "end_line": 167,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 168,
+        "end_line": 168,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 169,
+        "end_line": 169,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 172,
+        "end_line": 172,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 173,
+        "end_line": 173,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 174,
+        "end_line": 174,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 176,
+        "end_line": 176,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 178,
+        "end_line": 178,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 179,
+        "end_line": 179,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 194,
+        "end_line": 194,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 195,
+        "end_line": 195,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 198,
+        "end_line": 198,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 199,
+        "end_line": 199,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 200,
+        "end_line": 200,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 202,
+        "end_line": 202,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 205,
+        "end_line": 205,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 214,
+        "end_line": 214,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 215,
+        "end_line": 215,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 233,
+        "end_line": 233,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 234,
+        "end_line": 234,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 236,
+        "end_line": 236,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 237,
+        "end_line": 237,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 243,
+        "end_line": 243,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 246,
+        "end_line": 246,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 252,
+        "end_line": 252,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 255,
+        "end_line": 255,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 256,
+        "end_line": 256,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 257,
+        "end_line": 257,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 258,
+        "end_line": 258,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 273,
+        "end_line": 273,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 274,
+        "end_line": 274,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 275,
+        "end_line": 275,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 278,
+        "end_line": 278,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 279,
+        "end_line": 279,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 280,
+        "end_line": 280,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 282,
+        "end_line": 282,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 283,
+        "end_line": 283,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 287,
+        "end_line": 287,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 288,
+        "end_line": 288,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 289,
+        "end_line": 289,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 290,
+        "end_line": 290,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 291,
+        "end_line": 291,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 292,
+        "end_line": 292,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 293,
+        "end_line": 293,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 299,
+        "end_line": 299,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 301,
+        "end_line": 301,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 305,
+        "end_line": 305,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 673,
+        "end_line": 673,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 312,
+        "end_line": 312,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 331,
+        "end_line": 331,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 333,
+        "end_line": 333,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 344,
+        "end_line": 344,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 345,
+        "end_line": 345,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 346,
+        "end_line": 346,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 348,
+        "end_line": 348,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 351,
+        "end_line": 351,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 361,
+        "end_line": 361,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 362,
+        "end_line": 362,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 363,
+        "end_line": 363,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 365,
+        "end_line": 365,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 368,
+        "end_line": 368,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 379,
+        "end_line": 379,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 388,
+        "end_line": 388,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 389,
+        "end_line": 389,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 390,
+        "end_line": 390,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 391,
+        "end_line": 391,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 392,
+        "end_line": 392,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 393,
+        "end_line": 393,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 395,
+        "end_line": 395,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 396,
+        "end_line": 396,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 397,
+        "end_line": 397,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 400,
+        "end_line": 400,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 402,
+        "end_line": 402,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 403,
+        "end_line": 403,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 406,
+        "end_line": 406,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 408,
+        "end_line": 408,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 422,
+        "end_line": 422,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 436,
+        "end_line": 436,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 437,
+        "end_line": 437,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 438,
+        "end_line": 438,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 439,
+        "end_line": 439,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 440,
+        "end_line": 440,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 441,
+        "end_line": 441,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 443,
+        "end_line": 443,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 55,
+        "end_line": 55,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 445,
+        "end_line": 445,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 446,
+        "end_line": 446,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 448,
+        "end_line": 448,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 461,
+        "end_line": 461,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 462,
+        "end_line": 462,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 463,
+        "end_line": 463,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 486,
+        "end_line": 486,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 488,
+        "end_line": 488,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 490,
+        "end_line": 490,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 491,
+        "end_line": 491,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 503,
+        "end_line": 503,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 506,
+        "end_line": 506,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 507,
+        "end_line": 507,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 510,
+        "end_line": 510,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 518,
+        "end_line": 518,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 519,
+        "end_line": 519,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 521,
+        "end_line": 521,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 524,
+        "end_line": 524,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 525,
+        "end_line": 525,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 526,
+        "end_line": 526,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 530,
+        "end_line": 530,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 531,
+        "end_line": 531,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 534,
+        "end_line": 534,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 542,
+        "end_line": 542,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 568,
+        "end_line": 568,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 569,
+        "end_line": 569,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 574,
+        "end_line": 574,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Variable Assigned to Object Injection Sink",
+      "message": "Variable Assigned to Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 575,
+        "end_line": 575,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 589,
+        "end_line": 589,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 592,
+        "end_line": 592,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 593,
+        "end_line": 593,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 594,
+        "end_line": 594,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 595,
+        "end_line": 595,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 631,
+        "end_line": 631,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 661,
+        "end_line": 661,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 663,
+        "end_line": 663,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 664,
+        "end_line": 664,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 667,
+        "end_line": 667,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 668,
+        "end_line": 668,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 54,
+        "end_line": 54,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 671,
+        "end_line": 671,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 53,
+        "end_line": 53,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 52,
+        "end_line": 52,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 49,
+        "end_line": 49,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 47,
+        "end_line": 47,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 45,
+        "end_line": 45,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 672,
+        "end_line": 672,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 29,
+        "end_line": 29,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 26,
+        "end_line": 26,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 25,
+        "end_line": 25,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 24,
+        "end_line": 24,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 444,
+        "end_line": 444,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 99,
+        "end_line": 99,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 670,
+        "end_line": 670,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Unsafe Regular Expression",
+      "message": "Unsafe Regular Expression",
+      "description": "Potentially unsafe regular expressions. It may take a very long time to run.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-unsafe-regex",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 200,
+        "end_line": 200,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-unsafe-regex",
+          "value": "security/detect-unsafe-regex",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Unsafe Regular Expression",
+      "message": "Unsafe Regular Expression",
+      "description": "Potentially unsafe regular expressions. It may take a very long time to run.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-unsafe-regex",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 632,
+        "end_line": 632,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-unsafe-regex",
+          "value": "security/detect-unsafe-regex",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Unsafe Regular Expression",
+      "message": "Unsafe Regular Expression",
+      "description": "Potentially unsafe regular expressions. It may take a very long time to run.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-unsafe-regex",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 310,
+        "end_line": 310,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-unsafe-regex",
+          "value": "security/detect-unsafe-regex",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Unsafe Regular Expression",
+      "message": "Unsafe Regular Expression",
+      "description": "Potentially unsafe regular expressions. It may take a very long time to run.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-unsafe-regex",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 293,
+        "end_line": 293,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-unsafe-regex",
+          "value": "security/detect-unsafe-regex",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Unsafe Regular Expression",
+      "message": "Unsafe Regular Expression",
+      "description": "Potentially unsafe regular expressions. It may take a very long time to run.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-unsafe-regex",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 363,
+        "end_line": 363,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-unsafe-regex",
+          "value": "security/detect-unsafe-regex",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Unsafe Regular Expression",
+      "message": "Unsafe Regular Expression",
+      "description": "Potentially unsafe regular expressions. It may take a very long time to run.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-unsafe-regex",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 132,
+        "end_line": 132,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-unsafe-regex",
+          "value": "security/detect-unsafe-regex",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Unsafe Regular Expression",
+      "message": "Unsafe Regular Expression",
+      "description": "Potentially unsafe regular expressions. It may take a very long time to run.",
+      "cve": "dojo/static/dojo/js/datatables.min.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-unsafe-regex",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/datatables.min.js",
+        "start_line": 182,
+        "end_line": 182,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-unsafe-regex",
+          "value": "security/detect-unsafe-regex",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-unsafe-regex"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/index.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/index.js",
+        "start_line": 289,
+        "end_line": 289,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/index.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/index.js",
+        "start_line": 203,
+        "end_line": 203,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/index.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/index.js",
+        "start_line": 202,
+        "end_line": 202,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/static/dojo/js/index.js:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/static/dojo/js/index.js",
+        "start_line": 277,
+        "end_line": 277,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/edit_rule.html:174bf82e7bf9414dfe3028414c56de510e6e452ec85dc103a8d1ae8879d521a4:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/edit_rule.html",
+        "start_line": 74,
+        "end_line": 74,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/edit_rule.html:71101e0d191826f7a732714d5288da2446ab9bdb9eadb7e486b76624709f56ae:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/edit_rule.html",
+        "start_line": 71,
+        "end_line": 71,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/edit_rule.html:d89cdbb643440389e600693b61f838d7ebd9c0b6e51526fddef1566e555cbb02:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/edit_rule.html",
+        "start_line": 73,
+        "end_line": 73,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/edit_rule2.html:174bf82e7bf9414dfe3028414c56de510e6e452ec85dc103a8d1ae8879d521a4:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/edit_rule2.html",
+        "start_line": 81,
+        "end_line": 81,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/edit_rule2.html:71101e0d191826f7a732714d5288da2446ab9bdb9eadb7e486b76624709f56ae:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/edit_rule2.html",
+        "start_line": 78,
+        "end_line": 78,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/edit_rule2.html:d89cdbb643440389e600693b61f838d7ebd9c0b6e51526fddef1566e555cbb02:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/edit_rule2.html",
+        "start_line": 80,
+        "end_line": 80,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/endpoints.html:06c0a08b858a757bbfb193940ed6944251feb2c7e52c4092405edeb63fe8d9d4:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/endpoints.html",
+        "start_line": 140,
+        "end_line": 140,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/endpoints.html:06c0a08b858a757bbfb193940ed6944251feb2c7e52c4092405edeb63fe8d9d4:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/endpoints.html",
+        "start_line": 196,
+        "end_line": 196,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/endpoints.html:06c0a08b858a757bbfb193940ed6944251feb2c7e52c4092405edeb63fe8d9d4:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/endpoints.html",
+        "start_line": 183,
+        "end_line": 183,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/endpoints.html:09cd1a209ee7018f0590a7dd95372220e504852b7bbbdeb4a6577597e4e8c6b1:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/endpoints.html",
+        "start_line": 246,
+        "end_line": 246,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/endpoints.html:75d022b5aeb8d0ebd057ed8a6dd71e34c96fda0e982a79a89ecb64bfbe229d76:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/endpoints.html",
+        "start_line": 141,
+        "end_line": 141,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/new_rule.html:174bf82e7bf9414dfe3028414c56de510e6e452ec85dc103a8d1ae8879d521a4:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/new_rule.html",
+        "start_line": 89,
+        "end_line": 89,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/new_rule.html:71101e0d191826f7a732714d5288da2446ab9bdb9eadb7e486b76624709f56ae:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/new_rule.html",
+        "start_line": 86,
+        "end_line": 86,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/new_rule.html:d89cdbb643440389e600693b61f838d7ebd9c0b6e51526fddef1566e555cbb02:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/new_rule.html",
+        "start_line": 88,
+        "end_line": 88,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/view_cred_all_details.html:09cd1a209ee7018f0590a7dd95372220e504852b7bbbdeb4a6577597e4e8c6b1:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/view_cred_all_details.html",
+        "start_line": 236,
+        "end_line": 236,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/view_cred_details.html:09cd1a209ee7018f0590a7dd95372220e504852b7bbbdeb4a6577597e4e8c6b1:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/view_cred_details.html",
+        "start_line": 283,
+        "end_line": 283,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/view_objects.html:09cd1a209ee7018f0590a7dd95372220e504852b7bbbdeb4a6577597e4e8c6b1:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/view_objects.html",
+        "start_line": 131,
+        "end_line": 131,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Function Call Object Injection Sink",
+      "message": "Function Call Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/templates/dojo/view_objects_eng.html:09cd1a209ee7018f0590a7dd95372220e504852b7bbbdeb4a6577597e4e8c6b1:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/templates/dojo/view_objects_eng.html",
+        "start_line": 121,
+        "end_line": 121,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-4-findings-3-to-aggregate.html:68695edf4fa8fa9a21e1f17705ca2436a74e03690cd79bc121f8059aeff23d66:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-4-findings-3-to-aggregate.html",
+        "start_line": 6705,
+        "end_line": 6705,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-4-findings-3-to-aggregate.html:e68e1c09aea26f3557910e998c55d5efcc3fcf8f07ff618085cf9e2ff77c1377:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-4-findings-3-to-aggregate.html",
+        "start_line": 6709,
+        "end_line": 6709,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-4-findings-3-to-aggregate.html:e8208d82c08970eea19d4137099f8f71ee21a2cc9f51319dbccf1a2fe0bb2574:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-4-findings-3-to-aggregate.html",
+        "start_line": 6702,
+        "end_line": 6702,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-6-findings.html:68695edf4fa8fa9a21e1f17705ca2436a74e03690cd79bc121f8059aeff23d66:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-6-findings.html",
+        "start_line": 7494,
+        "end_line": 7494,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-6-findings.html:e68e1c09aea26f3557910e998c55d5efcc3fcf8f07ff618085cf9e2ff77c1377:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-6-findings.html",
+        "start_line": 7498,
+        "end_line": 7498,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-6-findings.html:e8208d82c08970eea19d4137099f8f71ee21a2cc9f51319dbccf1a2fe0bb2574:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-6-findings.html",
+        "start_line": 7491,
+        "end_line": 7491,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html:68695edf4fa8fa9a21e1f17705ca2436a74e03690cd79bc121f8059aeff23d66:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html",
+        "start_line": 437,
+        "end_line": 437,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html:e68e1c09aea26f3557910e998c55d5efcc3fcf8f07ff618085cf9e2ff77c1377:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html",
+        "start_line": 441,
+        "end_line": 441,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html:e8208d82c08970eea19d4137099f8f71ee21a2cc9f51319dbccf1a2fe0bb2574:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-rule-undefined.html",
+        "start_line": 434,
+        "end_line": 434,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-single-finding.html:68695edf4fa8fa9a21e1f17705ca2436a74e03690cd79bc121f8059aeff23d66:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-single-finding.html",
+        "start_line": 7443,
+        "end_line": 7443,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-single-finding.html:e68e1c09aea26f3557910e998c55d5efcc3fcf8f07ff618085cf9e2ff77c1377:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-single-finding.html",
+        "start_line": 7447,
+        "end_line": 7447,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-single-finding.html:e8208d82c08970eea19d4137099f8f71ee21a2cc9f51319dbccf1a2fe0bb2574:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-single-finding.html",
+        "start_line": 7440,
+        "end_line": 7440,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html:68695edf4fa8fa9a21e1f17705ca2436a74e03690cd79bc121f8059aeff23d66:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html",
+        "start_line": 486,
+        "end_line": 486,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html:e68e1c09aea26f3557910e998c55d5efcc3fcf8f07ff618085cf9e2ff77c1377:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html",
+        "start_line": 490,
+        "end_line": 490,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    },
+    {
+      "category": "sast",
+      "name": "Generic Object Injection Sink",
+      "message": "Generic Object Injection Sink",
+      "description": "Bracket object notation with user input is present, this might allow an attacker to access all properties of the object and even it's prototype, leading to possible code execution.",
+      "cve": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html:e8208d82c08970eea19d4137099f8f71ee21a2cc9f51319dbccf1a2fe0bb2574:security/detect-object-injection",
+      "severity": "Unknown",
+      "confidence": "Unknown",
+      "scanner": {
+        "id": "eslint",
+        "name": "ESLint"
+      },
+      "location": {
+        "file": "dojo/unittests/scans/sonarqube/sonar-table-in-table.html",
+        "start_line": 483,
+        "end_line": 483,
+        "dependency": {
+          "package": {}
+        }
+      },
+      "identifiers": [
+        {
+          "type": "eslint_rule_id",
+          "name": "ESLint rule ID security/detect-object-injection",
+          "value": "security/detect-object-injection",
+          "url": "https://github.com/nodesecurity/eslint-plugin-security#detect-object-injection"
+        }
+      ]
+    }
+  ],
+  "remediations": []
+}

--- a/dojo/unittests/test_gitlab_sast_parser.py
+++ b/dojo/unittests/test_gitlab_sast_parser.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+from dojo.tools.gitlab_sast.parser import GitlabSastReportParser
+from dojo.models import Test
+
+
+class TestGitlabSastReportParser(TestCase):
+
+    def test_parse_without_file_has_no_findings(self):
+        parser = GitlabSastReportParser(None, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_file_with_no_vuln_has_no_findings(self):
+        testfile = open("dojo/unittests/scans/gitlab_sast/gl-sast-report-0-vuln.json")
+        parser = GitlabSastReportParser(testfile, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_file_with_one_vuln_has_one_finding(self):
+        testfile = open("dojo/unittests/scans/gitlab_sast/gl-sast-report-1-vuln.json")
+        parser = GitlabSastReportParser(testfile, Test())
+        self.assertEqual(1, len(parser.items))
+
+    def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
+        testfile = open("dojo/unittests/scans/gitlab_sast/gl-sast-report-many-vuln.json")
+        parser = GitlabSastReportParser(testfile, Test())
+        self.assertTrue(len(parser.items) > 2)


### PR DESCRIPTION
Integration for GitLab SAST integrates into GitLab's Continuous Integration and leverages FLOSS scanning tools for the most common languages (<https://docs.gitlab.com/ee/user/application_security/sast/#supported-languages-and-frameworks>). It then reads the results of those tools and creates a report in a common JSON format.

Website: https://docs.gitlab.com/ee/user/application_security/sast/

PR for documentation: https://github.com/DefectDojo/Documentation/pull/84
PR for sample files: https://github.com/DefectDojo/sample-scan-files/pull/49


When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- N/A Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR 

