### PR TITLE
Added pwgen to install_os_dependencies for all platforms.

### DIFF
--- a/setup/scripts/common/dojo-shared-resources.sh
+++ b/setup/scripts/common/dojo-shared-resources.sh
@@ -381,7 +381,7 @@ function install_os_dependencies() {
         sudo yum install -y wget epel-release
         curl -sL https://rpm.nodesource.com/setup | sudo bash -
         sudo wget https://dl.yarnpkg.com/rpm/yarn.repo -O /etc/yum.repos.d/yarn.repo
-        sudo yum install gcc python-devel python-setuptools python-pip nodejs yarn wkhtmltopdf expect
+        sudo yum install gcc python-devel python-setuptools python-pip nodejs yarn wkhtmltopdf expect pwgen
         sudo yum groupinstall 'Development Tools'
     elif [[ ! -z "$APT_GET_CMD" ]]; then
         if [ "$AUTO_DOCKER" == "yes" ]; then
@@ -394,10 +394,10 @@ function install_os_dependencies() {
         #Node
         curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash
 
-        sudo apt-get install -y apt-transport-https libjpeg-dev gcc libssl-dev python-dev python-pip nodejs yarn wkhtmltopdf build-essential
+        sudo apt-get install -y apt-transport-https libjpeg-dev gcc libssl-dev python-dev python-pip nodejs yarn wkhtmltopdf build-essential pwgen
 
     elif [[ ! -z "$BREW_CMD" ]]; then
-        brew install gcc openssl python node npm yarn Caskroom/cask/wkhtmltopdf expect
+        brew install gcc openssl python node npm yarn Caskroom/cask/wkhtmltopdf expect pwgen
     else
         echo "ERROR! OS not supported, please try Docker. https://hub.docker.com/r/appsecpipeline/django-defectdojo/"
         exit 1;

--- a/setup/scripts/common/dojo-shared-resources.sh
+++ b/setup/scripts/common/dojo-shared-resources.sh
@@ -423,7 +423,7 @@ function install_db() {
         if [ "$DBTYPE" == $MYSQL ]; then
             echo "Installing MySQL client (and server if not already installed)"
             if [ "$AUTO_DOCKER" == "yes" ]; then
-              DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server pwgen libmysqlclient-dev
+              DEBIAN_FRONTEND=noninteractive apt-get install -y mysql-server libmysqlclient-dev
               sudo service mysql start
             else
               sudo apt-get install -y libmysqlclient-dev mysql-server


### PR DESCRIPTION
Previously, it was installed in install_db, but only for Docker installations. Moved it into install_os_dependencies.

Now, it installs for all supported platforms.

fixes#2500