### PR TITLE
Fixing Product Type Report error when there are no findings

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -768,7 +768,7 @@ def report_generate(request, obj, options):
                                                 test__finding__in=findings.qs).distinct()
         tests = Test.objects.filter(engagement__product__prod_type=product_type,
                                     finding__in=findings.qs).distinct()
-        if findings.qs.count() > 0:
+        if len(findings.qs) > 0:
             start_date = timezone.make_aware(datetime.combine(findings.qs.last().date, datetime.min.time()))
         else:
             start_date = timezone.now()

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -768,7 +768,7 @@ def report_generate(request, obj, options):
                                                 test__finding__in=findings.qs).distinct()
         tests = Test.objects.filter(engagement__product__prod_type=product_type,
                                     finding__in=findings.qs).distinct()
-        if findings:
+        if findings.qs.count() > 0:
             start_date = timezone.make_aware(datetime.combine(findings.qs.last().date, datetime.min.time()))
         else:
             start_date = timezone.now()

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -592,7 +592,7 @@ def generate_report(request, obj):
                                                 test__finding__in=findings.qs).distinct()
         tests = Test.objects.filter(engagement__product__prod_type=product_type,
                                     finding__in=findings.qs).distinct()
-        if findings:
+        if findings.qs.count() > 0:
             start_date = timezone.make_aware(datetime.combine(findings.qs.last().date, datetime.min.time()))
         else:
             start_date = timezone.now()

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -592,7 +592,7 @@ def generate_report(request, obj):
                                                 test__finding__in=findings.qs).distinct()
         tests = Test.objects.filter(engagement__product__prod_type=product_type,
                                     finding__in=findings.qs).distinct()
-        if findings.qs.count() > 0:
+        if len(findings.qs) > 0:
             start_date = timezone.make_aware(datetime.combine(findings.qs.last().date, datetime.min.time()))
         else:
             start_date = timezone.now()


### PR DESCRIPTION
**Steps to reproduce**
Steps to reproduce the behavior:
1. Create a new Product Type
2. In the Product Type List page, click on Report button (next to "Edit Product Type")

**Expected behavior**
User should be taken to Generate Product Type Report page.

**Traceback** (optional)

```
Traceback:

File "/usr/local/lib/python3.5/site-packages/django/core/handlers/exception.py" in inner
  34.             response = get_response(request)

File "/usr/local/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  115.                 response = self.process_exception_by_middleware(e, request)

File "/usr/local/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  113.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/usr/local/lib/python3.5/site-packages/django/contrib/auth/decorators.py" in _wrapped_view
  21.                 return view_func(request, *args, **kwargs)

File "./dojo/reports/views.py" in product_type_report
  333.     return generate_report(request, product_type)

File "./dojo/reports/views.py" in generate_report
  597.             start_date = timezone.make_aware(datetime.combine(findings.qs.last().date, datetime.min.time()))

Exception Type: AttributeError at /product/type/5/report
Exception Value: 'NoneType' object has no attribute 'date'
```
