### PR TITLE
dependency check parser: only set cve when available

### DIFF
--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -32,7 +32,7 @@ class DependencyCheckParser(object):
         title = '{0} | {1}'.format(filename, name)
         cve = name[:28]
         if cve and not cve.startswith('CVE'):
-            # for vulnerability sources which hava a CVE, it is the start of the 'name'.
+            # for vulnerability sources which have a CVE, it is the start of the 'name'.
             # for other sources, we have to set it to None
             cve = None
 

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -31,6 +31,11 @@ class DependencyCheckParser(object):
 
         title = '{0} | {1}'.format(filename, name)
         cve = name[:28]
+        if cve and not cve.startswith('CVE'):
+            # for vulnerability sources which hava a CVE, it is the start of the 'name'.
+            # for other sources, we have to set it to None
+            cve = None
+
         # Use CWE-1035 as fallback
         cwe = 1035  # Vulnerable Third Party Component
         if cwe_field:


### PR DESCRIPTION
the field from which we parse the CVE does not always contain a CVE, so we check have to check that before setting CVE, otherwise we get garbage in the cve field in DD.