### PR TITLE
Add more findings info to engagement/test views

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -300,12 +300,12 @@ def view_engagement(request, eid):
     eng = get_object_or_404(Engagement, id=eid)
     tests = (
         Test.objects.filter(engagement=eng)
-            .prefetch_related('tagged_items__tag', 'test_type')
-            .annotate(count_findings_test_all=Count('finding__id'))
-            .annotate(count_findings_test_active_verified=Count('finding__id', filter=Q(finding__active=True)))
-            .annotate(count_findings_test_mitigated=Count('finding__id', filter=Q(finding__is_Mitigated=True)))
-            .annotate(count_findings_test_dups=Count('finding__id', filter=Q(finding__duplicate=True)))
-            .order_by('test_type__name', '-updated')
+        .prefetch_related('tagged_items__tag', 'test_type')
+        .annotate(count_findings_test_all=Count('finding__id'))
+        .annotate(count_findings_test_active_verified=Count('finding__id', filter=Q(finding__active=True)))
+        .annotate(count_findings_test_mitigated=Count('finding__id', filter=Q(finding__is_Mitigated=True)))
+        .annotate(count_findings_test_dups=Count('finding__id', filter=Q(finding__duplicate=True)))
+        .order_by('test_type__name', '-updated')
     )
 
     prod = eng.product

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -297,6 +297,7 @@ class ComponentFilter(ProductComponentFilter):
         queryset=Product_Type.objects.all().order_by('name'),
         label="Product Type")
 
+
 class EngagementFilter(DojoFilter):
     engagement__lead = ModelChoiceFilter(
         queryset=User.objects.filter(

--- a/dojo/finding/urls.py
+++ b/dojo/finding/urls.py
@@ -31,6 +31,8 @@ urlpatterns = [
         name='product_all_findings'),
     url(r'^engagement/(?P<eid>\d+)/finding/open$', views.open_findings,
         name='engagment_open_findings'),
+    url(r'^engagement/(?P<eid>\d+)/finding/closed$', views.closed_findings,
+        name='engagment_closed_findings'),
     url(r'^engagement/(?P<eid>\d+)/finding/all$', views.open_findings, {'view': 'All'},
         name='engagment_all_findings'),
     url(r'^product/(?P<pid>\d+)/finding/closed$', views.closed_findings,

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -195,6 +195,7 @@ def view_product_components(request, pid):
                     'result': result,
     })
 
+
 def identify_view(request):
     get_data = request.GET
     view = get_data.get('type', None)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -545,6 +545,7 @@ def prefetch_for_view_engagements(engs):
         prefetched_engs = prefetched_engs.prefetch_related('test_set__test_type')  # test.name uses test_type
         prefetched_engs = prefetched_engs.annotate(count_findings_all=Count('test__finding__id'))
         prefetched_engs = prefetched_engs.annotate(count_findings_open=Count('test__finding__id', filter=Q(test__finding__active=True)))
+        prefetched_engs = prefetched_engs.annotate(count_findings_close=Count('test__finding__id', filter=Q(test__finding__is_Mitigated=True)))
         prefetched_engs = prefetched_engs.annotate(count_findings_duplicate=Count('test__finding__id', filter=Q(test__finding__duplicate=True)))
         prefetched_engs = prefetched_engs.prefetch_related('tagged_items__tag')
     else:

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -588,7 +588,6 @@ INSTALLED_APPS = (
 # MIDDLEWARE
 # ------------------------------------------------------------------------------
 DJANGO_MIDDLEWARE_CLASSES = [
-    # 'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.common.CommonMiddleware',
     'dojo.middleware.DojoSytemSettingsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -29,6 +29,7 @@
                     <th>Length</th>
                     <th>Tests</th>
                     <th>Open</th>
+                    <th>Mitigated</th>
                     <th>All</th>
                     <th>Duplicate</th>
                     <th>Updated</th>
@@ -81,6 +82,11 @@
                             <li role="presentation">
                               <a href="{% url 'engagment_open_findings' eng.id %}?active=2&verified=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement={{ eng.id }}">
                                 <i class="fa fa-file-text-o"></i> View Open Findings
+                              </a>
+                            </li>
+                            <li role="presentation">
+                              <a href="{% url 'engagment_closed_findings' eng.id %}?is_Mitigated=2&test__engagement={{ eng.id }}">
+                                <i class="fa fa-file-text-o"></i> View Mitigated Findings
                               </a>
                             </li>
                             <li role="presentation">
@@ -179,6 +185,7 @@
                       </div>
                     </td>
                     <td>{{ eng.count_findings_open }}</td>
+                    <td>{{ eng.count_findings_close }}</td>
                     <td>{{ eng.count_findings_all }}</td>
                     <td>{{ eng.count_findings_duplicate }}</td>
                     <td><a target="_blank" data-toggle="tooltip" data-placement="bottom" title="{{ eng.updated|default_if_none:"" }}">
@@ -230,7 +237,7 @@
 
             // Mapping of table columns to objects for proper cleanup and data formatting
             var dojoTable = $('#{{status}}').DataTable({
-                colReorder: true,              
+                colReorder: true,
                 "columns": [
                     { "data": "action" },
                     { "data": "eng_name" },
@@ -247,7 +254,7 @@
                     {% endif %}
                 ],
                 columnDefs: [
-                    { 
+                    {
                         "orderable": false,
                         "targets": [0]
                     },

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -31,7 +31,7 @@
                     <th>Open</th>
                     <th>Mitigated</th>
                     <th>All</th>
-                    <th>Duplicate</th>
+                    <th>Duplicates</th>
                     <th>Updated</th>
                     {% if status == "paused" or status == "closed" %}
                       <th>Status</th>

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -246,6 +246,7 @@
                     { "data": "length" },
                     { "data": "tests" },
                     { "data": "open" },
+                    { "data": "mitigated" },
                     { "data": "all" },
                     { "data": "dups" },
                     { "data": "updated" },

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -304,10 +304,10 @@
                                       {{ test.lead }}
                                   {% endif %}
                                 </td>
-                                <td><a href="{% url 'view_test' test.id %}">{{ test|count_findings_test_all }}</a></td>
-                                <td><a href="{% url 'view_test' test.id %}?active=true&verified=true">{{ test|count_findings_test_active_verified }}</a></td>
-                                <td><a href="{% url 'view_test' test.id %}?is_Mitigated=true">{{ test|count_findings_test_mitigated }}</a></td>
-                                <td><a href="{% url 'view_test' test.id %}?duplicate=true">{{ test|count_findings_test_duplicate }}</a></td>
+                                <td><a href="{% url 'view_test' test.id %}">{{ test.count_findings_test_all }}</a></td>
+                                <td><a href="{% url 'view_test' test.id %}?active=true&verified=true">{{ test.count_findings_test_active_verified }}</a></td>
+                                <td><a href="{% url 'view_test' test.id %}?is_Mitigated=true">{{ test.count_findings_test_mitigated }}</a></td>
+                                <td><a href="{% url 'view_test' test.id %}?duplicate=true">{{ test.count_findings_test_dups }}</a></td>
                                 <td class="nowrap">
                                   {% if test.notes.count %}
                                     <a href="{% url 'view_test' test.id %}#vuln_notes" alt="{{ test.notes.count }} comment{{ test.notes.count|pluralize }}">

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -239,8 +239,10 @@
                             <th></th>
                             <th>Date</th>
                             <th>Lead</th>
-                            <th>Findings</th>
-                            <th>Duplicate</th>
+                            <th>Total Findings</th>
+                            <th>Active and Verified</th>
+                            <th>Mitigated</th>
+                            <th>Duplicates</th>
                             <th>Notes</th>
                         </tr>
                         </thead>
@@ -303,7 +305,9 @@
                                   {% endif %}
                                 </td>
                                 <td><a href="{% url 'view_test' test.id %}">{{ test|count_findings_test_all }}</a></td>
-                                <td>{{ test|count_findings_test_duplicate }}</td>
+                                <td><a href="{% url 'view_test' test.id %}?active=true&verified=true">{{ test|count_findings_test_active_verified }}</a></td>
+                                <td><a href="{% url 'view_test' test.id %}?is_Mitigated=true">{{ test|count_findings_test_mitigated }}</a></td>
+                                <td><a href="{% url 'view_test' test.id %}?duplicate=true">{{ test|count_findings_test_duplicate }}</a></td>
                                 <td class="nowrap">
                                   {% if test.notes.count %}
                                     <a href="{% url 'view_test' test.id %}#vuln_notes" alt="{{ test.notes.count }} comment{{ test.notes.count|pluralize }}">
@@ -391,9 +395,9 @@
     <h4>Additional Features<span class="pull-right"><a name="collapsible" data-toggle="collapse" href="#add_feat">
       <i class="glyphicon glyphicon-chevron-down"></i></a></span></h4>
   </div>
-  
+
   <div id="add_feat" class="panel-body collapse">
-    
+
     {% if eng.engagement_type == "Interactive" %}
       <div class="panel panel-default">
         <div class="panel-heading">
@@ -410,7 +414,7 @@
                       <span class="fa fa-edit"></span></a></a>
               {% endif %}
             {% endif %}
-            
+
           </h4>
         </div>
         <div id="add_feat_check_list" class="panel-body collapse">
@@ -523,7 +527,7 @@
             <i class="glyphicon glyphicon-chevron-down"></i></a></span>
         </h4>
       </div>
-      
+
       <div id="add_feat_notes" class="panel-body collapse">
         <form class="form-horizontal" action="" method="post">{% csrf_token %}
           {% include "dojo/form_fields.html" with form=form %}
@@ -579,7 +583,7 @@
                           </form>
                         </div>
                       {% endif %}
-                      
+
                       <div class="row-sm-2">
                         <strong>{{ note.author.username }}</strong>
                         <span class="text-muted">commented {{ note.date }}</span>
@@ -594,7 +598,7 @@
                         <div class="row-sm-2">
                           <span class="text-muted">(will not appear in report)</span>
                         </div>
-                      {% endif %} 
+                      {% endif %}
                   </div>
                   <div class="panel-body">
                     {% if note.note_type != None %}
@@ -608,13 +612,13 @@
             {% endfor %}
           </div>
         </div>
-        
+
       </div>
-      
+
     </div>
 
   </div>
-</div> 
+</div>
 
 <!-- Sidebar -->
 </div>

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -252,6 +252,16 @@ def count_findings_test_duplicate(test):
     duplicate_findings = Finding.objects.filter(test=test, duplicate=True).count()
     return duplicate_findings
 
+@register.filter(name='count_findings_test_mitigated')
+def count_findings_test_mitigated(test):
+    mitigated_findings = Finding.objects.filter(test=test, is_Mitigated=True).count()
+    return mitigated_findings
+
+@register.filter(name='count_findings_test_active_verified')
+def count_findings_test_active_verified(test):
+    active_verified_findings = Finding.objects.filter(test=test, active=True, verified=True).count()
+    return active_verified_findings
+
 
 @register.filter(name='paginator')
 def paginator(page):

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -253,18 +253,6 @@ def count_findings_test_duplicate(test):
     return duplicate_findings
 
 
-@register.filter(name='count_findings_test_mitigated')
-def count_findings_test_mitigated(test):
-    mitigated_findings = Finding.objects.filter(test=test, is_Mitigated=True).count()
-    return mitigated_findings
-
-
-@register.filter(name='count_findings_test_active_verified')
-def count_findings_test_active_verified(test):
-    active_verified_findings = Finding.objects.filter(test=test, active=True, verified=True).count()
-    return active_verified_findings
-
-
 @register.filter(name='paginator')
 def paginator(page):
     page_value = paginator_value(page)

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -252,10 +252,12 @@ def count_findings_test_duplicate(test):
     duplicate_findings = Finding.objects.filter(test=test, duplicate=True).count()
     return duplicate_findings
 
+
 @register.filter(name='count_findings_test_mitigated')
 def count_findings_test_mitigated(test):
     mitigated_findings = Finding.objects.filter(test=test, is_Mitigated=True).count()
     return mitigated_findings
+
 
 @register.filter(name='count_findings_test_active_verified')
 def count_findings_test_active_verified(test):


### PR DESCRIPTION
Addresses https://github.com/DefectDojo/django-DefectDojo/issues/3001

I always find myself wondering how many mitigated findings or active/verified are in the engagements when looking at a glance.
With so many CI/CD imports, at a glance look become important.

This PR adds a couple columns when viewing engagements,

![image](https://user-images.githubusercontent.com/5468769/96348800-ae05cd80-10ab-11eb-99f1-939b09b9ae2c.png)

and drilling to tests

![image](https://user-images.githubusercontent.com/5468769/96348820-d097e680-10ab-11eb-865f-2dda01c4a066.png)


- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.

