### PR TITLE
always use __date__range for ranging datetime fields

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -376,7 +376,7 @@ class OpenFindingFilter(DojoFilter):
                    'thread_id', 'notes', 'scanner_confidence', 'mitigated',
                    'numerical_severity', 'reporter', 'last_reviewed', 'line',
                    'duplicate_finding', 'hash_code', 'images',
-                   'line_number', 'reviewers', 'mitigated_by', 'sourcefile', 'jira_creation', 'jira_change']
+                   'line_number', 'reviewers', 'mitigated_by', 'sourcefile', 'jira_creation', 'jira_change', 'created']
 
     def __init__(self, *args, **kwargs):
         self.user = None

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -27,9 +27,7 @@ def home(request):
 @user_passes_test(lambda u: u.is_staff)
 def dashboard(request):
     now = timezone.now()
-    # today = timezone.make_aware(datetime.combine(now, datetime.max.time()))
     seven_days_ago = now - timedelta(days=6)  # 6 days plus today
-    # seven_days_ago_start = timezone.make_aware(datetime.combine(seven_days_ago, datetime.min.time()))
 
     if request.user.is_superuser:
         engagement_count = Engagement.objects.filter(active=True).count()

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -27,7 +27,10 @@ def home(request):
 @user_passes_test(lambda u: u.is_staff)
 def dashboard(request):
     now = timezone.now()
-    seven_days_ago = now - timedelta(days=7)
+    # today = timezone.make_aware(datetime.combine(now, datetime.max.time()))
+    seven_days_ago = now - timedelta(days=6)  # 6 days plus today
+    # seven_days_ago_start = timezone.make_aware(datetime.combine(seven_days_ago, datetime.min.time()))
+
     if request.user.is_superuser:
         engagement_count = Engagement.objects.filter(active=True).count()
         finding_count = Finding.objects.filter(verified=True,
@@ -35,11 +38,11 @@ def dashboard(request):
                                                duplicate=False,
                                                date__range=[seven_days_ago,
                                                             now]).count()
-        mitigated_count = Finding.objects.filter(mitigated__range=[seven_days_ago,
+        mitigated_count = Finding.objects.filter(mitigated__date__range=[seven_days_ago,
                                                                    now]).count()
 
         accepted_count = len([finding for ra in Risk_Acceptance.objects.filter(
-            reporter=request.user, created__range=[seven_days_ago, now]) for finding in ra.accepted_findings.all()])
+            reporter=request.user, created__date__range=[seven_days_ago, now]) for finding in ra.accepted_findings.all()])
 
         # forever counts
         findings = Finding.objects.filter(verified=True, duplicate=False)
@@ -53,11 +56,11 @@ def dashboard(request):
                                                date__range=[seven_days_ago,
                                                             now]).count()
         mitigated_count = Finding.objects.filter(mitigated_by=request.user,
-                                                 mitigated__range=[seven_days_ago,
+                                                 mitigated__date__range=[seven_days_ago,
                                                                    now]).count()
 
         accepted_count = len([finding for ra in Risk_Acceptance.objects.filter(
-            reporter=request.user, created__range=[seven_days_ago, now]) for finding in ra.accepted_findings.all()])
+            reporter=request.user, created__date__range=[seven_days_ago, now]) for finding in ra.accepted_findings.all()])
 
         # forever counts
         findings = Finding.objects.filter(reporter=request.user,

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -48,7 +48,7 @@ def critical_product_metrics(request, mtype):
     })
 
 
-# @cache_page(60 * 5)  # cache for 5 minutes
+@cache_page(60 * 5)  # cache for 5 minutes
 def metrics(request, mtype):
     template = 'dojo/metrics.html'
     page_name = 'Product Type Metrics'

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -48,7 +48,7 @@ def critical_product_metrics(request, mtype):
     })
 
 
-@cache_page(60 * 5)  # cache for 5 minutes
+# @cache_page(60 * 5)  # cache for 5 minutes
 def metrics(request, mtype):
     template = 'dojo/metrics.html'
     page_name = 'Product Type Metrics'
@@ -112,14 +112,14 @@ def metrics(request, mtype):
                         tzinfo=timezone.get_current_timezone())
 
     if len(prod_type) > 0:
-        findings_closed = Finding.objects.filter(mitigated__range=[start_date, end_date],
+        findings_closed = Finding.objects.filter(mitigated__date__range=[start_date, end_date],
                                                  test__engagement__product__prod_type__in=prod_type).prefetch_related(
             'test__engagement__product')
         # capture the accepted findings in period
-        accepted_findings = Finding.objects.filter(risk_acceptance__created__range=[start_date, end_date],
+        accepted_findings = Finding.objects.filter(risk_acceptance__created__date__range=[start_date, end_date],
                                                    test__engagement__product__prod_type__in=prod_type). \
             prefetch_related('test__engagement__product')
-        accepted_findings_counts = Finding.objects.filter(risk_acceptance__created__range=[start_date, end_date],
+        accepted_findings_counts = Finding.objects.filter(risk_acceptance__created__date__range=[start_date, end_date],
                                                           test__engagement__product__prod_type__in=prod_type). \
             prefetch_related('test__engagement__product').aggregate(
             total=Sum(
@@ -148,11 +148,11 @@ def metrics(request, mtype):
                      output_field=IntegerField())),
         )
     else:
-        findings_closed = Finding.objects.filter(mitigated__range=[start_date, end_date]).prefetch_related(
+        findings_closed = Finding.objects.filter(mitigated__date__range=[start_date, end_date]).prefetch_related(
             'test__engagement__product')
-        accepted_findings = Finding.objects.filter(risk_acceptance__created__range=[start_date, end_date]). \
+        accepted_findings = Finding.objects.filter(risk_acceptance__created__date__range=[start_date, end_date]). \
             prefetch_related('test__engagement__product')
-        accepted_findings_counts = Finding.objects.filter(risk_acceptance__created__range=[start_date, end_date]). \
+        accepted_findings_counts = Finding.objects.filter(risk_acceptance__created__date__range=[start_date, end_date]). \
             prefetch_related('test__engagement__product').aggregate(
             total=Sum(
                 Case(When(severity__in=('Critical', 'High', 'Medium', 'Low'),
@@ -449,12 +449,12 @@ def product_type_counts(request):
 
             opened_in_period_list.append(oip)
 
-            closed_in_period = Finding.objects.filter(mitigated__range=[start_date, end_date],
+            closed_in_period = Finding.objects.filter(mitigated__date__range=[start_date, end_date],
                                                       test__engagement__product__prod_type=pt,
                                                       severity__in=('Critical', 'High', 'Medium', 'Low')).values(
                 'numerical_severity').annotate(Count('numerical_severity')).order_by('numerical_severity')
 
-            total_closed_in_period = Finding.objects.filter(mitigated__range=[start_date, end_date],
+            total_closed_in_period = Finding.objects.filter(mitigated__date__range=[start_date, end_date],
                                                             test__engagement__product__prod_type=pt,
                                                             severity__in=(
                                                                 'Critical', 'High', 'Medium', 'Low')).aggregate(

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -660,7 +660,7 @@ def get_punchcard_data(findings, start_date, weeks):
         # reminder: The first week of a year is the one that contains the year’s first Thursday
         # so we could have for 29/12/2019: week=1 and year=2019 :-D. So using week number from db is not practical
 
-        severities_by_day = findings.filter(created__gte=first_sunday).filter(created__lt=last_sunday) \
+        severities_by_day = findings.filter(created__date__gte=first_sunday).filter(created__date__lt=last_sunday) \
                                     .values('created__date') \
                                     .annotate(count=Count('id')) \
                                     .order_by('created__date')
@@ -786,11 +786,11 @@ def get_period_counts_legacy(findings,
             end_date = new_date + relativedelta(weeks=1, weekday=MO(1))
 
         closed_in_range_count = findings_closed.filter(
-            mitigated__range=[new_date, end_date]).count()
+            mitigated__date__range=[new_date, end_date]).count()
 
         if accepted_findings:
             risks_a = accepted_findings.filter(
-                risk_acceptance__created__range=[
+                risk_acceptance__created__date__range=[
                     datetime(
                         new_date.year,
                         new_date.month,
@@ -885,11 +885,11 @@ def get_period_counts(active_findings,
             end_date = new_date + relativedelta(weeks=1, weekday=MO(1))
 
         closed_in_range_count = findings_closed.filter(
-            mitigated__range=[new_date, end_date]).count()
+            mitigated__date__range=[new_date, end_date]).count()
 
         if accepted_findings:
             risks_a = accepted_findings.filter(
-                risk_acceptance__created__range=[
+                risk_acceptance__created__date__range=[
                     datetime(
                         new_date.year,
                         new_date.month,
@@ -1049,7 +1049,7 @@ def opened_in_period(start_date, end_date, pt):
         end_date,
         'closed':
         Finding.objects.filter(
-            mitigated__range=[start_date, end_date],
+            mitigated__date__range=[start_date, end_date],
             test__engagement__product__prod_type=pt,
             severity__in=('Critical', 'High', 'Medium', 'Low')).aggregate(
                 total=Sum(


### PR DESCRIPTION
Some date fields like `mitigated` and `risk_acceptance_created` are `DateTimeFields`, which results in queries like

SELECT * FROM FINDING WHERE MITIGATED > '2020-04-29 21:18:00'

when you want the findings mitigated in the last 7 days, apart from the fact that this is not what you want, it also prevents propert caching by any query caching module that some people may or will be using (I am running django-cachalot).

By adapting any query filters from `filter(finding__mitigated__range=[start,end])` to 'filter(finding__mitigated__date__range=[start,enf])` it will result in the queries we want

SELECT * FROM FINDING WHERE MITIGATED > '2020-04-29'

I simplified a bit because in reality there will be timezone conversions in the queries as well and an end date.

I also removed the filter 'created' from the open findings filter as it was not doing anything. At some point we have to look what to do with the `finding.date` field which is a date and not timezone aware. There seems to be a `created` field which is a datetime, but it is not set everywhere maybe.
For a future PR :-)

Dogfooding as usual.