### PR TITLE
parser: nessus: Fix CSV import

### DIFF
--- a/dojo/tools/nessus/parser.py
+++ b/dojo/tools/nessus/parser.py
@@ -23,14 +23,14 @@ def get_text_severity(severity_id):
 
 class NessusCSVParser(object):
     def __init__(self, filename, test):
-        content = open(filename.temporary_file_path(), "rb").read().replace("\r", "\n")
+        content = open(filename.temporary_file_path(), "r").read().replace("\r", "\n")
         # content = re.sub("\"(.*?)\n(.*?)\"", "\"\1\2\"", content)
         # content = re.sub("(?<=\")\n", "\\\\n", content)
-        with open("%s-filtered" % filename.temporary_file_path(), "wb") as out:
+        with open("%s-filtered" % filename.temporary_file_path(), "w") as out:
             out.write(content)
             out.close()
 
-        with open("%s-filtered" % filename.temporary_file_path(), "rb") as scan_file:
+        with open("%s-filtered" % filename.temporary_file_path(), "r") as scan_file:
             reader = csv.reader(scan_file,
                                 lineterminator="\n",
                                 quoting=csv.QUOTE_ALL)


### PR DESCRIPTION
The commit fixes an issue where Nessus reports in the CSV format are not processed correctly. The parser was broken since the Python2->Python3 migrations (strings were Bytes and now it's Unicode).

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
