### PR TITLE
require login for alert count

### DIFF
--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -1,7 +1,7 @@
 import logging
 from django.contrib import messages
 from django.contrib.auth import authenticate, logout
-from django.contrib.auth.decorators import user_passes_test
+from django.contrib.auth.decorators import user_passes_test, login_required
 from django.core import serializers
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
@@ -166,6 +166,7 @@ def migrate_alerts(request):
                     {'alerts': alerts})
 
 
+@login_required
 def alerts_json(request, limit=None):
     limit = request.GET.get('limit')
     if limit:


### PR DESCRIPTION
Whenever a session expires or is deleted, or somebody is starting with a clean database, an old browser session will poll for alerts every 5s. This creates exceptions in the logs due to the user no longer being logged in.
Multiply by 50 if you have 50 users ;-)
This PR adds a decorated that requires the user to be logged in to perform the alert_count function. If not logged in, the response is a 302 redirect to the login.