### PR TITLE
Verified Findings Check History

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -75,7 +75,7 @@ def sync_false_history(new_finding, *args, **kwargs):
     if total_findings.count() > 0:
         new_finding.false_p = True
         new_finding.active = False
-        new_finding.verified = False
+        new_finding.verified = True
         super(Finding, new_finding).save(*args, **kwargs)
 
 


### PR DESCRIPTION
This change in the utils.py file checks the history to see if the findings are already verified, in order to make sure that the history is not checked again. 