### PR TITLE
Reduce nginx client_max_body_size

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -11,7 +11,7 @@ http {
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
   access_log /var/log/nginx/access.log main;
-  client_max_body_size 800m;
+  client_max_body_size 20m;
   sendfile on;
   keepalive_timeout 65;
   upstream uwsgi_server {

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -12,7 +12,7 @@ http {
                     '$status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
   access_log /var/log/nginx/access.log main;
-  client_max_body_size 800m;
+  client_max_body_size 20m;
   sendfile on;
   keepalive_timeout 65;
   upstream uwsgi_server {


### PR DESCRIPTION
Let's avoid getting DoS'ed by supersized reports.

Addressed #2346 