### PR TITLE
Added endpoint to re_open a finding via the API

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -192,6 +192,19 @@ class FindingViewSet(mixins.ListModelMixin,
         else:
             return serializers.FindingSerializer
 
+    @action(detail=True, methods=['get'])
+    def re_open(self, request, pk=None):
+        finding = get_object_or_404(Finding.objects, id=pk)
+        if finding.is_Mitigated:
+            finding.active = True
+            finding.mitigated = None
+            finding.is_Mitigated = False
+            finding.mitigated_by = request.user
+            finding.last_reviewed = finding.mitigated
+            finding.last_reviewed_by = request.user
+            finding.save()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
     @action(detail=True, methods=['get', 'post'])
     def tags(self, request, pk=None):
         finding = get_object_or_404(Finding.objects, id=pk)

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -193,7 +193,7 @@ class FindingViewSet(mixins.ListModelMixin,
             return serializers.FindingSerializer
 
     @action(detail=True, methods=['get'])
-    def re_open(self, request, pk=None):
+    def open(self, request, pk=None):
         finding = get_object_or_404(Finding.objects, id=pk)
         if finding.is_Mitigated:
             finding.active = True


### PR DESCRIPTION
re-open a finding via the API. 
Stole most of the logic from the finding/views.py open endpoint logic.

pretty straight forward, but it will allow us to update a finding and remove the "Mitigated" status via the API which currently isn't possible. 