### PR TITLE
fix default sorting findings and products

### DIFF
--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -260,7 +260,7 @@
                                    </div>
                                 </td>
                                 {% endif %}
-                                <td>
+                                <td class="centered" data-order="{% severity_number_value finding.severity %}">
                                   <span class="label severity severity-{{ finding.severity }}">
                                       {{ finding.severity_display }}
                                   </span>
@@ -460,9 +460,11 @@
                         }},
                     {% endif %}
                 ],
-                order: [2],
+                order: [],
                 "columnDefs": [
-                    { "orderable": false, "targets": [0, 1] }
+                    { 
+                        "orderable": false, "targets": [0, 1]
+                    }
                 ],
                 dom: 'Bfrtip',
                 paging: false,
@@ -695,6 +697,7 @@
             };
 
         });
+
     </script>
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -346,7 +346,7 @@
                     { "data": "contacts" },
                     { "data": "product_type" },
                 ],
-                order: [1, "asc"],
+                order: [],
                 "columnDefs": [
                     { "orderable": false, "targets": [0] }
                 ],

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -13,7 +13,6 @@ from dojo.models import Check_List, FindingImageAccessToken, Finding, System_Set
 import markdown
 from django.db.models import Sum, Case, When, IntegerField, Value
 from django.utils import timezone
-from markdown.extensions import Extension
 import dateutil.relativedelta
 import datetime
 from ast import literal_eval
@@ -466,6 +465,11 @@ def severity_value(value):
         pass
 
     return value
+
+
+@register.simple_tag
+def severity_number_value(value):
+    return Finding.get_number_severity(value)
 
 
 @register.filter


### PR DESCRIPTION
Same as #2311 , but contains only the fix to disable clientside sorting on initial page load.