### PR TITLE
ZAP parser: do not resolve hostname to IP address during endpoint creation (#2284)

### DIFF
--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -58,7 +58,7 @@ class ZapXmlParser(object):
         items = list()
         for node in tree.findall('site'):
             site = Site(node)
-            main_host = Endpoint(host=site.ip + site.port if site.port is not None else "")
+            main_host = Endpoint(host=site.name + (":" + site.port) if site.port is not None else "")
             for item in site.items:
                 severity = item.riskdesc.split(' ', 1)[0]
                 references = ''
@@ -129,8 +129,8 @@ def get_attrib_from_subnode(xml_node, subnode_xpath_expr, attrib_name):
 class Site(object):
     def __init__(self, item_node):
         self.node = item_node
+        self.name = self.node.get('name')
         self.host = self.node.get('host')
-        self.ip = self.resolve(self.host)
         self.port = self.node.get('port')
         self.items = []
         for alert in self.node.findall('alerts/alertitem'):


### PR DESCRIPTION
#2284 

ZAP Parser:
* disabled fqdn to ip resolving;
* changed main endpoint visualization from IPport to scheme://fqdn:port