### PR TITLE
Quantify endpoint status objects when viewing findings

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -237,6 +237,7 @@ class RegulationSerializer(serializers.ModelSerializer):
         model = Regulation
         fields = '__all__'
 
+
 class ToolConfigurationSerializer(serializers.ModelSerializer):
     configuration_url = serializers.CharField(source='url')
 
@@ -257,6 +258,27 @@ class EndpointStatusSerializer(serializers.ModelSerializer):
     class Meta:
         model = Endpoint_Status
         fields = '__all__'
+
+    def create(self, validated_data):
+        print('\n\nValidated Data')
+        for k, v in validated_data.items():
+            print(k, ':', v)
+
+        endpoint = validated_data['endpoint']
+        finding = validated_data['finding']
+        status, created = Endpoint_Status.objects.get_or_create(
+            finding=finding,
+            endpoint=endpoint
+        )
+        endpoint.endpoint_status.add(status)
+        finding.endpoint_status.add(status)
+        status.mitigated = validated_data.get('mitigated', False)
+        status.false_positive = validated_data.get('false_positive', False)
+        status.out_of_scope = validated_data.get('out_of_scope', False)
+        status.risk_accepted = validated_data.get('risk_accepted', False)
+        status.date = validated_data.get('date', timezone.now())
+
+        return status
 
 
 class EndpointSerializer(TaggitSerializer, serializers.ModelSerializer):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -260,13 +260,9 @@ class EndpointStatusSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
     def create(self, validated_data):
-        print('\n\nValidated Data')
-        for k, v in validated_data.items():
-            print(k, ':', v)
-
         endpoint = validated_data['endpoint']
         finding = validated_data['finding']
-        status, created = Endpoint_Status.objects.get_or_create(
+        status = Endpoint_Status.objects.create(
             finding=finding,
             endpoint=endpoint
         )
@@ -277,7 +273,7 @@ class EndpointStatusSerializer(serializers.ModelSerializer):
         status.out_of_scope = validated_data.get('out_of_scope', False)
         status.risk_accepted = validated_data.get('risk_accepted', False)
         status.date = validated_data.get('date', timezone.now())
-
+        status.save()
         return status
 
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -203,6 +203,7 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('notes')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
         prefetched_findings = prefetched_findings.prefetch_related('endpoints')
+        prefetched_findings = prefetched_findings.prefetch_related('endpoint_status')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__authorized_users')
     else:
         logger.debug('unable to prefetch because query was already executed')

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -47,7 +47,7 @@ from dojo.notifications.helper import create_notification
 from dojo.tasks import add_jira_issue_task, update_jira_issue_task, update_external_issue_task, add_comment_task, \
     add_external_issue_task, close_external_issue_task, reopen_external_issue_task
 from django.template.defaultfilters import pluralize
-from django.db.models import Q, QuerySet, Prefetch
+from django.db.models import Q, QuerySet, Prefetch, Count
 
 logger = logging.getLogger(__name__)
 
@@ -194,7 +194,7 @@ def prefetch_for_findings(findings):
     prefetched_findings = findings
     if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
         prefetched_findings = prefetched_findings.select_related('reporter')
-        prefetched_findings = prefetched_findings.select_related('jira_issue')
+        prefetched_findings = prefetched_findings.prefetch_related('jira_issue')
         prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_pkey_set__conf')
         prefetched_findings = prefetched_findings.prefetch_related('found_by')
@@ -204,6 +204,8 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
         prefetched_findings = prefetched_findings.prefetch_related('endpoints')
         prefetched_findings = prefetched_findings.prefetch_related('endpoint_status')
+        prefetched_findings = prefetched_findings.annotate(active_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=False)))
+        prefetched_findings = prefetched_findings.annotate(mitigated_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=True)))
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__authorized_users')
     else:
         logger.debug('unable to prefetch because query was already executed')

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% load display_tags %}
+{% load get_endpoint_status %}
 {% load static from staticfiles %}
 {% block content %}
     <div class="row">
@@ -323,11 +324,15 @@
                                   <i class="fa fa-code has-popover dojo-sup" data-trigger="hover" data-content="{{ finding.file_path }}" data-placement="right" data-container="body" data-original-title="Files" title=""></i>
                                   {% else %}
                                     {% if finding.endpoints.all %}
-                                      <i class="fa fa-sitemap has-popover dojo-sup" data-html="true" data-trigger="hover" data-content="
+                                      <i class="fa fa-sitemap has-popover dojo-sup" data-html="true" data-trigger="hover" data-content='
                                       {% for endpoint in finding.endpoints.all %}
-                                        {{ endpoint }}<br/>
+                                        {% if endpoint|endpoint_check_active:finding %}
+                                          &#10005; {{ endpoint }}<br/>
+                                        {% else %}
+                                          &#10003; {{ endpoint }}<br/>
+                                        {% endif %}
                                       {% endfor %}
-                                      " data-placement="right" data-container="body" data-original-title="Endpoints" title=""></i>
+                                      ' data-placement="right" data-container="body" data-original-title="Endpoints ({{finding|vulnerable_endpoint_count}} Active, {{finding|mitigated_endpoint_count}} Mitigated)" title=""></i>
                                     {% endif %}
                                   {% endif %}
                                   {% if finding.component_name %}

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -324,7 +324,7 @@
                                   <i class="fa fa-code has-popover dojo-sup" data-trigger="hover" data-content="{{ finding.file_path }}" data-placement="right" data-container="body" data-original-title="Files" title=""></i>
                                   {% else %}
                                     {% if finding.endpoints.all %}
-                                      <i class="fa fa-sitemap has-popover dojo-sup" data-html="true" data-trigger="hover" data-content='
+                                      <i class="fa fa-sitemap has-popover dojo-sup" data-html="true" data-trigger="hover" data-content="
                                       {% for endpoint in finding.endpoints.all %}
                                         {% if endpoint|endpoint_check_active:finding %}
                                           &#10005; {{ endpoint }}<br/>
@@ -332,7 +332,7 @@
                                           &#10003; {{ endpoint }}<br/>
                                         {% endif %}
                                       {% endfor %}
-                                      ' data-placement="right" data-container="body" data-original-title="Endpoints ({{finding|vulnerable_endpoint_count}} Active, {{finding|mitigated_endpoint_count}} Mitigated)" title=""></i>
+                                      " data-placement="right" data-container="body" data-original-title="Endpoints ({{finding.active_endpoint_count}} Active, {{finding.mitigated_endpoint_count}} Mitigated)" title=""></i>
                                     {% endif %}
                                   {% endif %}
                                   {% if finding.component_name %}

--- a/dojo/templates/dojo/snippets/endpoints.html
+++ b/dojo/templates/dojo/snippets/endpoints.html
@@ -12,7 +12,7 @@
                             {% if finding.file_path %}
                             <h6> Location </h6>
                             {%  else %}
-                            <h6>Vulnerable Endpoints / Systems</h6>
+                            <h6>Vulnerable Endpoints / Systems ({{ endpoints|length }})</h6>
                             {% endif %}
                         </div>
 
@@ -70,7 +70,7 @@
                             {% if finding.file_path %}
                             <h6> Location </h6>
                             {%  else %}
-                            <h6>Mitigated Endpoints / Systems</h6>
+                            <h6>Mitigated Endpoints / Systems ({{ endpoints|length }})</h6>
                             {% endif %}
                         </div>
 
@@ -125,7 +125,7 @@
                 <div class="col-md-12">
                     <div class="panel panel-default table-responsive">
                         <div class="panel-heading">
-                            <h4>Vulnerable Endpoints / Systems
+                            <h4>Vulnerable Endpoints / Systems ({{ endpoints|length }})
                                 <span class="pull-right"><a data-toggle="collapse" href="#vuln_endpoints"><i
                                         class="glyphicon glyphicon-chevron-up"></i></a></span>
                             </h4>
@@ -186,7 +186,7 @@
                 <div class="col-md-12">
                     <div class="panel panel-default table-responsive">
                         <div class="panel-heading">
-                            <h4>Mitigated Endpoints / Systems
+                            <h4>Mitigated Endpoints / Systems ({{ endpoints|length }})
                                 <span class="pull-right"><a data-toggle="collapse" href="#remd_endpoints"><i
                                         class="glyphicon glyphicon-chevron-up"></i></a></span>
                             </h4>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load display_tags %}
+{% load get_endpoint_status %}
 {% load static from staticfiles %}
 {% load humanize %}
 {% block add_styles %}
@@ -476,10 +477,14 @@
                             {% else %}
                               {% if finding.endpoints.all %}
                                 <i class="fa dojo-sup fa-sitemap has-popover" data-html="true" data-trigger="hover" data-content="
-                                {% for endpoint in finding.endpoints.all %}
-                                  {{ endpoint }}<br/>
-                                {% endfor %}
-                                " data-placement="right" data-container="body" data-original-title="Endpoints" title=""></i>
+                                    {% for endpoint in finding.endpoints.all %}
+                                        {% if endpoint|endpoint_check_active:finding %}
+                                            &#10005; {{ endpoint }}<br/>
+                                        {% else %}
+                                            &#10003; {{ endpoint }}<br/>
+                                        {% endif %}
+                                    {% endfor %}
+                                " data-placement="right" data-container="body" data-original-title="Endpoints ({{finding|vulnerable_endpoint_count}} Active, {{finding|mitigated_endpoint_count}} Mitigated)" title=""></i>
                               {% endif %}
                             {% endif %}
                              {% if finding.notes.all %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -484,7 +484,7 @@
                                             &#10003; {{ endpoint }}<br/>
                                         {% endif %}
                                     {% endfor %}
-                                " data-placement="right" data-container="body" data-original-title="Endpoints ({{finding|vulnerable_endpoint_count}} Active, {{finding|mitigated_endpoint_count}} Mitigated)" title=""></i>
+                                " data-placement="right" data-container="body" data-original-title="Endpoints ({{finding.active_endpoint_count}} Active, {{finding.mitigated_endpoint_count}} Mitigated)" title=""></i>
                               {% endif %}
                             {% endif %}
                              {% if finding.notes.all %}

--- a/dojo/templatetags/get_endpoint_status.py
+++ b/dojo/templatetags/get_endpoint_status.py
@@ -16,6 +16,16 @@ def get_mitigated_endpoints(finding):
 
 
 @register.filter
+def vulnerable_endpoint_count(finding):
+    return finding.endpoint_status.all().filter(mitigated=False).count()
+
+
+@register.filter
+def mitigated_endpoint_count(finding):
+    return finding.endpoint_status.all().filter(mitigated=True).count()
+
+
+@register.filter
 def endpoint_display_status(endpoint, finding):
     status = Endpoint_Status.objects.get(endpoint=endpoint, finding=finding)
     if status.false_positive:
@@ -51,3 +61,9 @@ def endpoint_mitigator(endpoint, finding):
 def endpoint_mitigated_time(endpoint, finding):
     status = Endpoint_Status.objects.get(endpoint=endpoint, finding=finding)
     return status.mitigated_time
+
+
+@register.filter
+def endpoint_check_active(endpoint, finding):
+    status = Endpoint_Status.objects.get(endpoint=endpoint, finding=finding)
+    return not status.mitigated

--- a/dojo/templatetags/get_endpoint_status.py
+++ b/dojo/templatetags/get_endpoint_status.py
@@ -16,16 +16,6 @@ def get_mitigated_endpoints(finding):
 
 
 @register.filter
-def vulnerable_endpoint_count(finding):
-    return finding.endpoint_status.all().filter(mitigated=False).count()
-
-
-@register.filter
-def mitigated_endpoint_count(finding):
-    return finding.endpoint_status.all().filter(mitigated=True).count()
-
-
-@register.filter
 def endpoint_display_status(endpoint, finding):
     status = Endpoint_Status.objects.get(endpoint=endpoint, finding=finding)
     if status.false_positive:


### PR DESCRIPTION
Add visual representation of how many endpoint status objects are attached to each finding

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.