### PR TITLE
docker-compose-dev: allow chosing of admin password

### DIFF
--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -19,6 +19,7 @@ services:
     volumes:
       - '.:/app:z'
     environment:
+      DD_ADMIN_USER: ${DD_ADMIN_USER:-admin}
       DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-admin}
   nginx:
     volumes:


### PR DESCRIPTION
This PR ensures that the environment variable DD_ADMIN_USER and DD_ADMIN_PASSWORD present at build time are passed on to the initializer for the docker-compose-dev override environment.

This allows users to choose a predicatble admin password (and username) in dev. 

When you are working with different branches / pull requests it's not uncommon to clear containers/images/volumes often, which results in a new random admin password everytime. With this PR it becomes predictable.

The release docker-compose-override still generates a random admin password on initialization.