### PR TITLE
added unique_id_from_tool filter to APIv2 when retrieving findings

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -159,7 +159,7 @@ class FindingViewSet(mixins.ListModelMixin,
                      'mitigated', 'endpoints', 'test', 'active', 'verified',
                      'false_p', 'reporter', 'url', 'out_of_scope',
                      'duplicate', 'test__engagement__product',
-                     'test__engagement')
+                     'test__engagement', 'unique_id_from_tool')
 
     # Overriding mixins.UpdateModeMixin perform_update() method to grab push_to_jira
     # data and add that as a parameter to .save()


### PR DESCRIPTION
Looking to leverage the unique_id_from_tool field to find specific Findings via the API. Would love to get this merged in sometime.