### PR TITLE
fix product endpt html report

### DIFF
--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -514,6 +514,27 @@ def product_endpoint_report(request, pid):
                                  'Your report is building.',
                                  extra_tags='alert-success')
             return HttpResponseRedirect(reverse('reports'))
+        elif report_format == 'HTML':
+            return render(request,
+                          template,
+                          {
+                           'product_type': None,
+                           'product': product,
+                           'engagement': None,
+                           'test': None,
+                           'endpoint': None,
+                           'endpoints': endpoints.qs,
+                           'findings': None,
+                           'include_finding_notes': include_finding_notes,
+                           'include_finding_images': include_finding_images,
+                           'include_executive_summary': include_executive_summary,
+                           'include_table_of_contents': include_table_of_contents,
+                           'user': request.user,
+                           'title': 'Generate Report',
+
+                           })
+
+
         else:
             raise Http404()
 


### PR DESCRIPTION
Added a clause to the product endpoint report function to support html reports. This fixes issue #2745

- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is flake8 compliant.
- [X] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [X] Add the proper label to categorize your PR.