### PR TITLE
Feature/add tool ccvs

### DIFF
--- a/dojo/fixtures/test_type.json
+++ b/dojo/fixtures/test_type.json
@@ -619,5 +619,12 @@
     },
     "model": "dojo.test_type",
       "pk": 180
+	},
+	{
+    "fields": {
+      "name": "CCVS Report"
+    },
+    "model": "dojo.test_type",
+      "pk": 181
 	}
 ]

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -387,7 +387,8 @@ class ImportScanForm(forms.Form):
                          ("Harbor Vulnerability Scan", "Harbor Vulnerability Scan"),
                          ("Yarn Audit Scan", "Yarn Audit Scan"),
                          ("BugCrowd Scan", "BugCrowd Scan"),
-                         ("GitLab SAST Report", "GitLab SAST Report"))
+                         ("GitLab SAST Report", "GitLab SAST Report"),
+                         ("CCVS Report", "CCVS Report"))
 
     SORTED_SCAN_TYPE_CHOICES = sorted(SCAN_TYPE_CHOICES, key=lambda x: x[1])
     scan_date = forms.DateTimeField(

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -49,6 +49,7 @@
 	    response fields. These fields will be processed and made available in the 'Finding View' page.</li>
 	<li><b>Burp Enterprise Scam</b> - Import Burp Enterprise Edition findings in HTML format</li>
 	<li><b>Brakeman Scan</b> - Import Brakeman Scanner findings in JSON format.</li>
+	<li><b>CCVS Report</b> - Import CCVS Report vulnerabilities in JSON format.</li>
 	<li><b>Clair Scan</b> - Import JSON reports of Docker image vulnerabilities.</li>
 	<li><b>Clair Klar Scan</b> -  Import JSON reports of Docker image vulnerabilities from clair klar client.</li>
 	<li><b>Contrast Scanner</b> - CSV Report</b></li>

--- a/dojo/tools/ccvs/parser.py
+++ b/dojo/tools/ccvs/parser.py
@@ -1,0 +1,82 @@
+import json
+import hashlib
+from dojo.models import Finding
+
+
+class CCVSReportParser(object):
+
+    """
+    Read JSON data from CCVS compatible format and import it to DefectDojo
+    """
+
+    def __init__(self, json_output, test):
+        self.items = []
+
+        if json_output is None:
+            return
+
+        tree = self.parse_json(json_output)
+        if tree:
+            self.items = [data for data in self.get_items(tree, test)]
+
+    def parse_json(self, json_output):
+        try:
+            data = json_output.read()
+            try:
+                tree = json.loads(str(data, 'utf-8'))
+            except:
+                tree = json.loads(data)
+        except:
+            raise Exception("Invalid format")
+
+        return tree
+
+    def get_items(self, tree, test):
+        items = {}
+
+        for vendor in tree.get('ccvs_results', {}):
+            vendor_results = tree['ccvs_results'][vendor]
+            for severity in vendor_results:
+                for vuln in vendor_results[severity]:
+                    vuln['vendor'] = vendor
+                    vuln['image_id'] = tree['vendors'][vendor]['image_id']
+                    unique_key = hashlib.md5(
+                        str(vuln).encode('utf-8')).hexdigest()
+                    item = get_item(vuln, test)
+                    items[unique_key] = item
+
+        return list(items.values())
+
+
+def get_item(item_node, test):
+    if item_node['severity'] in ["Negligible", "Unknown"]:
+        item_node['severity'] = 'Info'
+
+    description = "Package: " + item_node['package_name'] + '\n'
+    description += "Version: " + item_node['package_version'] + '\n'
+    description += "Vendor: " + item_node['vendor']
+    mitigation = "Upgrade to " + item_node['package_name'] + \
+        ' ' + str(item_node['fix']) + '\n'
+    references = "URL: " + item_node['url'] + '\n'
+    title = item_node['name'] + ' - ' + item_node['package_name']
+
+    finding = Finding(
+        title=title,
+        test=test,
+        severity=item_node['severity'],
+        description=description,
+        mitigation=mitigation,
+        references=references,
+        active=False,
+        verified=False,
+        false_p=False,
+        duplicate=False,
+        out_of_scope=False,
+        mitigated=None,
+        component_name=item_node['package_name'],
+        component_version=item_node['package_version'],
+        static_finding=True,
+        dynamic_finding=False,
+        impact="No impact provided")
+
+    return finding

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -82,6 +82,7 @@ from dojo.tools.choctaw_hog.parser import ChoctawhogParser
 from dojo.tools.gitlab_sast.parser import GitlabSastReportParser
 from dojo.tools.yarn_audit.parser import YarnAuditParser
 from dojo.tools.bugcrowd.parser import BugCrowdCSVParser
+from dojo.tools.ccvs.parser import CCVSReportParser
 
 
 __author__ = 'Jay Paz'
@@ -265,6 +266,8 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
         parser = YarnAuditParser(file, test)
     elif scan_type == 'BugCrowd Scan':
         parser = BugCrowdCSVParser(file, test)
+    elif scan_type == 'CCVS Report':
+        parser = CCVSReportParser(file, test)
     else:
         raise ValueError('Unknown Test Type')
 

--- a/dojo/unittests/scans/ccvs/many_vulns.json
+++ b/dojo/unittests/scans/ccvs/many_vulns.json
@@ -1,0 +1,184 @@
+{
+    "id": "ff4cc20c-fdd8-4297-bd21-3703daba1bef",
+    "status": "finished",
+    "created_at": "2020-06-23T14:12:44.176922Z",
+    "updated_at": "2020-06-23T14:14:05.899405Z",
+    "image": "docker-image:tag",
+    "vendors": {
+        "anchore_engine": {            
+            "output": "anchore_output",
+            "image_id": "sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        "clair": {
+            "output": "clair_output",
+            "image_id": "sha256_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_yyyyyyyyyyyy"
+        }
+    },
+    "errors": [],
+    "result": "failed",
+    "ccvs_results": {
+        "anchore_engine": {
+            "low_vulns": [
+                {
+                    "fix": "232-25+deb9u7",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2018-16866",
+                    "name": "CVE-2018-16866",
+                    "severity": "Low",
+                    "package_name": "libsystemd0",
+                    "package_version": "232-25+deb9u4"
+                },
+                {
+                    "fix": "232-25+deb9u8",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-3815",
+                    "name": "CVE-2019-3815",
+                    "severity": "Low",
+                    "package_name": "libsystemd0",
+                    "package_version": "232-25+deb9u4"
+                },
+                {
+                    "fix": "232-25+deb9u7",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2018-16866",
+                    "name": "CVE-2018-16866",
+                    "severity": "Low",
+                    "package_name": "libudev1",
+                    "package_version": "232-25+deb9u4"
+                },
+                {
+                    "fix": "232-25+deb9u8",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-3815",
+                    "name": "CVE-2019-3815",
+                    "severity": "Low",
+                    "package_name": "libudev1",
+                    "package_version": "232-25+deb9u4"
+                }
+            ],
+            "high_vulns": [
+                {
+                    "fix": "1.4.9",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-3462",
+                    "name": "CVE-2019-3462",
+                    "severity": "High",
+                    "package_name": "apt",
+                    "package_version": "1.4.8"
+                },
+                {
+                    "fix": "1.4.9",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-3462",
+                    "name": "CVE-2019-3462",
+                    "severity": "High",
+                    "package_name": "libapt-pkg5.0",
+                    "package_version": "1.4.8"
+                }
+            ],
+            "medium_vulns": [
+                {
+                    "fix": "1.4.10",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2020-3810",
+                    "name": "CVE-2020-3810",
+                    "severity": "Medium",
+                    "package_name": "apt",
+                    "package_version": "1.4.8"
+                },
+                {
+                    "fix": "1.43.4-2+deb9u1",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-5094",
+                    "name": "CVE-2019-5094",
+                    "severity": "Medium",
+                    "package_name": "e2fslibs",
+                    "package_version": "1.43.4-2"
+                }
+            ],
+            "negligible_vulns": [
+                {
+                    "fix": "None",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+                    "name": "CVE-2011-3374",
+                    "severity": "Negligible",
+                    "package_name": "apt",
+                    "package_version": "1.4.8"
+                },
+                {
+                    "fix": "None",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2017-18018",
+                    "name": "CVE-2017-18018",
+                    "severity": "Negligible",
+                    "package_name": "coreutils",
+                    "package_version": "8.26-3"
+                },
+                {
+                    "fix": "None",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+                    "name": "CVE-2011-3374",
+                    "severity": "Negligible",
+                    "package_name": "libapt-pkg5.0",
+                    "package_version": "1.4.8"
+                }
+            ]
+        },
+        "clair": {
+            "low_vulns": [
+                {
+                    "fix": null,
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-17543",
+                    "name": "CVE-2019-17543",
+                    "severity": "Low",
+                    "package_name": "lz4",
+                    "package_version": "0.0~r131-2"
+                },
+                {
+                    "fix": null,
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-7665",
+                    "name": "CVE-2019-7665",
+                    "severity": "Low",
+                    "package_name": "elfutils",
+                    "package_version": "0.168-1"
+                }
+            ],
+            "unknown_vulns": [
+                {
+                    "fix": null,
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2020-3810",
+                    "name": "CVE-2020-3810",
+                    "severity": "Unknown",
+                    "package_name": "apt",
+                    "package_version": "1.4.8"
+                },
+                {
+                    "fix": "1.4.9",
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-3462",
+                    "name": "CVE-2019-3462",
+                    "severity": "Unknown",
+                    "package_name": "apt",
+                    "package_version": "1.4.8"
+                }
+            ],
+            "negligible_vulns": [
+                {
+                    "fix": null,
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2011-3374",
+                    "name": "CVE-2011-3374",
+                    "severity": "Negligible",
+                    "package_name": "apt",
+                    "package_version": "1.4.8"
+                },
+                {
+                    "fix": null,
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-7148",
+                    "name": "CVE-2019-7148",
+                    "severity": "Negligible",
+                    "package_name": "elfutils",
+                    "package_version": "0.168-1"
+                },
+                {
+                    "fix": null,
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2019-19882",
+                    "name": "CVE-2019-19882",
+                    "severity": "Negligible",
+                    "package_name": "shadow",
+                    "package_version": "1:4.4-4.1"
+                }
+            ]
+        }
+    },
+    "whitelist": {}
+}

--- a/dojo/unittests/scans/ccvs/no_vuln.json
+++ b/dojo/unittests/scans/ccvs/no_vuln.json
@@ -1,0 +1,24 @@
+{
+    "id": "4ce2f2cc-72a0-4efc-858f-bc9722daaf96",
+    "status": "finished",
+    "created_at": "2020-06-23T14:12:44.176922Z",
+    "updated_at": "2020-06-23T14:14:05.899405Z",
+    "image": "docker-image:tag",
+    "vendors": {
+        "anchore_engine": {            
+            "output": "anchore_output",
+            "image_id": "sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        "clair": {
+            "output": "clair_output",
+            "image_id": "sha256_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_yyyyyyyyyyyy"
+        }
+    },
+    "errors": [],
+    "result": "passed",
+    "ccvs_results": {
+        "anchore_engine": {},
+        "clair": {}
+    },
+    "whitelist": {}
+}

--- a/dojo/unittests/scans/ccvs/one_vuln_one_vendor.json
+++ b/dojo/unittests/scans/ccvs/one_vuln_one_vendor.json
@@ -1,0 +1,35 @@
+{
+    "id": "4ce2f2cc-72a0-4efc-858f-bc9722daaf96",
+    "status": "finished",
+    "created_at": "2020-06-23T14:12:44.176922Z",
+    "updated_at": "2020-06-23T14:14:05.899405Z",
+    "image": "docker-image:tag",
+    "vendors": {
+        "anchore_engine": {            
+            "output": "anchore_output",
+            "image_id": "sha256:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        },
+        "clair": {
+            "output": "clair_output",
+            "image_id": "sha256_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_yyyyyyyyyyyy"
+        }
+    },
+    "errors": [],
+    "result": "failed",
+    "ccvs_results": {
+        "anchore_engine": {},
+        "clair": {
+            "unknown_vulns": [
+                {
+                    "fix": "1.6_rc1-r0",
+                    "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-4074",
+                    "name": "CVE-2016-4074",
+                    "severity": "Unknown",
+                    "package_name": "jq",
+                    "package_version": "1.6-r0"
+                }
+            ]
+        }
+    },
+    "whitelist": {}
+}

--- a/dojo/unittests/test_ccvs_parser.py
+++ b/dojo/unittests/test_ccvs_parser.py
@@ -1,0 +1,22 @@
+from django.test import TestCase
+from dojo.tools.ccvs.parser import CCVSReportParser
+from dojo.models import Test
+
+
+class TestCCVSReportParser(TestCase):
+    def test_ccvs_parser_has_no_finding(self):
+        testfile = open("dojo/unittests/scans/ccvs/no_vuln.json")
+        parser = CCVSReportParser(testfile, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_ccvs_parser_has_one_finding(self):
+        testfile = open("dojo/unittests/scans/ccvs/one_vuln_one_vendor.json")
+        parser = CCVSReportParser(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(parser.items))
+
+    def test_ccvs_parser_has_many_findings(self):
+        testfile = open("dojo/unittests/scans/ccvs/many_vulns.json")
+        parser = CCVSReportParser(testfile, Test())
+        testfile.close()
+        self.assertEqual(18, len(parser.items))


### PR DESCRIPTION
This PR will add CCVS Report as a new scanner/importer

Checklist:
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [X] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [X] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.

Labels for this PR:
- Import Scans (for new scanners/importers)

See additional PRs 
- docs: DefectDojo/Documentation#104  
- samples: DefectDojo/sample-scan-files#56

What is CCVS?
<b>Central Container Vulnerability Scanning</b>, A central API to scan containers images using different vendors. There are multiples tools to scan containers/images. But each one can show different results against the same target. So this project has the goal to use multiples tools and has a complete vision of vulnerabilities

Github: https://github.com/William-Hill-Online/CCVS-API