### PR TITLE
Add Sonarqube integration endpoints to APIv2

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -5,7 +5,7 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Product_Type, JIRA_Conf, Endpoint, BurpRawRequestResponse, JIRA_PKey, \
     Notes, DojoMeta, FindingImage, Note_Type, App_Analysis, Endpoint_Status, \
     Sonarqube_Issue, Sonarqube_Issue_Transition, Sonarqube_Product
-    
+
 from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools import requires_file
 from dojo.tools.factory import import_parser_factory

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -3,7 +3,9 @@ from dojo.models import Product, Engagement, Test, Finding, \
     Finding_Template, Test_Type, Development_Environment, NoteHistory, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Product_Type, JIRA_Conf, Endpoint, BurpRawRequestResponse, JIRA_PKey, \
-    Notes, DojoMeta, FindingImage, Note_Type, App_Analysis, Endpoint_Status
+    Notes, DojoMeta, FindingImage, Note_Type, App_Analysis, Endpoint_Status, \
+    Sonarqube_Issue, Sonarqube_Issue_Transition, Sonarqube_Product
+    
 from dojo.forms import ImportScanForm, SEVERITY_CHOICES
 from dojo.tools import requires_file
 from dojo.tools.factory import import_parser_factory
@@ -354,6 +356,24 @@ class JIRAConfSerializer(serializers.ModelSerializer):
 class JIRASerializer(serializers.ModelSerializer):
     class Meta:
         model = JIRA_PKey
+        fields = '__all__'
+
+
+class SonarqubeIssueSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Sonarqube_Issue
+        fields = '__all__'
+
+
+class SonarqubeIssueTransitionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Sonarqube_Issue_Transition
+        fields = '__all__'
+
+
+class SonarqubeProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Sonarqube_Product
         fields = '__all__'
 
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -14,7 +14,8 @@ from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Find
     User, ScanSettings, Scan, Stub_Finding, Finding_Template, Notes, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Endpoint, JIRA_PKey, JIRA_Conf, DojoMeta, Development_Environment, \
-    Dojo_User, Note_Type, System_Settings, App_Analysis, Endpoint_Status
+    Dojo_User, Note_Type, System_Settings, App_Analysis, Endpoint_Status, \
+    Sonarqube_Issue, Sonarqube_Issue_Transition, Sonarqube_Product
 
 from dojo.endpoint.views import get_endpoint_ids
 from dojo.reports.views import report_url_resolver
@@ -428,6 +429,45 @@ class JiraViewSet(mixins.ListModelMixin,
     filter_fields = ('id', 'conf', 'product', 'component', 'project_key',
                      'push_all_issues', 'enable_engagement_epic_mapping',
                      'push_notes')
+
+        
+class SonarqubeIssueViewSet(mixins.ListModelMixin,
+                                mixins.RetrieveModelMixin,
+                                mixins.DestroyModelMixin,
+                                mixins.UpdateModelMixin,
+                                mixins.CreateModelMixin,
+                                viewsets.GenericViewSet):
+    serializer_class = serializers.SonarqubeIssueSerializer
+    queryset = Sonarqube_Issue.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'key', 'status', 'type')
+
+
+class SonarqubeIssueTransitionViewSet(mixins.ListModelMixin,
+                        mixins.RetrieveModelMixin,
+                        mixins.DestroyModelMixin,
+                        mixins.CreateModelMixin,
+                        mixins.UpdateModelMixin,
+                        viewsets.GenericViewSet):
+    serializer_class = serializers.SonarqubeIssueTransitionSerializer
+    queryset = Sonarqube_Issue_Transition.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'sonarqube_issue', 'finding_status',
+                     'sonarqube_status', 'transitions')
+
+
+class SonarqubeProductViewSet(mixins.ListModelMixin,
+                  mixins.RetrieveModelMixin,
+                  mixins.DestroyModelMixin,
+                  mixins.UpdateModelMixin,
+                  mixins.CreateModelMixin,
+                  viewsets.GenericViewSet):
+    serializer_class = serializers.SonarqubeProductSerializer
+    queryset = Sonarqube_Product.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'product', 'sonarqube_project_key',
+                     'sonarqube_tool_config')
+
 
 
 class DojoMetaViewSet(mixins.ListModelMixin,

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -430,7 +430,7 @@ class JiraViewSet(mixins.ListModelMixin,
                      'push_all_issues', 'enable_engagement_epic_mapping',
                      'push_notes')
 
-        
+
 class SonarqubeIssueViewSet(mixins.ListModelMixin,
                                 mixins.RetrieveModelMixin,
                                 mixins.DestroyModelMixin,

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -1230,6 +1230,35 @@
   },
   {
     "pk": 1,
+    "model": "dojo.sonarqube_issue",
+    "fields": {
+      "key": "AREwS5n5TxsDNHm31CxP",
+      "status": "OPEN",
+      "type": "VULNERABILITY"
+    }
+  },
+  {
+    "pk": 1,
+    "model": "dojo.sonarqube_issue_transition",
+    "fields": {
+      "sonarqube_issue": 1,
+      "created": "2020-06-23T22:37:10.369Z",
+      "finding_status": "Active, Verified",
+      "sonarqube_status": "OPEN",
+      "transitions": "confirm"
+    }
+  },
+  {
+    "pk": 1,
+    "model": "dojo.sonarqube_product",
+    "fields": {
+      "product": 2,
+      "sonarqube_project_key": "dojo_sonar_key",
+      "sonarqube_tool_config": 3
+    }
+  },
+  {
+    "pk": 1,
     "model": "dojo.tool_product_settings",
     "fields": {
       "product": 1,

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -1,14 +1,17 @@
 from dojo.models import Product, Engagement, Test, Finding, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
-    Finding_Template, Note_Type, App_Analysis, Endpoint_Status
+    Finding_Template, Note_Type, App_Analysis, Endpoint_Status, \
+    Sonarqube_Issue, Sonarqube_Issue_Transition, Sonarqube_Product
 
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
-    UsersViewSet, ImportScanView, NoteTypeViewSet, AppAnalysisViewSet, EndpointStatusViewSet
+    UsersViewSet, ImportScanView, NoteTypeViewSet, AppAnalysisViewSet, \
+    EndpointStatusViewSet, SonarqubeIssueViewSet, SonarqubeIssueTransitionViewSet, \
+    SonarqubeProductViewSet
 
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
@@ -302,6 +305,55 @@ class JiraTest(BaseClass.RESTEndpointTest):
             "conf": 2,
         }
         self.update_fields = {'conf': 3}
+        BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+    
+class SonarqubeIssueTest(BaseClass.RESTEndpointTest):
+    fixtures = ['dojo_testdata.json']
+
+    def __init__(self, *args, **kwargs):
+        self.endpoint_model = Sonarqube_Issue
+        self.viewname = 'sonarqube_issue'
+        self.viewset = SonarqubeIssueViewSet
+        self.payload = {
+            "key": "AREwS5n5TxsFUNm31CxP",
+            "status": "OPEN",
+            "type": "VULNERABILITY"
+        }
+        self.update_fields = {'key': 'AREwS5n5TxsFUNm31CxP'}
+        BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+
+class SonarqubeIssuesTransitionTest(BaseClass.RESTEndpointTest):
+    fixtures = ['dojo_testdata.json']
+
+    def __init__(self, *args, **kwargs):
+        self.endpoint_model = Sonarqube_Issue_Transition
+        self.viewname = 'sonarqube_issue_transition'
+        self.viewset = SonarqubeIssuesTransitionTest
+        self.payload = {
+            "sonarqube_issue": 1,
+            "finding_status": "Active, Verified",
+            "sonarqube_status": "OPEN",
+            "transitions": "confirm"
+        }
+        self.update_fields = {'sonarqube_status': 'CLOSED'}
+        BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+
+class SonarqubeProductTest(BaseClass.RESTEndpointTest):
+    fixtures = ['dojo_testdata.json']
+
+    def __init__(self, *args, **kwargs):
+        self.endpoint_model = Sonarqube_Product
+        self.viewname = 'sonarqube_product'
+        self.viewset = JiraViewSet
+        self.payload = {
+            "product": 2,
+            "sonarqube_project_key": "dojo_sonar_key",
+            "sonarqube_tool_config": 3
+        }
+        self.update_fields = {'sonarqube_tool_config': 2}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -307,7 +307,7 @@ class JiraTest(BaseClass.RESTEndpointTest):
         self.update_fields = {'conf': 3}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
-    
+
 class SonarqubeIssueTest(BaseClass.RESTEndpointTest):
     fixtures = ['dojo_testdata.json']
 

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -30,7 +30,7 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
     DevelopmentEnvironmentViewSet, NotesViewSet, NoteTypeViewSet, SystemSettingsViewSet, \
     AppAnalysisViewSet, EndpointStatusViewSet, SonarqubeIssueViewSet, SonarqubeIssueTransitionViewSet, \
-    SonarqubeProductViewSet   
+    SonarqubeProductViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -29,7 +29,8 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
     UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
     DevelopmentEnvironmentViewSet, NotesViewSet, NoteTypeViewSet, SystemSettingsViewSet, \
-    AppAnalysisViewSet, EndpointStatusViewSet
+    AppAnalysisViewSet, EndpointStatusViewSet, SonarqubeIssueViewSet, SonarqubeIssueTransitionViewSet, \
+    SonarqubeProductViewSet   
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -113,6 +114,9 @@ v2_api.register(r'products', ProductViewSet)
 v2_api.register(r'product_types', ProductTypeViewSet)
 v2_api.register(r'scan_settings', ScanSettingsViewSet)
 v2_api.register(r'scans', ScansViewSet)
+v2_api.register(r'sonarqube_issues', SonarqubeIssueViewSet)
+v2_api.register(r'sonarqube_transitions', SonarqubeIssueTransitionViewSet)
+v2_api.register(r'sonarqube_product_configurations', SonarqubeProductViewSet)
 v2_api.register(r'stub_findings', StubFindingsViewSet)
 v2_api.register(r'tests', TestsViewSet)
 v2_api.register(r'test_types', TestTypesViewSet)


### PR DESCRIPTION
Add the ability to attach sonarqube tool configs to a product, manage issues, and issue transitions. 

- [x] Your code is flake8 compliant.
- [x] Your code is python 3.5 compliant (specific python >=3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.