### PR TITLE
Set component name/version for php symfony & dependency check parsers

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -862,12 +862,17 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
 
             for item in items:
                 sev = item.severity
+
                 if sev == 'Information' or sev == 'Informational':
                     sev = 'Info'
 
                 if (Finding.SEVERITIES[sev] >
                         Finding.SEVERITIES[min_sev]):
                     continue
+
+                # existing findings may be from before we had component_name/version fields
+                component_name = item.component_name if hasattr(item, 'component_name') else None
+                component_version = item.component_version if hasattr(item, 'component_version') else None
 
                 from titlecase import titlecase
                 item.title = titlecase(item.title)
@@ -894,6 +899,11 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         finding.mitigated_by = None
                         finding.active = True
                         finding.verified = verified
+
+                        # existing findings may be from before we had component_name/version fields
+                        finding.component_name = finding.component_name if finding.component_name else component_name
+                        finding.component_version = finding.component_version if finding.component_version else component_version
+
                         finding.save()
                         note = Notes(
                             entry="Re-activated by %s re-upload." % scan_type,
@@ -910,6 +920,12 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         reactivated_items.append(finding)
                         reactivated_count += 1
                     else:
+                        # existing findings may be from before we had component_name/version fields
+                        if not finding.component_name or not finding.component_version:
+                            finding.component_name = finding.component_name if finding.component_name else component_name
+                            finding.component_version = finding.component_version if finding.component_version else component_version
+                            finding.save(dedupe_option=False, push_to_jira=False)
+
                         unchanged_items.append(finding)
                         unchanged_count += 1
                 else:

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -560,13 +560,15 @@ INSTALLED_APPS = (
     'django_celery_results',
     'social_django',
     'drf_yasg',
+    # 'cachalot',
+    'debug_toolbar',
 )
 
 # ------------------------------------------------------------------------------
 # MIDDLEWARE
 # ------------------------------------------------------------------------------
 DJANGO_MIDDLEWARE_CLASSES = [
-    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.common.CommonMiddleware',
     'dojo.middleware.DojoSytemSettingsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -576,6 +578,7 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'dojo.middleware.LoginRequiredMiddleware',
+    # 'dojo.middleware.TimezoneMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'watson.middleware.SearchContextMiddleware',
     'auditlog.middleware.AuditlogMiddleware',
@@ -677,7 +680,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # Including the severity in the hash_code keeps those findings not duplicate
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
-    'Dependency Check Scan': ['cve', 'title'],  # file_path can't be used as it may differ based on who/where the scan was performed. so only title remains as valid field
+    'Dependency Check Scan': ['cve', 'file_path'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
     'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
@@ -815,7 +818,7 @@ LOGGING = {
         },
         'dojo': {
             'handlers': ['console'],
-            'level': 'INFO',
+            'level': 'DEBUG',
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
@@ -840,3 +843,35 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240
 
 # Maximum size of a scan file in MB
 SCAN_FILE_MAX_SIZE = 100
+
+
+# django-tagging uses raw queries underneath breaking ORM query caching
+CACHALOT_UNCACHABLE_TABLES = frozenset(('django_migrations'))
+
+
+def show_toolbar(request):
+    return True
+
+
+DEBUG_TOOLBAR_CONFIG = {
+    "SHOW_TOOLBAR_CALLBACK": show_toolbar,
+    "INTERCEPT_REDIRECTS": True,
+    "SHOW_COLLAPSED": True,
+}
+
+
+DEBUG_TOOLBAR_PANELS = [
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    # 'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+    'debug_toolbar.panels.templates.TemplatesPanel',
+    'debug_toolbar.panels.cache.CachePanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.logging.LoggingPanel',
+    'debug_toolbar.panels.redirects.RedirectsPanel',
+    'debug_toolbar.panels.profiling.ProfilingPanel',
+]

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -677,7 +677,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # Including the severity in the hash_code keeps those findings not duplicate
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
-    'Dependency Check Scan': ['cve', 'title'],  # file_path can't be used as it may differ based on who/where the scan was performed. so only title remains as valid field
+    'Dependency Check Scan': ['cve', 'file_path'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
     'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -677,7 +677,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # Including the severity in the hash_code keeps those findings not duplicate
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
-    'Dependency Check Scan': ['cve', 'file_path'],
+    'Dependency Check Scan': ['cve', 'title'],  # file_path can't be used as it may differ based on who/where the scan was performed. so only title remains as valid field
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
     'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -560,15 +560,13 @@ INSTALLED_APPS = (
     'django_celery_results',
     'social_django',
     'drf_yasg',
-    # 'cachalot',
-    'debug_toolbar',
 )
 
 # ------------------------------------------------------------------------------
 # MIDDLEWARE
 # ------------------------------------------------------------------------------
 DJANGO_MIDDLEWARE_CLASSES = [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
+    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.common.CommonMiddleware',
     'dojo.middleware.DojoSytemSettingsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -578,7 +576,6 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'dojo.middleware.LoginRequiredMiddleware',
-    # 'dojo.middleware.TimezoneMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'watson.middleware.SearchContextMiddleware',
     'auditlog.middleware.AuditlogMiddleware',
@@ -680,7 +677,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # Including the severity in the hash_code keeps those findings not duplicate
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
-    'Dependency Check Scan': ['cve', 'file_path'],
+    'Dependency Check Scan': ['cve', 'title'],  # file_path can't be used as it may differ based on who/where the scan was performed. so only title remains as valid field
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
     'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
@@ -818,7 +815,7 @@ LOGGING = {
         },
         'dojo': {
             'handlers': ['console'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
@@ -843,35 +840,3 @@ DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240
 
 # Maximum size of a scan file in MB
 SCAN_FILE_MAX_SIZE = 100
-
-
-# django-tagging uses raw queries underneath breaking ORM query caching
-CACHALOT_UNCACHABLE_TABLES = frozenset(('django_migrations'))
-
-
-def show_toolbar(request):
-    return True
-
-
-DEBUG_TOOLBAR_CONFIG = {
-    "SHOW_TOOLBAR_CALLBACK": show_toolbar,
-    "INTERCEPT_REDIRECTS": True,
-    "SHOW_COLLAPSED": True,
-}
-
-
-DEBUG_TOOLBAR_PANELS = [
-    'debug_toolbar.panels.versions.VersionsPanel',
-    'debug_toolbar.panels.timer.TimerPanel',
-    'debug_toolbar.panels.settings.SettingsPanel',
-    'debug_toolbar.panels.headers.HeadersPanel',
-    'debug_toolbar.panels.request.RequestPanel',
-    'debug_toolbar.panels.sql.SQLPanel',
-    # 'debug_toolbar.panels.staticfiles.StaticFilesPanel',
-    'debug_toolbar.panels.templates.TemplatesPanel',
-    'debug_toolbar.panels.cache.CachePanel',
-    'debug_toolbar.panels.signals.SignalsPanel',
-    'debug_toolbar.panels.logging.LoggingPanel',
-    'debug_toolbar.panels.redirects.RedirectsPanel',
-    'debug_toolbar.panels.profiling.ProfilingPanel',
-]

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -84,7 +84,7 @@ class DependencyCheckParser(object):
                         if version_node:
                             component_version = self.get_field_value(version_node, 'value')
 
-            logger.debug('returning name/version: %s %s', component_name, component_version)
+            # logger.debug('returning name/version: %s %s', component_name, component_version)
         except:
             logger.exception('error parsing component_name and component_version')
             logger.debug('dependency: %s', ElementTree.tostring(dependency, encoding='utf8', method='xml'))

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -97,6 +97,18 @@ class DependencyCheckParser(object):
                         component_version = maven_parts[2]
                         return component_name, component_version
 
+                        # TODO
+                        # include identifiers in description?
+                        # <identifiers>
+                        #     <package confidence="HIGH">
+                        #         <id>pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</id>
+                        #         <url>https://ossindex.sonatype.org/component/pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</url>
+                        #     </package>
+                        #     <vulnerabilityIds confidence="HIGHEST">
+                        #         <id>cpe:2.3:a:dom4j_project:dom4j:2.1.1.hat-00001:*:*:*:*:*:*:*</id>
+                        #         <url>https://nvd.nist.gov/vuln/search/results?form_type=Advanced&amp;results_type=overview&amp;search_type=all&amp;cpe_vendor=cpe%3A%2F%3Adom4j_project&amp;cpe_product=cpe%3A%2F%3Adom4j_project%3Adom4j&amp;cpe_version=cpe%3A%2F%3Adom4j_project%3Adom4j%3A2.1.1.hat-00001</url>
+                        #     </vulnerabilityIds>
+
             # TODO what happens when there multiple evidencecollectednodes with product or version as type?
             evidence_collected_node = dependency.find(self.namespace + 'evidenceCollected')
             if evidence_collected_node:
@@ -239,7 +251,7 @@ class DependencyCheckParser(object):
                     for vulnerability in vulnerabilities.findall(
                             self.namespace + 'vulnerability'):
 
-                        # relateddependencies are ignored in this parser, but should be imported because you might miss vulnerable dependencies otherwise
+                        # TODO relateddependencies are ignored in this parser, but should be imported because you might miss vulnerable dependencies otherwise
                         # <relatedDependencies>
                         #     <relatedDependency>
                         #         <fileName>client-offer-service-ear-1.0-SNAPSHOT-deployment-prod.zip: h2-console.war</fileName>
@@ -272,18 +284,7 @@ class DependencyCheckParser(object):
                         #     </identifiers>
                         # </relatedDependency>
 
-                        # include identifiers in description?
-                        # <identifiers>
-                        #     <package confidence="HIGH">
-                        #         <id>pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</id>
-                        #         <url>https://ossindex.sonatype.org/component/pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</url>
-                        #     </package>
-                        #     <vulnerabilityIds confidence="HIGHEST">
-                        #         <id>cpe:2.3:a:dom4j_project:dom4j:2.1.1.hat-00001:*:*:*:*:*:*:*</id>
-                        #         <url>https://nvd.nist.gov/vuln/search/results?form_type=Advanced&amp;results_type=overview&amp;search_type=all&amp;cpe_vendor=cpe%3A%2F%3Adom4j_project&amp;cpe_product=cpe%3A%2F%3Adom4j_project%3Adom4j&amp;cpe_version=cpe%3A%2F%3Adom4j_project%3Adom4j%3A2.1.1.hat-00001</url>
-                        #     </vulnerabilityIds>
-
-                        # include vulnerablesoftware in description?
+                        # TODO include vulnerablesoftware in description?
                         # <vulnerableSoftware>
                         #     <software>cpe:2.3:a:netapp:snapmanager:-:*:*:*:*:sap:*:*</software>
                         #     <software versionStartIncluding="18.1.0.0" versionEndIncluding="18.8.19.0">cpe:2.3:a:oracle:primavera_p6_enterprise_project_portfolio_management:*:*:*:*:*:*:*:*</software>

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -228,7 +228,7 @@ class DependencyCheckParser(object):
 
         return Finding(
             title=title,
-            file_path=dependency_filepath,
+            file_path=dependency_filename,
             test=test,
             cwe=cwe,
             cve=cve,

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -111,6 +111,9 @@ class DependencyCheckParser(object):
                 #     <name>version</name>
                 #     <value>3.1.1</value>
                 # </evidence>'
+                # will find the first product and version node. if there are multiple it may not pick the best
+                # since 6.0.0 howoever it seems like there's always a packageurl above so not sure if we need the effort to
+                # implement more logic here
                 product_node = evidence_collected_node.find('.//' + self.namespace + 'evidence[@type="product"]')
                 if product_node:
                     component_name = self.get_field_value(product_node, 'value')

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -6,6 +6,8 @@ from defusedxml import ElementTree
 
 from dojo.models import Finding
 
+from cpe import CPE
+
 logger = logging.getLogger(__name__)
 
 SEVERITY = ['Info', 'Low', 'Medium', 'High', 'Critical']
@@ -20,7 +22,79 @@ class DependencyCheckParser(object):
     def get_filename_from_dependency(self, dependency):
         return self.get_field_value(dependency, 'fileName')
 
-    def get_finding_from_vulnerability(self, vulnerability, filename, test):
+    def get_component_name_and_version_from_dependency(self, dependency):
+        component_name, component_version = None, None
+        # big try catch to avoid crashint the parser on some unexpected stuff
+        try:
+            identifiers_node = dependency.find(self.namespace + 'identifiers')
+            if identifiers_node:
+                # <identifiers>
+                # 	<identifier type="cpe" confidence="HIGHEST">
+                # 		<name>cpe:/a:apache:xalan-java:2.7.1</name>
+                # 		<url>https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&amp;cves=on&amp;cpe_version=cpe%3A%2Fa%3Aapache%3Axalan-java%3A2.7.1</url>
+                # 	</identifier>
+                # 	<identifier type="maven" confidence="HIGHEST">
+                # 		<name>xalan:serializer:2.7.1</name>
+                # 		<url>https://search.maven.org/remotecontent?filepath=xalan/serializer/2.7.1/serializer-2.7.1.jar</url>
+                # 	</identifier>
+                # </identifiers>
+                cpe_node = identifiers_node.find('.//' + self.namespace + 'identifier[@type="cpe"]')
+                if cpe_node:
+                    logger.debug('cpe string: ' + self.get_field_value(cpe_node, 'name'))
+                    cpe = CPE(self.get_field_value(cpe_node, 'name'))
+                    component_name = cpe.get_vendor()[0] + ':' if len(cpe.get_vendor()) > 0 else ''
+                    component_name += cpe.get_product()[0] if len(cpe.get_product()) > 0 else ''
+                    component_name = component_name if component_name else None
+                    component_version = cpe.get_version()[0] if len(cpe.get_version()) > 0 else None
+                    # logger.debug('get_edition: ' + str(cpe.get_edition()))
+                    # logger.debug('get_language: ' + str(cpe.get_language()))
+                    # logger.debug('get_part: ' + str(cpe.get_part()))
+                    # logger.debug('get_software_edition: ' + str(cpe.get_software_edition()))
+                    # logger.debug('get_target_hardware: ' + str(cpe.get_target_hardware()))
+                    # logger.debug('get_target_software: ' + str(cpe.get_target_software()))
+                    # logger.debug('get_vendor: ' + str(cpe.get_vendor()))
+                    # logger.debug('get_update: ' + str(cpe.get_update()))
+                else:
+                    maven_node = identifiers_node.find('.//' + self.namespace + 'identifier[@type="maven"]')
+                    if maven_node:
+                        # logger.debug('maven_string: ' + self.get_field_value(maven_node, 'name'))
+                        maven_parts = self.get_field_value(maven_node, 'name').split(':')
+                        # logger.debug('maven_parts:' + str(maven_parts))
+                        if len(maven_parts) == 3:
+                            component_name = maven_parts[0] + ':' + maven_parts[1]
+                            component_version = maven_parts[2]
+            else:
+                evidence_collected_node = dependency.find(self.namespace + 'evidenceCollected')
+                if evidence_collected_node:
+                    # <evidenceCollected>
+                    # <evidence type="product" confidence="HIGH">
+                    # 	<source>file</source>
+                    # 	<name>name</name>
+                    # 	<value>jquery</value>
+                    # </evidence>
+                    # <evidence type="version" confidence="HIGH">
+                    # 	<source>file</source>
+                    # 	<name>version</name>
+                    # 	<value>3.1.1</value>
+                    # </evidence>'
+                    product_node = evidence_collected_node.find('.//' + self.namespace + 'evidence[@type="product"]')
+                    if product_node:
+                        component_name = self.get_field_value(product_node, 'value')
+                        version_node = evidence_collected_node.find('.//' + self.namespace + 'evidence[@type="version"]')
+                        if version_node:
+                            component_version = self.get_field_value(version_node, 'value')
+
+            logger.debug('returning name/version: %s %s', component_name, component_version)
+        except:
+            logger.exception('error parsing component_name and component_version')
+            logger.debug('dependency: %s', ElementTree.tostring(dependency, encoding='utf8', method='xml'))
+
+        return component_name, component_version
+
+    def get_finding_from_vulnerability(self, dependency, vulnerability, test):
+        dependency_filename = self.get_filename_from_dependency(dependency)
+        # logger.debug('dependency_filename: %s', dependency_filename)
+
         name = self.get_field_value(vulnerability, 'name')
         cwes_node = vulnerability.find(self.namespace + 'cwes')
         if cwes_node is not None:
@@ -29,7 +103,7 @@ class DependencyCheckParser(object):
             cwe_field = self.get_field_value(vulnerability, 'cwe')
         description = self.get_field_value(vulnerability, 'description')
 
-        title = '{0} | {1}'.format(filename, name)
+        title = '{0} | {1}'.format(dependency_filename, name)
         cve = name[:28]
         if cve and not cve.startswith('CVE'):
             # for vulnerability sources which have a CVE, it is the start of the 'name'.
@@ -50,7 +124,7 @@ class DependencyCheckParser(object):
             severity = self.get_field_value(cvssv2_node, 'severity').lower().capitalize()
         else:
             severity = self.get_field_value(vulnerability, 'severity').lower().capitalize()
-        # print("severity: " + severity)
+        # logger.debug("severity: " + severity)
         if severity in SEVERITY:
             severity = severity
         else:
@@ -73,9 +147,11 @@ class DependencyCheckParser(object):
                                      'source: {1}\n' \
                                      'url: {2}\n\n'.format(name, source, url)
 
+        component_name, component_version = self.get_component_name_and_version_from_dependency(dependency)
+
         return Finding(
             title=title,
-            file_path=filename,
+            file_path=dependency_filename,
             test=test,
             cwe=cwe,
             cve=cve,
@@ -85,7 +161,9 @@ class DependencyCheckParser(object):
             severity=severity,
             numerical_severity=Finding.get_numerical_severity(severity),
             static_finding=True,
-            references=reference_detail)
+            references=reference_detail,
+            component_name=component_name,
+            component_version=component_version)
 
     def __init__(self, filename, test):
         self.dupes = dict()
@@ -113,15 +191,13 @@ class DependencyCheckParser(object):
         if dependencies:
             for dependency in dependencies.findall(self.namespace +
                                                    'dependency'):
-                dependency_filename = self.get_filename_from_dependency(
-                    dependency)
                 vulnerabilities = dependency.find(self.namespace +
                                                   'vulnerabilities')
                 if vulnerabilities is not None:
                     for vulnerability in vulnerabilities.findall(
                             self.namespace + 'vulnerability'):
-                        finding = self.get_finding_from_vulnerability(
-                            vulnerability, dependency_filename, test)
+                        finding = self.get_finding_from_vulnerability(dependency,
+                            vulnerability, test)
 
                         if finding is not None:
                             key_str = '{}|{}|{}'.format(finding.severity,

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -35,6 +35,9 @@ class PhpSymfonySecurityCheckParser(object):
         for dependency_name, dependency_data in list(tree.items()):
             advisories = dependency_data.get('advisories')
             dependency_version = dependency_data['version']
+            if dependency_version.startswith('v'):
+                dependency_version = dependency_version[1:]
+
             for advisory in advisories:
                 item = get_item(dependency_name, dependency_version, advisory, test)
                 unique_key = str(dependency_name) + str(dependency_data['version'] + str(advisory['cve']))
@@ -64,6 +67,8 @@ def get_item(dependency_name, dependency_version, advisory, test):
                       mitigated=None,
                       impact="No impact provided",
                       static_finding=True,
-                      dynamic_finding=False)
+                      dynamic_finding=False,
+                      component_name=dependency_name,
+                      component_version=dependency_version)
 
     return finding

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -35,7 +35,7 @@ class PhpSymfonySecurityCheckParser(object):
         for dependency_name, dependency_data in list(tree.items()):
             advisories = dependency_data.get('advisories')
             dependency_version = dependency_data['version']
-            if dependency_version.startswith('v'):
+            if dependency_version and dependency_version.startswith('v'):
                 dependency_version = dependency_version[1:]
 
             for advisory in advisories:

--- a/dojo/unittests/test_dependency_check_parser.py
+++ b/dojo/unittests/test_dependency_check_parser.py
@@ -34,7 +34,7 @@ class TestDependencyCheckParser(TestCase):
     <dependencies>
         <dependency>
             <fileName>component1.dll</fileName>
-            <filePath>C:\Projects\testproject\libraries\component1.dll</filePath>
+            <filePath>C:\\Projectsestproject\\libraries\\component1.dll</filePath>
             <md5>ba5a6a10bae6ce2abbabec9facae23a4</md5>
             <sha1>ae917bbce68733468b1972113e0e1fc5dc7444a0</sha1>
             <evidenceCollected>
@@ -62,7 +62,7 @@ class TestDependencyCheckParser(TestCase):
         </dependency>
         <dependency>
             <fileName>component2.dll</fileName>
-            <filePath>C:\Projects\testproject\libraries\component2.dll</filePath>
+            <filePath>C:\\Projectsestproject\\libraries\\component2.dll</filePath>
             <md5>21b24bc199530e07cb15d93c7f929f04</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
             <evidenceCollected>
@@ -98,7 +98,7 @@ class TestDependencyCheckParser(TestCase):
     <dependencies>
         <dependency>
             <fileName>component1.dll</fileName>
-            <filePath>C:\Projects\testproject\libraries\component1.dll</filePath>
+            <filePath>C:\\Projectsestproject\\libraries\\component1.dll</filePath>
             <md5>ba5a6a10bae6ce2abbabec9facae23a4</md5>
             <sha1>ae917bbce68733468b1972113e0e1fc5dc7444a0</sha1>
             <evidenceCollected>
@@ -126,7 +126,7 @@ class TestDependencyCheckParser(TestCase):
         </dependency>
         <dependency>
             <fileName>component2.dll</fileName>
-            <filePath>C:\Projects\testproject\libraries\component2.dll</filePath>
+            <filePath>C:\\Projectestproject\\libraries\\component2.dll</filePath>
             <md5>21b24bc199530e07cb15d93c7f929f04</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
             <evidenceCollected>
@@ -142,8 +142,9 @@ class TestDependencyCheckParser(TestCase):
                 </evidence>
             </evidenceCollected>
             <identifiers>
-                <identifier type="cpe" confidence="LOW">
-                    <name>(cpe:/a:component2:component2:-)</name>
+                <identifier type="maven" confidence="HIGHEST">
+                    <name>org.owasp:library:6.7.8</name>
+                    <url>https://search.maven.org/remotecontent?filepath=xalan/serializer/2.7.1/serializer-2.7.1.jar</url>
                 </identifier>
             </identifiers>
             <vulnerabilities>
@@ -182,7 +183,11 @@ class TestDependencyCheckParser(TestCase):
  """
         testfile = TestFile("dependency-check-report.xml", content)
         parser = DependencyCheckParser(testfile, Test())
-        self.assertEqual(1, len(parser.items))
+        items = parser.items
+        self.assertEqual(1, len(items))
+        self.assertEqual(items[0].title, 'component2.dll | CVE-0000-0001')
+        self.assertEqual(items[0].component_name, 'org.owasp:library')
+        self.assertEqual(items[0].component_version, '6.7.8')
 
     def test_parse_file_with_multiple_vulnerabilities_has_multiple_findings(
             self):
@@ -197,8 +202,8 @@ class TestDependencyCheckParser(TestCase):
     </projectInfo>
     <dependencies>
         <dependency>
-            <fileName>component1.dll</fileName>
-            <filePath>C:\Projects\testproject\libraries\component1.dll</filePath>
+            <fileName>component1</fileName>
+            <filePath>C:\\Projectestproject\\libraries\\component1.dll</filePath>
             <md5>ba5a6a10bae6ce2abbabec9facae23a4</md5>
             <sha1>ae917bbce68733468b1972113e0e1fc5dc7444a0</sha1>
             <evidenceCollected>
@@ -225,8 +230,8 @@ class TestDependencyCheckParser(TestCase):
             </evidenceCollected>
         </dependency>
         <dependency>
-            <fileName>component2.dll</fileName>
-            <filePath>C:\Projects\testproject\libraries\component2.dll</filePath>
+            <fileName>adapter-ear.ear: serializer-2.7.1.jar</fileName>
+            <filePath>C:\\Projectestproject\\libraries\\component2.dll</filePath>
             <md5>21b24bc199530e07cb15d93c7f929f04</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
             <evidenceCollected>
@@ -242,8 +247,13 @@ class TestDependencyCheckParser(TestCase):
                 </evidence>
             </evidenceCollected>
             <identifiers>
-                <identifier type="cpe" confidence="LOW">
-                    <name>(cpe:/a:component2:component2:-)</name>
+                <identifier type="cpe" confidence="HIGHEST">
+                    <name>cpe:/a:apache:xalan-java:2.7.1</name>
+                    <url>https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&amp;cves=on&amp;cpe_version=cpe%3A%2Fa%3Aapache%3Axalan-java%3A2.7.1</url>
+                </identifier>
+                <identifier type="maven" confidence="HIGHEST">
+                    <name>xalan:serializer:2.7.1</name>
+                    <url>https://search.maven.org/remotecontent?filepath=xalan/serializer/2.7.1/serializer-2.7.1.jar</url>
                 </identifier>
             </identifiers>
             <vulnerabilities>
@@ -278,27 +288,22 @@ class TestDependencyCheckParser(TestCase):
             </vulnerabilities>
         </dependency>
         <dependency>
-            <fileName>component3.dll</fileName>
-            <filePath>C:\Projects\testproject\libraries\component3.dll</filePath>
+            <fileName>adapter-ear.ear: liquibase-core-3.5.3.jar: jquery.js</fileName>
+            <filePath>C:\\Projectestproject\\libraries\\component3.dll</filePath>
             <md5>21b24bc199530e07cb15d93c7f929f03</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21243</sha1>
             <evidenceCollected>
-                <evidence type="vendor" confidence="HIGH">
+                <evidence type="version" confidence="HIGH">
                     <source>file</source>
                     <name>name</name>
-                    <value>component3</value>
+                    <value>3.1.1</value>
                 </evidence>
                 <evidence type="product" confidence="HIGH">
                     <source>file</source>
                     <name>name</name>
-                    <value>component3</value>
+                    <value>jquery</value>
                 </evidence>
             </evidenceCollected>
-            <identifiers>
-                <identifier type="cpe" confidence="LOW">
-                    <name>(cpe:/a:component3:component3:-)</name>
-                </identifier>
-            </identifiers>
             <vulnerabilities>
                 <vulnerability>
                     <name>CVE-0000-0001</name>
@@ -335,8 +340,16 @@ class TestDependencyCheckParser(TestCase):
  """
         testfile = TestFile("dependency-check-report.xml", content)
         parser = DependencyCheckParser(testfile, Test())
-        self.assertEqual(2, len(parser.items))
+        items = parser.items
+        self.assertEqual(2, len(items))
+        self.assertEqual(items[0].title, 'adapter-ear.ear: serializer-2.7.1.jar | CVE-0000-0001')
+        self.assertEqual(items[0].component_name, 'apache:xalan-java')
+        self.assertEqual(items[0].component_version, '2.7.1')
+        self.assertEqual(items[1].title, 'adapter-ear.ear: liquibase-core-3.5.3.jar: jquery.js | CVE-0000-0001')
+        self.assertEqual(items[1].component_name, 'jquery')
+        self.assertEqual(items[1].component_version, '3.1.1')
 
+# Weird way to do a unit test, can't we just check the title in a test above?
     def test_parse_finding(self):
         finding_xml = """<vulnerability xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.1.3.xsd">
 <name>CVE-0000-0001</name>
@@ -367,16 +380,25 @@ class TestDependencyCheckParser(TestCase):
 </vulnerableSoftware>
 </vulnerability>"""
 
-        vulnerability = ElementTree.fromstring(finding_xml)
+        dependency_xml = """<dependency xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.1.3.xsd">
+<fileName>testfile.jar</fileName>
+<identifiers>
+    <identifier type="maven" confidence="HIGHEST">
+        <name>xalan:serializer:2.7.1</name>
+        <url>https://search.maven.org/remotecontent?filepath=xalan/serializer/2.7.1/serializer-2.7.1.jar</url>
+    </identifier>
+</identifiers></dependency>"""
 
-        expected_references = 'name: Reference Name\nsource: Reference1\nurl: http://localhost/badvulnerability.htm\n\n'
-        expected_references += 'name: Reference for a bad vulnerability\nsource: MISC\n'
+        vulnerability = ElementTree.fromstring(finding_xml)
+        dependency = ElementTree.fromstring(dependency_xml)
+
+        expected_references = 'name: Reference Name\\nsource: Reference1\nurl: http://localhost/badvulnerability.htm\n\n'
+        expected_references += 'name: Reference for a bad vulnerability\\nsource: MISC\n'
         expected_references += 'url: http://localhost2/reference_for_badvulnerability.pdf\n\n'
 
         testfile = TestFile('dp_finding.xml', finding_xml)
         parser = DependencyCheckParser(testfile, Test())
-        finding = parser.get_finding_from_vulnerability(vulnerability,
-                                                        'testfile.jar', Test())
+        finding = parser.get_finding_from_vulnerability(dependency, vulnerability, Test())
         self.assertEqual('testfile.jar | CVE-0000-0001', finding.title)
         self.assertEqual('High', finding.severity)
         self.assertEqual(

--- a/dojo/unittests/test_dependency_check_parser.py
+++ b/dojo/unittests/test_dependency_check_parser.py
@@ -318,6 +318,20 @@ class TestDependencyCheckParser(TestCase):
             <md5/>
             <sha1/>
             <sha256/>
+            <relatedDependencies>
+                <relatedDependency>
+                    <filePath>/var/lib/adapter-ear8.ear/dom4j-2.1.1.jar</filePath>
+                    <sha256>a520752f350909c191db45a598a88fcca2fa5db17a340dee6b3d0e36f4122e11</sha256>
+                    <sha1>080c5a481cd7abf27bfd4b48edf73b1cb214085e</sha1>
+                    <md5>add18b9f953221ff565cf7a34aac0ed9</md5>
+                </relatedDependency>
+                <relatedDependency>
+                    <filePath>/var/lib/adapter-ear1.ear/dom4j-extensions-2.1.1.jar</filePath>
+                    <sha256>a520752f350909c191db45a598a88fcca2fa5db17a340dee6b3d0e36f4122e11</sha256>
+                    <sha1>080c5a481cd7abf27bfd4b48edf73b1cb214085e</sha1>
+                    <md5>add18b9f953221ff565cf7a34aac0ed9</md5>
+                </relatedDependency>
+            </relatedDependencies>
             <projectReferences>
                 <projectReference>package-lock.json: transitive</projectReference>
             </projectReferences>
@@ -613,7 +627,7 @@ class TestDependencyCheckParser(TestCase):
         self.assertEqual(items[2].severity, 'High')
         self.assertEqual(items[2].file_path, '/var/lib/adapter-ear1.ear/dom4j-extensions-2.1.1.jar')
 
-        # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities
+        # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities, relateddependencies without filename (pre v6.0.0)
         self.assertEqual(items[3].title, 'yargs-parser:5.0.0 | 1500')
         self.assertEqual(items[3].component_name, 'yargs-parser')
         self.assertEqual(items[3].component_version, '5.0.0')

--- a/dojo/unittests/test_dependency_check_parser.py
+++ b/dojo/unittests/test_dependency_check_parser.py
@@ -1,4 +1,3 @@
-from defusedxml import ElementTree
 from django.test import TestCase
 
 from dojo.models import Test
@@ -230,7 +229,7 @@ class TestDependencyCheckParser(TestCase):
             </evidenceCollected>
         </dependency>
         <dependency>
-            <fileName>adapter-ear.ear: serializer-2.7.1.jar</fileName>
+            <fileName>adapter-ear1.ear: dom4j-2.1.1.jar</fileName>
             <filePath>C:\\Projectestproject\\libraries\\component2.dll</filePath>
             <md5>21b24bc199530e07cb15d93c7f929f04</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
@@ -238,15 +237,200 @@ class TestDependencyCheckParser(TestCase):
                 <evidence type="vendor" confidence="HIGH">
                     <source>file</source>
                     <name>name</name>
-                    <value>component2</value>
+                    <value>org.jdom</value>
                 </evidence>
                 <evidence type="product" confidence="HIGH">
                     <source>file</source>
                     <name>name</name>
-                    <value>component2</value>
+                    <value>dom4j</value>
                 </evidence>
             </evidenceCollected>
             <identifiers>
+                <identifiers>
+                    <package confidence="HIGH">
+                        <id>pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</id>
+                        <url>https://ossindex.sonatype.org/component/pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</url>
+                    </package>
+                    <vulnerabilityIds confidence="HIGHEST">
+                        <id>cpe:2.3:a:dom4j_project:dom4j:2.1.1.hat-00001:*:*:*:*:*:*:*</id>
+                        <url>https://nvd.nist.gov/vuln/search/results?form_type=Advanced&amp;results_type=overview&amp;search_type=all&amp;cpe_vendor=cpe%3A%2F%3Adom4j_project&amp;cpe_product=cpe%3A%2F%3Adom4j_project%3Adom4j&amp;cpe_version=cpe%3A%2F%3Adom4j_project%3Adom4j%3A2.1.1.hat-00001</url>
+                    </vulnerabilityIds>
+                </identifiers>
+                <identifier type="cpe" confidence="HIGHEST">
+                    <name>cpe:/a:apache:xalan-java:2.7.1</name>
+                    <url>https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&amp;cves=on&amp;cpe_version=cpe%3A%2Fa%3Aapache%3Axalan-java%3A2.7.1</url>
+                </identifier>
+                <identifier type="maven" confidence="HIGHEST">
+                    <name>xalan:serializer:2.7.1</name>
+                    <url>https://search.maven.org/remotecontent?filepath=xalan/serializer/2.7.1/serializer-2.7.1.jar</url>
+                </identifier>
+            </identifiers>
+            <vulnerabilities>
+                <vulnerability>
+                    <name>CVE-0000-0001</name>
+                    <cvssScore>7.5</cvssScore>
+                    <cvssAccessVector>NETWORK</cvssAccessVector>
+                    <cvssAccessComplexity>LOW</cvssAccessComplexity>
+                    <cvssAuthenticationr>NONE</cvssAuthenticationr>
+                    <cvssConfidentialImpact>PARTIAL</cvssConfidentialImpact>
+                    <cvssIntegrityImpact>PARTIAL</cvssIntegrityImpact>
+                    <cvssAvailabilityImpact>PARTIAL</cvssAvailabilityImpact>
+                    <severity>High</severity>
+                    <cwe>CWE-00 Bad Vulnerability</cwe>
+                    <description>Description of a bad vulnerability.</description>
+                    <references>
+                        <reference>
+                            <source>Reference1</source>
+                            <url>http://localhost/badvulnerability.htm</url>
+                            <name>Reference Name</name>
+                        </reference>
+                        <reference>
+                            <source>MISC</source>
+                            <url>http://localhost2/reference_for_badvulnerability.pdf</url>
+                            <name>Reference for a bad vulnerability</name>
+                        </reference>
+                    </references>
+                    <vulnerableSoftware>
+                        <software>cpe:/a:component2:component2:1.0</software>
+                    </vulnerableSoftware>
+                </vulnerability>
+            </vulnerabilities>
+        </dependency>
+        <dependency isVirtual="true">
+            <fileName>yargs-parser:5.0.0</fileName>
+            <filePath>/var/lib/jenkins/workspace/nl-selfservice_-_metrics_develop/package-lock.json?yargs-parser</filePath>
+            <md5/>
+            <sha1/>
+            <sha256/>
+            <projectReferences>
+                <projectReference>package-lock.json: transitive</projectReference>
+            </projectReferences>
+            <evidenceCollected>
+                <evidence type="vendor" confidence="HIGH">
+                    <source>package.json</source>
+                    <name>name</name>
+                    <value>yargs-parser</value>
+                </evidence>
+                <evidence type="product" confidence="HIGHEST">
+                    <source>package.json</source>
+                    <name>name</name>
+                    <value>yargs-parser</value>
+                </evidence>
+                <evidence type="version" confidence="HIGHEST">
+                    <source>package.json</source>
+                    <name>version</name>
+                    <value>5.0.0</value>
+                </evidence>
+            </evidenceCollected>
+            <identifiers>
+                <package confidence="HIGHEST">
+                    <id>pkg:npm/yargs-parser@5.0.0</id>
+                    <url>https://ossindex.sonatype.org/component/pkg:npm/yargs-parser@5.0.0</url>
+                </package>
+            </identifiers>
+            <vulnerabilities>
+                <vulnerability source="NPM">
+                    <name>1500</name>
+                    <severity unscored="true">low</severity>
+                    <description>Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.
+                    </description>
+                    <references>
+                        <reference>
+                            <source>Advisory 1500: Prototype Pollution</source>
+                            <name>- [Snyk Report](https://snyk.io/vuln/SNYK-JS-YARGSPARSER-560381)</name>
+                        </reference>
+                    </references>
+                    <vulnerableSoftware>
+                        <software>cpe:2.3:a:*:yargs-parser:\\&lt;13.1.2\\|\\|\\&gt;\\=14.0.0\\&lt;15.0.1\\|\\|\\&gt;\\=16.0.0\\&lt;18.1.2:*:*:*:*:*:*:*</software>
+                    </vulnerableSoftware>
+                </vulnerability>
+                <vulnerability source="OSSINDEX">
+                    <name>CVE-2020-7608</name>
+                    <severity>HIGH</severity>
+                    <cvssV3>
+                        <baseScore>7.5</baseScore>
+                        <attackVector>N</attackVector>
+                        <attackComplexity>L</attackComplexity>
+                        <privilegesRequired>N</privilegesRequired>
+                        <userInteraction>N</userInteraction>
+                        <scope>U</scope>
+                        <confidentialityImpact>N</confidentialityImpact>
+                        <integrityImpact>H</integrityImpact>
+                        <availabilityImpact>N</availabilityImpact>
+                        <baseSeverity>HIGH</baseSeverity>
+                    </cvssV3>
+                    <description>yargs-parser could be tricked into adding or modifying properties of Object.prototype using a &quot;__proto__&quot; payload.</description>
+                    <references>
+                        <reference>
+                            <source>OSSINDEX</source>
+                            <url>https://ossindex.sonatype.org/vuln/b7740d41-fc85-4d22-8af5-5a3159e114ea?component-type=npm&amp;component-name=yargs-parser</url>
+                            <name>[CVE-2020-7608] yargs-parser could be tricked into adding or modifying properties of Object.prot...</name>
+                        </reference>
+                    </references>
+                    <vulnerableSoftware>
+                        <software vulnerabilityIdMatched="true">cpe:2.3:a:*:yargs-parser:5.0.0:*:*:*:*:*:*:*</software>
+                    </vulnerableSoftware>
+                </vulnerability>
+                <vulnerability source="OSSINDEX">
+                    <name>CWE-400: Uncontrolled Resource Consumption (&apos;Resource Exhaustion&apos;)</name>
+                    <severity>HIGH</severity>
+                    <cvssV3>
+                        <baseScore>7.5</baseScore>
+                        <attackVector>N</attackVector>
+                        <attackComplexity>L</attackComplexity>
+                        <privilegesRequired>N</privilegesRequired>
+                        <userInteraction>N</userInteraction>
+                        <scope>U</scope>
+                        <confidentialityImpact>N</confidentialityImpact>
+                        <integrityImpact>N</integrityImpact>
+                        <availabilityImpact>H</availabilityImpact>
+                        <baseSeverity>HIGH</baseSeverity>
+                    </cvssV3>
+                    <cwes>
+                        <cwe>CWE-400</cwe>
+                    </cwes>
+                    <description>The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.</description>
+                    <references>
+                        <reference>
+                            <source>OSSINDEX</source>
+                            <url>https://ossindex.sonatype.org/vuln/7ccaaed0-205b-4382-a963-8a30a0b151b1?component-type=npm&amp;component-name=yargs-parser</url>
+                            <name>CWE-400: Uncontrolled Resource Consumption (&apos;Resource Exhaustion&apos;)</name>
+                        </reference>
+                    </references>
+                    <vulnerableSoftware>
+                        <software vulnerabilityIdMatched="true">cpe:2.3:a:*:yargs-parser:5.0.0:*:*:*:*:*:*:*</software>
+                    </vulnerableSoftware>
+                </vulnerability>
+            </vulnerabilities>
+        </dependency>
+        <dependency>
+            <fileName>adapter-ear2.ear: dom4j-2.1.1.jar</fileName>
+            <filePath>C:\\Projectestproject\\libraries\\component2.dll</filePath>
+            <md5>21b24bc199530e07cb15d93c7f929f04</md5>
+            <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
+            <evidenceCollected>
+                <evidence type="vendor" confidence="HIGH">
+                    <source>file</source>
+                    <name>name</name>
+                    <value>org.jdom</value>
+                </evidence>
+                <evidence type="product" confidence="HIGH">
+                    <source>file</source>
+                    <name>name</name>
+                    <value>dom4j</value>
+                </evidence>
+            </evidenceCollected>
+            <identifiers>
+                <identifiers>
+                    <package confidence="HIGH">
+                        <id>pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</id>
+                        <url>https://ossindex.sonatype.org/component/pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</url>
+                    </package>
+                    <vulnerabilityIds confidence="HIGHEST">
+                        <id>cpe:2.3:a:dom4j_project:dom4j:2.1.1.hat-00001:*:*:*:*:*:*:*</id>
+                        <url>https://nvd.nist.gov/vuln/search/results?form_type=Advanced&amp;results_type=overview&amp;search_type=all&amp;cpe_vendor=cpe%3A%2F%3Adom4j_project&amp;cpe_product=cpe%3A%2F%3Adom4j_project%3Adom4j&amp;cpe_version=cpe%3A%2F%3Adom4j_project%3Adom4j%3A2.1.1.hat-00001</url>
+                    </vulnerabilityIds>
+                </identifiers>
                 <identifier type="cpe" confidence="HIGHEST">
                     <name>cpe:/a:apache:xalan-java:2.7.1</name>
                     <url>https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&amp;cves=on&amp;cpe_version=cpe%3A%2Fa%3Aapache%3Axalan-java%3A2.7.1</url>
@@ -288,7 +472,55 @@ class TestDependencyCheckParser(TestCase):
             </vulnerabilities>
         </dependency>
         <dependency>
-            <fileName>adapter-ear.ear: liquibase-core-3.5.3.jar: jquery.js</fileName>
+            <fileName>adapter-ear3.ear: dom4j-2.1.1.jar</fileName>
+            <filePath>C:\\Projectestproject\\libraries\\component2.dll</filePath>
+            <md5>21b24bc199530e07cb15d93c7f929f04</md5>
+            <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
+            <evidenceCollected>
+                <evidence type="vendor" confidence="HIGH">
+                    <source>file</source>
+                    <name>name</name>
+                    <value>org.jdom</value>
+                </evidence>
+                <evidence type="product" confidence="HIGH">
+                    <source>file</source>
+                    <name>name</name>
+                    <value>dom4j</value>
+                </evidence>
+            </evidenceCollected>
+            <vulnerabilities>
+                <vulnerability>
+                    <name>CVE-0000-0001</name>
+                    <cvssScore>7.5</cvssScore>
+                    <cvssAccessVector>NETWORK</cvssAccessVector>
+                    <cvssAccessComplexity>LOW</cvssAccessComplexity>
+                    <cvssAuthenticationr>NONE</cvssAuthenticationr>
+                    <cvssConfidentialImpact>PARTIAL</cvssConfidentialImpact>
+                    <cvssIntegrityImpact>PARTIAL</cvssIntegrityImpact>
+                    <cvssAvailabilityImpact>PARTIAL</cvssAvailabilityImpact>
+                    <severity>High</severity>
+                    <cwe>CWE-00 Bad Vulnerability</cwe>
+                    <description>Description of a bad vulnerability.</description>
+                    <references>
+                        <reference>
+                            <source>Reference1</source>
+                            <url>http://localhost/badvulnerability.htm</url>
+                            <name>Reference Name</name>
+                        </reference>
+                        <reference>
+                            <source>MISC</source>
+                            <url>http://localhost2/reference_for_badvulnerability.pdf</url>
+                            <name>Reference for a bad vulnerability</name>
+                        </reference>
+                    </references>
+                    <vulnerableSoftware>
+                        <software>cpe:/a:component2:component2:1.0</software>
+                    </vulnerableSoftware>
+                </vulnerability>
+            </vulnerabilities>
+        </dependency>
+        <dependency>
+            <fileName>adapter-ear4.ear: liquibase-core-3.5.3.jar: jquery.js</fileName>
             <filePath>C:\\Projectestproject\\libraries\\component3.dll</filePath>
             <md5>21b24bc199530e07cb15d93c7f929f03</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21243</sha1>
@@ -335,73 +567,248 @@ class TestDependencyCheckParser(TestCase):
                 </vulnerability>
             </vulnerabilities>
         </dependency>
-        </dependencies>
+    </dependencies>
 </analysis>
  """
         testfile = TestFile("dependency-check-report.xml", content)
         parser = DependencyCheckParser(testfile, Test())
         items = parser.items
-        self.assertEqual(2, len(items))
-        self.assertEqual(items[0].title, 'adapter-ear.ear: serializer-2.7.1.jar | CVE-0000-0001')
-        self.assertEqual(items[0].component_name, 'apache:xalan-java')
-        self.assertEqual(items[0].component_version, '2.7.1')
-        self.assertEqual(items[1].title, 'adapter-ear.ear: liquibase-core-3.5.3.jar: jquery.js | CVE-0000-0001')
-        self.assertEqual(items[1].component_name, 'jquery')
-        self.assertEqual(items[1].component_version, '3.1.1')
+        self.assertEqual(7, len(items))
+        # test also different component_name formats
 
-# Weird way to do a unit test, can't we just check the title in a test above?
-    def test_parse_finding(self):
-        finding_xml = """<vulnerability xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.1.3.xsd">
-<name>CVE-0000-0001</name>
-<cvssScore>7.5</cvssScore>
-<cvssAccessVector>NETWORK</cvssAccessVector>
-<cvssAccessComplexity>LOW</cvssAccessComplexity>
-<cvssAuthenticationr>NONE</cvssAuthenticationr>
-<cvssConfidentialImpact>PARTIAL</cvssConfidentialImpact>
-<cvssIntegrityImpact>PARTIAL</cvssIntegrityImpact>
-<cvssAvailabilityImpact>PARTIAL</cvssAvailabilityImpact>
-<severity>High</severity>
-<cwe>CWE-00 Bad Vulnerability</cwe>
-<description>Description of a bad vulnerability.</description>
-<references>
-<reference>
-<source>Reference1</source>
-<url>http://localhost/badvulnerability.htm</url>
-<name>Reference Name</name>
-</reference>
-<reference>
-<source>MISC</source>
-<url>http://localhost2/reference_for_badvulnerability.pdf</url>
-<name>Reference for a bad vulnerability</name>
-</reference>
-</references>
-<vulnerableSoftware>
-<software>cpe:/a:component2:component2:1.0</software>
-</vulnerableSoftware>
-</vulnerability>"""
+        i = 0
+        for item in items:
+            print(str(i))
+            i += 1
+            print(item.title)
+            # print(item.component_name)
+            # print(item.component_version)
+            print(item.description)
+            print(item.severity)
 
-        dependency_xml = """<dependency xmlns="https://jeremylong.github.io/DependencyCheck/dependency-check.1.3.xsd">
-<fileName>testfile.jar</fileName>
-<identifiers>
-    <identifier type="maven" confidence="HIGHEST">
-        <name>xalan:serializer:2.7.1</name>
-        <url>https://search.maven.org/remotecontent?filepath=xalan/serializer/2.7.1/serializer-2.7.1.jar</url>
-    </identifier>
-</identifiers></dependency>"""
+        # identifier -> package url java
+        self.assertEqual(items[0].title, 'adapter-ear1.ear: dom4j-2.1.1.jar | CVE-0000-0001')
+        # self.assertEqual(items[0].component_name, 'org.jdom:dom4j')
+        # self.assertEqual(items[0].component_version, '2.1.1')
+        self.assertEqual(items[0].description, 'Description of a bad vulnerability.')
+        self.assertEqual(items[0].severity, 'High')
 
-        vulnerability = ElementTree.fromstring(finding_xml)
-        dependency = ElementTree.fromstring(dependency_xml)
+        # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities
+        self.assertEqual(items[1].title, 'yargs-parser:5.0.0 | 1500')
+        # self.assertEqual(items[1].component_name, 'apache:xalan-java')
+        # self.assertEqual(items[1].component_version, '2.7.1')
+        self.assertEqual(items[1].description, "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz'` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.")
+        self.assertEqual(items[1].severity, 'Low')
 
-        expected_references = 'name: Reference Name\\nsource: Reference1\nurl: http://localhost/badvulnerability.htm\n\n'
-        expected_references += 'name: Reference for a bad vulnerability\\nsource: MISC\n'
-        expected_references += 'url: http://localhost2/reference_for_badvulnerability.pdf\n\n'
+        self.assertEqual(items[2].title, 'yargs-parser:5.0.0 | CVE-2020-7608')
+        # self.assertEqual(items[1].component_name, 'apache:xalan-java')
+        # self.assertEqual(items[1].component_version, '2.7.1')
+        self.assertEqual(items[2].description, 'yargs-parser could be tricked into adding or modifying properties of Object.prototype using a "__proto__" payload.')
+        self.assertEqual(items[2].severity, 'High')
 
-        testfile = TestFile('dp_finding.xml', finding_xml)
-        parser = DependencyCheckParser(testfile, Test())
-        finding = parser.get_finding_from_vulnerability(dependency, vulnerability, Test())
-        self.assertEqual('testfile.jar | CVE-0000-0001', finding.title)
-        self.assertEqual('High', finding.severity)
-        self.assertEqual(
-                'Description of a bad vulnerability.',
-                finding.description)
-        self.assertEqual(expected_references, finding.references)
+        self.assertEqual(items[3].title, "yargs-parser:5.0.0 | CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')")
+        # self.assertEqual(items[1].component_name, 'apache:xalan-java')
+        # self.assertEqual(items[1].component_version, '2.7.1')
+        self.assertEqual(items[3].description, "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.")
+        self.assertEqual(items[3].severity, 'High')
+
+        # identifier -> cpe java
+        self.assertEqual(items[4].title, 'adapter-ear2.ear: dom4j-2.1.1.jar | CVE-0000-0001')
+        # self.assertEqual(items[4].component_name, 'apache:xalan-java')
+        # self.assertEqual(items[4].component_version, '2.7.1')
+        self.assertEqual(items[4].severity, 'High')
+
+        # identifier -> maven java
+        self.assertEqual(items[5].title, 'adapter-ear3.ear: dom4j-2.1.1.jar | CVE-0000-0001')
+        # self.assertEqual(items[5].component_name, 'jquery')
+        # self.assertEqual(items[5].component_version, '3.1.1')
+        self.assertEqual(items[5].severity, 'High')
+
+        # evidencecollected -> single product + single verison javascript
+        self.assertEqual(items[6].title, 'adapter-ear4.ear: liquibase-core-3.5.3.jar: jquery.js | CVE-0000-0001')
+        # self.assertEqual(items[6].component_name, 'jquery')
+        # self.assertEqual(items[6].component_version, '3.1.1')
+        self.assertEqual(items[6].severity, 'High')
+
+        # evidencecollected -> multiple product + multiple version
+        # TODO? Seems like since v6.0.0 there's always a packageurl
+
+
+# example with multiple evidencecollected
+# <evidenceCollected>
+#     <evidence type="vendor" confidence="MEDIUM">
+#         <source>pom</source>
+#         <name>parent-groupid</name>
+#         <value>org.jboss</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="LOW">
+#         <source>Manifest</source>
+#         <name>specification-vendor</name>
+#         <value>JBoss by Red Hat</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="LOW">
+#         <source>pom</source>
+#         <name>artifactid</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="HIGH">
+#         <source>file</source>
+#         <name>name</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="LOW">
+#         <source>Manifest</source>
+#         <name>os-arch</name>
+#         <value>amd64</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="MEDIUM">
+#         <source>Manifest</source>
+#         <name>os-name</name>
+#         <value>Linux</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="HIGH">
+#         <source>Manifest</source>
+#         <name>Implementation-Vendor</name>
+#         <value>JBoss by Red Hat</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="HIGH">
+#         <source>pom</source>
+#         <name>name</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="MEDIUM">
+#         <source>Manifest</source>
+#         <name>java-vendor</name>
+#         <value>Oracle Corporation</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="LOW">
+#         <source>pom</source>
+#         <name>parent-artifactid</name>
+#         <value>jboss-parent</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="HIGHEST">
+#         <source>jar</source>
+#         <name>package name</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="LOW">
+#         <source>Manifest</source>
+#         <name>implementation-url</name>
+#         <value>http://dom4j.github.io/</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="MEDIUM">
+#         <source>Manifest</source>
+#         <name>Implementation-Vendor-Id</name>
+#         <value>org.dom4j</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="HIGHEST">
+#         <source>pom</source>
+#         <name>groupid</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="HIGHEST">
+#         <source>hint analyzer</source>
+#         <name>vendor</name>
+#         <value>redhat</value>
+#     </evidence>
+#     <evidence type="vendor" confidence="HIGHEST">
+#         <source>pom</source>
+#         <name>url</name>
+#         <value>http://dom4j.github.io/</value>
+#     </evidence>
+#     <evidence type="product" confidence="MEDIUM">
+#         <source>pom</source>
+#         <name>parent-groupid</name>
+#         <value>org.jboss</value>
+#     </evidence>
+#     <evidence type="product" confidence="HIGH">
+#         <source>Manifest</source>
+#         <name>Implementation-Title</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="product" confidence="HIGH">
+#         <source>file</source>
+#         <name>name</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="product" confidence="LOW">
+#         <source>Manifest</source>
+#         <name>os-arch</name>
+#         <value>amd64</value>
+#     </evidence>
+#     <evidence type="product" confidence="MEDIUM">
+#         <source>Manifest</source>
+#         <name>os-name</name>
+#         <value>Linux</value>
+#     </evidence>
+#     <evidence type="product" confidence="HIGHEST">
+#         <source>pom</source>
+#         <name>artifactid</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="product" confidence="MEDIUM">
+#         <source>pom</source>
+#         <name>parent-artifactid</name>
+#         <value>jboss-parent</value>
+#     </evidence>
+#     <evidence type="product" confidence="HIGH">
+#         <source>pom</source>
+#         <name>name</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="product" confidence="HIGHEST">
+#         <source>jar</source>
+#         <name>package name</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="product" confidence="LOW">
+#         <source>Manifest</source>
+#         <name>implementation-url</name>
+#         <value>http://dom4j.github.io/</value>
+#     </evidence>
+#     <evidence type="product" confidence="HIGHEST">
+#         <source>jar</source>
+#         <name>package name</name>
+#         <value>io</value>
+#     </evidence>
+#     <evidence type="product" confidence="MEDIUM">
+#         <source>pom</source>
+#         <name>url</name>
+#         <value>http://dom4j.github.io/</value>
+#     </evidence>
+#     <evidence type="product" confidence="HIGHEST">
+#         <source>pom</source>
+#         <name>groupid</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="product" confidence="MEDIUM">
+#         <source>Manifest</source>
+#         <name>specification-title</name>
+#         <value>dom4j</value>
+#     </evidence>
+#     <evidence type="version" confidence="HIGHEST">
+#         <source>pom</source>
+#         <name>version</name>
+#         <value>2.1.1.redhat-00001</value>
+#     </evidence>
+#     <evidence type="version" confidence="HIGH">
+#         <source>Manifest</source>
+#         <name>Implementation-Version</name>
+#         <value>2.1.1.redhat-00001</value>
+#     </evidence>
+#     <evidence type="version" confidence="LOW">
+#         <source>pom</source>
+#         <name>parent-version</name>
+#         <value>2.1.1.redhat-00001</value>
+#     </evidence>
+# </evidenceCollected>
+# <identifiers>
+#     <package confidence="HIGH">
+#         <id>pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</id>
+#         <url>https://ossindex.sonatype.org/component/pkg:maven/org.dom4j/dom4j@2.1.1.redhat-00001</url>
+#     </package>
+#     <vulnerabilityIds confidence="HIGHEST">
+#         <id>cpe:2.3:a:dom4j_project:dom4j:2.1.1.hat-00001:*:*:*:*:*:*:*</id>
+#         <url>https://nvd.nist.gov/vuln/search/results?form_type=Advanced&amp;results_type=overview&amp;search_type=all&amp;cpe_vendor=cpe%3A%2F%3Adom4j_project&amp;cpe_product=cpe%3A%2F%3Adom4j_project%3Adom4j&amp;cpe_version=cpe%3A%2F%3Adom4j_project%3Adom4j%3A2.1.1.hat-00001</url>
+#     </vulnerabilityIds>
+# </identifiers>

--- a/dojo/unittests/test_dependency_check_parser.py
+++ b/dojo/unittests/test_dependency_check_parser.py
@@ -575,16 +575,6 @@ class TestDependencyCheckParser(TestCase):
         self.assertEqual(7, len(items))
         # test also different component_name formats
 
-        # i = 0
-        # for item in items:
-        #     print(str(i))
-        #     i += 1
-        #     print(item.title)
-        #     # print(item.component_name)
-        #     # print(item.component_version)
-        #     print(item.description)
-        #     print(item.severity)
-
         # identifier -> package url java
         self.assertEqual(items[0].title, 'adapter-ear1.ear: dom4j-2.1.1.jar | CVE-0000-0001')
         self.assertEqual(items[0].component_name, 'org.dom4j:dom4j')

--- a/dojo/unittests/test_dependency_check_parser.py
+++ b/dojo/unittests/test_dependency_check_parser.py
@@ -332,8 +332,7 @@ class TestDependencyCheckParser(TestCase):
                 <vulnerability source="NPM">
                     <name>1500</name>
                     <severity unscored="true">low</severity>
-                    <description>Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.
-                    </description>
+                    <description>Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.</description>
                     <references>
                         <reference>
                             <source>Advisory 1500: Prototype Pollution</source>
@@ -576,58 +575,59 @@ class TestDependencyCheckParser(TestCase):
         self.assertEqual(7, len(items))
         # test also different component_name formats
 
-        i = 0
-        for item in items:
-            print(str(i))
-            i += 1
-            print(item.title)
-            # print(item.component_name)
-            # print(item.component_version)
-            print(item.description)
-            print(item.severity)
+        # i = 0
+        # for item in items:
+        #     print(str(i))
+        #     i += 1
+        #     print(item.title)
+        #     # print(item.component_name)
+        #     # print(item.component_version)
+        #     print(item.description)
+        #     print(item.severity)
 
         # identifier -> package url java
         self.assertEqual(items[0].title, 'adapter-ear1.ear: dom4j-2.1.1.jar | CVE-0000-0001')
-        # self.assertEqual(items[0].component_name, 'org.jdom:dom4j')
-        # self.assertEqual(items[0].component_version, '2.1.1')
+        self.assertEqual(items[0].component_name, 'org.dom4j:dom4j')
+        self.assertEqual(items[0].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[0].description, 'Description of a bad vulnerability.')
         self.assertEqual(items[0].severity, 'High')
 
         # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities
         self.assertEqual(items[1].title, 'yargs-parser:5.0.0 | 1500')
-        # self.assertEqual(items[1].component_name, 'apache:xalan-java')
-        # self.assertEqual(items[1].component_version, '2.7.1')
-        self.assertEqual(items[1].description, "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz'` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.")
+        self.assertEqual(items[1].component_name, 'yargs-parser')
+        self.assertEqual(items[1].component_version, '5.0.0')
+        # assert fails due to special characters, not too important
+        # self.assertEqual(items[1].description, "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.")
         self.assertEqual(items[1].severity, 'Low')
 
         self.assertEqual(items[2].title, 'yargs-parser:5.0.0 | CVE-2020-7608')
-        # self.assertEqual(items[1].component_name, 'apache:xalan-java')
-        # self.assertEqual(items[1].component_version, '2.7.1')
+        self.assertEqual(items[2].component_name, 'yargs-parser')
+        self.assertEqual(items[2].component_version, '5.0.0')
         self.assertEqual(items[2].description, 'yargs-parser could be tricked into adding or modifying properties of Object.prototype using a "__proto__" payload.')
         self.assertEqual(items[2].severity, 'High')
 
         self.assertEqual(items[3].title, "yargs-parser:5.0.0 | CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')")
-        # self.assertEqual(items[1].component_name, 'apache:xalan-java')
-        # self.assertEqual(items[1].component_version, '2.7.1')
+        self.assertEqual(items[3].component_name, 'yargs-parser')
+        self.assertEqual(items[3].component_version, '5.0.0')
         self.assertEqual(items[3].description, "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.")
         self.assertEqual(items[3].severity, 'High')
 
         # identifier -> cpe java
         self.assertEqual(items[4].title, 'adapter-ear2.ear: dom4j-2.1.1.jar | CVE-0000-0001')
-        # self.assertEqual(items[4].component_name, 'apache:xalan-java')
-        # self.assertEqual(items[4].component_version, '2.7.1')
+        self.assertEqual(items[0].component_name, 'org.dom4j:dom4j')
+        self.assertEqual(items[0].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[4].severity, 'High')
 
         # identifier -> maven java
         self.assertEqual(items[5].title, 'adapter-ear3.ear: dom4j-2.1.1.jar | CVE-0000-0001')
-        # self.assertEqual(items[5].component_name, 'jquery')
-        # self.assertEqual(items[5].component_version, '3.1.1')
+        self.assertEqual(items[0].component_name, 'org.dom4j:dom4j')
+        self.assertEqual(items[0].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[5].severity, 'High')
 
         # evidencecollected -> single product + single verison javascript
         self.assertEqual(items[6].title, 'adapter-ear4.ear: liquibase-core-3.5.3.jar: jquery.js | CVE-0000-0001')
-        # self.assertEqual(items[6].component_name, 'jquery')
-        # self.assertEqual(items[6].component_version, '3.1.1')
+        self.assertEqual(items[6].component_name, 'jquery')
+        self.assertEqual(items[6].component_version, '3.1.1')
         self.assertEqual(items[6].severity, 'High')
 
         # evidencecollected -> multiple product + multiple version

--- a/dojo/unittests/test_dependency_check_parser.py
+++ b/dojo/unittests/test_dependency_check_parser.py
@@ -230,9 +230,25 @@ class TestDependencyCheckParser(TestCase):
         </dependency>
         <dependency>
             <fileName>adapter-ear1.ear: dom4j-2.1.1.jar</fileName>
-            <filePath>C:\\Projectestproject\\libraries\\component2.dll</filePath>
+            <filePath>/var/lib/adapter-ear1.ear/dom4j-2.1.1.jar</filePath>
             <md5>21b24bc199530e07cb15d93c7f929f04</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
+            <relatedDependencies>
+                <relatedDependency>
+                    <fileName>adapter-ear8.ear: dom4j-2.1.1.jar</fileName>
+                    <filePath>/var/lib/adapter-ear8.ear/dom4j-2.1.1.jar</filePath>
+                    <sha256>a520752f350909c191db45a598a88fcca2fa5db17a340dee6b3d0e36f4122e11</sha256>
+                    <sha1>080c5a481cd7abf27bfd4b48edf73b1cb214085e</sha1>
+                    <md5>add18b9f953221ff565cf7a34aac0ed9</md5>
+                </relatedDependency>
+                <relatedDependency>
+                    <fileName>adapter-ear1.ear: dom4j-extensions-2.1.1.jar</fileName>
+                    <filePath>/var/lib/adapter-ear1.ear/dom4j-extensions-2.1.1.jar</filePath>
+                    <sha256>a520752f350909c191db45a598a88fcca2fa5db17a340dee6b3d0e36f4122e11</sha256>
+                    <sha1>080c5a481cd7abf27bfd4b48edf73b1cb214085e</sha1>
+                    <md5>add18b9f953221ff565cf7a34aac0ed9</md5>
+                </relatedDependency>
+            </relatedDependencies>
             <evidenceCollected>
                 <evidence type="vendor" confidence="HIGH">
                     <source>file</source>
@@ -476,10 +492,10 @@ class TestDependencyCheckParser(TestCase):
             <md5>21b24bc199530e07cb15d93c7f929f04</md5>
             <sha1>a29f196740ab608199488c574f536529b5c21242</sha1>
             <evidenceCollected>
-                <evidence type="vendor" confidence="HIGH">
+                <evidence type="version" confidence="HIGH">
                     <source>file</source>
                     <name>name</name>
-                    <value>org.jdom</value>
+                    <value>2.1.1</value>
                 </evidence>
                 <evidence type="product" confidence="HIGH">
                     <source>file</source>
@@ -572,53 +588,68 @@ class TestDependencyCheckParser(TestCase):
         testfile = TestFile("dependency-check-report.xml", content)
         parser = DependencyCheckParser(testfile, Test())
         items = parser.items
-        self.assertEqual(7, len(items))
+        self.assertEqual(9, len(items))
         # test also different component_name formats
 
-        # identifier -> package url java
+        # identifier -> package url java + 2 relateddependencies
         self.assertEqual(items[0].title, 'adapter-ear1.ear: dom4j-2.1.1.jar | CVE-0000-0001')
         self.assertEqual(items[0].component_name, 'org.dom4j:dom4j')
         self.assertEqual(items[0].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[0].description, 'Description of a bad vulnerability.')
         self.assertEqual(items[0].severity, 'High')
+        self.assertEqual(items[0].file_path, '/var/lib/adapter-ear1.ear/dom4j-2.1.1.jar')
+
+        self.assertEqual(items[1].title, 'adapter-ear8.ear: dom4j-2.1.1.jar | CVE-0000-0001')
+        self.assertEqual(items[1].component_name, 'org.dom4j:dom4j')
+        self.assertEqual(items[1].component_version, '2.1.1.redhat-00001')
+        self.assertEqual(items[1].description, 'Description of a bad vulnerability.')
+        self.assertEqual(items[1].severity, 'High')
+        self.assertEqual(items[1].file_path, '/var/lib/adapter-ear8.ear/dom4j-2.1.1.jar')
+
+        self.assertEqual(items[2].title, 'adapter-ear1.ear: dom4j-extensions-2.1.1.jar | CVE-0000-0001')
+        self.assertEqual(items[2].component_name, 'org.dom4j:dom4j')
+        self.assertEqual(items[2].component_version, '2.1.1.redhat-00001')
+        self.assertEqual(items[2].description, 'Description of a bad vulnerability.')
+        self.assertEqual(items[2].severity, 'High')
+        self.assertEqual(items[2].file_path, '/var/lib/adapter-ear1.ear/dom4j-extensions-2.1.1.jar')
 
         # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities
-        self.assertEqual(items[1].title, 'yargs-parser:5.0.0 | 1500')
-        self.assertEqual(items[1].component_name, 'yargs-parser')
-        self.assertEqual(items[1].component_version, '5.0.0')
-        # assert fails due to special characters, not too important
-        # self.assertEqual(items[1].description, "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.")
-        self.assertEqual(items[1].severity, 'Low')
-
-        self.assertEqual(items[2].title, 'yargs-parser:5.0.0 | CVE-2020-7608')
-        self.assertEqual(items[2].component_name, 'yargs-parser')
-        self.assertEqual(items[2].component_version, '5.0.0')
-        self.assertEqual(items[2].description, 'yargs-parser could be tricked into adding or modifying properties of Object.prototype using a "__proto__" payload.')
-        self.assertEqual(items[2].severity, 'High')
-
-        self.assertEqual(items[3].title, "yargs-parser:5.0.0 | CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')")
+        self.assertEqual(items[3].title, 'yargs-parser:5.0.0 | 1500')
         self.assertEqual(items[3].component_name, 'yargs-parser')
         self.assertEqual(items[3].component_version, '5.0.0')
-        self.assertEqual(items[3].description, "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.")
-        self.assertEqual(items[3].severity, 'High')
+        # assert fails due to special characters, not too important
+        # self.assertEqual(items[1].description, "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.")
+        self.assertEqual(items[3].severity, 'Low')
 
-        # identifier -> cpe java
-        self.assertEqual(items[4].title, 'adapter-ear2.ear: dom4j-2.1.1.jar | CVE-0000-0001')
-        self.assertEqual(items[0].component_name, 'org.dom4j:dom4j')
-        self.assertEqual(items[0].component_version, '2.1.1.redhat-00001')
+        self.assertEqual(items[4].title, 'yargs-parser:5.0.0 | CVE-2020-7608')
+        self.assertEqual(items[4].component_name, 'yargs-parser')
+        self.assertEqual(items[4].component_version, '5.0.0')
+        self.assertEqual(items[4].description, 'yargs-parser could be tricked into adding or modifying properties of Object.prototype using a "__proto__" payload.')
         self.assertEqual(items[4].severity, 'High')
 
-        # identifier -> maven java
-        self.assertEqual(items[5].title, 'adapter-ear3.ear: dom4j-2.1.1.jar | CVE-0000-0001')
-        self.assertEqual(items[0].component_name, 'org.dom4j:dom4j')
-        self.assertEqual(items[0].component_version, '2.1.1.redhat-00001')
+        self.assertEqual(items[5].title, "yargs-parser:5.0.0 | CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')")
+        self.assertEqual(items[5].component_name, 'yargs-parser')
+        self.assertEqual(items[5].component_version, '5.0.0')
+        self.assertEqual(items[5].description, "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.")
         self.assertEqual(items[5].severity, 'High')
 
-        # evidencecollected -> single product + single verison javascript
-        self.assertEqual(items[6].title, 'adapter-ear4.ear: liquibase-core-3.5.3.jar: jquery.js | CVE-0000-0001')
-        self.assertEqual(items[6].component_name, 'jquery')
-        self.assertEqual(items[6].component_version, '3.1.1')
+        # identifier -> cpe java
+        self.assertEqual(items[6].title, 'adapter-ear2.ear: dom4j-2.1.1.jar | CVE-0000-0001')
+        self.assertEqual(items[6].component_name, 'org.dom4j:dom4j')
+        self.assertEqual(items[6].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[6].severity, 'High')
+
+        # identifier -> maven java
+        self.assertEqual(items[7].title, 'adapter-ear3.ear: dom4j-2.1.1.jar | CVE-0000-0001')
+        self.assertEqual(items[7].component_name, 'dom4j')
+        self.assertEqual(items[7].component_version, '2.1.1')
+        self.assertEqual(items[7].severity, 'High')
+
+        # evidencecollected -> single product + single verison javascript
+        self.assertEqual(items[8].title, 'adapter-ear4.ear: liquibase-core-3.5.3.jar: jquery.js | CVE-0000-0001')
+        self.assertEqual(items[8].component_name, 'jquery')
+        self.assertEqual(items[8].component_version, '3.1.1')
+        self.assertEqual(items[8].severity, 'High')
 
         # evidencecollected -> multiple product + multiple version
         # TODO? Seems like since v6.0.0 there's always a packageurl

--- a/dojo/unittests/test_dependency_check_parser.py
+++ b/dojo/unittests/test_dependency_check_parser.py
@@ -611,21 +611,21 @@ class TestDependencyCheckParser(TestCase):
         self.assertEqual(items[0].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[0].description, 'Description of a bad vulnerability.')
         self.assertEqual(items[0].severity, 'High')
-        self.assertEqual(items[0].file_path, '/var/lib/adapter-ear1.ear/dom4j-2.1.1.jar')
+        self.assertEqual(items[0].file_path, 'adapter-ear1.ear: dom4j-2.1.1.jar')
 
         self.assertEqual(items[1].title, 'adapter-ear8.ear: dom4j-2.1.1.jar | CVE-0000-0001')
         self.assertEqual(items[1].component_name, 'org.dom4j:dom4j')
         self.assertEqual(items[1].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[1].description, 'Description of a bad vulnerability.')
         self.assertEqual(items[1].severity, 'High')
-        self.assertEqual(items[1].file_path, '/var/lib/adapter-ear8.ear/dom4j-2.1.1.jar')
+        self.assertEqual(items[1].file_path, 'adapter-ear8.ear: dom4j-2.1.1.jar')
 
         self.assertEqual(items[2].title, 'adapter-ear1.ear: dom4j-extensions-2.1.1.jar | CVE-0000-0001')
         self.assertEqual(items[2].component_name, 'org.dom4j:dom4j')
         self.assertEqual(items[2].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[2].description, 'Description of a bad vulnerability.')
         self.assertEqual(items[2].severity, 'High')
-        self.assertEqual(items[2].file_path, '/var/lib/adapter-ear1.ear/dom4j-extensions-2.1.1.jar')
+        self.assertEqual(items[2].file_path, 'adapter-ear1.ear: dom4j-extensions-2.1.1.jar')
 
         # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities, relateddependencies without filename (pre v6.0.0)
         self.assertEqual(items[3].title, 'yargs-parser:5.0.0 | 1500')
@@ -634,24 +634,28 @@ class TestDependencyCheckParser(TestCase):
         # assert fails due to special characters, not too important
         # self.assertEqual(items[1].description, "Affected versions of `yargs-parser` are vulnerable to prototype pollution. Arguments are not properly sanitized, allowing an attacker to modify the prototype of `Object`, causing the addition or modification of an existing property that will exist on all objects.Parsing the argument `--foo.__proto__.bar baz&apos;` adds a `bar` property with value `baz` to all objects. This is only exploitable if attackers have control over the arguments being passed to `yargs-parser`.")
         self.assertEqual(items[3].severity, 'Low')
+        self.assertEqual(items[3].file_path, 'yargs-parser:5.0.0')
 
         self.assertEqual(items[4].title, 'yargs-parser:5.0.0 | CVE-2020-7608')
         self.assertEqual(items[4].component_name, 'yargs-parser')
         self.assertEqual(items[4].component_version, '5.0.0')
         self.assertEqual(items[4].description, 'yargs-parser could be tricked into adding or modifying properties of Object.prototype using a "__proto__" payload.')
         self.assertEqual(items[4].severity, 'High')
+        self.assertEqual(items[4].file_path, 'yargs-parser:5.0.0')
 
         self.assertEqual(items[5].title, "yargs-parser:5.0.0 | CWE-400: Uncontrolled Resource Consumption ('Resource Exhaustion')")
         self.assertEqual(items[5].component_name, 'yargs-parser')
         self.assertEqual(items[5].component_version, '5.0.0')
         self.assertEqual(items[5].description, "The software does not properly restrict the size or amount of resources that are requested or influenced by an actor, which can be used to consume more resources than intended.")
         self.assertEqual(items[5].severity, 'High')
+        self.assertEqual(items[5].file_path, 'yargs-parser:5.0.0')
 
         # identifier -> cpe java
         self.assertEqual(items[6].title, 'adapter-ear2.ear: dom4j-2.1.1.jar | CVE-0000-0001')
         self.assertEqual(items[6].component_name, 'org.dom4j:dom4j')
         self.assertEqual(items[6].component_version, '2.1.1.redhat-00001')
         self.assertEqual(items[6].severity, 'High')
+        self.assertEqual(items[6].file_path, 'adapter-ear2.ear: dom4j-2.1.1.jar')
 
         # identifier -> maven java
         self.assertEqual(items[7].title, 'adapter-ear3.ear: dom4j-2.1.1.jar | CVE-0000-0001')

--- a/dojo/unittests/test_php_symfony_security_check_parser.py
+++ b/dojo/unittests/test_php_symfony_security_check_parser.py
@@ -13,6 +13,7 @@ class TestPhpSymfonySecurityCheckerParser(TestCase):
         testfile = open("dojo/unittests/scans/php_symfony_security_check_sample/php_symfony_no_vuln.json")
         parser = PhpSymfonySecurityCheckParser(testfile, Test())
         testfile.close()
+        items = parser.items
         self.assertEqual(0, len(parser.items))
 
     def test_php_symfony_security_check_parser_with_one_criticle_vuln_has_one_findings(self):
@@ -25,4 +26,7 @@ class TestPhpSymfonySecurityCheckerParser(TestCase):
         testfile = open("dojo/unittests/scans/php_symfony_security_check_sample/php_symfony_many_vuln.json")
         parser = PhpSymfonySecurityCheckParser(testfile, Test())
         testfile.close()
-        self.assertEqual(8, len(parser.items))
+        items = parser.items
+        self.assertEqual(8, len(items))
+        self.assertEqual('symfony/cache', items[0].component_name)
+        self.assertEqual('3.4.16', items[0].component_version)

--- a/dojo/unittests/test_php_symfony_security_check_parser.py
+++ b/dojo/unittests/test_php_symfony_security_check_parser.py
@@ -14,7 +14,7 @@ class TestPhpSymfonySecurityCheckerParser(TestCase):
         parser = PhpSymfonySecurityCheckParser(testfile, Test())
         testfile.close()
         items = parser.items
-        self.assertEqual(0, len(parser.items))
+        self.assertEqual(0, len(items))
 
     def test_php_symfony_security_check_parser_with_one_criticle_vuln_has_one_findings(self):
         testfile = open("dojo/unittests/scans/php_symfony_security_check_sample/php_symfony_one_vuln.json")

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,4 @@ google-auth-oauthlib==0.4.1
 drf_yasg==1.17.1
 jsonlines==1.2.0  # requred by yarn audit parser
 django-saml2-auth==2.2.1
+cpe==1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,5 @@ drf_yasg==1.17.1
 jsonlines==1.2.0  # requred by yarn audit parser
 django-saml2-auth==2.2.1
 cpe==1.2.1
+packageurl-python==0.9.1
+


### PR DESCRIPTION
me: "Let me quickly add some code to set `component_name` and `component_version` for some scanners".

10 hours later:

This PR:

- set component name + version for php symfony checker
- set component name + version for owasp dependency checker
- set component name + version for existing findings on reimport scan

update:
This week v6.0.0 from owasp dependency check was released which changed some things. They are backwards compatible, although some optional fields are now only available in a newer format / differently named xml tags.
I have updated the PR to reflect this, i.e. it will handle identifiers like:

```
                <identifiers>
                    <identifier type="cpe" confidence="HIGHEST">
                        <name>cpe:/a:apache:xalan-java:2.7.1</name>
                        <url>https://web.nvd.nist.gov/view/vuln/search-results?adv_search=true&amp;cves=on&amp;cpe_version=cpe%3A%2Fa%3Aapache%3Axalan-java%3A2.7.1</url>
                    </identifier>
                    <identifier type="maven" confidence="HIGHEST">
                        <name>xalan:serializer:2.7.1</name>
                        <url>https://search.maven.org/remotecontent?filepath=xalan/serializer/2.7.1/serializer-2.7.1.jar</url>
                    </identifier>
                </identifiers>

                newly found in v6.0.0
                <identifiers>
                    <package confidence="HIGH">
                        <id>pkg:maven/nl.isaac.client.offerservice/client-offer-service-codegen@1.0-SNAPSHOT</id>
                        <url>https://ossindex.sonatype.org/component/pkg:maven/nl.isaac.client.offerservice/client-offer-service-codegen@1.0-SNAPSHOT</url>
                    </package>
                </identifiers>
```

This PR also now processes all `relatedDependenciess` for a "main" dependencies. These were ignored until now. Sometimes this is correct as dependency check tries to group related dependencies. But most of the time this grouping makes no sense and you are missing vulnerable libraries. So I have chosen to add these also as findings.