### PR TITLE
docker-compose: add REMOTE_USER header authentication support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - uwsgi
     environment: 
       NGINX_METRICS_ENABLED: ${NGINX_METRICS_ENABLED:-false}
+      NGINX_ACTIVATE_REMOTE_USER_AUTHENTICATION: 'False'
+      # header name in the request arriving to nginx server containing the remote user name.
+      # Low-case only and "-" replaced by "_". Starting with "x_" by convention. For "x-my-header" for example:
+      NGINX_REMOTE_USER_HEADER: 'x_my_header'
     ports:
       - target: ${DD_PORT:-8080}
         published: ${DD_PORT:-8080}
@@ -36,6 +40,7 @@ services:
       DD_CELERY_BROKER_PASSWORD: ${DD_CELERY_BROKER_USER:-guest}
       DD_SECRET_KEY: ${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}
       DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}
+      DD_ACTIVATE_REMOTE_USER_AUTHENTICATION: 'False'
   celerybeat:
     image: defectdojo/defectdojo-django:latest
     depends_on:

--- a/docker/entrypoint-nginx.sh
+++ b/docker/entrypoint-nginx.sh
@@ -32,6 +32,14 @@ else
   echo "Basic auth is off (HTTP_AUTH_PASSWORD not provided)"
 fi
 
+
+# Activate remote user authentication at nginx level
+if [ "${NGINX_ACTIVATE_REMOTE_USER_AUTHENTICATION}" = "True" -a "${NGINX_REMOTE_USER_HEADER}" != "" ]; then
+  echo "Activating REMOTE_USER : the user name contained in ${NGINX_REMOTE_USER_HEADER} header will be automatically authenticated"
+  sed -i "s/#uwsgi_param  REMOTE_USER/uwsgi_param  REMOTE_USER/g;" /etc/nginx/wsgi_params
+  sed -i "s/<NGINX_REMOTE_USER_HEADER>/${NGINX_REMOTE_USER_HEADER}/g;" /etc/nginx/wsgi_params
+fi
+
 echo "uwsgi_pass ${DD_UWSGI_PASS};" > /run/uwsgi_pass
 echo "server ${DD_UWSGI_HOST}:${DD_UWSGI_PORT};" > /run/uwsgi_server
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -96,6 +96,7 @@ env = environ.Env(
     # merging findings doesn't always work well with dedupe and reimport etc.
     # disable it if you see any issues (and report them on github)
     DD_DISABLE_FINDING_MERGE=(bool, False),
+    DD_ACTIVATE_REMOTE_USER_AUTHENTICATION=(bool, False),
 )
 
 
@@ -523,6 +524,13 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'watson.middleware.SearchContextMiddleware',
     'auditlog.middleware.AuditlogMiddleware',
 ]
+
+# If remote user authentication is allowed, insert this middleware after AuthenticationMiddleware
+# Ref: https://docs.djangoproject.com/en/2.2/howto/auth-remote-user/
+if env('DD_ACTIVATE_REMOTE_USER_AUTHENTICATION'):
+    DJANGO_MIDDLEWARE_CLASSES.insert(
+        DJANGO_MIDDLEWARE_CLASSES.index('django.contrib.auth.middleware.AuthenticationMiddleware') + 1,
+        'django.contrib.auth.middleware.RemoteUserMiddleware')
 
 MIDDLEWARE = DJANGO_MIDDLEWARE_CLASSES
 

--- a/wsgi_params
+++ b/wsgi_params
@@ -14,3 +14,7 @@ uwsgi_param  REMOTE_ADDR        $remote_addr;
 uwsgi_param  REMOTE_PORT        $remote_port;
 uwsgi_param  SERVER_PORT        $server_port;
 uwsgi_param  SERVER_NAME        $server_name;
+
+# do no edit the following line, instead set the environment  
+# variables NGINX_ACTIVATE_REMOTE_USER_AUTHENTICATION and NGINX_REMOTE_USER_HEADER
+#uwsgi_param  REMOTE_USER        $http_<NGINX_REMOTE_USER_HEADER>;


### PR DESCRIPTION
This makes it possible to log in using the django "remote_user" feature. Useful for some single sign on systems

Ref: https://docs.djangoproject.com/fr/2.2/howto/auth-remote-user/

By default it's disabled.

To log in, the user needs to set a configurable header with the wanted username in order to be logged in the application with that user. 
Nginx will pass-on this configurable header to uwsgi, translating it to the appropriate header that uwsgi needs. 
Obviously this should be activated only in a controlled network environment, with a reverse proxy controlling this header based on any other authentication system handled outside of defectdojo (ldap for example).
Example: 
- the reverse proxy sets x-my-header=admin when calling defectdojo's nginx
- nginx sets REMOTE_USER=admin when calling uwsgi
- uwsgi automatically authenticate the user as "admin" (no password needed). Works with any user existing in the database


Usage: 
- docker-compose.yml (or .env orverrides): 
  - set `NGINX_ACTIVATE_REMOTE_USER_AUTHENTICATION=True` so that nginx does the header translation
  - Configure `NGINX_REMOTE_USER_HEADER` to the name of the header that you want to use when entering into nginx
  - set `DD_ACTIVATE_REMOTE_USER_AUTHENTICATION=True` so that uwsgi accepts remote_user authentication