### PR TITLE
npm audit parser: fix cve parsing

### DIFF
--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from dojo.models import Finding
 
@@ -69,6 +70,13 @@ def get_item(item_node, test):
         if len(npm_finding['paths']) > 25:
             paths += "\n  - ..... (list of paths truncated after 25 paths)"
 
+    # Use CWE-1035 as fallback
+    cwe = 1035  # Vulnerable Third Party Component
+    if item_node['cwe']:
+        m = re.match(r"^(CWE-)?(\d+)", item_node['cwe'])
+        if m:
+            cwe = int(m.group(2))
+
     dojo_finding = Finding(title=item_node['title'] + " - " + "(" + item_node['module_name'] + ", " + item_node['vulnerable_versions'] + ")",
                       test=test,
                       severity=severity,
@@ -81,7 +89,7 @@ def get_item(item_node, test):
                       str(paths) + "\n CWE: " +
                       str(item_node['cwe']) + "\n Access: " +
                       str(item_node['access']),
-                      cwe=item_node['cwe'][4:],
+                      cwe=cwe,
                       cve=item_node['cves'][0] if (len(item_node['cves']) > 0) else None,
                       mitigation=item_node['recommendation'],
                       references=item_node['url'],

--- a/dojo/unittests/scans/npm_audit_sample/many_vuln.json
+++ b/dojo/unittests/scans/npm_audit_sample/many_vuln.json
@@ -367,7 +367,7 @@
       "references": "[Issue #167](https://github.com/broofa/node-mime/issues/167)",
       "access": "public",
       "severity": "moderate",
-      "cwe": "CWE-400",
+      "cwe": "CWE-",
       "metadata": {
         "module_type": "Multi.Library",
         "exploitability": 4,


### PR DESCRIPTION
recently the npm published a advisory without a CWE. Instead of using an empty/null value for the CWE field, they have set it to `CWE-`. The npm audit parser chokes on that. This PR fixes that. 

In the future we should ook at extracting some common / shared logic for parsers: #2808