### PR TITLE
Revert "docker: update to python 3.6"

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -7,7 +7,7 @@
 # Using 3.5.7 to avoid compatibility issues that may be introduced by python 3.6 and 3.7.
 # Please upgrade before end-of-life in september 2020!
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.6.10-buster@sha256:07c839d23caa4edadf682020e13b88331eb499f630765f47eef780f4b07c1268 as build
+FROM python:3.5.9-buster@sha256:1baef6be00b82fbd77f1b60ab227a1dbede6f23825ce1b7f1e9c6f7d1469a45c as build
 WORKDIR /app
 RUN \
   apt-get -y update && \
@@ -24,7 +24,7 @@ RUN \
 COPY requirements.txt ./
 RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM python:3.6.10-slim-buster@sha256:07c839d23caa4edadf682020e13b88331eb499f630765f47eef780f4b07c1268
+FROM python:3.5.9-slim-buster@sha256:dfb042910e4ef352b5c6aa223031ce768f53f4f1aacf95936152e5508162bcb0
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -3,7 +3,7 @@
 # The code for the build image should be idendical with the code in
 # Dockerfile.django to use the caching mechanism of Docker.
 
-FROM python:3.6.10-buster@sha256:07c839d23caa4edadf682020e13b88331eb499f630765f47eef780f4b07c1268 as build
+FROM python:3.5.9-buster@sha256:1baef6be00b82fbd77f1b60ab227a1dbede6f23825ce1b7f1e9c6f7d1469a45c as build
 WORKDIR /app
 RUN \
   apt-get -y update && \


### PR DESCRIPTION
Reverts DefectDojo/django-DefectDojo#2178

It broke the build