### PR TITLE
Fix JIRA webhook event type compares

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -34,7 +34,7 @@ def webhook(request):
 
     if request.method == 'POST':
         parsed = json.loads(request.body.decode('utf-8'))
-        if parsed['webhookEvent'] == 'jira:issue_updated':
+        if parsed.get('webhookEvent') == 'jira:issue_updated':
             jid = parsed['issue']['id']
             jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
             if jissue.finding is not None:
@@ -89,7 +89,7 @@ def webhook(request):
                     eng.status = 'Completed'
                     eng.save()
            """
-        if parsed['webhookEvent'] == 'comment_created':
+        if parsed.get('webhookEvent') == 'comment_created':
             comment_text = parsed['comment']['body']
             commentor = parsed['comment']['updateAuthor']['displayName']
             jid = parsed['comment']['self'].split('/')[7]
@@ -103,8 +103,8 @@ def webhook(request):
             finding.jira_change = timezone.now()
             finding.save()
 
-        if parsed['webhookEvent'] not in ['comment_created', 'jira:issue_updated']:
-            logger.info('Unrecognized JIRA webhook event recieved: {}'.format(parsed['webhookEvent']))
+        if parsed.get('webhookEvent') not in ['comment_created', 'jira:issue_updated']:
+            logger.info('Unrecognized JIRA webhook event received: {}'.format(parsed.get('webhookEvent')))
     return HttpResponse('')
 
 

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -34,7 +34,7 @@ def webhook(request):
 
     if request.method == 'POST':
         parsed = json.loads(request.body.decode('utf-8'))
-        if 'issue' in list(parsed.keys()):
+        if parsed['webhookEvent'] == 'jira:issue_updated':
             jid = parsed['issue']['id']
             jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
             if jissue.finding is not None:
@@ -89,7 +89,7 @@ def webhook(request):
                     eng.status = 'Completed'
                     eng.save()
            """
-        else:
+        if parsed['webhookEvent'] == 'comment_created':
             comment_text = parsed['comment']['body']
             commentor = parsed['comment']['updateAuthor']['displayName']
             jid = parsed['comment']['self'].split('/')[7]
@@ -102,6 +102,9 @@ def webhook(request):
             finding.notes.add(new_note)
             finding.jira_change = timezone.now()
             finding.save()
+
+        if parsed['webhookEvent'] not in ['comment_created', 'jira:issue_updated']:
+            logger.info('Unrecognized JIRA webhook event recieved: {}'.format(parsed['webhookEvent']))
     return HttpResponse('')
 
 


### PR DESCRIPTION
This is a fix for bug 2501.

The current version version fo DDJ uses the existence of an "issue" key in the JIRA webhook to determine if a webhook request is an update to the state of the ticket or a new comment.  The current version of JIRA may include an "issue" key for comment update.  This breaks the current classification method.  

https://developer.atlassian.com/server/jira/platform/webhooks/#executing-a-webhook

JIRA provides a key-value ("webhookEvent") to determine the type of message that is being sent.  

This template is for your information. Please clear everything when submitting your pull request.

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ X] Your code is flake8 compliant.
- [ X] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.


Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- performance
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
- New Migration

# Git Tips
## Rebase on dev branch
If the dev branch has changed since you started working on it, please rebase your work after the current dev.

On your working branch `mybranch`:
```
git rebase dev mybranch
```
In case of conflict:
```
 git mergetool
 git rebase --continue
 ```

When everything's fine on your local branch, force push to your `myOrigin` remote: 
```
git push myOrigin --force-with-lease
```

To cancel everything: 
```
git rebase --abort
```


## Squashing commits
```
git rebase -i origin/dev
```
- Replace `pick` by `fixup` on the commits you want squashed out
- Replace `pick` by `reword` on the first commit if you want to change the commit message
- Save the file and quit your editor

Force push to your `myOrigin` remote: 
```
git push myOrigin --force-with-lease
```
