### PR TITLE
Merge master into release 1.6.0

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,7 +6,7 @@ update_configs:
     update_schedule: "live"
 
   - package_manager: "javascript"
-    directory: "/"
+    directory: "/components"
     target_branch: "dev"
     update_schedule: "live"
 

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -1,0 +1,39 @@
+name: Generate PlantUML Diagrams
+on:
+  push:
+    paths:
+      - '**.puml'
+    branches:
+      - master
+      - dev
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    env:
+      UML_FILES: ".puml"
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v1
+      - name: Get changed UML files
+        id: getfile
+        run: |
+          echo "::set-output name=files::$(git diff-tree -r --no-commit-id --name-only ${{ github.sha }} | grep ${{ env.UML_FILES }} | xargs)"
+      - name: UML files considered echo output
+        run: |
+          echo ${{ steps.getfile.outputs.files }}
+      - name: Generate SVG Diagrams
+        uses: cloudbees/plantuml-github-action@master
+        with:
+          args: -v -tsvg ${{ steps.getfile.outputs.files }}
+      - name: Generate PNG Diagrams
+        uses: cloudbees/plantuml-github-action@master
+        with:
+          args: -v -tpng ${{ steps.getfile.outputs.files }}
+      - name: Push Local Changes
+        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        with:
+          commit_user_name: "PlantUML_bot"
+          commit_user_email: "noreply@defectdojo.org"
+          commit_author: "PlantUML Bot <noreply@defectdojo.org>"
+          commit_message: "Generate SVG and PNG images for PlantUML diagrams"
+          branch: ${{ github.head_ref }}

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,8 +1,8 @@
 # Running with Docker Compose
 
-Docker compose is not intended for production use.
-If you want to deploy a containerized DefectDojo to a production environment,
-use the [Default installation](setup/README.md) approach.
+The docker-compose.yml in this repo is not intended for production use without first customizing it to fit your specific situation.  Please consider the docker-compose.yml files are templates to create on that fits your needs.
+Docker Compose is acceptable if you want to deploy a containerized DefectDojo to a production environment.
+It is one of the supported [Default installation](setup/README.md) methods.
 
 # Prerequisites
 *  Docker version

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ For detailed documentation you can visit
 [Read the Docs](https://defectdojo.readthedocs.io/).
 
 ## Supported Installation Options
-* [Kubernetes](KUBERNETES.md)
-* [Setup.bash](https://github.com/DefectDojo/django-DefectDojo/blob/dev/setup/README.md)
-* [Docker](DOCKER.md)
+
+* [Docker / Docker Compose](DOCKER.md)
+* [Setup.bash](https://github.com/DefectDojo/django-DefectDojo/blob/master/setup/README.MD)
 
 ## Getting Started
 
@@ -119,6 +119,7 @@ Project Moderators can help you with pull requests or feedback on dev ideas.
 * Jay Paz ([@jjpaz](https://twitter.com/jjpaz)) – Jay was a DefectDojo
   maintainer for years. He performed Dojo's first UI overhaul, optimized code structure/features, and added numerous enhancements.
 
+
 ## Contributing
 
 We greatly appreciate all of our
@@ -145,6 +146,7 @@ Proceeds are used for testing, infrastructure, etc.
 [![Xing](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/XING_logo.png)](https://corporate.xing.com/en/about-xing/security/)
 [![10Security](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/10Security-logo.png)](https://10security.com/services-by-technology/defectdojo-commercial-support/)
 [![GCSecurity](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/gc_logo_2018.png)](https://gcsec.com.br/)
+[![ISAAC](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/isaac.png)](https://isaac.nl "ISAAC")
 [![Timo-Pagel](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/timo-pagel-logo.png )](https://pagel.pro/)
 [![SDA-SE](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/sda-se-logo.png)](https://sda-se.com/)
 [![Signal-Iduna](https://raw.githubusercontent.com/DefectDojo/Documentation/master/doc/img/signal-iduna.png)](https://signal-iduna.de/)

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -11,7 +11,7 @@ createMysqlSecret: false
 # create postgresql secret in defectdojo chart, outside of postgresql chart
 createPostgresqlSecret: false
 ## Configuration value to select database type
-## Option to use "postgresql" or "mysql" database type, by default "postgresql" is chosen
+## Option to use "postgresql" or "mysql" database type, by default "mysql" is chosen
 ## Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select
 database: postgresql
 host: defectdojo.default.minikube.local

--- a/setup/postgresql.txt
+++ b/setup/postgresql.txt
@@ -1,3 +1,4 @@
+
 # Pip installs needed for PostgreSQL DB support 
 -r ../requirements.txt
 psycopg2-binary==2.8.5


### PR DESCRIPTION
In the new (git flow based) branching/release model, our branches should never be behind master. At least not for a long time or for many commits.

![image](https://user-images.githubusercontent.com/4426050/82152175-d1f48700-985f-11ea-9632-8b4df642ad7d.png)

Currently `dev` and also `release/1.6.0` are 62 commits behind. This PR resolves that for the `release/1.6.0` branch. After the release, the release branch will be merged to `master`, but also to `dev` as per git flow and the plantuml diagram by @madchap 

The step in this PR is only needed one-time because in the past we didn't have a clear branching/releasing model.

Does this make sense?