### PR TITLE
JIRA/github improvements and fixes July 2020

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -40,7 +40,7 @@ from dojo.models import Finding, Notes, NoteHistory, Note_Type, \
 from dojo.utils import get_page_items, add_breadcrumb, FileIterWrapper, process_notifications, \
     add_comment, jira_get_resolution_id, jira_change_resolution_id, get_jira_connection, \
     get_system_setting, apply_cwe_to_template, Product_Tab, calculate_grade, log_jira_alert, \
-    redirect_to_return_url_or_else, get_return_url
+    redirect_to_return_url_or_else, get_return_url, add_issue, update_issue
 from dojo.notifications.helper import create_notification
 
 from dojo.tasks import add_issue_task, update_issue_task, update_external_issue_task, add_comment_task, \
@@ -1787,9 +1787,15 @@ def finding_bulk_update_all(request, pid=None):
                         #     product=finding.test.engagement.product).push_all_issues
                         if form.cleaned_data['push_to_jira'] or push_anyway:
                             if JIRA_Issue.objects.filter(finding=finding).exists():
-                                update_issue_task.delay(finding, True)
+                                if request.user.usercontactinfo.block_execution:
+                                    update_issue(finding, True)
+                                else:
+                                    update_issue_task.delay(finding, True)
                             else:
-                                add_issue_task.delay(finding, True)
+                                if request.user.usercontactinfo.block_execution:
+                                    add_issue(finding, True)
+                                else:
+                                    add_issue_task.delay(finding, True)
 
                 messages.add_message(request,
                                      messages.SUCCESS,

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2042,6 +2042,7 @@ class JIRAFindingForm(forms.Form):
             self.fields['push_to_jira'].widget.attrs['checked'] = 'checked'
             self.fields['push_to_jira'].disabled = True
 
+    # existing_issue = forms.URLField(required=False, disabled=True, label="Existing JIRA issue", help_text = "Existing JIRA issue connected to this Finding")
     push_to_jira = forms.BooleanField(required=False, label="Push to JIRA")
 
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2042,7 +2042,6 @@ class JIRAFindingForm(forms.Form):
             self.fields['push_to_jira'].widget.attrs['checked'] = 'checked'
             self.fields['push_to_jira'].disabled = True
 
-    # existing_issue = forms.URLField(required=False, disabled=True, label="Existing JIRA issue", help_text = "Existing JIRA issue connected to this Finding")
     push_to_jira = forms.BooleanField(required=False, label="Push to JIRA")
 
 

--- a/dojo/github.py
+++ b/dojo/github.py
@@ -118,10 +118,19 @@ def add_external_issue_github(find, prod, eng):
             logger.debug('Look for project: ' + github_product_key.git_project)
             repo = g.get_repo(github_product_key.git_project)
             logger.debug('Found repo: ' + str(repo.url))
-            issue = repo.create_issue(title=find.title, body=find.long_desc(), labels=["defectdojo", "security / " + find.severity])
+            issue = repo.create_issue(title=find.title, body=long_description(find), labels=["defectdojo", "security / " + find.severity])
             logger.debug('created issue: ' + str(issue.html_url))
             g_issue = GITHUB_Issue(issue_id=issue.number, issue_url=issue.html_url, finding=find)
             g_issue.save()
         except:
             e = sys.exc_info()[0]
             logger.error('cannot create finding in github: ' + e)
+
+
+def long_description(find):
+    from dojo.utils import get_full_url
+    return (
+            "*Dojo URL:* " + str(get_full_url(find.get_absolute_url())) + "\n\n" +
+            find.long_desc() +
+            "\n\n*Dojo ID:* " + str(find.id) + "\n\n"
+    )

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -318,6 +318,10 @@ class Dojo_User(User):
     def __str__(self):
         return self.get_full_name()
 
+    @staticmethod
+    def wants_block_execution(user):
+        return hasattr(user, 'usercontactinfo') and user.usercontactinfo.block_execution
+
 
 class UserContactInfo(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1757,7 +1757,7 @@ class Finding(models.Model):
     # newer version that can work with prefetching
     def github_conf_new(self):
         try:
-            return self.test.engagement.product.github_pkey_set.all()[0].conf
+            return self.test.engagement.product.github_pkey_set.all()[0].git_conf
         except:
             return None
             pass

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1916,22 +1916,18 @@ class Finding(models.Model):
 
         # Adding a snippet here for push to JIRA so that it's in one place
         if push_to_jira:
-            if 'Active' in self.status() and 'Verified' in self.status():
-                from dojo.tasks import update_issue_task, add_issue_task
-                from dojo.utils import add_issue, update_issue
-                if jira_issue_exists:
-                    if self.reporter.usercontactinfo.block_execution:
-                        update_issue(self, True)
-                    else:
-                        update_issue_task.delay(self, True)
+            from dojo.tasks import update_issue_task, add_issue_task
+            from dojo.utils import add_issue, update_issue
+            if jira_issue_exists:
+                if self.reporter.usercontactinfo.block_execution:
+                    update_issue(self, True)
                 else:
-                    if self.reporter.usercontactinfo.block_execution:
-                        add_issue(self, True)
-                    else:
-                        add_issue_task.delay(self, True)
+                    update_issue_task.delay(self, True)
             else:
-                from dojo.utils import log_jira_alert
-                log_jira_alert("A Finding needs to be both Active and Verified to be pushed to JIRA.", self)
+                if self.reporter.usercontactinfo.block_execution:
+                    add_issue(self, True)
+                else:
+                    add_issue_task.delay(self, True)
 
     def delete(self, *args, **kwargs):
         for find in self.original_finding.all():

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -94,7 +94,7 @@
                     </label>
                     <div class="col-sm-10 form-control-static">
                         {% if finding.github_issue and finding.github_conf_new %}
-                            <a href="{{ finding.github_issue.issue_url }}" target="_blank" title="{{ finding.github_issue.issue_url }}"> {{finding.github_issue.issue_id}} </a>
+                            <a href="{{ finding.github_issue.issue_url }}" target="_blank" title="{{ finding.github_issue.issue_url }}">{{finding.github_issue.issue_url}}</a>
                         {% else %}
                             None
                         {% endif %}

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -68,10 +68,39 @@
             {% if jform %}
                 <h4> JIRA </h4>
                 <hr>
+                <div class="form-group">
+                    <label class="col-sm-2 control-label" for="id_jira_issue">JIRA issue
+                        <i class="fa fa-question-circle has-popover" data-trigger="hover" data-content="JIRA issue connected to this finding" data-placement="right" data-container="body" data-original-title="" title="">
+                        </i>
+                    </label>
+                    <div class="col-sm-10 form-control-static">
+                        {% if finding.jira_issue and finding.jira_conf_new %}
+                            <a href="{{ finding.jira_conf_new.url }}/browse/{{ finding.jira_issue.jira_key }}"
+                            target="_blank"> {{ finding.jira_conf_new.url }}/browse/{{ finding.jira_issue.jira_key }} </a>
+                        {% else %}
+                        None
+                        {% endif %}
+                    </div>
+                </div>
                 {% include "dojo/form_fields.html" with form=jform %}
             {% endif %}
             {% if gform %}
-                {% include "dojo/form_fields.html" with form=gform %}
+                <h4> GitHub </h4>
+                <hr>
+                <div class="form-group">
+                    <label class="col-sm-2 control-label" for="id_github_issue">GitHub issue
+                        <i class="fa fa-question-circle has-popover" data-trigger="hover" data-content="Github issue connected to this finding" data-placement="right" data-container="body" data-original-title="" title="">
+                        </i>
+                    </label>
+                    <div class="col-sm-10 form-control-static">
+                        {% if finding.github_issue and finding.github_conf_new %}
+                            <a href="{{ finding.github_issue.issue_url }}" target="_blank" title="{{ finding.github_issue.issue_url }}"> {{finding.github_issue.issue_id}} </a>
+                        {% else %}
+                            None
+                        {% endif %}
+                    </div>
+                </div>
+                 {% include "dojo/form_fields.html" with form=gform %}
             {% endif %}
             <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -447,7 +447,7 @@
                         <td>
                         {% with github_issue=finding.github_issue %}
                         {% if github_issue %}
-                            <a href="{{ github_issue.issue_url }}" target="_blank" title="{{ github_issue.issue_url }}"> {{ github_issue.issue_id }} </a>                            
+                            <a href="{{ github_issue.issue_url }}" target="_blank" title="{{ github_issue.issue_url }}">#{{ github_issue.issue_id }}</a>                            
                         {% endif %}                        
                         {% endwith %}
                         </td>

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -390,6 +390,12 @@
                     {% if finding.component_version %}
                     <th>Component Version</th>
                     {% endif %}
+                    {% if finding.jira_conf_new %}
+                    <th>JIRA</th>
+                    {% endif %}                    
+                    {% if finding.github_conf_new %}
+                    <th>GitHub</th>
+                    {% endif %}                    
                 </tr>
                 <tr>
                     <td>
@@ -424,6 +430,29 @@
                         </span>
                     </td>
                     {% endif %}
+                    {% with jira_conf=finding.jira_conf_new %}
+                    {% if jira_conf%}
+                        <td>
+                        {% with jira_issue=finding.jira_issue %}
+                        {% if jira_issue %}
+                            <a href="{{ jira_conf.url }}/browse/{{ jira_issue.jira_key }}"
+                            target="_blank" title="{{ jira_conf.url }}/browse/{{ jira_issue.jira_key }}">{{ jira_issue.jira_key }}</a>
+                        {% endif %}                        
+                        {% endwith %}
+                        </td>
+                    {% endif %}
+                    {% endwith %}                    
+                    {% with github_conf=finding.github_conf_new %}                    
+                    {% if github_conf %}
+                        <td>
+                        {% with github_issue=finding.github_issue %}
+                        {% if github_issue %}
+                            <a href="{{ github_issue.issue_url }}" target="_blank" title="{{ github_issue.issue_url }}"> {{ github_issue.issue_id }} </a>                            
+                        {% endif %}                        
+                        {% endwith %}
+                        </td>
+                    {% endif %}
+                    {% endwith %}
                 </tr>
             </table>
         </div>
@@ -455,43 +484,6 @@
             </table>
         </div>
     {% endif %}
-    {% if jissue and jconf %}
-        <div class="row to_highlight">
-            <div class="col-md-12">
-                <div class="panel panel-default endpoints table-responsive">
-                    <div class="panel-heading">
-                        <h4>JIRA Link
-                            <span class="pull-right"><a data-toggle="collapse" href="#jira_link"><i
-                                    class="glyphicon glyphicon-chevron-up"></i></a></span>
-                        </h4>
-                    </div>
-                    <div id="jira_link" class="panel-body endpoint-panel table-responsive collapse in">
-                        <a href="{{ jconf.url }}/browse/{{ jissue.jira_key }}"
-                           target="_blank"> {{ jconf.url }}/browse/{{ jissue.jira_key }} </a>
-                    </div>
-                </div>
-            </div>
-        </div>
-    {% endif %}
-    {% if gissue and gconf %}
-    <div class="row to_highlight">
-        <div class="col-md-12">
-            <div class="panel panel-default endpoints table-responsive">
-                <div class="panel-heading">
-                    <h4>Github Link
-                        <span class="pull-right"><a data-toggle="collapse" href="#jira_link"><i
-                                class="glyphicon glyphicon-chevron-up"></i></a></span>
-                    </h4>
-                </div>
-                <div id="github_link" class="panel-body endpoint-panel table-responsive collapse in">
-                    <a href="{{gissue.issue_url }}"
-                       target="_blank"> {{gissue.issue_url}} </a>
-                </div>
-            </div>
-        </div>
-    </div>
-    {% endif %}
-
     {% with findings=finding.similar_findings %}
         {% if findings %}
             <div class="panel panel-default">

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -30,7 +30,7 @@ from dojo.models import Finding, Test, Notes, Note_Type, BurpRawRequestResponse,
     Finding_Template, JIRA_PKey, Cred_Mapping, Dojo_User, System_Settings
 from dojo.tools.factory import import_parser_factory
 from dojo.utils import get_page_items, get_page_items_and_count, add_breadcrumb, get_cal_event, message, process_notifications, get_system_setting, \
-    Product_Tab, max_safe, is_scan_file_too_large
+    Product_Tab, max_safe, is_scan_file_too_large, add_issue
 from dojo.notifications.helper import create_notification
 from dojo.tasks import add_issue_task
 from functools import reduce
@@ -445,7 +445,11 @@ def add_temp_finding(request, tid, fid):
             if 'jiraform-push_to_jira' in request.POST:
                 jform = JIRAFindingForm(request.POST, prefix='jiraform', enabled=True)
                 if jform.is_valid():
-                    add_issue_task.delay(new_finding, jform.cleaned_data.get('push_to_jira'))
+                    if request.user.usercontactinfo.block_execution:
+                        add_issue(new_finding, jform.cleaned_data.get('push_to_jira'))
+                    else:
+                        add_issue_task.delay(new_finding, jform.cleaned_data.get('push_to_jira'))
+
             messages.add_message(request,
                                  messages.SUCCESS,
                                  'Finding from template added successfully.',

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1294,8 +1294,8 @@ def get_labels(find):
 
 def jira_long_description(find, jira_conf_finding_text):
     return (
+            "*Dojo URL:* " + str(get_full_url(find.get_absolute_url())) + "\n\n" +
             find.long_desc() +
-            "\n\n*Dojo URL:* " + str(get_full_url(find.get_absolute_url())) + "\n\n" +
             "\n\n*Dojo ID:* " + str(find.id) + "\n\n" +
             jira_conf_finding_text
     )


### PR DESCRIPTION
bugfixes:
- bulk edit with push to github: create github issue instead of JIRA issue

improvements:
- set `duedate` field based on SLA targets when creating JIRA issue and if SLA is enabled in DD
- display jira issue + url in  edit_finding
- display github issue + url in  edit_finding (fixes #2607)
- simplify displaying of jira_issue and github_issue in view_finding
- send full url to DD finding to JIRA / GitHub instead of only finding id
- send labels to JIRA in the same call as creating/updating an issue

maintenance
- if a user has set `block_execution` set to True in their profile, the JIRA/GitHub actions will now run in uwsgi and not in celery. (similar to what happens with dedupe, notifications etc)
- simplify code around accessing jira/github issue and configuration in view/edit finding.

![image](https://user-images.githubusercontent.com/4426050/86507439-8af32e80-bdd8-11ea-8369-e08313e1df38.png)
![image](https://user-images.githubusercontent.com/4426050/86507445-9181a600-bdd8-11ea-9bc5-934dd0cb0c05.png)
