### PR TITLE
Add SAML2 support

### DIFF
--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -9,7 +9,8 @@ def globalize_oauth_vars(request):
             'GOOGLE_ENABLED': settings.GOOGLE_OAUTH_ENABLED,
             'OKTA_ENABLED': settings.OKTA_OAUTH_ENABLED,
             'GITLAB_ENABLED': settings.GITLAB_OAUTH2_ENABLED,
-            'AZUREAD_TENANT_OAUTH2_ENABLED': settings.AZUREAD_TENANT_OAUTH2_ENABLED}
+            'AZUREAD_TENANT_OAUTH2_ENABLED': settings.AZUREAD_TENANT_OAUTH2_ENABLED,
+            'SAML2_ENABLED': settings.SAML2_ENABLED, }
 
 
 def bind_system_settings(request):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -94,6 +94,28 @@ env = environ.Env(
     DD_SOCIAL_AUTH_GITLAB_API_URL=(str, 'https://gitlab.com'),
     DD_SOCIAL_AUTH_GITLAB_SCOPE=(list, ['api', 'read_user', 'openid', 'profile', 'email']),
     DD_SAML2_ENABLED=(bool, False),
+    DD_SAML2_METADATA_AUTO_CONF_URL=(str, ''),
+    DD_SAML2_METADATA_LOCAL_FILE_PATH=(str, ''),
+    DD_SAML2_ASSERTION_URL=(str, ''),
+    DD_SAML2_ENTITY_ID=(str, ''),
+    DD_SAML2_DEFAULT_NEXT_URL=(str, '/dashboard'),
+    DD_SAML2_NEW_USER_PROFILE=(dict, {
+        # The default group name when a new user logs in
+        'USER_GROUPS': [],
+        # The default active status for new users
+        'ACTIVE_STATUS': True,
+        # The staff status for new users
+        'STAFF_STATUS': False,
+        # The superuser status for new users
+        'SUPERUSER_STATUS': False,
+    }),
+    DD_SAML2_ATTRIBUTES_MAP=(dict, {
+        # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
+        'email': 'Email',
+        'username': 'UserName',
+        'first_name': 'FirstName',
+        'last_name': 'LastName',
+    }),
     # merging findings doesn't always work well with dedupe and reimport etc.
     # disable it if you see any issues (and report them on github)
     DD_DISABLE_FINDING_MERGE=(bool, False),
@@ -333,50 +355,19 @@ SOCIAL_AUTH_AUTH0_SCOPE = env('DD_SOCIAL_AUTH_AUTH0_SCOPE')
 SOCIAL_AUTH_TRAILING_SLASH = env('DD_SOCIAL_AUTH_TRAILING_SLASH')
 
 
-# For configuration and customization options, see django-saml2-auth documentation
+# For more configuration and customization options, see django-saml2-auth documentation
 # https://github.com/fangli/django-saml2-auth
 SAML2_ENABLED = env('DD_SAML2_ENABLED')
 SAML2_AUTH = {
     # Metadata is required, choose either remote url or local file path
-    'METADATA_AUTO_CONF_URL': '[The auto(dynamic) metadata configuration URL of SAML2]',
-    'METADATA_LOCAL_FILE_PATH': '[The metadata configuration file path]',
-
+    'METADATA_AUTO_CONF_URL': env('DD_SAML2_METADATA_AUTO_CONF_URL'),
+    'METADATA_LOCAL_FILE_PATH': env('DD_SAML2_METADATA_LOCAL_FILE_PATH'),
+    'ASSERTION_URL': env('DD_SAML2_ASSERTION_URL'),
+    'ENTITY_ID': env('DD_SAML2_ENTITY_ID'),
     # Optional settings below
-    # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
-    'DEFAULT_NEXT_URL': '/dashboard',
-    # Create a new Django user when a new user logs in. Defaults to True.
-    'CREATE_USER': True,
-    'NEW_USER_PROFILE': {
-        # The default group name when a new user logs in
-        'USER_GROUPS': [],
-        # The default active status for new users
-        'ACTIVE_STATUS': True,
-        # The staff status for new users
-        'STAFF_STATUS': True,
-        # The superuser status for new users
-        'SUPERUSER_STATUS': False,
-    },
-    # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
-    'ATTRIBUTES_MAP': {
-        'email': 'Email',
-        'username': 'UserName',
-        'first_name': 'FirstName',
-        'last_name': 'LastName',
-    },
-    'TRIGGER': {
-        'CREATE_USER': 'path.to.your.new.user.hook.method',
-        'BEFORE_LOGIN': 'path.to.your.login.hook.method',
-    },
-    # Custom URL to validate incoming SAML requests against
-    'ASSERTION_URL': 'https://mysite.com',
-    # Populates the Issuer element in authn request
-    'ENTITY_ID': 'https://mysite.com/saml2/acs/',
-    # Sets the Format property of authn NameIDPolicy element
-    'NAME_ID_FORMAT': None,
-    # Set this to True if you are running a Single Page Application (SPA) with Django Rest Framework (DRF), and are using JWT authentication to authorize client users
-    'USE_JWT': False,
-    # Redirect URL for the client if you are using JWT auth with DRF. See explanation below
-    'FRONTEND_URL': None,
+    'DEFAULT_NEXT_URL': env('DD_SAML2_DEFAULT_NEXT_URL'),
+    'NEW_USER_PROFILE': env('DD_SAML2_NEW_USER_PROFILE'),
+    'ATTRIBUTES_MAP': env('DD_SAML2_ATTRIBUTES_MAP'),
 }
 
 LOGIN_EXEMPT_URLS = (

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -93,6 +93,7 @@ env = environ.Env(
     DD_SOCIAL_AUTH_GITLAB_SECRET=(str, ''),
     DD_SOCIAL_AUTH_GITLAB_API_URL=(str, 'https://gitlab.com'),
     DD_SOCIAL_AUTH_GITLAB_SCOPE=(list, ['api', 'read_user', 'openid', 'profile', 'email']),
+    DD_SAML2_ENABLED=(bool, False),
     # merging findings doesn't always work well with dedupe and reimport etc.
     # disable it if you see any issues (and report them on github)
     DD_DISABLE_FINDING_MERGE=(bool, False),
@@ -331,6 +332,53 @@ SOCIAL_AUTH_AUTH0_DOMAIN = env('DD_SOCIAL_AUTH_AUTH0_DOMAIN')
 SOCIAL_AUTH_AUTH0_SCOPE = env('DD_SOCIAL_AUTH_AUTH0_SCOPE')
 SOCIAL_AUTH_TRAILING_SLASH = env('DD_SOCIAL_AUTH_TRAILING_SLASH')
 
+
+# For configuration and customization options, see django-saml2-auth documentation
+# https://github.com/fangli/django-saml2-auth
+SAML2_ENABLED = env('DD_SAML2_ENABLED')
+SAML2_AUTH = {
+    # Metadata is required, choose either remote url or local file path
+    'METADATA_AUTO_CONF_URL': '[The auto(dynamic) metadata configuration URL of SAML2]',
+    'METADATA_LOCAL_FILE_PATH': '[The metadata configuration file path]',
+
+    # Optional settings below
+    # Custom target redirect URL after the user get logged in. Default to /admin if not set. This setting will be overwritten if you have parameter ?next= specificed in the login URL.
+    'DEFAULT_NEXT_URL': '/dashboard',
+    # Create a new Django user when a new user logs in. Defaults to True.
+    'CREATE_USER': True,
+    'NEW_USER_PROFILE': {
+        # The default group name when a new user logs in
+        'USER_GROUPS': [],
+        # The default active status for new users
+        'ACTIVE_STATUS': True,
+        # The staff status for new users
+        'STAFF_STATUS': True,
+        # The superuser status for new users
+        'SUPERUSER_STATUS': False,
+    },
+    # Change Email/UserName/FirstName/LastName to corresponding SAML2 userprofile attributes.
+    'ATTRIBUTES_MAP': {
+        'email': 'Email',
+        'username': 'UserName',
+        'first_name': 'FirstName',
+        'last_name': 'LastName',
+    },
+    'TRIGGER': {
+        'CREATE_USER': 'path.to.your.new.user.hook.method',
+        'BEFORE_LOGIN': 'path.to.your.login.hook.method',
+    },
+    # Custom URL to validate incoming SAML requests against
+    'ASSERTION_URL': 'https://mysite.com',
+    # Populates the Issuer element in authn request
+    'ENTITY_ID': 'https://mysite.com/saml2/acs/',
+    # Sets the Format property of authn NameIDPolicy element
+    'NAME_ID_FORMAT': None,
+    # Set this to True if you are running a Single Page Application (SPA) with Django Rest Framework (DRF), and are using JWT authentication to authorize client users
+    'USE_JWT': False,
+    # Redirect URL for the client if you are using JWT auth with DRF. See explanation below
+    'FRONTEND_URL': None,
+}
+
 LOGIN_EXEMPT_URLS = (
     r'^%sstatic/' % URL_PREFIX,
     r'^%swebhook/' % URL_PREFIX,
@@ -339,6 +387,8 @@ LOGIN_EXEMPT_URLS = (
     r'^%sfinding/image/(?P<token>[^/]+)$' % URL_PREFIX,
     r'^%sapi/v2/' % URL_PREFIX,
     r'complete/',
+    r'saml2/login',
+    r'saml2/acs',
     r'empty_questionnaire/([\d]+)/answer'
 )
 

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -62,6 +62,14 @@
                         </button>
                     </div>
                 {% endif %}
+
+                {% if SAML2_ENABLED is True %}
+                    <div class="col-sm-offset-1 col-sm-2">
+                        <button class="btn btn-success" type="button">
+                            <a href="/saml2/login" style="color: rgb(255,255,255)">Login with SAML</a>
+                        </button>
+                    </div>
+                {% endif %}
             </div>
         </fieldset>
     </form>

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -10,6 +10,7 @@ from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 from django.http import HttpResponse
+import django_saml2_auth.views
 
 
 from dojo import views
@@ -174,6 +175,13 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
+    # These are the SAML2 related URLs. You can change "^saml2_auth/" regex to
+    # any path you want, like "^sso_auth/", "^sso_login/", etc. (required)
+    url(r'^saml2/', include('django_saml2_auth.urls')),
+    # The following line will replace the default user login with SAML2 (optional)
+    # If you want to specific the after-login-redirect-URL, use parameter "?next=/the/path/you/want"
+    # with this view.
+    url(r'^saml2/login/$', django_saml2_auth.views.signin),
     #  tastypie api
     url(r'^%sapi/' % get_system_setting('url_prefix'), include(v1_api.urls)),
     #  Django Rest Framework API v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ google-api-python-client==1.9.3
 google-auth-oauthlib==0.4.1
 drf_yasg==1.17.1
 jsonlines==1.2.0  # requred by yarn audit parser
+django-saml2-auth==2.2.1


### PR DESCRIPTION
Copy of #2573 due to hastily deletion of old branch.

Adds a plugin that makes SAML2 authentication setup very similar to the OAuth suite currently in place.

[Documentation](https://github.com/DefectDojo/Documentation/pull/102)

- [x] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.