### PR TITLE
Add annotations for pods

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.7.1"
+appVersion: "1.8.0"
 description: A Helm chart for Kubernetes to installs DefectDojo
 name: defectdojo
-version: 1.3.1
+version: 1.3.2
 icon: https://www.defectdojo.org/img/favicon.ico
 dependencies:
   - name: mysql

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.8.0"
 description: A Helm chart for Kubernetes to installs DefectDojo
 name: defectdojo
-version: 1.3.2
+version: 1.4.0
 icon: https://www.defectdojo.org/img/favicon.ico
 dependencies:
   - name: mysql

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         defectdojo.org/component: celery
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+      {{- with .Values.celery.beat.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         defectdojo.org/component: celery
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+      {{- with .Values.celery.worker.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -22,6 +22,10 @@ spec:
         defectdojo.org/component: django
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+      {{- with .Values.django.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -42,6 +42,7 @@ celery:
   broker: rabbitmq
   logLevel: DEBUG
   beat:
+    annotations: {}
     affinity: {}
     nodeSelector: {}
     replicas: 1
@@ -54,6 +55,7 @@ celery:
         memory: 256Mi
     tolerations: []
   worker:
+    annotations: {}
     affinity: {}
     logLevel: DEBUG
     nodeSelector: {}
@@ -77,6 +79,7 @@ celery:
       # prefetch_multiplier: 128
 
 django:
+  annotations: {}
   affinity: {}
   ingress:
     enabled: true


### PR DESCRIPTION
Allows to put annotations for django pod, celery pods.

Useful to add monitoring annotation, for example. Tested with datadog here, works well.

Also bumped up chart version as well as app version we didn't do last release.