### PR TITLE
search: restore missing index fields

### DIFF
--- a/dojo/apps.py
+++ b/dojo/apps.py
@@ -21,11 +21,11 @@ class DojoAppConfig(AppConfig):
         # charfields/textfields are the fields that watson indexes by default (but we have to repeat here if we add extra fields)
         # and watson likes to have tuples instead of lists
 
-        watson.register(self.get_model('Product'), fields=get_model_fields_with_extra(self.get_model('Product'), ('prod_type__name', )), store=('prod_type__name', ))
+        watson.register(self.get_model('Product'), fields=get_model_fields_with_extra(self.get_model('Product'), ('id', 'prod_type__name', )), store=('prod_type__name', ))
 
-        watson.register(self.get_model('Test'), fields=get_model_fields_with_extra(self.get_model('Test'), ('engagement__product__name', )), store=('engagement__product__name', ))  # test_type__name?
+        watson.register(self.get_model('Test'), fields=get_model_fields_with_extra(self.get_model('Test'), ('id', 'engagement__product__name', )), store=('engagement__product__name', ))  # test_type__name?
 
-        watson.register(self.get_model('Finding'), fields=get_model_fields_with_extra(self.get_model('Finding'), ('test__engagement__product__name', 'jira_issue__jira_key', )),
+        watson.register(self.get_model('Finding'), fields=get_model_fields_with_extra(self.get_model('Finding'), ('id', 'url', 'unique_id_from_tool', 'test__engagement__product__name', 'jira_issue__jira_key', )),
                         store=('cve', 'status', 'jira_issue__jira_key', 'test__engagement__product__name', 'severity', 'severity_display', 'latest_note'))
 
         # some thoughts on Finding fields that are not indexed yet:
@@ -56,7 +56,7 @@ class DojoAppConfig(AppConfig):
 
         watson.register(self.get_model('Finding_Template'))
         watson.register(self.get_model('Endpoint'), store=('product__name', ))  # add product name also?
-        watson.register(self.get_model('Engagement'), fields=get_model_fields_with_extra(self.get_model('Engagement'), ('product__name', )), store=('product__name', ))
+        watson.register(self.get_model('Engagement'), fields=get_model_fields_with_extra(self.get_model('Engagement'), ('id', 'product__name', )), store=('product__name', ))
         watson.register(self.get_model('App_Analysis'))
 
         # YourModel = self.get_model("YourModel")


### PR DESCRIPTION
restore `id`, `url` and `unique_id_from_tool` as indexable fields in watson. this allows for search by finding id, i.e.

`finding:1234`

needs an index rebuild, docs: https://github.com/DefectDojo/Documentation/pull/138