### PR TITLE
Do not show "push to github" if no product config set

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -601,8 +601,7 @@ def edit_finding(request, fid):
 
     gform = None
     if get_system_setting('enable_github'):
-        if GITHUB_PKey.objects.filter(
-            product=finding.test.engagement.product).exclude(git_conf_id=None):
+        if GITHUB_PKey.objects.filter(product=finding.test.engagement.product).exclude(git_conf_id=None):
             gform = GITHUBFindingForm(enabled=github_enabled, prefix='githubform')
 
     if request.method == 'POST':

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -587,24 +587,23 @@ def edit_finding(request, fid):
         enabled = finding.test.engagement.product.jira_pkey_set.first().push_all_issues
         jform = JIRAFindingForm(enabled=enabled, prefix='jiraform')
 
-    gform = None
     try:
         jissue = JIRA_Issue.objects.get(finding=finding)
         enabled = True
     except:
         enabled = False
-        pass
 
     try:
         gissue = GITHUB_Issue.objects.get(finding=finding)
-        enabled = True
+        github_enabled = True
     except:
-        enabled = False
-        pass
+        github_enabled = False
 
-    if get_system_setting('enable_github') and GITHUB_PKey.objects.filter(
-            product=finding.test.engagement.product) != 0:
-        gform = GITHUBFindingForm(enabled=enabled, prefix='githubform')
+    gform = None
+    if get_system_setting('enable_github'):
+        if GITHUB_PKey.objects.filter(
+            product=finding.test.engagement.product).exclude(git_conf_id=None):
+            gform = GITHUBFindingForm(enabled=github_enabled, prefix='githubform')
 
     if request.method == 'POST':
         form = FindingForm(request.POST, instance=finding, template=False)
@@ -676,7 +675,7 @@ def edit_finding(request, fid):
 
             if 'githubform-push_to_github' in request.POST:
                 gform = GITHUBFindingForm(
-                    request.POST, prefix='githubform', enabled=enabled)
+                    request.POST, prefix='githubform', enabled=github_enabled)
                 if gform.is_valid():
                     if GITHUB_Issue.objects.filter(finding=new_finding).exists():
                         update_external_issue_task.delay(

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1682,7 +1682,7 @@ def finding_bulk_update_all(request, pid=None):
                     logger.info('push selected findings to github')
                     finds = Finding.objects.filter(id__in=finding_to_update)
                     for finding in finds:
-                        print('will push to github finding: ' + str(finding))
+                        print('will push to GitHub finding: ' + str(finding))
                         old_status = finding.status()
                         if form.cleaned_data['push_to_github']:
                             if GITHUB_Issue.objects.filter(finding=finding).exists():

--- a/dojo/github.py
+++ b/dojo/github.py
@@ -109,7 +109,7 @@ def add_external_issue_github(find, prod, eng):
         eng = Engagement.objects.get(test=find.test)
         prod = Product.objects.get(engagement=eng)
         github_product_key = GITHUB_PKey.objects.get(product=prod)
-        github_conf = github_product_key.git_conf
+        github_conf = github_product_key.git_conf_id
         logger.info('Create issue with github profile: ' + str(github_conf) + ' on product: ' + str(github_product_key))
 
         try:

--- a/dojo/github.py
+++ b/dojo/github.py
@@ -110,7 +110,7 @@ def add_external_issue_github(find, prod, eng):
         prod = Product.objects.get(engagement=eng)
         github_product_key = GITHUB_PKey.objects.get(product=prod)
         github_conf = github_product_key.git_conf
-        logger.debug('Create issue with github profile: ' + str(github_conf) + ' on product: ' + str(github_product_key))
+        logger.info('Create issue with github profile: ' + str(github_conf) + ' on product: ' + str(github_product_key))
 
         try:
             g = Github(github_conf.api_key)

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -26,7 +26,7 @@
                 {% include "dojo/form_fields.html" with form=jform %}
             {% endif %}
             {% if gform %}
-                <h3> Github </h3>
+                <h3> GitHub </h3>
                 <hr>
                 {% include "dojo/form_fields.html" with form=gform %}
             {% endif %}

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -74,8 +74,8 @@
                                 </label>
                                 {% endif %}
                                 {% if system_settings.enable_github %}
-                                <label style="font-size: 80%; font-weight: bold; display: block">Push to Github
-                                  <input id="id_push_togithub" name="push_to_github" type="checkbox" alt="Select to push to Github"/>
+                                <label style="font-size: 80%; font-weight: bold; display: block">Push to GitHub
+                                  <input id="id_push_togithub" name="push_to_github" type="checkbox" alt="Select to push to GitHub"/>
                                 </label>
                                 <br/>
                                 {% endif %}


### PR DESCRIPTION
Addresses https://github.com/DefectDojo/django-DefectDojo/issues/2351

Also aligns case to `GitHub` in cases that I could see show on screen.

fyi @mestrade