### PR TITLE
kubernetes: add missing affinity

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -57,4 +57,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.initializer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 1

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -95,6 +95,7 @@ django:
 initializer:
   run: true
   keepSeconds: 60
+  affinity: {}
   nodeSelector: {}
   resources:
     requests:
@@ -135,7 +136,13 @@ postgresql:
   # To use an external secret for the password for PostgreSQL
   # instance, set enabled to false and provide the name of the secret on the
   # line below:
-  # existingSecret: ""    
+  # existingSecret: ""
+  master:
+    affinity: {}
+    nodeSelector: {}
+  slave:
+    affinity: {}
+    nodeSelector: {}
 
 rabbitmq:
   enabled: true
@@ -143,7 +150,8 @@ rabbitmq:
   rabbitmq:
     existingPasswordSecret: defectdojo-rabbitmq-specific
     existingErlangSecret: defectdojo-rabbitmq-specific
-
+    affinity: {}
+    nodeSelector: {}
 redis:
   enabled: false
   existingSecret: defectdojo-redis-specific


### PR DESCRIPTION
add missing affinity for the initializer, plus a couple of affinity/nodeselector templates in the values.yaml