### PR TITLE
improve layout handling of finding title

### DIFF
--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -268,7 +268,7 @@
                                 <td>
                                   {% if finding.title %}
                                   <a title="{{ finding.title }}"
-                                                      href="{% url 'view_finding' finding.id %}">{{ finding.title }}</a>
+                                                      href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:60 }}</a>
                                   {% else %}
                                   <a title="{{ finding.id }}"
                                                       href="{% url 'view_finding' finding.id %}">{{ finding.id }}</a>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -407,7 +407,7 @@
                                 {{ finding.severity_display }}
                             </span>
                         </td>
-                        <td class="nowrap"><a href="{% url 'view_finding' finding.id %}">{{ finding.title }}</a>
+                        <td><a href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:60 }}</a>
                           {% if finding.file_path %}
                           <i class="fa dojo-sup fa-code has-popover" data-trigger="hover" data-content="{{ finding.file_path }}" data-placement="right" data-container="body" data-original-title="Files" title=""></i>
                             {% if finding.component_name %}


### PR DESCRIPTION
fix some pages where the finding.title was not yet truncated causing the remaining columns to fall of the screen.