### PR TITLE
fix chosen js dependency

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "JUMFlot": "jumjum123/JUMFlot#*",
     "bootstrap": "^3.4.0",
-    "bootstrap-chosen": "^1.4.2",
     "bootstrap-social": "^4.0.0",
     "bootstrap-wysiwyg": "^2.0.0",
     "bootswatch": "3.4.1",
+    "chosen-bootstrap": "https://github.com/dbtek/chosen-bootstrap",
     "chosen-js": "^1.8.7",
     "clipboard": "^2.0.6",
     "components-jqueryui": "^1.0.0",

--- a/components/package.json
+++ b/components/package.json
@@ -2,11 +2,11 @@
   "dependencies": {
     "JUMFlot": "jumjum123/JUMFlot#*",
     "bootstrap": "^3.4.0",
+    "bootstrap-chosen": "^1.4.2",
     "bootstrap-social": "^4.0.0",
     "bootstrap-wysiwyg": "^2.0.0",
     "bootswatch": "3.4.1",
-    "chosen": "harvesthq/bower-chosen#~1.4.0",
-    "chosen-bootstrap": "dbtek/chosen-bootstrap#~1.1.0",
+    "chosen-js": "^1.8.7",
     "clipboard": "^2.0.6",
     "components-jqueryui": "^1.0.0",
     "datatables.net": "^1.10.22",

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -67,11 +67,6 @@ base64-js@^1.1.2, base64-js@^1.3.0:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
-bootstrap-chosen@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/bootstrap-chosen/-/bootstrap-chosen-1.4.2.tgz#d7a184b21ecd952d586982339c60128f8827334d"
-  integrity sha1-16GEsh7NlS1YaYIznGASj4gnM00=
-
 bootstrap-social@^4.0.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/bootstrap-social/-/bootstrap-social-4.11.0.tgz#7896d176fe366b06992196945a13fc9bfa6061b2"
@@ -137,6 +132,10 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+"chosen-bootstrap@https://github.com/dbtek/chosen-bootstrap":
+  version "0.0.0"
+  resolved "https://github.com/dbtek/chosen-bootstrap#12dcd363d1482c54c740ed9fe0e92549d81e9176"
 
 chosen-js@^1.8.7:
   version "1.8.7"

--- a/components/yarn.lock
+++ b/components/yarn.lock
@@ -67,6 +67,11 @@ base64-js@^1.1.2, base64-js@^1.3.0:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+bootstrap-chosen@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/bootstrap-chosen/-/bootstrap-chosen-1.4.2.tgz#d7a184b21ecd952d586982339c60128f8827334d"
+  integrity sha1-16GEsh7NlS1YaYIznGASj4gnM00=
+
 bootstrap-social@^4.0.0:
   version "4.11.0"
   resolved "https://registry.yarnpkg.com/bootstrap-social/-/bootstrap-social-4.11.0.tgz#7896d176fe366b06992196945a13fc9bfa6061b2"
@@ -133,13 +138,10 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-chosen-bootstrap@dbtek/chosen-bootstrap#~1.1.0:
-  version "0.0.0"
-  resolved "https://codeload.github.com/dbtek/chosen-bootstrap/tar.gz/12dcd363d1482c54c740ed9fe0e92549d81e9176"
-
-chosen@harvesthq/bower-chosen#~1.4.0:
-  version "0.0.0"
-  resolved "https://codeload.github.com/harvesthq/bower-chosen/tar.gz/d7eba35cf214d2416fabee25c5d4619542a23d8d"
+chosen-js@^1.8.7:
+  version "1.8.7"
+  resolved "https://registry.yarnpkg.com/chosen-js/-/chosen-js-1.8.7.tgz#9bfa5597f5081d602ff4ae904af9aef33265bb1d"
+  integrity sha512-eVdrZJ2U5ISdObkgsi0od5vIJdLwq1P1Xa/Vj/mgxkMZf14DlgobfB6nrlFi3kW4kkvKLsKk4NDqZj1MU1DCpw==
 
 clipboard@^2.0.6:
   version "2.0.6"

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -34,6 +34,8 @@
     <!-- Metis Menu Plugin JavaScript -->
     <script src="{% static "metismenu/dist/metisMenu.min.js" %}"></script>
 
+    <script src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
+
     <!-- Custom Theme JavaScript -->
     <script src="{% static "startbootstrap-sb-admin-2/dist/js/sb-admin-2.js" %}"></script>
     <!-- Calendar JavaScript -->

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -75,7 +75,7 @@
     {% endblock %}
     <link rel="stylesheet" href="{% static "components-jqueryui/themes/flick/jquery-ui.min.css" %}">
     <link rel="shortcut icon" href="{% static "dojo/img/favicon.ico" %}"/>
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
     <link rel="stylesheet" href="{% static "fullcalendar/dist/fullcalendar.min.css" %}">
     <link rel="stylesheet" href="{% static "dojo/css/dojo.css" %}">
     <link rel="stylesheet" href="{% static "datatables.net-dt/css/jquery.dataTables.min.css" %}">

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -73,7 +73,7 @@
     {% endblock %}
     <link rel="stylesheet" href="{% static "components-jqueryui/themes/flick/jquery-ui.min.css" %}">
     <link rel="shortcut icon" href="{% static "dojo/img/favicon.ico" %}"/>
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "fullcalendar/dist/fullcalendar.min.css" %}">
     <link rel="stylesheet" href="{% static "dojo/css/dojo.css" %}">
     <link rel="stylesheet" href="{% static "datatables.net-dt/css/jquery.dataTables.min.css" %}">

--- a/dojo/templates/defectDojo-engagement-survey/edit_question.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_question.html
@@ -16,7 +16,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{{ STATIC_URL }}chosen-js/chosen.jquery.min.js"></script>
     <script type="application/javascript">
         $(function () {
             $("#id_choices").bind("DOMSubtreeModified", function () {

--- a/dojo/templates/defectDojo-engagement-survey/edit_question.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_question.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block add_css %}
-    <link rel="stylesheet" href="{{ STATIC_URL }}bootstrap-chosen/bootstrap-chosen.css">
+    <link rel="stylesheet" href="{{ STATIC_URL }}chosen-bootstrap/chosen.bootstrap.min.css">
 {% endblock %}
 {% block content %}
     <h3>Edit Question: {{ question.name }}</h3>

--- a/dojo/templates/defectDojo-engagement-survey/edit_question.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_question.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block add_css %}
-    <link rel="stylesheet" href="{{ STATIC_URL }}chosen-bootstrap/chosen.bootstrap.min.css">
+    <link rel="stylesheet" href="{{ STATIC_URL }}bootstrap-chosen/bootstrap-chosen.css">
 {% endblock %}
 {% block content %}
     <h3>Edit Question: {{ question.name }}</h3>
@@ -16,7 +16,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{{ STATIC_URL }}chosen/chosen.jquery.min.js"></script>
+    <script type="application/javascript" src="{{ STATIC_URL }}chosen-js/chosen.jquery.min.js"></script>
     <script type="application/javascript">
         $(function () {
             $("#id_choices").bind("DOMSubtreeModified", function () {

--- a/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block add_css %}
-    <link rel="stylesheet" href="{{ STATIC_URL }}chosen-bootstrap/chosen.bootstrap.min.css">
+    <link rel="stylesheet" href="{{ STATIC_URL }}bootstrap-chosen/bootstrap-chosen.css">
 {% endblock %}
 {% block content %}
     <h3>Edit Questionnaire Questions ({{ survey.name }})</h3>
@@ -16,7 +16,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{{ STATIC_URL }}chosen/chosen.jquery.min.js"></script>
+    <script type="application/javascript" src="{{ STATIC_URL }}chosen-js/chosen.jquery.min.js"></script>
     <script type="application/javascript">
         $(function () {
             $("#id_questions").bind("DOMSubtreeModified", function() {

--- a/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block add_css %}
-    <link rel="stylesheet" href="{{ STATIC_URL }}bootstrap-chosen/bootstrap-chosen.css">
+    <link rel="stylesheet" href="{{ STATIC_URL }}chosen-bootstrap/chosen.bootstrap.min.css">
 {% endblock %}
 {% block content %}
     <h3>Edit Questionnaire Questions ({{ survey.name }})</h3>

--- a/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
@@ -16,7 +16,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{{ STATIC_URL }}chosen-js/chosen.jquery.min.js"></script>
     <script type="application/javascript">
         $(function () {
             $("#id_questions").bind("DOMSubtreeModified", function() {

--- a/dojo/templates/dojo/add_endpoint.html
+++ b/dojo/templates/dojo/add_endpoint.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
     .chosen-container {
     width: 70% !important;
@@ -21,8 +19,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
-
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 

--- a/dojo/templates/dojo/add_endpoint.html
+++ b/dojo/templates/dojo/add_endpoint.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {
@@ -21,7 +21,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>

--- a/dojo/templates/dojo/add_endpoint_meta_data.html
+++ b/dojo/templates/dojo/add_endpoint_meta_data.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Add Endpoint ({{ endpoint.host }}) Metadata</h3>

--- a/dojo/templates/dojo/add_endpoint_meta_data.html
+++ b/dojo/templates/dojo/add_endpoint_meta_data.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Add Endpoint ({{ endpoint.host }}) Metadata</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -84,7 +84,6 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -84,7 +84,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>

--- a/dojo/templates/dojo/add_product_meta_data.html
+++ b/dojo/templates/dojo/add_product_meta_data.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Add {{ product.name }} Custom Fields</h3>

--- a/dojo/templates/dojo/add_product_meta_data.html
+++ b/dojo/templates/dojo/add_product_meta_data.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Add {{ product.name }} Custom Fields</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/add_related.html
+++ b/dojo/templates/dojo/add_related.html
@@ -31,7 +31,7 @@
     <link rel="stylesheet" href="{% static "components-jqueryui/themes/base/jquery-ui.min.css" %}">
     <link rel="shortcut icon" href="{% static "dojo/img/favicon.ico" %}"/>
     <link rel="stylesheet" href="{% static "fullcalendar/dist/fullcalendar.min.css" %}">
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "dojo/css/dojo.css" %}">
     <style>
         .chosen-container {
@@ -77,7 +77,7 @@
 <script src="{% static "moment/min/moment.min.js" %}"></script>
 <script src="{% static "fullcalendar/dist/fullcalendar.min.js" %}"></script>
 <!-- our JS -->
-<script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+<script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 
 <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
 <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>

--- a/dojo/templates/dojo/add_related.html
+++ b/dojo/templates/dojo/add_related.html
@@ -31,7 +31,7 @@
     <link rel="stylesheet" href="{% static "components-jqueryui/themes/base/jquery-ui.min.css" %}">
     <link rel="shortcut icon" href="{% static "dojo/img/favicon.ico" %}"/>
     <link rel="stylesheet" href="{% static "fullcalendar/dist/fullcalendar.min.css" %}">
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
     <link rel="stylesheet" href="{% static "dojo/css/dojo.css" %}">
     <style>
         .chosen-container {

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -43,7 +43,6 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript">

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -43,7 +43,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript">

--- a/dojo/templates/dojo/add_tests.html
+++ b/dojo/templates/dojo/add_tests.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
 .chosen-container {
     width: 70% !important;
@@ -25,7 +23,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/add_tests.html
+++ b/dojo/templates/dojo/add_tests.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
 .chosen-container {
@@ -25,7 +25,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/add_user.html
+++ b/dojo/templates/dojo/add_user.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> {{ name }} {% if to_edit %}- {{ to_edit.username }}{% endif %}</h3>
     <div class="alert alert-info" role="alert">
@@ -37,8 +35,7 @@
 {% endblock %}
 {% block postscript %}
     {% if to_add or to_edit and not to_edit.is_staff %}
-        <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
-        <script type="application/javascript">
+            <script type="application/javascript">
             $(function () {
                 $('#id_authorized_products').chosen({'placeholder_text_multiple': 'Select some products...'});
             });

--- a/dojo/templates/dojo/add_user.html
+++ b/dojo/templates/dojo/add_user.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> {{ name }} {% if to_edit %}- {{ to_edit.username }}{% endif %}</h3>
@@ -37,7 +37,7 @@
 {% endblock %}
 {% block postscript %}
     {% if to_add or to_edit and not to_edit.is_staff %}
-        <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+        <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
         <script type="application/javascript">
             $(function () {
                 $('#id_authorized_products').chosen({'placeholder_text_multiple': 'Select some products...'});

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -32,7 +32,7 @@
 {% block postscript %}
     
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript">

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -32,7 +32,6 @@
 {% block postscript %}
     
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript">

--- a/dojo/templates/dojo/benchmark.html
+++ b/dojo/templates/dojo/benchmark.html
@@ -3,7 +3,7 @@
 {% load event_tags %}
 {% load display_tags %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
       <div class="panel panel-default">
@@ -97,7 +97,7 @@
 </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
         function highlight_level(desired_level) {
             $( ".level2_select" ).removeClass("level2");

--- a/dojo/templates/dojo/benchmark.html
+++ b/dojo/templates/dojo/benchmark.html
@@ -2,9 +2,7 @@
 {% load static from staticfiles %}
 {% load event_tags %}
 {% load display_tags %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
       <div class="panel panel-default">
           <div class="panel-heading">
@@ -97,7 +95,6 @@
 </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
         function highlight_level(desired_level) {
             $( ".level2_select" ).removeClass("level2");

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <form method="GET" id="calfilter" action="/calendar">
@@ -33,7 +33,7 @@
     <br/><br/>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
           $(function () {
             $('#caltype').change(function() { $('#calfilter').attr('action', '/calendar/' + $(this).val()); });

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -1,8 +1,6 @@
 {% extends 'base.html' %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <form method="GET" id="calfilter" action="/calendar">
         <div class="container-fluid chosen-container side-by-side">
@@ -33,7 +31,6 @@
     <br/><br/>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
           $(function () {
             $('#caltype').change(function() { $('#calfilter').attr('action', '/calendar/' + $(this).val()); });

--- a/dojo/templates/dojo/clear_finding_review.html
+++ b/dojo/templates/dojo/clear_finding_review.html
@@ -1,9 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
 .chosen-container {
     width: 70% !important;
@@ -24,7 +22,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_reviewers').chosen({'placeholder_text_multiple': 'Select some reviewers...'});

--- a/dojo/templates/dojo/clear_finding_review.html
+++ b/dojo/templates/dojo/clear_finding_review.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
 .chosen-container {
@@ -24,7 +24,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_reviewers').chosen({'placeholder_text_multiple': 'Select some reviewers...'});

--- a/dojo/templates/dojo/edit_cred.html
+++ b/dojo/templates/dojo/edit_cred.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit Credential Configuration</h3>
@@ -15,5 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_cred.html
+++ b/dojo/templates/dojo/edit_cred.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit Credential Configuration</h3>
     <form class="form-horizontal" enctype="multipart/form-data" method="post">{% csrf_token %}
@@ -15,5 +13,4 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_cred_all.html
+++ b/dojo/templates/dojo/edit_cred_all.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit {{cred_type}} Credential</h3>
@@ -15,5 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_cred_all.html
+++ b/dojo/templates/dojo/edit_cred_all.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit {{cred_type}} Credential</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
@@ -15,5 +13,4 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_endpoint.html
+++ b/dojo/templates/dojo/edit_endpoint.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
 .chosen-container {
     width: 70% !important;
@@ -20,7 +18,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/edit_endpoint.html
+++ b/dojo/templates/dojo/edit_endpoint.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
 .chosen-container {
@@ -20,7 +20,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/edit_endpoint_meta_data.html
+++ b/dojo/templates/dojo/edit_endpoint_meta_data.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit Endpoint ({{ endpoint.host }}) Metadata</h3>

--- a/dojo/templates/dojo/edit_endpoint_meta_data.html
+++ b/dojo/templates/dojo/edit_endpoint_meta_data.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit Endpoint ({{ endpoint.host }}) Metadata</h3>
     <p>

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -3,7 +3,7 @@
 {% load display_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -122,7 +122,6 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -3,7 +3,7 @@
 {% load display_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -122,7 +122,7 @@
 {% endblock %}
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>

--- a/dojo/templates/dojo/edit_jira.html
+++ b/dojo/templates/dojo/edit_jira.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit JIRA Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
@@ -15,5 +13,4 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_jira.html
+++ b/dojo/templates/dojo/edit_jira.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit JIRA Configuration</h3>
@@ -15,5 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_object.html
+++ b/dojo/templates/dojo/edit_object.html
@@ -1,8 +1,6 @@
-d{% extends "base.html" %}
+{% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3>Edit Tracked Files</h3>
     <form class="form-horizontal" enctype="multipart/form-data" method="post">{% csrf_token %}
@@ -15,7 +13,6 @@ d{% extends "base.html" %}
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/edit_object.html
+++ b/dojo/templates/dojo/edit_object.html
@@ -1,7 +1,7 @@
 d{% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3>Edit Tracked Files</h3>
@@ -15,7 +15,7 @@ d{% extends "base.html" %}
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -39,7 +39,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -39,7 +39,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/edit_product_meta_data.html
+++ b/dojo/templates/dojo/edit_product_meta_data.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit {{ product.name }} Metadata</h3>

--- a/dojo/templates/dojo/edit_product_meta_data.html
+++ b/dojo/templates/dojo/edit_product_meta_data.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit {{ product.name }} Metadata</h3>
     <p>

--- a/dojo/templates/dojo/edit_regulation.html
+++ b/dojo/templates/dojo/edit_regulation.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit Regulation Configuration</h3>
@@ -16,5 +16,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_regulation.html
+++ b/dojo/templates/dojo/edit_regulation.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit Regulation Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
@@ -16,5 +14,4 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_test.html
+++ b/dojo/templates/dojo/edit_test.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
 .chosen-container {
     width: 70% !important;
@@ -21,7 +19,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/edit_test.html
+++ b/dojo/templates/dojo/edit_test.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
 .chosen-container {
@@ -21,7 +21,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/edit_tool_config.html
+++ b/dojo/templates/dojo/edit_tool_config.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit Tool Configuration</h3>
@@ -15,5 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_config.html
+++ b/dojo/templates/dojo/edit_tool_config.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit Tool Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
@@ -15,5 +13,4 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_product.html
+++ b/dojo/templates/dojo/edit_tool_product.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit Product Tool Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
@@ -15,5 +13,4 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_product.html
+++ b/dojo/templates/dojo/edit_tool_product.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit Product Tool Configuration</h3>
@@ -15,5 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_type.html
+++ b/dojo/templates/dojo/edit_tool_type.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Edit Tool Type Configuration</h3>
@@ -15,5 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_type.html
+++ b/dojo/templates/dojo/edit_tool_type.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Edit Tool Type Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
@@ -15,5 +13,4 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 {% endblock %}

--- a/dojo/templates/dojo/filter_js_snippet.html
+++ b/dojo/templates/dojo/filter_js_snippet.html
@@ -1,5 +1,5 @@
 {% load static from staticfiles %}
-<script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+<script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 <script type="application/javascript">
     $(function () {
         $(".{{ request.path|slugify }}-filters :input").not("button").addClass("form-control input-sm");

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -1,7 +1,7 @@
 {% load navigation_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}
 <div class="filter-set">
     <form method="get" {% if form_id %}id="{{form_id}}"{% endif %} class="{{ request.path|slugify }}-filters form-inline dojo-filter-set">

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -1,7 +1,7 @@
 {% load navigation_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 <div class="filter-set">
     <form method="get" {% if form_id %}id="{{form_id}}"{% endif %} class="{{ request.path|slugify }}-filters form-inline dojo-filter-set">

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -436,7 +436,7 @@
 
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         // DataTables Setup
         $(document).ready(function() {

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
 .chosen-container {
@@ -150,7 +150,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
-	<script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+	<script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 	<script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
 	<script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
 	<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
 .chosen-container {
     width: 70% !important;
@@ -150,7 +148,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
-	<script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 	<script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
 	<script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
 	<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>

--- a/dojo/templates/dojo/manage_images.html
+++ b/dojo/templates/dojo/manage_images.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
     <h3> Add images to {{ finding }}</h3>

--- a/dojo/templates/dojo/manage_images.html
+++ b/dojo/templates/dojo/manage_images.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
     <h3> Add images to {{ finding }}</h3>
     <div class="alert alert-info" role="alert">

--- a/dojo/templates/dojo/merge_findings.html
+++ b/dojo/templates/dojo/merge_findings.html
@@ -3,7 +3,7 @@
 {% load display_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}

--- a/dojo/templates/dojo/merge_findings.html
+++ b/dojo/templates/dojo/merge_findings.html
@@ -3,7 +3,7 @@
 {% load display_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -54,7 +54,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -54,7 +54,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/new_object.html
+++ b/dojo/templates/dojo/new_object.html
@@ -1,8 +1,6 @@
 {% extends "base.html"%}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block content %}
  {{ block.super }}
     <h3> Add Tracked Files to a Product</h3>
@@ -16,7 +14,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/new_object.html
+++ b/dojo/templates/dojo/new_object.html
@@ -1,7 +1,7 @@
 {% extends "base.html"%}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block content %}
  {{ block.super }}
@@ -16,7 +16,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_tags').chosen({

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -39,7 +39,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
@@ -39,7 +39,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/notifications.html
+++ b/dojo/templates/dojo/notifications.html
@@ -2,7 +2,7 @@
 {% load static from staticfiles %}
 {% load event_tags %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 
 {% block content %}
@@ -73,7 +73,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
         $(function () {
             $(".chosen-select").chosen({disable_search_threshold: 10});

--- a/dojo/templates/dojo/notifications.html
+++ b/dojo/templates/dojo/notifications.html
@@ -1,9 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% load event_tags %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 
 {% block content %}
     <h3> {% if scope == 'system' %}System{% else %}Personal{% endif %} Notification Settings </h3>
@@ -73,7 +71,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
         $(function () {
             $(".chosen-select").chosen({disable_search_threshold: 10});

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -55,7 +55,6 @@
     <script src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script src="{% static "google-code-prettify/src/prettify.js" %}"></script>
     <script src="{% static "bootstrap-wysiwyg/src/bootstrap-wysiwyg.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
         function setUpFindingFilters() {
             $(".report-filter-set :input").not("button").addClass("form-control input-sm");

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -55,7 +55,7 @@
     <script src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script src="{% static "google-code-prettify/src/prettify.js" %}"></script>
     <script src="{% static "bootstrap-wysiwyg/src/bootstrap-wysiwyg.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script>
         function setUpFindingFilters() {
             $(".report-filter-set :input").not("button").addClass("form-control input-sm");

--- a/dojo/templates/dojo/report_filter_snippet.html
+++ b/dojo/templates/dojo/report_filter_snippet.html
@@ -1,7 +1,7 @@
 {% load navigation_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
+    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}
 <div class="filter-set report-filter-set">
     <form id="{{ title|slugify }}" method="get" class="{{ title|slugify }} {{ request.path|slugify }}-filters form-inline dojo-filter-set">

--- a/dojo/templates/dojo/report_filter_snippet.html
+++ b/dojo/templates/dojo/report_filter_snippet.html
@@ -1,7 +1,7 @@
 {% load navigation_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 <div class="filter-set report-filter-set">
     <form id="{{ title|slugify }}" method="get" class="{{ title|slugify }} {{ request.path|slugify }}-filters form-inline dojo-filter-set">

--- a/dojo/templates/dojo/review_finding.html
+++ b/dojo/templates/dojo/review_finding.html
@@ -1,9 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
 .chosen-container {
     width: 70% !important;
@@ -24,7 +22,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_reviewers').chosen({'placeholder_text_multiple': 'Select some reviewers...'});

--- a/dojo/templates/dojo/review_finding.html
+++ b/dojo/templates/dojo/review_finding.html
@@ -2,7 +2,7 @@
 {% load event_tags %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
 .chosen-container {
@@ -24,7 +24,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
             $('#id_reviewers').chosen({'placeholder_text_multiple': 'Select some reviewers...'});

--- a/dojo/templates/dojo/system_settings.html
+++ b/dojo/templates/dojo/system_settings.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
 .chosen-container {
     width: 70% !important;

--- a/dojo/templates/dojo/system_settings.html
+++ b/dojo/templates/dojo/system_settings.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/up_risk.html
+++ b/dojo/templates/dojo/up_risk.html
@@ -1,8 +1,6 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
     .chosen-container {
     width: 70% !important;

--- a/dojo/templates/dojo/up_risk.html
+++ b/dojo/templates/dojo/up_risk.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {

--- a/dojo/templates/dojo/view_risk.html
+++ b/dojo/templates/dojo/view_risk.html
@@ -2,9 +2,7 @@
 {% load display_tags %}
 {% load humanize %}
 {% load static from staticfiles %}
-{% block add_css %}
-    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
-{% endblock %}
+
 {% block add_styles %}
     .chosen-container {
     width: 70% !important;

--- a/dojo/templates/dojo/view_risk.html
+++ b/dojo/templates/dojo/view_risk.html
@@ -3,7 +3,7 @@
 {% load humanize %}
 {% load static from staticfiles %}
 {% block add_css %}
-    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
+    <link rel="stylesheet" href="{% static "bootstrap-chosen/bootstrap-chosen.css" %}">
 {% endblock %}
 {% block add_styles %}
     .chosen-container {

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -735,7 +735,7 @@
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen/chosen.jquery.min.js" %}"></script>
+    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="text/javascript">
         $(function () {
           $(".chosen-select").chosen({

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -735,7 +735,6 @@
 {% block postscript %}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
-    <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="text/javascript">
         $(function () {
           $(".chosen-select").chosen({

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -236,7 +236,7 @@ class BaseTestCase(unittest.TestCase):
             http://localhost:8080/static/dojo/img/zoom-in.cur - Failed to load resource: the server responded with a status of 404 (Not Found)
             http://localhost:8080/media/CACHE/images/finding_images/1bf9c0b1-5ed1-4b4e-9551-bcbfd198b90a/7d8d9af058566b8f2fe6548d96c63237.jpg - Failed to load resource: the server responded with a status of 404 (Not Found)
             """
-            accepted_javascript_messages = r'((zoom\-in\.cur.*)|(images\/finding_images\/.*))404\ \(Not\ Found\)'
+            accepted_javascript_messages = r'((zoom\-in\.cur.*)|(images\/finding_images\/.*))404\ \(Not\ Found\)|(bootstrap\-chosen\.css\.map)'
 
             if (entry['level'] == 'SEVERE'):
                 # print(self.driver.current_url)  # TODO actually this seems to be the previous url

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -236,7 +236,8 @@ class BaseTestCase(unittest.TestCase):
             http://localhost:8080/static/dojo/img/zoom-in.cur - Failed to load resource: the server responded with a status of 404 (Not Found)
             http://localhost:8080/media/CACHE/images/finding_images/1bf9c0b1-5ed1-4b4e-9551-bcbfd198b90a/7d8d9af058566b8f2fe6548d96c63237.jpg - Failed to load resource: the server responded with a status of 404 (Not Found)
             """
-            accepted_javascript_messages = r'((zoom\-in\.cur.*)|(images\/finding_images\/.*))404\ \(Not\ Found\)|(bootstrap\-chosen\.css\.map)'
+            accepted_javascript_messages = r'((zoom\-in\.cur.*)|(images\/finding_images\/.*))404\ \(Not\ Found\)'
+            # accepted_javascript_messages = r'((zoom\-in\.cur.*)|(images\/finding_images\/.*))404\ \(Not\ Found\)|(bootstrap\-chosen\.css\.map)'
 
             if (entry['level'] == 'SEVERE'):
                 # print(self.driver.current_url)  # TODO actually this seems to be the previous url


### PR DESCRIPTION
I noticed some errors in the dependabot logs and they seem to be caused by `chosen` being installed from git instead of the yarn/npm registry. This PR fixes that. Affects lots of files because the path of the css/js files has changed, but it's just that.

UPATE: Turns out 95% of files are extending `base.html`, so I included the js+css there and removed the includes in all those seperate pages.

