### PR TITLE
kubernetes security fixes:

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -61,6 +61,11 @@ spec:
               name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
               key: mysql-password
               {{- end }}
+        - name: DD_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $fullName }}
+              key: DD_SECRET_KEY
         resources:
           {{- toYaml .Values.celery.beat.resources | nindent 10 }}
       {{- with .Values.celery.beat.nodeSelector }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -59,7 +59,12 @@ spec:
               # Use secret handled outside of the chart
               name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
               key: mysql-password
-              {{- end }}   
+              {{- end }}
+        - name: DD_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $fullName }}
+              key: DD_SECRET_KEY
         resources:
           {{- toYaml .Values.celery.worker.resources | nindent 10 }}
       {{- with .Values.celery.worker.nodeSelector }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -64,7 +64,21 @@ spec:
               # Use secret handled outside of the chart
               name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
               key: mysql-password
-              {{- end }}   
+              {{- end }}
+        - name: DD_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $fullName }}
+              key: DD_SECRET_KEY
+        - name: DD_CREDENTIAL_AES_256_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ $fullName }}
+              key: DD_CREDENTIAL_AES_256_KEY
+        - name: DD_SESSION_COOKIE_SECURE
+          value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
+        - name: DD_CSRF_COOKIE_SECURE
+          value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
         resources:
           {{- toYaml .Values.django.uwsgi.resources | nindent 10 }}
       - name: nginx

--- a/helm/defectdojo/templates/secret.yaml
+++ b/helm/defectdojo/templates/secret.yaml
@@ -16,7 +16,7 @@ metadata:
 type: Opaque
 data:
   DD_ADMIN_PASSWORD: {{ randAlphaNum 22 | b64enc | quote }}
-  DD_SECRET_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+  DD_SECRET_KEY: {{ randAlphaNum 50 | b64enc | quote }}
   DD_CREDENTIAL_AES_256_KEY: {{ randAlphaNum 32 | b64enc | quote }}
   METRICS_HTTP_AUTH_PASSWORD: {{ randAlphaNum 32 | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
- added DD_SECRET_KEY in all django containers

Django SECRET_KEY get it's value from environment variable DD_SECRET_KEY or defaults to weak and known "." string as per settings.dist.py

DD_SECRET_KEY  environment variable was injected in the initializer container but not the other ones. I believe it's required for all django containers : more importantly uwsgi, but celery beat and celery worker too

As per django documentation https://docs.djangoproject.com/en/2.2/ref/settings/#secret-key :
```
Running Django with a known SECRET_KEY defeats many of Django’s security protections, and can lead to privilege escalation and remote code execution vulnerabilities.
```

- added DD_CREDENTIAL_AES_256_KEY in uwsgi

DB_KEY get it's value from the environment variable DD_CREDENTIAL_AES_256_KEY or defaults to weak and known "." string as per settings.dist.py

DD_CREDENTIAL_AES_256_KEY was missing in the uwsgi container. It was injected only in the initializer. 

I believe it's required (only) for uwsgi as it's used in the templating engine (see utils.py dojo_crypto_encrypt function, see dojo\templates\dojo\view_cred.html)

I've left it in the initializer "just in case"; all the secrets from the `defectdojo` secret are injected into the initializer: 
```
        envFrom:
(...)
        - secretRef:
            name: {{ $fullName }}
```

- increased DD_SECRET_KEY size

As per django advisor, this key should be at least 50 char long: 
$ python manage.py check --deploy

WARNINGS:
(...)
?: (security.W009) Your SECRET_KEY has less than 50 characters or less than 5 unique characters. Please generate a long and random SECRET_KEY, otherwise many of Django's security-critical features will be vulnerable to attack.

- add secure flag to session cookies when TLS is activated

when TLS is activated (either at ingress level or end-to-end TLS until the nginx container), set the secure flag to our cookies using SESSION_COOKIE_SECURE=True and CSRF_COOKIE_SECURE=True django variables


Note: you can check the instantiated values of all settings.py parameters using: 
```
python manage.py diffsettings --all
```

(see https://docs.djangoproject.com/en/2.2/ref/django-admin/#diffsettings)
