### PR TITLE
k8s: Add hint about preventing gateway timeouts

### DIFF
--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -69,6 +69,9 @@ django:
     annotations:
       # Restricts the type of ingress controller that can interact with our chart (nginx, traefik, ...)
       #kubernetes.io/ingress.class: nginx
+      # Depending on the size and complexity of your scans, you might want to increase the default ingress timeouts if you see repeated 504 Gateway Timeouts
+      #nginx.ingress.kubernetes.io/proxy-read-timeout: "1800"
+      #nginx.ingress.kubernetes.io/proxy-send-timeout: "1800"
   nginx:
     tls:
       enabled: false


### PR DESCRIPTION
This PR adds a hint to the helm `values.yaml` about how to fix Gateway Timeouts that frequently happened in our setup during dependency-scan uploads with a default nginx-ingress configuration.

Labels:
enhancement