### PR TITLE
False positive history: Recognized false positives marked as verified

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -73,7 +73,7 @@ def sync_false_history(new_finding, *args, **kwargs):
     if total_findings.count() > 0:
         new_finding.false_p = True
         new_finding.active = False
-        new_finding.verified = False
+        new_finding.verified = True
         super(Finding, new_finding).save(*args, **kwargs)
 
 


### PR DESCRIPTION
This change makes sure that if a finding has been seen before, the history will be marked as verified.