### PR TITLE
More descriptive Benchmark progress bar

### DIFF
--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -159,13 +159,13 @@
                 <span class="float-md-left"><strong>{{Abenchpercent.0}}</strong></span>
               </div>
               <div class="col-md-6 text-right">
-              <span class="float-md-right">{{Abenchpercent.1}} Complete</span>
+              <span class="float-md-right">{{Abenchpercent.1|default:"0&#37;"}} Complete</span>
               </div>
             </div>
             <div class="progress">
               <div class="progress-bar" role="progressbar" aria-valuenow="{{Abenchpercent.1}}"
               aria-valuemin="0%" aria-valuemax="100%" style="width:{{Abenchpercent.1}}">
-              <span class="sr-only">{{Abenchpercent.1}} Complete</span>
+              <span class="sr-only">{{Abenchpercent.1|default:"0&#37;"}} Complete</span>
               </div>
             </div>
           </li>


### PR DESCRIPTION
Updating to **0% Complete** as the default value for Benchmark progress instead of just **Complete**

**Before**
![image](https://user-images.githubusercontent.com/4240075/82183785-8f10ce80-98b4-11ea-8beb-d22f3b112ecb.png)

**After**
![image](https://user-images.githubusercontent.com/4240075/82183827-a354cb80-98b4-11ea-8492-3b0edf096d6f.png)
