### PR TITLE
merge findings: allow setting to disable it

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -684,6 +684,10 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'DSOP Scan': DEDUPE_ALGO_HASH_CODE,
 }
 
+# merging findings doesn't always work well with dedupe and reimport etc.
+# disable it if you see any issues (and report them on github)
+DISABLE_FINDING_MERGE = False
+
 # ------------------------------------------------------------------------------
 # JIRA
 # ------------------------------------------------------------------------------

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -93,6 +93,9 @@ env = environ.Env(
     DD_SOCIAL_AUTH_GITLAB_SECRET=(str, ''),
     DD_SOCIAL_AUTH_GITLAB_API_URL=(str, 'https://gitlab.com'),
     DD_SOCIAL_AUTH_GITLAB_SCOPE=(list, ['api', 'read_user', 'openid', 'profile', 'email']),
+    # merging findings doesn't always work well with dedupe and reimport etc.
+    # disable it if you see any issues (and report them on github)
+    DD_DISABLE_FINDING_MERGE=(bool, False),
 )
 
 
@@ -684,9 +687,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'DSOP Scan': DEDUPE_ALGO_HASH_CODE,
 }
 
-# merging findings doesn't always work well with dedupe and reimport etc.
-# disable it if you see any issues (and report them on github)
-DISABLE_FINDING_MERGE = False
+DISABLE_FINDING_MERGE = env('DD_DISABLE_FINDING_MERGE')
 
 # ------------------------------------------------------------------------------
 # JIRA

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -92,7 +92,7 @@
                     </ul>
                   </div>
                   <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
-                    {% if product_tab %}
+                    {% if product_tab and not 'DISABLE_FINDING_MERGE'|setting_enabled %}
                     <button type="button" class="btn btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
                       <a class="white-color merge" href="#" alt="Merge Findings">
                         <i class="fa fa-compress"></i>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -210,7 +210,7 @@
                 <span class="caret"></span>
             </button>
             <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
-                {% if product_tab %}
+                {% if product_tab and not 'DISABLE_FINDING_MERGE'|setting_enabled %}
                     <button type="button" class="btn btn-info btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
                         <a class="white-color merge" href="#" alt="Merge Findings">
                             <i class="fa fa-compress"></i>

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -741,9 +741,8 @@ def full_url(url):
     return get_full_url(url)
 
 
-# settings value
-# usage {% settings_value "LANGUAGE_CODE" %}
+# check if setting is enabled in django settings.py
+# use 'DISABLE_FINDING_MERGE'|setting_enabled
 @register.filter
 def setting_enabled(name):
-    print(getattr(settings, name))
     return getattr(settings, name, False)

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -19,6 +19,8 @@ from ast import literal_eval
 from urllib.parse import urlparse
 import bleach
 import git
+from django.conf import settings
+
 
 register = template.Library()
 
@@ -737,3 +739,11 @@ def get_severity_count(id, table):
 @register.filter
 def full_url(url):
     return get_full_url(url)
+
+
+# settings value
+# usage {% settings_value "LANGUAGE_CODE" %}
+@register.filter
+def setting_enabled(name):
+    print(getattr(settings, name))
+    return getattr(settings, name, False)


### PR DESCRIPTION
I have seen some weird stuff happening when users are merging findings and then the next (re)import comes from jenkins or any other ci tooling.
Sometimes existing findings get closed and the new ones get created, but the new ones are then removed by dedupe. And then when the user had chosen merge and delete initially the findings are gone.
Could be some bugs in the importer, but don't have the time to look into it.
Just added a quick setting to allow sysadmins to disable merging alltogether.
It's in settings.py as I don't want to spend too much time maintaining a database migration for this.