### PR TITLE
Disable XXE when parsing Qualys reports

### DIFF
--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -229,7 +229,7 @@ def issue_r(raw_row, vuln):
 
 
 def qualys_parser(qualys_xml_file):
-    parser = etree.XMLParser(remove_blank_text=True, no_network=True, recover=True)
+    parser = etree.XMLParser(resolve_entities=False, remove_blank_text=True, no_network=True, recover=True)
     d = etree.parse(qualys_xml_file, parser)
     r = d.xpath('//ASSET_DATA_REPORT/HOST_LIST/HOST')
     master_list = []

--- a/dojo/tools/qualys_webapp/parser.py
+++ b/dojo/tools/qualys_webapp/parser.py
@@ -140,7 +140,7 @@ def issue_r(raw_row, vuln, test, issueType):
 
 
 def qualys_webapp_parser(qualys_xml_file, test):
-    parser = etree.XMLParser(remove_blank_text=True, no_network=True, recover=True)
+    parser = etree.XMLParser(resolve_entities=False, remove_blank_text=True, no_network=True, recover=True)
     d = etree.parse(qualys_xml_file, parser)
 
     right = d.xpath('/WAS_WEBAPP_REPORT/RESULTS/WEB_APPLICATION/VULNERABILITY_LIST/VULNERABILITY')


### PR DESCRIPTION
As discussed on H1,
this PR disable XXE when parsing Qualys reports.

PS: this vulnerability was automatically found by [SonarQube](https://www.sonarqube.org/)/[SonarCloud](https://sonarcloud.io/)/[SonarLint](https://www.sonarlint.org/) products during our work to improve [XXE vulnerabilities detection](https://jira.sonarsource.com/browse/RSPEC-2755) for Python.

Eric
