### PR TITLE
fix version numbers missed in 1.6.1

### DIFF
--- a/dojo/__init__.py
+++ b/dojo/__init__.py
@@ -4,7 +4,7 @@
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app  # noqa
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'
 __url__ = 'https://github.com/DefectDojo/django-DefectDojo'
 __docs__ = 'http://defectdojo.readthedocs.io/'
 __demo__ = 'http://defectdojo.pythonanywhere.com/'

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='DefectDojo',
-    version='1.5.4',
+    version='1.6.2',
     author='Greg Anderson',
     description="Tool for managing vulnerability engagements",
     install_requires=[


### PR DESCRIPTION
When releasing `1.6.1`, version numbers were not updated. The version number in `setup.py` wasn't updated since `1.5.4`.