### PR TITLE
fix broken html due to invalid truncate

### DIFF
--- a/dojo/templates/dojo/all_product_findings.html
+++ b/dojo/templates/dojo/all_product_findings.html
@@ -43,7 +43,7 @@
                         {% for finding in findings %}
                             <tr>
                                 <td><a title="{{ finding.title }}"
-                                       href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars:60 }}</a>
+                                       href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:60 }}</a>
                                        <sup>
                                            {% for tag in finding.tags %}
                                            <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>

--- a/dojo/templates/dojo/custom_pdf_report_endpoint_list.html
+++ b/dojo/templates/dojo/custom_pdf_report_endpoint_list.html
@@ -213,7 +213,7 @@
                     {% endif %}
                     {% if finding.get_response %}
                         <h6>Response</h6>
-                        <pre>{{ finding.get_response|truncatechars:800 }}</pre>
+                        <pre>{{ finding.get_response|truncatechars_html:800 }}</pre>
                     {% endif %}
                     <h6>Impact</h6>
                     <pre>{{ finding.impact }}</pre>

--- a/dojo/templates/dojo/custom_pdf_report_finding_list.html
+++ b/dojo/templates/dojo/custom_pdf_report_finding_list.html
@@ -199,7 +199,7 @@
             {% endif %}
             {% if finding.get_response %}
                 <h6>Response</h6>
-                <pre>{{ finding.get_response|truncatechars:800 }}</pre>
+                <pre>{{ finding.get_response|truncatechars_html:800 }}</pre>
             {% endif %}
             <h6>Impact</h6>
             <pre>{{ finding.impact }}</pre>

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -273,7 +273,7 @@
                            <pre>{{ req.get_request }}</pre>
                         {% if req.get_response %}
                            <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars:800 }}</pre>
+                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
                         {% endif %}
                         {% endfor %}
                         {% endif %}

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -399,7 +399,7 @@
                            <pre>{{ req.get_request }}</pre>
                         {% if req.get_response %}
                            <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars:800 }}</pre>
+                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
                         {% endif %}
                         {% endfor %}
                         {% endif %}

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -248,7 +248,7 @@
                            <pre>{{ req.get_request }}</pre>
                         {% if req.get_response %}
                            <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars:800 }}</pre>
+                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
                         {% endif %}
                         {% endfor %}
                         {% endif %}

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -315,12 +315,12 @@
                                                     <td>{{ finding.test.engagement.product.prod_type.name }}</td>
                                                     <td>
                                         <span title="{{ finding.test.engagement.product.name }}">
-                                            {{ finding.test.engagement.product.name|truncatechars:20 }}
+                                            {{ finding.test.engagement.product.name|truncatechars_html:20 }}
                                         </span>
                                                     </td>
                                                     <td>{{ finding.severity_display }}</td>
                                                     <td><a href="{% url 'view_finding' finding.id %}"
-                                                           title="{{ finding.title }}">{{ finding.title|truncatechars:20 }}</a>
+                                                           title="{{ finding.title }}">{{ finding.title|truncatechars_html:20 }}</a>
                                                     </td>
                                                     <td>{{ finding.age }}</td>
                                                     <td>{{ finding.status }}</td>

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -322,7 +322,7 @@
                            <pre>{{ req.get_request }}</pre>
                         {% if req.get_response %}
                            <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars:800 }}</pre>
+                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
                         {% endif %}
                         {% endfor %}
                         {% endif %}

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -379,7 +379,7 @@
                            <pre class="raw_request">{{ req.get_request }}</pre>
                         {% if req.get_response != "" %}
                            <h6>Response {{forloop.counter}}</h6>
-                           <pre class="raw_request">{{ req.get_response|truncatechars:800 }}</pre>
+                           <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
                         {% endif %}
                         {% endfor %}
                         {% endif %}

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -307,7 +307,7 @@
                            <pre>{{ req.get_request }}</pre>
                         {% if req.get_response %}
                            <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars:800 }}</pre>
+                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
                         {% endif %}
                         {% endfor %}
                         {% endif %}

--- a/dojo/templates/dojo/report_endpoints.html
+++ b/dojo/templates/dojo/report_endpoints.html
@@ -37,7 +37,7 @@
                     <tbody>
                     {% for e in endpoints %}
                         <tr>
-                            <td><a href="{% url 'view_endpoint' e.id %}">{{ e|truncatechars:70 }}</a></td>
+                            <td><a href="{% url 'view_endpoint' e.id %}">{{ e|truncatechars_html:70 }}</a></td>
                             <td><a href="{% url 'view_product' e.product.id %}">{{ e.product }}</a></td>
                             <td>
                               <a href="{% url 'open_findings' %}?endpoints={{ e.id }}">{{ e.finding_count_endpoint }}</a>

--- a/dojo/templates/dojo/request_endpoint_report.html
+++ b/dojo/templates/dojo/request_endpoint_report.html
@@ -49,7 +49,7 @@
 
                         {% for e in endpoints %}
                             <tr>
-                                <td><a href="{% url 'view_endpoint' e.id %}">{{ e|truncatechars:70 }}</a>
+                                <td><a href="{% url 'view_endpoint' e.id %}">{{ e|truncatechars_html:70 }}</a>
                                   {% if e.tags %}
                                       <sup>
                                           {% for tag in e.tags %}

--- a/dojo/templates/dojo/request_report.html
+++ b/dojo/templates/dojo/request_report.html
@@ -76,7 +76,7 @@
                         {% for finding in paged_findings %}
                             <tr>
                                 <td><a title="{{ finding.title }}"
-                                       href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars:50 }}</a>
+                                       href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:50 }}</a>
                                        {% if finding.tags %}
                                        <sup>
                                            {% for tag in finding.tags %}

--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -93,7 +93,7 @@
                                         {% endfor %}
                                     </sup>
                                 </td>
-                                <td>{{ product.object.description|truncatechars:150|markdown_render }}</td>
+                                <td>{{ product.object.description|truncatechars_html:150|markdown_render }}</td>
                             </tr>
                         {% endfor %}
                         </tbody>

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -39,7 +39,7 @@
                     <tr>
                     <td style="width: 250px;">
                     <a href="{% url 'view_engagement' eng.id %}" data-toggle="tooltip" data-placement="bottom" title="{{ eng.name|default:"N/A" }}">
-                    {{ eng.name|truncatechars:35|default:"N/A" }}</a>
+                    {{ eng.name|truncatechars_html:35|default:"N/A" }}</a>
                     {% if eng.version %}
                         <sup>
                               <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ eng.version }}">

--- a/dojo/templates/dojo/templates.html
+++ b/dojo/templates/dojo/templates.html
@@ -75,8 +75,8 @@
                                     {% if add_from_template %}
                                         <a href="{% url 'add_temp_finding' tid finding.id %}"
                                            class="template-popover" data-placement="auto bottom" data-toggle="popover"
-                                           data-trigger="hover" title="{{ finding.title|truncatechars:100 }}"
-                                           data-content="{{ finding.description|truncatechars:500 }}">
+                                           data-trigger="hover" title="{{ finding.title|truncatechars_html:100 }}"
+                                           data-content="{{ finding.description|truncatechars_html:500 }}">
                                             {{ finding.title }}
                                             <sup>
                                                 {% for tag in finding.tags %}
@@ -87,8 +87,8 @@
                                     {% elif apply_template %}
                                         <a href="{% url 'choose_finding_template_options' finding.id fid %}"
                                            class="template-popover" data-placement="auto bottom" data-toggle="popover"
-                                           data-trigger="hover" title="{{ finding.title|truncatechars:100 }}"
-                                           data-content="{{ finding.description|truncatechars:500 }}">
+                                           data-trigger="hover" title="{{ finding.title|truncatechars_html:100 }}"
+                                           data-content="{{ finding.description|truncatechars_html:500 }}">
                                             {{ finding.title }}
                                             <sup>
                                                 {% for tag in finding.tags %}

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -413,7 +413,7 @@
                            <pre>{{ req.get_request }}</pre>
                         {% if req.get_response %}
                            <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars:800 }}</pre>
+                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
                         {% endif %}
                         {% endfor %}
                         {% endif %}

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -114,7 +114,7 @@
                     <div class="panel-heading">
                         <div class="clearfix">
                             <h4 class="pull-left">
-                            Engagement Presets <small>{{ eng.preset.title|truncatechars:60 }}</small>
+                            Engagement Presets <small>{{ eng.preset.title|truncatechars_html:60 }}</small>
                             </h4>
                             <div class="dropdown pull-right">
                                 <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
@@ -592,7 +592,7 @@
             </tr>
             <tr>
               <td><strong>Commit Hash</strong></td>
-              <td>{{ eng.commit_hash|notspecified|truncatechars:13 }}</td>
+              <td>{{ eng.commit_hash|notspecified|truncatechars_html:13 }}</td>
             </tr>
             <tr>
               <td><strong>Branch/Tag</strong></td>

--- a/dojo/templates/dojo/view_risk.html
+++ b/dojo/templates/dojo/view_risk.html
@@ -68,7 +68,7 @@
                           </span>
                         </td>
                         <td><a href="{% url 'view_finding' finding.id %}"
-                               title="{{ finding.title }}">{{ finding.title|truncatechars:140 }}</a></td>
+                               title="{{ finding.title }}">{{ finding.title|truncatechars_html:140 }}</a></td>
                         <td>{{ finding.date }}</td>
                         <td>{{ finding.active }}</td>
 


### PR DESCRIPTION
in `view_eng.html` we use the django built-in filter `truncatechars`. However currently on `dev` this outputs something like this:

```
<tr>
              <td><strong>Commit Hash</strong></td>
              <td><em class="t…</td>
            </tr>
            <tr>
              <td><strong>Branch/Tag</strong></td>
              <td>develop</td>
            </tr>
            <tr>
              <td><strong>Orchestration</strong></td>
              <td>
                    <em class=" text-muted"="">Not Specified</em>
                  
              </td>
            </tr>
````
which breaks the html because it opens a `<em>` tag and never closes it.

using django built-in filter `truncatchars_html" must be used