### PR TITLE
make notifications work with users created without usercontactinfo

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -686,6 +686,7 @@ def import_scan_results(request, eid=None, pid=None):
                     extra_tags='alert-success')
 
                 create_notification(
+                    initiator=request.user,
                     event='scan_added',
                     title=str(finding_count) + " findings for " + engagement.product.name,
                     finding_count=finding_count,

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1789,14 +1789,10 @@ class Finding(models.Model):
         if rules_option:
             from dojo.tasks import async_rules
             from dojo.utils import sync_rules
-            try:
-                if self.reporter.usercontactinfo.block_execution:
-                    sync_rules(self, *args, **kwargs)
-                else:
-                    async_rules(self, *args, **kwargs)
-            except UserContactInfo.DoesNotExist:
+            if hasattr(self.reporter, 'usercontactinfo') and self.reporter.usercontactinfo.block_execution:
+                sync_rules(self, *args, **kwargs)
+            else:
                 async_rules(self, *args, **kwargs)
-                pass
         from dojo.utils import calculate_grade
         calculate_grade(self.test.engagement.product)
         # Assign the numerical severity for correct sorting order

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -15,7 +15,7 @@ from tastypie.models import ApiKey
 
 from dojo.filters import UserFilter
 from dojo.forms import DojoUserForm, AddDojoUserForm, DeleteUserForm, APIKeyForm, UserContactInfoForm
-from dojo.models import Product, Dojo_User, UserContactInfo, Alerts
+from dojo.models import Product, Dojo_User, Alerts
 from dojo.utils import get_page_items, add_breadcrumb
 
 logger = logging.getLogger(__name__)
@@ -183,11 +183,7 @@ def alertcount(request):
 
 def view_profile(request):
     user = get_object_or_404(Dojo_User, pk=request.user.id)
-    try:
-        user_contact = UserContactInfo.objects.get(user=user)
-    except UserContactInfo.DoesNotExist:
-        user_contact = None
-
+    user_contact = user.usercontactinfo if hasattr(user, 'usercontactinfo') else None
     form = DojoUserForm(instance=user)
     if user_contact is None:
         contact_form = UserContactInfoForm()
@@ -313,10 +309,9 @@ def edit_user(request, uid):
         form.fields['is_staff'].widget.attrs['disabled'] = True
         form.fields['is_superuser'].widget.attrs['disabled'] = True
         form.fields['is_active'].widget.attrs['disabled'] = True
-    try:
-        user_contact = UserContactInfo.objects.get(user=user)
-    except UserContactInfo.DoesNotExist:
-        user_contact = None
+
+    user_contact = user.usercontactinfo if hasattr(user, 'usercontactinfo') else None
+
     if user_contact is None:
         contact_form = UserContactInfoForm()
     else:


### PR DESCRIPTION
Add a check to avoid exceptions for users created without usercontactinfo (i.e. via /admin, or manage.py createsuper).