### PR TITLE
jira issue and endpoints prefetching fixes

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -200,6 +200,7 @@ def prefetch_for_findings(findings):
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
+        prefetched_findings = prefetched_findings.prefetch_related('endpoints')
     else:
         logger.debug('unable to prefetch because query was already executed')
 

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -493,7 +493,7 @@
                         {% if system_settings.enable_jira %}
                             {% if jira_config and product_tab or not product_tab %}
                                 <td>
-                                    <a href="{{finding.jira_conf.url}}/browse/{{finding.jira.jira_key}}" target="_blank"> {{finding.jira.jira_key}} </a>
+                                    <a href="{{finding.jira_conf_new.url}}/browse/{{finding.jira_issue.jira_key}}" target="_blank"> {{finding.jira_issue.jira_key}} </a>
                                 </td>
 
                                 {% if finding.jira_creation %}

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -144,12 +144,16 @@ def prefetch_for_findings(findings):
     prefetched_findings = findings
     if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
         prefetched_findings = prefetched_findings.select_related('reporter')
+        prefetched_findings = prefetched_findings.select_related('jira_issue')
+        prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
+        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
+        prefetched_findings = prefetched_findings.prefetch_related('found_by')
         prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
-        prefetched_findings = prefetched_findings.prefetch_related('endpoints')
-        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
+        prefetched_findings = prefetched_findings.prefetch_related('endpoints')
+
     else:
         logger.debug('unable to prefetch because query was already executed')
 


### PR DESCRIPTION
Fixes #2623 and another missing prefetch when viewing a list of findings with 1 or more endpoints