### PR TITLE
Veracode: use unique_id_from_tool (fixed deduplication issues)

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -768,7 +768,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'PHP Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
     'Clair Scan': DEDUPE_ALGO_HASH_CODE,
     'Clair Klar Scan': DEDUPE_ALGO_HASH_CODE,
-    'Veracode Scan': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
+    'Veracode Scan': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
     # for backwards compatibility because someone decided to rename this scanner:
     'Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
     'DSOP Scan': DEDUPE_ALGO_HASH_CODE,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -768,6 +768,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'PHP Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
     'Clair Scan': DEDUPE_ALGO_HASH_CODE,
     'Clair Klar Scan': DEDUPE_ALGO_HASH_CODE,
+    'Veracode Scan': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     # for backwards compatibility because someone decided to rename this scanner:
     'Symfony Security Check': DEDUPE_ALGO_HASH_CODE,
     'DSOP Scan': DEDUPE_ALGO_HASH_CODE,


### PR DESCRIPTION
I added the use of `unique_id_from_tool` during import, so that deduplication can be much more effective.
We had problems since the description-field was part of the hashing, but it changed sometimes, for example when a component has the version in it's name, highly dependent on how teams implement their CI/CD.

For SAST findings, we rely now on the app_id and issue_id from the report.
For SCA, it's vendor, library and version.

edit: Also moved the variable stuff (that component name) and veracode issue id to the references section, which should keep the description field a bit more static.