### PR TITLE
Docker images - removing superfluous chmod on symlink

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -74,7 +74,6 @@ COPY tests/ ./tests/
 RUN \
   mkdir -p dojo/migrations && \
   chmod g=u dojo/migrations && \
-  chmod g=u /var/run && \
   true
 USER root
 RUN chmod -R 0777 /app

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -71,7 +71,6 @@ COPY docker/entrypoint-nginx.sh /
 RUN \
   apk add --no-cache openssl && \
   chmod -R g=u /var/cache/nginx && \
-  chmod -R g=u /var/run && \
   mkdir -p /etc/nginx/ssl && \
   chmod -R g=u /etc/nginx && \
   true


### PR DESCRIPTION
It actually make kaniko builds fail.
`/var/run` is actually a symlink to `/run` and this chmod has no effect (except making kaniko build fail)

cc @ccojocar