### PR TITLE
Bump helm chart versions

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.7"
+appVersion: "1.7.1"
 description: A Helm chart for Kubernetes to installs DefectDojo
 name: defectdojo
 version: 1.3.0

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.7"
 description: A Helm chart for Kubernetes to installs DefectDojo
 name: defectdojo
-version: 1.2.0
+version: 1.3.0
 icon: https://www.defectdojo.org/img/favicon.ico


### PR DESCRIPTION
- Bump chart to 1.3.0 due to the most recent changes brought about by PR #2847
- Bump defectdojo app version to latest released one, 1.7.1.