### PR TITLE
api_v2: fix push notes to Jira

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -289,6 +289,9 @@ class FindingViewSet(mixins.ListModelMixin,
             note.save()
             finding.notes.add(note)
 
+            if finding.has_jira_issue():
+                add_comment_task(finding, note)
+
             serialized_note = serializers.NoteSerializer({
                 "author": author, "entry": entry,
                 "private": private


### PR DESCRIPTION
This commit fixes an issue where notes were not pushed to Jira when they were created from the API_V2.