### PR TITLE
mentioning a user: fix notifications

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1638,21 +1638,24 @@ def send_review_email(request, user, finding, users, new_note):
 
 def process_notifications(request, note, parent_url, parent_title):
     regex = re.compile(r'(?:\A|\s)@(\w+)\b')
+
     usernames_to_check = set([un.lower() for un in regex.findall(note.entry)])
+
     users_to_notify = [
         User.objects.filter(username=username).get()
         for username in usernames_to_check
         if User.objects.filter(is_active=True, username=username).exists()
     ]  # is_staff also?
-    user_posting = request.user
+
     if len(note.entry) > 200:
         note.entry = note.entry[:200]
         note.entry += "..."
+
     create_notification(
         event='user_mentioned',
         section=parent_title,
         note=note,
-        user=request.user,
+        initiator=request.user,
         title='%s jotted a note' % request.user,
         url=parent_url,
         icon='commenting',


### PR DESCRIPTION
fixes #2564

- change exotic use of `user` into `initiator` when sending notifications for mentioning a user
- don't send notifications to all admins if specific recipients are selected
- fix notification settings handling for users that are mentioned