### PR TITLE
setup.bash: print message when user selects unsupported database scen…

### DIFF
--- a/setup/scripts/common/prompt.sh
+++ b/setup/scripts/common/prompt.sh
@@ -329,6 +329,21 @@ prompt_for_config_vals() {
 		esac
     done
 
+	# Sanity check answers, and exit if DB does not yet exist and DBTYPE is no mysql
+	if [ ! "$DB_TYPE" = "MySQL" ] && [ "$DB_EXISTS" = false ]; then
+	    echo ""
+		echo "##############################################################################"
+		echo "#  AN ERROR HAS OCCURED                                                      #"
+		echo "##############################################################################"
+	    echo ""
+		echo "  You answered that the $DB_TYPE doesn't already exist"
+	    echo "  This installer currently can only create MySQL database."
+	    echo "  Please create a database manually and re-run this installer"
+	    echo "  Exiting..."
+	    echo ""
+	    exit 1
+	fi
+
 	# Sanity check answers, and exit if DB is remote and doesn't exists aka beyond the scope of this installer
 	# Case 1: Remote database + database doesn't exist
 	if [ "$DB_LOCAL" = false ] && [ "$DB_EXISTS" = false ]; then

--- a/setup/scripts/common/prompt.sh
+++ b/setup/scripts/common/prompt.sh
@@ -329,7 +329,7 @@ prompt_for_config_vals() {
 		esac
     done
 
-	# Sanity check answers, and exit if DB does not yet exist and DBTYPE is no mysql
+	# Sanity check answers, and exit if DB does not yet exist and DBTYPE is not mysql
 	if [ ! "$DB_TYPE" = "MySQL" ] && [ "$DB_EXISTS" = false ]; then
 	    echo ""
 		echo "##############################################################################"
@@ -337,7 +337,7 @@ prompt_for_config_vals() {
 		echo "##############################################################################"
 	    echo ""
 		echo "  You answered that the $DB_TYPE doesn't already exist"
-	    echo "  This installer currently can only create MySQL database."
+	    echo "  This installer currently can only create MySQL databases."
 	    echo "  Please create a database manually and re-run this installer"
 	    echo "  Exiting..."
 	    echo ""


### PR DESCRIPTION
setup.bash currently only can create mysql databases. if the user selects a different scenario, a clear error message is now printed.

so sqlite and postgres databases have to be created by the user manually before starting the installer.
fixes #2372, or at least warns the user.