### PR TITLE
Update to Gitleak deduplication algorithm

### DIFF
--- a/dojo/tools/gitleaks/parser.py
+++ b/dojo/tools/gitleaks/parser.py
@@ -32,13 +32,13 @@ class GitleaksJSONParser(object):
             description += "**Author:** " + issue["author"] + " <" + issue["email"] + ">" + "\n"
             description += "**Reason:** " + reason + "\n"
             description += "**Path:** " + file_path + "\n"
-            description += "\n**String Found:**\n" + issue["line"] + "\n"
+            description += "\n**String Found:**\n" + issue["line"].replace(issue["offender"], "REDACTED") + "\n"
 
             severity = "High"
             if "Github" in reason or "AWS" in reason or "Heroku" in reason:
                 severity = "Critical"
 
-            dupe_key = hashlib.md5((file_path + issue["line"] + issue["commit"]).encode("utf-8")).hexdigest()
+            dupe_key = hashlib.md5((issue["offender"]).encode("utf-8")).hexdigest()
 
             if dupe_key not in self.dupes:
                 self.dupes[dupe_key] = Finding(title=titleText,


### PR DESCRIPTION
TLDR: _After using the current version of the Gitleaks parser (that I developed) in production for quite some time, I realized that the deduplication algorithm was too strict and not efficient._

The current version reports (almost) every single instance of a secret across all files and commits, etc. which means secrets related findings are duplicated many times. When a secret is identified in source code, it should be considered as leaked and it's better to use DD to do a proper deduplication job and return 1 unique finding/secret than dozen of findings/secrets that will need more engineering time to triage.

This new update to the deduplication algorithm will reduce the number of findings to 1 per actual secret which I think is the best way to handle this particular use case.

Current accepted labels for PRs:
- enhancement
