### PR TITLE
Add obvious way to delete metadata in UI

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -355,8 +355,11 @@ def edit_meta_data(request, eid):
                 if value:
                     cfv.value = value
                     cfv.save()
-                else:
-                    cfv.delete()
+            if key.startswith('delete_'):
+                cfv_id = int(key.split('_')[2])
+                cfv = get_object_or_404(DojoMeta, id=cfv_id)
+                cfv.delete()
+
         messages.add_message(request,
                              messages.SUCCESS,
                              'Metadata edited successfully.',

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -867,8 +867,11 @@ def edit_meta_data(request, pid):
                 if value:
                     cfv.value = value
                     cfv.save()
-                else:
-                    cfv.delete()
+            if key.startswith('delete_'):
+                cfv_id = int(key.split('_')[2])
+                cfv = get_object_or_404(DojoMeta, id=cfv_id)
+                cfv.delete()
+
         messages.add_message(request,
                              messages.SUCCESS,
                              'Metadata edited successfully.',

--- a/dojo/templates/dojo/edit_product_meta_data.html
+++ b/dojo/templates/dojo/edit_product_meta_data.html
@@ -17,10 +17,10 @@
                 <div class="col-sm-10">
                     <input type="text" class="form-control" id="cfv_{{ cf.id }}" name="cfv_{{ cf.id }}"
                            value="{{ cf.value }}">
+                    <span for="cfv_{{ cf.id }}">Delete</span>
+                    <input type="checkbox" name="delete_cfv_{{ cf.id }}" id="delete_cfv_{{ cf.id }}"/>
                 </div>
             </div>
-
-
         {% endfor %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">

--- a/dojo/templates/dojo/edit_product_meta_data.html
+++ b/dojo/templates/dojo/edit_product_meta_data.html
@@ -18,7 +18,7 @@
                     <input type="text" class="form-control" id="cfv_{{ cf.id }}" name="cfv_{{ cf.id }}"
                            value="{{ cf.value }}">
                     <span for="cfv_{{ cf.id }}">Delete</span>
-                    <input type="checkbox" name="delete_cfv_{{ cf.id }}" id="delete_cfv_{{ cf.id }}"/>
+                    <input type="checkbox" label="Delete Checkbox" name="delete_cfv_{{ cf.id }}" id="delete_cfv_{{ cf.id }}"/>
                 </div>
             </div>
         {% endfor %}


### PR DESCRIPTION
Removing Product/Endpoint metadata was secretive such that leaving the field empty would remove the item. There was no mention of this anywhere. To make is more usable, a checkbox is added to make it clearly removable and done so in bulk.

- [x] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.