### PR TITLE
add flake8 check as github action

### DIFF
--- a/.github/workflows/flake8-your-pr.yml
+++ b/.github/workflows/flake8-your-pr.yml
@@ -1,0 +1,14 @@
+name: Flake8 your PR
+on: [pull_request]
+jobs:
+  flake8-your-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      # - uses: tayfun/flake8-your-pr@master
+      - uses: valentijnscholten/flake8-your-pr@master
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/flake8-your-pr.yml
+++ b/.github/workflows/flake8-your-pr.yml
@@ -1,5 +1,6 @@
 name: Flake8 your PR
-on: [pull_request]
+# run on pull_request_target instead of just pull_request as we need write access to update the status check
+on: [pull_request_target]
 jobs:
   flake8-your-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I wanted to do some testing with GitHub Actions, as they are now free for public repositories.

The idea: "Let me quickly add a flake8 action/check"

Reality: There are N different actions all doing something with flake8 on PRs. None of them did what I wanted, or were failing in some way with errors.

Solution: As any real developer, I created the N+1-th flake8 GitHub action :-D

Honestly I just forked an existing one, but made it work better. Some of the others were posting all the flake8 violations as comments on the PR. But that was cluttering too much, so this one annotates the source code in the "Files Changed" tab.
So you can see exactly where the violations are. The annotations will just dissappear when they are fixed. See example image below.

I didn't make this GitHub action a required check before a PR can be merged. But if we like it enough we could do so, maybe even replacing the flake8 check in travis.

![image](https://user-images.githubusercontent.com/4426050/94347984-2216fd80-0039-11eb-8eb8-02a021e426db.png)
