### PR TITLE
Improve Burp Enterprise parser and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ dojo/uploads/risk/*
 dojo/uploads/reports/*
 dojo/scans/scan*
 dojo/uploads/threat/*
+dojo/fixtures/initial_surveys.json
 .idea
 *.sqlite
 *.db


### PR DESCRIPTION
Improve Burp Enterprise parser to correctly import the correct amount of findings, include multiple endpoints on a single finding, and deduplicate description fields.

Since it hasn't been done before, I've added survey fixtures to the gitignore list. Every time fixtures are loaded, the fixtures file needs to be updated to accommodate to polymorphic id before being loaded. Now it will never be seen as a modified file. 

- [x] Give a meaninful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.