### PR TITLE
Specific variable for https port

### DIFF
--- a/docker-compose.override.https.yml
+++ b/docker-compose.override.https.yml
@@ -6,8 +6,8 @@ services:
       USE_TLS: 'true'
       GENERATE_TLS_CERTIFICATE: 'true'
     ports:
-      - target: ${DD_PORT:-8443}
-        published: ${DD_PORT:-8443}
+      - target: ${DD_TLS_PORT:-8443}
+        published: ${DD_TLS_PORT:-8443}
         protocol: tcp
         mode: host
   uwsgi:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,15 @@ services:
       - uwsgi
     environment:
       NGINX_METRICS_ENABLED: ${NGINX_METRICS_ENABLED:-false}
+      DD_PORT: ${DD_PORT:-8080}
+      DD_TLS_PORT: ${DD_TLS_PORT:-8443}
     ports:
       - target: ${DD_PORT:-8080}
         published: ${DD_PORT:-8080}
         protocol: tcp
         mode: host
-      - target: ${DD_PORT:-8443}
-        published: ${DD_PORT:-8443}
+      - target: ${DD_TLS_PORT:-8443}
+        published: ${DD_TLS_PORT:-8443}
         protocol: tcp
         mode: host
   uwsgi:

--- a/docker/entrypoint-nginx.sh
+++ b/docker/entrypoint-nginx.sh
@@ -14,8 +14,11 @@ fi
 
 if [ "${USE_TLS}" = true ]; then
   NGINX_CONFIG="/etc/nginx/nginx_TLS.conf"
+  sed -i "s/listen 8080/listen ${DD_PORT}/" $NGINX_CONFIG
+  sed -i "s/listen 8443 ssl/listen ${DD_TLS_PORT} ssl/" $NGINX_CONFIG
 else
   NGINX_CONFIG="/etc/nginx/nginx.conf"
+  sed -i "s/listen 8080/listen ${DD_PORT}/" $NGINX_CONFIG
 fi
 
 if [ "${NGINX_METRICS_ENABLED}" = true ]; then


### PR DESCRIPTION
Specifying a port through `DD_PORT` results in an error, as that variable is used for both the http and https endpoint.
This PR simply specifies a new variable for the https endpoint and adapts the nginx config file accordingly.
Some extra passing of variables needed.

```
$ docker-compose up -d                                             
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.nginx.ports value [{'target': 8081, 'published': 8081, 'protocol': 'tcp', 'mode': 'host'}, {'target': 8081, 'published': 8081, 'protocol': 'tcp', 'mode': 'host'}] has non-unique elements
```

Grepping through the codebase, this is apparently the only place that has it.