### PR TITLE
jira hotfix when no usercontactinfo for reporter

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1886,7 +1886,7 @@ class Finding(models.Model):
             if system_settings.enable_deduplication:
                 from dojo.tasks import async_dedupe
                 try:
-                    if self.reporter.usercontactinfo.block_execution:
+                    if hasattr(self.reporter, 'usercontactinfo') and self.reporter.usercontactinfo.block_execution:
                         dedupe_signal.send(sender=self.__class__, new_finding=self)
                     else:
                         async_dedupe.delay(self, *args, **kwargs)
@@ -1899,7 +1899,7 @@ class Finding(models.Model):
             from dojo.tasks import async_false_history
             from dojo.utils import sync_false_history
             try:
-                if self.reporter.usercontactinfo.block_execution:
+                if hasattr(self.reporter, 'usercontactinfo') and self.reporter.usercontactinfo.block_execution:
                     sync_false_history(self, *args, **kwargs)
                 else:
                     async_false_history.delay(self, *args, **kwargs)
@@ -1919,12 +1919,12 @@ class Finding(models.Model):
             from dojo.tasks import update_issue_task, add_issue_task
             from dojo.utils import add_issue, update_issue
             if jira_issue_exists:
-                if self.reporter.usercontactinfo.block_execution:
+                if hasattr(self.reporter, 'usercontactinfo') and self.reporter.usercontactinfo.block_execution:
                     update_issue(self, True)
                 else:
                     update_issue_task.delay(self, True)
             else:
-                if self.reporter.usercontactinfo.block_execution:
+                if hasattr(self.reporter, 'usercontactinfo') and self.reporter.usercontactinfo.block_execution:
                     add_issue(self, True)
                 else:
                     add_issue_task.delay(self, True)


### PR DESCRIPTION
For some reason sometimes the `usercontactinfo` doesn't exist for some users in a clean instance, so made the code a bit more safe.