### PR TITLE
Exception preventing in (re)import-scan

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1509,7 +1509,7 @@ class ImportScanResource(MultipartResource, Resource):
         t.tags = bundle.data['tags']
 
         try:
-            parser = import_parser_factory(bundle.data.get('file'), t, bundle.data['active'], bundle.data['verified'],
+            parser = import_parser_factory(bundle.data.get('file', None), t, bundle.data['active'], bundle.data['verified'],
                                            bundle.data['scan_type'])
         except ValueError:
             raise NotFound("Parser ValueError")
@@ -1692,7 +1692,7 @@ class ReImportScanResource(MultipartResource, Resource):
         active = bundle.obj.__getattr__('active')
 
         try:
-            parser = import_parser_factory(bundle.data.get('file'), test, active, verified, scan_type)
+            parser = import_parser_factory(bundle.data.get('file', None), test, active, verified, scan_type)
         except ValueError:
             raise NotFound("Parser ValueError")
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -630,7 +630,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         if 'tags' in data:
             test.tags = ' '.join(data['tags'])
         try:
-            parser = import_parser_factory(data.get('file'),
+            parser = import_parser_factory(data.get('file', None),
                                            test,
                                            active,
                                            verified,
@@ -800,7 +800,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         active = data['active']
 
         try:
-            parser = import_parser_factory(data.get('file'),
+            parser = import_parser_factory(data.get('file', None),
                                            test,
                                            active,
                                            verified,

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -535,7 +535,7 @@ def import_scan_results(request, eid=None, pid=None):
                 engagement.active = True
                 engagement.status = 'In Progress'
                 engagement.save()
-            file = request.FILES.get('file')
+            file = request.FILES.get('file', None)
             scan_date = form.cleaned_data['scan_date']
             min_sev = form.cleaned_data['minimum_severity']
             active = form.cleaned_data['active']

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -630,7 +630,7 @@ def re_import_scan_results(request, tid):
                 scan_date_time = timezone.make_aware(scan_date_time, timezone.get_default_timezone())
 
             min_sev = form.cleaned_data['minimum_severity']
-            file = request.FILES['file']
+            file = request.FILES.get('file', None)
             scan_type = test.test_type.name
             active = form.cleaned_data['active']
             verified = form.cleaned_data['verified']


### PR DESCRIPTION
In an instance when using a scanner that does not require a file, such as the SonarQube API importer, an exception is thrown when trying to retrieve the file from the request. While it does not inhibit the UI, it is still annoying to see in the logs.

```
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]: Internal Server Error: /test/59/re_import_scan_results
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]: Traceback (most recent call last):
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:   File "/opt/dojo/lib/python3.6/site-packages/django/utils/datastructures.py", line 78, in __getitem__
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:     list_ = super().__getitem__(key)
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]: KeyError: 'file'
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]: During handling of the above exception, another exception occurred:
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]: Traceback (most recent call last):
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:   File "/opt/dojo/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:     response = get_response(request)
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:   File "/opt/dojo/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:     response = self.process_exception_by_middleware(e, request)
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:   File "/opt/dojo/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:     response = wrapped_callback(request, *callback_args, **callback_kwargs)
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:   File "/opt/dojo/lib/python3.6/site-packages/django/contrib/auth/decorators.py", line 21, in _wrapped_view
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:     return view_func(request, *args, **kwargs)
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:   File "./dojo/test/views.py", line 624, in re_import_scan_results
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:     file = request.FILES['file']
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:   File "/opt/dojo/lib/python3.6/site-packages/django/utils/datastructures.py", line 80, in __getitem__
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]:     raise MultiValueDictKeyError(key)
Jun 23 23:04:58 ip-172-31-26-104 dojo[13105]: django.utils.datastructures.MultiValueDictKeyError: 'file'
```

- [x] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.