### PR TITLE
Fixing visibility of popover content in Benchmarks page

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -838,6 +838,10 @@ h4.finding-title {
     cursor: pointer;
 }
 
+#test-pulldown .popover-content {
+    color: #000000;
+}
+
 span.endpoint_product {
     display: block;
     font-size: 14px;


### PR DESCRIPTION
The content of the popovers in Benchmarks page was not visible. 

**Before**
![image](https://user-images.githubusercontent.com/4240075/82180564-c8464000-98ae-11ea-8b2c-ec4b0fe08d66.png)



**After**
![image](https://user-images.githubusercontent.com/4240075/82180389-6dace400-98ae-11ea-894a-2f45ec611405.png)
