### PR TITLE
Add migration to create endpoint_status objects

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ This template is for your information. Please clear everything when submitting y
 
 When submitting a pull request, please make sure you have completed the following checklist:
 
-- [ ] Give a meaninful name to your PR, as it may end up being used in the release notes.
+- [ ] Give a meaningful name to your PR, as it may end up being used in the release notes.
 - [ ] Your code is flake8 compliant.
 - [ ] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
 - [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.

--- a/dojo/db_migrations/0048_create_endpoint_status.py
+++ b/dojo/db_migrations/0048_create_endpoint_status.py
@@ -1,0 +1,50 @@
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    """
+    This script will create endpoint status objects for findings and endpoints for
+    databases that already contain those objects.
+    """
+    def create_status_objects(apps, schema_editor):
+        # Retreive the correct models
+        Finding = apps.get_model('dojo', 'Finding')
+        Endpoint_Status = apps.get_model('dojo', 'Endpoint_Status')
+        # Get a list of findings that have endpoints
+        findings = Finding.objects.annotate(count=models.Count('endpoints')).filter(count__gt=0)
+        for finding in findings:
+            # Get the list of endpoints on the current finding
+            endpoints = finding.endpoints.all()
+            for endpoint in endpoints:
+                # Superflous error checking
+                try:
+                    # Create a new status for each endpoint
+                    status, created = Endpoint_Status.objects.get_or_create(
+                        finding=finding,
+                        endpoint=endpoint,
+                    )
+                    # Check if the status object was created, otherwise, there is nothing to do
+                    if created:
+                        status.date = finding.date
+                        # If the parent endpoint was mitigated with the old system,
+                        # reflect the same on the endpoint status object
+                        if endpoint.mitigated:
+                            status.mitigated = True
+                            status.mitigated_by = finding.reporter
+                        # Save the status object with at least one updated field
+                        status.save()
+                        # Attach the status to the endpoint and finding
+                        endpoint.endpoint_status.add(status)
+                        finding.endpoint_status.add(status)
+                except Exception as e:
+                    # Something wild happened
+                    print(e)
+                    pass
+
+    dependencies = [
+        ('dojo', '0047_jira_minimum_severity_default'),
+    ]
+
+    operations = [migrations.RunPython(create_status_objects)]


### PR DESCRIPTION
* After the upgrade to 1.7.0, endpoints on a finding were no longer displayed in the UI. This is because an Endpoint_Status object had not been created for the endpoint/finding pair. This migration will create and Endpoint_Status object for each Endpoint associated with a Finding. 
* Fix typo in PR template that I just now noticed :)

- [x] Give a meaninful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.
