### PR TITLE
sync renovate config from master

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   ],
   "dependencyDashboardApproval": true,
   "baseBranches": ["dev"],  
+  "rebaseWhen": "conflicted",
   "ignorePaths": ["setup.py", "requirements.txt", "components/package.json", "components/package-lock.json", "dojo/components/yarn.lock", "dojo/components/package.json", "Dockerfile**"],
   "packageRules": [{
     "packagePatterns": ["*"],

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "packageRules": [{
     "packagePatterns": ["*"],
     "commitMessageExtra": "from {{currentVersion}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
-    "commitMessageSuffix": "({{packageFile}})"
+    "commitMessageSuffix": "({{packageFile}})",
     "labels": ["dependencies"]
   }]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
     "packagePatterns": ["*"],
     "commitMessageExtra": "from {{currentVersion}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
     "commitMessageSuffix": "({{packageFile}})"
+    "labels": ["dependencies"]
   }]
 }


### PR DESCRIPTION
I had to make some tests/changes to the renovate config directly on master. Merging them "back" into dev to get in sync again and not getting surprised at the next release.