### PR TITLE
bugfix nmap parser

### DIFF
--- a/dojo/tools/nmap/parser.py
+++ b/dojo/tools/nmap/parser.py
@@ -83,4 +83,3 @@ class NmapXMLParser(object):
 
                 find.unsaved_endpoints.append(Endpoint(host=ip, fqdn=fqdn, port=port, protocol=protocol))
         self.items = list(self.dupes.values())
-

--- a/dojo/tools/nmap/parser.py
+++ b/dojo/tools/nmap/parser.py
@@ -83,3 +83,4 @@ class NmapXMLParser(object):
 
                 find.unsaved_endpoints.append(Endpoint(host=ip, fqdn=fqdn, port=port, protocol=protocol))
         self.items = list(self.dupes.values())
+


### PR DESCRIPTION
Without this bug fix we sometimes got a "Server 500" error when importing nmap scan result xml files (see [stacktrace.log](https://github.com/DefectDojo/django-DefectDojo/files/4528633/stacktrace.log)).

The reason was that the description field could fill up to several hundreds MegaBytes because of the faulty nmap parser. The parser appended wrongly host info by iterating over the wrong xml node ("root" instead of "host"), so the host info within the description became wrongly longer and longer.

We also renamed some variable names in the parser to comply with python naming conventions. Last but not least we reformatted the output of the description for easier reading.
