### PR TITLE
Add Note Type APIv2 endpoint

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -21,13 +21,13 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Finding_Template, Test_Type, Development_Environment, \
     BurpRawRequestResponse, Endpoint, Notes, JIRA_PKey, JIRA_Conf, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
-    Languages, Language_Type, App_Analysis, Product_Type
+    Languages, Language_Type, App_Analysis, Product_Type, Note_Type
 from dojo.forms import ProductForm, EngForm, TestForm, \
     ScanSettingsForm, FindingForm, StubFindingForm, FindingTemplateForm, \
     ImportScanForm, SEVERITY_CHOICES, JIRAForm, JIRA_PKeyForm, EditEndpointForm, \
     JIRA_IssueForm, ToolConfigForm, ToolProductSettingsForm, \
     ToolTypeForm, LanguagesTypeForm, Languages_TypeTypeForm, App_AnalysisTypeForm, \
-    Development_EnvironmentForm, Product_TypeForm, Test_TypeForm
+    Development_EnvironmentForm, Product_TypeForm, Test_TypeForm, NoteTypeForm
 from dojo.tools import requires_file
 from dojo.tools.factory import import_parser_factory
 from datetime import datetime
@@ -498,6 +498,43 @@ class Tool_ConfigurationResource(BaseModelResource):
         def validation(self):
             return ModelFormValidation(form_class=ToolConfigForm, resource=Tool_ConfigurationResource)
 
+
+"""
+    /api/v1/note_type/
+    GET [/id/], DELETE [/id/]
+    Expects: no params or id
+    Returns Note_TypeResource
+    Relevant apply filter ?test_type=?, ?id=?
+
+    POST, PUT, DLETE [/id/]
+"""
+
+
+class Note_TypeResource(BaseModelResource):
+
+    # note_type = fields.ForeignKey(Note_Type, 'note_Type')
+
+    class Meta:
+        resource_name = 'note_type'
+        list_allowed_methods = ['get', 'post', 'put', 'delete']
+        detail_allowed_methods = ['get', 'post', 'put', 'delete']
+        queryset = Note_Type.objects.all()
+        include_resource_uri = True
+        filtering = {
+            'id': ALL,
+            'name': ALL,
+            'description': ALL_WITH_RELATIONS,
+            'is_single': ALL,
+            'is_active': ALL,
+            'is_mandatory': ALL,
+        }
+        authentication = DojoApiKeyAuthentication()
+        authorization = DjangoAuthorization()
+        serializer = Serializer(formats=['json'])
+
+        @property
+        def validation(self):
+            return ModelFormValidation(form_class=NoteTypeForm, resource=Note_TypeResource)
 
 """
     POST, PUT [/id/]

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -987,7 +987,7 @@ class NoteSerializer(serializers.ModelSerializer):
         model = Notes
         fields = '__all__'
 
-    
+
 class NoteTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Note_Type

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -3,7 +3,7 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Finding_Template, Test_Type, Development_Environment, NoteHistory, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Product_Type, JIRA_Conf, Endpoint, BurpRawRequestResponse, JIRA_PKey, \
-    Notes, DojoMeta, FindingImage
+    Notes, DojoMeta, FindingImage, Note_Type
 from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools import requires_file
 from dojo.tools.factory import import_parser_factory
@@ -985,6 +985,12 @@ class NoteSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Notes
+        fields = '__all__'
+
+    
+class NoteTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Note_Type
         fields = '__all__'
 
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -13,7 +13,8 @@ from dojo.engagement.services import close_engagement, reopen_engagement
 from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, Notes, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
-    Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment, Dojo_User
+    Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment, \
+    Dojo_User, Note_Type
 
 from dojo.endpoint.views import get_endpoint_ids
 from dojo.reports.views import report_url_resolver
@@ -689,6 +690,18 @@ class ReImportScanView(mixins.CreateModelMixin,
         if enabled:
             push_to_jira = True
         serializer.save(push_to_jira=push_to_jira)
+
+
+class NoteTypeViewSet(mixins.ListModelMixin,
+                       mixins.RetrieveModelMixin,
+                       mixins.DestroyModelMixin,
+                       mixins.CreateModelMixin,
+                       mixins.UpdateModelMixin,
+                       viewsets.GenericViewSet):
+    serializer_class = serializers.NoteTypeSerializer
+    queryset = Note_Type.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'name', 'description', 'is_single', 'is_active', 'is_mandatory')
 
 
 class NotesViewSet(mixins.ListModelMixin,

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -1114,6 +1114,17 @@
   },
   {
     "pk": 1,
+    "model": "dojo.note_type", 
+    "fields": {
+      "name": "Test Note Type", 
+      "description": "not that much", 
+      "is_single": false, 
+      "is_active": true, 
+      "is_mandatory": false
+    }
+  }, 
+  {
+    "pk": 1,
     "model": "dojo.tool_type",
     "fields": {
       "name": "Tool Type 1",

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -1,14 +1,14 @@
 from dojo.models import Product, Engagement, Test, Finding, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
-    Finding_Template
+    Finding_Template, Note_Type
 
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView
+    UsersViewSet, ImportScanView, NoteTypeViewSet
 
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
@@ -398,6 +398,24 @@ class ToolTypesTest(BaseClass.RESTEndpointTest):
         self.payload = {
             "name": "Tool Type",
             "description": "test tool type"
+        }
+        self.update_fields = {'description': 'changed description'}
+        BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+
+class NoteTypesTest(BaseClass.RESTEndpointTest):
+    fixtures = ['dojo_testdata.json']
+
+    def __init__(self, *args, **kwargs):
+        self.endpoint_model = Note_Type
+        self.viewname = 'note_type'
+        self.viewset = NoteTypeViewSet
+        self.payload = {
+            "name": "Test Note",
+            "description": "not that much",
+            "is_single": False,
+            "is_active": True,
+            "is_mandatory": False
         }
         self.update_fields = {'description': 'changed description'}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -19,14 +19,15 @@ from dojo.api import UserResource, ProductResource, EngagementResource, \
     ReImportScanResource, JiraResource, JIRA_ConfResource, EndpointResource, \
     JIRA_IssueResource, ToolProductSettingsResource, Tool_ConfigurationResource, \
     Tool_TypeResource, LanguagesResource, LanguageTypeResource, App_AnalysisResource, \
-    BuildDetails, DevelopmentEnvironmentResource, ProductTypeResource, TestTypeResource
+    BuildDetails, DevelopmentEnvironmentResource, ProductTypeResource, TestTypeResource, \
+    Note_TypeResource
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, TestTypesViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
     UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
-    DevelopmentEnvironmentViewSet, NotesViewSet
+    DevelopmentEnvironmentViewSet, NotesViewSet, NoteTypeViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -86,6 +87,7 @@ v1_api.register(JIRA_IssueResource())
 v1_api.register(ToolProductSettingsResource())
 v1_api.register(Tool_ConfigurationResource())
 v1_api.register(Tool_TypeResource())
+v1_api.register(Note_TypeResource())
 v1_api.register(LanguagesResource())
 v1_api.register(LanguageTypeResource())
 v1_api.register(App_AnalysisResource())
@@ -117,6 +119,7 @@ v2_api.register(r'import-scan', ImportScanView, basename='importscan')
 v2_api.register(r'reimport-scan', ReImportScanView, basename='reimportscan')
 v2_api.register(r'metadata', DojoMetaViewSet, basename='metadata')
 v2_api.register(r'notes', NotesViewSet)
+v2_api.register(r'note_type', NoteTypeViewSet)
 
 ur = []
 ur += dev_env_urls


### PR DESCRIPTION
**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

Add API v1 and v2 endpoints for managing Nots Types. This was requested by @mtesauro 

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
