### PR TITLE
fix crash when running fix_loop_duplicates.py

### DIFF
--- a/dojo/management/commands/fix_loop_duplicates.py
+++ b/dojo/management/commands/fix_loop_duplicates.py
@@ -1,8 +1,5 @@
 from django.core.management.base import BaseCommand
-from pytz import timezone
 from dojo.utils import fix_loop_duplicates
-
-locale = timezone(get_system_setting('time_zone'))
 
 """
 Author: Marian Gawron


### PR DESCRIPTION
Erroring due to missing `get_system_settings`

```
$ docker exec -ti madchap_ddojo_uwsgi_1 bash -c 'python manage.py fix_loop_duplicates'
enabling audit logging
patching TagDescriptor
Traceback (most recent call last):
  File "manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.5/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.5/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.5/site-packages/django/core/management/__init__.py", line 224, in fetch_command
    klass = load_command_class(app_name, subcommand)
  File "/usr/local/lib/python3.5/site-packages/django/core/management/__init__.py", line 36, in load_command_class
    module = import_module('%s.management.commands.%s' % (app_name, name))
  File "/usr/local/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 985, in _gcd_import
  File "<frozen importlib._bootstrap>", line 968, in _find_and_load
  File "<frozen importlib._bootstrap>", line 957, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 697, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/app/dojo/management/commands/fix_loop_duplicates.py", line 5, in <module>
    locale = timezone(get_system_setting('time_zone'))
NameError: name 'get_system_setting' is not defined
```

fyi @marianG