### PR TITLE
jira: fix looping when pushing from api

### DIFF
--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -9,7 +9,7 @@ unset DD_DATABASE_URL
 python3 manage.py makemigrations dojo
 python3 manage.py migrate
 
-python3 manage.py test dojo.unittests --keepdb -v 2
+python3 manage.py test dojo.unittests --keepdb -v 3
 
 echo "End of tests. Leaving the container up"
 tail -f /dev/null

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -23,7 +23,10 @@ import datetime
 import six
 from django.utils.translation import ugettext_lazy as _
 import json
+import logging
 
+
+logger = logging.getLogger(__name__)
 
 class TagList(list):
     def __init__(self, *args, **kwargs):
@@ -636,6 +639,26 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
         model = Finding
         fields = '__all__'
 
+    # Overriding this to push add Push to JIRA functionality
+    def update(self, instance, validated_data):
+        # remove tags from validated data and store them seperately
+        to_be_tagged, validated_data = self._pop_tags(validated_data)
+
+        # pop push_to_jira so it won't get send to the model as a field
+        push_to_jira = validated_data.pop('push_to_jira') or instance.get_push_all_to_jira()
+
+        instance = super(TaggitSerializer, self).update(instance, validated_data)
+        # No need to save the finding twice if we're not pushing to JIRA
+        if push_to_jira:
+            instance.save(push_to_jira=push_to_jira)
+        else:
+            instance.save()
+        
+        # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug        #         
+        tag_object = self._save_tags(instance, to_be_tagged)
+        return tag_object
+        pass
+
     def validate(self, data):
         if self.context['request'].method == 'PATCH':
             is_active = data.get('active', self.instance.active)
@@ -698,21 +721,25 @@ class FindingCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
 
     # Overriding this to push add Push to JIRA functionality
     def create(self, validated_data):
+        # remove tags from validated data and store them seperately
         to_be_tagged, validated_data = self._pop_tags(validated_data)
+
+        # pop push_to_jira so it won't get send to the model as a field
         push_to_jira = validated_data.pop('push_to_jira')
-        # Somewhere in the below line finding.save() is called, but I'm not sure how to get
-        # push_to_jira to it.
-        tag_object = super(TaggitSerializer, self).create(validated_data)
 
-        has_jira_config = tag_object.test.engagement.product.jira_pkey_set.first() is not None
-        if not push_to_jira and has_jira_config:
-            push_to_jira = tag_object.test.engagement.product.jira_pkey_set.first().push_all_issues
+        # first save, so we have an instance to get push_all_to_jira from
+        new_finding = super(TaggitSerializer, self).create(validated_data)
 
-        # No need to save the finding twice if we're not pushing to JIRA
+        push_to_jira = push_to_jira or new_finding.get_push_all_to_jira()
+
+        # If we need to push to JIRA, an extra save call is needed.
+        # TODO try to combine create and save, but for now I'm just fixing a bug and don't want to change to much
         if push_to_jira:
-            # Saving again with push_to_jira context
-            tag_object.save(push_to_jira=push_to_jira)
-        return self._save_tags(tag_object, to_be_tagged)
+            new_finding.save(push_to_jira=push_to_jira)
+        
+        # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug        #         
+        tag_object = self._save_tags(new_finding, to_be_tagged)
+        return tag_object
         pass
 
     def validate(self, data):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -658,7 +658,6 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
         # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug
         tag_object = self._save_tags(instance, to_be_tagged)
         return tag_object
-        pass
 
     def validate(self, data):
         if self.context['request'].method == 'PATCH':
@@ -741,7 +740,6 @@ class FindingCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
         # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug
         tag_object = self._save_tags(new_finding, to_be_tagged)
         return tag_object
-        pass
 
     def validate(self, data):
         if ((data['active'] or data['verified']) and data['duplicate']):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -28,6 +28,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class TagList(list):
     def __init__(self, *args, **kwargs):
         pretty_print = kwargs.pop("pretty_print", True)
@@ -648,13 +649,13 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
         push_to_jira = validated_data.pop('push_to_jira') or instance.get_push_all_to_jira()
 
         instance = super(TaggitSerializer, self).update(instance, validated_data)
-        # No need to save the finding twice if we're not pushing to JIRA
+
+        # If we need to push to JIRA, an extra save call is needed.
+        # TODO try to combine create and save, but for now I'm just fixing a bug and don't want to change to much
         if push_to_jira:
             instance.save(push_to_jira=push_to_jira)
-        else:
-            instance.save()
-        
-        # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug        #         
+
+        # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug
         tag_object = self._save_tags(instance, to_be_tagged)
         return tag_object
         pass
@@ -736,8 +737,8 @@ class FindingCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
         # TODO try to combine create and save, but for now I'm just fixing a bug and don't want to change to much
         if push_to_jira:
             new_finding.save(push_to_jira=push_to_jira)
-        
-        # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug        #         
+
+        # not sure why we are returning a tag_object, but don't want to change too much now as we're just fixing a bug
         tag_object = self._save_tags(new_finding, to_be_tagged)
         return tag_object
         pass

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -239,16 +239,16 @@ class FindingViewSet(mixins.ListModelMixin,
     # Overriding mixins.UpdateModeMixin perform_update() method to grab push_to_jira
     # data and add that as a parameter to .save()
     def perform_update(self, serializer):
-        enabled = False
+        push_all = False
         push_to_jira = serializer.validated_data.get('push_to_jira')
         # IF JIRA is enabled and this product has a JIRA configuration
         if get_system_setting('enable_jira') and \
                 serializer.instance.test.engagement.product.jira_pkey_set.first() is not None:
             # Check if push_all_issues is set on this product
-            enabled = serializer.instance.test.engagement.product.jira_pkey_set.first().push_all_issues
+            push_all = serializer.instance.test.engagement.product.jira_pkey_set.first().push_all_issues
 
         # If push_all_issues is set:
-        if enabled:
+        if push_all:
             push_to_jira = True
 
         # add a check for the product having push all issues enabled right here.

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1869,6 +1869,10 @@ class Finding(models.Model):
             return None
             pass
 
+    def get_push_all_to_jira(self):
+        if self.jira_pkey():
+            return self.jira_pkey().push_all_issues
+
     def long_desc(self):
         long_desc = ''
         long_desc += '*' + self.title + '*\n\n'
@@ -1903,8 +1907,7 @@ class Finding(models.Model):
             logger.debug('finding.save() getting current user: %s', user)
 
         jira_issue_exists = JIRA_Issue.objects.filter(finding=self).exists()
-        push_to_jira = getattr(self, 'push_to_jira', push_to_jira)
-
+        
         if self.pk is None:
             # We enter here during the first call from serializers.py
             logger.debug("Saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is None)")
@@ -2062,7 +2065,6 @@ class Finding(models.Model):
             return note.date.strftime("%Y-%m-%d %H:%M:%S") + ': ' + note.author.get_full_name() + ' : ' + note.entry
 
         return ''
-
 
 Finding.endpoints.through.__unicode__ = lambda \
     x: "Endpoint: " + x.endpoint.host

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1907,7 +1907,7 @@ class Finding(models.Model):
             logger.debug('finding.save() getting current user: %s', user)
 
         jira_issue_exists = JIRA_Issue.objects.filter(finding=self).exists()
-        
+
         if self.pk is None:
             # We enter here during the first call from serializers.py
             logger.debug("Saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is None)")
@@ -2065,6 +2065,7 @@ class Finding(models.Model):
             return note.date.strftime("%Y-%m-%d %H:%M:%S") + ': ' + note.author.get_full_name() + ' : ' + note.entry
 
         return ''
+
 
 Finding.endpoints.through.__unicode__ = lambda \
     x: "Endpoint: " + x.endpoint.host

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -45,7 +45,6 @@ class BaseClass():
 
         @skipIfNotSubclass('ListModelMixin')
         def test_list(self):
-
             if hasattr(self.endpoint_model, 'tags') and self.payload:
                 # create a new instance first to make sure there's at least 1 instance with tags set by payload to trigger tag handling code
                 response = self.client.post(self.url, self.payload)
@@ -90,7 +89,10 @@ class BaseClass():
             response = self.client.patch(
                 relative_url, self.update_fields)
             for key, value in self.update_fields.items():
-                self.assertEqual(value, response.data[key])
+                # some exception as push_to_jira has been implemented strangely in the update methods in the api
+                if key != 'push_to_jira':
+                    self.assertEqual(value, response.data[key])
+            self.assertFalse('push_to_jira' in response.data)
             response = self.client.put(
                 relative_url, self.payload)
             self.assertEqual(200, response.status_code)
@@ -244,7 +246,7 @@ class FindingsTest(BaseClass.RESTEndpointTest):
             "dynamic_finding": False,
             "endpoints": [1, 2],
             "images": []}
-        self.update_fields = {'active': True}
+        self.update_fields = {'active': True, "push_to_jira": "True"}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 


### PR DESCRIPTION
Fixes #2948 

When adding jira_push_all and push_to_jira to the api, there was a bug introduced by passing on the push_to_jira as a model field instead of a parameter. This had no downside yet for us, until in #2801 code was added that was trying to use this field to fix another bug where push_to_jira wasn't passed for PATCH (update) requests. That caused loops to occur:

findings.save -> update_jira_issue -> finding.save -> update_jira_issue -> finding.save -> ... (#2948)

This PR fixes this by:
- reverting the changes in #2801 
- fixing the original bug in the serializer.update()

According to the django docs the current of handling push_to_jira in the api is not how it was envisioned, and a get_serializer_context should be used. But that had other side effects when I tried it. So I decided to leave as much as possible in place and just fix the bug(s).

Here and there I changed some code / names to make it more readable for the future.