### PR TITLE
Fixed typos in ENV varible - changed DD_DATABASE_PASsWORD to DD_DATAB…

### DIFF
--- a/entrypoint_scripts/common/dojo-shared-resources.sh
+++ b/entrypoint_scripts/common/dojo-shared-resources.sh
@@ -223,18 +223,18 @@ function ensure_mysql_application_db() {
         if [ -z "$DD_DATABASE_USER" ]; then
             DD_DATABASE_USER="root"
         fi
-        if [ -z "$DD_DATABASE_PASsWORD" -a "$BATCH_MODE" == "yes" ]; then
+        if [ -z "$DD_DATABASE_PASSWORD" -a "$BATCH_MODE" == "yes" ]; then
             echo "SQL Password not provided, exiting"
             exit 1
         else
-            DD_DATABASE_PASsWORD="dojodb_install"
+            DD_DATABASE_PASSWORD="dojodb_install"
         fi
         if [ -z "$DD_DATABASE_NAME" ]; then
             DD_DATABASE_NAME="dojodb"
         fi
     fi
 
-    if mysql -fs --protocol=TCP -h "$DD_DATABASE_HOST" -P "$DD_DATABASE_PORT" -u"$DD_DATABASE_USER" -p"$DD_DATABASE_PASsWORD" "$DD_DATABASE_NAME" >/dev/null 2>&1 </dev/null; then
+    if mysql -fs --protocol=TCP -h "$DD_DATABASE_HOST" -P "$DD_DATABASE_PORT" -u"$DD_DATABASE_USER" -p"$DD_DATABASE_PASSWORD" "$DD_DATABASE_NAME" >/dev/null 2>&1 </dev/null; then
         echo "Database $DD_DATABASE_NAME already exists!"
         echo
         if [ "$AUTO_DOCKER" == "yes" ] || [ "$BATCH_MODE" == "yes" ]; then
@@ -247,15 +247,15 @@ function ensure_mysql_application_db() {
             read -p "Drop database $DD_DATABASE_NAME? [Y/n] " DELETE
         fi
         if [[ ! $DELETE =~ ^[nN]$ ]]; then
-            mysqladmin -f --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASsWORD" drop "$DD_DATABASE_NAME"
-            mysqladmin    --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASsWORD" create "$DD_DATABASE_NAME"
+            mysqladmin -f --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASSWORD" drop "$DD_DATABASE_NAME"
+            mysqladmin    --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASSWORD" create "$DD_DATABASE_NAME"
         fi
     else
         echo "Setting password..."
         # Set the root password for mysql
         set_random_mysql_db_pwd
         sudo service mysql start
-        if mysqladmin --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASsWORD" create $DD_DATABASE_NAME; then
+        if mysqladmin --protocol=TCP --host="$DD_DATABASE_HOST" --port="$DD_DATABASE_PORT" --user="$DD_DATABASE_USER" --password="$DD_DATABASE_PASSWORD" create $DD_DATABASE_NAME; then
             echo "Created database $DD_DATABASE_NAME."
         else
             echo "Error! Failed to create database $DD_DATABASE_NAME. Check your credentials."
@@ -271,18 +271,18 @@ function ensure_postgres_application_db() {
     read -p "Postgres port: " $DD_DATABASE_PORT
     read -p "Postgres user (should already exist): " $DD_DATABASE_USER
     stty -echo
-    read -p "Password for user: " $DD_DATABASE_PASsWORD; echo
+    read -p "Password for user: " $DD_DATABASE_PASSWORD; echo
     stty echo
     read -p "Database name (should NOT exist): " $DD_DATABASE_NAME
 
-    if [ "$( PGPASSWORD=$DD_DATABASE_PASsWORD psql -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER -tAc "SELECT 1 FROM pg_database WHERE datname='$DD_DATABASE_NAME'" )" = '1' ]
+    if [ "$( PGPASSWORD=$DD_DATABASE_PASSWORD psql -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER -tAc "SELECT 1 FROM pg_database WHERE datname='$DD_DATABASE_NAME'" )" = '1' ]
     then
         echo "Database $DD_DATABASE_NAME already exists!"
         echo
         read -p "Drop database $DD_DATABASE_NAME? [Y/n] " DELETE
         if [[ ! $DELETE =~ ^[nN]$ ]]; then
-            PGPASSWORD=$DD_DATABASE_PASsWORD dropdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
-            PGPASSWORD=$DD_DATABASE_PASsWORD createdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
+            PGPASSWORD=$DD_DATABASE_PASSWORD dropdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
+            PGPASSWORD=$DD_DATABASE_PASSWORD createdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
         else
             read -p "Try and install anyway? [Y/n] " INSTALL
             if [[ $INSTALL =~ ^[nN]$ ]]; then
@@ -291,7 +291,7 @@ function ensure_postgres_application_db() {
             fi
         fi
     else
-        PGPASSWORD=$DD_DATABASE_PASsWORD createdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
+        PGPASSWORD=$DD_DATABASE_PASSWORD createdb $DD_DATABASE_NAME -h $DD_DATABASE_HOST -p $DD_DATABASE_PORT -U $DD_DATABASE_USER
         if [ $? = 0 ]
         then
             echo "Created database $DD_DATABASE_NAME."
@@ -447,10 +447,10 @@ function prepare_settings_file() {
     if [ "$DBTYPE" == "$SQLITE" ]; then
         echo 'DD_DATABASE_URL="sqlite:///defectdojo.db"' >> ${ENV_SETTINGS_FILE}
     elif [ "$DBTYPE" == "$MYSQL" ]; then
-        SAFE_URL=$(urlenc "$DD_DATABASE_USER")":"$(urlenc "$DD_DATABASE_PASsWORD")"@"$(urlenc "$DD_DATABASE_HOST")":"$(urlenc "$DD_DATABASE_PORT")"/"$(urlenc "$DD_DATABASE_NAME")
+        SAFE_URL=$(urlenc "$DD_DATABASE_USER")":"$(urlenc "$DD_DATABASE_PASSWORD")"@"$(urlenc "$DD_DATABASE_HOST")":"$(urlenc "$DD_DATABASE_PORT")"/"$(urlenc "$DD_DATABASE_NAME")
         echo "DD_DATABASE_URL=mysql://$SAFE_URL" >> ${ENV_SETTINGS_FILE}
     elif [ "$DBTYPE" == "$POSTGRES" ]; then
-        SAFE_URL=$(urlenc "$DD_DATABASE_USER")":"$(urlenc "$DD_DATABASE_PASsWORD")"@"$(urlenc "$DD_DATABASE_HOST")":"$(urlenc "$DD_DATABASE_PORT")"/"$(urlenc "$DD_DATABASE_NAME")
+        SAFE_URL=$(urlenc "$DD_DATABASE_USER")":"$(urlenc "$DD_DATABASE_PASSWORD")"@"$(urlenc "$DD_DATABASE_HOST")":"$(urlenc "$DD_DATABASE_PORT")"/"$(urlenc "$DD_DATABASE_NAME")
         echo "DD_DATABASE_URL=postgres://$SAFE_URL" >> ${ENV_SETTINGS_FILE}
     fi
 
@@ -540,10 +540,10 @@ function set_random_mysql_db_pwd() {
   sudo mysqld_safe --skip-grant-tables >/dev/null 2>&1 &
   sleep 5
   DB_ROOT_PASS_LEN=`shuf -i 50-60 -n 1`
-  if [[ -z "$DD_DATABASE_PASsWORD" ]]; then
-    DD_DATABASE_PASsWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
+  if [[ -z "$DD_DATABASE_PASSWORD" ]]; then
+    DD_DATABASE_PASSWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
   fi
-  mysql mysql -e "UPDATE user SET authentication_string=PASSWORD('$DD_DATABASE_PASsWORD'), plugin='mysql_native_password' WHERE User='root';FLUSH PRIVILEGES;"
+  mysql mysql -e "UPDATE user SET authentication_string=PASSWORD('$DD_DATABASE_PASSWORD'), plugin='mysql_native_password' WHERE User='root';FLUSH PRIVILEGES;"
   sudo service mysql stop
 }
 

--- a/entrypoint_scripts/run/startup-docker.bash
+++ b/entrypoint_scripts/run/startup-docker.bash
@@ -41,8 +41,8 @@ if cat dojo/settings/.env.prod | grep -q "mysql://root:dojodb_install@localhost:
 	#DB_ROOT_PASS_USER=`pwgen -scn $DB_ROOT_PASS_LEN 1`
 	#entrypoint_scripts/common/setup-superuser.expect product_manager "$DD_ADMIN_PASSWORD"
 
-	#DD_DATABASE_PASsWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
-	#entrypoint_scripts/common/setup-superuser.expect user2 "$DD_DATABASE_PASsWORD"
+	#DD_DATABASE_PASSWORD=`pwgen -scn $DB_ROOT_PASS_LEN 1`
+	#entrypoint_scripts/common/setup-superuser.expect user2 "$DD_DATABASE_PASSWORD"
 
 	echo
 	echo "=============================================================================="


### PR DESCRIPTION
…ASE_PASSWORD

Fixing same issue as in PR 2228 on master - fixing typo of ENV variable

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [ ] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
