### PR TITLE
Replaced SimpleMDE with EasyMDE

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -12,6 +12,7 @@
     "datatables": "1.10.18",
     "drmonty-datatables-plugins": "^1.0.0",
     "drmonty-datatables-responsive": "^1.0.0",
+    "easymde": "^2.10.1",
     "flot": "flot/flot#~0.8.3",
     "flot-axis": "markrcote/flot-axislabels#*",
     "font-awesome": "^4.0.0",
@@ -26,7 +27,6 @@
     "metismenu": "~3.0.6",
     "moment": "^2.25.3",
     "morris.js": "morrisjs/morris.js",
-    "simplemde": "^1.0.0",
     "startbootstrap-sb-admin-2": "1.0.7"
   },
   "engines": {

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -46,17 +46,17 @@ clipboard@^2.0.6:
     select "^1.1.2"
     tiny-emitter "^2.0.0"
 
-codemirror-spell-checker@*:
+codemirror-spell-checker@1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz#1c660f9089483ccb5113b9ba9ca19c3f4993371e"
   integrity sha1-HGYPkIlIPMtRE7m6nKGcP0mTNx4=
   dependencies:
     typo-js "*"
 
-codemirror@*:
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.0.tgz#4dbd6aef7f0e63db826b9a23922f0c03ac75c0a7"
-  integrity sha512-K2UB6zjscrfME03HeRe/IuOmCeqNpw7PLKGHThYpLbZEuKf+ZoujJPhxZN4hHJS1O7QyzEsV7JJZGxuQWVaFCg==
+codemirror@^5.52.2:
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.54.0.tgz#82b6adf662b29eeb7b867fe7839d49e25e4a0b38"
+  integrity sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q==
 
 components-jqueryui@^1.0.0:
   version "1.12.1"
@@ -88,6 +88,15 @@ drmonty-datatables-responsive@^1.0.0:
   integrity sha1-HFwd5ezlTu+s85+V2vdcQ7f//v0=
   dependencies:
     jquery ">=1.7.0"
+
+easymde@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/easymde/-/easymde-2.10.1.tgz#671836ed08033def1a4379bfa2d193994c46471d"
+  integrity sha512-khKYfB18ZYbkJAGEeQXaV2ZZ1QS7BavNj2xdcPGpO8GXi30qA9bVxzswGW8QNZQRmPtaXiQDG236Yv/BQY7P2A==
+  dependencies:
+    codemirror "^5.52.2"
+    codemirror-spell-checker "1.1.2"
+    marked "^0.8.2"
 
 eve-raphael@0.5.0:
   version "0.5.0"
@@ -162,10 +171,10 @@ justgage@^1.3.0:
   dependencies:
     raphael "^2.2.8"
 
-marked@*:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.0.tgz#ec5c0c9b93878dc52dd54be8d0e524097bd81a99"
-  integrity sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ==
+marked@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
+  integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
 metismenu@~3.0.6:
   version "3.0.6"
@@ -192,15 +201,6 @@ select@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
   integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
-
-simplemde@^1.0.0:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/simplemde/-/simplemde-1.11.2.tgz#a23a35d978d2c40ef07dec008c92f070d8e080e3"
-  integrity sha1-ojo12XjSxA7wfewAjJLwcNjggOM=
-  dependencies:
-    codemirror "*"
-    codemirror-spell-checker "*"
-    marked "*"
 
 startbootstrap-sb-admin-2@1.0.7:
   version "1.0.7"

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -51,7 +51,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
@@ -38,7 +38,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
     <script type="application/javascript">
         $ = django.jQuery;
@@ -50,7 +50,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -110,7 +110,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -3,7 +3,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {
@@ -56,7 +56,7 @@
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 
@@ -109,7 +109,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -2,7 +2,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {
@@ -44,7 +44,7 @@
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript">
         $ = django.jQuery;
@@ -86,7 +86,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -87,7 +87,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -3,7 +3,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {
@@ -33,7 +33,7 @@
     
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+   <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript">
         $ = django.jQuery;
@@ -67,7 +67,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -68,7 +68,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -4,7 +4,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {
@@ -85,7 +85,7 @@
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 
@@ -131,7 +131,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -132,7 +132,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -34,7 +34,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -2,7 +2,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
@@ -23,7 +23,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
@@ -33,7 +33,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -63,9 +63,9 @@
                     ]
               });
               mde.render();
-m           });
+            });
             $('#id_product_manager').chosen({'placeholder_text_single': 'Select a Product Manager...'});
-            $('#id_team_manager').chosen({'placeholder_text_single': 'Select a TeaManager...'});
+            $('#id_team_manager').chosen({'placeholder_text_single': 'Select a Team Manager...'});
             $('#id_technical_contact').chosen({'placeholder_text_single': 'Select a Technical Contact...'});
             $('#id_authorized_users').chosen({'placeholder_text_multiple': 'Select some users...'});
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -51,7 +51,7 @@
               }
 
               var mde = new EasyMDE({
-                  spellChecker: true,
+                  spellChecker: false,
                   element: elem,
                   autofocus: false,
                   forceSync: true,

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -2,7 +2,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
@@ -40,7 +40,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
           $("textarea").each(function (index, elem) {
@@ -50,7 +50,7 @@
                   elem.id = "req"
               }
 
-              var mde = new SimpleMDE({
+              var mde = new EasyMDE({
                   spellChecker: true,
                   element: elem,
                   autofocus: false,
@@ -63,9 +63,9 @@
                     ]
               });
               mde.render();
-          });
+m           });
             $('#id_product_manager').chosen({'placeholder_text_single': 'Select a Product Manager...'});
-            $('#id_team_manager').chosen({'placeholder_text_single': 'Select a Team Manager...'});
+            $('#id_team_manager').chosen({'placeholder_text_single': 'Select a TeaManager...'});
             $('#id_technical_contact').chosen({'placeholder_text_single': 'Select a Technical Contact...'});
             $('#id_authorized_users').chosen({'placeholder_text_multiple': 'Select some users...'});
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -127,7 +127,7 @@
 {% block postscript %}
 	<script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
 	<script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-	<script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+	<script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
 	<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
 	<script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 	<script type="application/javascript">

--- a/dojo/templates/dojo/merge_findings.html
+++ b/dojo/templates/dojo/merge_findings.html
@@ -4,7 +4,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -47,7 +47,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -2,7 +2,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
@@ -36,7 +36,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
@@ -46,7 +46,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -34,7 +34,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -2,7 +2,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
@@ -23,7 +23,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
@@ -33,7 +33,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -51,7 +51,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -2,7 +2,7 @@
 {% load static from staticfiles %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
@@ -39,8 +39,8 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
     <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
@@ -50,7 +50,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "simplemde/dist/simplemde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
@@ -35,7 +35,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "simplemde/dist/simplemde.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
     <script type="application/javascript">
@@ -56,7 +56,7 @@
                     elem.id = "req"
                 }
 
-                var mde = new SimpleMDE({
+                var mde = new EasyMDE({
                     spellChecker: true,
                     element: elem,
                     autofocus: false,

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -57,7 +57,7 @@
                 }
 
                 var mde = new EasyMDE({
-                    spellChecker: true,
+                    spellChecker: false,
                     element: elem,
                     autofocus: false,
                     forceSync: true,


### PR DESCRIPTION
SimpleMDE hasn't been updated in [4 years.](https://github.com/sparksuite/simplemde-markdown-editor/commit/6abda7ab68cc20f4aca870eb243747951b90ab04) 

[EasyMDE ](https://github.com/Ionaru/easy-markdown-editor)is the most popular and active fork of SimpleMDE. 

This _should_ fix #2410 now that we have `spellChecker` set to false.
