### PR TITLE
JIRA: small bugfixes, improvements and cleanup

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -976,10 +976,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
             test.save()
             test.engagement.save()
 
-            print(len(new_items))
-            print(reactivated_count)
-            print(mitigated_count)
-            print(unchanged_count - mitigated_count)
+            # print(len(new_items))
+            # print(reactivated_count)
+            # print(mitigated_count)
+            # print(unchanged_count - mitigated_count)
 
             updated_count = mitigated_count + reactivated_count + len(new_items)
             if updated_count > 0:

--- a/dojo/cred/views.py
+++ b/dojo/cred/views.py
@@ -556,11 +556,11 @@ def new_cred_finding(request, fid):
             cred_lookup = Cred_Mapping.objects.filter(
                 cred_id=cred_user.cred_id, finding=finding.id)
 
-            if cred_lookup:
-                print("Cred lookup valid")
+            # if cred_lookup:
+            #     print("Cred lookup valid")
 
-            if cred_user:
-                print("Cred user")
+            # if cred_user:
+            #     print("Cred user")
 
             message = "Credential already associated."
             status_tag = 'alert-danger'
@@ -703,7 +703,7 @@ def view_selenium(request, ttid):
 
     mimetypes.init()
     cred = Cred_Mapping.objects.get(pk=ttid)
-    print(cred.cred_id.selenium_script)
+    # print(cred.cred_id.selenium_script)
     # mimetype, encoding = mimetypes.guess_type(cred.cred_id.selenium_script)
     response = StreamingHttpResponse(
         FileIterWrapper(open(cred.cred_id.selenium_script)))

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -228,7 +228,7 @@ def edit_engagement(request, eid):
         form = EngForm(initial={'product': eng.product.id}, instance=eng, cicd=ci_cd_form, product=eng.product.id)
 
         if use_jira:
-            jform = JIRAEngagementForm(prefix='jiraform', instance=eng, jira_pkey=eng.product.jira_pkey)
+            jform = JIRAEngagementForm(prefix='jiraform', instance=eng)
         else:
             jform = None
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -603,8 +603,8 @@ def import_scan_results(request, eid=None, pid=None):
                         push_to_jira = jform.cleaned_data.get('push_to_jira')
 
                 for item in parser.items:
-                    print("item blowup")
-                    print(item)
+                    # print("item blowup")
+                    # print(item)
                     sev = item.severity
                     if sev == 'Information' or sev == 'Informational':
                         sev = 'Info'

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -615,14 +615,11 @@ def edit_finding(request, fid):
         if use_jira:
             jform = JIRAFindingForm(request.POST, prefix='jiraform', push_all=push_all_jira_issues, instance=finding)
 
-        print('form.is_valid: ', form.is_valid())
-        if jform:
-            print('jform.is_valid: ', jform.is_valid())
-
         if form.is_valid() and (jform is None or jform.is_valid()):
             if jform:
-                print('jform.jira_issue: ', jform.cleaned_data.get('jira_issue'))
-                print('jform.push_to_jira: ', jform.cleaned_data.get('push_to_jira'))
+                logger.debug('jform.jira_issue: %s', jform.cleaned_data.get('jira_issue'))
+                logger.debug('jform.push_to_jira: %s', jform.cleaned_data.get('push_to_jira'))
+
             new_finding = form.save(commit=False)
             new_finding.test = finding.test
             new_finding.numerical_severity = Finding.get_numerical_severity(
@@ -788,12 +785,7 @@ def edit_finding(request, fid):
             title=finding.title).exclude(
             id=finding.id)
     product_tab = Product_Tab(finding.test.engagement.product.id, title="Edit Finding", tab="findings")
-    print('form.errors:')
-    print(form.errors.as_text())
 
-    if jform:
-        print('jform.errors:')
-        print(jform.errors.as_text())
     return render(request, 'dojo/edit_finding.html', {
         'product_tab': product_tab,
         'form': form,
@@ -1174,14 +1166,10 @@ def promote_to_finding(request, fid):
         if use_jira:
             jform = JIRAFindingForm(request.POST, prefix='jiraform', push_all=push_all_jira_issues, jira_pkey=test.engagement.product.jira_pkey)
 
-        print('form.is_valid: ', form.is_valid())
-        if jform:
-            print('jform.is_valid: ', jform.is_valid())
-
         if form.is_valid() and (jform is None or jform.is_valid()):
             if jform:
-                print('jform.jira_issue: ', jform.cleaned_data.get('jira_issue'))
-                print('jform.push_to_jira: ', jform.cleaned_data.get('push_to_jira'))
+                logger.debug('jform.jira_issue: %s', jform.cleaned_data.get('jira_issue'))
+                logger.debug('jform.push_to_jira: %s', jform.cleaned_data.get('push_to_jira'))
 
             new_finding = form.save(commit=False)
             new_finding.test = test

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1003,9 +1003,7 @@ class FindingForm(forms.ModelForm):
         t = [(tag.name, tag.name) for tag in tags]
         super(FindingForm, self).__init__(*args, **kwargs)
         self.fields['tags'].widget.choices = t
-        # print(self.instance.get_simple_risk_acceptance())
         self.fields['simple_risk_accept'].initial = True if self.instance.is_simple_risk_accepted else False
-        # print(self.fields['simple_risk_accept'].initial)
 
     def clean(self):
         cleaned_data = super(FindingForm, self).clean()
@@ -2066,7 +2064,6 @@ class JIRAFindingForm(forms.Form):
             self.fields['push_to_jira'].disabled = True
 
         if self.instance:
-            print('self.instance.has_jira_issue: ', self.instance.has_jira_issue())
             if self.instance.has_jira_issue():
                 self.initial['jira_issue'] = self.instance.jira_issue.jira_key
 
@@ -2146,7 +2143,6 @@ class JIRAEngagementForm(forms.Form):
         super(JIRAEngagementForm, self).__init__(*args, **kwargs)
 
         if self.instance:
-            print('self.instance.has_jira_issue: ', self.instance.has_jira_issue())
             if self.instance.has_jira_issue():
                 self.fields['push_to_jira'].widget.attrs['checked'] = 'checked'
                 self.fields['push_to_jira'].label = 'Update JIRA Epic'

--- a/dojo/github_issue_link/views.py
+++ b/dojo/github_issue_link/views.py
@@ -50,7 +50,7 @@ def new_github(request):
                                      extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('github', ))
             except Exception as info:
-                print(info)
+                logger.error(info)
                 messages.add_message(request,
                                      messages.ERROR,
                                      'Unable to authenticate on github.',

--- a/dojo/management/commands/push_to_jira_update.py
+++ b/dojo/management/commands/push_to_jira_update.py
@@ -2,7 +2,7 @@ from django.core.management.base import BaseCommand
 from pytz import timezone
 
 from dojo.models import Finding
-from dojo.utils import update_issue, get_system_setting
+from dojo.utils import update_jira_issue, get_system_setting
 
 locale = timezone(get_system_setting('time_zone'))
 
@@ -22,5 +22,5 @@ class Command(BaseCommand):
 
         for finding in findings:
             print("Checking issue:" + str(finding.id))
-            update_issue(finding, True)
+            update_jira_issue(finding, True)
             print("########\n")

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1521,7 +1521,6 @@ class Finding(models.Model):
         self.save()
 
     def simple_risk_unaccept(self):
-        print('unaccepting risk')
         # removing from ManyToMany will not fail for non-existing entries
         self.get_simple_risk_acceptance().accepted_findings.remove(self)
         # risk acceptance no longer in place, so reactivate, but only when it makes sense
@@ -2467,22 +2466,20 @@ class Notifications(models.Model):
 
     @classmethod
     def merge_notifications_list(cls, notifications_list):
-        print('merging')
         if not notifications_list:
-            print('return empty list')
             return []
 
         result = None
         for notifications in notifications_list:
-            print('id: ', notifications.id)
-            print('not.user.get_full_name: ', notifications.user.get_full_name())
+            # print('id: ', notifications.id)
+            # print('not.user.get_full_name: ', notifications.user.get_full_name())
             if result is None:
                 # we start by copying the first instance, because creating a new instance would set all notification columns to 'alert' :-()
                 result = notifications
                 # result.pk = None # detach from db
             else:
                 # from dojo.utils import concat_comma_separated_strings
-                print('combining: ' + str(result.scan_added) + ' with ' + str(notifications.scan_added))
+                # print('combining: ' + str(result.scan_added) + ' with ' + str(notifications.scan_added))
                 # result.scan_added = (result.scan_added or []).extend(notifications.scan_added)
                 # if result.scan_added:
                 #     result.scan_added.extend(notifications.scan_added)

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1948,18 +1948,18 @@ class Finding(models.Model):
         # Adding a snippet here for push to JIRA so that it's in one place
         if push_to_jira:
             logger.debug('pushing to jira from finding.save()')
-            from dojo.tasks import update_issue_task, add_issue_task
-            from dojo.utils import add_issue, update_issue
+            from dojo.tasks import update_jira_issue_task, add_jira_issue_task
+            from dojo.utils import add_jira_issue, update_jira_issue
             if jira_issue_exists:
                 if hasattr(self.reporter, 'usercontactinfo') and self.reporter.usercontactinfo.block_execution:
-                    update_issue(self, True)
+                    update_jira_issue(self, True)
                 else:
-                    update_issue_task.delay(self, True)
+                    update_jira_issue_task.delay(self, True)
             else:
                 if hasattr(self.reporter, 'usercontactinfo') and self.reporter.usercontactinfo.block_execution:
-                    add_issue(self, True)
+                    add_jira_issue(self, True)
                 else:
-                    add_issue_task.delay(self, True)
+                    add_jira_issue_task.delay(self, True)
 
     def delete(self, *args, **kwargs):
         for find in self.original_finding.all():
@@ -2438,6 +2438,7 @@ NOTIFICATION_CHOICES = (
     ("slack", "slack"), ("hipchat", "hipchat"), ("mail", "mail"),
     ("alert", "alert")
 )
+
 
 class Notifications(models.Model):
     product_added = MultiSelectField(choices=NOTIFICATION_CHOICES, default='alert', blank=True)

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -238,7 +238,7 @@ def send_mail_notification(event, user=None, *args, **kwargs):
 
 
 def send_alert_notification(event, user=None, *args, **kwargs):
-    print('sending alert notification')
+    logger.info('sending alert notification')
     try:
         icon = kwargs.get('icon', 'info-circle')
         alert = Alerts(

--- a/dojo/object/parser.py
+++ b/dojo/object/parser.py
@@ -58,7 +58,7 @@ def import_object_eng(request, engagement, json_data):
     review_status = Objects_Review.objects.get(pk=review_status_id)
 
     for file in data:
-        print(file["path"])
+        # print(file["path"])
         # Save the file if the object isn't in object table
         file_type, found_object = find_item(file["path"], object_queryset)
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -109,12 +109,7 @@ def view_product(request, pid):
     prod = get_object_or_404(prod_query, id=pid)
     auth = request.user.is_staff or request.user in prod.authorized_users.all()
 
-    # instance = Notificationws.objects.filter(user=request.user).filter(product=prod).first()
-    # print(vars(instance))
-
     personal_notifications_form = ProductNotificationsForm(instance=Notifications.objects.filter(user=request.user).filter(product=prod).first())
-
-    print(vars(personal_notifications_form))
 
     if not auth:
         # will render 403
@@ -773,10 +768,6 @@ def new_eng_for_app(request, pid, cicd=False):
             if 'jiraform-push_to_jira' in request.POST:
                 jform = JIRAEngagementForm(request.POST, prefix='jiraform')
 
-            print('form.is_valid: ', form.is_valid())
-            if jform:
-                print('jform.is_valid: ', jform.is_valid())
-
             if form.is_valid() and (jform is None or jform.is_valid()):
                 if 'jiraform-push_to_jira' in request.POST:
                     if request.user.usercontactinfo.block_execution:
@@ -943,10 +934,6 @@ def ad_hoc_finding(request, pid):
                                      extra_tags='alert-danger')
         if use_jira:
             jform = JIRAFindingForm(request.POST, prefix='jiraform', push_all=push_all_jira_issues, jira_pkey=test.engagement.product.jira_pkey)
-
-        print('form.is_valid: ', form.is_valid())
-        if jform:
-            print('jform.is_valid: ', jform.is_valid())
 
         if form.is_valid() and (jform is None or jform.is_valid()):
             new_finding = form.save(commit=False)
@@ -1165,15 +1152,14 @@ def delete_engagement_presets(request, pid, eid):
 
 
 def edit_notifications(request, pid):
-    print('editing them notifications')
     prod = get_object_or_404(Product, id=pid)
     if request.method == 'POST':
         product_notifications = Notifications.objects.filter(user=request.user).filter(product=prod).first()
         if not product_notifications:
             product_notifications = Notifications(user=request.user, product=prod)
-            print('no existing product notifications found')
+            logger.debug('no existing product notifications found')
         else:
-            print('existing product notifications found')
+            logger.debug('existing product notifications found')
 
         form = ProductNotificationsForm(request.POST, instance=product_notifications)
         # print(vars(form))

--- a/dojo/rules/views.py
+++ b/dojo/rules/views.py
@@ -1,7 +1,6 @@
 # Standard library imports
 import json
 import logging
-import sys
 
 # Third party imports
 from django.contrib import messages
@@ -133,15 +132,15 @@ def delete_rule(request, tid):
     form = DeleteRuleForm(instance=rule)
 
     if request.method == 'POST':
-        print('id' in request.POST, file=sys.stderr)
-        print(str(rule.id) == request.POST['id'], file=sys.stderr)
-        print(str(rule.id) == request.POST['id'], file=sys.stderr)
+        # print('id' in request.POST, file=sys.stderr)
+        # print(str(rule.id) == request.POST['id'], file=sys.stderr)
+        # print(str(rule.id) == request.POST['id'], file=sys.stderr)
         # if 'id' in request.POST and str(rule.id) == request.POST['id']:
         form = DeleteRuleForm(request.POST, instance=rule)
-        print(form.is_valid(), file=sys.stderr)
-        print(form.errors, file=sys.stderr)
-        print(form.non_field_errors(), file=sys.stderr)
-        print('id' in request.POST, file=sys.stderr)
+        # print(form.is_valid(), file=sys.stderr)
+        # print(form.errors, file=sys.stderr)
+        # print(form.non_field_errors(), file=sys.stderr)
+        # print('id' in request.POST, file=sys.stderr)
         if form.is_valid():
             rule.delete()
             messages.add_message(request,

--- a/dojo/tag/prefetching_tag_descriptor.py
+++ b/dojo/tag/prefetching_tag_descriptor.py
@@ -1,4 +1,7 @@
 from tagging.managers import TagDescriptor
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class PrefetchingTagDescriptor(object):
@@ -12,6 +15,6 @@ class PrefetchingTagDescriptor(object):
         return self.__old__get__(instance, owner)
 
     def patch():
-        print('patching TagDescriptor')
+        logger.debug('patching TagDescriptor')
         TagDescriptor.__old__get__ = TagDescriptor.__get__
         TagDescriptor.__get__ = PrefetchingTagDescriptor.get_with_prefetch

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -17,7 +17,7 @@ from dojo.celery import app
 from dojo.tools.tool_issue_updater import tool_issue_updater, update_findings_from_source_issues
 from dojo.utils import sync_false_history, calculate_grade
 from dojo.reports.widgets import report_widget_factory
-from dojo.utils import add_comment, add_epic, add_issue, update_epic, update_issue, \
+from dojo.utils import add_comment, add_epic, add_jira_issue, update_epic, update_jira_issue, \
                        close_epic, sync_rules, fix_loop_duplicates, \
                        rename_whitesource_finding, update_external_issue, add_external_issue, \
                        close_external_issue, reopen_external_issue, sla_compute_and_notify
@@ -262,16 +262,16 @@ def reopen_external_issue_task(find, note, external_issue_provider):
     reopen_external_issue(find, note, external_issue_provider)
 
 
-@task(name='add_issue_task')
-def add_issue_task(find, push_to_jira):
+@task(name='add_jira_issue_task')
+def add_jira_issue_task(find, push_to_jira):
     logger.info("add issue task")
-    add_issue(find, push_to_jira)
+    add_jira_issue(find, push_to_jira)
 
 
-@task(name='update_issue_task')
-def update_issue_task(find, push_to_jira):
+@task(name='update_jira_issue_task')
+def update_jira_issue_task(find, push_to_jira):
     logger.info("update issue task")
-    update_issue(find, push_to_jira)
+    update_jira_issue(find, push_to_jira)
 
 
 @task(name='add_epic_task')

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -314,15 +314,10 @@ def add_findings(request, tid):
         if use_jira:
             jform = JIRAFindingForm(request.POST, prefix='jiraform', push_all=push_all_jira_issues, jira_pkey=test.engagement.product.jira_pkey)
 
-        print('form.is_valid: ', form.is_valid())
-
-        if jform:
-            print('jform.is_valid: ', jform.is_valid())
-
         if form.is_valid() and (jform is None or jform.is_valid()):
             if jform:
-                print('jform.jira_issue: ', jform.cleaned_data.get('jira_issue'))
-                print('jform.push_to_jira: ', jform.cleaned_data.get('push_to_jira'))
+                logger.debug('jform.jira_issue: %s', jform.cleaned_data.get('jira_issue'))
+                logger.debug('jform.push_to_jira: %s', jform.cleaned_data.get('push_to_jira'))
 
             new_finding = form.save(commit=False)
             new_finding.test = test
@@ -338,14 +333,11 @@ def add_findings(request, tid):
             new_finding.save(dedupe_option=False, push_to_jira=False)
             new_finding.endpoints.set(form.cleaned_data['endpoints'])
 
-            print('jira handling')
-
             # Push to jira?
             push_to_jira = False
             jira_message = None
             if jform and jform.is_valid():
                 # Push to Jira?
-                logger.debug('jira form valid')
                 push_to_jira = push_all_jira_issues or jform.cleaned_data.get('push_to_jira')
 
                 # if the jira issue key was changed, update database

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -155,7 +155,9 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
         prefetched_findings = prefetched_findings.prefetch_related('endpoints')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__authorized_users')
+    else:
         logger.debug('unable to prefetch because query was already executed')
+
     return prefetched_findings
 
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -30,9 +30,9 @@ from dojo.models import Finding, Test, Notes, Note_Type, BurpRawRequestResponse,
     Finding_Template, JIRA_PKey, Cred_Mapping, Dojo_User, System_Settings, Endpoint_Status
 from dojo.tools.factory import import_parser_factory
 from dojo.utils import get_page_items, get_page_items_and_count, add_breadcrumb, get_cal_event, message, process_notifications, get_system_setting, \
-    Product_Tab, max_safe, is_scan_file_too_large, add_issue
+    Product_Tab, max_safe, is_scan_file_too_large, add_jira_issue
 from dojo.notifications.helper import create_notification
-from dojo.tasks import add_issue_task
+from dojo.tasks import add_jira_issue_task
 from functools import reduce
 from dojo.finding.views import finding_link_jira, finding_unlink_jira
 
@@ -492,9 +492,9 @@ def add_temp_finding(request, tid, fid):
                 jform = JIRAFindingForm(request.POST, prefix='jiraform', push_all=push_all_jira_issues, jira_pkey=test.engagement.product.jira_pkey)
                 if jform.is_valid():
                     if request.user.usercontactinfo.block_execution:
-                        add_issue(new_finding, jform.cleaned_data.get('push_to_jira'))
+                        add_jira_issue(new_finding, jform.cleaned_data.get('push_to_jira'))
                     else:
-                        add_issue_task.delay(new_finding, jform.cleaned_data.get('push_to_jira'))
+                        add_jira_issue_task.delay(new_finding, jform.cleaned_data.get('push_to_jira'))
 
             messages.add_message(request,
                                  messages.SUCCESS,

--- a/dojo/tools/acunetix/parser.py
+++ b/dojo/tools/acunetix/parser.py
@@ -1,6 +1,9 @@
 from .parser_helper import get_defectdojo_findings
 from dojo.models import Finding
 import re
+import logging
+
+logger = logging.getLogger(__name__)
 
 __author__ = "Vijay Bheemineni"
 __license__ = "MIT"
@@ -50,7 +53,7 @@ class AcunetixScannerParser(object):
                 )
                 defectdojo_findings.append(finding)
             else:
-                print(("Duplicate finding : {defectdojo_title}".format(defectdojo_title=defectdojo_title)))
+                logger.debug(("Duplicate finding : {defectdojo_title}".format(defectdojo_title=defectdojo_title)))
 
         self.items = defectdojo_findings
 
@@ -69,7 +72,7 @@ def get_defectdojo_date(date):
     mon = date[1]
     year = date[2]
     defectdojo_date = "{year}-{mon}-{day}".format(year=year, mon=mon, day=day)
-    print(defectdojo_date)
+    # print(defectdojo_date)
     return defectdojo_date
 
 

--- a/dojo/tools/aws_prowler/parser.py
+++ b/dojo/tools/aws_prowler/parser.py
@@ -61,7 +61,7 @@ class AWSProwlerParser(object):
     def formatview(self, depth):
         if depth > 1:
             return "* "
-            print("depth hit")
+            # print("depth hit")
         else:
             return ""
 

--- a/dojo/tools/aws_scout2/parser.py
+++ b/dojo/tools/aws_scout2/parser.py
@@ -100,7 +100,7 @@ class AWSScout2Parser(object):
     def formatview(self, depth):
         if depth > 1:
             return "* "
-            print("depth hit")
+            # print("depth hit")
         else:
             return ""
 

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -50,13 +50,13 @@ class DependencyCheckParser(object):
             severity = self.get_field_value(cvssv2_node, 'severity').lower().capitalize()
         else:
             severity = self.get_field_value(vulnerability, 'severity').lower().capitalize()
-        print("severity: " + severity)
+        # print("severity: " + severity)
         if severity in SEVERITY:
             severity = severity
         else:
             tag = "Severity is inaccurate : " + str(severity)
             title += " | " + tag
-            print("Warning: Inaccurate severity detected. Setting it's severity to Medium level.\n" + "Title is :" + title)
+            logger.warn("Warning: Inaccurate severity detected. Setting it's severity to Medium level.\n" + "Title is :" + title)
             severity = "Medium"
 
         reference_detail = None

--- a/dojo/tools/outpost24/parser.py
+++ b/dojo/tools/outpost24/parser.py
@@ -1,5 +1,8 @@
 from defusedxml import ElementTree
 from dojo.models import Finding, Endpoint
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Outpost24Parser:
@@ -51,7 +54,7 @@ class Outpost24Parser:
                 try:
                     port = int(detail.findtext('./portinfo/portnumber'))
                 except ValueError as ve:
-                    print("General port given. Assigning 0 as default.")
+                    logger.debug("General port given. Assigning 0 as default.")
                     port = 0
                 finding.unsaved_endpoints.append(Endpoint(protocol=protocol, host=host, port=port))
             items.append(finding)

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -29,7 +29,7 @@ class PhpSymfonySecurityCheckParser(object):
         return tree
 
     def get_items(self, tree, test):
-        print(('tree: ', tree))
+        # print(('tree: ', tree))
         items = {}
 
         for dependency_name, dependency_data in list(tree.items()):
@@ -39,7 +39,7 @@ class PhpSymfonySecurityCheckParser(object):
                 item = get_item(dependency_name, dependency_version, advisory, test)
                 unique_key = str(dependency_name) + str(dependency_data['version'] + str(advisory['cve']))
                 items[unique_key] = item
-                print(('item: ', item))
+                # print(('item: ', item))
 
         return list(items.values())
 

--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -85,7 +85,7 @@ def report_writer(report_dic, output_filename):
         csvWriter = utfdictcsv.DictUnicodeWriter(outFile, REPORT_HEADERS, quoting=csv.QUOTE_ALL)
         csvWriter.writerow(CUSTOM_HEADERS)
         csvWriter.writerows(report_dic)
-    print("Successfully parsed.")
+    logger.debug("Successfully parsed.")
 
 ################################################################
 

--- a/dojo/tools/qualys_infrascan_webgui/parser.py
+++ b/dojo/tools/qualys_infrascan_webgui/parser.py
@@ -42,7 +42,7 @@ def report_writer(report_dic, output_filename):
         csvWriter = utfdictcsv.DictUnicodeWriter(outFile, REPORT_HEADERS, quoting=csv.QUOTE_ALL)
         csvWriter.writerow(CUSTOM_HEADERS)
         csvWriter.writerows(report_dic)
-    print("Successfully parsed.")
+    logger.debug("Successfully parsed.")
 
 
 def issue_r(raw_row, vuln, scan_date):
@@ -203,7 +203,7 @@ if __name__ == "__main__":
     try:
         qualys_parser(args.qualys_xml_file)
     except IOError:
-        print("[!] Error processing file: {}".format(args.qualys_xml_file))
+        logger.error("[!] Error processing file: {}".format(args.qualys_xml_file))
         exit()
 
 

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -1,11 +1,13 @@
 import io
 import csv
 import json
-
+import logging
 import hashlib
 
 from django.utils.html import escape
 from dojo.models import Finding
+
+logger = logging.getLogger(__name__)
 
 
 class TwistlockCSVParser(object):
@@ -119,7 +121,7 @@ class TwistlockJsonParser(object):
                         node['packageVersion']) + str(node['severity']))
                     items[unique_key] = item
             except KeyError as ke:
-                print("Could not find key {}".format(ke))
+                logger.warn("Could not find key {}".format(ke))
 
         return list(items.values())
 

--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -67,7 +67,7 @@ class WhitesourceJSONParser(object):
                             topfix_node.get('fixResolution')
                         )
                 except Exception as e:
-                    ("Error handling topFix node. {}").format(e)
+                    print("Error handling topFix node. {}").format(e)
 
             filepaths = []
             if 'sourceFiles' in node:

--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -67,7 +67,7 @@ class WhitesourceJSONParser(object):
                             topfix_node.get('fixResolution')
                         )
                 except Exception as e:
-                    print("Error handling topFix node. {}").format(e)
+                    ("Error handling topFix node. {}").format(e)
 
             filepaths = []
             if 'sourceFiles' in node:

--- a/dojo/unittests/test_notifications.py
+++ b/dojo/unittests/test_notifications.py
@@ -18,22 +18,22 @@ class TestNotifications(TestCase):
 
         global_personal_notifications = Notifications.objects.get(id=global_personal_notifications.id)
 
-        print(vars(global_personal_notifications))
+        # print(vars(global_personal_notifications))
 
         personal_product_notifications.product_added = ['mail']
         personal_product_notifications.test_added = ['mail', 'alert']
         personal_product_notifications.scan_added = None
-        print(vars(personal_product_notifications))
+        # print(vars(personal_product_notifications))
 
         personal_product_notifications.save()
 
         personal_product_notifications = Notifications.objects.get(id=personal_product_notifications.id)
 
-        print(vars(personal_product_notifications))
+        # print(vars(personal_product_notifications))
 
         merged_notifications = Notifications.merge_notifications_list([global_personal_notifications, personal_product_notifications])
 
-        print(vars(merged_notifications))
+        # print(vars(merged_notifications))
 
         self.assertEqual('alert' in merged_notifications.product_added, True)
         self.assertEqual('mail' in merged_notifications.product_added, True)

--- a/dojo/unittests/test_taggit_tags.py
+++ b/dojo/unittests/test_taggit_tags.py
@@ -9,7 +9,7 @@ class TaggitTests(TestCase):
         pass
 
     def test_tags_prefetching(self):
-        print('\nadding tags')
+        # print('\nadding tags')
         for product in Product.objects.all():
             product.tags = self.add_tags(product.tags, ['product_' + str(product.id)])
             product.save()

--- a/dojo/user/helper.py
+++ b/dojo/user/helper.py
@@ -73,7 +73,7 @@ def user_must_be_authorized(model, perm_type, arg, lookup="pk", view_func=None):
             logger.warn('User %s is not authorized to %s for %s', request.user, perm_type, obj)
             raise PermissionDenied()
 
-        print('user is authorized for: ', obj)
+        # print('user is authorized for: ', obj)
         # Django doesn't seem to easily support just passing on the original positional parameters
         # so we resort to explicitly putting lookup_value here (which is for example the 'fid' parameter)
         return view_func(request, lookup_value, *args, **kwargs)

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -40,7 +40,6 @@ from django.http import HttpResponseRedirect
 # import traceback
 
 
-
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
@@ -1336,7 +1335,7 @@ def reopen_external_issue(find, note, external_issue_provider):
         reopen_external_issue_github(find, note, prod, eng)
 
 
-def add_issue(find, push_to_jira):
+def add_jira_issue(find, push_to_jira):
     logger.info('trying to create a new jira issue for %d:%s', find.id, find.title)
 
     # traceback.print_stack()
@@ -1432,7 +1431,7 @@ def add_issue(find, push_to_jira):
 
                 new_note = Notes()
                 new_note.entry = 'created JIRA issue %s for finding' % (jira_issue_url)
-                new_note.author = find.reporter  # quick hack because we don't have request.user here
+                new_note.author, created = User.objects.get_or_create(username='JIRA')  # quick hack copied from webhook because we don't have request.user here
                 new_note.save()
                 find.notes.add(new_note)
 
@@ -1445,7 +1444,7 @@ def add_issue(find, push_to_jira):
                     # if jpkey.enable_engagement_epic_mapping:
                     #      epic = JIRA_Issue.objects.get(engagement=eng)
                     #      issue_list = [j_issue.jira_id,]
-                    #      jira.add_issues_to_epic(epic_id=epic.jira_id, issue_keys=[str(j_issue.jira_id)], ignore_epics=True)
+                    #      jira.add_jira_issues_to_epic(epic_id=epic.jira_id, issue_keys=[str(j_issue.jira_id)], ignore_epics=True)
             except JIRAError as e:
                 logger.error(e.text)
                 log_jira_alert(e.text, find)
@@ -1491,7 +1490,7 @@ def jira_check_attachment(issue, source_file_name):
     return file_exists
 
 
-def update_issue(find, push_to_jira):
+def update_jira_issue(find, push_to_jira):
     logger.info('trying to update a linked jira issue for %d:%s', find.id, find.title)
     prod = Product.objects.get(
         engagement=Engagement.objects.get(test=find.test))

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1670,7 +1670,7 @@ def jira_get_issue(jpkey, issue_key):
             server=jira_conf.url,
             basic_auth=(jira_conf.username, jira_conf.password))
         issue = jira.issue(issue_key)
-        print(vars(issue))
+        # print(vars(issue))
         return issue
     except JIRAError as jira_error:
         logger.debug('error retrieving jira issue ' + issue_key + ' ' + str(jira_error))


### PR DESCRIPTION
- bugfix on `edit_engagement`
- set note author to be `jira` after pushing/linking to JIRA issue instead of `finding.reporter`. This is not perfect, but in celery we don't have the request object so we don't know who is actually pushing it.
- rename `add_issue` and `update_issue` in utils to more explicit `add_jira_issue` and `update_jira_issue`
- cleanup left over print/log statements from #2649 
- cleanup other print/log statements because they are not my favourite