### PR TITLE
parser: clair/klar: set finding type to "static"

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -622,6 +622,8 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'ZAP Scan': ['cwe', 'endpoints', 'severity'],
     'Qualys Scan': ['title', 'endpoints', 'severity'],
     'PHP Symfony Security Check': ['title', 'cve'],
+    'Clair Scan': ['title', 'cve', 'description', 'severity'],
+    'Clair Klar Scan': ['title', 'description', 'severity'],
     # for backwards compatibility because someone decided to rename this scanner:
     'Symfony Security Check': ['title', 'cve'],
     'DSOP Scan': ['cve'],
@@ -674,6 +676,8 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'ZAP Scan': DEDUPE_ALGO_HASH_CODE,
     'Qualys Scan': DEDUPE_ALGO_HASH_CODE,
     'PHP Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
+    'Clair Scan': DEDUPE_ALGO_HASH_CODE,
+    'Clair Klar Scan': DEDUPE_ALGO_HASH_CODE,
     # for backwards compatibility because someone decided to rename this scanner:
     'Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
     'DSOP Scan': DEDUPE_ALGO_HASH_CODE,

--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -61,6 +61,8 @@ def get_item(item_node, test):
                       duplicate=False,
                       out_of_scope=False,
                       mitigated=None,
+                      static_finding=True,
+                      dynamic_finding=False,
                       impact="No impact provided")
 
     return finding

--- a/dojo/tools/clair_klar/parser.py
+++ b/dojo/tools/clair_klar/parser.py
@@ -93,6 +93,8 @@ def get_item(item_node, test):
                       out_of_scope=False,
                       mitigated=None,
                       cwe=1035,  # Vulnerable Third Party Component
+                      static_finding=True,
+                      dynamic_finding=False,
                       impact="No impact provided")
 
     return finding


### PR DESCRIPTION
This commit fixes an issue where the finding type was defaulting
to "dynamic" for both Clair and Clair_klar parsers. Now DDJ will
be able to properly deduplicate findings based on clair and
clair_klar reports.

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant 
- [ ] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
