### PR TITLE
Improve the helm chart and add support for cloudsql-proxy

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "1.7"
 description: A Helm chart for Kubernetes
 name: defectdojo
 version: 1.1.0

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: defectdojo
-version: 1.0.0
+version: 1.1.0
 icon: https://www.defectdojo.org/img/favicon.ico

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.7"
-description: A Helm chart for Kubernetes
+description: A Helm chart for Kubernetes to installs DefectDojo
 name: defectdojo
-version: 1.1.0
+version: 1.2.0
 icon: https://www.defectdojo.org/img/favicon.ico

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -23,11 +23,26 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: defectdojo
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
       {{- end }}
       containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+        command: ["/cloud_sql_proxy"]
+        args:
+        {{- if eq .Values.database "postgresql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.postgresql.service.port }}"
+        {{- else if eq .Values.database "mysql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.mysql.service.port }}"
+        {{- end }}
+      {{- end }}
       - command:
         - /entrypoint-celery-beat.sh
         name: celery
@@ -40,25 +55,16 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
-              # Use broker chart secret
-              # name: {{ $fullName }}-{{ .Values.celery.broker }}
-              # Use secret handled outside of the chart
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              # use postgresql chart secret
-              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              # Use mysql chart secret
-              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -61,10 +61,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.existingSecret }}
+              name: {{ .Values.postgresql.secret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.existingSecret }}
+              name: {{ .Values.mysql.secret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{- $fullName }}
+      serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
@@ -61,10 +61,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.secret }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.secret }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: defectdojo
+      serviceAccountName: {{- $fullName }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -60,10 +60,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.secret }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.secret }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -60,10 +60,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.existingSecret }}
+              name: {{ .Values.postgresql.secret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.existingSecret }}
+              name: {{ .Values.mysql.secret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -23,11 +23,26 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: defectdojo
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
       {{- end }}
       containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+        command: ["/cloud_sql_proxy"]
+        args:
+        {{- if eq .Values.database "postgresql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.postgresql.service.port }}"
+        {{- else if eq .Values.database "mysql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.mysql.service.port }}"
+        {{- end }}
+      {{- end }}
       - name: celery
         image: "{{ template "celery.repository" . }}:{{ .Values.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -39,25 +54,16 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
-              # Use broker chart secret
-              # name: {{ $fullName }}-{{ .Values.celery.broker }}
-              # Use secret handled outside of the chart
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              # use postgresql chart secret
-              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              # Use mysql chart secret
-              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: defectdojo
+      serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
   DD_ALLOWED_HOSTS: {{ .Values.host }}
   DD_CELERY_BROKER_SCHEME: {{ if eq .Values.celery.broker "rabbitmq" }}amqp{{ end }}{{ if eq .Values.celery.broker "redis" }}redis{{ end }}
   DD_CELERY_BROKER_USER: '{{ if eq .Values.celery.broker "rabbitmq" }}user{{ end }}'
-  DD_CELERY_BROKER_HOST: {{ $fullName }}-{{ if eq .Values.celery.broker "rabbitmq" }}rabbitmq{{ end }}{{ if eq .Values.celery.broker "redis" }}redis-master{{ end }}
+  DD_CELERY_BROKER_HOST: {{ .Release.Name }}-{{ if eq .Values.celery.broker "rabbitmq" }}rabbitmq{{ end }}{{ if eq .Values.celery.broker "redis" }}redis-master{{ end }}
   DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}5672{{ end }}{{ if eq .Values.celery.broker "redis" }}6379{{ end }}'
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}
   DD_DATABASE_ENGINE: django.db.backends.{{ if eq .Values.database "postgresql" }}postgresql{{ end }}{{ if eq .Values.database "mysql" }}mysql{{ end }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -65,10 +65,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.existingSecret }}
+              name: {{ .Values.postgresql.secret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.existingSecret }}
+              name: {{ .Values.mysql.secret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -23,6 +23,7 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: defectdojo
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
@@ -31,6 +32,20 @@ spec:
       - name: run
         emptyDir: {}
       containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+        command: ["/cloud_sql_proxy"]
+        args:
+        {{- if eq .Values.database "postgresql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.postgresql.service.port }}"
+        {{- else if eq .Values.database "mysql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.mysql.service.port }}"
+        {{- end }}
+      {{- end }}
       - name: uwsgi
         image: '{{ template "django.uwsgi.repository" . }}:{{ .Values.tag }}'
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -44,25 +59,16 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
-              # Use broker chart secret
-              # name: {{ $fullName }}-{{ .Values.celery.broker }}
-              # Use secret handled outside of the chart
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              # use postgresql chart secret
-              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              # Use mysql chart secret
-              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -65,10 +65,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.secret }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.secret }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         - name: DD_SECRET_KEY

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: defectdojo
+      serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -18,7 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: {{- $fullName }}
+      serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
@@ -53,10 +53,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.secret }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.secret }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         resources:

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -18,7 +18,7 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
-      serviceAccountName: defectdojo
+      serviceAccountName: {{- $fullName }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -53,10 +53,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.existingSecret }}
+              name: {{ .Values.postgresql.secret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.existingSecret }}
+              name: {{ .Values.mysql.secret }}
               key: mysql-password
               {{- end }}
         resources:

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -18,11 +18,26 @@ spec:
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      serviceAccountName: defectdojo
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
       {{- end }}
       containers:
+      {{- if .Values.cloudsql.enabled  }}
+      - name: cloudsql-proxy
+        image: {{ .Values.cloudsql.image.repository }}:{{ .Values.cloudsql.image.tag }}
+        imagePullPolicy: {{ .Values.cloudsql.image.pullPolicy }}
+        securityContext:
+          runAsNonRoot: true
+        command: ["/cloud_sql_proxy"]
+        args:
+        {{- if eq .Values.database "postgresql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.postgresql.service.port }}"
+        {{- else if eq .Values.database "mysql" }}
+        - "-instances={{ .Values.cloudsql.instance }}=tcp:{{ .Values.mysql.service.port }}"
+        {{- end }}
+      {{- end }}
       - name: initializer
         image: "{{ template "initializer.repository" . }}:{{ .Values.tag }}"
         imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -38,16 +53,10 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              # use postgresql chart secret
-              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              # Use mysql chart secret
-              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
         resources:

--- a/helm/defectdojo/templates/sa.yaml
+++ b/helm/defectdojo/templates/sa.yaml
@@ -1,7 +1,8 @@
+{{- $fullName := include "defectdojo.fullname" . -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: defectdojo
+  name: {{ $fullName }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/defectdojo/templates/sa.yaml
+++ b/helm/defectdojo/templates/sa.yaml
@@ -1,8 +1,7 @@
-{{- if .Values.createPostgresqlSecret -}}
+kind: ServiceAccount
 apiVersion: v1
-kind: Secret
 metadata:
-  name: {{ .Values.postgresql.existingSecret }}
+  name: defectdojo
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -12,11 +11,6 @@ metadata:
     helm.sh/resource-policy: keep
     helm.sh/hook: "pre-install"
     helm.sh/hook-delete-policy: "before-hook-creation"
-type: Opaque
-data:
-{{- if .Values.postgresql.enabled }}
-  postgresql-password : {{ randAlphaNum 10 | b64enc | quote }}
-{{- else }}
-  postgresql-password : {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
-{{- end }}
-{{- end }}
+    {{- with .Values.annotations }}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}

--- a/helm/defectdojo/templates/secret-mysql.yaml
+++ b/helm/defectdojo/templates/secret-mysql.yaml
@@ -15,8 +15,16 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.mysql.enabled }}
+{{- if .Values.mysql.mysqlRootPassword }}
+  mysql-root-password: {{ .Values.mysql.mysqlRootPassword | b64enc | quote }}
+{{- else }}
   mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
+{{- end }}
+{{- if .Values.mysql.mysqlPassword }}
+  mysql-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
+{{- else }}
   mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
+{{- end}}
 {{- else }}
   mysql-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
 {{- end }}

--- a/helm/defectdojo/templates/secret-mysql.yaml
+++ b/helm/defectdojo/templates/secret-mysql.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: defectdojo-mysql-specific
+  name: {{ .Values.mysql.secret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/defectdojo/templates/secret-mysql.yaml
+++ b/helm/defectdojo/templates/secret-mysql.yaml
@@ -14,7 +14,10 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
+{{- if .Values.mysql.enabled }}
   mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
   mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
-
+{{- else }}
+  mysql-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/helm/defectdojo/templates/secret-mysql.yaml
+++ b/helm/defectdojo/templates/secret-mysql.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.mysql.secret }}
+  name: {{ .Values.mysql.existingSecret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/defectdojo/templates/secret-postgresql.yaml
+++ b/helm/defectdojo/templates/secret-postgresql.yaml
@@ -15,7 +15,11 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.postgresql.enabled }}
+{{- if .Values.postgresql.postgresqlPassword }}
+  postgresql-password : {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
+{{- else }}
   postgresql-password : {{ randAlphaNum 10 | b64enc | quote }}
+{{- end }}
 {{- else }}
   postgresql-password : {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
 {{- end }}

--- a/helm/defectdojo/templates/secret-postgresql.yaml
+++ b/helm/defectdojo/templates/secret-postgresql.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.postgresql.secret }}
+  name: {{ .Values.postgresql.existingSecret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/defectdojo/templates/secret-postgresql.yaml
+++ b/helm/defectdojo/templates/secret-postgresql.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.postgresql.existingSecret }}
+  name: {{ .Values.postgresql.secret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/defectdojo/templates/secret-rabbitmq.yaml
+++ b/helm/defectdojo/templates/secret-rabbitmq.yaml
@@ -14,6 +14,14 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
+{{- if .Values.rabbitmq.rabbitmq.password }}
+  rabbitmq-password: {{ .Values.rabbitmq.rabbitmq.password | b64enc | quote }}
+{{- else }}
   rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
+{{- end}}
+{{- if .Values.rabbitmq.rabbitmq.erlangCookie }}
+  rabbitmq-erlang-cookie: {{ .Values.rabbitmq.rabbitmq.erlangCookie | b64enc | quote }}
+{{- else }}
   rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/helm/defectdojo/templates/secret-rabbitmq.yaml
+++ b/helm/defectdojo/templates/secret-rabbitmq.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: defectdojo-rabbitmq-specific
+  name: {{ .Values.rabbitmq.rabbitmq.existingPasswordSecret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/defectdojo/templates/secret-redis.yaml
+++ b/helm/defectdojo/templates/secret-redis.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: defectdojo-redis-specific
+  name: {{ .Values.redis.existingSecret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/defectdojo/templates/secret-redis.yaml
+++ b/helm/defectdojo/templates/secret-redis.yaml
@@ -14,5 +14,9 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
+{{- if .Values.redis.password }}
+  redis-password: {{ .Values.redis.password | b64enc | quote }}
+{{- else }}
   redis-password: {{ randAlphaNum 10 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/helm/defectdojo/templates/secret.yaml
+++ b/helm/defectdojo/templates/secret.yaml
@@ -15,8 +15,24 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
+{{- if .Values.admin.password }}
+  DD_ADMIN_PASSWORD: {{ .Values.admin.password | b64enc | quote }}
+{{- else}}
   DD_ADMIN_PASSWORD: {{ randAlphaNum 22 | b64enc | quote }}
+{{- end}}
+{{- if .Values.admin.secretKey }}
+  DD_SECRET_KEY: {{ .Values.admin.secretKey | b64enc | quote }}
+{{- else}}
   DD_SECRET_KEY: {{ randAlphaNum 128 | b64enc | quote }}
+{{- end}}
+{{- if .Values.admin.credentialAes256Key }}
+  DD_CREDENTIAL_AES_256_KEY: {{ .Values.admin.credentialAes256Key | b64enc | quote }}
+{{- else}}
   DD_CREDENTIAL_AES_256_KEY: {{ randAlphaNum 128 | b64enc | quote }}
+{{- end}}
+{{- if .Values.admin.metricsHttpAuthPassword }}
+  METRICS_HTTP_AUTH_PASSWORD: {{ .Values.admin.metricsHttpAuthPassword | b64enc | quote }}
+{{- else}}
   METRICS_HTTP_AUTH_PASSWORD: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end}}
 {{- end }}

--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -38,19 +38,12 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              # use postgresql chart secret
-              # name: {{- if .Values.postgresql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.postgresql.enabled }} defectdojo-postgresql-specific {{- else }} {{ .Values.postgresql.existingSecret }} {{- end }}
+              name: {{ .Values.postgresql.existingSecret }}
               key: postgresql-password
               {{- else if eq .Values.database "mysql" }}
-              # Use mysql chart secret
-              # name: {{- if .Values.mysql.enabled }} {{ $fullName }}-{{ .Values.database }} {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
-              # Use secret handled outside of the chart
-              name: {{- if .Values.mysql.enabled }} defectdojo-mysql-specific {{- else }} {{ .Values.mysql.mysqlPasswordSecret }} {{- end }}
+              name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
-              key: {{ if eq .Values.database "postgresql" }}{{ .Values.database }}-password{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.database }}-root-password{{ end }}
         - name: DD_DEBUG
           value: 'True'
   restartPolicy: Never

--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -44,6 +44,7 @@ spec:
               name: {{ .Values.mysql.existingSecret }}
               key: mysql-password
               {{- end }}
+              key: {{ if eq .Values.database "postgresql" }}{{ .Values.database }}-password{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.database }}-root-password{{ end }}
         - name: DD_DEBUG
           value: 'True'
   restartPolicy: Never

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -31,6 +31,8 @@ admin:
 monitoring:
   enabled: false
 
+annotations: {}
+
 # Components
 celery:
   broker: rabbitmq
@@ -111,20 +113,19 @@ initializer:
 mysql:
   enabled: false
   mysqlUser: defectdojo
+  mysqlPassword: 
   existingSecret: defectdojo-mysql-specific
   mysqlDatabase: defectdojo
   service:
     port: 3306  
   # To use an external mySQL instance, set enabled to false and uncomment
   # the line below:
-  # mysqlServer: ""
-  # To use an external secret for the password for an external mySQL instance,
-  # set enabled to false and provide the name of the secret on the line below:
-  # mysqlPasswordSecret: ""  
+  mysqlServer: "127.0.0.1"
 
 postgresql:
   enabled: true
   postgresqlUsername: defectdojo
+  postgresqlPassword: 
   postgresqlDatabase: defectdojo
   existingSecret: defectdojo-postgresql-specific
   persistence:
@@ -135,17 +136,25 @@ postgresql:
     port: 5432  
   # To use an external PostgreSQL instance, set enabled to false and uncomment
   # the line below:
-  # postgresServer: ""
-  # To use an external secret for the password for PostgreSQL
-  # instance, set enabled to false and provide the name of the secret on the
-  # line below:
-  # existingSecret: ""
+  postgresServer: "127.0.0.1"
   master:
     affinity: {}
     nodeSelector: {}
   slave:
     affinity: {}
     nodeSelector: {}
+
+# Google CloudSQL support in GKE via gce-proxy
+cloudsql:
+  # To use CloudSQL in GKE set 'enable: true'
+  enabled: true
+  image:
+    # set repo and image tag of gce-proxy
+    repository: gcr.io/cloudsql-docker/gce-proxy
+    tag: 1.17
+    pullPolicy: IfNotPresent
+  # set CloudSQL instance: 'project:zone:instancname'
+  instance: ""
 
 rabbitmq:
   enabled: true
@@ -155,9 +164,9 @@ rabbitmq:
     existingErlangSecret: defectdojo-rabbitmq-specific
     affinity: {}
     nodeSelector: {}
+
 redis:
   enabled: false
   existingSecret: defectdojo-redis-specific
   cluster:
     slaveCount: 1
-

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -147,7 +147,7 @@ postgresql:
 # Google CloudSQL support in GKE via gce-proxy
 cloudsql:
   # To use CloudSQL in GKE set 'enable: true'
-  enabled: true
+  enabled: false
   image:
     # set repo and image tag of gce-proxy
     repository: gcr.io/cloudsql-docker/gce-proxy

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -119,7 +119,7 @@ mysql:
   mysqlUser: defectdojo
   mysqlPassword: ""
   mysqlRootPassword: ""
-  secret: defectdojo-mysql-specific
+  existingSecret: defectdojo-mysql-specific
   mysqlDatabase: defectdojo
   service:
     port: 3306  
@@ -132,7 +132,7 @@ postgresql:
   postgresqlUsername: defectdojo
   postgresqlPassword: ""
   postgresqlDatabase: defectdojo
-  secret: defectdojo-postgresql-specific
+  existingSecret: defectdojo-postgresql-specific
   persistence:
     enabled: true
   replication:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -24,9 +24,13 @@ tag: latest
 
 admin:
   user: admin
+  password:
   firstName: Administrator
   lastName: User
   mail: admin@defectdojo.local
+  secretKey:
+  credentialAes256Key:
+  metricsHttpAuthPassword:
 
 monitoring:
   enabled: false
@@ -113,7 +117,8 @@ initializer:
 mysql:
   enabled: false
   mysqlUser: defectdojo
-  mysqlPassword: 
+  mysqlPassword: ""
+  mysqlRootPassword: ""
   existingSecret: defectdojo-mysql-specific
   mysqlDatabase: defectdojo
   service:
@@ -125,7 +130,7 @@ mysql:
 postgresql:
   enabled: true
   postgresqlUsername: defectdojo
-  postgresqlPassword: 
+  postgresqlPassword: ""
   postgresqlDatabase: defectdojo
   existingSecret: defectdojo-postgresql-specific
   persistence:
@@ -160,6 +165,8 @@ rabbitmq:
   enabled: true
   replicas: 1
   rabbitmq:
+    password: ""
+    erlangCookie: ""
     existingPasswordSecret: defectdojo-rabbitmq-specific
     existingErlangSecret: defectdojo-rabbitmq-specific
     affinity: {}
@@ -168,5 +175,6 @@ rabbitmq:
 redis:
   enabled: false
   existingSecret: defectdojo-redis-specific
+  password: ""
   cluster:
     slaveCount: 1

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -119,7 +119,7 @@ mysql:
   mysqlUser: defectdojo
   mysqlPassword: ""
   mysqlRootPassword: ""
-  existingSecret: defectdojo-mysql-specific
+  secret: defectdojo-mysql-specific
   mysqlDatabase: defectdojo
   service:
     port: 3306  
@@ -132,7 +132,7 @@ postgresql:
   postgresqlUsername: defectdojo
   postgresqlPassword: ""
   postgresqlDatabase: defectdojo
-  existingSecret: defectdojo-postgresql-specific
+  secret: defectdojo-postgresql-specific
   persistence:
     enabled: true
   replication:


### PR DESCRIPTION
The following improvements are made to the helm chart:
- create a dedicated service account for all pods created by defectdojo and allows custom annotations (e.g. this is useful for workload identity)
- add support for cloudsql-proxy which is deployed as a side car container in all Pods which needs to connect to DB
- extend the mysql and postgresql secrets to allow to inject a user password via a helm value when the in-cluster DB is not used (e.g. useful for an external cloud hosted DB)
- change the deployments to use the same secret for DB password instead of expecting secrets to be created outside of the helm chart
- fix the celery host in the configmap
- increase the chart version to 1.1.0

Signed-off-by: Cosmin Cojocar <cosmin.cojocar@gmx.ch>

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.