### PR TITLE
In-page doc for twistlock now accepting CSV as input

### DIFF
--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -110,7 +110,7 @@
 	<li><b>Trivy Scan</b> - Import trivy JSON scan report.</li>
 	<li><b>Trufflehog</b> - JSON Output of Trufflehog.</li>
 	<li><b>Trustwave</b> - CSV output of Trustwave vulnerability scan.</li>
-	<li><b>Twistlock image scan</b> - JSON output of twistcli image scan.</li>
+	<li><b>Twistlock image scan</b> - JSON output of twistcli image scan or CSV.</li>
 	<li><b>Visual Code Grepper (VCG)</b> - VCG output can be imported in CSV or Xml formats.</li>
 	<li><b>Veracode</b> - Detailed XML Report</li>
 	<li><b>Wapiti Scan</b> - Import XML report.</li>


### PR DESCRIPTION
Follow-up to https://github.com/DefectDojo/django-DefectDojo/pull/2626