### PR TITLE
product_metrics: fix and align statuses with views

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -369,25 +369,15 @@ def inactive_findings(request, pid=None, eid=None, view=None):
     pid_local = None
     tags = Tag.objects.usage_for_model(Finding)
     if pid:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement__product__id=pid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement__product__id=pid, active=False, duplicate=False).order_by('numerical_severity')
+        findings = Finding.objects.filter(test__engagement__product__id=pid)
     elif eid:
         eng = get_object_or_404(Engagement, id=eid)
         pid_local = eng.product.id
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement=eid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement=eid, active=False, duplicate=False).order_by('numerical_severity')
+        findings = Finding.objects.filter(test__engagement=eid)
     else:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.all().order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(active=False, duplicate=False).order_by('numerical_severity')
+        findings = Finding.objects.all()
+
+    findings = findings.filter(active=False, duplicate=False, is_Mitigated=False, false_p=False, out_of_scope=False).order_by('numerical_severity')
 
     if request.user.is_staff:
         findings = OpenFingingSuperFilter(

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -231,7 +231,7 @@ def view_product_metrics(request, pid):
                                            duplicate=False,
                                            out_of_scope=False,
                                            active=True,
-                                           mitigated__isnull=True)
+                                           is_Mitigated=False)
 
     inactive_findings = Finding.objects.filter(test__engagement__product=prod,
                                            date__range=[start_date, end_date],
@@ -239,28 +239,30 @@ def view_product_metrics(request, pid):
                                            duplicate=False,
                                            out_of_scope=False,
                                            active=False,
-                                           mitigated__isnull=True)
+                                           is_Mitigated=False)
 
     closed_findings = Finding.objects.filter(test__engagement__product=prod,
                                              date__range=[start_date, end_date],
                                              false_p=False,
-                                             verified=False,
                                              duplicate=False,
                                              out_of_scope=False,
                                              active=False,
-                                             mitigated__isnull=False)
+                                             is_Mitigated=True)
 
     false_positive_findings = Finding.objects.filter(test__engagement__product=prod,
                                              date__range=[start_date, end_date],
                                              false_p=True,
-                                             verified=False,
                                              duplicate=False,
                                              out_of_scope=False)
 
     out_of_scope_findings = Finding.objects.filter(test__engagement__product=prod,
                                              date__range=[start_date, end_date],
+                                             false_p=False,
                                              duplicate=False,
                                              out_of_scope=True)
+
+    all_findings = Finding.objects.filter(test__engagement__product=prod,
+                                             date__range=[start_date, end_date])
 
     open_vulnerabilities = Finding.objects.filter(
         test__engagement__product=prod,
@@ -390,6 +392,7 @@ def view_product_metrics(request, pid):
                    'out_of_scope_findings': out_of_scope_findings,
                    'accepted_findings': accepted_findings,
                    'new_findings': new_verified_findings,
+                   'all_findings': all_findings,
                    'open_vulnerabilities': open_vulnerabilities,
                    'all_vulnerabilities': all_vulnerabilities,
                    'start_date': start_date,
@@ -946,7 +949,6 @@ def ad_hoc_finding(request, pid):
                                         enabled=enabled)
                 if jform.is_valid():
                     push_to_jira = jform.cleaned_data.get('push_to_jira')
-
 
                 messages.add_message(request,
                                      messages.SUCCESS,

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -97,7 +97,7 @@
                             <h5>Accepted Findings</h5>
                         </div>
                         <div class="panel-body">
-                            <div id="reported_findings" class="graph"></div>
+                            <div id="accepted_findings" class="graph"></div>
                         </div>
                     </div>
                 </div>
@@ -517,7 +517,7 @@
                 }
             ];
 
-            $.plot("#reported_findings", data, {
+            $.plot("#accepted_findings", data, {
                 series: {
                     stack: true,
                     bars: {

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -109,12 +109,13 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa fa-bug fa-2x"></i>
+                                <i class="fa fa-crosshairs fa-2x"></i>
 
                                 <div class="pull-right inline-block text-right">
-                                    <span class=" fa-2x">{{ inactive_findings|length }}</span>
-                                    <span><a href="{% url 'product_inactive_findings' prod.id %}?test__engagement__product={{ prod.id }}">Inactive
-                                        Finding{{ inactive_findings|length|pluralize }} <i
+                                    <span class=" fa-2x">{{ verified_findings|length }}</span>
+                                    <span><a
+                                            href="{% url 'product_verified_findings' prod.id %}?test__engagement__product={{ prod.id }}">Verified
+                                        Finding{{ verified_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
                                 </div>
@@ -122,12 +123,12 @@
                         </div>
                     </div>
                     <div class="panel-body">
-                        <div id="inactive_findings" class="graph"></div>
+                        <div id="verified_findings" class="graph"></div>
                     </div>
                     <div class="panel-footer">
-                        <i title="Ingested since {{ start_date }}"
+                        <i title="Since {{ start_date }}."
                            class="text-info fa fa-info-circle"></i>
-                        <small>Ingested since {{ start_date|date:"D., M. d, Y" }}</small>
+                        <small>Verified since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
             </div>
@@ -155,6 +156,33 @@
                         <i title="Accepted since {{ start_date }}"
                            class="text-info fa fa-info-circle"></i>
                         <small>Opened since {{ start_date|date:"D., M. d, Y" }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <i class="fa fa-check fa-2x"></i>
+
+                                <div class="pull-right text-right">
+                                    <span class="fa-2x">{{ accepted_findings|length }}</span>
+                                    <span><a
+                                            href="{% url 'accepted_findings' %}?test__engagement__product={{ prod.id }}">Accepted
+                                    Findings <i class="fa fa-arrow-circle-right"></i></a>
+                                </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body">
+                        <div id="accepted_findings" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i title="Accepted since {{ start_date }}"
+                           class="text-info fa fa-info-circle"></i>
+                        <small>Accepted since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
             </div>
@@ -217,61 +245,6 @@
                     <div class="panel-heading">
                         <div class="row">
                             <div class="col-xs-12">
-                                <i class="fa fa-check fa-2x"></i>
-
-                                <div class="pull-right text-right">
-                                    <span class="fa-2x">{{ accepted_findings|length }}</span>
-                                    <span><a
-                                            href="{% url 'accepted_findings' %}?test__engagement__product={{ prod.id }}">Accepted
-                                    Findings <i class="fa fa-arrow-circle-right"></i></a>
-                                </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="panel-body">
-                        <div id="reported_findings" class="graph"></div>
-                    </div>
-                    <div class="panel-footer">
-                        <i title="Accepted since {{ start_date }}"
-                           class="text-info fa fa-info-circle"></i>
-                        <small>Accepted since {{ start_date|date:"D., M. d, Y" }}</small>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-3">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <div class="row">
-                            <div class="col-xs-12">
-                                <i class="fa fa-crosshairs fa-2x"></i>
-
-                                <div class="pull-right inline-block text-right">
-                                    <span class=" fa-2x">{{ verified_findings|length }}</span>
-                                    <span><a
-                                            href="{% url 'product_verified_findings' prod.id %}?test__engagement__product={{ prod.id }}">Verified
-                                        Finding{{ verified_findings|length|pluralize }} <i
-                                                class="fa fa-arrow-circle-right"></i></a>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="panel-body">
-                        <div id="verified_findings" class="graph"></div>
-                    </div>
-                    <div class="panel-footer">
-                        <i title="Since {{ start_date }}."
-                           class="text-info fa fa-info-circle"></i>
-                        <small>Verified since {{ start_date|date:"D., M. d, Y" }}</small>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-3">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <div class="row">
-                            <div class="col-xs-12">
                                 <i class="fa fa-fire-extinguisher fa-2x"></i>
 
                                 <div class="pull-right inline-block text-right">
@@ -295,8 +268,62 @@
                     </div>
                 </div>
             </div>
-          </div>
-      </div>
+            <div class="col-md-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <i class="fa fa-bullseye fa-2x"></i>
+
+                                <div class="text-right pull-right">
+                                    <span class="fa-2x">{{ all_findings|length }}</span>
+                                    <span><a href="{% url 'product_false_positive_findings' prod.id %}?test__engagement__product={{ prod.id }}">Total 
+                                        Finding{{ all_findings|length|pluralize }} <i
+                                                class="fa fa-arrow-circle-right"></i></a>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body">
+                        <div id="all_findings" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i title="Since {{ start_date }}"
+                           class="text-info fa fa-info-circle"></i>
+                        <small>Since {{ start_date|date:"D., M. d, Y" }}</small>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        <div class="row">
+                            <div class="col-xs-12">
+                                <i class="fa fa-bug fa-2x"></i>
+
+                                <div class="pull-right inline-block text-right">
+                                    <span class=" fa-2x">{{ inactive_findings|length }}</span>
+                                    <span><a href="{% url 'product_inactive_findings' prod.id %}?test__engagement__product={{ prod.id }}">Inactive
+                                        Finding{{ inactive_findings|length|pluralize }} <i
+                                                class="fa fa-arrow-circle-right"></i></a>
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel-body">
+                        <div id="inactive_findings" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i title="Ingested since {{ start_date }}"
+                           class="text-info fa fa-info-circle"></i>
+                        <small>Ingested since {{ start_date|date:"D., M. d, Y" }}</small>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <div class="panel panel-default">
         <div class="panel-heading tight">
@@ -483,11 +510,9 @@
                     </div>
                 </div>
             </div>
-
         </div>
     </div>
-    </div>
-
+</div>
 {% endblock %}
 {% block postscript %}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
@@ -541,6 +566,7 @@
             closed_findings();
             false_positive_findings();
             out_of_scope_findings();
+            all_findings();
             new_findings();
             open_close_weekly();
             severity_weekly();
@@ -656,7 +682,7 @@
                 }
             ];
 
-            $.plot("#reported_findings", data, {
+            $.plot("#accepted_findings", data, {
                 series: {
                     stack: true,
                     bars: {
@@ -1340,6 +1366,138 @@
                 xaxis: {
                     ticks: ticks,
                 },
+            });
+        }
+        ;
+
+        function all_findings() {
+            var critical = 0;
+            var high = 0;
+            var medium = 0;
+            var low = 0;
+            var info = 0;
+            var ticks = [
+                [0, "Critical"], [1, "High"], [2, "Medium"], [3, "Low"], [4, "Info"]
+            ];
+
+            {% for f in all_findings %}
+                {% if f.severity == 'Critical' %}
+                    critical += 1;
+                {% elif f.severity == 'High' %}
+                    high += 1;
+                {% elif f.severity == 'Medium' %}
+                    medium += 1;
+                {% elif f.severity == 'Low' %}
+                    low += 1;
+                {% elif f.severity == 'Info' %}
+                    info += 1;
+                {% endif %}
+            {% endfor %}
+
+            var d1 = [
+                [0, critical],
+            ];
+            var d2 = [
+                [1, high],
+            ];
+            var d3 = [
+                [2, medium],
+            ];
+            var d4 = [
+                [3, low],
+            ];
+            var d5 = [
+                [4, info],
+            ];
+
+            var data = [
+                {
+                    label: "Critical",
+                    data: d1,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 1,
+                        fillColor: "#d9534f"
+                    },
+                    color: "#d9534f"
+                },
+                {
+                    label: "High",
+                    data: d2,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 2,
+                        fillColor: "#f0ad4e"
+                    },
+                    color: "#f0ad4e"
+                },
+                {
+                    label: "Medium",
+                    data: d3,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 3,
+                        fillColor: "#f0de28"
+                    },
+                    color: "#f0de28"
+                },
+                {
+                    label: "Low",
+                    data: d4,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#337ab7"
+                    },
+                    color: "#337ab7"
+                },
+                {
+                    label: "info",
+                    data: d5,
+                    bars: {
+                        show: true,
+                        fill: true,
+                        lineWidth: 1,
+                        order: 4,
+                        fillColor: "#80699B"
+                    },
+                    color: "#80699B"
+                }
+            ];
+
+            $.plot("#all_findings", data, {
+                series: {
+                    stack: true,
+                    bars: {
+                        show: true,
+                        barWidth: .9,
+                        'align': "center",
+                    },
+
+                },
+                grid: {
+                    hoverable: false,
+                    borderWidth: 1,
+                    borderColor: '#e7e7e7',
+
+                },
+                tooltip: false,
+                legend: {
+                    show: false,
+                    position: "ne"
+                },
+                xaxis: {
+                    ticks: ticks,
+                },
+
             });
         }
         ;

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -114,7 +114,8 @@
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ verified_findings|length }}</span>
                                     <span><a
-                                            href="{% url 'product_verified_findings' prod.id %}?test__engagement__product={{ prod.id }}">Verified
+                                            href="{% url 'product_verified_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                            title="Findings that are open/active and verified">Verified
                                         Finding{{ verified_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
@@ -141,7 +142,8 @@
 
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ open_findings|length }}</span>
-                                    <span><a href="{% url 'product_open_findings' prod.id %}?test__engagement__product={{ prod.id }}">Open
+                                    <span><a href="{% url 'product_open_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                        title="Findings that are open/active, but not (yet) verified">Open
                                         Finding{{ open_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
@@ -169,7 +171,8 @@
                                 <div class="pull-right text-right">
                                     <span class="fa-2x">{{ accepted_findings|length }}</span>
                                     <span><a
-                                            href="{% url 'accepted_findings' %}?test__engagement__product={{ prod.id }}">Accepted
+                                            href="{% url 'accepted_findings' %}?test__engagement__product={{ prod.id }}"
+                                            title="Findings that have been accepted in a risk acceptance.">Accepted
                                     Findings <i class="fa fa-arrow-circle-right"></i></a>
                                 </span>
                                 </div>
@@ -195,7 +198,8 @@
 
                                 <div class="text-right pull-right">
                                     <span class="fa-2x">{{ closed_findings|length }}</span>
-                                    <span><a href="{% url 'closed_findings' %}?test__engagement__product={{ prod.id }}">Closed
+                                    <span><a href="{% url 'closed_findings' %}?test__engagement__product={{ prod.id }}"
+                                             title="Findings that are closed and mitigated.">Closed
                                         Finding{{ closed_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
@@ -222,7 +226,8 @@
 
                                 <div class="text-right pull-right">
                                     <span class="fa-2x">{{ false_positive_findings|length }}</span>
-                                    <span><a href="{% url 'product_false_positive_findings' prod.id %}?test__engagement__product={{ prod.id }}">False-postive
+                                    <span><a href="{% url 'product_false_positive_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                             title="Findings that are marked as false postive.">False-postive
                                         Finding{{ false_positive_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
@@ -250,7 +255,8 @@
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ out_of_scope_findings|length }}</span>
                                     <span><a
-                                            href="{% url 'product_out_of_scope_findings' prod.id %}?test__engagement__product={{ prod.id }}">Out Of Scope
+                                            href="{% url 'product_out_of_scope_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                            title="Findings that are marked as out of scope.">Out Of Scope
                                         Finding{{ out_of_scope_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
@@ -277,7 +283,8 @@
 
                                 <div class="text-right pull-right">
                                     <span class="fa-2x">{{ all_findings|length }}</span>
-                                    <span><a href="{% url 'product_false_positive_findings' prod.id %}?test__engagement__product={{ prod.id }}">Total 
+                                    <span><a href="{% url 'product_false_positive_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                            title="All findings.">Total 
                                         Finding{{ all_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
@@ -304,7 +311,8 @@
 
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ inactive_findings|length }}</span>
-                                    <span><a href="{% url 'product_inactive_findings' prod.id %}?test__engagement__product={{ prod.id }}">Inactive
+                                    <span><a href="{% url 'product_inactive_findings' prod.id %}?test__engagement__product={{ prod.id }}"
+                                             title="Findings that are not active but not mitigated for some reason">Inactive
                                         Finding{{ inactive_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>


### PR DESCRIPTION
The product metrics page/tab has been subject of some reported issues lately, mainly around closed/inactive findings not being shown en in general the reported numbers being different from what they see when they click on one of the tiles. (#2130, #2187, questions on slack)

This PR:
- Fixes inactive and closed queries (Closed==mitigated, Inactive==not mitigated but also not active).
- Renames a div for accepted_findings (was called reported_findings)
- Aligns and simplifies the queries for inactive findings in finding/views.py
- Add title/tooltip to explain statuses

This is in initial step for #2215 , but there's lots more todo in future PRs as described in #2215.
