### PR TITLE
Add required fields in package.json

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "DefectDojo",
+  "version": "1.9.0-dev",
   "dependencies": {
     "JUMFlot": "jumjum123/JUMFlot#*",
     "bootstrap": "^3.4.0",


### PR DESCRIPTION
Name and version are required fields and some tools (i.e. whitesource) fail if they are missing.

On behalf of DB Systel GmbH