### PR TITLE
reorder queries to make prefetching work everywhere

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -136,6 +136,8 @@ def prefetch_for_products_with_engagments(products_with_engagements):
         return products_with_engagements.prefetch_related('tagged_items__tag',
             'engagement_set__tagged_items__tag',
             'engagement_set__test_set__tagged_items__tag')
+
+    logger.debug('unable to prefetch because query was already executed')
     return products_with_engagements
 
 

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -406,7 +406,7 @@ class OpenFindingFilter(DojoFilter):
             del self.form.fields['test__engagement__product']
 
 
-class OpenFingingSuperFilter(OpenFindingFilter):
+class OpenFindingSuperFilter(OpenFindingFilter):
     reporter = ModelMultipleChoiceFilter(
         queryset=Dojo_User.objects.all())
     test__engagement__product__prod_type = ModelMultipleChoiceFilter(
@@ -472,7 +472,7 @@ class ClosedFindingFilter(DojoFilter):
         self.form.fields['cwe'].choices = list(cwe.items())
 
 
-class ClosedFingingSuperFilter(ClosedFindingFilter):
+class ClosedFindingSuperFilter(ClosedFindingFilter):
     reporter = ModelMultipleChoiceFilter(
         queryset=Dojo_User.objects.all())
 
@@ -538,7 +538,7 @@ class AcceptedFindingFilter(DojoFilter):
         self.form.fields['cwe'].choices = list(cwe.items())
 
 
-class AcceptedFingingSuperFilter(AcceptedFindingFilter):
+class AcceptedFindingSuperFilter(AcceptedFindingFilter):
     test__engagement__risk_acceptance__reporter = \
         ModelMultipleChoiceFilter(
             queryset=Dojo_User.objects.all(),

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -27,14 +27,14 @@ from tagging.models import Tag
 from itertools import chain
 
 from dojo.filters import OpenFindingFilter, \
-    OpenFingingSuperFilter, AcceptedFingingSuperFilter, \
-    ClosedFingingSuperFilter, TemplateFindingFilter
+    OpenFindingSuperFilter, AcceptedFindingSuperFilter, \
+    ClosedFindingSuperFilter, TemplateFindingFilter
 from dojo.forms import NoteForm, FindingNoteForm, CloseFindingForm, FindingForm, PromoteFindingForm, FindingTemplateForm, \
     DeleteFindingTemplateForm, FindingImageFormSet, JIRAFindingForm, GITHUBFindingForm, ReviewFindingForm, ClearFindingReviewForm, \
     DefectFindingForm, StubFindingForm, DeleteFindingForm, DeleteStubFindingForm, ApplyFindingTemplateForm, \
     FindingFormID, FindingBulkUpdateForm, MergeFindings
 from dojo.models import Product_Type, Finding, Notes, NoteHistory, Note_Type, \
-    Risk_Acceptance, BurpRawRequestResponse, Stub_Finding, Endpoint, Finding_Template, FindingImage, \
+    BurpRawRequestResponse, Stub_Finding, Endpoint, Finding_Template, FindingImage, \
     FindingImageAccessToken, JIRA_Issue, JIRA_PKey, GITHUB_PKey, GITHUB_Issue, Dojo_User, Cred_Mapping, Test, Product, User, Engagement
 from dojo.utils import get_page_items, add_breadcrumb, FileIterWrapper, process_notifications, \
     add_comment, jira_get_resolution_id, jira_change_resolution_id, get_jira_connection, \
@@ -45,7 +45,6 @@ from dojo.tasks import add_issue_task, update_issue_task, update_external_issue_
     add_external_issue_task, close_external_issue_task, reopen_external_issue_task
 from django.template.defaultfilters import pluralize
 from django.db.models.query import QuerySet
-
 
 logger = logging.getLogger(__name__)
 
@@ -78,22 +77,24 @@ def verified_findings(request, pid=None, eid=None, view=None):
         else:
             findings = Finding.objects.filter(verified=True).order_by('numerical_severity')
 
-    if request.user.is_staff:
-        findings = OpenFingingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
+    if not request.user.is_staff:
         findings = findings.filter(
             test__engagement__product__authorized_users__in=[request.user])
-        findings = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
 
     title_words = [
-        word for finding in findings.qs for word in finding.title.split()
+        word for finding in findings for word in finding.title.split()
         if len(word) > 2
     ]
-
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings.qs, 25)
+
+    if request.user.is_staff:
+        findings_filter = OpenFindingSuperFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+    else:
+        findings_filter = OpenFindingFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+
+    paged_findings = get_page_items(request, findings_filter.qs, 25)
 
     product_type = None
     if 'test__engagement__product__prod_type' in request.GET:
@@ -113,7 +114,7 @@ def verified_findings(request, pid=None, eid=None, view=None):
 
     found_by = None
     try:
-        found_by = findings.found_by.all().distinct()
+        found_by = findings_filter.found_by.all().distinct()
     except:
         found_by = None
         pass
@@ -143,7 +144,7 @@ def verified_findings(request, pid=None, eid=None, view=None):
             'show_product_column': show_product_column,
             "product_tab": product_tab,
             "findings": paged_findings,
-            "filtered": findings,
+            "filtered": findings_filter,
             "title_words": title_words,
             'found_by': found_by,
             'custom_breadcrumb': custom_breadcrumb,
@@ -182,22 +183,24 @@ def out_of_scope_findings(request, pid=None, eid=None, view=None):
         else:
             findings = Finding.objects.filter(active=False, out_of_scope=True).order_by('numerical_severity')
 
-    if request.user.is_staff:
-        findings = OpenFingingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
+    if not request.user.is_staff:
         findings = findings.filter(
             test__engagement__product__authorized_users__in=[request.user])
-        findings = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
 
     title_words = [
-        word for finding in findings.qs for word in finding.title.split()
+        word for finding in findings for word in finding.title.split()
         if len(word) > 2
     ]
-
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings.qs, 25)
+
+    if request.user.is_staff:
+        findings_filter = OpenFindingSuperFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+    else:
+        findings_filter = OpenFindingFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+
+    paged_findings = get_page_items(request, findings_filter.qs, 25)
 
     product_type = None
     if 'test__engagement__product__prod_type' in request.GET:
@@ -247,7 +250,7 @@ def out_of_scope_findings(request, pid=None, eid=None, view=None):
             'show_product_column': show_product_column,
             "product_tab": product_tab,
             "findings": paged_findings,
-            "filtered": findings,
+            "filtered": findings_filter,
             "title_words": title_words,
             'found_by': found_by,
             'custom_breadcrumb': custom_breadcrumb,
@@ -286,22 +289,24 @@ def false_positive_findings(request, pid=None, eid=None, view=None):
         else:
             findings = Finding.objects.filter(active=False, duplicate=False, false_p=True).order_by('numerical_severity')
 
-    if request.user.is_staff:
-        findings = OpenFingingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
+    if not request.user.is_staff:
         findings = findings.filter(
             test__engagement__product__authorized_users__in=[request.user])
-        findings = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
 
     title_words = [
-        word for finding in findings.qs for word in finding.title.split()
+        word for finding in findings for word in finding.title.split()
         if len(word) > 2
     ]
-
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings.qs, 25)
+
+    if request.user.is_staff:
+        findings_filter = OpenFindingSuperFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+    else:
+        findings_filter = OpenFindingFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+
+    paged_findings = get_page_items(request, findings_filter.qs, 25)
 
     product_type = None
     if 'test__engagement__product__prod_type' in request.GET:
@@ -351,7 +356,7 @@ def false_positive_findings(request, pid=None, eid=None, view=None):
             'show_product_column': show_product_column,
             "product_tab": product_tab,
             "findings": paged_findings,
-            "filtered": findings,
+            "filtered": findings_filter,
             "title_words": title_words,
             'found_by': found_by,
             'custom_breadcrumb': custom_breadcrumb,
@@ -380,22 +385,20 @@ def inactive_findings(request, pid=None, eid=None, view=None):
 
     findings = findings.filter(active=False, duplicate=False, is_Mitigated=False, false_p=False, out_of_scope=False).order_by('numerical_severity')
 
-    if request.user.is_staff:
-        findings = OpenFingingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
-        findings = findings.filter(
-            test__engagement__product__authorized_users__in=[request.user])
-        findings = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-
     title_words = [
-        word for finding in findings.qs for word in finding.title.split()
+        word for finding in findings for word in finding.title.split()
         if len(word) > 2
     ]
-
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings.qs, 25)
+
+    if request.user.is_staff:
+        findings_filter = OpenFindingSuperFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+    else:
+        findings_filter = OpenFindingFilter(
+            request.GET, queryset=findings, user=request.user, pid=pid)
+
+    paged_findings = get_page_items(request, findings_filter.qs, 25)
 
     product_type = None
     if 'test__engagement__product__prod_type' in request.GET:
@@ -445,7 +448,7 @@ def inactive_findings(request, pid=None, eid=None, view=None):
             'show_product_column': show_product_column,
             "product_tab": product_tab,
             "findings": paged_findings,
-            "filtered": findings,
+            "filtered": findings_filter,
             "title_words": title_words,
             'found_by': found_by,
             'custom_breadcrumb': custom_breadcrumb,
@@ -495,7 +498,7 @@ def open_findings(request, pid=None, eid=None, view=None):
     title_words = sorted(set(title_words))
 
     if request.user.is_staff:
-        findings_filter = OpenFingingSuperFilter(
+        findings_filter = OpenFindingSuperFilter(
             request.GET, queryset=findings, user=request.user, pid=pid)
     else:
         findings_filter = OpenFindingFilter(
@@ -580,6 +583,9 @@ def prefetch_for_findings(findings):
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
+    else:
+        logger.debug('unable to prefetch because query was already executed')
+
     return prefetched_findings
 
 
@@ -593,15 +599,14 @@ def accepted_findings(request, pid=None):
     # user = request.user
 
     findings = Finding.objects.filter(risk_acceptance__isnull=False)
-    findings = AcceptedFingingSuperFilter(request.GET, queryset=findings)
+    findings_filter = AcceptedFindingSuperFilter(request.GET, queryset=findings)
     title_words = [
-        word for ra in Risk_Acceptance.objects.all() for finding in
-        ra.accepted_findings.order_by('title').values('title').distinct()
-        for word in finding['title'].split() if len(word) > 2
+        word for finding in findings for word in finding.title.split()
+        if len(word) > 2
     ]
 
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings.qs, 25)
+    paged_findings = get_page_items(request, findings_filter.qs, 25)
 
     product_tab = None
     if pid:
@@ -614,7 +619,7 @@ def accepted_findings(request, pid=None):
             "findings": paged_findings,
             "product_tab": product_tab,
             "filter_name": "Accepted",
-            "filtered": findings,
+            "filtered": findings_filter,
             "title_words": title_words,
         })
 
@@ -622,14 +627,14 @@ def accepted_findings(request, pid=None):
 @user_passes_test(lambda u: u.is_staff)
 def closed_findings(request, pid=None):
     findings = Finding.objects.filter(mitigated__isnull=False)
-    findings = ClosedFingingSuperFilter(request.GET, queryset=findings)
+    findings_filter = ClosedFindingSuperFilter(request.GET, queryset=findings)
     title_words = [
-        word for finding in findings.qs for word in finding.title.split()
+        word for finding in findings for word in finding.title.split()
         if len(word) > 2
     ]
 
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings.qs.order_by('-mitigated'), 25)
+    paged_findings = get_page_items(request, findings_filter.qs.order_by('-mitigated'), 25)
 
     product_tab = None
     if pid:
@@ -641,7 +646,7 @@ def closed_findings(request, pid=None):
         request, 'dojo/findings_list.html', {
             "findings": paged_findings,
             "product_tab": product_tab,
-            "filtered": findings,
+            "filtered": findings_filter,
             "filter_name": "Closed",
             "title_words": title_words,
         })

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -601,12 +601,12 @@ def accepted_findings(request, pid=None):
     findings = Finding.objects.filter(risk_acceptance__isnull=False)
     findings_filter = AcceptedFindingSuperFilter(request.GET, queryset=findings)
     title_words = [
-        word for finding in findings for word in finding.title.split()
+        word for finding in findings_filter.qs for word in finding.title.split()
         if len(word) > 2
     ]
 
     title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings_filter.qs, 25)
+    paged_findings = get_page_items(request, findings_filter.qs.order_by('numerical_severity'), 25)
 
     product_tab = None
     if pid:

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -91,7 +91,7 @@ class DojoSytemSettingsMiddleware(object):
 class System_Settings_Manager(models.Manager):
 
     def get_from_db(self, *args, **kwargs):
-        # logger.debug('resfreshing system_settings from db')
+        logger.debug('refreshing system_settings from db')
         try:
             from_db = super(System_Settings_Manager, self).get(*args, **kwargs)
         except:
@@ -104,13 +104,13 @@ class System_Settings_Manager(models.Manager):
 
     def get(self, no_cache=False, *args, **kwargs):
         if no_cache:
-            # logger.debug('no_cache specified or cached value found, loading system settings from db')
+            logger.debug('no_cache specified or cached value found, loading system settings from db')
             return self.get_from_db(*args, **kwargs)
 
         from_cache = DojoSytemSettingsMiddleware.get_system_settings()
 
         if not from_cache:
-            # logger.debug('no cached value found, loading system settings from db')
+            logger.debug('no cached value found, loading system settings from db')
             return self.get_from_db(*args, **kwargs)
 
         return from_cache

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -92,6 +92,8 @@ def prefetch_for_product(prods):
                 finding__mitigated__isnull=True)
         prefetched_prods = prefetched_prods.prefetch_related(Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
         prefetched_prods = prefetched_prods.prefetch_related('tagged_items__tag')
+    else:
+        logger.debug('unable to prefetch because query was already executed')
 
     return prefetched_prods
 
@@ -475,6 +477,9 @@ def prefetch_for_view_engagements(engs):
         prefetched_engs = prefetched_engs.annotate(count_findings_open=Count('test__finding__id', filter=Q(test__finding__active=True)))
         prefetched_engs = prefetched_engs.annotate(count_findings_duplicate=Count('test__finding__id', filter=Q(test__finding__duplicate=True)))
         prefetched_engs = prefetched_engs.prefetch_related('tagged_items__tag')
+    else:
+        logger.debug('unable to prefetch because query was already executed')
+
     return prefetched_engs
 
 

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -56,6 +56,8 @@ def prefetch_for_product_type(prod_types):
 
         prefetch_prod_types = prefetch_prod_types.annotate(findings_count=Count('prod_type__engagement__test__finding__id', filter=active_findings_query))
         prefetch_prod_types = prefetch_prod_types.annotate(prod_count=Count('prod_type', distinct=True))
+    else:
+        logger.debug('unable to prefetch because query was already executed')
 
     return prefetch_prod_types
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -146,6 +146,9 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('notes')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
+    else:
+        logger.debug('unable to prefetch because query was already executed')
+
     return prefetched_findings
 
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -27,7 +27,7 @@ from dojo.forms import NoteForm, TestForm, FindingForm, \
     ImportScanForm, ReImportScanForm, FindingBulkUpdateForm, JIRAFindingForm
 from dojo.models import Product, Finding, Test, Notes, Note_Type, BurpRawRequestResponse, Endpoint, Stub_Finding, Finding_Template, JIRA_PKey, Cred_Mapping, Dojo_User, JIRA_Issue, System_Settings
 from dojo.tools.factory import import_parser_factory
-from dojo.utils import get_page_items, add_breadcrumb, get_cal_event, message, process_notifications, get_system_setting, Product_Tab, calculate_grade, log_jira_alert, max_safe
+from dojo.utils import get_page_items, get_page_items_and_count, add_breadcrumb, get_cal_event, message, process_notifications, get_system_setting, Product_Tab, calculate_grade, log_jira_alert, max_safe
 from dojo.notifications.helper import create_notification
 from dojo.tasks import add_issue_task, update_issue_task
 from functools import reduce
@@ -71,8 +71,8 @@ def view_test(request, tid):
     else:
         form = NoteForm()
 
-    fpage = get_page_items(request, prefetch_for_findings(findings.qs), 25)
-    sfpage = get_page_items(request, stub_findings, 25)
+    paged_findings, total_findings_count = get_page_items_and_count(request, prefetch_for_findings(findings.qs), 25)
+    paged_stub_findings = get_page_items(request, stub_findings, 25)
     show_re_upload = any(test.test_type.name in code for code in ImportScanForm.SCAN_TYPE_CHOICES)
 
     product_tab = Product_Tab(prod.id, title="Test", tab="engagements")
@@ -119,10 +119,10 @@ def view_test(request, tid):
     return render(request, 'dojo/view_test.html',
                   {'test': test,
                    'product_tab': product_tab,
-                   'findings': fpage,
+                   'findings': paged_findings,
                    'filtered': findings,
-                   'findings_count': findings.qs.count(),
-                   'stub_findings': sfpage,
+                   'findings_count': total_findings_count,
+                   'stub_findings': paged_stub_findings,
                    'form': form,
                    'notes': notes,
                    'person': person,
@@ -144,6 +144,7 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
+        prefetched_findings = prefetched_findings.prefetch_related('endpoints')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
     else:

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1175,6 +1175,15 @@ def get_page_items(request, items, page_size, param_name='page'):
     return paginator.get_page(page)
 
 
+def get_page_items_and_count(request, items, page_size, param_name='page'):
+    size = request.GET.get('page_size', page_size)
+    paginator = Paginator(items, size)
+    page = request.GET.get(param_name)
+
+    # new get_page method will handle invalid page value, out of bounds pages, etc
+    return paginator.get_page(page), paginator.count
+
+
 def handle_uploaded_threat(f, eng):
     name, extension = os.path.splitext(f.name)
     with open(settings.MEDIA_ROOT + '/threat/%s%s' % (eng.id, extension),


### PR DESCRIPTION
there were some places where prefetching wasn't working, resulting in 250+ queries per page.
this PR reorders some queries for accepted findings, false positive findings, out of scope findings.
it also renames 2filters with typo's.

in a future PR we should do some code deduplication here...