### PR TITLE
bugfix for risk acceptance migration

### DIFF
--- a/dojo/db_migrations/0042_risk_acceptance_improvements.py
+++ b/dojo/db_migrations/0042_risk_acceptance_improvements.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='risk_acceptance',
             name='name',
-            field=models.CharField(default=None, max_length=100, help_text="Descriptive name which in the future may also be used to group risk acceptances together across engagements and products"),
+            field=models.CharField(default="Legacy acceptance", max_length=100, help_text="Descriptive name which in the future may also be used to group risk acceptances together across engagements and products"),
         ),
         migrations.RunPython(set_name_from_created_date),
         migrations.AlterField(


### PR DESCRIPTION
With existing risk acceptances in the database I got some error when running the migrations: psycopg2.errors.NotNullViolation: column "name" contains null values

Setting the default value to a dummy string instead of None fixes this error. Should not have any impact on current installations because the field is renamed by the following instruction anyway.