### PR TITLE
In Helm added   secret for replication

### DIFF
--- a/helm/defectdojo/templates/secret-postgresql.yaml
+++ b/helm/defectdojo/templates/secret-postgresql.yaml
@@ -14,6 +14,8 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
-  postgresql-password : {{ randAlphaNum 10 | b64enc | quote }}
-
+  postgresql-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ if .Values.postgresql.replication.enabled -}}
+  postgresql-replication-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ end }}
 {{- end }}


### PR DESCRIPTION
In helm definition secret for postgresql replication has been missing.

