### PR TITLE
deduplicate code in finding views

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -75,12 +75,8 @@ def engagement(request):
         queryset=products_with_engagements.prefetch_related('engagement_set', 'prod_type', 'engagement_set__lead',
                                                             'engagement_set__test_set__lead', 'engagement_set__test_set__test_type'))
     prods = get_page_items(request, filtered.qs, 25)
-    name_words = [
-        product.name for product in products_with_engagements.only('name')
-    ]
-    eng_words = [
-        engagement.name for engagement in Engagement.objects.filter(active=True)
-    ]
+    name_words = products_with_engagements.values_list('name', flat=True)
+    eng_words = Engagement.objects.filter(active=True).values_list('name', flat=True)
 
     add_breadcrumb(
         title="Active Engagements",
@@ -108,12 +104,9 @@ def engagements_all(request):
                                                             'engagement_set__test_set__lead', 'engagement_set__test_set__test_type'))
 
     prods = get_page_items(request, filtered.qs, 25)
-    name_words = [
-        product.name for product in products_with_engagements.only('name')
-    ]
-    eng_words = [
-        engagement.name for engagement in Engagement.objects.filter(active=True)
-    ]
+
+    name_words = products_with_engagements.values_list('name', flat=True)
+    eng_words = Engagement.objects.all().values_list('name', flat=True)
 
     add_breadcrumb(
         title="All Engagements",

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -76,7 +76,7 @@ def engagement(request):
                                                             'engagement_set__test_set__lead', 'engagement_set__test_set__test_type'))
     prods = get_page_items(request, filtered.qs, 25)
     name_words = products_with_engagements.values_list('name', flat=True)
-    eng_words = Engagement.objects.filter(active=True).values_list('name', flat=True)
+    eng_words = Engagement.objects.filter(active=True).values_list('name', flat=True).distinct()
 
     add_breadcrumb(
         title="Active Engagements",
@@ -106,7 +106,7 @@ def engagements_all(request):
     prods = get_page_items(request, filtered.qs, 25)
 
     name_words = products_with_engagements.values_list('name', flat=True)
-    eng_words = Engagement.objects.all().values_list('name', flat=True)
+    eng_words = Engagement.objects.all().values_list('name', flat=True).distinct()
 
     add_breadcrumb(
         title="All Engagements",

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -465,9 +465,9 @@ class ClosedFindingFilter(DojoFilter):
     def __init__(self, *args, **kwargs):
         super(ClosedFindingFilter, self).__init__(*args, **kwargs)
         cwe = dict()
-        cwe = dict([finding.cwe, finding.cwe]
-                   for finding in self.queryset.distinct()
-                   if type(finding.cwe) is int and finding.cwe is not None and finding.cwe > 0 and finding.cwe not in cwe)
+        cwe = dict([cwe, cwe]
+                   for cwe in self.queryset.values_list('cwe', flat=True).distinct()
+                   if type(cwe) is int and cwe is not None and cwe > 0)
         cwe = collections.OrderedDict(sorted(cwe.items()))
         self.form.fields['cwe'].choices = list(cwe.items())
 

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -389,9 +389,9 @@ class OpenFindingFilter(DojoFilter):
         super(OpenFindingFilter, self).__init__(*args, **kwargs)
 
         cwe = dict()
-        cwe = dict([finding.cwe, finding.cwe]
-                   for finding in self.queryset.distinct()
-                   if type(finding.cwe) is int and finding.cwe is not None and finding.cwe > 0 and finding.cwe not in cwe)
+        cwe = dict([cwe, cwe]
+                   for cwe in self.queryset.values_list('cwe', flat=True).distinct()
+                   if type(cwe) is int and cwe is not None and cwe > 0)
         cwe = collections.OrderedDict(sorted(cwe.items()))
         self.form.fields['cwe'].choices = list(cwe.items())
         if self.user is not None and not self.user.is_staff:

--- a/dojo/finding/urls.py
+++ b/dojo/finding/urls.py
@@ -16,6 +16,9 @@ urlpatterns = [
         name='open_findings'),
     url(r'^product/(?P<pid>\d+)/finding/open$', views.open_findings,
         name='product_open_findings'),
+    # legacy url kept for old bookmarks etc
+    url(r'^product/(?P<pid>\d+)/findings$', views.open_findings,
+       name='view_product_findings_old'),
     url(r'^product/(?P<pid>\d+)/finding/verified$', views.verified_findings,
         name='product_verified_findings'),
     url(r'^product/(?P<pid>\d+)/finding/out_of_scope$', views.out_of_scope_findings,

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -187,6 +187,24 @@ django_filter=open_findings_filter):
         })
 
 
+def prefetch_for_findings(findings):
+    prefetched_findings = findings
+    if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_findings = prefetched_findings.select_related('reporter')
+        prefetched_findings = prefetched_findings.select_related('jira_issue')
+        prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
+        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
+        prefetched_findings = prefetched_findings.prefetch_related('found_by')
+        prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
+        # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
+        prefetched_findings = prefetched_findings.prefetch_related('notes')
+        prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
+    else:
+        logger.debug('unable to prefetch because query was already executed')
+
+    return prefetched_findings
+
+
 def view_finding(request, fid):
     finding = get_object_or_404(Finding, id=fid)
     findings = Finding.objects.filter(test=finding.test).order_by('numerical_severity')

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -151,7 +151,7 @@ django_filter=open_findings_filter):
     findings_filter = django_filter(request, findings, request.user, pid)
 
     title_words = [
-        word for word in list(findings_filter.qs.values_list('title', flat=True).distinct()) if len(word) > 2
+        word for title in findings_filter.qs.values_list('title', flat=True) for word in title.split() if len(word) > 2
     ]
     title_words = sorted(set(title_words))
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -150,28 +150,12 @@ django_filter=open_findings_filter):
 
     findings_filter = django_filter(request, findings, request.user, pid)
 
-    # if request.user.is_staff:
-    #     findings_filter = OpenFindingSuperFilter(
-    #         request.GET, queryset=findings, user=request.user, pid=pid)
-    # else:
-    #     findings = findings.filter(
-    #         test__engagement__product__authorized_users__in=[request.user])
-    #     findings_filter = OpenFindingFilter(
-    #         request.GET, queryset=findings, user=request.user, pid=pid)
-
     title_words = [
         word for word in list(findings_filter.qs.values_list('title', flat=True).distinct()) if len(word) > 2
     ]
     title_words = sorted(set(title_words))
 
     paged_findings = get_page_items(request, prefetch_for_findings(findings_filter.qs), 25)
-
-    # what does this do besides checking for existence?
-    # product_type = None
-    # if 'test__engagement__product__prod_type' in request.GET:
-    #     p = request.GET.getlist('test__engagement__product__prod_type', [])
-    #     if len(p) == 1:
-    #         product_type = get_object_or_404(Product_Type, id=p[0])
 
     # show custom breadcrumb if user has filtered by exactly 1 endpoint
     endpoint = None
@@ -184,20 +168,11 @@ django_filter=open_findings_filter):
             filter_name = "Vulnerable Endpoints"
             custom_breadcrumb = OrderedDict([("Endpoints", reverse('vulnerable_endpoints')), (endpoint, reverse('view_endpoint', args=(endpoint.id, )))])
 
-    # found by not used anymore in any template. openfindingsfilter has its own query
-    # found_by = None
-    # try:
-    #     found_by = findings_filter.found_by.all().distinct()
-    # except:
-    #     found_by = None
-    #     pass
-
     if jira_config:
         jira_config = jira_config.conf_id
     if github_config:
         github_config = github_config.conf_id
 
-    # paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -33,7 +33,7 @@ from dojo.forms import NoteForm, FindingNoteForm, CloseFindingForm, FindingForm,
     DeleteFindingTemplateForm, FindingImageFormSet, JIRAFindingForm, GITHUBFindingForm, ReviewFindingForm, ClearFindingReviewForm, \
     DefectFindingForm, StubFindingForm, DeleteFindingForm, DeleteStubFindingForm, ApplyFindingTemplateForm, \
     FindingFormID, FindingBulkUpdateForm, MergeFindings
-from dojo.models import Product_Type, Finding, Notes, NoteHistory, Note_Type, \
+from dojo.models import Finding, Notes, NoteHistory, Note_Type, \
     BurpRawRequestResponse, Stub_Finding, Endpoint, Finding_Template, FindingImage, \
     FindingImageAccessToken, JIRA_Issue, JIRA_PKey, GITHUB_PKey, GITHUB_Issue, Dojo_User, Cred_Mapping, Test, Product, User, Engagement
 from dojo.utils import get_page_items, add_breadcrumb, FileIterWrapper, process_notifications, \
@@ -44,516 +44,160 @@ from dojo.notifications.helper import create_notification
 from dojo.tasks import add_issue_task, update_issue_task, update_external_issue_task, add_comment_task, \
     add_external_issue_task, close_external_issue_task, reopen_external_issue_task
 from django.template.defaultfilters import pluralize
-from django.db.models.query import QuerySet
+from django.db.models import Q
 
 logger = logging.getLogger(__name__)
 
+OPEN_FINDINGS_QUERY = Q(active=True)
+VERIFIED_FINDINGS_QUERY = Q(verified=True)
+OUT_OF_SCOPE_FINDINGS_QUERY = Q(active=False, out_of_scope=True)
+FALSE_POSITIVE_FINDINGS_QUERY = Q(active=False, duplicate=False, false_p=True)
+INACTIVE_FINDINGS_QUERY = Q(active=False, duplicate=False, is_Mitigated=False, false_p=False, out_of_scope=False)
+ACCEPTED_FINDINGS_QUERY = Q(risk_acceptance__isnull=False)
+CLOSED_FINDINGS_QUERY = Q(mitigated__isnull=False)
 
-def verified_findings(request, pid=None, eid=None, view=None):
-    show_product_column = True
-    title = None
-    custom_breadcrumb = None
-    filter_name = "Verified"
-    pid_local = None
-    tags = Tag.objects.usage_for_model(Finding)
-    if pid:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement__product__id=pid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement__product__id=pid, verified=True).order_by('numerical_severity')
-    elif eid:
-        eng = get_object_or_404(Engagement, id=eid)
-        pid_local = eng.product.id
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement=eid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement=eid, verified=True).order_by('numerical_severity')
+
+def open_findings_filter(request, queryset, user, pid):
+    if user.is_staff:
+        return OpenFindingSuperFilter(request.GET, queryset=queryset, user=user, pid=pid)
     else:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.all().order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(verified=True).order_by('numerical_severity')
-
-    if not request.user.is_staff:
-        findings = findings.filter(
-            test__engagement__product__authorized_users__in=[request.user])
-
-    title_words = [
-        word for finding in findings for word in finding.title.split()
-        if len(word) > 2
-    ]
-    title_words = sorted(set(title_words))
-
-    if request.user.is_staff:
-        findings_filter = OpenFindingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
-        findings_filter = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-
-    paged_findings = get_page_items(request, findings_filter.qs, 25)
-
-    product_type = None
-    if 'test__engagement__product__prod_type' in request.GET:
-        p = request.GET.getlist('test__engagement__product__prod_type', [])
-        if len(p) == 1:
-            product_type = get_object_or_404(Product_Type, id=p[0])
-
-    endpoint = None
-    if 'endpoints' in request.GET:
-        endpoints = request.GET.getlist('endpoints', [])
-        if len(endpoints) == 1:
-            endpoint = endpoints[0]
-            endpoint = get_object_or_404(Endpoint, id=endpoint)
-            pid = endpoint.product.id
-            title = "Vulnerable Endpoints"
-            custom_breadcrumb = OrderedDict([("Endpoints", reverse('vulnerable_endpoints')), (endpoint, reverse('view_endpoint', args=(endpoint.id, )))])
-
-    found_by = None
-    try:
-        found_by = findings_filter.found_by.all().distinct()
-    except:
-        found_by = None
-        pass
-
-    product_tab = None
-    active_tab = None
-    jira_config = None
-
-    # Only show product tab view in product or engagement
-    if pid:
-        show_product_column = False
-        product_tab = Product_Tab(pid, title="Findings", tab="findings")
-        jira_config = JIRA_PKey.objects.filter(product=pid).first()
-    elif eid and pid_local:
-        show_product_column = False
-        product_tab = Product_Tab(pid_local, title=eng.name, tab="engagements")
-        jira_config = JIRA_PKey.objects.filter(product__engagement=eid).first()
-    else:
-        add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
-    if jira_config:
-        jira_config = jira_config.conf_id
-
-    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
-
-    return render(
-        request, 'dojo/findings_list.html', {
-            'show_product_column': show_product_column,
-            "product_tab": product_tab,
-            "findings": paged_findings,
-            "filtered": findings_filter,
-            "title_words": title_words,
-            'found_by': found_by,
-            'custom_breadcrumb': custom_breadcrumb,
-            'filter_name': filter_name,
-            'title': title,
-            'tag_input': tags,
-            'jira_config': jira_config,
-        })
+        return OpenFindingFilter(request.GET, queryset=queryset, user=user, pid=pid)
 
 
-def out_of_scope_findings(request, pid=None, eid=None, view=None):
-    show_product_column = True
-    title = None
-    custom_breadcrumb = None
-    filter_name = "Out of scope"
-    pid_local = None
-    tags = Tag.objects.usage_for_model(Finding)
-    if pid:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement__product__id=pid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement__product__id=pid, out_of_scope=True).order_by('numerical_severity')
-    elif eid:
-        eng = get_object_or_404(Engagement, id=eid)
-        pid_local = eng.product.id
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement=eid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement=eid, out_of_scope=True).order_by('numerical_severity')
-    else:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.all().order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(active=False, out_of_scope=True).order_by('numerical_severity')
-
-    if not request.user.is_staff:
-        findings = findings.filter(
-            test__engagement__product__authorized_users__in=[request.user])
-
-    title_words = [
-        word for finding in findings for word in finding.title.split()
-        if len(word) > 2
-    ]
-    title_words = sorted(set(title_words))
-
-    if request.user.is_staff:
-        findings_filter = OpenFindingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
-        findings_filter = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-
-    paged_findings = get_page_items(request, findings_filter.qs, 25)
-
-    product_type = None
-    if 'test__engagement__product__prod_type' in request.GET:
-        p = request.GET.getlist('test__engagement__product__prod_type', [])
-        if len(p) == 1:
-            product_type = get_object_or_404(Product_Type, id=p[0])
-
-    endpoint = None
-    if 'endpoints' in request.GET:
-        endpoints = request.GET.getlist('endpoints', [])
-        if len(endpoints) == 1:
-            endpoint = endpoints[0]
-            endpoint = get_object_or_404(Endpoint, id=endpoint)
-            pid = endpoint.product.id
-            title = "Vulnerable Endpoints"
-            custom_breadcrumb = OrderedDict([("Endpoints", reverse('vulnerable_endpoints')), (endpoint, reverse('view_endpoint', args=(endpoint.id, )))])
-
-    found_by = None
-    try:
-        found_by = findings.found_by.all().distinct()
-    except:
-        found_by = None
-        pass
-
-    product_tab = None
-    active_tab = None
-    jira_config = None
-
-    # Only show product tab view in product or engagement
-    if pid:
-        show_product_column = False
-        product_tab = Product_Tab(pid, title="Findings", tab="findings")
-        jira_config = JIRA_PKey.objects.filter(product=pid).first()
-    elif eid and pid_local:
-        show_product_column = False
-        product_tab = Product_Tab(pid_local, title=eng.name, tab="engagements")
-        jira_config = JIRA_PKey.objects.filter(product__engagement=eid).first()
-    else:
-        add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
-    if jira_config:
-        jira_config = jira_config.conf_id
-
-    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
-
-    return render(
-        request, 'dojo/findings_list.html', {
-            'show_product_column': show_product_column,
-            "product_tab": product_tab,
-            "findings": paged_findings,
-            "filtered": findings_filter,
-            "title_words": title_words,
-            'found_by': found_by,
-            'custom_breadcrumb': custom_breadcrumb,
-            'filter_name': filter_name,
-            'title': title,
-            'tag_input': tags,
-            'jira_config': jira_config,
-        })
+def accepted_findings_filter(request, queryset, user, pid):
+    assert user.is_staff
+    return AcceptedFindingSuperFilter(request.GET, queryset=queryset)
 
 
-def false_positive_findings(request, pid=None, eid=None, view=None):
-    show_product_column = True
-    title = None
-    custom_breadcrumb = None
-    filter_name = "False Positive"
-    pid_local = None
-    tags = Tag.objects.usage_for_model(Finding)
-    if pid:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement__product__id=pid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement__product__id=pid, duplicate=False, active=False, false_p=True).order_by('numerical_severity')
-    elif eid:
-        eng = get_object_or_404(Engagement, id=eid)
-        pid_local = eng.product.id
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement=eid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement=eid, duplicate=False, active=False, false_p=True).order_by('numerical_severity')
-    else:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.all().order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(active=False, duplicate=False, false_p=True).order_by('numerical_severity')
-
-    if not request.user.is_staff:
-        findings = findings.filter(
-            test__engagement__product__authorized_users__in=[request.user])
-
-    title_words = [
-        word for finding in findings for word in finding.title.split()
-        if len(word) > 2
-    ]
-    title_words = sorted(set(title_words))
-
-    if request.user.is_staff:
-        findings_filter = OpenFindingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
-        findings_filter = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-
-    paged_findings = get_page_items(request, findings_filter.qs, 25)
-
-    product_type = None
-    if 'test__engagement__product__prod_type' in request.GET:
-        p = request.GET.getlist('test__engagement__product__prod_type', [])
-        if len(p) == 1:
-            product_type = get_object_or_404(Product_Type, id=p[0])
-
-    endpoint = None
-    if 'endpoints' in request.GET:
-        endpoints = request.GET.getlist('endpoints', [])
-        if len(endpoints) == 1:
-            endpoint = endpoints[0]
-            endpoint = get_object_or_404(Endpoint, id=endpoint)
-            pid = endpoint.product.id
-            title = "Vulnerable Endpoints"
-            custom_breadcrumb = OrderedDict([("Endpoints", reverse('vulnerable_endpoints')), (endpoint, reverse('view_endpoint', args=(endpoint.id, )))])
-
-    found_by = None
-    try:
-        found_by = findings.found_by.all().distinct()
-    except:
-        found_by = None
-        pass
-
-    product_tab = None
-    active_tab = None
-    jira_config = None
-
-    # Only show product tab view in product or engagement
-    if pid:
-        show_product_column = False
-        product_tab = Product_Tab(pid, title="Findings", tab="findings")
-        jira_config = JIRA_PKey.objects.filter(product=pid).first()
-    elif eid and pid_local:
-        show_product_column = False
-        product_tab = Product_Tab(pid_local, title=eng.name, tab="engagements")
-        jira_config = JIRA_PKey.objects.filter(product__engagement=eid).first()
-    else:
-        add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
-    if jira_config:
-        jira_config = jira_config.conf_id
-
-    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
-
-    return render(
-        request, 'dojo/findings_list.html', {
-            'show_product_column': show_product_column,
-            "product_tab": product_tab,
-            "findings": paged_findings,
-            "filtered": findings_filter,
-            "title_words": title_words,
-            'found_by': found_by,
-            'custom_breadcrumb': custom_breadcrumb,
-            'filter_name': filter_name,
-            'title': title,
-            'tag_input': tags,
-            'jira_config': jira_config,
-        })
-
-
-def inactive_findings(request, pid=None, eid=None, view=None):
-    show_product_column = True
-    title = None
-    custom_breadcrumb = None
-    filter_name = "Inactive"
-    pid_local = None
-    tags = Tag.objects.usage_for_model(Finding)
-    if pid:
-        findings = Finding.objects.filter(test__engagement__product__id=pid)
-    elif eid:
-        eng = get_object_or_404(Engagement, id=eid)
-        pid_local = eng.product.id
-        findings = Finding.objects.filter(test__engagement=eid)
-    else:
-        findings = Finding.objects.all()
-
-    findings = findings.filter(active=False, duplicate=False, is_Mitigated=False, false_p=False, out_of_scope=False).order_by('numerical_severity')
-
-    title_words = [
-        word for finding in findings for word in finding.title.split()
-        if len(word) > 2
-    ]
-    title_words = sorted(set(title_words))
-
-    if request.user.is_staff:
-        findings_filter = OpenFindingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
-        findings_filter = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-
-    paged_findings = get_page_items(request, findings_filter.qs, 25)
-
-    product_type = None
-    if 'test__engagement__product__prod_type' in request.GET:
-        p = request.GET.getlist('test__engagement__product__prod_type', [])
-        if len(p) == 1:
-            product_type = get_object_or_404(Product_Type, id=p[0])
-
-    endpoint = None
-    if 'endpoints' in request.GET:
-        endpoints = request.GET.getlist('endpoints', [])
-        if len(endpoints) == 1:
-            endpoint = endpoints[0]
-            endpoint = get_object_or_404(Endpoint, id=endpoint)
-            pid = endpoint.product.id
-            title = "Vulnerable Endpoints"
-            custom_breadcrumb = OrderedDict([("Endpoints", reverse('vulnerable_endpoints')), (endpoint, reverse('view_endpoint', args=(endpoint.id, )))])
-
-    found_by = None
-    try:
-        found_by = findings.found_by.all().distinct()
-    except:
-        found_by = None
-        pass
-
-    product_tab = None
-    active_tab = None
-    jira_config = None
-
-    # Only show product tab view in product or engagement
-    if pid:
-        show_product_column = False
-        product_tab = Product_Tab(pid, title="Findings", tab="findings")
-        jira_config = JIRA_PKey.objects.filter(product=pid).first()
-    elif eid and pid_local:
-        show_product_column = False
-        product_tab = Product_Tab(pid_local, title=eng.name, tab="engagements")
-        jira_config = JIRA_PKey.objects.filter(product__engagement=eid).first()
-    else:
-        add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
-    if jira_config:
-        jira_config = jira_config.conf_id
-
-    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
-
-    return render(
-        request, 'dojo/findings_list.html', {
-            'show_product_column': show_product_column,
-            "product_tab": product_tab,
-            "findings": paged_findings,
-            "filtered": findings_filter,
-            "title_words": title_words,
-            'found_by': found_by,
-            'custom_breadcrumb': custom_breadcrumb,
-            'filter_name': filter_name,
-            'title': title,
-            'tag_input': tags,
-            'jira_config': jira_config,
-        })
+def closed_findings_filter(request, queryset, user, pid):
+    assert user.is_staff
+    return ClosedFindingSuperFilter(request.GET, queryset=queryset)
 
 
 def open_findings(request, pid=None, eid=None, view=None):
+    return findings(request, pid=pid, eid=eid, view=view, filter_name="Open", query_filter=OPEN_FINDINGS_QUERY)
+
+
+def verified_findings(request, pid=None, eid=None, view=None):
+    return findings(request, pid=pid, eid=eid, view=view, filter_name="Verified", query_filter=VERIFIED_FINDINGS_QUERY)
+
+
+def out_of_scope_findings(request, pid=None, eid=None, view=None):
+    return findings(request, pid=pid, eid=eid, view=view, filter_name="Out of Scope", query_filter=OUT_OF_SCOPE_FINDINGS_QUERY)
+
+
+def false_positive_findings(request, pid=None, eid=None, view=None):
+    return findings(request, pid=pid, eid=eid, view=view, filter_name="False Positive", query_filter=FALSE_POSITIVE_FINDINGS_QUERY)
+
+
+def inactive_findings(request, pid=None, eid=None, view=None):
+    return findings(request, pid=pid, eid=eid, view=view, filter_name="Inactive", query_filter=INACTIVE_FINDINGS_QUERY)
+
+
+@user_passes_test(lambda u: u.is_staff)
+def accepted_findings(request, pid=None, eid=None, view=None):
+    return findings(request, pid=pid, eid=eid, view=view, filter_name="Accepted", query_filter=ACCEPTED_FINDINGS_QUERY,
+                    django_filter=accepted_findings_filter)
+
+
+@user_passes_test(lambda u: u.is_staff)
+def closed_findings(request, pid=None, eid=None, view=None):
+    return findings(request, pid=pid, eid=eid, view=view, filter_name="Closed", query_filter=CLOSED_FINDINGS_QUERY, order_by=('-mitigated'),
+                    django_filter=closed_findings_filter)
+
+
+def findings(request, pid=None, eid=None, view=None, filter_name=None, query_filter=None, order_by='numerical_severity',
+django_filter=open_findings_filter):
     show_product_column = True
-    title = None
     custom_breadcrumb = None
-    filter_name = "Open"
-    pid_local = None
-    tags = Tag.objects.usage_for_model(Finding)
-    if pid:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement__product__id=pid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement__product__id=pid, active=True, duplicate=False).order_by('numerical_severity')
-    elif eid:
-        eng = get_object_or_404(Engagement, id=eid)
-        pid_local = eng.product.id
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.filter(test__engagement=eid).order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(test__engagement=eid, active=True, duplicate=False).order_by('numerical_severity')
-    else:
-        if view == "All":
-            filter_name = "All"
-            findings = Finding.objects.all().order_by('numerical_severity')
-        else:
-            findings = Finding.objects.filter(active=True, duplicate=False).order_by('numerical_severity')
-
-    if not request.user.is_staff:
-        findings = findings.filter(
-            test__engagement__product__authorized_users__in=[request.user])
-
-    title_words = [
-        word for finding in findings for word in finding.title.split()
-        if len(word) > 2
-    ]
-    title_words = sorted(set(title_words))
-
-    if request.user.is_staff:
-        findings_filter = OpenFindingSuperFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-    else:
-        findings_filter = OpenFindingFilter(
-            request.GET, queryset=findings, user=request.user, pid=pid)
-
-    paged_findings = get_page_items(request, findings_filter.qs, 25)
-
-    product_type = None
-    if 'test__engagement__product__prod_type' in request.GET:
-        p = request.GET.getlist('test__engagement__product__prod_type', [])
-        if len(p) == 1:
-            product_type = get_object_or_404(Product_Type, id=p[0])
-
-    endpoint = None
-    if 'endpoints' in request.GET:
-        endpoints = request.GET.getlist('endpoints', [])
-        if len(endpoints) == 1:
-            endpoint = endpoints[0]
-            endpoint = get_object_or_404(Endpoint, id=endpoint)
-            pid = endpoint.product.id
-            title = "Vulnerable Endpoints"
-            custom_breadcrumb = OrderedDict([("Endpoints", reverse('vulnerable_endpoints')), (endpoint, reverse('view_endpoint', args=(endpoint.id, )))])
-
-    found_by = None
-    try:
-        found_by = findings_filter.found_by.all().distinct()
-    except:
-        found_by = None
-        pass
-
     product_tab = None
-    active_tab = None
     jira_config = None
     github_config = None
 
-    # Only show product tab view in product or engagement
+    tags = Tag.objects.usage_for_model(Finding)
+
+    findings = Finding.objects.all()
+    if view == "All":
+        filter_name = "All"
+    else:
+        findings = findings.filter(query_filter)
+
+    findings = findings.order_by(order_by)
+
     if pid:
+        get_object_or_404(Product, id=pid)
+        findings = findings.filter(test__engagement__product__id=pid)
+
         show_product_column = False
         product_tab = Product_Tab(pid, title="Findings", tab="findings")
         jira_config = JIRA_PKey.objects.filter(product=pid).first()
         github_config = GITHUB_PKey.objects.filter(product=pid).first()
-    elif eid and pid_local:
+
+    elif eid:
+        eng = get_object_or_404(Engagement, id=eid)
+        findings = Finding.objects.filter(test__engagement=eid).order_by('numerical_severity')
+
         show_product_column = False
-        product_tab = Product_Tab(pid_local, title=eng.name, tab="engagements")
+        product_tab = Product_Tab(eng.product_id, title=eng.name, tab="engagements")
         jira_config = JIRA_PKey.objects.filter(product__engagement=eid).first()
         github_config = GITHUB_PKey.objects.filter(product__engagement=eid).first()
     else:
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
+
+    if not request.user.is_staff:
+        findings = findings.filter(
+            test__engagement__product__authorized_users__in=[request.user])
+
+    findings_filter = django_filter(request, findings, request.user, pid)
+
+    # if request.user.is_staff:
+    #     findings_filter = OpenFindingSuperFilter(
+    #         request.GET, queryset=findings, user=request.user, pid=pid)
+    # else:
+    #     findings = findings.filter(
+    #         test__engagement__product__authorized_users__in=[request.user])
+    #     findings_filter = OpenFindingFilter(
+    #         request.GET, queryset=findings, user=request.user, pid=pid)
+
+    title_words = [
+        word for word in list(findings_filter.qs.values_list('title', flat=True).distinct()) if len(word) > 2
+    ]
+    title_words = sorted(set(title_words))
+
+    paged_findings = get_page_items(request, prefetch_for_findings(findings_filter.qs), 25)
+
+    # what does this do besides checking for existence?
+    # product_type = None
+    # if 'test__engagement__product__prod_type' in request.GET:
+    #     p = request.GET.getlist('test__engagement__product__prod_type', [])
+    #     if len(p) == 1:
+    #         product_type = get_object_or_404(Product_Type, id=p[0])
+
+    # show custom breadcrumb if user has filtered by exactly 1 endpoint
+    endpoint = None
+    if 'endpoints' in request.GET:
+        endpoints = request.GET.getlist('endpoints', [])
+        if len(endpoints) == 1:
+            endpoint = endpoints[0]
+            endpoint = get_object_or_404(Endpoint, id=endpoint)
+            pid = endpoint.product.id
+            filter_name = "Vulnerable Endpoints"
+            custom_breadcrumb = OrderedDict([("Endpoints", reverse('vulnerable_endpoints')), (endpoint, reverse('view_endpoint', args=(endpoint.id, )))])
+
+    # found by not used anymore in any template. openfindingsfilter has its own query
+    # found_by = None
+    # try:
+    #     found_by = findings_filter.found_by.all().distinct()
+    # except:
+    #     found_by = None
+    #     pass
+
     if jira_config:
         jira_config = jira_config.conf_id
     if github_config:
         github_config = github_config.conf_id
 
-    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
-
+    # paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
     return render(
         request, 'dojo/findings_list.html', {
             'show_product_column': show_product_column,
@@ -561,94 +205,10 @@ def open_findings(request, pid=None, eid=None, view=None):
             "findings": paged_findings,
             "filtered": findings_filter,
             "title_words": title_words,
-            'found_by': found_by,
             'custom_breadcrumb': custom_breadcrumb,
             'filter_name': filter_name,
-            'title': title,
             'tag_input': tags,
             'jira_config': jira_config,
-            'github_config': github_config,
-        })
-
-
-def prefetch_for_findings(findings):
-    prefetched_findings = findings
-    if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
-        prefetched_findings = prefetched_findings.select_related('reporter')
-        prefetched_findings = prefetched_findings.select_related('jira_issue')
-        prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
-        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
-        prefetched_findings = prefetched_findings.prefetch_related('found_by')
-        prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
-        # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
-        prefetched_findings = prefetched_findings.prefetch_related('notes')
-        prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
-    else:
-        logger.debug('unable to prefetch because query was already executed')
-
-    return prefetched_findings
-
-
-"""
-Accepted findings returns all the accepted findings for all products or a specific product
-"""
-
-
-@user_passes_test(lambda u: u.is_staff)
-def accepted_findings(request, pid=None):
-    # user = request.user
-
-    findings = Finding.objects.filter(risk_acceptance__isnull=False)
-    findings_filter = AcceptedFindingSuperFilter(request.GET, queryset=findings)
-    title_words = [
-        word for finding in findings_filter.qs for word in finding.title.split()
-        if len(word) > 2
-    ]
-
-    title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings_filter.qs.order_by('numerical_severity'), 25)
-
-    product_tab = None
-    if pid:
-        product_tab = Product_Tab(pid, title="Accepted Findings", tab="findings")
-
-    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
-
-    return render(
-        request, 'dojo/findings_list.html', {
-            "findings": paged_findings,
-            "product_tab": product_tab,
-            "filter_name": "Accepted",
-            "filtered": findings_filter,
-            "title_words": title_words,
-        })
-
-
-@user_passes_test(lambda u: u.is_staff)
-def closed_findings(request, pid=None):
-    findings = Finding.objects.filter(mitigated__isnull=False)
-    findings_filter = ClosedFindingSuperFilter(request.GET, queryset=findings)
-    title_words = [
-        word for finding in findings for word in finding.title.split()
-        if len(word) > 2
-    ]
-
-    title_words = sorted(set(title_words))
-    paged_findings = get_page_items(request, findings_filter.qs.order_by('-mitigated'), 25)
-
-    product_tab = None
-    if pid:
-        product_tab = Product_Tab(pid, title="Closed Findings", tab="findings")
-
-    paged_findings.object_list = prefetch_for_findings(paged_findings.object_list)
-
-    return render(
-        request, 'dojo/findings_list.html', {
-            "findings": paged_findings,
-            "product_tab": product_tab,
-            "filtered": findings_filter,
-            "filter_name": "Closed",
-            "title_words": title_words,
         })
 
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -44,7 +44,7 @@ from dojo.notifications.helper import create_notification
 from dojo.tasks import add_issue_task, update_issue_task, update_external_issue_task, add_comment_task, \
     add_external_issue_task, close_external_issue_task, reopen_external_issue_task
 from django.template.defaultfilters import pluralize
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -251,7 +251,7 @@ def metrics(request, mtype):
 
         if finding.test.engagement.product.name not in in_period_details:
             in_period_details[finding.test.engagement.product.name] = {
-                'path': reverse('view_product_findings', args=(finding.test.engagement.product.id,)),
+                'path': reverse('product_open_findings', args=(finding.test.engagement.product.id,)),
                 'Critical': 0, 'High': 0, 'Medium': 0, 'Low': 0, 'Info': 0, 'Total': 0}
         in_period_details[
             finding.test.engagement.product.name
@@ -771,7 +771,7 @@ def view_engineer(request, eid):
                 ).count()
         prod = Product.objects.get(id=product)
         all_findings_link = "<a href='%s'>%s</a>" % (
-            reverse('view_product_findings', args=(prod.id,)), escape(prod.name))
+            reverse('product_open_findings', args=(prod.id,)), escape(prod.name))
         update.append([all_findings_link, z_count, o_count, t_count, h_count,
                        z_count + o_count + t_count + h_count])
     total_update = []
@@ -804,7 +804,7 @@ def view_engineer(request, eid):
                     severity='Low').count()
         prod = Product.objects.get(id=product)
         all_findings_link = "<a href='%s'>%s</a>" % (
-            reverse('view_product_findings', args=(prod.id,)), escape(prod.name))
+            reverse('product_open_findings', args=(prod.id,)), escape(prod.name))
         total_update.append([all_findings_link, z_count, o_count, t_count,
                              h_count, z_count + o_count + t_count + h_count])
 

--- a/dojo/note_type/views.py
+++ b/dojo/note_type/views.py
@@ -17,8 +17,7 @@ logger = logging.getLogger(__name__)
 @user_passes_test(lambda u: u.is_superuser)
 def note_type(request):
     initial_queryset = Note_Type.objects.all().order_by('name')
-    name_words = [note_type.name for note_type in
-                  initial_queryset]
+    name_words = initial_queryset.values_list('name', flat=True)
     ntl = NoteTypesFilter(request.GET, queryset=initial_queryset)
     nts = get_page_items(request, ntl.qs, 25)
     add_breadcrumb(title="Note Type List", top_level=True, request=request)

--- a/dojo/product/urls.py
+++ b/dojo/product/urls.py
@@ -20,8 +20,6 @@ urlpatterns = [
     url(r'^product/(?P<pid>\d+)/delete$', views.delete_product,
         name='delete_product'),
     url(r'^product/add', views.new_product, name='new_product'),
-    url(r'^product/(?P<pid>\d+)/findings$',
-        views.all_product_findings, name='view_product_findings'),
     url(r'^product/(?P<pid>\d+)/new_engagement$', views.new_eng_for_app,
         name='new_eng_for_prod'),
     url(r'^product/(?P<pid>\d+)/new_engagement/cicd$', views.new_eng_for_app_cicd,

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -53,8 +53,7 @@ def product(request):
     # perform all stuff for filtering and pagination first, before annotation/prefetching
     # otherwise the paginator will perform all the annotations/prefetching already only to count the total number of records
     # see https://code.djangoproject.com/ticket/23771 and https://code.djangoproject.com/ticket/25375
-    name_words = [product.name for product in prods
-                    for word in product.name.split() if len(word) > 2]
+    name_words = prods.values_list('name', flat=True)
 
     prod_filter = ProductFilter(request.GET, queryset=prods, user=request.user)
     prod_list = get_page_items(request, prod_filter.qs, 25)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -17,7 +17,7 @@ from django.db.models import Sum, Count, Q, Max
 from django.contrib.admin.utils import NestedObjects
 from django.db import DEFAULT_DB_ALIAS
 from dojo.templatetags.display_tags import get_level
-from dojo.filters import ProductFilter, ProductFindingFilter, EngagementFilter
+from dojo.filters import ProductFilter, EngagementFilter
 from dojo.forms import ProductForm, EngForm, DeleteProductForm, DojoMetaDataForm, JIRAPKeyForm, JIRAFindingForm, AdHocFindingForm, \
                        EngagementPresetsForm, DeleteEngagementPresetsForm, Sonarqube_ProductForm, ProductNotificationsForm, \
                        GITHUB_Product_Form, GITHUBFindingForm
@@ -733,29 +733,6 @@ def delete_product(request, pid):
                    'form': form,
                    'product_tab': product_tab,
                    'rels': rels,
-                   })
-
-
-def all_product_findings(request, pid):
-    p = get_object_or_404(Product, id=pid)
-    auth = request.user.is_staff or request.user in p.authorized_users.all()
-    if not auth:
-        # will render 403
-        raise PermissionDenied
-    result = ProductFindingFilter(
-        request.GET,
-        queryset=Finding.objects.filter(test__engagement__product=p,
-                                        active=True))
-    page = get_page_items(request, result.qs, 25)
-
-    add_breadcrumb(title="Open findings", top_level=False, request=request)
-
-    return render(request,
-                  "dojo/all_product_findings.html",
-                  {"findings": page,
-                   "product": p,
-                   "filtered": result,
-                   "user": request.user,
                    })
 
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -57,11 +57,10 @@ def product(request):
                     for word in product.name.split() if len(word) > 2]
 
     prod_filter = ProductFilter(request.GET, queryset=prods, user=request.user)
-    # prod_list = get_page_items(request, prod_filter.qs, 25)
-    prod_list = get_page_items(request, prefetch_for_product(prod_filter.qs), 25)
+    prod_list = get_page_items(request, prod_filter.qs, 25)
 
     # perform annotation/prefetching by replacing the queryset in the page with an annotated/prefetched queryset.
-    # prod_list.object_list = prefetch_for_product(prod_list.object_list)
+    prod_list.object_list = prefetch_for_product(prod_list.object_list)
 
     """
     if 'tags' in request.GET:

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -57,10 +57,11 @@ def product(request):
                     for word in product.name.split() if len(word) > 2]
 
     prod_filter = ProductFilter(request.GET, queryset=prods, user=request.user)
-    prod_list = get_page_items(request, prod_filter.qs, 25)
+    # prod_list = get_page_items(request, prod_filter.qs, 25)
+    prod_list = get_page_items(request, prefetch_for_product(prod_filter.qs), 25)
 
     # perform annotation/prefetching by replacing the queryset in the page with an annotated/prefetched queryset.
-    prod_list.object_list = prefetch_for_product(prod_list.object_list)
+    # prod_list.object_list = prefetch_for_product(prod_list.object_list)
 
     """
     if 'tags' in request.GET:

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -24,7 +24,7 @@ Product Type views
 
 def product_type(request):
     # query for names outside of query with prefetch to avoid the complex prefetch query from executing twice
-    name_words = [prod_type.name for prod_type in Product_Type.objects.all().only('name')]
+    name_words = Product_Type.objects.all().values_list('name', flat=True)
 
     prod_types = Product_Type.objects.all()
 

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -447,12 +447,14 @@
                             return type === 'export' ? getDojoExportValueFromTag(data, 'a') :  data;
                     }},
                     {% if system_settings.enable_jira %}
+                      {% if jira_config and product_tab or not product_tab %}                    
                         { "data": "jira_age", render: function (data, type, row) {
                                 return type === 'export' ? getDojoExportValueFromTag(data, 'td') :  data;
                         }},
                         { "data": "jira_change", render: function (data, type, row) {
                                 return type === 'export' ? getDojoExportValueFromTag(data, 'td') :  data;
                         }},
+                      {% endif %}                          
                     {% endif %}
                     {% if show_product_column and product_tab is None %}
                         { "data": "product" , render: function (data, type, row) {

--- a/dojo/test_type/views.py
+++ b/dojo/test_type/views.py
@@ -23,8 +23,7 @@ Test Type views
 @user_passes_test(lambda u: u.is_staff)
 def test_type(request):
     initial_queryset = Test_Type.objects.all().order_by('name')
-    name_words = [tt.name for tt in
-                  initial_queryset]
+    name_words = initial_queryset.values_list('name', flat=True)
     test_types = TestTypeFilter(request.GET, queryset=initial_queryset)
     tts = get_page_items(request, test_types.qs, 25)
     add_breadcrumb(title="Test Type List", top_level=True, request=request)

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -12,7 +12,19 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 class FindingTest(BaseTestCase):
 
-    def test_list_finding(self):
+    def test_list_findings_all(self):
+        return self.test_list_findings('finding/all')
+
+    def test_list_findings_closed(self):
+        return self.test_list_findings('finding/closed')
+
+    def test_list_findings_accepted(self):
+        return self.test_list_findings('finding/accepted')
+
+    def test_list_findings_open(self):
+        return self.test_list_findings('finding/open')
+
+    def test_list_findings(self, suffix):
         # bulk edit dropdown menu
         driver = self.login_page()
         driver.get(self.base_url + "finding")
@@ -282,7 +294,11 @@ def suite():
     # success and failure is output by the test
     suite.addTest(ProductTest('test_create_product'))
     suite.addTest(ProductTest('test_add_product_finding'))
-    suite.addTest(FindingTest('test_list_finding'))
+    # TODO add some more findings with different statuses
+    suite.addTest(FindingTest('test_list_findings_all'))
+    suite.addTest(FindingTest('test_list_findings_closed'))
+    suite.addTest(FindingTest('test_list_findings_accepted'))
+    suite.addTest(FindingTest('test_list_findings_open'))
     suite.addTest(FindingTest('test_edit_finding'))
     suite.addTest(FindingTest('test_add_image'))
     suite.addTest(FindingTest('test_delete_image'))


### PR DESCRIPTION
When listing all the findings and statuses for #2215, I noticed the views in `finding/views.py` that show findings, were basically all the same with some small differences like display name and filter criteria.

This PR deduplicates that:
- Deduplicate code in `finding/views.py`
- Simplify loading of CWE dropdown
- Fix javascript error when displaying findings with/without jira config (fixes #2317)
- Remove `found_by` and `prod_type` code from views, they did nothing and are set by the filter
- Simplify prefetching as we don't need the pagination workaround here due to the queries being simple.
- Define reusable query fragements which define "Open Findings", "Accepted Findings", etc.
- Replace `all_product_findings` by `product_open_findings` as it is the same.

This can be further improved in #2215 once we agree on the exact global definitions of statuses and displayfilters for those statuses.