### PR TITLE
api_v2: fix push_to_jira when using the PATCH method

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1865,6 +1865,7 @@ class Finding(models.Model):
         new_finding = False
 
         jira_issue_exists = JIRA_Issue.objects.filter(finding=self).exists()
+        push_to_jira = getattr(self, 'push_to_jira', push_to_jira)
 
         if self.pk is None:
             # We enter here during the first call from serializers.py


### PR DESCRIPTION
This commit fixes an issue with Jira when using the PATCH method on the api_v2. It's now possible to send only ```{"push_to_jira": "True"}``` on a certain finding without repushing all the fields like we would do with a PUT or a POST.

I've tested the patch and it doesn't break the push_to_jira mechanism from the web-interface.

I'll also send a PR later to simplify the logic to avoid that kind of hack -> https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/api_v2/serializers.py#L482 (re-creating an a temporary object to enrich it....).

