### PR TITLE
Cleaning Gosec parser code

### DIFF
--- a/dojo/tools/gosec/parser.py
+++ b/dojo/tools/gosec/parser.py
@@ -12,15 +12,10 @@ class GosecScannerParser(object):
         dupes = dict()
 
         for item in data["Issues"]:
-            categories = ''
-            language = ''
-            mitigation = ''
             impact = ''
             references = ''
             findingdetail = ''
             title = ''
-            group = ''
-            status = ''
             filename = item.get("file")
             line = item.get("line")
             scanner_confidence = item.get("confidence")
@@ -35,7 +30,6 @@ class GosecScannerParser(object):
             findingdetail += "```{}```".format(item["code"])
 
             sev = item["severity"]
-            mitigation = "coming soon"
             # Best attempt at ongoing documentation provided by gosec, based on rule id
             references = "https://securego.io/docs/rules/{}.html".format(item['rule_id']).lower()
 
@@ -66,16 +60,13 @@ class GosecScannerParser(object):
                                description=findingdetail,
                                severity=sev.title(),
                                numerical_severity=Finding.get_numerical_severity(sev),
-                               mitigation=mitigation,
                                impact=impact,
                                references=references,
                                file_path=filename,
                                line=line,
-                               url='N/A',
                                scanner_confidence=scanner_confidence,
                                static_finding=True)
 
                 dupes[dupe_key] = find
-                findingdetail = ''
 
         self.items = list(dupes.values())


### PR DESCRIPTION
This PR just remove unused/unnecessary variables in the Gosec parser.
Some static strings have been removed because they don't have value and take space in the DB.

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant 
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted)
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR 

Current accepted labels for PRs:
- enhancement
- maintenance (a.k.a chores)
