### PR TITLE
integration tests: grep celery work logs for ERRORs

### DIFF
--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -44,7 +44,7 @@ function mark_failed_celery() {
 
 function success() {
     echo "Grepping celery logs for errors:"
-    docker-compose logs --tail="all" celeryworker | grep -A 12 " ERROR" && mark_failed_celery()
+    docker-compose logs --tail="all" celeryworker | grep -A 12 " ERROR" && mark_failed_celery
     echo "Success: $1 test passed\n"
 }
 

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -35,9 +35,15 @@ function fail() {
     exit 1    
 }
 
+failures=false
+function mark_failed() {
+    # can be used to mark the build as failed, but still continue to see what the rest of the test suite does
+    failures=true
+}
+
 function success() {
     echo "Grepping celery logs for errors:"
-    docker-compose logs --tail="all" celeryworker | grep -A 12 " ERROR" && exit 1
+    docker-compose logs --tail="all" celeryworker | grep -A 12 " ERROR" && mark_failed()
     echo "Success: $1 test passed\n"
 }
 
@@ -162,5 +168,10 @@ fi
 # else
 #     echo "Error: Zap integration test failed"; exit 1
 # fi
+
+if [ $failures = true ] ; then
+    echo "there were failures, for example ERRORs found in the celery worker logs"
+    exit 1
+fi
 
 exec echo "Done Running all configured integration tests."

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -37,7 +37,7 @@ function fail() {
 
 function success() {
     echo "Grepping celery logs for errors:"
-    docker-compose logs --tail="all" celeryworker | grep " ERROR" && exit 1
+    docker-compose logs --tail="all" celeryworker | grep -A 12 " ERROR" && exit 1
     echo "Success: $1 test passed\n"
 }
 

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -36,6 +36,8 @@ function fail() {
 }
 
 function success() {
+    echo "Grepping celery logs for errors:"
+    docker-compose logs --tail="all" celeryworker | grep " ERROR" && exit 1
     echo "Success: $1 test passed\n"
 }
 

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -29,21 +29,22 @@ echo "export DD_ADMIN_USER=admin" >> ~/.profile && \
 
 export DD_BASE_URL='http://localhost:8080/'
 
+test_failures=false
 function fail() {
     echo "Error: $1 test failed\n"
     docker-compose logs --tail="120" uwsgi
-    exit 1    
+    test_failures=true
 }
 
-failures=false
-function mark_failed() {
+celery_failures=false
+function mark_failed_celery() {
     # can be used to mark the build as failed, but still continue to see what the rest of the test suite does
-    failures=true
+    celery_failures=true
 }
 
 function success() {
     echo "Grepping celery logs for errors:"
-    docker-compose logs --tail="all" celeryworker | grep -A 12 " ERROR" && mark_failed()
+    docker-compose logs --tail="all" celeryworker | grep -A 12 " ERROR" && mark_failed_celery()
     echo "Success: $1 test passed\n"
 }
 
@@ -169,8 +170,13 @@ fi
 #     echo "Error: Zap integration test failed"; exit 1
 # fi
 
-if [ $failures = true ] ; then
-    echo "there were failures, for example ERRORs found in the celery worker logs"
+if [ $test_failures = true ] ; then
+    echo "there ERRORs found in the celery worker logs, see above"
+    exit 1
+fi
+
+if [ $celery_failures = true ] ; then
+    echo "there ERRORs found in the celery worker logs, see above"
     exit 1
 fi
 


### PR DESCRIPTION
Sometimes erros occur in the celery worker but our current tests suite doesn't see these and ignores them. This could make the travis builds be "false positively green". This PR checks the celery worker logs for ERRORs after each integration test, and fails if ERRORs are found.

This PR will also make sure the tests keep running even if one of them fails. This allows for a complete overview of all failures in 1 travis run instead of needing multiple runs if there are multiple issues.