### PR TITLE
title: suppress superfluous log lines

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -849,6 +849,13 @@ LOGGING = {
             'propagate': False,
         },
         'MARKDOWN': {
+            # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
+            'handlers': ['console'],
+            'level': 'WARNING',
+            'propagate': False,
+        },
+        'titlecase': {
+            # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
             'handlers': ['console'],
             'level': 'WARNING',
             'propagate': False,


### PR DESCRIPTION
Do you also NOT like this log line appearing everywhere? 
```
No config file found at /home/john_doe/.titlecase.txt
```

This PR suppresses that.