### PR TITLE
API V2: add the possibility to filter by "is_Mitigated" status

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -170,7 +170,7 @@ class FindingViewSet(mixins.ListModelMixin,
     queryset = Finding.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'title', 'date', 'severity', 'description',
-                     'mitigated', 'endpoints', 'test', 'active', 'verified',
+                     'mitigated', 'is_Mitigated', 'endpoints', 'test', 'active', 'verified',
                      'false_p', 'reporter', 'url', 'out_of_scope',
                      'duplicate', 'test__engagement__product',
                      'test__engagement', 'unique_id_from_tool')


### PR DESCRIPTION
This makes it possible to filter the /findings APIv2 endpoint by `is_Mitigated` status. 
This will output only findings that are not "mitigated": 
`&is_Mitigated=0`

I have left the `mitigated` filter just in case, altough it's probably a typo (it's the date of mitigation, not the mitigated status) . 
