### PR TITLE
run some Integration tests with block execution = true

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -3,7 +3,7 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Finding_Template, Test_Type, Development_Environment, NoteHistory, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Product_Type, JIRA_Conf, Endpoint, BurpRawRequestResponse, JIRA_PKey, \
-    Notes, DojoMeta, FindingImage, Note_Type, System_Settings
+    Notes, DojoMeta, FindingImage, Note_Type
 from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools import requires_file
 from dojo.tools.factory import import_parser_factory

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -208,8 +208,6 @@ class FindingTest(BaseTestCase):
         driver = self.login_page()
         # Navigate to All Finding page
         print("\nListing findings \n")
-        driver.get(self.base_url + "finding")
-        self.assertNoConsoleErrors()
         self.goto_all_findings_list(driver)
         # Select and click on the particular finding to edit
         driver.find_element_by_link_text("App Vulnerable to XSS").click()
@@ -303,11 +301,13 @@ class FindingTest(BaseTestCase):
         # check that user was redirect back to url where it came from based on return_url
 
 
-def add_finding_tests_to_suite(suite, jira=False, github=False):
+def add_finding_tests_to_suite(suite, jira=False, github=False, block_execution=False):
     if jira:
         suite.addTest(FindingTest('enable_jira'))
     if github:
         suite.addTest(FindingTest('enable_github'))
+    if block_execution:
+        suite.addTest(FindingTest('enable_block_execution'))
 
     # Add each test the the suite to be run
     # success and failure is output by the test
@@ -340,8 +340,8 @@ def add_finding_tests_to_suite(suite, jira=False, github=False):
 
 def suite():
     suite = unittest.TestSuite()
-    add_finding_tests_to_suite(suite, jira=False, github=False)
-    add_finding_tests_to_suite(suite, jira=True, github=True)
+    add_finding_tests_to_suite(suite, jira=False, github=False, block_execution=False)
+    add_finding_tests_to_suite(suite, jira=True, github=True, block_execution=True)
     return suite
 
 

--- a/tests/Product_unit_test.py
+++ b/tests/Product_unit_test.py
@@ -384,6 +384,7 @@ def suite():
     add_product_tests_to_suite(suite)
     suite.addTest(ProductTest('enable_jira'))
     suite.addTest(ProductTest('enable_github'))
+    suite.addTest(ProductTest('enable_block_execution'))
     add_product_tests_to_suite(suite)
     return suite
 

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -193,6 +193,19 @@ class BaseTestCase(unittest.TestCase):
     def enable_github(self):
         return self.enable_system_setting('id_enable_github')
 
+    def enable_block_execution(self):
+        # we set the admin user (ourselves) to have block_execution checked
+        # this will force dedupe to happen synchronously, among other things like notifications, rules, ...
+        driver = self.login_page()
+        driver.get(self.base_url + 'profile')
+        if not driver.find_element_by_id('id_block_execution').is_selected():
+            driver.find_element_by_xpath('//*[@id="id_block_execution"]').click()
+            # save settings
+            driver.find_element_by_css_selector("input.btn.btn-primary").click()
+            # check if it's enabled after reload
+            self.assertTrue(driver.find_element_by_id('id_block_execution').is_selected())
+        return driver
+
     def is_alert_present(self):
         try:
             self.driver.switch_to_alert()

--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -482,6 +482,7 @@ def suite():
     add_dedupe_tests_to_suite(suite)
     suite.addTest(DedupeTest('enable_jira'))
     suite.addTest(DedupeTest('enable_github'))
+    suite.addTest(DedupeTest('enable_block_execution'))
     add_dedupe_tests_to_suite(suite)
     return suite
 


### PR DESCRIPTION
As seen in #2370 sometimes exceptions occur in background (celery) processes. By running some integration tests (also) with `block_execution` enabled, everything will run synchronously in the django/uwsgi process.This allows us to catch some of these exceptions in the integration testsuite.