### PR TITLE
Add delete methods for products and environments in api v2

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -561,6 +561,7 @@ class DojoMetaViewSet(mixins.ListModelMixin,
 class ProductViewSet(mixins.ListModelMixin,
                      mixins.RetrieveModelMixin,
                      mixins.CreateModelMixin,
+                     mixins.DestroyModelMixin,
                      mixins.UpdateModelMixin,
                      viewsets.GenericViewSet):
     serializer_class = serializers.ProductSerializer
@@ -720,6 +721,7 @@ class StubFindingsViewSet(mixins.ListModelMixin,
 class DevelopmentEnvironmentViewSet(mixins.ListModelMixin,
                                     mixins.RetrieveModelMixin,
                                     mixins.CreateModelMixin,
+                                    mixins.DestroyModelMixin,
                                     mixins.UpdateModelMixin,
                                     viewsets.GenericViewSet):
     serializer_class = serializers.DevelopmentEnvironmentSerializer


### PR DESCRIPTION
In this PR we add the following to the API V2 :
- New endpoint to delete a product.
- New endpoint to delete an environment.

We have tested that in both cases the deletion cascade correctly. 
These changes have been made in collaboration with @xens 