### PR TITLE
Don't copy inexistent certs folder in Dockerfile.django

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,7 +116,8 @@ Pipfile*
 
 
 #ignore locally added certs
-certs/
+docker/certs/*
+!docker/certs/readme.txt
 
 # Helm dependencies
 helm/defectdojo/charts

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -67,7 +67,7 @@ COPY \
   docker/entrypoint-unit-tests.sh \
   docker/entrypoint-unit-tests-devDocker.sh \
   docker/wait-for-it.sh \
-  certs/* \
+  docker/certs/* \
   /
 COPY wsgi.py manage.py tests/unit-tests.sh ./
 COPY dojo/ ./dojo/
@@ -76,6 +76,7 @@ RUN \
   cp dojo/settings/settings.dist.py dojo/settings/settings.py
 COPY tests/ ./tests/
 RUN \
+  rm -f /readme.txt && \
   mkdir -p dojo/migrations && \
   chmod g=u dojo/migrations && \
   true

--- a/docker/certs/readme.txt
+++ b/docker/certs/readme.txt
@@ -1,0 +1,1 @@
+Certificates added to this directory will automatically be added to django docker image.


### PR DESCRIPTION
When building Dockerfile.django with DOCKER_BUILDKIT=1 option in docker, the build fails with:

failed to solve with frontend dockerfile.v0: failed to build LLB: lstat /var/lib/docker/tmp/buildkit-mount548069851/certs: no such file or directory

- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
