### PR TITLE
Fixed cve field showing None when importing nessus .xml reports

### DIFF
--- a/dojo/tools/nessus/parser.py
+++ b/dojo/tools/nessus/parser.py
@@ -201,6 +201,9 @@ class NessusXMLParser(object):
                     for xref in item.iter("xref"):
                         references += xref.text + "\n"
 
+                    cve = None
+                    if item.findtext("cve"):
+                        cve = item.find("cve").text
                     cwe = None
                     if item.findtext("cwe"):
                         cwe = item.find("cwe").text
@@ -222,7 +225,8 @@ class NessusXMLParser(object):
                                        mitigation=mitigation,
                                        impact=impact,
                                        references=references,
-                                       cwe=cwe)
+                                       cwe=cwe,
+                                       cve=cve)
                         find.unsaved_endpoints = list()
                         dupes[dupe_key] = find
 


### PR DESCRIPTION
Added a field within the Nessus XML Scanner for cve's so now you can import nessus reports by .xml files. This partially fixes issue #2762 Since the issue reporter never responded to the query for a sample csv file, I cannot test importing nessus reports using .csv type, only .xml type.

- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is flake8 compliant.
- [X] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [X] Add the proper label to categorize your PR.