### PR TITLE
view_test: fix javascript for bulk edit enablement

### DIFF
--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -736,6 +736,87 @@
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
+        // DataTables setup
+        $(document).ready(function(){
+            date =  new Date().toISOString().slice(0, 10);
+            var fileDated = 'Findings_List_' + date;
+            var buttonCommon = {
+                exportOptions: {
+                    columns: ':not(:eq(8))',
+                    stripHtml: true,
+                    stripNewlines: true,
+                    trim: true,
+                    orthogonal: 'export'
+                },
+                filename: fileDated,
+                title: 'Findings List'
+            };
+
+            // Mapping of table columns to objects for proper cleanup and data formatting
+            var dojoTable = $('#test_findings').DataTable({
+                drawCallback: function(){
+                    $('.has-popover').popover({'trigger':'hover'});
+                },
+                colReorder: true,
+                "columns": [
+                    {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}                    
+                    { "data": "dropdown" },
+                    {% endif %}
+                    { "data": "action" },
+                    { "data": "severity" },
+                    { "data": "name" },
+                    { "data": "cwe" },
+                    { "data": "date" },
+                    { "data": "age" },
+                    {% if system_settings.enable_finding_sla %}
+                        { "data": "sla" },
+                    {% endif %}
+                    { "data": "reporter" },
+                    { "data": "status" },
+                    {% if system_settings.enable_jira %}
+                        {% if jira_config and product_tab or not product_tab %}
+                            { "data": "jira" },
+                            { "data": "jira_age" },
+                            { "data": "jira_change" },
+                        {% endif %}
+                    {% endif %}
+                ],
+                columnDefs: [
+                    { 
+                        "orderable": false,
+                        "targets": [0]
+                    },
+                ],
+                dom: 'Bfrtip',
+                paging: false,
+                buttons: [
+                    {
+                        extend: 'colvis',
+                        columns: ':not(.noVis)'
+                    },
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'copy'
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'excel',
+                        autoFilter: true,
+                        sheetName: 'Exported data',
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'csv'
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'pdf',
+                        orientation: 'landscape',
+                        pageSize: 'LETTER'
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'print'
+                    }),
+                ],
+            });
+        });
+
         $(function () {
           $(".chosen-select").chosen({
             'placeholder_text_multiple': 'Select or add some tags...',
@@ -805,36 +886,36 @@
               $('.table-responsive').css( "overflow", "auto" );
             })
             $('input[type="checkbox"]').change(function () {
-              checkbox_count = 0;
-              finding = $(this).attr("name");
-              if (finding.indexOf("select_") >= 0)
-              {
-                var checkbox_values = $("input[type=checkbox][name^='select_']");
-                for (var i = 0; i < checkbox_values.length; i++) {
-                  if ($(checkbox_values[i]).prop("checked")) {
-                    checkbox_count++;
-                  }
-                }
-
-                if ($(this).prop("checked")) {
-                  $('div#bulk_edit_menu').removeClass('hidden');
-                } else {
-                  checkbox_count--;
+                checkbox_count = 0;
+                finding = $(this).attr("name");
+                if (finding.indexOf("select_") >= 0)
+                {
                   var checkbox_values = $("input[type=checkbox][name^='select_']");
-                  var checked = false;
-
                   for (var i = 0; i < checkbox_values.length; i++) {
                     if ($(checkbox_values[i]).prop("checked")) {
-                      checked = true;
+                      checkbox_count++;
                     }
                   }
-                  if (checked == false) {
-                    $('div#bulk_edit_menu').addClass('hidden');
+  
+                  if ($(this).prop("checked")) {
+                    $('div#bulk_edit_menu').removeClass('hidden');
+                  } else {
+                    checkbox_count--;
+                    var checkbox_values = $("input[type=checkbox][name^='select_']");
+                    var checked = false;
+  
+                    for (var i = 0; i < checkbox_values.length; i++) {
+                      if ($(checkbox_values[i]).prop("checked")) {
+                        checked = true;
+                      }
+                    }
+                    if (checked == false) {
+                      $('div#bulk_edit_menu').addClass('hidden');
+                    }
                   }
+  
                 }
-
-              }
-            });
+              });
             $('a.merge').on('click', function (e) {
               if (checkbox_count > 1)
               {
@@ -994,86 +1075,6 @@
 
         });
 
-        // DataTables setup
-        $(document).ready(function(){
-            date =  new Date().toISOString().slice(0, 10);
-            var fileDated = 'Findings_List_' + date;
-            var buttonCommon = {
-                exportOptions: {
-                    columns: ':not(:eq(8))',
-                    stripHtml: true,
-                    stripNewlines: true,
-                    trim: true,
-                    orthogonal: 'export'
-                },
-                filename: fileDated,
-                title: 'Findings List'
-            };
-
-            // Mapping of table columns to objects for proper cleanup and data formatting
-            var dojoTable = $('#test_findings').DataTable({
-                drawCallback: function(){
-                    $('.has-popover').popover({'trigger':'hover'});
-                },
-                colReorder: true,
-                "columns": [
-                    {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}                    
-                    { "data": "dropdown" },
-                    {% endif %}
-                    { "data": "action" },
-                    { "data": "severity" },
-                    { "data": "name" },
-                    { "data": "cwe" },
-                    { "data": "date" },
-                    { "data": "age" },
-                    {% if system_settings.enable_finding_sla %}
-                        { "data": "sla" },
-                    {% endif %}
-                    { "data": "reporter" },
-                    { "data": "status" },
-                    {% if system_settings.enable_jira %}
-                        {% if jira_config and product_tab or not product_tab %}
-                            { "data": "jira" },
-                            { "data": "jira_age" },
-                            { "data": "jira_change" },
-                        {% endif %}
-                    {% endif %}
-                ],
-                columnDefs: [
-                    { 
-                        "orderable": false,
-                        "targets": [0]
-                    },
-                ],
-                dom: 'Bfrtip',
-                paging: false,
-                buttons: [
-                    {
-                        extend: 'colvis',
-                        columns: ':not(.noVis)'
-                    },
-                    $.extend( true, {}, buttonCommon, {
-                        extend: 'copy'
-                    }),
-                    $.extend( true, {}, buttonCommon, {
-                        extend: 'excel',
-                        autoFilter: true,
-                        sheetName: 'Exported data',
-                    }),
-                    $.extend( true, {}, buttonCommon, {
-                        extend: 'csv'
-                    }),
-                    $.extend( true, {}, buttonCommon, {
-                        extend: 'pdf',
-                        orientation: 'landscape',
-                        pageSize: 'LETTER'
-                    }),
-                    $.extend( true, {}, buttonCommon, {
-                        extend: 'print'
-                    }),
-                ],
-            });
-        });
     </script>
     {% include "dojo/filter_js_snippet.html" %}    
 {% endblock %}


### PR DESCRIPTION
fixes #3027 
The javascript for the bulk edit menu was lagging behind the javascript being used by findings_list.html.
But the real cause was that datatables need to initialized before assigning any listeners to the checkboxes.

hopefully one day somebody will get rid of the view_test.html generating it's own table and just reuse findings_list.html :-)