### PR TITLE
K8s check dd status 

### DIFF
--- a/travis/script.sh
+++ b/travis/script.sh
@@ -163,6 +163,11 @@ if [ -z "${TEST}" ]; then
     return_value=1
   fi
 
+  echo
+  echo "UWSGI logs"
+  sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi
+  echo
+
   echo "Testing DefectDojo Service"
   # sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
   
@@ -173,12 +178,12 @@ if [ -z "${TEST}" ]; then
   # curl -s -m 10 -I http://defectdojo.default.minikube.local:8888/login?next= -vvv
   # CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
 
-  curl -s http://localhost:8080 -m 120 -vvv
-  curl -s -m 10 -I http://localhost:8080/login?next= -vvv
+  # curl -s http://localhost:8080 -m 120 -vvv
+  # curl -s -m 10 -I http://localhost:8080/login?next= -vvv
 
-  curl -s http://$DD_HOST:8080 -m 120 -vvv
-  curl -s -m 10 -I http://$DD_HOST:8080/login?next= -vvv
-  CR=$(curl -s -m 10 -I http://$DD_HOST:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  curl -s http://$DD_HOST -vvv
+  curl -s -m 10 -I http://$DD_HOST/login?next= -vvv
+  CR=$(curl -s -m 10 -I http://$DD_HOST/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
   echo CR: $CR
       
   if [ "$CR" != 200 ]; then

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -164,7 +164,7 @@ if [ -z "${TEST}" ]; then
   fi
 
   echo "Testing DefectDojo Service"
-  sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
+  # sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
   
   # echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
   # echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -145,6 +145,16 @@ if [ -z "${TEST}" ]; then
   if [[ ${i} -gt ${TIMEOUT} ]]; then
     return_value=1
   fi
+
+  echo "Testing DefectDojo Service"
+  curl -s -o "/dev/null" http://defectdojo.default.minikube.local:8080 -m 120
+  CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  if [ "$CR" != 200 ]; then
+    echo "ERROR: cannot display login screen; got HTTP code $CR"
+    docker-compose logs  --tail="all" uwsgi
+    exit 1
+  fi
+
   echo
   echo "UWSGI logs"
   sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -191,7 +191,7 @@ if [ -z "${TEST}" ]; then
 
 
   echo "Testing DefectDojo Service"
-  # sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
+  sudo kubectl port-forward --namespace=default service/defectdojo-django 80:8080
   
   # echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
   # echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -130,6 +130,15 @@ if [ -z "${TEST}" ]; then
 
   echo "describe"
   sudo kubectl describe --namespace=default service/defectdojo-django
+  echo "describe2"
+  sudo kubectl describe --namespace=default service/defectdojo-django | grep IP
+  echo "describe3"
+  sudo kubectl describe --namespace=default service/defectdojo-django | grep IP | cut  -d' ' -f2
+  echo "describe4"
+  DD_HOST=$(sudo kubectl describe --namespace=default service/defectdojo-django | grep IP | cut  -d' ' -f2)
+  echo DD_HOST: $DD_HOST
+
+
   echo "json"
   sudo kubectl describe --namespace=default service/defectdojo-django -o json
     echo "jsonpath"
@@ -164,16 +173,16 @@ if [ -z "${TEST}" ]; then
   curl -s -m 10 -I http://defectdojo.default.minikube.local:8888/login?next= -vvv
   CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
 
-  curl -s http://defectdojo.default.minikube.local -m 120 -vvv
-  curl -s -m 10 -I http://defectdojo.default.minikube.local/login?next= -vvv
-  CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  curl -s http://$DD_HOST:8080 -m 120 -vvv
+  curl -s -m 10 -I http://$DD_HOST:8080/login?next= -vvv
+  CR=$(curl -s -m 10 -I http://$DD_HOST:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
 
   # curl -s http://localhost:8080 -m 120 -vvv
   # curl -s -m 10 -I http://localhost:8080/login?next= -vvv
   # curl -s http://localhost:80 -m 120 -vvv
   # curl -s -m 10 -I http://localhost:80/login?next= -vvv
   
-  CR=$(curl -s -m 10 -I http://localhost:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  CR=$(curl -s -m 10 -I http://$DD_HOST:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
   if [ "$CR" != 200 ]; then
     echo "ERROR: cannot display login screen; got HTTP code $CR"
     sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -147,13 +147,15 @@ if [ -z "${TEST}" ]; then
   fi
 
   echo "Testing DefectDojo Service"
-  kubectl port-forward --namespace=default service/defectdojo-django 8080:80
+  sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
   echo "describe"
-  kubectl describe --namespace=default service/defectdojo-django
-  echo "json out"
-  kubectl describe --namespace=default service/defectdojo-django -o jsonpath='{.spec.clusterIP}'  
+  sudo kubectl describe --namespace=default service/defectdojo-django
+  echo "json"
+  sudo kubectl describe --namespace=default service/defectdojo-django -o json
+    echo "jsonpath"
+  sudo kubectl describe --namespace=default service/defectdojo-django -o=jsonpath='{.spec.clusterIP}'  
   echo "yaml grep"
-  kubectl get svc <your-service> -o yaml | grep ip
+  sudo kubectl get --namespace=default svc service/defectdojo-django -o yaml | grep ip
 
   echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
   echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -147,13 +147,19 @@ if [ -z "${TEST}" ]; then
   fi
 
   echo "Testing DefectDojo Service"
+  kubectl port-forward --namespace=default service/defectdojo-django 8080:80
+
   # curl -s -o "/dev/null" http://defectdojo.default.minikube.local:8080 -m 120
   # CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
-  curl -s -o "/dev/null" http://localhost:8080 -m 120
+  curl -s http://localhost:8080 -m 120 -vvv
+  curl -s -m 10 -I http://localhost:8080/login?next= -vvv
+  curl -s http://localhost:80 -m 120 -vvv
+  curl -s -m 10 -I http://localhost:80/login?next= -vvv
+  
   CR=$(curl -s -m 10 -I http://localhost:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
   if [ "$CR" != 200 ]; then
     echo "ERROR: cannot display login screen; got HTTP code $CR"
-    docker-compose logs  --tail="all" uwsgi
+    sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi
     exit 1
   fi
 

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -155,6 +155,11 @@ if [ -z "${TEST}" ]; then
   curl -s http://defectdojo.default.minikube.local:8080 -m 120 -vvv
   curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= -vvv
   CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+
+  curl -s http://defectdojo.default.minikube.local -m 120 -vvv
+  curl -s -m 10 -I http://defectdojo.default.minikube.local/login?next= -vvv
+  CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+
   # curl -s http://localhost:8080 -m 120 -vvv
   # curl -s -m 10 -I http://localhost:8080/login?next= -vvv
   # curl -s http://localhost:80 -m 120 -vvv

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -131,11 +131,11 @@ if [ -z "${TEST}" ]; then
   echo "describe"
   sudo kubectl describe --namespace=default service/defectdojo-django
   echo "describe2"
-  sudo kubectl describe --namespace=default service/defectdojo-django | grep IP
+  sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:'
   echo "describe3"
-  sudo kubectl describe --namespace=default service/defectdojo-django | grep IP | cut  -d' ' -f2
+  sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:' | cut -d ':' -f 2 | xargs
   echo "describe4"
-  DD_HOST=$(sudo kubectl describe --namespace=default service/defectdojo-django | grep IP | cut  -d' ' -f2)
+  DD_HOST=$(sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:' | cut -d ':' -f 2 | xargs)
   echo DD_HOST: $DD_HOST
 
 

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -128,23 +128,23 @@ if [ -z "${TEST}" ]; then
     ${HELM_DATABASE_SETTINGS} \
     --set createSecret=true
 
-  echo "describe"
-  sudo kubectl describe --namespace=default service/defectdojo-django
-  echo "describe2"
-  sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:'
-  echo "describe3"
-  sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:' | cut -d ':' -f 2 | xargs
-  echo "describe4"
+  # echo "describe"
+  # sudo kubectl describe --namespace=default service/defectdojo-django
+  # echo "describe2"
+  # sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:'
+  # echo "describe3"
+  # sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:' | cut -d ':' -f 2 | xargs
+  # echo "describe4"
   DD_HOST=$(sudo kubectl describe --namespace=default service/defectdojo-django | grep 'IP:' | cut -d ':' -f 2 | xargs)
   echo DD_HOST: $DD_HOST
 
 
-  echo "json"
-  sudo kubectl describe --namespace=default service/defectdojo-django -o json
-    echo "jsonpath"
-  sudo kubectl describe --namespace=default service/defectdojo-django -o=jsonpath='{.spec.clusterIP}'  
-  echo "yaml grep"
-  sudo kubectl get --namespace=default svc service/defectdojo-django -o yaml | grep ip
+  # echo "json"
+  # sudo kubectl describe --namespace=default service/defectdojo-django -o json
+  #   echo "jsonpath"
+  # sudo kubectl describe --namespace=default service/defectdojo-django -o=jsonpath='{.spec.clusterIP}'  
+  # echo "yaml grep"
+  # sudo kubectl get --namespace=default svc service/defectdojo-django -o yaml | grep ip
 
   echo -n "Waiting for DefectDojo to become ready "
   i=0
@@ -164,25 +164,23 @@ if [ -z "${TEST}" ]; then
   fi
 
   echo "Testing DefectDojo Service"
-  sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:8888
+  sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
   
-  echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
-  echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
+  # echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
+  # echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
 
-  curl -s http://defectdojo.default.minikube.local:8888 -m 120 -vvv
-  curl -s -m 10 -I http://defectdojo.default.minikube.local:8888/login?next= -vvv
-  CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  # curl -s http://defectdojo.default.minikube.local:8888 -m 120 -vvv
+  # curl -s -m 10 -I http://defectdojo.default.minikube.local:8888/login?next= -vvv
+  # CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+
+  curl -s http://localhost:8080 -m 120 -vvv
+  curl -s -m 10 -I http://localhost:8080/login?next= -vvv
 
   curl -s http://$DD_HOST:8080 -m 120 -vvv
   curl -s -m 10 -I http://$DD_HOST:8080/login?next= -vvv
   CR=$(curl -s -m 10 -I http://$DD_HOST:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
-
-  # curl -s http://localhost:8080 -m 120 -vvv
-  # curl -s -m 10 -I http://localhost:8080/login?next= -vvv
-  # curl -s http://localhost:80 -m 120 -vvv
-  # curl -s -m 10 -I http://localhost:80/login?next= -vvv
-  
-  CR=$(curl -s -m 10 -I http://$DD_HOST:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  echo CR: $CR
+      
   if [ "$CR" != 200 ]; then
     echo "ERROR: cannot display login screen; got HTTP code $CR"
     sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -128,6 +128,14 @@ if [ -z "${TEST}" ]; then
     ${HELM_DATABASE_SETTINGS} \
     --set createSecret=true
 
+  echo "describe"
+  sudo kubectl describe --namespace=default service/defectdojo-django
+  echo "json"
+  sudo kubectl describe --namespace=default service/defectdojo-django -o json
+    echo "jsonpath"
+  sudo kubectl describe --namespace=default service/defectdojo-django -o=jsonpath='{.spec.clusterIP}'  
+  echo "yaml grep"
+  sudo kubectl get --namespace=default svc service/defectdojo-django -o yaml | grep ip
 
   echo -n "Waiting for DefectDojo to become ready "
   i=0
@@ -147,21 +155,13 @@ if [ -z "${TEST}" ]; then
   fi
 
   echo "Testing DefectDojo Service"
-  sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
-  echo "describe"
-  sudo kubectl describe --namespace=default service/defectdojo-django
-  echo "json"
-  sudo kubectl describe --namespace=default service/defectdojo-django -o json
-    echo "jsonpath"
-  sudo kubectl describe --namespace=default service/defectdojo-django -o=jsonpath='{.spec.clusterIP}'  
-  echo "yaml grep"
-  sudo kubectl get --namespace=default svc service/defectdojo-django -o yaml | grep ip
-
+  sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:8888
+  
   echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
   echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
 
-  curl -s http://defectdojo.default.minikube.local:8080 -m 120 -vvv
-  curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= -vvv
+  curl -s http://defectdojo.default.minikube.local:8888 -m 120 -vvv
+  curl -s -m 10 -I http://defectdojo.default.minikube.local:8888/login?next= -vvv
   CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
 
   curl -s http://defectdojo.default.minikube.local -m 120 -vvv

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -168,30 +168,6 @@ if [ -z "${TEST}" ]; then
   sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi
   echo
 
-  echo "Testing DefectDojo Service"
-  # sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
-  
-  # echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
-  # echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
-
-  # curl -s http://defectdojo.default.minikube.local:8888 -m 120 -vvv
-  # curl -s -m 10 -I http://defectdojo.default.minikube.local:8888/login?next= -vvv
-  # CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
-
-  # curl -s http://localhost:8080 -m 120 -vvv
-  # curl -s -m 10 -I http://localhost:8080/login?next= -vvv
-
-  curl -s http://$DD_HOST -vvv
-  curl -s -m 10 -I http://$DD_HOST/login?next= -vvv
-  CR=$(curl -s -m 10 -I http://$DD_HOST/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
-  echo CR: $CR
-      
-  if [ "$CR" != 200 ]; then
-    echo "ERROR: cannot display login screen; got HTTP code $CR"
-    sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi
-    exit 1
-  fi
-
   echo
   echo "UWSGI logs"
   sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi
@@ -212,6 +188,35 @@ if [ -z "${TEST}" ]; then
   echo
   echo "Pods"
   sudo kubectl get pods
+
+
+  echo "Testing DefectDojo Service"
+  # sudo kubectl port-forward --namespace=default service/defectdojo-django 8080:80
+  
+  # echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
+  # echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
+
+  # curl -s http://defectdojo.default.minikube.local:8888 -m 120 -vvv
+  # curl -s -m 10 -I http://defectdojo.default.minikube.local:8888/login?next= -vvv
+  # CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+
+  # curl -s http://localhost:8080 -m 120 -vvv
+  # curl -s -m 10 -I http://localhost:8080/login?next= -vvv
+
+  curl -s http://$DD_HOST:8080 -vvv
+  curl -s -m 10 -I http://$DD_HOST:8080/login?next= -vvv
+  
+  curl -s http://$DD_HOST -vvv
+  curl -s -m 10 -I http://$DD_HOST/login?next= -vvv
+
+  CR=$(curl -s -m 10 -I http://$DD_HOST/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  echo CR: $CR
+      
+  if [ "$CR" != 200 ]; then
+    echo "ERROR: cannot display login screen; got HTTP code $CR"
+    sudo kubectl logs --selector=defectdojo.org/component=django -c uwsgi
+    exit 1
+  fi
 
   # Uninstall
   echo "Deleting DefectDojo from Kubernetes"

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -149,12 +149,16 @@ if [ -z "${TEST}" ]; then
   echo "Testing DefectDojo Service"
   kubectl port-forward --namespace=default service/defectdojo-django 8080:80
 
-  # curl -s -o "/dev/null" http://defectdojo.default.minikube.local:8080 -m 120
-  # CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
-  curl -s http://localhost:8080 -m 120 -vvv
-  curl -s -m 10 -I http://localhost:8080/login?next= -vvv
-  curl -s http://localhost:80 -m 120 -vvv
-  curl -s -m 10 -I http://localhost:80/login?next= -vvv
+  echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
+  echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
+
+  curl -s http://defectdojo.default.minikube.local:8080 -m 120 -vvv
+  curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= -vvv
+  CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  # curl -s http://localhost:8080 -m 120 -vvv
+  # curl -s -m 10 -I http://localhost:8080/login?next= -vvv
+  # curl -s http://localhost:80 -m 120 -vvv
+  # curl -s -m 10 -I http://localhost:80/login?next= -vvv
   
   CR=$(curl -s -m 10 -I http://localhost:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
   if [ "$CR" != 200 ]; then

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -148,6 +148,7 @@ if [ -z "${TEST}" ]; then
 
   echo "Testing DefectDojo Service"
   kubectl port-forward --namespace=default service/defectdojo-django 8080:80
+  kubectl describe --namespace=default service/defectdojo-django
 
   echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
   echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -148,7 +148,12 @@ if [ -z "${TEST}" ]; then
 
   echo "Testing DefectDojo Service"
   kubectl port-forward --namespace=default service/defectdojo-django 8080:80
+  echo "describe"
   kubectl describe --namespace=default service/defectdojo-django
+  echo "json out"
+  kubectl describe --namespace=default service/defectdojo-django -o jsonpath='{.spec.clusterIP}'  
+  echo "yaml grep"
+  kubectl get svc <your-service> -o yaml | grep ip
 
   echo '::1       defectdojo.default.minikube.local' | sudo tee -a /etc/hosts
   echo '127.0.0.1 defectdojo.default.minikube.local' | sudo tee -a /etc/hosts

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -147,8 +147,10 @@ if [ -z "${TEST}" ]; then
   fi
 
   echo "Testing DefectDojo Service"
-  curl -s -o "/dev/null" http://defectdojo.default.minikube.local:8080 -m 120
-  CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  # curl -s -o "/dev/null" http://defectdojo.default.minikube.local:8080 -m 120
+  # CR=$(curl -s -m 10 -I http://defectdojo.default.minikube.local:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  curl -s -o "/dev/null" http://localhost:8080 -m 120
+  CR=$(curl -s -m 10 -I http://localhost:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
   if [ "$CR" != 200 ]; then
     echo "ERROR: cannot display login screen; got HTTP code $CR"
     docker-compose logs  --tail="all" uwsgi


### PR DESCRIPTION
In travis build https://travis-ci.org/github/DefectDojo/django-DefectDojo/builds/708492749 we see that defect dojo is not working correctly, the login page doesn't work. The integrationtests step in travis detects this and lets the test fail correctly.
The kubernest steps in travis are still looking green and happy. This PR is an attempt to add the same check there to avoid false negatives.