### PR TITLE
Setting a duplicate without a parent_finding

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1557,8 +1557,12 @@ class Finding(models.Model):
                 r.delete()
 
     def duplicate_finding_set(self):
-        if self.duplicate and self.duplicate_finding is not None:
-            return Finding.objects.get(id=self.duplicate_finding.id).original_finding.all().order_by('title')
+        if self.duplicate:
+            if self.duplicate_finding is not None:
+                return Finding.objects.get(
+                    id=self.duplicate_finding.id).original_finding.all().order_by('title')
+            else:
+                return []
         else:
             return self.original_finding.all().order_by('title')
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1557,7 +1557,7 @@ class Finding(models.Model):
                 r.delete()
 
     def duplicate_finding_set(self):
-        if self.duplicate:
+        if self.duplicate and self.duplicate_finding is not None:
             return Finding.objects.get(id=self.duplicate_finding.id).original_finding.all().order_by('title')
         else:
             return self.original_finding.all().order_by('title')


### PR DESCRIPTION
Will keep from receiving a 500 error when viewing the Finding.