### PR TITLE
Fix checkmarx parser when an exploitable finding is hidden by a false…

### DIFF
--- a/dojo/unittests/scans/checkmarx/two_aggregated_findings_one_is_false_positive.xml
+++ b/dojo/unittests/scans/checkmarx/two_aggregated_findings_one_is_false_positive.xml
@@ -1,0 +1,193 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<CxXMLResults InitiatorName="Initiator Name" Owner="domain\user" ScanId="1000227" ProjectId="121" ProjectName="Webgoat" TeamFullPathOnReportDate="team\full\path" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121" ScanStart="Sunday, February 25, 2018 11:35:52 AM" Preset="Checkmarx Default" ScanTime="00h:07m:13s" LinesOfCodeScanned="92054" FilesScanned="480" ReportCreationTime="Monday, April 22, 2019 3:12:18 PM" Team="team_name" CheckmarxVersion="8.6.0 HF1" ScanComments="" ScanType="Full" SourceOrigin="LocalPath" Visibility="Public">
+  <Query id="594" categories="PCI DSS v3.2;PCI DSS (3.2) - 6.5.1 - Injection flaws - particularly SQL injection,OWASP Top 10 2013;A1-Injection,FISMA 2014;System And Information Integrity,NIST SP 800-53;SI-10 Information Input Validation (P1),OWASP Top 10 2017;A1-Injection,OWASP Mobile Top 10 2016;M7-Client Code Quality" cweId="89" name="SQL_Injection" group="Java_High_Risk" Severity="High" Language="Java" LanguageHash="0125540914009541" LanguageChangeDate="2018-02-12T00:00:00.0000000" SeverityIndex="3" QueryPath="Java\Cx\Java High Risk\SQL Injection Version:1" QueryVersionCode="56142311">
+    <Result NodeId="10002270020" FileName="WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java" Status="New" Line="38" Column="52" FalsePositive="True" Severity="High" AssignToUser="" state="0" Remark="" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121&amp;pathid=20" SeverityIndex="3">
+      <Path ResultId="1000227" PathId="20" SimilarityId="-1145061043">
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>38</Line>
+          <Column>52</Column>
+          <NodeId>1</NodeId>
+          <Name>username_login</Name>
+          <Type></Type>
+          <Length>14</Length>
+          <Snippet>
+            <Line>
+              <Number>38</Number>
+              <Code>    public AttackResult login(@RequestParam String username_login, @RequestParam String password_login) throws Exception {</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>49</Line>
+          <Column>134</Column>
+          <NodeId>2</NodeId>
+          <Name>username_login</Name>
+          <Type></Type>
+          <Length>14</Length>
+          <Snippet>
+            <Line>
+              <Number>49</Number>
+              <Code>        PreparedStatement statement = connection.prepareStatement("select password from " + USERS_TABLE_NAME + " where userid = '" + username_login + "' and password = '" + password_login + "'");</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>49</Line>
+          <Column>66</Column>
+          <NodeId>3</NodeId>
+          <Name>prepareStatement</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>49</Number>
+              <Code>        PreparedStatement statement = connection.prepareStatement("select password from " + USERS_TABLE_NAME + " where userid = '" + username_login + "' and password = '" + password_login + "'");</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>49</Line>
+          <Column>27</Column>
+          <NodeId>4</NodeId>
+          <Name>statement</Name>
+          <Type></Type>
+          <Length>9</Length>
+          <Snippet>
+            <Line>
+              <Number>49</Number>
+              <Code>        PreparedStatement statement = connection.prepareStatement("select password from " + USERS_TABLE_NAME + " where userid = '" + username_login + "' and password = '" + password_login + "'");</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>50</Line>
+          <Column>31</Column>
+          <NodeId>5</NodeId>
+          <Name>statement</Name>
+          <Type></Type>
+          <Length>9</Length>
+          <Snippet>
+            <Line>
+              <Number>50</Number>
+              <Code>        ResultSet resultSet = statement.executeQuery();</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>50</Line>
+          <Column>53</Column>
+          <NodeId>6</NodeId>
+          <Name>executeQuery</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>50</Number>
+              <Code>        ResultSet resultSet = statement.executeQuery();</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+      </Path>
+    </Result>
+    <Result NodeId="10002270021" FileName="WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java" Status="New" Line="38" Column="89" FalsePositive="False" Severity="High" AssignToUser="" state="0" Remark="" DeepLink="https://checkmarxserver.com/CxWebClient/ViewerMain.aspx?scanid=1000227&amp;projectid=121&amp;pathid=21" SeverityIndex="3">
+      <Path ResultId="1000227" PathId="21" SimilarityId="-658085948">
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>38</Line>
+          <Column>89</Column>
+          <NodeId>1</NodeId>
+          <Name>password_login</Name>
+          <Type></Type>
+          <Length>14</Length>
+          <Snippet>
+            <Line>
+              <Number>38</Number>
+              <Code>    public AttackResult login(@RequestParam String username_login, @RequestParam String password_login) throws Exception {</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>49</Line>
+          <Column>174</Column>
+          <NodeId>2</NodeId>
+          <Name>password_login</Name>
+          <Type></Type>
+          <Length>14</Length>
+          <Snippet>
+            <Line>
+              <Number>49</Number>
+              <Code>        PreparedStatement statement = connection.prepareStatement("select password from " + USERS_TABLE_NAME + " where userid = '" + username_login + "' and password = '" + password_login + "'");</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>49</Line>
+          <Column>66</Column>
+          <NodeId>3</NodeId>
+          <Name>prepareStatement</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>49</Number>
+              <Code>        PreparedStatement statement = connection.prepareStatement("select password from " + USERS_TABLE_NAME + " where userid = '" + username_login + "' and password = '" + password_login + "'");</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>49</Line>
+          <Column>27</Column>
+          <NodeId>4</NodeId>
+          <Name>statement</Name>
+          <Type></Type>
+          <Length>9</Length>
+          <Snippet>
+            <Line>
+              <Number>49</Number>
+              <Code>        PreparedStatement statement = connection.prepareStatement("select password from " + USERS_TABLE_NAME + " where userid = '" + username_login + "' and password = '" + password_login + "'");</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>50</Line>
+          <Column>31</Column>
+          <NodeId>5</NodeId>
+          <Name>statement</Name>
+          <Type></Type>
+          <Length>9</Length>
+          <Snippet>
+            <Line>
+              <Number>50</Number>
+              <Code>        ResultSet resultSet = statement.executeQuery();</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+        <PathNode>
+          <FileName>WebGoat/webgoat-lessons/challenge/src/main/java/org/owasp/webgoat/plugin/challenge5/challenge6/Assignment5.java</FileName>
+          <Line>50</Line>
+          <Column>53</Column>
+          <NodeId>6</NodeId>
+          <Name>executeQuery</Name>
+          <Type></Type>
+          <Length>1</Length>
+          <Snippet>
+            <Line>
+              <Number>50</Number>
+              <Code>        ResultSet resultSet = statement.executeQuery();</Code>
+            </Line>
+          </Snippet>
+        </PathNode>
+      </Path>
+    </Result>
+  </Query>
+</CxXMLResults>

--- a/dojo/unittests/test_checkmarx_parser.py
+++ b/dojo/unittests/test_checkmarx_parser.py
@@ -224,8 +224,29 @@ class TestCheckmarxParser(TestCase):
         self.assertEqual(True, item.false_p)
 
 # ----------------------------------------------------------------------------
+# two findings with the same aggregate keys, but one is false positive
+# the result should be one exploitable finding, even though the first one found was false positive
+# ----------------------------------------------------------------------------
+
+    def test_file_name_aggregated_parse_file_with_two_aggregated_findings_one_is_false_p(self):
+        my_file_handle, product, engagement, test = self.init("dojo/unittests/scans/checkmarx/two_aggregated_findings_one_is_false_positive.xml")
+        self.parser = CheckmarxXMLParser(my_file_handle, test)
+        self.teardown(my_file_handle)
+        self.assertEqual(1, len(self.parser.items))
+        # check content for aggregated finding
+        item = self.parser.items[0]
+        # finding is never active/verified yet at this time
+        self.assertEqual(bool, type(item.active))
+        self.assertEqual(False, item.active)
+        self.assertEqual(bool, type(item.verified))
+        self.assertEqual(False, item.verified)
+        self.assertEqual(bool, type(item.false_p))
+        self.assertEqual(False, item.false_p)
+
+# ----------------------------------------------------------------------------
 # multiple_findings : source filename = sink filename.
 # ----------------------------------------------------------------------------
+
     def test_file_name_aggregated_parse_file_with_multiple_vulnerabilities_has_multiple_findings(self):
         my_file_handle, product, engagement, test = self.init("dojo/unittests/scans/checkmarx/multiple_findings.xml")
         self.parser = CheckmarxXMLParser(my_file_handle, test)


### PR DESCRIPTION
One of the checkmarx parser aggregates vulnerabilites found in the report. When there are several vulnerabilities in the same aggregate and the first one is false positive, the whole aggregate (=the defectdojo finding) is false positive even if one of the other vulnerabilities is exploitable
This fixes it by making the defectdojo finding exploitable if at least one of the vulnerabilites in the aggregate is exploitable