### PR TITLE
Add Technology (App Analysis) management via UI and APIv2

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -16,4 +16,6 @@ exec uwsgi \
   --enable-threads \
   --processes 2 \
   --threads 2 \
+  --reload-mercy 1 \
+  --worker-reload-mercy 1 \
   --py-autoreload 1

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -3,7 +3,7 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Finding_Template, Test_Type, Development_Environment, NoteHistory, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Product_Type, JIRA_Conf, Endpoint, BurpRawRequestResponse, JIRA_PKey, \
-    Notes, DojoMeta, FindingImage, Note_Type
+    Notes, DojoMeta, FindingImage, Note_Type, App_Analysis
 from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools import requires_file
 from dojo.tools.factory import import_parser_factory
@@ -216,6 +216,12 @@ class EngagementSerializer(TaggitSerializer, serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     'Your target start date exceeds your target end date')
         return data
+
+
+class AppAnalysisSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = App_Analysis
+        fields = '__all__'
 
 
 class ToolTypeSerializer(serializers.ModelSerializer):

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -14,7 +14,7 @@ from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Find
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, Notes, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment, \
-    Dojo_User, Note_Type, System_Settings
+    Dojo_User, Note_Type, System_Settings, App_Analysis
 
 from dojo.endpoint.views import get_endpoint_ids
 from dojo.reports.views import report_url_resolver
@@ -138,6 +138,16 @@ class EngagementViewSet(mixins.ListModelMixin,
         data = report_generate(request, engagement, options)
         report = serializers.ReportGenerateSerializer(data)
         return Response(report.data)
+
+
+class AppAnalysisViewSet(mixins.ListModelMixin,
+                        mixins.RetrieveModelMixin,
+                        mixins.UpdateModelMixin,
+                        mixins.DestroyModelMixin,
+                        mixins.CreateModelMixin,
+                        viewsets.GenericViewSet):
+    serializer_class = serializers.AppAnalysisSerializer
+    queryset = App_Analysis.objects.all()
 
 
 class FindingTemplatesViewSet(mixins.ListModelMixin,

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -331,6 +331,23 @@
   },
   {
     "pk": 1,
+    "model": "dojo.app_analysis",
+    "fields": {
+      "product": 1,
+      "name": "Tomcat",
+      "user": [
+          "admin"
+      ],
+      "confidence": 100,
+      "version": "8.5.1",
+      "icon": null,
+      "website": null,
+      "website_found": null,
+      "created": "2018-08-16T16:58:23.908Z"
+    }
+  },
+  {
+    "pk": 1,
     "model": "dojo.scansettings",
     "fields": {
       "product": 1,

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -190,9 +190,13 @@ class ProductForm(forms.ModelForm):
         queryset=None,
         required=False, label="Authorized Users")
 
+    app_analysis = forms.ModelMultipleChoiceField(label='Technologies',
+                                           queryset=App_Analysis.objects.all().order_by('name'),
+                                           required=False)
+
     product_manager = forms.ModelChoiceField(queryset=Dojo_User.objects.exclude(is_active=False).order_by('first_name', 'last_name'), required=False)
     technical_contact = forms.ModelChoiceField(queryset=Dojo_User.objects.exclude(is_active=False).order_by('first_name', 'last_name'), required=False)
-    product_manager = forms.ModelChoiceField(queryset=Dojo_User.objects.exclude(is_active=False).order_by('first_name', 'last_name'), required=False)
+    team_manager = forms.ModelChoiceField(queryset=Dojo_User.objects.exclude(is_active=False).order_by('first_name', 'last_name'), required=False)
 
     def __init__(self, *args, **kwargs):
         non_staff = Dojo_User.objects.exclude(is_staff=True) \
@@ -205,7 +209,7 @@ class ProductForm(forms.ModelForm):
 
     class Meta:
         model = Product
-        fields = ['name', 'description', 'tags', 'product_manager', 'technical_contact', 'team_manager', 'prod_type', 'regulations',
+        fields = ['name', 'description', 'tags', 'product_manager', 'technical_contact', 'team_manager', 'prod_type', 'regulations', 'app_analysis',
                   'authorized_users', 'business_criticality', 'platform', 'lifecycle', 'origin', 'user_records', 'revenue', 'external_audience', 'internet_accessible']
 
 

--- a/dojo/product/urls.py
+++ b/dojo/product/urls.py
@@ -22,6 +22,8 @@ urlpatterns = [
     url(r'^product/add', views.new_product, name='new_product'),
     url(r'^product/(?P<pid>\d+)/new_engagement$', views.new_eng_for_app,
         name='new_eng_for_prod'),
+    url(r'^product/(?P<pid>\d+)/new_technology$', views.new_tech_for_prod,
+         name='new_tech_for_prod'),
     url(r'^product/(?P<pid>\d+)/new_engagement/cicd$', views.new_eng_for_app_cicd,
         name='new_eng_for_prod_cicd'),
     url(r'^product/(?P<pid>\d+)/add_meta_data', views.add_meta_data,

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -20,7 +20,7 @@ from dojo.templatetags.display_tags import get_level
 from dojo.filters import ProductFilter, EngagementFilter
 from dojo.forms import ProductForm, EngForm, DeleteProductForm, DojoMetaDataForm, JIRAPKeyForm, JIRAFindingForm, AdHocFindingForm, \
                        EngagementPresetsForm, DeleteEngagementPresetsForm, Sonarqube_ProductForm, ProductNotificationsForm, \
-                       GITHUB_Product_Form, GITHUBFindingForm
+                       GITHUB_Product_Form, GITHUBFindingForm, App_AnalysisTypeForm
 from dojo.models import Product_Type, Note_Type, Finding, Product, Engagement, ScanSettings, Risk_Acceptance, Test, JIRA_PKey, GITHUB_PKey, Finding_Template, \
                         Test_Type, System_Settings, Languages, App_Analysis, Benchmark_Type, Benchmark_Product_Summary, \
                         Endpoint, Engagement_Presets, DojoMeta, Sonarqube_Product, Notifications
@@ -800,6 +800,26 @@ def new_eng_for_app(request, pid, cicd=False):
                    'product_tab': product_tab,
                    'jform': jform
                    })
+
+
+@user_passes_test(lambda u: u.is_staff)
+def new_tech_for_prod(request, pid):
+    prod = Product.objects.get(id=pid)
+    if request.method == 'POST':
+        form = App_AnalysisTypeForm(request.POST)
+        if form.is_valid():
+            tech = form.save(commit=False)
+            tech.product_id = pid
+            tech.save()
+            messages.add_message(request,
+                                messages.SUCCESS,
+                                'Technology added successfully.',
+                                extra_tags='alert-success')
+            return HttpResponseRedirect(reverse('view_product', args=(pid,)))
+
+    form = App_AnalysisTypeForm()
+    return render(request, 'dojo/new_tech.html',
+                {'form': form, 'pid': pid})
 
 
 @user_passes_test(lambda u: u.is_staff)

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -447,12 +447,12 @@
                         </li>
                         <li role="presentation">
                             <a class="" href="{% url 'add_meta_data' product_tab.product.id %}">
-                                <i class="fa fa-list-alt"></i> Add Custom Fields
+                                <i class="fa fa-plus"></i> Add Custom Fields
                             </a>
                         </li>
                         <li role="presentation">
                             <a class="" href="{% url 'new_object' product_tab.product.id %}">
-                                <i class="fa fa-list-alt"></i> Add Product Tracking Files
+                                <i class="fa fa-plus"></i> Add Product Tracking Files
                             </a>
                         </li>
                         <li role="separator" class="divider"></li>
@@ -463,7 +463,7 @@
                         </li>
                         <li role="presentation">
                             <a href="{% url 'all_cred_product' product_tab.product.id %}">
-                                <i class="fa fa-plus"></i> View Credentials
+                                <i class="fa fa-list-alt"></i> View Credentials
                             </a>
                         </li>
                         <li role="separator" class="divider"></li>
@@ -474,7 +474,7 @@
                         </li>
                         <li role="presentation">
                             <a href="{% url 'all_tool_product' product_tab.product.id %}">
-                                <i class="fa fa-plus"></i> View Tools
+                                <i class="fa fa-list-alt"></i> View Tools
                             </a>
                         </li>
                         <li role="separator" class="divider"></li>
@@ -485,7 +485,7 @@
                         </li>
                         <li role="presentation">
                             <a href="{% url 'engagement_presets' product_tab.product.id %}">
-                                <i class="fa fa-plus"></i> View Engagement Presets
+                                <i class="fa fa-list-alt"></i> View Engagement Presets
                             </a>
                         </li>
                         <li role="separator" class="divider"></li>

--- a/dojo/templates/dojo/new_tech.html
+++ b/dojo/templates/dojo/new_tech.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+ {% block content %}
+     <h3> Register a new Technology </h3>
+     <form class="form-horizontal" action="{%  url 'new_tech_for_prod' pid %}" method="post">{% csrf_token %}
+         {% include "dojo/form_fields.html" with form=form %}
+         <div class="form-group">
+             <div class="col-sm-offset-2 col-sm-10">
+                 <input class="btn btn-primary" label="submit" type="submit" value="Submit"/>
+             </div>
+         </div>
+     </form>
+ {% endblock %}

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -117,7 +117,9 @@
   <div class="col-md-6">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h3 class="panel-title"><span class="fa fa-bolt" aria-hidden="true"></span> Technologies {%if app_analysis%}({{ app_analysis.count }}){%endif%}</h3>
+        <h3 class="panel-title"><span class="fa fa-bolt" aria-hidden="true"></span> Technologies {%if app_analysis%}({{ app_analysis.count }}){%endif%}
+          <a title="Add New Technology" class="pull-right btn btn-sm btn-primary" href="/product/{{ prod.id }}/new_technology"><span class="fa fa-plus"></span> </a>
+        </h3>      
       </div>
       <ul class="list-group">
       {% for app in app_analysis %}
@@ -362,6 +364,9 @@
   <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
   <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
   <script type="text/javascript">
+    $(function(){
+               $('[data-toggle="tooltip"]').tooltip();
+    });
     $(function() {
       if (document.referrer.indexOf('simple_search') > 0) {
         var terms = '';

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -1,14 +1,14 @@
 from dojo.models import Product, Engagement, Test, Finding, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
-    Finding_Template, Note_Type
+    Finding_Template, Note_Type, App_Analysis
 
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView, NoteTypeViewSet
+    UsersViewSet, ImportScanView, NoteTypeViewSet, AppAnalysisViewSet
 
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
@@ -91,6 +91,28 @@ class BaseClass():
             response = self.client.put(
                 relative_url, self.payload)
             self.assertEqual(200, response.status_code)
+
+
+class AppAnalysisTest(BaseClass.RESTEndpointTest):
+    fixtures = ['dojo_testdata.json']
+
+    def __init__(self, *args, **kwargs):
+        self.endpoint_model = App_Analysis
+        self.viewname = 'app_analysis'
+        self.viewset = AppAnalysisViewSet
+        self.payload = {
+            'product': 1,
+            'name': 'Tomcat',
+            'user': 1,
+            'confidence': 100,
+            'version': '8.5.1',
+            'icon': '',
+            'website': '',
+            'website_found': '',
+            'created': '2018-08-16T16:58:23.908Z'
+        }
+        self.update_fields = {'version': '9.0'}
+        BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
 class EndpointTest(BaseClass.RESTEndpointTest):

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -27,7 +27,8 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, TestTypesViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
     UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
-    DevelopmentEnvironmentViewSet, NotesViewSet, NoteTypeViewSet, SystemSettingsViewSet
+    DevelopmentEnvironmentViewSet, NotesViewSet, NoteTypeViewSet, SystemSettingsViewSet, \
+    AppAnalysisViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -97,6 +98,7 @@ v1_api.register(BuildDetails())
 
 # v2 api written in django-rest-framework
 v2_api = DefaultRouter()
+v2_api.register(r'technologies', AppAnalysisViewSet)
 v2_api.register(r'endpoints', EndPointViewSet)
 v2_api.register(r'engagements', EngagementViewSet)
 v2_api.register(r'development_environments', DevelopmentEnvironmentViewSet)


### PR DESCRIPTION
Supersedes #2309 

Previously, managing technologies (renamed from app_analysis) was only accessible through APIv1. Now, they can also be managed through the UI on the product page or APIv2. This was requested by @mtesauro

Docker-compose dev config also has a change to reduce wait times in auto reloading for processes to be killed off. Instead of the default 60 seconds, processes will now be killed after 1 seconds.

- [x] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.