### PR TITLE
Bugfixing when the title of a vulnerability is more than 511 characters in SonarQube API

### DIFF
--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -68,7 +68,10 @@ class SonarQubeApiImporter(object):
                     continue
 
                 type = issue['type']
-                title = issue['message']
+                if len(issue['message']) > 511:
+                    title = issue['message'][0:507] + "..."
+                else:
+                    title = issue['message']
                 component_key = issue['component']
                 line = issue.get('line')
                 rule_id = issue['rule']


### PR DESCRIPTION
The length of it is limited. Prevent MySQLdb._exceptions.DataError: (1406, "Data too long for column 'title' at row 1").


