### PR TITLE
Add SSL verification variable to JIRA integration

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -127,7 +127,8 @@ def express_new_jira(request):
                 # Instantiate JIRA instance for validating url, username and password
                 try:
                     jira = JIRA(server=jira_server,
-                         basic_auth=(jira_username, jira_password))
+                        basic_auth=(jira_username, jira_password),
+                        verify=settings.JIRA_SSL_VERIFY)
                 except Exception:
                     messages.add_message(request,
                                      messages.ERROR,
@@ -208,7 +209,8 @@ def new_jira(request):
 
                 # Instantiate JIRA instance for validating url, username and password
                 JIRA(server=jira_server,
-                     basic_auth=(jira_username, jira_password))
+                     basic_auth=(jira_username, jira_password),
+                     verify=settings.JIRA_SSL_VERIFY)
 
                 new_j = jform.save(commit=False)
                 new_j.url = jira_server
@@ -255,7 +257,8 @@ def edit_jira(request, jid):
 
                 # Instantiate JIRA instance for validating url, username and password
                 JIRA(server=jira_server,
-                    basic_auth=(jira_username, jira_password))
+                    basic_auth=(jira_username, jira_password),
+                    verify=settings.JIRA_SSL_VERIFY)
 
                 new_j = jform.save(commit=False)
                 new_j.url = jira_server
@@ -296,7 +299,8 @@ def delete_issue(request, find):
     jira_conf = find.jira_conf()
     jira = JIRA(server=jira_conf.url,
                 basic_auth=(jira_conf.username,
-                            jira_conf.password))
+                            jira_conf.password),
+                verify=settings.JIRA_SSL_VERIFY)
     issue = jira.issue(j_issue.jira_id)
     issue.delete()
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -136,7 +136,8 @@ env = environ.Env(
 
     # maximum number of result in search as search can be an expensive operation
     DD_SEARCH_MAX_RESULTS=(int, 100),
-    DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000)
+    DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
+    DD_JIRA_SSL_VERIFY=(bool, True)
 )
 
 
@@ -792,6 +793,8 @@ JIRA_ISSUE_TYPE_CHOICES_CONFIG = (
     ('Bug', 'Bug'),
     ('Security', 'Security')
 )
+
+JIRA_SSL_VERIFY = env('DD_JIRA_SSL_VERIFY')
 
 
 # ------------------------------------------------------------------------------

--- a/dojo/tool_type/views.py
+++ b/dojo/tool_type/views.py
@@ -59,7 +59,9 @@ def edit_tool_type(request, ttid):
 @user_passes_test(lambda u: u.is_staff)
 def delete_issue(request, find):
     j_issue = JIRA_Issue.objects.get(finding=find)
-    jira = JIRA(server=Tool_Type.url, basic_auth=(Tool_Type.username, Tool_Type.password))
+    jira = JIRA(server=Tool_Type.url,
+                basic_auth=(Tool_Type.username, Tool_Type.password),
+                verify=settings.JIRA_SSL_VERIFY)
     issue = jira.issue(j_issue.jira_id)
     issue.delete()
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1219,7 +1219,8 @@ def get_jira_connection(finding):
         if jira_conf is not None:
             jira = JIRA(
                 server=jira_conf.url,
-                basic_auth=(jira_conf.username, jira_conf.password))
+                basic_auth=(jira_conf.username, jira_conf.password),
+                verify=settings.JIRA_SSL_VERIFY)
     except JIRA_PKey.DoesNotExist:
         pass
     return jira
@@ -1367,7 +1368,8 @@ def add_jira_issue(find, push_to_jira):
                 JIRAError.log_to_tempfile = False
                 jira = JIRA(
                     server=jira_conf.url,
-                    basic_auth=(jira_conf.username, jira_conf.password))
+                    basic_auth=(jira_conf.username, jira_conf.password),
+                    verify=settings.JIRA_SSL_VERIFY)
 
                 meta = None
 
@@ -1511,7 +1513,8 @@ def update_jira_issue(find, push_to_jira):
             JIRAError.log_to_tempfile = False
             jira = JIRA(
                 server=jira_conf.url,
-                basic_auth=(jira_conf.username, jira_conf.password))
+                basic_auth=(jira_conf.username, jira_conf.password),
+                verify=settings.JIRA_SSL_VERIFY)
             issue = jira.issue(j_issue.jira_id)
 
             meta = None
@@ -1624,7 +1627,8 @@ def update_epic(eng, push_to_jira):
         try:
             jira = JIRA(
                 server=jira_conf.url,
-                basic_auth=(jira_conf.username, jira_conf.password))
+                basic_auth=(jira_conf.username, jira_conf.password),
+                verify=settings.JIRA_SSL_VERIFY)
             j_issue = JIRA_Issue.objects.get(engagement=eng)
             issue = jira.issue(j_issue.jira_id)
             issue.update(summary=eng.name, description=eng.name)
@@ -1654,7 +1658,8 @@ def add_epic(eng, push_to_jira):
         try:
             jira = JIRA(
                 server=jira_conf.url,
-                basic_auth=(jira_conf.username, jira_conf.password))
+                basic_auth=(jira_conf.username, jira_conf.password),
+                verify=settings.JIRA_SSL_VERIFY)
             new_issue = jira.create_issue(fields=issue_dict)
             j_issue = JIRA_Issue(
                 jira_id=new_issue.id,
@@ -1678,7 +1683,8 @@ def jira_get_issue(jpkey, issue_key):
     try:
         jira = JIRA(
             server=jira_conf.url,
-            basic_auth=(jira_conf.username, jira_conf.password))
+            basic_auth=(jira_conf.username, jira_conf.password),
+            verify=settings.JIRA_SSL_VERIFY)
         issue = jira.issue(issue_key)
         # print(vars(issue))
         return issue
@@ -1703,7 +1709,8 @@ def add_comment(find, note, force_push=False):
                 try:
                     jira = JIRA(
                         server=jira_conf.url,
-                        basic_auth=(jira_conf.username, jira_conf.password))
+                        basic_auth=(jira_conf.username, jira_conf.password),
+                        verify=settings.JIRA_SSL_VERIFY)
                     j_issue = JIRA_Issue.objects.get(finding=find)
                     jira.add_comment(
                         j_issue.jira_id,
@@ -1719,7 +1726,8 @@ def add_simple_jira_comment(jira_conf, jira_issue, comment):
     try:
         jira = JIRA(
             server=jira_conf.url,
-            basic_auth=(jira_conf.username, jira_conf.password)
+            basic_auth=(jira_conf.username, jira_conf.password),
+            verify=settings.JIRA_SSL_VERIFY
         )
         jira.add_comment(
             jira_issue.jira_id, comment


### PR DESCRIPTION
Add a variable in settings to specify whether SSL certs will be verified by Jira. The default is `True` in the package used on our integration, so it will be the same in settings. Reference to the argument in their [docs](https://jira.readthedocs.io/en/latest/api.html#jira).

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.