### PR TITLE
fix alerts for product_added, and more

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2890,6 +2890,7 @@ admin.site.register(Cred_Mapping)
 admin.site.register(System_Settings, System_SettingsAdmin)
 admin.site.register(CWE)
 admin.site.register(Regulation)
+admin.site.register(Notifications)
 
 # Watson
 watson.register(Product)

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -17,7 +17,12 @@ def create_notification(event=None, *args, **kwargs):
         system_notifications = Notifications()
 
     logger.debug('creating system notifications')
-    process_notifications(event, system_notifications, *args, **kwargs)
+
+    # send system notifications to all admin users
+    admin_users = Dojo_User.objects.filter(is_staff=True)
+    for admin_user in admin_users:
+        system_notifications.user = admin_user
+        process_notifications(event, system_notifications, *args, **kwargs)
 
     if 'recipients' in kwargs:
         # mimic existing code so that when recipients is specified, no other personal notifications are sent.
@@ -115,7 +120,6 @@ def process_notifications(event, notifications=None, *args, **kwargs):
         else:
             send_mail_notification(event, notifications.user, *args, **kwargs)
 
-    print(getattr(notifications, event, None))
     if 'alert' in getattr(notifications, event, None):
         if not sync:
             send_alert_notification_task.delay(event, notifications.user, *args, **kwargs)

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -18,7 +18,10 @@ from dojo.tools.tool_issue_updater import tool_issue_updater, update_findings_fr
 from dojo.utils import sync_false_history, calculate_grade
 from dojo.reports.widgets import report_widget_factory
 from dojo.utils import add_comment, add_epic, add_issue, update_epic, update_issue, \
-                       close_epic, create_notification, sync_rules, fix_loop_duplicates, rename_whitesource_finding, update_external_issue, add_external_issue, close_external_issue, reopen_external_issue
+                       close_epic, sync_rules, fix_loop_duplicates, \
+                       rename_whitesource_finding, update_external_issue, add_external_issue, \
+                       close_external_issue, reopen_external_issue
+from dojo.notifications.helper import create_notification
 
 
 import logging


### PR DESCRIPTION
There were some issues with notifications / alerts after the revamp earlier:
- alerts were not created for staff/admin users
- ~~alerts were failing for product_added notifications~~ already fixed in #2412