### PR TITLE
Change encoding from utf-8 to utf-8-sig

### DIFF
--- a/dojo/tools/netsparker/parser.py
+++ b/dojo/tools/netsparker/parser.py
@@ -19,7 +19,7 @@ class NetsparkerParser(object):
     def __init__(self, filename, test):
         tree = filename.read()
         try:
-            data = json.loads(str(tree, 'utf-8'))
+            data = json.loads(str(tree, 'utf-8-sig'))
         except:
             data = json.loads(tree)
         dupes = dict()


### PR DESCRIPTION
To fix error on unexpected BOM in vulnerabilities json exported from Netsparker 5.8

uwsgi_1         | the JSON object must be str, not 'bytes'
uwsgi_1         | Traceback (most recent call last):
uwsgi_1         |   File "./dojo/tools/netsparker/parser.py", line 22, in __init__
uwsgi_1         |     data = json.loads(str(tree, 'utf-8'))
uwsgi_1         |   File "/usr/local/lib/python3.5/json/__init__.py", line 315, in loads
uwsgi_1         |     s, 0)
uwsgi_1         | json.decoder.JSONDecodeError: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)
uwsgi_1         |
uwsgi_1         | During handling of the above exception, another exception occurred:
uwsgi_1         |
uwsgi_1         | Traceback (most recent call last):
uwsgi_1         |   File "./dojo/engagement/views.py", line 583, in import_scan_results
uwsgi_1         |     parser = import_parser_factory(file, t, active, verified)
uwsgi_1         |   File "./dojo/tools/factory.py", line 164, in import_parser_factory
uwsgi_1         |     parser = NetsparkerParser(file, test)
uwsgi_1         |   File "./dojo/tools/netsparker/parser.py", line 24, in __init__
uwsgi_1         |     data = json.loads(tree)
uwsgi_1         |   File "/usr/local/lib/python3.5/json/__init__.py", line 312, in loads
uwsgi_1         |     s.__class__.__name__))
uwsgi_1         | TypeError: the JSON object must be str, not 'bytes'
uwsgi_1         | Error in parser: the JSON object must be str, not 'bytes'

This template is for your information. Please clear everything when submitting your pull request.

**Note: DefectDojo is now on Python3.5 and Django 2.2.x Please submit your pull requests to the 'dev' branch as the 'legacy-python2.7' branch is only for bug fixes. Any new features submitted to the legacy branch will be ignored and closed.**

When submitting a pull request, please make sure you have completed the following checklist:

- [ ] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.


Current accepted labels for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- performance
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
- New Migration

# Git Tips
## Rebase on dev branch
If the dev branch has changed since you started working on it, please rebase your work after the current dev.

On your working branch `mybranch`:
```
git rebase dev mybranch
```
In case of conflict:
```
 git mergetool
 git rebase --continue
 ```

When everything's fine on your local branch, force push to your `myOrigin` remote: 
```
git push myOrigin --force-with-lease
```

To cancel everything: 
```
git rebase --abort
```


## Squashing commits
```
git rebase -i origin/dev
```
- Replace `pick` by `fixup` on the commits you want squashed out
- Replace `pick` by `reword` on the first commit if you want to change the commit message
- Save the file and quit your editor

Force push to your `myOrigin` remote: 
```
git push myOrigin --force-with-lease
```
