### PR TITLE
zap parser: add title to dedupe fields + unittests

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -623,7 +623,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cve + file_path + severity
     'Whitesource Scan': ['title', 'severity', 'description'],
-    'ZAP Scan': ['cwe', 'endpoints', 'severity'],
+    'ZAP Scan': ['title', 'cwe', 'endpoints', 'severity'],
     'Qualys Scan': ['title', 'endpoints', 'severity'],
     'PHP Symfony Security Check': ['title', 'cve'],
     'Clair Scan': ['title', 'cve', 'description', 'severity'],

--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -11,7 +11,7 @@ import re
 import socket
 from urllib.parse import urlparse
 from defusedxml import ElementTree as ET
-from django.utils.html import strip_tags
+from django.utils.html import strip_tags, escape
 from dojo.models import Finding, Endpoint
 
 
@@ -191,6 +191,8 @@ class Item(object):
         description_detail = "\n"
         for instance in item_node.findall('instances/instance'):
             for node in instance.getiterator():
+                print('tag: ' + node.tag)
+                print('text:' + escape(node.text))
                 if node.tag == "uri":
                     if node.text != "":
                         description_detail += "URL: " + node.text
@@ -202,7 +204,7 @@ class Item(object):
                         description_detail += "Parameter: " + node.text
                 if node.tag == "evidence":
                     if node.text != "":
-                        description_detail += "Evidence: " + node.text
+                        description_detail += "Evidence: " + escape(node.text)
                 description_detail += "\n"
 
         self.desc += description_detail

--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -27,6 +27,11 @@ class ZapXmlParser(object):
     """
 
     def __init__(self, xml_output, test):
+        self.items = []
+
+        if xml_output is None:
+            return
+
         tree = self.parse_xml(xml_output)
 
         if tree:
@@ -105,7 +110,7 @@ def get_attrib_from_subnode(xml_node, subnode_xpath_expr, attrib_name):
 
     if ETREE_VERSION[0] <= 1 and ETREE_VERSION[1] < 3:
 
-        match_obj = re.search("([^\@]+?)\[\@([^=]*?)=\'([^\']*?)\'", subnode_xpath_expr)
+        match_obj = re.search(r"([^\@]+?)\[\@([^=]*?)=\'([^\']*?)\'", subnode_xpath_expr)
         if match_obj is not None:
             node_to_find = match_obj.group(1)
             xpath_attrib = match_obj.group(2)
@@ -180,7 +185,8 @@ class Item(object):
         if self.get_text_from_subnode('cweid'):
             self.ref.append("CWE-" + self.get_text_from_subnode('cweid'))
             self.cwe = self.get_text_from_subnode('cweid')
-        else: self.cwe = 0
+        else:
+            self.cwe = 0
 
         description_detail = "\n"
         for instance in item_node.findall('instances/instance'):

--- a/dojo/unittests/scans/zap/empty_2.9.0.xml
+++ b/dojo/unittests/scans/zap/empty_2.9.0.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0"?><OWASPZAPReport version="2.9.0" generated="Tue, 12 May 2020 20:59:12">
+<site name="https://isaac.nl" host="isaac.nl" port="443" ssl="true"><alerts></alerts></site></OWASPZAPReport>

--- a/dojo/unittests/scans/zap/some_2.9.0.xml
+++ b/dojo/unittests/scans/zap/some_2.9.0.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0"?><OWASPZAPReport version="2.9.0" generated="Tue, 12 May 2020 20:57:30">
+<site name="https://justasite.nl" host="justasite.nl" port="443" ssl="true"><alerts><alertitem>
+  <pluginid>10011</pluginid>
+  <alert>Cookie Without Secure Flag</alert>
+  <name>Cookie Without Secure Flag</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;A cookie has been set without the secure flag, which means that the cookie can be accessed via unencrypted connections.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>opvc</param>
+  <evidence>Set-Cookie: opvc</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>dmid</param>
+  <evidence>Set-Cookie: dmid</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>sitevisitscookie</param>
+  <evidence>Set-Cookie: sitevisitscookie</evidence>
+  </instance>
+  </instances>
+  <count>3</count>
+  <solution>&lt;p&gt;Whenever a cookie contains sensitive information or is a session token, then it should always be passed using an encrypted channel. Ensure that the secure flag is set for cookies containing such sensitive information.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;http://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)&lt;/p&gt;</reference>
+  <cweid>614</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10054</pluginid>
+  <alert>Cookie Without SameSite Attribute</alert>
+  <name>Cookie Without SameSite Attribute</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;A cookie has been set without the SameSite attribute, which means that the cookie can be sent as a result of a &apos;cross-site&apos; request. The SameSite attribute is an effective counter measure to cross-site request forgery, cross-site script inclusion, and timing attacks.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>sitevisitscookie</param>
+  <evidence>Set-Cookie: sitevisitscookie</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>dmid</param>
+  <evidence>Set-Cookie: dmid</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>JSESSIONID</param>
+  <evidence>Set-Cookie: JSESSIONID</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>opvc</param>
+  <evidence>Set-Cookie: opvc</evidence>
+  </instance>
+  </instances>
+  <count>4</count>
+  <solution>&lt;p&gt;Ensure that the SameSite attribute is set to either &apos;lax&apos; or ideally &apos;strict&apos; for all cookies.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site&lt;/p&gt;</reference>
+  <cweid>16</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10055</pluginid>
+  <alert>CSP Scanner: Wildcard Directive</alert>
+  <name>CSP Scanner: Wildcard Directive</name>
+  <riskcode>2</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Medium (Medium)</riskdesc>
+  <desc>&lt;p&gt;The following directives either allow wildcard sources (or ancestors), are not defined, or are overly broadly defined: &lt;/p&gt;&lt;p&gt;script-src, script-src-elem, script-src-attr, style-src, style-src-elem, style-src-attr, img-src, connect-src, frame-src, font-src, media-src, object-src, manifest-src, worker-src, prefetch-src&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>Content-Security-Policy</param>
+  <evidence>frame-ancestors &apos;self&apos;;</evidence>
+  </instance>
+  </instances>
+  <count>1</count>
+  <solution>&lt;p&gt;Ensure that your web server, application server, load balancer, etc. is properly configured to set the Content-Security-Policy header.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;http://www.w3.org/TR/CSP2/&lt;/p&gt;&lt;p&gt;http://www.w3.org/TR/CSP/&lt;/p&gt;&lt;p&gt;http://caniuse.com/#search=content+security+policy&lt;/p&gt;&lt;p&gt;http://content-security-policy.com/&lt;/p&gt;&lt;p&gt;https://github.com/shapesecurity/salvation&lt;/p&gt;</reference>
+  <cweid>16</cweid>
+  <wascid>15</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10010</pluginid>
+  <alert>Cookie No HttpOnly Flag</alert>
+  <name>Cookie No HttpOnly Flag</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;A cookie has been set without the HttpOnly flag, which means that the cookie can be accessed by JavaScript. If a malicious script can be run on this page then the cookie will be accessible and can be transmitted to another site. If this is a session cookie then session hijacking may be possible.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>opvc</param>
+  <evidence>Set-Cookie: opvc</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>dmid</param>
+  <evidence>Set-Cookie: dmid</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>sitevisitscookie</param>
+  <evidence>Set-Cookie: sitevisitscookie</evidence>
+  </instance>
+  </instances>
+  <count>3</count>
+  <solution>&lt;p&gt;Ensure that the HttpOnly flag is set for all cookies.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;http://www.owasp.org/index.php/HttpOnly&lt;/p&gt;</reference>
+  <cweid>16</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10096</pluginid>
+  <alert>Timestamp Disclosure - Unix</alert>
+  <name>Timestamp Disclosure - Unix</name>
+  <riskcode>0</riskcode>
+  <confidence>1</confidence>
+  <riskdesc>Informational (Low)</riskdesc>
+  <desc>&lt;p&gt;A timestamp was disclosed by the application/web server - Unix&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <evidence>265151019</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <evidence>398525181</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <evidence>153792000</evidence>
+  </instance>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <evidence>1028274645</evidence>
+  </instance>
+  </instances>
+  <count>4</count>
+  <solution>&lt;p&gt;Manually confirm that the timestamp data is not sensitive, and that the data cannot be aggregated to disclose exploitable patterns.&lt;/p&gt;</solution>
+  <otherinfo>&lt;p&gt;265151019, which evaluates to: 1978-05-27 22:03:39&lt;/p&gt;</otherinfo>
+  <reference>&lt;p&gt;https://www.owasp.org/index.php/Top_10_2013-A6-Sensitive_Data_Exposure&lt;/p&gt;&lt;p&gt;http://projects.webappsec.org/w/page/13246936/Information%20Leakage&lt;/p&gt;</reference>
+  <cweid>200</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10017</pluginid>
+  <alert>Cross-Domain JavaScript Source File Inclusion</alert>
+  <name>Cross-Domain JavaScript Source File Inclusion</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;The page includes one or more script files from a third-party domain.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>https://consent.cookiebot.com/uc.js</param>
+  <evidence>&lt;script id=&quot;Cookiebot&quot; src=&quot;https://consent.cookiebot.com/uc.js&quot; data-cbid=&quot;4079ecf4-44a4-4dca-b14c-fa341fdbefd4&quot; type=&quot;text/javascript&quot; defer&gt;&lt;/script&gt;</evidence>
+  </instance>
+  </instances>
+  <count>1</count>
+  <solution>&lt;p&gt;Ensure JavaScript source files are loaded from only trusted sources, and the sources can&apos;t be controlled by end users of the application.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;&lt;/p&gt;</reference>
+  <cweid>829</cweid>
+  <wascid>15</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+<alertitem>
+  <pluginid>10015</pluginid>
+  <alert>Incomplete or No Cache-control and Pragma HTTP Header Set</alert>
+  <name>Incomplete or No Cache-control and Pragma HTTP Header Set</name>
+  <riskcode>1</riskcode>
+  <confidence>2</confidence>
+  <riskdesc>Low (Medium)</riskdesc>
+  <desc>&lt;p&gt;The cache-control and pragma HTTP header have not been set properly or are missing allowing the browser and proxies to cache content.&lt;/p&gt;</desc>
+  <instances>
+  <instance>
+  <uri>https://justasite.nl</uri>
+  <method>GET</method>
+  <param>Cache-Control</param>
+  </instance>
+  </instances>
+  <count>1</count>
+  <solution>&lt;p&gt;Whenever possible ensure the cache-control HTTP header is set with no-cache, no-store, must-revalidate; and that the pragma HTTP header is set with no-cache.&lt;/p&gt;</solution>
+  <reference>&lt;p&gt;https://www.owasp.org/index.php/Session_Management_Cheat_Sheet#Web_Content_Caching&lt;/p&gt;</reference>
+  <cweid>525</cweid>
+  <wascid>13</wascid>
+  <sourceid>3</sourceid>
+</alertitem>
+</alerts></site></OWASPZAPReport>

--- a/dojo/unittests/test_zap.py
+++ b/dojo/unittests/test_zap.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+from dojo.tools.zap.parser import ZapXmlParser
+from dojo.models import Test, Engagement, Product
+
+
+class TestZAPXML(TestCase):
+
+    def setUp(self):
+        self.test = Test()
+        self.test.engagement = Engagement()
+        self.test.engagement.product = Product()
+
+    def test_parse_without_file_has_no_findings(self):
+        parser = ZapXmlParser(None, self.test)
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_no_findings(self):
+        testfile = open("dojo/unittests/scans/zap/empty_2.9.0.xml")
+        parser = ZapXmlParser(testfile, self.test)
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_some_findings(self):
+        testfile = open("dojo/unittests/scans/zap/some_2.9.0.xml")
+        parser = ZapXmlParser(testfile, self.test)
+        self.assertEqual(7, len(parser.items))


### PR DESCRIPTION
The current dedupe config for ZAP scans is "not unique enough':

`ZAP Scan': ['cwe', 'endpoints', 'severity']`

even our own zap sample contains multiple different findings with the same `cwe` + `endpoints` + `severity`, so we need to include either the `name` or `pluginid` or `alert` fields.

https://github.com/DefectDojo/django-DefectDojo/blob/dev/tests/zap_sample.xml

Only the `name` field is available in defect dojo and it is stored in the `title` field, so unfortunately we have to include the `title` field`

Also add unittests for the zap parser as they were missing (just basic tests as any other parser, not dedupe or anything).