### PR TITLE
Fix safety parser (Issue #1754)

### DIFF
--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -46,22 +46,19 @@ def get_item(item_node, test, safety_db):
     severity = 'Info'  # Because Safety doesn't include severity rating
     cve = ''.join(a['cve'] or ''
                   for a in safety_db[item_node['package']]
-                  if a['id'] == 'pyup.io-' + item_node['id'])
+                  if a['id'] == 'pyup.io-' + item_node['id']) or None
     title = item_node['package'] + " (" + item_node['affected'] + ")"
-    if cve:
-        title = title + " | " + cve
-    else:
-        cve = "N/A"
 
-    finding = Finding(title=title,
+    finding = Finding(title=title + " | " + cve if cve else title,
                       test=test,
                       severity=severity,
                       description=item_node['description'] +
                                   "\n Vulnerable Package: " + item_node['package'] +
                                   "\n Installed Version: " + item_node['installed'] +
                                   "\n Vulnerable Versions: " + item_node['affected'] +
-                                  "\n CVE: " + cve +
+                                  "\n CVE: " + (cve or "N/A") +
                                   "\n ID: " + item_node['id'],
+                      cve=cve,
                       cwe=1035,  # Vulnerable Third Party Component
                       mitigation="No mitigation provided",
                       references="No reference provided",

--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -19,7 +19,7 @@ class SafetyParser(object):
             self.items = []
 
     def parse_json(self, json_output):
-        data = json_output.read()
+        data = json_output.read() or '[]'
         try:
             json_obj = json.loads(str(data, 'utf-8'))
         except:
@@ -44,7 +44,9 @@ class SafetyParser(object):
 
 def get_item(item_node, test, safety_db):
     severity = 'Info'  # Because Safety doesn't include severity rating
-    cve = ''.join(a['cve'] for a in safety_db[item_node['package']] if a['id'] == 'pyup.io-' + item_node['id'])
+    cve = ''.join(a['cve'] or ''
+                  for a in safety_db[item_node['package']]
+                  if a['id'] == 'pyup.io-' + item_node['id'])
     title = item_node['package'] + " (" + item_node['affected'] + ")"
     if cve:
         title = title + " | " + cve

--- a/dojo/unittests/scans/safety/example_report.json
+++ b/dojo/unittests/scans/safety/example_report.json
@@ -1,0 +1,23 @@
+[
+  [
+    "django",
+    "<1.2.7",
+    "1.2.2",
+    "django.contrib.sessions in Django before 1.2.7 and 1.3.x before 1.3.1, when session data is stored in the cache, uses the root namespace for both session identifiers and application-data keys, which allows remote attackers to modify a session by triggering use of a key that is equal to that session's identifier.",
+    "33063"
+  ],
+  [
+    "django",
+    "<1.2.7",
+    "1.2.2",
+    "The verify_exists functionality in the URLField implementation in Django before 1.2.7 and 1.3.x before 1.3.1 relies on Python libraries that attempt access to an arbitrary URL with no timeout, which allows remote attackers to cause a denial of service (resource consumption) via a URL associated with (1) a slow response, (2) a completed TCP connection with no application data sent, or (3) a large amount of application data, a related issue to CVE-2011-1521.",
+    "33064"
+  ],
+  [
+    "django",
+    "<1.2.7",
+    "1.2.2",
+    "The verify_exists functionality in the URLField implementation in Django before 1.2.7 and 1.3.x before 1.3.1 originally tests a URL's validity through a HEAD request, but then uses a GET request for the new target URL in the case of a redirect, which might allow remote attackers to trigger arbitrary GET requests with an unintended source IP address via a crafted Location header.",
+    "33065"
+  ]
+]

--- a/dojo/unittests/scans/safety/multiple_cves.json
+++ b/dojo/unittests/scans/safety/multiple_cves.json
@@ -1,0 +1,9 @@
+[
+    [
+        "ampache",
+        "<4.0.0",
+        "3.8.2",
+        "ampache 4.0.0:\r\n* Resolves CVE-2019-12385 for the SQL Injection\r\n* Resolves CVE-2019-12386 for the persistent XSS\r\n* Resolves NS-18-046 Multiple Reflected Cross-site Scripting Vulnerabilities in Ampache 3.9.0",
+        "37863"
+    ]
+]

--- a/dojo/unittests/scans/safety/no_cve.json
+++ b/dojo/unittests/scans/safety/no_cve.json
@@ -1,0 +1,9 @@
+[
+    [
+        "httplib2",
+        "<=0.9.2",
+        "0.9.2",
+        "httplib2 before and including 0.9.2 on \"SSL certificate hostname mismatch\" it is checked only once: https://github.com/httplib2/httplib2/issues/5",
+        "25848"
+    ]
+]

--- a/dojo/unittests/test_safety_parser.py
+++ b/dojo/unittests/test_safety_parser.py
@@ -1,0 +1,24 @@
+from django.test import TestCase
+
+from dojo.models import Test
+from dojo.tools.safety.parser import SafetyParser
+
+
+class TestSafetyParser(TestCase):
+    def test_example_report(self):
+        testfile = "dojo/unittests/scans/safety/example_report.json"
+        with open(testfile) as f:
+            parser = SafetyParser(f, Test())
+        self.assertEqual(3, len(parser.items))
+
+    def test_no_cve(self):
+        testfile = "dojo/unittests/scans/safety/no_cve.json"
+        with open(testfile) as f:
+            parser = SafetyParser(f, Test())
+        self.assertEqual(1, len(parser.items))
+
+    def test_empty_report(self):
+        testfile = "dojo/unittests/scans/safety/empty.json"
+        with open(testfile) as f:
+            parser = SafetyParser(f, Test())
+        self.assertEqual(0, len(parser.items))

--- a/dojo/unittests/test_safety_parser.py
+++ b/dojo/unittests/test_safety_parser.py
@@ -10,15 +10,26 @@ class TestSafetyParser(TestCase):
         with open(testfile) as f:
             parser = SafetyParser(f, Test())
         self.assertEqual(3, len(parser.items))
+        for item in parser.items:
+            self.assertIsNotNone(item.cve)
 
     def test_no_cve(self):
         testfile = "dojo/unittests/scans/safety/no_cve.json"
         with open(testfile) as f:
             parser = SafetyParser(f, Test())
         self.assertEqual(1, len(parser.items))
+        self.assertIsNone(parser.items[0].cve)
 
     def test_empty_report(self):
         testfile = "dojo/unittests/scans/safety/empty.json"
         with open(testfile) as f:
             parser = SafetyParser(f, Test())
         self.assertEqual(0, len(parser.items))
+
+    def test_multiple_cves(self):
+        testfile = "dojo/unittests/scans/safety/multiple_cves.json"
+        with open(testfile) as f:
+            parser = SafetyParser(f, Test())
+        self.assertEqual(1, len(parser.items))
+        cves = parser.items[0].cve.split(',')
+        self.assertEqual(2, len(cves))


### PR DESCRIPTION
Bug fixes for safety parser:
- fixed issue #1754 when cve for finding is `None`
- fixed issue with importing empty file
- set cve to finding's object for safety