### PR TITLE
Allow specifying the key for the database secrets

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -65,10 +65,10 @@ spec:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
               name: {{ .Values.postgresql.existingSecret }}
-              key: postgresql-password
+              key: {{ .Values.postgresql.secretKey }}
               {{- else if eq .Values.database "mysql" }}
               name: {{ .Values.mysql.existingSecret }}
-              key: mysql-password
+              key: {{ .Values.mysql.secretKey }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -64,10 +64,10 @@ spec:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
               name: {{ .Values.postgresql.existingSecret }}
-              key: postgresql-password
+              key: {{ .Values.postgresql.secretKey }}
               {{- else if eq .Values.database "mysql" }}
               name: {{ .Values.mysql.existingSecret }}
-              key: mysql-password
+              key: {{ .Values.mysql.secretKey }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -69,10 +69,10 @@ spec:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
               name: {{ .Values.postgresql.existingSecret }}
-              key: postgresql-password
+              key: {{ .Values.postgresql.secretKey }}
               {{- else if eq .Values.database "mysql" }}
               name: {{ .Values.mysql.existingSecret }}
-              key: mysql-password
+              key: {{ .Values.mysql.secretKey }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -54,10 +54,10 @@ spec:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
               name: {{ .Values.postgresql.existingSecret }}
-              key: postgresql-password
+              key: {{ .Values.postgresql.secretKey }}
               {{- else if eq .Values.database "mysql" }}
               name: {{ .Values.mysql.existingSecret }}
-              key: mysql-password
+              key: {{ .Values.mysql.secretKey }}
               {{- end }}
         resources:
           {{- toYaml .Values.initializer.resources | nindent 10 }}

--- a/helm/defectdojo/templates/secret-mysql.yaml
+++ b/helm/defectdojo/templates/secret-mysql.yaml
@@ -21,11 +21,11 @@ data:
   mysql-root-password: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}
 {{- if .Values.mysql.mysqlPassword }}
-  mysql-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
+  {{ .Values.mysql.secretKey }}: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
 {{- else }}
-  mysql-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ .Values.mysql.secretKey }}: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end}}
 {{- else }}
-  mysql-password: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
+  {{ .Values.mysql.secretKey }}: {{ .Values.mysql.mysqlPassword | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/helm/defectdojo/templates/secret-postgresql.yaml
+++ b/helm/defectdojo/templates/secret-postgresql.yaml
@@ -16,12 +16,12 @@ type: Opaque
 data:
 {{- if .Values.postgresql.enabled }}
 {{- if .Values.postgresql.postgresqlPassword }}
-  postgresql-password : {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
+  {{ .Values.postgresql.secretKey }}: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
 {{- else }}
-  postgresql-password : {{ randAlphaNum 10 | b64enc | quote }}
+  {{ .Values.postgresql.secretKey }}: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}
 {{- else }}
-  postgresql-password : {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
+  {{ .Values.postgresql.secretKey }}: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
 {{- end }}
 # TODO: check if replicatio password in injected into the values
 {{ if .Values.postgresql.replication.enabled -}}

--- a/helm/defectdojo/templates/secret-redis.yaml
+++ b/helm/defectdojo/templates/secret-redis.yaml
@@ -15,8 +15,8 @@ metadata:
 type: Opaque
 data:
 {{- if .Values.redis.password }}
-  redis-password: {{ .Values.redis.password | b64enc | quote }}
+  {{ .Values.redis.secretKey }}: {{ .Values.redis.password | b64enc | quote }}
 {{- else }}
-  redis-password: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ .Values.redis.secretKey }}: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -39,10 +39,10 @@ spec:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
               name: {{ .Values.postgresql.existingSecret }}
-              key: postgresql-password
+              key: {{ .Values.postgresql.secretKey }}
               {{- else if eq .Values.database "mysql" }}
               name: {{ .Values.mysql.existingSecret }}
-              key: mysql-password
+              key: {{ .Values.mysql.secretKey }}
               {{- end }}
               key: {{ if eq .Values.database "postgresql" }}{{ .Values.database }}-password{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.database }}-root-password{{ end }}
         - name: DD_DEBUG

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -121,6 +121,7 @@ mysql:
   mysqlPassword: ""
   mysqlRootPassword: ""
   existingSecret: defectdojo-mysql-specific
+  secretKey: mysql-password
   mysqlDatabase: defectdojo
   service:
   # To use an external mySQL instance, set enabled to false and uncomment
@@ -134,6 +135,7 @@ postgresql:
   postgresqlPassword: ""
   postgresqlDatabase: defectdojo
   existingSecret: defectdojo-postgresql-specific
+  secretKey: postgresql-password
   persistence:
     enabled: true
   replication:
@@ -175,6 +177,7 @@ rabbitmq:
 redis:
   enabled: false
   existingSecret: defectdojo-redis-specific
+  secretKey: redis-password
   password: ""
   cluster:
     slaveCount: 1


### PR DESCRIPTION
Allow to use a specific key in existing secrets for database passwords.

- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
