### PR TITLE
merge master into dev after release 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For detailed documentation you can visit
 ## Supported Installation Options
 
 * [Docker / Docker Compose](DOCKER.md)
-* [Setup.bash](https://github.com/DefectDojo/django-DefectDojo/blob/master/setup/README.MD)
+* [Setup.bash](https://github.com/DefectDojo/django-DefectDojo/blob/master/setup/README.md)
 
 ## Getting Started
 

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -333,7 +333,8 @@ def add_finding_tests_to_suite(suite, jira=False, github=False):
 
     suite.addTest(FindingTest('test_import_scan_result'))
     suite.addTest(FindingTest('test_delete_finding'))
-    suite.addTest(FindingTest('test_delete_finding_template'))
+    # skip because it is failing in chrome 83 (but working in chrome 81 and earlier), only on 1.6.0 release branch to get the release out.
+    # suite.addTest(FindingTest('test_delete_finding_template'))
     suite.addTest(ProductTest('test_delete_product'))
     return suite
 


### PR DESCRIPTION
I thought we already did this, but it seems `dev` is still/again 80+ commits behind `master`. This shouldn't happen with Git Flow, but maybe we need one more merge like this to get a clean start from now on.