### PR TITLE
Add user post endpoint to APIv2

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -266,7 +266,7 @@ class ProductMetaSerializer(serializers.ModelSerializer):
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login')
+        fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_staff')
 
 
 class NoteHistorySerializer(serializers.ModelSerializer):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -264,6 +264,8 @@ class ProductMetaSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
+    last_login = serializers.DateTimeField(read_only=True)
+
     class Meta:
         model = User
         fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_staff')

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -884,7 +884,8 @@ class RegulationsViewSet(mixins.ListModelMixin,
     filter_fields = ('id', 'name', 'description')
 
 
-class UsersViewSet(mixins.ListModelMixin,
+class UsersViewSet(mixins.CreateModelMixin,
+                   mixins.ListModelMixin,
                    mixins.RetrieveModelMixin,
                    viewsets.GenericViewSet):
     serializer_class = serializers.UserSerializer

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -572,6 +572,13 @@ class UsersTest(BaseClass.RESTEndpointTest):
         self.endpoint_model = User
         self.viewname = 'user'
         self.viewset = UsersViewSet
+        self.payload = {
+            "username": "test_user",
+            "first_name": "test",
+            "last_name": "user",
+            "email": "example@email.com",
+            "is_active": True,
+        }
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 


### PR DESCRIPTION
Add a `post` function to APIv2 that creates users.

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.