### PR TITLE
BUG-2824, add missing trivy finding fields and settings for deduplication

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -677,6 +677,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # for backwards compatibility because someone decided to rename this scanner:
     'Symfony Security Check': ['title', 'cve'],
     'DSOP Scan': ['cve'],
+    'Trivy Scan': ['title', 'severity', 'cve', 'cwe'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
@@ -692,6 +693,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'ZAP Scan': False,
     'Qualys Scan': True,
     'DSOP Scan': True,
+    'Trivy Scan': True,
 }
 
 # List of fields that are known to be usable in hash_code computation)
@@ -733,6 +735,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     # for backwards compatibility because someone decided to rename this scanner:
     'Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
     'DSOP Scan': DEDUPE_ALGO_HASH_CODE,
+    'Trivy Scan': DEDUPE_ALGO_HASH_CODE,
 }
 
 DISABLE_FINDING_MERGE = env('DD_DISABLE_FINDING_MERGE')

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -20,6 +20,7 @@ TRIVY_SEVERITIES = {
 
 DESCRIPTION_TEMPLATE = """{title}
 Target: {target}
+Type: {type}
 Fixed version: {fixed_version}
 
 {description_text}
@@ -59,6 +60,10 @@ class TrivyParser:
                 package_version = vuln.get('InstalledVersion', '')
                 references = '\n'.join(vuln.get('References', []))
                 mitigation = vuln.get('FixedVersion', '')
+                if len(vuln.get('CweIDs', [])) > 0:
+                    cwe = vuln['CweIDs'][0].split("-")[1]
+                else:
+                    cwe = 0
                 title = ' '.join([
                     vuln_id,
                     package_name,
@@ -67,6 +72,7 @@ class TrivyParser:
                 description = DESCRIPTION_TEMPLATE.format(
                     title=vuln.get('Title', ''),
                     target=target,
+                    type=target_data.get('Type', ''),
                     fixed_version=mitigation,
                     description_text=vuln.get('Description', ''),
                 )
@@ -75,9 +81,14 @@ class TrivyParser:
                         test=test,
                         title=title,
                         cve=vuln_id,
+                        cwe=cwe,
                         severity=severity,
                         references=references,
                         description=description,
                         mitigation=mitigation,
+                        component_name=package_name,
+                        component_version=package_version,
+                        static_finding=True,
+                        dynamic_finding=False,
                     )
                 )

--- a/dojo/unittests/scans/trivy/trivy_mix.json
+++ b/dojo/unittests/scans/trivy/trivy_mix.json
@@ -1,6 +1,7 @@
 [
   {
     "Target": "php-app/composer.lock",
+    "Type": "composer",
     "Vulnerabilities": [
       {
         "PkgName": "simplito/elliptic-php"
@@ -9,6 +10,7 @@
   },
   {
     "Target": "node-app/package-lock.json",
+    "Type": "npm",
     "Vulnerabilities": [
       {
         "VulnerabilityID": "CVE-2018-16487",
@@ -18,6 +20,9 @@
         "Title": "lodash: Prototype pollution in utilities function",
         "Description": "A prototype pollution vulnerability was found in lodash <4.17.11 where the functions merge, mergeWith, and defaultsDeep can be tricked into adding or modifying properties of Object.prototype.",
         "Severity": "HIGH",
+        "CweIDs": [
+          "CWE-190"
+        ],
         "References": [
           "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16487"
         ]
@@ -26,6 +31,7 @@
   },
   {
     "Target": "trivy-ci-test (alpine 3.7.1)",
+    "Type": "alpine",
     "Vulnerabilities": [
       {
         "VulnerabilityID": "CVE-2018-16840",
@@ -92,14 +98,17 @@
   },
   {
     "Target": "python-app/Pipfile.lock",
+    "Type": "pip",
     "Vulnerabilities": null
   },
   {
     "Target": "ruby-app/Gemfile.lock",
+    "Type": "rubygems",
     "Vulnerabilities": null
   },
   {
     "Target": "rust-app/Cargo.lock",
+    "Type": "cargo",
     "Vulnerabilities": null
   }
 ]

--- a/dojo/unittests/test_trivy_parser.py
+++ b/dojo/unittests/test_trivy_parser.py
@@ -18,3 +18,18 @@ class TestTrivyParser(TestCase):
         with open(sample_path('trivy_mix.json')) as test_file:
             trivy_parser = TrivyParser(test_file, self.dojo_test)
         self.assertEqual(len(trivy_parser.items), 6)
+        self.check_title(trivy_parser.items)
+        self.check_cve(trivy_parser.items)
+        self.check_cwe(trivy_parser.items)
+
+    def check_title(self, trivy_findings):
+        self.assertEqual(trivy_findings[0].title, 'CVE-2018-16487 lodash 4.17.4')
+        self.assertEqual(trivy_findings[1].title, 'CVE-2018-16840 curl 7.61.0-r0')
+
+    def check_cve(self, trivy_findings):
+        self.assertEqual(trivy_findings[0].cve, 'CVE-2018-16487')
+        self.assertEqual(trivy_findings[1].cve, 'CVE-2018-16840')
+
+    def check_cwe(self, trivy_findings):
+        self.assertEqual(trivy_findings[0].cwe, '190')
+        self.assertEqual(trivy_findings[1].cwe, 0)


### PR DESCRIPTION
Fixes bug #2824 

When importing trivy scans:

- Adds missing cwe to the extracted fields
- Adds the type (npm, pip, cargo, debian, alpine, etc) to the description
- Adds missing component_name, component_version fields
- Sets finding as a static_finding

It also updates the settings so deduplication works with findings imported from trivy scans.

labels:
bugfix
settings_changes