### PR TITLE
similar findings: fix bug and extend with identical issues

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -7,6 +7,7 @@
     "bootswatch": "3.4.1",
     "chosen": "harvesthq/bower-chosen#~1.4.0",
     "chosen-bootstrap": "dbtek/chosen-bootstrap#~1.1.0",
+    "clipboard": "^2.0.6",
     "components-jqueryui": "^1.0.0",
     "datatables": "1.10.18",
     "drmonty-datatables-plugins": "^1.0.0",

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -37,6 +37,15 @@ chosen@harvesthq/bower-chosen#~1.4.0:
   version "0.0.0"
   resolved "https://codeload.github.com/harvesthq/bower-chosen/tar.gz/d7eba35cf214d2416fabee25c5d4619542a23d8d"
 
+clipboard@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
+  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 codemirror-spell-checker@*:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz#1c660f9089483ccb5113b9ba9ca19c3f4993371e"
@@ -60,6 +69,11 @@ datatables@1.10.18:
   integrity sha512-ntatMgS9NN6UMpwbmO+QkYJuKlVeMA2Mi0Gu/QxyIh+dW7ZjLSDhPT2tWlzjpIWEkDYgieDzS9Nu7bdQCW0sbQ==
   dependencies:
     jquery ">=1.7"
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 drmonty-datatables-plugins@^1.0.0:
   version "1.10.12"
@@ -102,6 +116,13 @@ fullcalendar@^3.0.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/fullcalendar/-/fullcalendar-3.10.1.tgz#cca3f9a2656a7e978a3f3facb7f35934a91185db"
   integrity sha512-E0ioaHVmwdS4es8pNTUNva7505wPkUMFdn9JGFLYo+J12ARhN3zDBwoPj2DfB8rL7Yc1sSve+FqDHC3s2SZ7Fw==
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
 
 google-code-prettify@^1.0.0:
   version "1.0.5"
@@ -167,6 +188,11 @@ raphael@^2.2.8:
   dependencies:
     eve-raphael "0.5.0"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
+
 simplemde@^1.0.0:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/simplemde/-/simplemde-1.11.2.tgz#a23a35d978d2c40ef07dec008c92f070d8e080e3"
@@ -180,6 +206,11 @@ startbootstrap-sb-admin-2@1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/startbootstrap-sb-admin-2/-/startbootstrap-sb-admin-2-1.0.7.tgz#ef36a90903afb4a84a25c329b0292d06bf05b130"
   integrity sha1-7zapCQOvtKhKJcMpsCktBr8FsTA=
+
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 typo-js@*:
   version "1.1.0"

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2248,7 +2248,12 @@ def mark_finding_duplicate(request, original_id, duplicate_id):
 
     if original.test.engagement != duplicate.test.engagement:
         if original.test.engagement.deduplication_on_engagement or duplicate.test.engagement.deduplication_on_engagement:
-            raise ValueError('Marking finding {} as duplicate of {} failed as they are not in the same engagement and deduplication_on_engagement is enabled for at least one of them')
+            messages.add_message(
+                request,
+                messages.ERROR,
+                'Marking finding as duplicate/original failed as they are not in the same engagement and deduplication_on_engagement is enabled for at least one of them',
+                extra_tags='alert-danger')
+            return HttpResponseRedirect(request.META.get('HTTP_REFERER'))
 
     duplicate.duplicate = True
     duplicate.active = False

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1456,24 +1456,27 @@ class Finding(models.Model):
 
     @property
     def similar_findings(self):
-        filtered = Finding.objects.all()
+        similar = Finding.objects.all()
 
         if self.test.engagement.deduplication_on_engagement:
-            filtered = filtered.filter(test__engagement=self.test.engagement)
+            similar = similar.filter(test__engagement=self.test.engagement)
         else:
-            filtered = filtered.filter(test__engagement__product=self.test.engagement.product)
+            similar = similar.filter(test__engagement__product=self.test.engagement.product)
 
         if self.cve:
-            filtered = filtered.filter(cve=self.cve)
+            similar = similar.filter(cve=self.cve)
         if self.cwe:
-            filtered = filtered.filter(cwe=self.cwe)
+            similar = similar.filter(cwe=self.cwe)
         if self.file_path:
-            filtered = filtered.filter(file_path=self.file_path)
+            similar = similar.filter(file_path=self.file_path)
         if self.line:
-            filtered = filtered.filter(line=self.line)
+            similar = similar.filter(line=self.line)
         if self.unique_id_from_tool:
-            filtered = filtered.filter(unique_id_from_tool=self.unique_id_from_tool)
-        return filtered.exclude(pk=self.pk)[:10]
+            similar = similar.filter(unique_id_from_tool=self.unique_id_from_tool)
+
+        identical = Finding.objects.all().filter(test__engagement__product=self.test.engagement.product).filter(hash_code=self.hash_code).exclude(pk=self.pk)
+
+        return (similar.exclude(pk=self.pk) | identical)[:10]
 
     def compute_hash_code(self):
         if hasattr(settings, 'HASHCODE_FIELDS_PER_SCANNER') and hasattr(settings, 'HASHCODE_ALLOWS_NULL_CWE') and hasattr(settings, 'HASHCODE_ALLOWED_FIELDS'):

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -500,16 +500,16 @@
                                 </td>
                                 <td>{{ similar.status }}{% if similar.duplicate_finding_id %}, <a href="{% url 'view_finding' similar.duplicate_finding_id %}">Original</a> {% endif %}</td>
                                 <td>
-                                    <a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ similar.title }}" href="{% url 'view_finding' similar.id %}">{{ similar.date }}</a>
+                                    {{ similar.date|date }}</br>
                                     {% with similar.notes.count as note_count %}
                                         ({{ note_count }} note{{ note_count|pluralize }})
                                     {% endwith %}
                                 </td>
                                 <td><a href="{% url 'view_test' similar.test_id %}">{{ similar.test.test_type.name }}</a></td>
                                 <td><a href="{% url 'view_engagement' similar.test.engagement_id %}">{{ similar.test.engagement.name }}</a>
-                                {% if similar.test.engagement.version%}
+                                {% if similar.test.engagement.version %}
                                     <sup>
-                                          <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ eng.version }}">
+                                          <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ similar.test.engagement.version }}">
                                           {{ similar.test.engagement.version }}</a>
                                     </sup>
                                 {% endif %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -473,12 +473,14 @@
                 <div id="similar_findings" class="panel-body collapse in">
                     <table class="table table-striped table-hover centered">
                         <tr>
-                            <th>Finding</th>
+                            <th>Title</th>
                             <th>Status</th>
-                            <th>Tags</th>
+                            <th>Date</th>
                             <th>Test</th>
                             <th>Engagement</th>
-                            <th>Version</th>
+                            {% if finding.cwe > 0 %}
+                            <th>CWE</th>
+                            {% endif %}
                             <th>CVE</th>
                             <th>File</th>
                             <th>Deduplicate?</th>
@@ -486,27 +488,41 @@
                         {% for similar in findings %}
                             <tr>
                                 <td>
+                                    <a title="{{ similar.title }}" href="{% url 'view_finding' similar.id %}">{{ similar.title|truncatechars_html:80 }}</a>
+                                    {% if similar.tags %}
+                                    <small>
+                                        {% for tag in similar.tags %}
+                                            <a title="Search {{ tag }}" class="tag-label tag-color"
+                                               href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
+                                        {% endfor %}
+                                    </small>
+                                    {% endif %}
+                                </td>
+                                <td>{{ similar.status }}{% if similar.duplicate_finding_id %}, <a href="{% url 'view_finding' similar.duplicate_finding_id %}">Original</a> {% endif %}</td>
+                                <td>
                                     <a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ similar.title }}" href="{% url 'view_finding' similar.id %}">{{ similar.date }}</a>
                                     {% with similar.notes.count as note_count %}
                                         ({{ note_count }} note{{ note_count|pluralize }})
                                     {% endwith %}
                                 </td>
-                                <td>{{ similar.status }}{% if similar.duplicate_finding_id %}, <a href="{% url 'view_finding' similar.duplicate_finding_id %}">Original</a> {% endif %}</td>
-                                <td>
-                                    {% if similar.tags %}
-                                        <small>
-                                            {% for tag in similar.tags %}
-                                                <a title="Search {{ tag }}" class="tag-label tag-color"
-                                                   href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
-                                            {% endfor %}
-                                        </small>
-                                    {% endif %}
-                                </td>
                                 <td><a href="{% url 'view_test' similar.test_id %}">{{ similar.test.test_type.name }}</a></td>
-                                <td><a href="{% url 'view_engagement' similar.test.engagement_id %}">{{ similar.test.engagement.name }}</a></td>
-                                <td>{{ similar.test.engagement.version }}</td>
+                                <td><a href="{% url 'view_engagement' similar.test.engagement_id %}">{{ similar.test.engagement.name }}</a>
+                                {% if similar.test.engagement.version%}
+                                    <sup>
+                                          <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ eng.version }}">
+                                          {{ similar.test.engagement.version }}</a>
+                                    </sup>
+                                {% endif %}
+                                </td>
+                                {% if finding.cwe > 0 %}
+                                <td>
+                                    <a target="_blank" href="https://cwe.mitre.org/data/definitions/{{ finding.cwe }}.html">
+                                        <i class="fa fa-external-link"></i> {{ finding.cwe }}
+                                    </a>
+                                </td>
+                                {% endif %}
                                 <td>{{ similar.cve }}</td>
-                                <td>{{ similar.file_path }}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}</td>
+                                <td title="{{similar.file_path}}">{{ similar.file_path|truncatechars_html:20 }}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}</td>
                                 <td>
                                     {% if similar.duplicate %}
                                         <form method="post"
@@ -514,7 +530,7 @@
                                             {% csrf_token %}
                                             <input type="submit" value="Reset duplicate status"/>
                                         </form>
-                                    {% elif finding.duplicate_finding_id != similar.id %}
+                                    {% elif finding.original_finding.id != similar.id %}
                                         <form method="post"
                                               action="{% url 'mark_finding_duplicate' original_id=similar.id duplicate_id=finding.id %}">
                                             {% csrf_token %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -366,8 +366,9 @@
                 </tr>
                 <tr>
                     <td>
-                        <span>
-                           {{ finding.file_path }}
+                        <span>{{ finding.file_path }} 
+                            <i class="fa fa-copy fa-align-right copytoclipboard" title="copy to clipboard"
+                            data-clipboard-text="{{finding.file_path}}"></i>
                         </span>
                     </td>
                     <td>
@@ -522,7 +523,10 @@
                                 </td>
                                 {% endif %}
                                 <td>{{ similar.cve }}</td>
-                                <td title="{{similar.file_path}}">{{ similar.file_path|truncatechars_html:20 }}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}</td>
+                                <td title="{{similar.file_path}}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}">
+                                    {{ similar.file_path|truncatechars_html:20 }}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}
+                                    <i class="fa fa-copy fa-align-right copytoclipboard" title="copy full path to clipboard"
+                                    data-clipboard-text="{{similar.file_path}}{% if similar.line > 0 %} (Line {{ similar.line }}){% endif %}"></i></td>
                                 <td>
                                     {% if similar.duplicate %}
                                         <form method="post"
@@ -919,6 +923,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    <script src="{% static "clipboard/dist/clipboard.min.js" %}"></script>
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
@@ -1025,5 +1030,7 @@
                 }
             });
         });
+
+        var clipboard = new ClipboardJS('.copytoclipboard');
     </script>
 {% endblock %}


### PR DESCRIPTION
Bugfix:
- The field `duplicate_finding_id` was recently removed in the dedupe fields overhaul, braking the showing of buttons for similar findings to mark them as duplicate (or ofiginal).

Enhancements:
- Not only show similar findings, but also show identical findings based on hash_code within the same product. This shows you on which engagement (branch) a finding is also seen. 
- With dedupe on engagement enabled, the buttons for marking as duplicate in this case won't work as there is a server side check to prevent this from completing.
- Hiding the buttons from the template is too much hassle as you need to expose certain functions from the views as template tags. Or just copy and paste code into the html template.
- Also improved the layout a bit to make it more readable.

I'm dogfooding this.