### PR TITLE
travis: merge docker step with integration tests step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
   matrix:
     - TEST=flake8
-    - TEST=integration_tests
-    - TEST=docker
+    - TEST=docker_integration_tests
     - BROKER=rabbitmq DATABASE=mysql
     - BROKER=rabbitmq DATABASE=postgresql
     - BROKER=redis DATABASE=mysql

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -147,8 +147,6 @@ class BaseTestCase(unittest.TestCase):
         return len(elems) > 0
 
     def change_system_setting(self, id, enable=True):
-        # we set the admin user (ourselves) to have block_execution checked
-        # this will force dedupe to happen synchronously as the celeryworker is not reliable in travis
         print("changing system setting " + id + " enable: " + str(enable))
         driver = self.login_page()
         driver.get(self.base_url + 'system_settings')
@@ -176,10 +174,6 @@ class BaseTestCase(unittest.TestCase):
 
     def disable_system_setting(self, id):
         return self.change_system_setting(id, enable=False)
-
-    # def enable_block_execution(self):
-    # won't work, is on user profile instead of system settings
-    #     return self.enable_system_setting('id_block_execution')
 
     def enable_jira(self):
         return self.enable_system_setting('id_enable_jira')

--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -446,7 +446,6 @@ class DedupeTest(BaseTestCase):
 def add_dedupe_tests_to_suite(suite):
     suite.addTest(ProductTest('test_create_product'))
     suite.addTest(DedupeTest('test_enable_deduplication'))
-    # suite.addTest(DedupeTest('test_enable_block_execution'))
     # Test same scanners - same engagement - static - dedupe
     suite.addTest(DedupeTest('test_delete_findings'))
     suite.addTest(DedupeTest('test_add_path_test_suite'))

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -216,9 +216,6 @@ echo "Running test ${TEST}"
       docker-compose -f docker-compose.yml ps
 
       echo "run integration_test scripts"
-      # wait for containers to start from images and services to become available
-      sleep 100 # giving long enough time
-
       source ./travis/integration_test-script.sh
       ;;
     snyk)

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -189,9 +189,17 @@ echo "Running test ${TEST}"
           echo "Skipping because not on dev branch"
       fi
       ;;
-    docker)
+    docker_integration_tests)
       echo "Validating docker compose"
-      build_containers
+      # change user id withn Docker container to user id of travis user
+      sed -i -e "s/USER\ 1001/USER\ `id -u`/g" ./Dockerfile.django
+      cp ./dojo/settings/settings.dist.py ./dojo/settings/settings.py
+      # incase of failure and you need to debug
+      # change the 'release' mode to 'dev' mode in order to activate debug=True
+      # make sure you remember to change back to 'release' before making a PR
+      source ./docker/setEnv.sh release
+      docker-compose build
+
       docker-compose up -d
       echo "Waiting for services to start"
       # Wait for services to become available
@@ -206,20 +214,8 @@ echo "Running test ${TEST}"
       fi
       echo "Docker compose container status"
       docker-compose -f docker-compose.yml ps
-      ;;
-    integration_tests)
-      echo "run integration_test scripts"
-      # change user id withn Docker container to user id of travis user
-      sed -i -e "s/USER\ 1001/USER\ `id -u`/g" ./Dockerfile.django
-      cp ./dojo/settings/settings.dist.py ./dojo/settings/settings.py
-      # incase of failure and you need to debug
-      # change the 'release' mode to 'dev' mode in order to activate debug=True
-      # make sure you remember to change back to 'release' before making a PR
-      source ./docker/setEnv.sh release
-      docker-compose build
 
-      echo "Waiting for services to start"
-      docker-compose up -d
+      echo "run integration_test scripts"
       # wait for containers to start from images and services to become available
       sleep 100 # giving long enough time
 


### PR DESCRIPTION
Currently there are 2 travis steps doing almost exactly the same:

`docker` | `integration tests`
---------|--------------------
build containers | build containers
start containers | start containers
check if defect dojo is running | check if defect dojo is running
_ | perform integration test suite 

This PR merges these 2 steps to make it more efficient and not burn too many trees with our testsuite.

I noticed there are two ways to build the containers right now in the travis scripts, but since we're moving away from travis I didn't want to spend time there to see which one is best.