### PR TITLE
upgrade to drf_yasg2 which is needed for django rest framework 3.12 and higher

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -7,7 +7,7 @@ from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from django_filters.rest_framework import DjangoFilterBackend
-from drf_yasg.utils import swagger_auto_schema, no_body
+from drf_yasg2.utils import swagger_auto_schema, no_body
 import base64
 from dojo.engagement.services import close_engagement, reopen_engagement
 from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \

--- a/dojo/risk_acceptance/api.py
+++ b/dojo/risk_acceptance/api.py
@@ -7,7 +7,7 @@ from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
-from drf_yasg.utils import swagger_auto_schema
+from drf_yasg2.utils import swagger_auto_schema
 
 from dojo.api_v2.serializers import RiskAcceptanceSerializer
 from dojo.models import Engagement, Risk_Acceptance, User

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -588,7 +588,7 @@ INSTALLED_APPS = (
     # 'axes'
     'django_celery_results',
     'social_django',
-    'drf_yasg',
+    'drf_yasg2',
 )
 
 # ------------------------------------------------------------------------------

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -7,8 +7,8 @@ from tastypie_swagger.views import SwaggerView, ResourcesView, SchemaView
 from rest_framework.routers import DefaultRouter
 from rest_framework.authtoken import views as tokenviews
 from rest_framework import permissions
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
+from drf_yasg2.views import get_schema_view
+from drf_yasg2 import openapi
 from django.http import HttpResponse
 import django_saml2_auth.views
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ django-tastypie==0.14.2
 django-watson==1.5.5
 django-prometheus==2.1.0
 Django==2.2.16
-djangorestframework==3.11.1
+djangorestframework==3.12.1
 gunicorn==20.0.4
 html2text==2020.1.16
 humanize==3.0.1
@@ -57,7 +57,7 @@ ptvsd>=4.2.7
 google-auth==1.22.1
 google-api-python-client==1.12.3
 google-auth-oauthlib==0.4.1
-drf_yasg==1.17.1
+drf_yasg2==1.19.2
 jsonlines==1.2.0  # requred by yarn audit parser
 django-saml2-auth==2.2.1
 cpe==1.2.1


### PR DESCRIPTION
upgrade to drf-yaswg2 which is needed for django rest framework 3.12 and higher, see #2925 and linked PRs their from libraries.