### PR TITLE
import scan ui: don't open datepicker by default

### DIFF
--- a/dojo/static/dojo/js/index.js
+++ b/dojo/static/dojo/js/index.js
@@ -31,7 +31,7 @@ $(function () {
     $('#side-menu').metisMenu();
 
     // auto focus on first form field
-    $('#base-content form:first *:input[type!=hidden]:first').not('button, input[type=submit]').not('.filters :input, textarea#id_entry, input#quick_add_finding').not('input[type=checkbox]').focus();
+    $('#base-content form:first *:input[type!=hidden]:first').not('button, input[type=submit]').not('.filters :input, textarea#id_entry, input#quick_add_finding').not('input[type=checkbox]').not('.datepicker').focus();
 
     $('a#minimize-menu').on('click', sidebar);
 


### PR DESCRIPTION
When importing a scan via the UI, a datepicker pops up right in your face.
I think it would be nicer to only open it when users click on the datefield that belongs to it.