### PR TITLE
Modify uwsgi entrypoint to allow for overriding settings.py

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# Allow for bind-mount setting.py overrides
+FILE=/settings/settings.py
+if test -f "$FILE"; then
+    echo "============================================================"
+    echo "     Overriding DefectDojo's settings.py with $FILE."
+    echo "============================================================"
+    cp "$FILE" /app/dojo/settings/settings.py
+fi
+
 umask 0002
 
 exec uwsgi \


### PR DESCRIPTION
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [N/A ] Your code is flake8 compliant.
- [N/A ] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [N/A] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [N/A] Add applicable tests to the unit tests.
- [X] Add the proper label to categorize your PR.

This minor enhancement adds an if statement to the existing entrypoint_uswgi.sh to allow the settings file in a container to be overridden by one that is bind mounted or otherwise injected into the container at /settings/.  If the uwsgi container is started with the path /settings/settings.py, that settings.py file will overwrite the one 'baked" into the Docker container.

Note: If you don't inject a file at /settings/settings.py via a bind mount or similar, there is no change to the current behaviour for the uwsgi container so this will not break any existing container deployments. 

This was originally created to work around a bug in django-environ where the conversion of a Bash environmental variable to a complex Python Dict failed.  However, it can be useful in other ways as well such as:
* allowing easy direct editing of settings.py from outside the container
* quickly editing/testing changes to settings.py
* For CI/CD, re-using the same docker-compose for multiple changes to settings.py
* that cool thing you think of :-)

This was tested with the following bind mount for the uwsgi container using docker-compose:

```
      - type: bind
        source: /opt/dojo/settings
        target: /settings
```
where 
```
$ ls /opt/dojo/settings
settings.py
```