### PR TITLE
implement redirects to open products/engagements by name and by metadata etc

### DIFF
--- a/dojo/product/urls.py
+++ b/dojo/product/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-from django.urls import path
 
 from dojo.product import views
 
@@ -8,10 +7,6 @@ urlpatterns = [
     url(r'^product$', views.product, name='product'),
     url(r'^product/(?P<pid>\d+)$', views.view_product,
         name='view_product'),
-    path('product/name/<str:pname>', views.view_product_by_name,
-        name='view_product_by_name'),
-    path('product/meta/<str:pmeta_name>/<str:pmeta_value>', views.view_product_by_meta,
-        name='view_product_by_meta'),
     url(r'^product/(?P<pid>\d+)/engagements$', views.view_engagements,
         name='view_engagements'),
     url(r'^product/(?P<pid>\d+)/engagements/cicd$', views.view_engagements_cicd,

--- a/dojo/product/urls.py
+++ b/dojo/product/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.urls import path
 
 from dojo.product import views
 
@@ -7,6 +8,10 @@ urlpatterns = [
     url(r'^product$', views.product, name='product'),
     url(r'^product/(?P<pid>\d+)$', views.view_product,
         name='view_product'),
+    path('product/name/<str:pname>', views.view_product_by_name,
+        name='view_product_by_name'),
+    path('product/meta/<str:pmeta_name>/<str:pmeta_value>', views.view_product_by_meta,
+        name='view_product_by_meta'),
     url(r'^product/(?P<pid>\d+)/engagements$', views.view_engagements,
         name='view_engagements'),
     url(r'^product/(?P<pid>\d+)/engagements/cicd$', views.view_engagements_cicd,

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -101,6 +101,17 @@ def iso_to_gregorian(iso_year, iso_week, iso_day):
     return start + timedelta(weeks=iso_week - 1, days=iso_day - 1)
 
 
+def view_product_by_name(request, pname):
+    prod = get_object_or_404(Product, name=pname)
+    return HttpResponseRedirect(reverse('view_product', args=(prod.id,)))
+
+
+def view_product_by_meta(request, pmeta_name, pmeta_value):
+    prod_query = Product.objects.filter(product_meta__name=pmeta_name, product_meta__value=pmeta_value)
+    prod = get_object_or_404(prod_query)
+    return HttpResponseRedirect(reverse('view_product', args=(prod.id,)))
+
+
 def view_product(request, pid):
     prod_query = Product.objects.all().select_related('product_manager', 'technical_contact', 'team_manager').prefetch_related('authorized_users')
     prod = get_object_or_404(prod_query, id=pid)
@@ -946,7 +957,6 @@ def ad_hoc_finding(request, pid):
                                         enabled=enabled)
                 if jform.is_valid():
                     push_to_jira = jform.cleaned_data.get('push_to_jira')
-
 
                 messages.add_message(request,
                                      messages.SUCCESS,

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -101,17 +101,6 @@ def iso_to_gregorian(iso_year, iso_week, iso_day):
     return start + timedelta(weeks=iso_week - 1, days=iso_day - 1)
 
 
-def view_product_by_name(request, pname):
-    prod = get_object_or_404(Product, name=pname)
-    return HttpResponseRedirect(reverse('view_product', args=(prod.id,)))
-
-
-def view_product_by_meta(request, pmeta_name, pmeta_value):
-    prod_query = Product.objects.filter(product_meta__name=pmeta_name, product_meta__value=pmeta_value)
-    prod = get_object_or_404(prod_query)
-    return HttpResponseRedirect(reverse('view_product', args=(prod.id,)))
-
-
 def view_product(request, pid):
     prod_query = Product.objects.all().select_related('product_manager', 'technical_contact', 'team_manager').prefetch_related('authorized_users')
     prod = get_object_or_404(prod_query, id=pid)

--- a/dojo/redirects/urls.py
+++ b/dojo/redirects/urls.py
@@ -1,0 +1,16 @@
+from django.urls import path
+
+from dojo.redirects import views
+
+urlpatterns = [
+    path('s/product/name/<str:pname>', views.view_product_by_name,
+        name='view_product_by_name'),
+    path('s/product/meta/<str:pmeta_name>/<str:pmeta_value>', views.view_product_by_meta,
+        name='view_product_by_meta'),
+    path('s/product/meta/<str:pmeta_name>/<str:pmeta_value>/engagement/name/<str:ename>', views.view_engagement_by_name_by_product_name,
+        name='view_engagement_by_name_by_product_name'),
+    path('s/product/meta/<str:pmeta_name>/<str:pmeta_value>/engagement/branch_tag/<str:btname>', views.view_engagement_by_branch_tag_by_product_name,
+        name='view_engagement_by_branch_tag_by_product_name'),
+
+
+]

--- a/dojo/redirects/urls.py
+++ b/dojo/redirects/urls.py
@@ -3,10 +3,23 @@ from django.urls import path
 from dojo.redirects import views
 
 urlpatterns = [
+    # some prefixs in the url path are duplicated, can't find a way to resuse them in django
+    # ideally we want to just match the first part and then use the remainder in the redirect
+    # is /s/product/name/pname/xxxx/yyyy/zzzz redirect to /product/id/xxxx/yyyy/zzzz
+
+    # find product
     path('s/product/name/<str:pname>', views.view_product_by_name,
         name='view_product_by_name'),
     path('s/product/meta/<str:pmeta_name>/<str:pmeta_value>', views.view_product_by_meta,
         name='view_product_by_meta'),
+
+    # cicd engagements inside product
+    path('s/product/name/<str:pname>/engagements/cicd', views.view_cicd_engagements_by_product_by_name,
+        name='view_cicd_engagements_by_product_by_name'),
+    path('s/product/meta/<str:pmeta_name>/<str:pmeta_value>/engagements/cicd', views.view_cicd_engagements_by_product_by_meta,
+        name='view_cicd_engagements_by_product_by_meta'),
+
+    # find engagement inside product
     path('s/product/meta/<str:pmeta_name>/<str:pmeta_value>/engagement/name/<str:ename>', views.view_engagement_by_name_by_product_name,
         name='view_engagement_by_name_by_product_name'),
     path('s/product/meta/<str:pmeta_name>/<str:pmeta_value>/engagement/branch_tag/<str:btname>', views.view_engagement_by_branch_tag_by_product_name,

--- a/dojo/redirects/views.py
+++ b/dojo/redirects/views.py
@@ -19,7 +19,7 @@ def view_cicd_engagements_by_product_by_name(request, pname):
 
 
 def view_cicd_engagements_by_product_by_meta(request, pmeta_name, pmeta_value):
-    return redirect(get_prod_by_meta(pmeta_name, pmeta_value), '/engagement/cicd')
+    return redirect(get_prod_by_meta(pmeta_name, pmeta_value), '/engagements/cicd')
 
 
 def view_engagement_by_name_by_product_name(request, pmeta_name, pmeta_value, ename):

--- a/dojo/redirects/views.py
+++ b/dojo/redirects/views.py
@@ -14,6 +14,14 @@ def view_product_by_meta(request, pmeta_name, pmeta_value):
     return redirect(get_prod_by_meta(pmeta_name, pmeta_value))
 
 
+def view_cicd_engagements_by_product_by_name(request, pname):
+    return redirect(get_prod_by_name(pname), '/engagements/cicd')
+
+
+def view_cicd_engagements_by_product_by_meta(request, pmeta_name, pmeta_value):
+    return redirect(get_prod_by_meta(pmeta_name, pmeta_value), '/engagement/cicd')
+
+
 def view_engagement_by_name_by_product_name(request, pmeta_name, pmeta_value, ename):
     prod = get_prod_by_meta(pmeta_name, pmeta_value)
     eng = get_eng_by_product_and_name(prod.id, ename)

--- a/dojo/redirects/views.py
+++ b/dojo/redirects/views.py
@@ -1,5 +1,6 @@
 from dojo.models import Product, Engagement
 from dojo.utils import redirect
+from django.shortcuts import get_object_or_404
 import logging
 
 logger = logging.getLogger(__name__)

--- a/dojo/redirects/views.py
+++ b/dojo/redirects/views.py
@@ -1,0 +1,41 @@
+from dojo.models import Product, Engagement
+from dojo.utils import redirect
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def view_product_by_name(request, pname):
+    return redirect(get_prod_by_name(pname))
+
+
+def view_product_by_meta(request, pmeta_name, pmeta_value):
+    return redirect(get_prod_by_meta(pmeta_name, pmeta_value))
+
+
+def view_engagement_by_name_by_product_name(request, pmeta_name, pmeta_value, ename):
+    prod = get_prod_by_meta(pmeta_name, pmeta_value)
+    eng = get_eng_by_product_and_name(prod.id, ename)
+    return redirect(eng)
+
+
+def view_engagement_by_branch_tag_by_product_name(request, pmeta_name, pmeta_value, btname):
+    prod = get_prod_by_meta(pmeta_name, pmeta_value)
+    eng = get_eng_by_product_and_branch_tag_name(prod.id, btname)
+    return redirect(eng)
+
+
+def get_prod_by_name(name):
+    return get_object_or_404(Product.objects.all().only('id'), name=name)
+
+
+def get_prod_by_meta(name, value):
+    return get_object_or_404(Product.objects.filter(product_meta__name=name, product_meta__value=value).only('id'))
+
+
+def get_eng_by_product_and_name(pid, ename):
+    return get_object_or_404(Engagement.objects.filter(product__id=pid, name=ename).only('id'))
+
+
+def get_eng_by_product_and_branch_tag_name(pid, btname):
+    return get_object_or_404(Engagement.objects.filter(product__id=pid, branch_tag=btname).only('id'))

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -57,6 +57,7 @@ from dojo.notes.urls import urlpatterns as notes_urls
 from dojo.note_type.urls import urlpatterns as note_type_urls
 from dojo.google_sheet.urls import urlpatterns as google_sheets_urls
 from dojo.banner.urls import urlpatterns as banner_urls
+from dojo.redirects.urls import urlpatterns as redirects_urls
 
 admin.autodiscover()
 
@@ -147,6 +148,7 @@ ur += notes_urls
 ur += note_type_urls
 ur += google_sheets_urls
 ur += banner_urls
+ur += redirects_urls
 
 swagger_urls = [
     url(r'^$', SwaggerView.as_view(), name='index'),

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -20,6 +20,7 @@ from django.urls import get_resolver, reverse
 from django.db.models import Q, Sum, Case, When, IntegerField, Value, Count
 from django.template.defaultfilters import pluralize
 from django.template.loader import render_to_string
+from django.http import HttpResponseRedirect
 from django.utils import timezone
 from jira import JIRA
 from jira.exceptions import JIRAError
@@ -2105,3 +2106,12 @@ def truncate_with_dots(the_string, max_length_including_dots):
 
 def max_safe(list):
     return max(i for i in list if i is not None)
+
+
+def redirect(obj):
+    if isinstance(obj, Engagement):
+        return HttpResponseRedirect(reverse('view_engagement', args=(obj.id,)))
+    elif isinstance(obj, Product):
+        return HttpResponseRedirect(reverse('view_product', args=(obj.id,)))
+    else:
+        raise NotImplementedError

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2108,10 +2108,15 @@ def max_safe(list):
     return max(i for i in list if i is not None)
 
 
-def redirect(obj):
+def redirect(obj, suffix=None):
+
+    real_suffix = ''
+    if suffix:
+        real_suffix = suffix
+
     if isinstance(obj, Engagement):
-        return HttpResponseRedirect(reverse('view_engagement', args=(obj.id,)))
+        return HttpResponseRedirect(reverse('view_engagement', args=(obj.id,)) + real_suffix)
     elif isinstance(obj, Product):
-        return HttpResponseRedirect(reverse('view_product', args=(obj.id,)))
+        return HttpResponseRedirect(reverse('view_product', args=(obj.id,)) + real_suffix)
     else:
         raise NotImplementedError


### PR DESCRIPTION
Sometimes products are logically linked to products/applications/projectes/repositories in other system, i.e. gitlab. If the setup is such that their names are equal in both systems, it would be nice if a link to defect dojo could work by product name, i.e.

`https://dojo/s/product/name/valentijn`

In other situations people can use the custom fields in Defect Dojo to add a name+value to logically link the DD product to some other system, i.e. instance=valentijn. In that case it would be nice if a link to defect dojo could work by this custom field, i.e.:

`https://dojo/s/product/meta/instance/valentijn`

It's called meta because that's how DD stores the data.

This PR implements both. There may be more stuff coming around this as I am contemplating a badge system that could use similar urls.

I have put all the redirect code in a separate folder / module.

EDIT: added also some redirects for engagement by name, branch_tag.