### PR TITLE
Kubernetes liveness and readiness improvement

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -10,4 +10,5 @@ exec uwsgi \
   --threads ${DD_UWSGI_NUM_OF_THREADS:-2} \
   --wsgi dojo.wsgi:application \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-4096}" \
+  # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a serivce.
   --http 0.0.0.0:8081 --http-to ${DD_UWSGI_ENDPOINT}

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -9,4 +9,5 @@ exec uwsgi \
   --processes ${DD_UWSGI_NUM_OF_PROCESSES:-2} \
   --threads ${DD_UWSGI_NUM_OF_THREADS:-2} \
   --wsgi dojo.wsgi:application \
-  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-4096}"
+  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-4096}" \
+  --http 0.0.0.0:8081 --http-to ${DD_UWSGI_ENDPOINT}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -92,19 +92,20 @@ spec:
           value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
         - name: DD_CSRF_COOKIE_SECURE
           value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
+        {{- if .Values.django.uwsgi.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
             path: /login?next=/
             port: http
-            {{- if .Values.django.nginx.tls.enabled }}
-            scheme: HTTPS
-            {{- end }}
             httpHeaders:
             - name: Host
               value: {{ .Values.host }}
-          initialDelaySeconds: 120
-          periodSeconds: 10
-          failureThreshold: 6
+          failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold | default 6 }}
+          initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds | default 120 }}
+          periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds | default 10 }}
+          successThreshold: {{ .Values.django.uwsgi.livenessProbe.successThreshold | default 1 }}
+          timeoutSeconds: {{ .Values.django.uwsgi.livenessProbe.timeoutSeconds | default 5 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.django.uwsgi.resources | nindent 10 }}
       - name: nginx
@@ -143,6 +144,7 @@ spec:
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 6
+        {{- if .Values.django.uwsgi.livenessProbe.enabled }}
         readinessProbe:
           httpGet:
             path: /uwsgi_health
@@ -153,9 +155,12 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ .Values.host }}
-          initialDelaySeconds: 120
-          periodSeconds: 10
-          failureThreshold: 12
+          failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold | default 6 }}
+          initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds | default 120 }}
+          periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds | default 10 }}
+          successThreshold: {{ .Values.django.uwsgi.livenessProbe.successThreshold | default 1 }}
+          timeoutSeconds: {{ .Values.django.uwsgi.livenessProbe.timeoutSeconds | default 5 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.django.nginx.resources | nindent 10 }}
       {{- with .Values.django.nodeSelector }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -52,6 +52,10 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run/defectdojo
+        ports:
+        - name: http
+          protocol: TCP
+          containerPort: 8081
         envFrom:
         - configMapRef:
             name: {{ $fullName }}
@@ -88,6 +92,19 @@ spec:
           value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
         - name: DD_CSRF_COOKIE_SECURE
           value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /login?next=/
+            port: http
+            {{- if .Values.django.nginx.tls.enabled }}
+            scheme: HTTPS
+            {{- end }}
+            httpHeaders:
+            - name: Host
+              value: {{ .Values.host }}
+          initialDelaySeconds: 120
+          periodSeconds: 10
+          failureThreshold: 6
         resources:
           {{- toYaml .Values.django.uwsgi.resources | nindent 10 }}
       - name: nginx
@@ -115,7 +132,7 @@ spec:
           value: '{{ .Values.django.nginx.tls.generateCertificate }}'
         livenessProbe:
           httpGet:
-            path: /
+            path: /nginx_health
             port: http
             {{- if .Values.django.nginx.tls.enabled }}
             scheme: HTTPS
@@ -123,12 +140,12 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ .Values.host }}
-          initialDelaySeconds: 120
+          initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 6
         readinessProbe:
           httpGet:
-            path: /
+            path: /uwsgi_health
             port: http
             {{- if .Values.django.nginx.tls.enabled }}
             scheme: HTTPS

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -100,11 +100,11 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ .Values.host }}
-          failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold | default 6 }}
-          initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds | default 120 }}
-          periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds | default 10 }}
-          successThreshold: {{ .Values.django.uwsgi.livenessProbe.successThreshold | default 1 }}
-          timeoutSeconds: {{ .Values.django.uwsgi.livenessProbe.timeoutSeconds | default 5 }}
+          failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.django.uwsgi.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.django.uwsgi.livenessProbe.timeoutSeconds }}
         {{- end }}
         resources:
           {{- toYaml .Values.django.uwsgi.resources | nindent 10 }}
@@ -155,11 +155,11 @@ spec:
             httpHeaders:
             - name: Host
               value: {{ .Values.host }}
-          failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold | default 6 }}
-          initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds | default 120 }}
-          periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds | default 10 }}
-          successThreshold: {{ .Values.django.uwsgi.livenessProbe.successThreshold | default 1 }}
-          timeoutSeconds: {{ .Values.django.uwsgi.livenessProbe.timeoutSeconds | default 5 }}
+          failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold }}
+          initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.django.uwsgi.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.django.uwsgi.livenessProbe.timeoutSeconds }}
         {{- end }}
         resources:
           {{- toYaml .Values.django.nginx.resources | nindent 10 }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -106,11 +106,11 @@ django:
     livenessProbe:
       # Enable liveness checks on uwsgi container. Those values are use on nginx readiness checks as well.
       enabled: true
-      # failureThreshold: 2s
-      # initialDelaySeconds: 120
-      # periodSeconds: 5
-      # successThreshold: 1
-      # timeoutSeconds: 3
+      failureThreshold: 6
+      initialDelaySeconds: 120
+      periodSeconds: 10
+      successThreshold: 1
+      timeoutSeconds: 5
     resources:
       requests:
         cpu: 100m

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -103,6 +103,14 @@ django:
   replicas: 1
   tolerations: []
   uwsgi:
+    livenessProbe:
+      # Enable liveness checks on uwsgi container. Those values are use on nginx readiness checks as well.
+      enabled: true
+      # failureThreshold: 2s
+      # initialDelaySeconds: 120
+      # periodSeconds: 5
+      # successThreshold: 1
+      # timeoutSeconds: 3
     resources:
       requests:
         cpu: 100m

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -57,6 +57,7 @@ http {
     }
     # Used by Kuebernetes readiness checks
     location = /uwsgi_health {
+      limit_except GET { deny all; }
       rewrite /.+ /login?next=/ break;
       include /run/defectdojo/uwsgi_pass;
       include /etc/nginx/wsgi_params;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -50,6 +50,19 @@ http {
       #stub_status  on;
       access_log   off;
     }
+    # Used by Kubernetes liveness checks
+    location = /nginx_health {
+      return 200 "Born to be alive!\n";
+      access_log off;
+    }
+    # Used by Kuebernetes readiness checks
+    location = /uwsgi_health {
+      rewrite /.+ /login?next=/ break;
+      include /run/defectdojo/uwsgi_pass;
+      include /etc/nginx/wsgi_params;
+      access_log off;
+    }
+
 
     error_page 500 502 503 504 /50x.html;
   }

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -113,6 +113,17 @@ http {
       # redirects, we set the Host: header above already.
       proxy_redirect off;
     }
+    # Used by Kubernetes liveness and readiness checks
+    location = /nginx_health {
+      return 200 "Born to be alive!\n";
+      access_log off;
+    }
+    location = /uwsgi_health {
+      rewrite /.+ /login?next=/ break;
+      include /run/defectdojo/uwsgi_pass;
+      include /etc/nginx/wsgi_params;
+      access_log off;
+    }
     error_page 500 502 503 504 /50x.html;
   }
 }

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -119,6 +119,7 @@ http {
       access_log off;
     }
     location = /uwsgi_health {
+      limit_except GET { deny all; }
       rewrite /.+ /login?next=/ break;
       include /run/defectdojo/uwsgi_pass;
       include /etc/nginx/wsgi_params;


### PR DESCRIPTION
The current liveness and readiness checks are done on the nginx container which proxy to uswgi. If uwsgi hangs or is overloaded, only the nginx container is restarted.

This PR correct this by doing the following:
* nginx: Check the liveness of nginx by using a dummy endpoint. This will avoid nginx getting restarted because of uwsgi failure.
* nginx: Check the readiness by checking the availability of uwsgi. In case of uwsgi failure, nginx will be removed from the loadbalancer but won't be restarted.
* uwsgi: Enabled the http server and check the availability of uwsgi. In case of failure, uwsgi will be restarted. There is no point to do readiness on this container since there is no service for it.