### PR TITLE
Fix generic parser

### DIFF
--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -326,13 +326,9 @@ class GenericFindingUploadCsvParser(object):
 
                 column_number += 1
 
-            if self.active:
-                finding.active = ActiveColumnMappingStrategy.evaluate_bool_value(row[9])
-            else:
+            if not self.active:
                 finding.active = False
-            if self.verified:
-                finding.verified = VerifiedColumnMappingStrategy.evaluate_bool_value(row[10])
-            else:
+            if not self.verified:
                 finding.verified = False
             if finding is not None:
                 key = hashlib.md5((finding.severity + '|' + finding.title + '|' + finding.description).encode("utf-8")).hexdigest()

--- a/dojo/unittests/test_generic_finding_upload.py
+++ b/dojo/unittests/test_generic_finding_upload.py
@@ -284,3 +284,31 @@ Code Line: Response.Write(output);","None Currently Available","Impact is curren
         file = TestFile("findings.csv", content)
         self.parser = GenericFindingUploadCsvParser(file, self.test, True, True)
         self.assertEqual(False, self.parser.items[0].duplicate)
+
+    def test_missing_columns_is_fine(self):
+        content = """Date,Title,Url,Severity,Description,References,Active,Verified"""
+        file = TestFile("findings.csv", content)
+        self.parser = GenericFindingUploadCsvParser(file, self.test, True, True)
+
+    def test_column_order_is_flexible(self):
+        content1 = """\
+Date,Title,CweId,Url,Severity,Description,Mitigation,Impact,References,Active,Verified
+11/7/2015,Title,0,Url,Severity,Description,Mitigation,Impact,References,True,True
+"""
+        content2 = """\
+Verified,Date,Title,CweId,Url,Severity,Description,Mitigation,Impact,References,Active
+True,11/7/2015,Title,0,Url,Severity,Description,Mitigation,Impact,References,True
+"""
+        file1 = TestFile("findings.csv", content1)
+        file2 = TestFile("findings.csv", content2)
+
+        parser1 = GenericFindingUploadCsvParser(file1, self.test, True, True)
+        parser2 = GenericFindingUploadCsvParser(file2, self.test, True, True)
+
+        finding1 = parser1.items[0]
+        finding2 = parser2.items[0]
+
+        fields1 = {k: v for k, v in finding1.__dict__.items() if k != '_state'}
+        fields2 = {k: v for k, v in finding2.__dict__.items() if k != '_state'}
+
+        self.assertEqual(fields1, fields2)


### PR DESCRIPTION
Previously, the parser looked for the active and verified columns twice:
First, by looking for such column names and, secondly, by checking
column number 9 and 10 (which are fixed).  This PR removes the
latter part.