### PR TITLE
Veracode import: fixed false-positives and added SCA findings

### DIFF
--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -5,6 +5,10 @@ from dojo.models import Finding
 from hashlib import sha256
 
 
+'''
+This parser is written for Veracode Detailed XML reports, version 1.5.
+Version is annotated in the report, `detailedreport/@report_format_version`.
+'''
 class VeracodeXMLParser(object):
     ns = {'x': 'https://www.veracode.com/schema/reports/export/1.0'}
     vc_severity_mapping = {
@@ -16,8 +20,15 @@ class VeracodeXMLParser(object):
     }
 
     def __init__(self, filename, test):
+        if filename is None:
+            self.items = list()
+            return
+        try:
+            xml = etree.parse(filename)
+        except:
+            raise NamespaceErr('Cannot parse this report. Make sure to upload a proper Veracode Detailed XML report.')
+
         ns = self.ns
-        xml = etree.parse(filename)
         report_node = xml.xpath('/x:detailedreport', namespaces=self.ns)[0]
 
         if not report_node:

--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -1,159 +1,147 @@
-__author__ = 'jay7958'
-
 from xml.dom import NamespaceErr
-from defusedxml import ElementTree
+from lxml import etree
 from datetime import datetime
-
 from dojo.models import Finding
 
 
 class VeracodeXMLParser(object):
-    def __init__(self, filename, test):
-        vscan = ElementTree.parse(filename)
-        root = vscan.getroot()
+    ns = {'x': 'https://www.veracode.com/schema/reports/export/1.0'}
 
-        if 'https://www.veracode.com/schema/reports/export/1.0' not in str(
-                root):
-            # version not supported
+    def __init__(self, filename, test):
+        ns = self.ns
+        xml = etree.parse(filename)
+        report_node = xml.xpath('/x:detailedreport', namespaces=self.ns)[0]
+
+        if not report_node:
             raise NamespaceErr(
                 'This version of Veracode report is not supported.  '
                 'Please make sure the export is formatted using the '
                 'https://www.veracode.com/schema/reports/export/1.0 schema.')
 
         dupes = dict()
-        severitycount = 0
 
-        for severity in root.iter(
-                '{https://www.veracode.com/schema/reports/export/1.0}severity'
-        ):
-            if severity.attrib['level'] == '5':
-                sev = 'Critical'
-            elif severity.attrib['level'] == '4':
-                sev = 'High'
-            elif severity.attrib['level'] == '3':
-                sev = 'Medium'
-            elif severity.attrib['level'] == '2':
-                sev = 'Low'
-            else:
-                sev = 'Info'
+        # This assumes `<category/>` only exists with the `<severity/>` nodes.
+        for category_node in report_node.xpath('//x:category', namespaces=ns):
 
-            for category in severity.iter(
-                    '{https://www.veracode.com/schema/reports/export/1.0}category'
-            ):
-                recommendations = category.find(
-                    '{https://www.veracode.com/schema/reports/export/1.0}recommendations'
-                )
-                mitigation = ''
-                for para in recommendations.iter(
-                        '{https://www.veracode.com/schema/reports/export/1.0}para'
-                ):
-                    mitigation += para.attrib['text'] + '\n\n'
-                    for bullet in para.iter(
-                            '{https://www.veracode.com/schema/reports/export/1.0}bulletitem'
-                    ):
-                        mitigation += "    * " + bullet.attrib['text'] + '\n'
-                for flaw in category.iter(
-                        '{https://www.veracode.com/schema/reports/export/1.0}flaw'
-                ):
-                    try:
-                        dupe_key = sev + flaw.attrib['cweid'] + flaw.attrib['module'] + flaw.attrib['type'] + flaw.attrib['line'] + flaw.attrib['issueid']
-                    except:
-                        dupe_key = sev + flaw.attrib['cweid'] + flaw.attrib['module'] + flaw.attrib['type'] + flaw.attrib['issueid']
+            # Mitigation text.
+            mitigation_text = ''
+            mitigation_text += category_node.xpath('string(x:recommendations/x:para/@text)', namespaces=ns) + "\n\n"
+            # Bullet list of recommendations:
+            mitigation_text += ''.join(list(map(
+                lambda x: '    * ' + x + '\n',
+                category_node.xpath('x:recommendations/x:para/x:bulletitem/@text', namespaces=ns))))
 
-                    if dupe_key in dupes:
-                        find = dupes[dupe_key]
-                    else:
-                        dupes[dupe_key] = True
-                        description = flaw.attrib['description'].replace(
-                            '. ', '.\n')
-                        if 'References:' in description:
-                            references = description[description.index(
-                                'References:') + 13:].replace(')  ', ')\n')
-                        else:
-                            references = 'None'
-                        mitigatedTest = 0
-                        if 'date_first_occurrence' in flaw.attrib:
-                            find_date = datetime.strptime(
-                                flaw.attrib['date_first_occurrence'],
-                                '%Y-%m-%d %H:%M:%S %Z')
-                        else:
-                            find_date = test.target_start
-                        if 'falsepositive' in flaw.attrib:
-                            mitigatedTest = 1
-                            for mitigations in flaw.iter(
-                                    '{https://www.veracode.com/schema/reports/export/1.0}mitigations'
-                            ):
-                                for mitigation in mitigations.iter(
-                                        '{https://www.veracode.com/schema/reports/export/1.0}mitigation'
-                                ):
-                                    mitigated = datetime.strptime(
-                                        mitigation.attrib.get('date'),
-                                        '%Y-%m-%d %H:%M:%S %Z')
-                            mitigated_by_id = 4
-                        else:
-                            pass
-                        try:
-                            line_number = flaw.attrib['line']
-                        except:
-                            line_number = None
-                        try:
-                            file_path = flaw.attrib['sourcefilepath'] + flaw.attrib['sourcefile']
-                        except:
-                            file_path = "Not Provided"
-                        if mitigatedTest == 1:
-                            find = Finding(
-                                title=flaw.attrib['categoryname'],
-                                line_number=line_number,
-                                file_path=file_path,
-                                line=flaw.attrib['line'],
-                                static_finding=True,
-                                sourcefile=flaw.attrib['sourcefile'],
-                                cwe=int(flaw.attrib['cweid']),
-                                test=test,
-                                active=False,
-                                verified=False,
-                                description=description +
-                                "\n\nVulnerable Module: " +
-                                flaw.attrib['module'] + ' Type: ' +
-                                flaw.attrib['type'] + ' Issue ID: ' +
-                                flaw.attrib['issueid'],
-                                mitigated=mitigated,
-                                mitigated_by_id=mitigated_by_id,
-                                severity=sev,
-                                numerical_severity=Finding.
-                                get_numerical_severity(sev),
-                                mitigation=mitigation,
-                                impact='CIA Impact: ' +
-                                flaw.attrib['cia_impact'].upper(),
-                                references=references,
-                                url='N/A',
-                                date=find_date)
-                        else:
-                            find = Finding(
-                                title=flaw.attrib['categoryname'],
-                                line_number=line_number,
-                                file_path=file_path,
-                                line=line_number,
-                                static_finding=True,
-                                sourcefile=file_path,
-                                cwe=int(flaw.attrib['cweid']),
-                                test=test,
-                                active=False,
-                                verified=False,
-                                description=description +
-                                "\n\nVulnerable Module: " +
-                                flaw.attrib['module'] + ' Type: ' +
-                                flaw.attrib['type'] + ' Issue ID: ' +
-                                flaw.attrib['issueid'],
-                                severity=sev,
-                                numerical_severity=Finding.
-                                get_numerical_severity(sev),
-                                mitigation=mitigation,
-                                impact='CIA Impact: ' +
-                                flaw.attrib['cia_impact'].upper(),
-                                references=references,
-                                url='N/A',
-                                date=find_date)
-                        dupes[dupe_key] = find
+            for flaw in category_node.xpath('.//x:staticflaws/x:flaw', namespaces=ns):
+                dupe_key = self.__xml_flaw_to_dupekey(flaw)
+
+                # Only process if we didn't do that before.
+                if dupe_key not in dupes:
+                    # Add to list.
+                    dupes[dupe_key] = self.__xml_flaw_to_finding(flaw, mitigation_text, test)
 
         self.items = list(dupes.values())
+
+    @classmethod
+    def __xml_flaw_to_dupekey(cls, xml_node):
+        severity = cls.__xml_flaw_to_severity(xml_node)
+        try:
+            dupe_key = severity + xml_node.attrib['cweid'] + xml_node.attrib['module'] + xml_node.attrib['type'] + \
+                       xml_node.attrib['line'] + xml_node.attrib['issueid']
+        except:
+            dupe_key = severity + xml_node.attrib['cweid'] + xml_node.attrib['module'] + xml_node.attrib['type'] + \
+                       xml_node.attrib['issueid']
+        return dupe_key
+
+    @classmethod
+    def __xml_flaw_to_severity(cls, xml_node):
+        vc_severity_mapping = {
+            1: 'Info',
+            2: 'Low',
+            3: 'Medium',
+            4: 'High',
+            5: 'Critical'
+        }
+        return vc_severity_mapping.get(xml_node.attrib['severity'], 'Info')
+
+    @classmethod
+    def __xml_flaw_to_finding(cls, xml_node, mitigation_text, test):
+        ns = cls.ns
+
+        # Defaults
+        finding = Finding()
+        finding.test = test
+        finding.mitigation = mitigation_text
+        finding.verified = False
+        finding.active = False
+        finding.static_finding = True
+        finding.dynamic_finding = False
+
+        # Report values
+        finding.severity = cls.__xml_flaw_to_severity(xml_node)
+        finding.numerical_severity = Finding.get_numerical_severity(finding.severity)
+        finding.cwe = int(xml_node.attrib['cweid'])
+        finding.title = '[' + xml_node.attrib['issueid'] + '] ' + xml_node.attrib['categoryname']
+        finding.impact = 'CIA Impact: ' + xml_node.attrib['cia_impact'].upper()
+
+        _description = xml_node.attrib['description'].replace('. ', '.\n')
+        finding.description = _description \
+            + "\n\nVulnerable Module: " \
+            + xml_node.attrib['module'] + ' Type: ' \
+            + xml_node.attrib['type'] + ' Issue ID: ' \
+            + xml_node.attrib['issueid']
+
+        _references = 'None'
+        if 'References:' in _description:
+            _references = _description[_description.index(
+                'References:') + 13:].replace(')  ', ')\n')
+        finding.references = _references
+
+        _date_found = test.target_start
+        if 'date_first_occurrence' in xml_node.attrib:
+            _date_found = datetime.strptime(
+                xml_node.attrib['date_first_occurrence'],
+                '%Y-%m-%d %H:%M:%S %Z')
+        finding.date = _date_found
+
+        _is_mitigated = False
+        _mitigated_date = None
+        if ('mitigation_status' in xml_node.attrib and
+                xml_node.attrib["mitigation_status"].lower() == "accepted"):
+            # This happens if any mitigation (including 'Potential false positive')
+            # was accepted in VC.
+            _is_mitigated = True
+            _mitigated_date = datetime.strptime(
+                xml_node.xpath('string(.//x:mitigations/x:mitigation[last()]/@date)', namespaces=ns),
+                '%Y-%m-%d %H:%M:%S %Z')
+        finding.is_Mitigated = _is_mitigated
+        finding.mitigated = _mitigated_date
+        finding.active = not _is_mitigated
+
+        # Check if it's a FP in veracode.
+        # Only check in case finding was mitigated, since DD doesn't allow
+        # both `verified` and `false_p` to be true, while `verified` is implied on the import
+        # level, not on the finding-level.
+        _false_positive = False
+        if _is_mitigated:
+            _remediation_status = xml_node.xpath('string(@remediation_status)', namespaces=ns).lower()
+            if "false positive" in _remediation_status or "falsepositive" in _remediation_status:
+                _false_positive = True
+        finding.false_p = _false_positive
+
+        _line_number = xml_node.xpath('string(@line)')
+        finding.line = _line_number if _line_number else None
+        finding.line_number = finding.line
+        finding.sast_source_line = finding.line
+
+        _source_file = xml_node.xpath('string(@sourcefile)')
+        finding.file_path = _source_file if _source_file else None
+        finding.sourcefile = finding.file_path
+        finding.sast_source_file_path = finding.file_path
+
+        _component = xml_node.xpath('string(@module)') + ': ' + xml_node.xpath('string(@scope)')
+        finding.component_name = _component if _component != ': ' else None
+
+        _sast_source_obj = xml_node.xpath('string(@functionprototype)')
+        finding.sast_source_object = _sast_source_obj if _sast_source_obj else None
+
+        return finding

--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -2,10 +2,17 @@ from xml.dom import NamespaceErr
 from lxml import etree
 from datetime import datetime
 from dojo.models import Finding
-
+from hashlib import sha256
 
 class VeracodeXMLParser(object):
     ns = {'x': 'https://www.veracode.com/schema/reports/export/1.0'}
+    vc_severity_mapping = {
+        1: 'Info',
+        2: 'Low',
+        3: 'Medium',
+        4: 'High',
+        5: 'Critical'
+    }
 
     def __init__(self, filename, test):
         ns = self.ns
@@ -20,6 +27,7 @@ class VeracodeXMLParser(object):
 
         dupes = dict()
 
+        # Get SAST findings
         # This assumes `<category/>` only exists with the `<severity/>` nodes.
         for category_node in report_node.xpath('//x:category', namespaces=ns):
 
@@ -31,13 +39,22 @@ class VeracodeXMLParser(object):
                 lambda x: '    * ' + x + '\n',
                 category_node.xpath('x:recommendations/x:para/x:bulletitem/@text', namespaces=ns))))
 
-            for flaw in category_node.xpath('.//x:staticflaws/x:flaw', namespaces=ns):
-                dupe_key = self.__xml_flaw_to_dupekey(flaw)
+            for flaw_node in category_node.xpath('.//x:staticflaws/x:flaw', namespaces=ns):
+                dupe_key = self.__xml_flaw_to_dupekey(flaw_node)
 
                 # Only process if we didn't do that before.
                 if dupe_key not in dupes:
                     # Add to list.
-                    dupes[dupe_key] = self.__xml_flaw_to_finding(flaw, mitigation_text, test)
+                    dupes[dupe_key] = self.__xml_flaw_to_finding(flaw_node, mitigation_text, test)
+
+        # Get SCA findings
+        for vulnerable_lib_node in xml.xpath('/x:detailedreport/x:software_composition_analysis/x:vulnerable_components'
+                                             '/x:component[@vulnerabilities > 0]', namespaces=ns):
+            dupe_key = self.__xml_sca_flaw_to_dupekey(vulnerable_lib_node)
+
+            # Only process if we didn't do that before.
+            if dupe_key not in dupes:
+                dupes[dupe_key] = self.__xml_sca_flaw_to_finding(vulnerable_lib_node, test)
 
         self.items = list(dupes.values())
 
@@ -54,14 +71,7 @@ class VeracodeXMLParser(object):
 
     @classmethod
     def __xml_flaw_to_severity(cls, xml_node):
-        vc_severity_mapping = {
-            1: 'Info',
-            2: 'Low',
-            3: 'Medium',
-            4: 'High',
-            5: 'Critical'
-        }
-        return vc_severity_mapping.get(xml_node.attrib['severity'], 'Info')
+        return cls.vc_severity_mapping.get(int(xml_node.attrib['severity']), 'Info')
 
     @classmethod
     def __xml_flaw_to_finding(cls, xml_node, mitigation_text, test):
@@ -80,7 +90,7 @@ class VeracodeXMLParser(object):
         finding.severity = cls.__xml_flaw_to_severity(xml_node)
         finding.numerical_severity = Finding.get_numerical_severity(finding.severity)
         finding.cwe = int(xml_node.attrib['cweid'])
-        finding.title = '[' + xml_node.attrib['issueid'] + '] ' + xml_node.attrib['categoryname']
+        finding.title = xml_node.attrib['categoryname']
         finding.impact = 'CIA Impact: ' + xml_node.attrib['cia_impact'].upper()
 
         _description = xml_node.attrib['description'].replace('. ', '.\n')
@@ -143,5 +153,77 @@ class VeracodeXMLParser(object):
 
         _sast_source_obj = xml_node.xpath('string(@functionprototype)')
         finding.sast_source_object = _sast_source_obj if _sast_source_obj else None
+
+        return finding
+
+    @classmethod
+    def __xml_sca_flaw_to_dupekey(cls, xml_node):
+        return sha256(
+            ('sca_' + xml_node.attrib['vendor'] + xml_node.attrib['library'] + xml_node.attrib['version']).encode()) \
+            .hexdigest()
+
+    @classmethod
+    def __cvss_to_severity(cls, cvss):
+        if cvss >= 9:
+            return cls.vc_severity_mapping.get(5)
+        elif cvss >= 7:
+            return cls.vc_severity_mapping.get(4)
+        elif cvss >= 4:
+            return cls.vc_severity_mapping.get(3)
+        elif cvss > 0:
+            return cls.vc_severity_mapping.get(2)
+        else:
+            return cls.vc_severity_mapping.get(1)
+
+    @classmethod
+    def __xml_sca_flaw_to_finding(cls, xml_node, test):
+        ns = cls.ns
+
+        # Defaults
+        finding = Finding()
+        finding.test = test
+        finding.mitigation = "Make sure to upgrade this component."
+        finding.verified = False
+        finding.active = False
+        finding.static_finding = True
+        finding.dynamic_finding = False
+
+        _library = xml_node.xpath('string(@library)', namespaces=ns)
+        _vendor = xml_node.xpath('string(@vendor)', namespaces=ns)
+        _version = xml_node.xpath('string(@version)', namespaces=ns)
+        _cvss = xml_node.xpath('number(@max_cvss_score)', namespaces=ns)
+        _file = xml_node.xpath('string(@file_name)', namespaces=ns)
+        _file_path = xml_node.xpath('string(x:file_paths/x:file_path/@value)', namespaces=ns)
+
+        # Report values
+        finding.severity = cls.__cvss_to_severity(_cvss)
+        finding.numerical_severity = Finding.get_numerical_severity(finding.severity)
+        finding.cwe = 937
+        finding.title = "Vulnerable component: {0}:{1}".format(_library, _version)
+        finding.component_name = _vendor + " / " + _library + ":" + _version
+        finding.file_path = _file
+
+        # Use report-date, otherwise DD doesn't
+        # overwrite old matching SCA findings.
+        finding.date = datetime.strptime(
+            xml_node.xpath('string(//x:component/ancestor::x:detailedreport/@last_update_time)', namespaces=ns),
+            '%Y-%m-%d %H:%M:%S %Z')
+
+        _description = 'This library has known vulnerabilities.\n'
+        _description += 'Full component path: ' + _file_path + '\n'
+        _description += 'Vulnerabilities:\n\n'
+        for vuln_node in xml_node.xpath('x:vulnerabilities/x:vulnerability', namespaces=ns):
+            _description += \
+                "**CVE: [{0}](https://nvd.nist.gov/vuln/detail/{0})** ({1})\n" \
+                "CVS Score: {2} ({3})\n" \
+                "Summary: \n>{4}" \
+                "\n\n-----\n\n".format(
+                    vuln_node.xpath('string(@cve_id)', namespaces=ns),
+                    datetime.strptime(vuln_node.xpath('string(@first_found_date)', namespaces=ns),
+                                      '%Y-%m-%d %H:%M:%S %Z').strftime("%Y/%m"),
+                    vuln_node.xpath('string(@cvss_score)', namespaces=ns),
+                    cls.vc_severity_mapping.get(int(vuln_node.xpath('string(@severity)', namespaces=ns)), 'Info'),
+                    vuln_node.xpath('string(@cve_summary)', namespaces=ns))
+        finding.description = _description
 
         return finding

--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from dojo.models import Finding
 from hashlib import sha256
 
+
 class VeracodeXMLParser(object):
     ns = {'x': 'https://www.veracode.com/schema/reports/export/1.0'}
     vc_severity_mapping = {

--- a/dojo/unittests/scans/veracode/many_findings.xml
+++ b/dojo/unittests/scans/veracode/many_findings.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<detailedreport xmlns:xsi="http&#x3a;&#x2f;&#x2f;www.w3.org&#x2f;2001&#x2f;XMLSchema-instance" xmlns="https&#x3a;&#x2f;&#x2f;www.veracode.com&#x2f;schema&#x2f;reports&#x2f;export&#x2f;1.0" xsi:schemaLocation="https&#x3a;&#x2f;&#x2f;www.veracode.com&#x2f;schema&#x2f;reports&#x2f;export&#x2f;1.0 https&#x3a;&#x2f;&#x2f;analysiscenter.veracode.com&#x2f;resource&#x2f;detailedreport.xsd" report_format_version="1.5" account_id="1234" app_name="myapp" app_id="1234" analysis_id="1234" static_analysis_unit_id="1234" sandbox_id="1234" first_build_submitted_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" version="myapp-1234" build_id="1234" submitter="You" platform="Not Specified" assurance_level="1" business_criticality="1" generation_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" veracode_level="VL1" total_flaws="2" flaws_not_mitigated="2" teams="" life_cycle_stage="Not Specified" planned_deployment_date="" last_update_time="2020-06-01 10&#x3a;02&#x3a;01 UTC" is_latest_build="true" policy_name="Veracode Recommended Very Low" policy_version="1" policy_compliance_status="Pass" policy_rules_status="Pass" grace_period_expired="false" scan_overdue="false" business_owner="" business_unit="Not Specified" tags="" legacy_scan_engine="false">
+    <static-analysis rating="B" score="70" submitted_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" published_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" version="myapp-1234" mitigated_rating="B" mitigated_score="70" analysis_size_bytes="1234" engine_version="1234">
+      <modules>
+         <module name="myapp-1234.jar" compiler="JAVAC_8" os="Java J2SE 8" architecture="JVM" loc="5" score="70" numflawssev0="0" numflawssev1="0" numflawssev2="0" numflawssev3="2" numflawssev4="0" numflawssev5="0"/>
+      </modules>
+   </static-analysis>
+   <severity level="5"/>
+   <severity level="4"/>
+   <severity level="3">
+      <category categoryid="123" categoryname="catname" pcirelated="true">
+         <desc>
+            <para text="Flaw description"/>
+         </desc>
+         <recommendations>
+            <para text="Problem text">
+               <bulletitem text="Bullet text"/>
+            </para>
+         </recommendations>
+         <cwe cweid="123" cwename="cwename" pcirelated="true" owasp="123" sans="123">
+            <description>
+               <text text="Description"/>
+            </description>
+            <staticflaws>
+               <flaw severity="3" categoryname="catname" count="1" issueid="1" module="myapp-1234.jar" type="badMethod" description="Description" note="" cweid="123" remediationeffort="1" exploitLevel="1" categoryid="123" pcirelated="true" date_first_occurrence="2020-06-01 10&#x3a;02&#x3a;01 UTC" remediation_status="Open" cia_impact="" grace_period_expires="" affects_policy_compliance="false" mitigation_status="proposed" mitigation_status_desc="Mitigation Proposed" sourcefile="MyApp.java" line="1" sourcefilepath="sourcefilepath" scope="scope" functionprototype="functionprototype" functionrelativelocation="1">
+                  <mitigations>
+                     <mitigation action="Reviewed - No Action Taken" description="description" user="You" date="2020-06-01 10&#x3a;02&#x3a;01 UTC"/>
+                  </mitigations>
+               </flaw>
+           </staticflaws>
+         </cwe>
+      </category>
+   </severity>
+   <severity level="2"/>
+   <severity level="1"/>
+   <severity level="0"/>
+   <flaw-status new="0" reopen="0" open="2" cannot-reproduce="0" fixed="0" total="2" not_mitigated="2" sev-1-change="0" sev-2-change="0" sev-3-change="0" sev-4-change="0" sev-5-change="0"/>
+   <customfields/>
+   <software_composition_analysis third_party_components="2" violate_policy="false" components_violated_policy="0">
+      <vulnerable_components>
+          <component component_id="1234" file_name="bad-component.jar" sha1="1234abcd" vulnerabilities="1" max_cvss_score="7.5" version="1234" library="library" vendor="vendor" description="" added_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" new="false" component_affects_policy_compliance="false">
+              <file_paths>
+                  <file_path value="filepath.jar"/>
+              </file_paths>
+              <licenses>
+                  <license name="Apache License 2.0" spdx_id="Apache-2.0" license_url="https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html" risk_rating="1"/>
+              </licenses>
+              <vulnerabilities>
+                  <vulnerability cve_id="CVE-1234-1234" cvss_score="7.5" severity="4" cwe_id="" first_found_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" cve_summary="CVE summary" severity_desc="High" mitigation="false" vulnerability_affects_policy_compliance="false"/>
+              </vulnerabilities>
+              <violated_policy_rules/>
+          </component>
+          <component component_id="5678" file_name="bad-component1.jar" sha1="5678abcd" vulnerabilities="1" max_cvss_score="7.5" version="1234" library="library1" vendor="vendor1" description="" added_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" new="false" component_affects_policy_compliance="false">
+              <file_paths>
+                  <file_path value="filepath1.jar"/>
+              </file_paths>
+              <licenses>
+                  <license name="Apache License 2.0" spdx_id="Apache-2.0" license_url="https&#x3a;&#x2f;&#x2f;spdx.org&#x2f;licenses&#x2f;Apache-2.0.html" risk_rating="1"/>
+              </licenses>
+              <vulnerabilities>
+                  <vulnerability cve_id="CVE-5678-5678" cvss_score="7.5" severity="4" cwe_id="" first_found_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" cve_summary="CVE summary" severity_desc="High" mitigation="false" vulnerability_affects_policy_compliance="false"/>
+              </vulnerabilities>
+              <violated_policy_rules/>
+          </component>
+      </vulnerable_components>
+   </software_composition_analysis>
+</detailedreport>

--- a/dojo/unittests/scans/veracode/one_finding.xml
+++ b/dojo/unittests/scans/veracode/one_finding.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<detailedreport xmlns:xsi="http&#x3a;&#x2f;&#x2f;www.w3.org&#x2f;2001&#x2f;XMLSchema-instance" xmlns="https&#x3a;&#x2f;&#x2f;www.veracode.com&#x2f;schema&#x2f;reports&#x2f;export&#x2f;1.0" xsi:schemaLocation="https&#x3a;&#x2f;&#x2f;www.veracode.com&#x2f;schema&#x2f;reports&#x2f;export&#x2f;1.0 https&#x3a;&#x2f;&#x2f;analysiscenter.veracode.com&#x2f;resource&#x2f;detailedreport.xsd" report_format_version="1.5" account_id="1234" app_name="myapp" app_id="1234" analysis_id="1234" static_analysis_unit_id="1234" sandbox_id="1234" first_build_submitted_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" version="myapp-1234" build_id="1234" submitter="You" platform="Not Specified" assurance_level="1" business_criticality="1" generation_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" veracode_level="VL1" total_flaws="2" flaws_not_mitigated="2" teams="" life_cycle_stage="Not Specified" planned_deployment_date="" last_update_time="2020-06-01 10&#x3a;02&#x3a;01 UTC" is_latest_build="true" policy_name="Veracode Recommended Very Low" policy_version="1" policy_compliance_status="Pass" policy_rules_status="Pass" grace_period_expired="false" scan_overdue="false" business_owner="" business_unit="Not Specified" tags="" legacy_scan_engine="false">
+    <static-analysis rating="B" score="70" submitted_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" published_date="2020-06-01 10&#x3a;02&#x3a;01 UTC" version="myapp-1234" mitigated_rating="B" mitigated_score="70" analysis_size_bytes="1234" engine_version="1234">
+      <modules>
+         <module name="myapp-1234.jar" compiler="JAVAC_8" os="Java J2SE 8" architecture="JVM" loc="5" score="70" numflawssev0="0" numflawssev1="0" numflawssev2="0" numflawssev3="1" numflawssev4="0" numflawssev5="0"/>
+      </modules>
+   </static-analysis>
+   <severity level="5"/>
+   <severity level="4"/>
+   <severity level="3">
+      <category categoryid="123" categoryname="catname" pcirelated="true">
+         <desc>
+            <para text="Flaw description"/>
+         </desc>
+         <recommendations>
+            <para text="Problem text">
+               <bulletitem text="Bullet text"/>
+            </para>
+         </recommendations>
+         <cwe cweid="123" cwename="cwename" pcirelated="true" owasp="123" sans="123">
+            <description>
+               <text text="Description"/>
+            </description>
+            <staticflaws>
+               <flaw severity="3" categoryname="catname" count="1" issueid="1" module="myapp-1234.jar" type="badMethod" description="Description" note="" cweid="123" remediationeffort="1" exploitLevel="1" categoryid="123" pcirelated="true" date_first_occurrence="2020-06-01 10&#x3a;02&#x3a;01 UTC" remediation_status="Open" cia_impact="" grace_period_expires="" affects_policy_compliance="false" mitigation_status="proposed" mitigation_status_desc="Mitigation Proposed" sourcefile="MyApp.java" line="1" sourcefilepath="sourcefilepath" scope="scope" functionprototype="functionprototype" functionrelativelocation="1">
+                  <mitigations>
+                     <mitigation action="Reviewed - No Action Taken" description="description" user="You" date="2020-06-01 10&#x3a;02&#x3a;01 UTC"/>
+                  </mitigations>
+               </flaw>
+           </staticflaws>
+         </cwe>
+      </category>
+   </severity>
+   <severity level="2"/>
+   <severity level="1"/>
+   <severity level="0"/>
+   <flaw-status new="0" reopen="0" open="1" cannot-reproduce="0" fixed="0" total="1" not_mitigated="1" sev-1-change="0" sev-2-change="0" sev-3-change="0" sev-4-change="0" sev-5-change="0"/>
+   <customfields/>
+   <software_composition_analysis third_party_components="0" violate_policy="false" components_violated_policy="0">
+      <vulnerable_components/>
+   </software_composition_analysis>
+</detailedreport>

--- a/dojo/unittests/test_veracode_parser.py
+++ b/dojo/unittests/test_veracode_parser.py
@@ -1,0 +1,20 @@
+from django.test import SimpleTestCase
+from dojo.tools.veracode.parser import VeracodeXMLParser
+from dojo.models import Test
+
+
+class TestVeracodeScannerParser(SimpleTestCase):
+
+    def test_parse_without_file(self):
+        parser = VeracodeXMLParser(None, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_file_with_one_finding(self):
+        testfile = open("dojo/unittests/scans/veracode/one_finding.xml")
+        parser = VeracodeXMLParser(testfile, Test())
+        self.assertEqual(1, len(parser.items))
+
+    def test_parse_file_with_multiple_finding(self):
+        testfile = open("dojo/unittests/scans/veracode/many_findings.xml")
+        parser = VeracodeXMLParser(testfile, Test())
+        self.assertEqual(3, len(parser.items))


### PR DESCRIPTION
The veracode parser didn't fully work: false positives didn't get detected as such.
Since we're just using the 'detailed XML report's from veracode, it seems their structure was changed a bit (or it never actually worked).

In any case, I decided to refactor the whole parser, split some code, got rid of some deeply nested loops (using xpath) etc.
On the fly, some more details (loc, sast-source) were added to the report.

In addition, as veracode now produces SCA findings in that same report, I added parsing for that as well:
<img width="1458" alt="Screen Shot 2020-09-17 at 18 26 45 PM" src="https://user-images.githubusercontent.com/4497866/93503515-796ded00-f918-11ea-8880-9a16cb6ffaf8.png">

As for a unit test: there wasn't one, and I didn't add one, since I have already been spending quite some of my clients time on this.

Manually tested cases:

-   import a fresh report with both SAST and SCA findings from veracode: all findings imported with correct data
-   import a second report (same project, same build), but now with a finding marked `false positive` and `mitigation accepted`: finding marked as mitigated and FP in dojo
-   import a third report, now with a build that fixed a finding: new finding was recorded as inactive/mitigated

Please note that the dupe_key for SAST findings is still the same to have that backwards compatible.
