### PR TITLE
uwsgi: add variable to configure the buffer-size

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -18,4 +18,5 @@ exec uwsgi \
   --threads 2 \
   --reload-mercy 1 \
   --worker-reload-mercy 1 \
-  --py-autoreload 1
+  --py-autoreload 1 \
+  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-4096}"

--- a/docker/entrypoint-uwsgi-ptvsd.sh
+++ b/docker/entrypoint-uwsgi-ptvsd.sh
@@ -17,4 +17,5 @@ exec uwsgi \
   --protocol uwsgi \
   --wsgi dojo.wsgi:application \
   --py-autoreload 1 \
-  --enable-threads --lazy-apps --honour-stdin
+  --enable-threads --lazy-apps --honour-stdin \
+  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-4096}"

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -8,4 +8,5 @@ exec uwsgi \
   --enable-threads \
   --processes 2 \
   --threads 2 \
-  --wsgi dojo.wsgi:application
+  --wsgi dojo.wsgi:application \
+  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-4096}"


### PR DESCRIPTION
This commit adds a variable DD_UWSGI_BUFFER_SIZE to set the USWGI buffer-size, so it'll then be possible to set a custom buffer-size as the default one is very small (4096 Bytes) and can cause issue with large cookies.

(ref to #2662)