### PR TITLE
hotfix: do not reopen false positives and out_of_scope

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -291,7 +291,7 @@ def set_duplicate(new_finding, existing_finding):
     if existing_finding.id == new_finding.id:
         raise Exception("Can not add duplicate to itself")
     deduplicationLogger.debug('New finding ' + str(new_finding.id) + ' is a duplicate of existing finding ' + str(existing_finding.id))
-    if (existing_finding.is_Mitigated or existing_finding.mitigated) and new_finding.active and not new_finding.is_Mitigated:
+    if (existing_finding.is_Mitigated or existing_finding.mitigated) and not existing_finding.out_of_scope and not existing_finding.false_p and new_finding.active and not new_finding.is_Mitigated:
         existing_finding.mitigated = new_finding.mitigated
         existing_finding.is_Mitigated = new_finding.is_Mitigated
         existing_finding.active = new_finding.active


### PR DESCRIPTION
see https://github.com/DefectDojo/django-DefectDojo/issues/2525

I have tested the fix locally.

From my point of view, this needs to be a hotfix and 1.6.3. should be released. I will wait one day and in case there is not release, I will build and deploy my own dd version with this fix (this is something I would not expect for a bug like this).