### PR TITLE
bump Chart to v2

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.7.1"
 description: A Helm chart for Kubernetes to installs DefectDojo
 name: defectdojo


### PR DESCRIPTION
This was overlooked and needed to generate a Chart.lock instead of the requirements.lock. Without this, things are not so peachy.