### PR TITLE
edit finding: fix parent/original duplicate + small fixes

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2242,7 +2242,7 @@ def calculate_possible_related_actions_for_similar_finding(request, finding, sim
     else:
         if similar_finding.duplicate_finding:
             # reset duplicate status is always possible
-            actions.append({'action': 'reset_finding_duplicate_status', 'reason': 'This will remove the finding from the cluster, effectively marking it no longer as duplicate'})
+            actions.append({'action': 'reset_finding_duplicate_status', 'reason': 'This will remove the finding from the cluster, effectively marking it no longer as duplicate. Will not trigger deduplication logic after saving.'})
 
             # logger.debug(similar_finding.duplicate_finding)
             # logger.debug(finding)

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -647,20 +647,8 @@ def edit_finding(request, fid):
                 new_finding.false_p = False
                 new_finding.mitigated = None
                 new_finding.mitigated_by = None
-            if new_finding.duplicate:
-                new_finding.duplicate = True
-                new_finding.active = False
-                new_finding.verified = False
-                parent_find_string = request.POST.get('duplicate_choice', '')
-                if parent_find_string:
-                    parent_find = Finding.objects.get(id=int(parent_find_string.split(':')[0]))
-                    new_finding.duplicate_finding = parent_find
-                    parent_find.found_by.add(new_finding.test.test_type)
-            if not new_finding.duplicate and new_finding.duplicate_finding:
-                parent_find = new_finding.duplicate_finding
-                if parent_find.found_by is not new_finding.found_by:
-                    parent_find.original_finding.remove(new_finding)
-                parent_find.found_by.remove(new_finding.test.test_type)
+            if not new_finding.duplicate:
+                new_finding.duplicate = False
                 new_finding.duplicate_finding = None
 
             if form['simple_risk_accept'].value():

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -309,7 +309,7 @@ def view_finding(request, fid):
     similar_findings = prefetch_for_findings(similar_findings_filter.qs[:10])
     for similar_finding in similar_findings:
         similar_finding.related_actions = calculate_possible_related_actions_for_similar_finding(request, finding, similar_finding)
-        logger.debug('jira_conf_new: %s', similar_finding.jira_conf_new())
+        # logger.debug('jira_conf_new: %s', similar_finding.jira_conf_new())
 
     product_tab = Product_Tab(finding.test.engagement.product.id, title="View Finding", tab="findings")
     lastPos = (len(findings)) - 1
@@ -648,6 +648,7 @@ def edit_finding(request, fid):
                 new_finding.mitigated = None
                 new_finding.mitigated_by = None
             if not new_finding.duplicate:
+                logger.debug('resetting duplicate status for %i', new_finding.id)
                 new_finding.duplicate = False
                 new_finding.duplicate_finding = None
 
@@ -779,15 +780,6 @@ def edit_finding(request, fid):
         form.fields['endpoints'].queryset = finding.endpoints.all()
     form.initial['tags'] = [tag.name for tag in finding.tags]
 
-    if finding.test.engagement.deduplication_on_engagement:
-        finding_dupes = Finding.objects.all().filter(
-            test__engagement=finding.test.engagement).filter(
-            title=finding.title).exclude(
-            id=finding.id)
-    else:
-        finding_dupes = Finding.objects.all().filter(
-            title=finding.title).exclude(
-            id=finding.id)
     product_tab = Product_Tab(finding.test.engagement.product.id, title="Edit Finding", tab="findings")
 
     return render(request, 'dojo/edit_finding.html', {
@@ -796,7 +788,6 @@ def edit_finding(request, fid):
         'finding': finding,
         'jform': jform,
         'gform': gform,
-        'dupes': finding_dupes,
         'return_url': get_return_url(request)
     })
 
@@ -2229,7 +2220,7 @@ def duplicate_cluster(request, finding):
     # populate actions for findings in duplicate cluster
     for duplicate_member in duplicate_cluster:
         duplicate_member.related_actions = calculate_possible_related_actions_for_similar_finding(request, finding, duplicate_member)
-        logger.debug('dupe: jira_conf_new: %s', duplicate_member.jira_conf_new())
+        # logger.debug('dupe: jira_conf_new: %s', duplicate_member.jira_conf_new())
 
     return duplicate_cluster
 
@@ -2271,6 +2262,6 @@ def calculate_possible_related_actions_for_similar_finding(request, finding, sim
                 actions.append({'action': 'mark_finding_duplicate', 'reason': 'Will mark this finding as duplicate of the finding on this page.'})
                 actions.append({'action': 'set_finding_as_original', 'reason': 'Sets this finding as the Original marking the finding on this page as duplicate of this original.'})
 
-    logger.debug('related_actions for %i: %s', similar_finding.id, {finding.id: actions})
+    # logger.debug('related_actions for %i: %s', similar_finding.id, {finding.id: actions})
 
     return actions

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1009,7 +1009,7 @@ class FindingForm(forms.ModelForm):
         self.fields['simple_risk_accept'].initial = True if self.instance.is_simple_risk_accepted else False
 
         if self.instance.duplicate:
-            self.fields['duplicate'].help_text = "Original finding that is being duplicated here (readonly). Use view finding page to manage duplicate relationships. Unchecking duplicate here will reset this findings duplicate status."
+            self.fields['duplicate'].help_text = "Original finding that is being duplicated here (readonly). Use view finding page to manage duplicate relationships. Unchecking duplicate here will reset this findings duplicate status, but will trigger deduplication logic."
         else:
             self.fields['duplicate'].help_text = "You can mark findings as duplicate only from the view finding page."
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1009,9 +1009,9 @@ class FindingForm(forms.ModelForm):
         self.fields['simple_risk_accept'].initial = True if self.instance.is_simple_risk_accepted else False
 
         if self.instance.duplicate:
-            self.fields['duplicate'].help_text = "Original finding that is being duplicated here (readonly, use view finding page to manage duplicate relationships)"
+            self.fields['duplicate'].help_text = "Original finding that is being duplicated here (readonly). Use view finding page to manage duplicate relationships. Unchecking duplicate here will reset this findings duplicate status."
         else:
-            self.fields['duplicate'].help_text = "You can mark findings as duplicate only from the view finding page. Unchecking duplicate here will reset this findings duplicate status, but will run the deuplication logic after saving."
+            self.fields['duplicate'].help_text = "You can mark findings as duplicate only from the view finding page."
 
     def clean(self):
         cleaned_data = super(FindingForm, self).clean()

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1008,6 +1008,11 @@ class FindingForm(forms.ModelForm):
         self.fields['tags'].widget.choices = t
         self.fields['simple_risk_accept'].initial = True if self.instance.is_simple_risk_accepted else False
 
+        if self.instance.duplicate:
+            self.fields['duplicate'].help_text = "Original finding that is being duplicated here (readonly, use view finding page to manage duplicate relationships)"
+        else:
+            self.fields['duplicate'].help_text = "You can mark findings as duplicate only from the view finding page. Unchecking duplicate here will reset this findings duplicate status, but will run the deuplication logic after saving."
+
     def clean(self):
         cleaned_data = super(FindingForm, self).clean()
         if (cleaned_data['active'] or cleaned_data['verified']) and cleaned_data['duplicate']:

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -44,7 +44,38 @@
                 <input type="hidden" name="return_url" value="{{ return_url }}" />            
             {% endif %}
             {% include "dojo/form_fields.html" with form=form %}
-            <div class="form-group hidden">
+            {% if finding.duplicate_finding %}
+                <div class="form-group">
+                    <label class="col-sm-2 control-label" for="id_jira_issue">Original finding
+                        <i class="fa fa-question-circle has-popover" data-trigger="hover" data-content="Original finding that is being duplicated here (readonly, use view finding page to manage duplicate relationships)" data-placement="right" data-container="body" data-original-title="" title="">
+                        </i>
+                    </label>
+                    <div class="col-sm-10 form-control-static">
+                        {{ finding.duplicate_finding.id }}: 
+                        {% if finding.duplicate_finding.cve %}
+                            <a href="{{finding.duplicate_finding.cve|cve_url}} ">({{finding.duplicate_finding.cve}})</a>
+                        {% endif %}                        
+                        {{ finding.duplicate_finding.title }},
+                        {{ finding.duplicate_finding.test.engagement.product.name }}/
+                        {{ finding.duplicate_finding.test.engagement.name }}/
+                        {% if finding.duplicate_finding.test.title %}
+                            {{finding.duplicate_finding.test.title}}
+                        {% else %}
+                            {{finding.duplicate_finding.test.test_type}}
+                        {% endif %}
+
+                        {% if finding.duplicate_finding.jira_issue %}
+                            <a href="{{ finding.duplicate_finding.jira_conf_new.url }}/browse/{{ finding.duplicate_finding.jira_issue.jira_key }}"
+                            target="_blank" title="{{ finding.duplicate_finding.jira_conf_new.url }}/browse/{{ finding.duplicate_finding.jira_issue.jira_key }}">{{ finding.duplicate_finding.jira_issue.jira_key }}</a>
+                        {% endif %}
+                        {% if finding.duplicate_finding.cwe > 0 %}
+                            <a href="{{finding.duplicate_finding.cwe|cwe_url}} ">(CWE-{{finding.duplicate_finding.cwe}})</a>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endif %}
+
+            {% comment %} <div class="form-group hidden">
                 {% if dupes %}
                     <label class="col-sm-2 control-label" for="dupe_choice">Parent Duplicate</label>
                     <div class="col-sm-10">
@@ -63,7 +94,7 @@
                         </select>
                     </div>
                 {% endif %}
-            </div>
+            </div> {% endcomment %}
 
             {% if jform %}
                 <h4> JIRA </h4>

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -44,57 +44,30 @@
                 <input type="hidden" name="return_url" value="{{ return_url }}" />            
             {% endif %}
             {% include "dojo/form_fields.html" with form=form %}
-            {% if finding.duplicate_finding %}
-                <div class="form-group">
-                    <label class="col-sm-2 control-label" for="id_jira_issue">Original finding
-                        <i class="fa fa-question-circle has-popover" data-trigger="hover" data-content="Original finding that is being duplicated here (readonly, use view finding page to manage duplicate relationships)" data-placement="right" data-container="body" data-original-title="" title="">
-                        </i>
-                    </label>
-                    <div class="col-sm-10 form-control-static">
-                        {{ finding.duplicate_finding.id }}: 
-                        {% if finding.duplicate_finding.cve %}
-                            <a href="{{finding.duplicate_finding.cve|cve_url}} ">({{finding.duplicate_finding.cve}})</a>
-                        {% endif %}                        
-                        {{ finding.duplicate_finding.title }},
-                        {{ finding.duplicate_finding.test.engagement.product.name }}/
-                        {{ finding.duplicate_finding.test.engagement.name }}/
-                        {% if finding.duplicate_finding.test.title %}
-                            {{finding.duplicate_finding.test.title}}
-                        {% else %}
-                            {{finding.duplicate_finding.test.test_type}}
-                        {% endif %}
-
-                        {% if finding.duplicate_finding.jira_issue %}
-                            <a href="{{ finding.duplicate_finding.jira_conf_new.url }}/browse/{{ finding.duplicate_finding.jira_issue.jira_key }}"
-                            target="_blank" title="{{ finding.duplicate_finding.jira_conf_new.url }}/browse/{{ finding.duplicate_finding.jira_issue.jira_key }}">{{ finding.duplicate_finding.jira_issue.jira_key }}</a>
-                        {% endif %}
-                        {% if finding.duplicate_finding.cwe > 0 %}
-                            <a href="{{finding.duplicate_finding.cwe|cwe_url}} ">(CWE-{{finding.duplicate_finding.cwe}})</a>
-                        {% endif %}
-                    </div>
-                </div>
-            {% endif %}
-
-            {% comment %} <div class="form-group hidden">
-                {% if dupes %}
-                    <label class="col-sm-2 control-label" for="dupe_choice">Parent Duplicate</label>
-                    <div class="col-sm-10">
-                        <select class="form-control" name=duplicate_choice id="dupe_choice">
-                            {% for dupe in dupes %}
-                                <option>{{ dupe.id }}: {{ dupe.title }},
-                                        {{ dupe.test.engagement.product.name }}/
-                                        {{ dupe.test.engagement.name }}/
-                                        {% if dupe.test.title %}
-                                            {{dupe.test.title}}
-                                        {% else %}
-                                            {{dupe.test.test_type}}
-                                        {% endif %}
-                                </option>
-                            {% endfor %}
-                        </select>
-                    </div>
+            <span id="original_finding" class="small">
+                {% if finding.duplicate_finding %}
+                    [original:
+                    <a href="{% url 'view_finding' finding.duplicate_finding.id %}">{{ finding.duplicate_finding.id }} : {{ finding.duplicate_finding.title }}</a>/
+                    <a href="{% url 'view_product' finding.duplicate_finding.test.engagement.product.id %}">{{ finding.duplicate_finding.test.engagement.product.name }}</a>/
+                    <a href="{% url 'view_engagement' finding.duplicate_finding.test.engagement.id %}">{{ finding.duplicate_finding.test.engagement.name }}</a>
+                    {% if finding.duplicate_finding.test.title %}
+                        {{finding.duplicate_finding.test.title}}
+                    {% else %}
+                        {{finding.duplicate_finding.test.test_type}}
+                    {% endif %}
+                    {% if finding.duplicate_finding.cve %}
+                        <a href="{{finding.duplicate_finding.cve|cve_url}}">({{finding.duplicate_finding.cve}})</a>
+                    {% endif %}                        
+                    {% if finding.duplicate_finding.cwe > 0 %}
+                        <a href="{{finding.duplicate_finding.cwe|cwe_url}}">(CWE-{{finding.duplicate_finding.cwe}})</a>
+                    {% endif %}
+                    {% if finding.duplicate_finding.jira_issue %}
+                        <a href="{{ finding.duplicate_finding.jira_conf_new.url }}/browse/{{ finding.duplicate_finding.jira_issue.jira_key }}"
+                        target="_blank" title="{{ finding.duplicate_finding.jira_conf_new.url }}/browse/{{ finding.duplicate_finding.jira_issue.jira_key }}">{{ finding.duplicate_finding.jira_issue.jira_key }}</a>
+                    {% endif %}
+                    ]
                 {% endif %}
-            </div> {% endcomment %}
+            </span>
 
             {% if jform %}
                 <h4> JIRA </h4>
@@ -212,33 +185,16 @@
             });
         });
 
-
-        {% if dupes %}
+        {% comment %} crazy legacy stuff to force the original finding to be displayede at the right place {% endcomment %}
         window.onload = function() {
-            var menu = document.getElementById("dupe_choice").parentElement.parentElement
-            var dupe_box = document.getElementById("id_duplicate").parentElement.parentElement.parentElement.parentElement
+            var original_finding = document.getElementById("original_finding")
+            var duplicate_checkbox = document.getElementById("id_duplicate").parentElement.parentElement
             if ($("#id_duplicate").prop("checked")) {
-                dupe_box.insertAdjacentElement("afterend", menu)
-                menu.setAttribute("class", "form-group");
-            }
-            else {
-                menu.setAttribute("class", "form-group hidden");
+                $("#id_duplicate").parent().parent().append(original_finding)
+            } else {
+                $("#id_duplicate").click(function(){ alert('findings can only be marked as duplicates from the view finding screen'); return false; });
             }
         };
-        
-        $("#id_duplicate").change(function () {
-            var menu = document.getElementById("dupe_choice").parentElement.parentElement
-            var dupe_box = document.getElementById("id_duplicate").parentElement.parentElement.parentElement.parentElement
-            if ($(this).prop("checked")) {
-                dupe_box.insertAdjacentElement("afterend", menu)
-                menu.setAttribute("class", "form-group");
-            }
-            else {
-                menu.setAttribute("class", "form-group hidden");
-            }
-            
-        });
-        {% endif %}
 
         $("#add_finding").submit(function () {
             var isFormValid = true;

--- a/dojo/templates/dojo/finding_related_row.html
+++ b/dojo/templates/dojo/finding_related_row.html
@@ -4,7 +4,7 @@
 <tr>
     {% if similar_finding.duplicate_finding == finding_context %}
         <td title="The finding on the top of this page is the original for this related finding">Duplicate{% if finding_context == similar_finding %}(this){% endif %}</td>
-    {% elif finding_context.duplicate_finding == similar_finding  or finding_context == similar_finding%}
+    {% elif finding_context.duplicate_finding == similar_finding %}
         <td title="The finding on the top of this page is a duplicate of this so called original finding">Original{% if finding_context == similar_finding %} (this){% endif %}</td>
     {% elif similar_finding.duplicate and similar_finding.duplicate_finding == finding_context.duplicate_finding %}
         <td title="This finding is a duplicate of the same original above">Duplicate{% if finding_context == similar_finding %}(this){% endif %}</td>


### PR DESCRIPTION
The parent duplicate status + dropdown on the edit finding page has two (breaking) issues:
![image](https://user-images.githubusercontent.com/4426050/92311349-87397f00-efb6-11ea-9add-81de1b5ce510.png)

1) When the page is loaded, the first findingin the dropdown is selected. So when quickly editing a finding to change a field and pressing save leads to the parent/original finding being changed silently

2) On the view finding page duplication can be managed and the finding can be marked as a finding that will not occur on the dropdown above. Basically meaning the finding can no longer be edited without breaking the duplicate relationship.

Solutions:
A) Add the similar finding filtering stuff also to the edit finding page. Could be done but would require either a long dropdown, or some ajaxy filtering and tables.

Feel free to add that, but for now that's too much work. Especially because all the duplication relationships can now be managed quite well from the view_finding page since #1906 

B) Make the parent duplicate (original finding) readonly on the edit_finding page.

This PR implements option B:

for duplicates:
![image](https://user-images.githubusercontent.com/4426050/92311416-19da1e00-efb7-11ea-8ec6-dec9ccd2a5e3.png)
![image](https://user-images.githubusercontent.com/4426050/92311441-49892600-efb7-11ea-80bd-aa32c9d58694.png)

for non duplicates:
![image](https://user-images.githubusercontent.com/4426050/92311448-5d348c80-efb7-11ea-87b7-d9bec552ff6e.png)

PR also includes some small fixes