### PR TITLE
Add configurable SAML2 logout endpoint

### DIFF
--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -10,7 +10,8 @@ def globalize_oauth_vars(request):
             'OKTA_ENABLED': settings.OKTA_OAUTH_ENABLED,
             'GITLAB_ENABLED': settings.GITLAB_OAUTH2_ENABLED,
             'AZUREAD_TENANT_OAUTH2_ENABLED': settings.AZUREAD_TENANT_OAUTH2_ENABLED,
-            'SAML2_ENABLED': settings.SAML2_ENABLED, }
+            'SAML2_ENABLED': settings.SAML2_ENABLED,
+            'SAML2_LOGOUT_URL': settings.SAML2_LOGOUT_URL}
 
 
 def bind_system_settings(request):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -101,6 +101,7 @@ env = environ.Env(
     DD_SAML2_METADATA_LOCAL_FILE_PATH=(str, ''),
     DD_SAML2_ASSERTION_URL=(str, ''),
     DD_SAML2_ENTITY_ID=(str, ''),
+    DD_SAML2_LOGOUT_URL=(str, ''),
     DD_SAML2_DEFAULT_NEXT_URL=(str, '/dashboard'),
     DD_SAML2_NEW_USER_PROFILE=(dict, {
         # The default group name when a new user logs in
@@ -376,6 +377,7 @@ SOCIAL_AUTH_TRAILING_SLASH = env('DD_SOCIAL_AUTH_TRAILING_SLASH')
 # For more configuration and customization options, see django-saml2-auth documentation
 # https://github.com/fangli/django-saml2-auth
 SAML2_ENABLED = env('DD_SAML2_ENABLED')
+SAML2_LOGOUT_URL = env('DD_SAML2_LOGOUT_URL')
 SAML2_AUTH = {
     'ASSERTION_URL': env('DD_SAML2_ASSERTION_URL'),
     'ENTITY_ID': env('DD_SAML2_ENTITY_ID'),

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -160,6 +160,9 @@
                             {% endif %}
                         {% endblock %}
                         {% if request.user.is_authenticated %}
+                            {% if SAML2_LOGOUT_URL != '' %}
+                                <li><a href="{{ SAML2_LOGOUT_URL }}"><i class="fa fa-sign-out fa-fw"></i>SAML Logout</a></li>
+                            {% endif %}
                             <li><a href="{% url 'logout' %}"><i class="fa fa-sign-out fa-fw"></i> Logout</a></li>
                         {% endif %}
                     </ul>


### PR DESCRIPTION
The SAML package we use does not have a logout endpoint that does anything worthwhile. This additional setting allows IdP logout endpoints to be leveraged. If the setting is specified, an additional logout button will be available with that link.

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ x] Add the proper label to categorize your PR.