### PR TITLE
fix popovers in view_test and improve js overall

### DIFF
--- a/dojo/templates/dojo/edit_rule.html
+++ b/dojo/templates/dojo/edit_rule.html
@@ -16,7 +16,6 @@
     $(document).ready(function() {
         $('#id_applied_field).empty();
         $('#id_match_field).empty();
-        $('.has-popover').popover({'trigger':'hover'});
         $('.dropdown-toggle').click(function() { get_alerts(); });
 
         setInterval(function() {

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -149,9 +149,6 @@
           }
         }
         $(function () {
-            $(document).ready(function(){
-              $('[data-toggle="tooltip"]').tooltip();
-            });
             check_checked_endpoint();
 
             $('#id_status').on('click', function (e) {
@@ -170,8 +167,6 @@
                   $( form_element ).submit();
               }
             });
-
-            $('[data-toggle="tooltip"]').tooltip();
 
             $('input[type="checkbox"]').change(function () {
               checkbox_count = 0;

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -320,10 +320,10 @@
                                                       href="{% url 'view_finding' finding.id %}">{{ finding.id }}</a>
                                   {% endif %}
                                   {% if finding.file_path %}
-                                  <i class="fa dojo-sup fa-code has-popover" data-trigger="hover" data-content="{{ finding.file_path }}" data-placement="right" data-container="body" data-original-title="Files" title=""></i>
+                                  <i class="fa fa-code has-popover dojo-sup" data-trigger="hover" data-content="{{ finding.file_path }}" data-placement="right" data-container="body" data-original-title="Files" title=""></i>
                                   {% else %}
                                     {% if finding.endpoints.all %}
-                                      <i class="fa dojo-sup fa-sitemap has-popover" data-html="true" data-trigger="hover" data-content="
+                                      <i class="fa fa-sitemap has-popover dojo-sup" data-html="true" data-trigger="hover" data-content="
                                       {% for endpoint in finding.endpoints.all %}
                                         {{ endpoint }}<br/>
                                       {% endfor %}
@@ -331,18 +331,21 @@
                                     {% endif %}
                                   {% endif %}
                                   {% if finding.component_name %}
-                                    <i class="fa dojo-sup fa-file has-popover" data-trigger="hover" data-placement="right"
+                                    <i class="fa fa-file has-popover dojo-sup" data-trigger="hover" data-placement="right"
                                        data-content="{{ finding.component_name }} - {{ finding.component_version }}"
                                        data-container="body" data-original-title="Component" title=""></i>
                                   {% endif %}
                                   {% if finding.notes.all %}
-                                    <i class="fa fa-comment has-popover" data-trigger="hover" data-content="{{ finding.notes.all.0 }}" data-placement="left" data-container="body" data-original-title="Most Recent Note" title=""></i>
+                                    <i class="glyphicon glyphicon-comment has-popover dojo-sup" data-trigger="hover" data-content="{{ finding.notes.all.0 }}" data-placement="left" data-container="body" data-original-title="Most Recent Note ({{ finding.notes.count }} total)" title=""></i>
+                                    <a href="{% url 'view_finding' finding.id %}#vuln_notes" class="dojo-sup" alt="{{ finding.notes.count }} note{{ finding.notes.count|pluralize }}">
+                                        ({{ finding.notes.count }})
+                                    </a>
                                   {% endif %}
-                                    <sup>
-                                        {% for tag in finding.tags %}
-                                        <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
-                                        {% endfor %}
-                                    </sup>
+                                  <sup>
+                                      {% for tag in finding.tags %}
+                                      <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query={{ tag }}">{{ tag }}</a>
+                                      {% endfor %}
+                                  </sup>
                                 </td>
                                 <td class="nowrap">
                                 {% if finding.cwe > 0 %}
@@ -380,11 +383,6 @@
                                       <a href="{{finding.jira_conf_new.url}}/browse/{{finding.jira_issue.jira_key}}" target="_blank" 
                                            alt="Jira Bug - {{finding.jira_issue.jira_key}}" data-toggle="tooltip" data-placement="bottom" title="{{finding.jira_issue.jira_key}}"><i class="fa fa-bug fa-fw"></i></a>
                                     {% endif %}
-                                    {% if finding.notes.count %}
-                                      <a href="{% url 'view_finding' finding.id %}#vuln_notes" alt="{{ finding.notes.count }} comment{{ finding.notes.count|pluralize }}">
-                                        <span class="glyphicon glyphicon-comment"></span> {{ finding.notes.count }}
-                                      </a>
-                                    {% endif %}                                    
                                   {% endif %}
                                 </td>
                                 {% if system_settings.enable_jira %}
@@ -555,9 +553,6 @@
           }
         }
         $(function () {
-            $(document).ready(function(){
-              $('[data-toggle="tooltip"]').tooltip();
-            });
             check_checked_finding();
 
             $('#id_bulk_status').on('click', function (e) {
@@ -595,7 +590,6 @@
                   $( form_element ).submit();
               }
             });
-            $('[data-toggle="tooltip"]').tooltip();
 
             var availableTags = [
                 {% for word in title_words %}

--- a/dojo/templates/dojo/new_rule.html
+++ b/dojo/templates/dojo/new_rule.html
@@ -31,7 +31,6 @@
     $(document).ready(function() {
         $('#id_applied_field).empty();
         $('#id_match_field).empty();
-        $('.has-popover').popover({'trigger':'hover'});
         $('.dropdown-toggle').click(function() { get_alerts(); });
 
         setInterval(function() {

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -267,7 +267,6 @@
     <script src="{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     <script type="text/javascript">
         $(function () {
-            $('[data-toggle="tooltip"]').tooltip();
             $(document).on('click', '.panel-heading button.clickable', function (e) {
                 var $this = $(this);
                 if (!$this.hasClass('panel-collapsed')) {

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -810,9 +810,6 @@
                 i.toggleClass('glyphicon-chevron-up').toggleClass('glyphicon-chevron-down');
             });
 
-            $(document).ready(function(){
-              $('[data-toggle="tooltip"]').tooltip();
-            });
             //Ensures dropdown has proper zindex
             $('.table-responsive').on('show.bs.dropdown', function () {
               $('.table-responsive').css( "overflow", "inherit" );

--- a/dojo/templates/dojo/view_engagements.html
+++ b/dojo/templates/dojo/view_engagements.html
@@ -37,7 +37,6 @@
                   {% endif %}
                 }
             });
-            $('[data-toggle="tooltip"]').tooltip();
             //Ensures dropdown has proper zindex
             $('.table-responsive').on('show.bs.dropdown', function () {
               $('.table-responsive').css( "overflow", "inherit" );

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -958,7 +958,6 @@
                 var i = $($(this).find('i').get(0));
                 i.toggleClass('glyphicon-chevron-up').toggleClass('glyphicon-chevron-down');
             })
-            $('[data-toggle="tooltip"]').tooltip()
         });
 
         // keyboard shortcuts
@@ -1088,9 +1087,6 @@
         }
 
         $(function () {
-            $(document).ready(function(){
-              $('[data-toggle="tooltip"]').tooltip();
-            });
             check_checked_finding();
 
             // Keep the dropdown menu open for selecting severity status
@@ -1105,8 +1101,6 @@
             $('.table-responsive').on('hide.bs.dropdown', function () {
               $('.table-responsive').css( "overflow", "auto" );
             })
-
-            $('[data-toggle="tooltip"]').tooltip();
 
             $('#bulk_edit_menu #id_bulk_active').on("click", function (e){
                 var checked = this.checked;

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -368,9 +368,6 @@
   <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
   <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
   <script type="text/javascript">
-    $(function(){
-               $('[data-toggle="tooltip"]').tooltip();
-    });
     $(function() {
       if (document.referrer.indexOf('simple_search') > 0) {
         var terms = '';

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -483,7 +483,10 @@
                               {% endif %}
                             {% endif %}
                              {% if finding.notes.all %}
-                                    <i class="fa fa-comment has-popover" data-trigger="hover" data-content="{{ finding.notes.all.0 }}" data-placement="left" data-container="body" data-original-title="Most Recent Note" title=""></i>
+                                <i class="glyphicon glyphicon-comment has-popover dojo-sup" data-trigger="hover" data-content="{{ finding.notes.all.0 }}" data-placement="left" data-container="body" data-original-title="Most Recent Note ({{ finding.notes.count }} total)" title=""></i>
+                                <a href="{% url 'view_finding' finding.id %}#vuln_notes" class="dojo-sup" alt="{{ finding.notes.count }} note{{ finding.notes.count|pluralize }}">
+                                    ({{ finding.notes.count }})
+                                </a>
                              {% endif %}
                           {% if finding.tags %}
                               <sup>
@@ -778,10 +781,6 @@
         });
 
         $(function () {
-            $(document).ready(function(){
-              $('[data-toggle="tooltip"]').tooltip();
-            });
-
             check_checked_finding();
             $('#id_bulk_status').on('click', function (e) {
                 var checked = this.checked;
@@ -929,7 +928,6 @@
             }
             ;
 
-
             $('form#quick-add-form').on("submit", function (e) {
                 if ($("input#quick_add_finding").val().length == 0) {
                   alert('Potential finding description needs a value.');
@@ -998,7 +996,7 @@
         });
 
         // DataTables setup
-        $(document).ready(function() {
+        $(document).ready(function(){
             date =  new Date().toISOString().slice(0, 10);
             var fileDated = 'Findings_List_' + date;
             var buttonCommon = {
@@ -1015,6 +1013,9 @@
 
             // Mapping of table columns to objects for proper cleanup and data formatting
             var dojoTable = $('#test_findings').DataTable({
+                drawCallback: function(){
+                    $('.has-popover').popover({'trigger':'hover'});
+                },
                 "columns": [
                     {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled %}                    
                     { "data": "dropdown" },


### PR DESCRIPTION
- popovers were broken on `view_test` page (fixes #2631)
- extracted `tooltip` and `popover` javascript calls into `base.html`
- moved the `notes` icon from the JIRA column to the title column
- improved styling of notes icon and number of notes displayment
- some small js / whitespace changes here and there
