### PR TITLE
setup.py: update django rest framework to fix security issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'django-tastypie-swagger',
         'django-tastypie>=0.12.2',
         'django-rest-swagger==2.1.2',
-        'djangorestframework==3.7.7',
+        'djangorestframework==3.11.0',
         'django-environ==0.4.5',
         'django-axes',
         'gunicorn>=19.1.1',


### PR DESCRIPTION
According to dependabot there's an XSS vulnerability in Django DRF 3.7.7 used in setup.py. I don't know exactly how setup.py uses those dependencies and if other depenendencies need updates as well, but I'd thought updating DRF at least.