### PR TITLE
Search by CVE and index extra fields

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3125,7 +3125,9 @@ admin.site.register(Notifications)
 # Watson
 watson.register(Product)
 watson.register(Test)
-watson.register(Finding)
+watson.register(Finding, fields=('id', 'title', 'cve', 'url', 'severity', 'description', 'mitigation', 'impact', 'steps_to_reproduce',
+                                 'severity_justification', 'references', 'sourcefilepath', 'sourcefile', 'hash_code', 'file_path',
+                                 'component_name', 'component_version', 'unique_id_from_tool', ))
 watson.register(Finding_Template)
 watson.register(Endpoint)
 watson.register(Engagement)

--- a/dojo/search/views.py
+++ b/dojo/search/views.py
@@ -8,8 +8,12 @@ from dojo.forms import SimpleSearchForm
 from dojo.models import Finding, Finding_Template, Product, Test, Endpoint, Engagement, Languages, \
     App_Analysis
 from dojo.utils import add_breadcrumb
+import re
 
 logger = logging.getLogger(__name__)
+
+# explicitly use our own regex pattern here as django-watson is sensitive so we want to control it here independently of models.py etc.
+cve_pattern = re.compile(r'(^CVE-(1999|2\d{3})-(0\d{2}[0-9]|[1-9]\d{3,}))$')
 
 
 def simple_search(request):
@@ -43,13 +47,27 @@ def simple_search(request):
             search_operator = ""
             # Check for search operator like finding:, endpoint:, test: product:
             original_clean_query = clean_query
+            # print('clean_query: ', clean_query)
             if ":" in clean_query:
                 operator = clean_query.split(":")
                 search_operator = operator[0]
                 clean_query = operator[1].lstrip()
+
+            # if the query contains hyphens, django-watson will escape these leading to problems.
+            # for cve we make this workaround because we really want to be able to search for CVEs
+            # problem still remains for other case, i.e. searching for "valentijn-scholten" will return no results because of the hyphen.
+            # see:
+            # - https://github.com/etianen/django-watson/issues/223
+            # - https://github.com/DefectDojo/django-DefectDojo/issues/1092
+            # - https://github.com/DefectDojo/django-DefectDojo/issues/2081
+
+            if bool(cve_pattern.match(clean_query)):
+                clean_query = '\'' + clean_query + '\''
+                # print('new clean_query: ', clean_query)
+
             tags = clean_query
             if request.user.is_staff:
-                if "finding" in search_operator or search_operator == "":
+                if "finding" in search_operator or "cve" in search_operator or "id" in search_operator or search_operator == "":
                     findings = watson.search(clean_query, models=(Finding,))
 
                 if "template" in search_operator or search_operator == "":
@@ -88,7 +106,7 @@ def simple_search(request):
                     app_analysis = App_Analysis.objects.filter(name__icontains=clean_query)
 
             else:
-                if "finding" in search_operator or search_operator == "":
+                if "finding" in search_operator or "cve" in search_operator or "id" in search_operator or search_operator == "":
                     findings = watson.search(clean_query, models=(
                         Finding.objects.filter(
                             test__engagement__product__authorized_users__in=[


### PR DESCRIPTION
This PR fixes some issues with the simple search and includes some enhancements:

Fixes:
- Workaround to be able to search for CVE (see #1092 #2081)
- Allow search by finding id (i.e. for those seeing a JIRA issue with a Defect Dojo id in it)

Enhancements:
- Add fields to indexing to allow them to search them:
```
'id', 'title', 'cve', 'url', 'severity', 'description', 'mitigation', 'impact', 'steps_to_reproduce',
                                 'severity_justification', 'references', 'sourcefilepath', 'sourcefile', 'hash_code', 'file_path',
                                 'component_name', 'component_version', 'unique_id_from_tool'
```

Because this PR updates the django-watson config for the `Finding` model, a index rebuild is needed. I thought about adding the rebuild as a migration. But that could lead to seriously long migrations for larger instances.

Please let me know any suggestions on how to handle this. For now I've added some upgrade notes to the docs: https://github.com/DefectDojo/Documentation/pull/107