### PR TITLE
Feature/helm external redis

### DIFF
--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 
 {{/*
-  Determine the hostname to use for PostgreSQL/mySQL.
+  Determine the hostname to use for PostgreSQL/mySQL/Redis.
 */}}
 {{- define "postgresql.hostname" -}}
 {{- if eq .Values.database "postgresql" -}}
@@ -50,6 +50,15 @@ Create chart name and version as used by the chart label.
 {{- printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s" .Values.mysql.mysqlServer -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- define "redis.hostname" -}}
+{{- if eq .Values.celery.broker "redis" -}}
+{{- if .Values.redis.enabled -}}
+{{- printf "%s-%s" .Release.Name "redis-master" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" .Values.redis.redisServer -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
   DD_ALLOWED_HOSTS: {{ .Values.host }}
   DD_CELERY_BROKER_SCHEME: {{ if eq .Values.celery.broker "rabbitmq" }}amqp{{ end }}{{ if eq .Values.celery.broker "redis" }}redis{{ end }}
   DD_CELERY_BROKER_USER: '{{ if eq .Values.celery.broker "rabbitmq" }}user{{ end }}'
-  DD_CELERY_BROKER_HOST: {{ .Release.Name }}-{{ if eq .Values.celery.broker "rabbitmq" }}rabbitmq{{ end }}{{ if eq .Values.celery.broker "redis" }}redis-master{{ end }}
+  DD_CELERY_BROKER_HOST: {{ if eq .Values.celery.broker "rabbitmq" }}{{ .Release.Name }}-rabbitmq{{ else if eq .Values.celery.broker "redis" }}{{ template "redis.hostname" . }}{{ end }}
   DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}5672{{ end }}{{ if eq .Values.celery.broker "redis" }}6379{{ end }}'
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}
   DD_DATABASE_ENGINE: django.db.backends.{{ if eq .Values.database "postgresql" }}postgresql{{ end }}{{ if eq .Values.database "mysql" }}mysql{{ end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -178,6 +178,9 @@ redis:
   password: ""
   cluster:
     slaveCount: 1
+  # To use an external Redis instance, set enabled to false and uncomment
+  # the line below:
+  # redisServer: myrediscluster
 
 # To add extra variables not predefined by helm config it is possible to define in extraConfigs block, e.g. below:
 # NOTE  Do not store any kind of sensitive information inside of it


### PR DESCRIPTION
Allow to install the helm chart with an external Redis server.

- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
