### PR TITLE
jira: only set duedate when field is available in jira

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -571,7 +571,6 @@ def delete_finding(request, fid):
 # def edit_finding(request, finding):
 @user_must_be_authorized(Finding, 'change', 'fid')
 def edit_finding(request, fid):
-    print('fid=', fid)
     finding = get_object_or_404(Finding, id=fid)
     old_status = finding.status()
     form = FindingForm(instance=finding, template=False)
@@ -1732,7 +1731,7 @@ def finding_bulk_update_all(request, pid=None):
                 if form.cleaned_data['push_to_github']:
                     logger.info('push selected findings to github')
                     for finding in finds:
-                        print('will push to GitHub finding: ' + str(finding))
+                        logger.debug('will push to GitHub finding: ' + str(finding))
                         old_status = finding.status()
                         if form.cleaned_data['push_to_github']:
                             if GITHUB_Issue.objects.filter(finding=finding).exists():

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1394,14 +1394,12 @@ def add_issue(find, push_to_jira):
                     # meta = jira.createmeta(projectKeys=jpkey.project_key, expand="fields")
                     if not meta:
                         meta = jira_meta(jira, jpkey)
-                    # print('VALENTIJN:', meta['projects'][0]['issuetypes'][0]['fields']['summary'])
 
                     if 'duedate' in meta['projects'][0]['issuetypes'][0]['fields']:
                         # print('DUE: ', meta['projects'][0]['issuetypes'][0]['fields']['duedate'])
 
                         # jira wants YYYY-MM-DD
                         duedate = find.sla_deadline().strftime('%Y-%m-%d')
-                        # fields['duedate'] = '2020-12-31'
                         fields['duedate'] = duedate
 
                 if len(find.endpoints.all()) > 0:
@@ -1409,13 +1407,11 @@ def add_issue(find, push_to_jira):
                         meta = jira_meta(jira, jpkey)
 
                     if 'environment' in meta['projects'][0]['issuetypes'][0]['fields']:
-                        # print('ENV: ', meta['projects'][0]['issuetypes'][0]['fields']['environment'])
 
                         environment = "\n".join([str(endpoint) for endpoint in find.endpoints.all()])
                         fields['environment'] = environment
 
-                # print('fields:')
-                # print(fields)
+                logger.debug('sending fields to JIRA: %s', fields)
 
                 new_issue = jira.create_issue(fields)
 
@@ -1520,8 +1516,6 @@ def update_issue(find, push_to_jira):
                     meta = jira_meta(jira, jpkey)
 
                 if 'environment' in meta['projects'][0]['issuetypes'][0]['fields']:
-                    print('ENV: ', meta['projects'][0]['issuetypes'][0]['fields']['environment'])
-
                     environment = "\n".join([str(endpoint) for endpoint in find.endpoints.all()])
                     fields['environment'] = environment
 
@@ -1529,6 +1523,8 @@ def update_issue(find, push_to_jira):
             for pic in find.images.all():
                 jira_attachment(jira, issue,
                                 settings.MEDIA_ROOT + pic.image_large.name)
+
+            logger.debug('sending fields to JIRA: %s', fields)
 
             issue.update(
                 summary=find.title,
@@ -2071,11 +2067,11 @@ def merge_sets_safe(set1, set2):
 
 def get_return_url(request):
     return_url = request.POST.get('return_url', None)
-    print('return_url from POST: ', return_url)
+    # print('return_url from POST: ', return_url)
     if return_url is None or not return_url.strip():
         # for some reason using request.GET.get('return_url') never works
         return_url = request.GET['return_url'] if 'return_url' in request.GET else None
-        print('return_url from GET: ', return_url)
+        # print('return_url from GET: ', return_url)
 
     return return_url if return_url else None
 


### PR DESCRIPTION
Setting duedate field based on SLA in #2630 breaks JIRA integration if the `duedate` field is not available for that JIRA project + issuetype.
This PR retrieves metadata from JIRA and only sets `duedate` field when possible.

Now that we have the metadata anyway, we also set the environment field to contain the list of endpoints for the finding if possible.