### PR TITLE
Revert "Move helm deps to Chart.yaml (#3013)"

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -4,20 +4,3 @@ description: A Helm chart for Kubernetes to installs DefectDojo
 name: defectdojo
 version: 1.3.1
 icon: https://www.defectdojo.org/img/favicon.ico
-dependencies:
-  - name: mysql
-    version: 1.6.7
-    repository: "@stable"
-    condition: mysql.enabled
-  - name: postgresql
-    version: 8.6.4
-    repository: "@stable"
-    condition: postgresql.enabled
-  - name: rabbitmq
-    version: 6.18.2
-    repository: "@stable"
-    condition: rabbitmq.enabled
-  - name: redis
-    version: 10.5.7
-    repository: "@stable"
-    condition: redis.enabled

--- a/helm/defectdojo/requirements.lock
+++ b/helm/defectdojo/requirements.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: mysql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 1.6.2
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 8.1.2
+- name: rabbitmq
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 6.16.0
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 10.3.1
+digest: sha256:7a56248ce55c83f10d5e2b17628eb5e4279f93fdb53681bf205638b756f66cd7
+generated: "2020-09-14T13:56:08.501821138+02:00"

--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -1,0 +1,17 @@
+dependencies:
+  - name: mysql
+    version: 1.6.7
+    repository: "@stable"
+    condition: mysql.enabled
+  - name: postgresql
+    version: 8.6.4
+    repository: "@stable"
+    condition: postgresql.enabled
+  - name: rabbitmq
+    version: 6.18.2
+    repository: "@stable"
+    condition: rabbitmq.enabled
+  - name: redis
+    version: 10.5.7
+    repository: "@stable"
+    condition: redis.enabled


### PR DESCRIPTION
This reverts commit 082d576a12ba4e632d7237fb46eafd639f8ad790.

Reverting since `conditions` no longer work if moving to Chart v2 with dependencies in the Chart.yaml itself.