### PR TITLE
bug report template: better git cmd

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment information**
  - Operating System: [e.g. Ubuntu 18.04]
- - DefectDojo Commit Message: [use `git show -s --format="%h: %s [%ci]"`]
+ - DefectDojo Commit Message: [use `git show --oneline -s`]
 
 **Sample scan files** (optional)
 If applicable, add sample scan files to help reproduce your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment information**
  - Operating System: [e.g. Ubuntu 18.04]
- - DefectDojo Commit Message: [use `git show --oneline -s`]
+ - DefectDojo Commit Message: [use `git show -s --format="%d %h: %s [%ci]"`]
 
 **Sample scan files** (optional)
 If applicable, add sample scan files to help reproduce your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment information**
  - Operating System: [e.g. Ubuntu 18.04]
- - DefectDojo Commit Message: [use `git show -s --format="%d %h: %s [%ci]"`]
+ - DefectDojo Commit Message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
 
 **Sample scan files** (optional)
 If applicable, add sample scan files to help reproduce your problem.


### PR DESCRIPTION
The current git command in the bug report template doesn't output the branch the user is on. So it's not always clear if the user is on `master` or `dev` or maybe something like `1.6.5`.

New command:
```
(venv_dd) valentijn@LAP$ git show -s --format="[%ci] %h: %s [%d]"
[2020-07-08 15:48:13 +0200] b4e3faa8: bug report template: better git cmd [ (HEAD -> bug-report-template, origin/bug-report-template)]
```