### PR TITLE
 Product : Retrieving related object with single request

### DIFF
--- a/docker-compose.override.https.yml
+++ b/docker-compose.override.https.yml
@@ -6,8 +6,8 @@ services:
       USE_TLS: 'true'
       GENERATE_TLS_CERTIFICATE: 'true'
     ports:
-      - target: ${DD_PORT:-8443}
-        published: ${DD_PORT:-8443}
+      - target: 8443
+        published: ${DD_TLS_PORT:-8443}
         protocol: tcp
         mode: host
   uwsgi:

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -320,15 +320,18 @@ class NoteTypeSerializer(serializers.ModelSerializer):
         model = Note_Type
         fields = '__all__'
 
+
 class ProductTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Product_Type
         fields = '__all__'
 
+
 class RegulationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Regulation
         fields = '__all__'
+
 
 class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
     findings_count = serializers.SerializerMethodField()
@@ -358,7 +361,7 @@ class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
         rep = super().to_representation(instance)
         params = self.context["request"].GET
 
-        if not "expand" in params:
+        if "expand" not in params:
             return rep
 
         fields = params["expand"].split(",")

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -320,6 +320,15 @@ class NoteTypeSerializer(serializers.ModelSerializer):
         model = Note_Type
         fields = '__all__'
 
+class ProductTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product_Type
+        fields = '__all__'
+
+class RegulationSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Regulation
+        fields = '__all__'
 
 class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
     findings_count = serializers.SerializerMethodField()
@@ -327,6 +336,15 @@ class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
 
     tags = TagListSerializerField(required=False)
     product_meta = ProductMetaSerializer(read_only=True, many=True)
+
+    _expansion_serializers = {
+        "technical_contact": UserSerializer(read_only=True),
+        "product_manager": UserSerializer(read_only=True),
+        "team_manager": UserSerializer(read_only=True),
+        "prod_type": ProductTypeSerializer(read_only=True),
+        "authorized_users": UserSerializer(read_only=True, many=True),
+        "regulations": RegulationSerializer(read_only=True, many=True)
+    }
 
     class Meta:
         model = Product
@@ -336,20 +354,27 @@ class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
             'authorized_users': {'queryset': User.objects.exclude(is_staff=True).exclude(is_active=False)}
         }
 
+    def to_representation(self, instance):
+        rep = super().to_representation(instance)
+        params = self.context["request"].GET
+
+        if not "expand" in params:
+            return rep
+
+        fields = params["expand"].split(",")
+        for field in fields:
+            if field in rep and not rep[field] is None:
+                if field in self._expansion_serializers:
+                    rep.pop(field)
+                    rep[field] = self._expansion_serializers[field].to_representation(getattr(instance, field))
+
+        return rep
+
     def get_findings_count(self, obj):
         return obj.findings_count
 
     def get_findings_list(self, obj):
         return obj.open_findings_list()
-
-
-class ProductTypeSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Product_Type
-        fields = '__all__'
-        extra_kwargs = {
-            'authorized_users': {'queryset': User.objects.exclude(is_staff=True).exclude(is_active=False)}
-        }
 
 
 class EngagementSerializer(TaggitSerializer, serializers.ModelSerializer):
@@ -386,12 +411,6 @@ class AppAnalysisSerializer(serializers.ModelSerializer):
 class ToolTypeSerializer(serializers.ModelSerializer):
     class Meta:
         model = Tool_Type
-        fields = '__all__'
-
-
-class RegulationSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Regulation
         fields = '__all__'
 
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -571,19 +571,21 @@ class DojoMetaViewSet(mixins.ListModelMixin,
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'product', 'endpoint', 'name', 'finding')
 
+
 def _product_expand_decorator():
     return swagger_auto_schema(
-    responses={status.HTTP_200_OK: serializers.ProductSerializer},
-    manual_parameters=[
-        openapi.Parameter(
-            name="expand", 
-            in_=openapi.IN_QUERY, 
-            description="Fields to expand based on their relation", 
-            type=openapi.TYPE_ARRAY, 
-            items=openapi.Items(
-                type=openapi.TYPE_STRING,
-                enum=list(serializers.ProductSerializer._expansion_serializers.keys())))
-    ])
+        responses={status.HTTP_200_OK: serializers.ProductSerializer},
+        manual_parameters=[
+            openapi.Parameter(
+                name="expand",
+                in_=openapi.IN_QUERY,
+                description="Fields to expand based on their relation",
+                type=openapi.TYPE_ARRAY,
+                items=openapi.Items(
+                    type=openapi.TYPE_STRING,
+                    enum=list(serializers.ProductSerializer._expansion_serializers.keys())))
+        ])
+
 
 @method_decorator(name="list", decorator=_product_expand_decorator())
 @method_decorator(name="retrieve", decorator=_product_expand_decorator())

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -580,7 +580,9 @@ def _product_expand_decorator():
             in_=openapi.IN_QUERY, 
             description="Fields to expand based on their relation", 
             type=openapi.TYPE_ARRAY, 
-            items=openapi.Items(openapi.TYPE_STRING))
+            items=openapi.Items(
+                type=openapi.TYPE_STRING,
+                enum=list(serializers.ProductSerializer._expansion_serializers.keys())))
     ])
 
 @method_decorator(name="list", decorator=_product_expand_decorator())

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -7,7 +7,9 @@ from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from django_filters.rest_framework import DjangoFilterBackend
+from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema, no_body
+from drf_yasg import openapi
 import base64
 from dojo.engagement.services import close_engagement, reopen_engagement
 from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Finding, \
@@ -569,7 +571,20 @@ class DojoMetaViewSet(mixins.ListModelMixin,
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'product', 'endpoint', 'name', 'finding')
 
+def _product_expand_decorator():
+    return swagger_auto_schema(
+    responses={status.HTTP_200_OK: serializers.ProductSerializer},
+    manual_parameters=[
+        openapi.Parameter(
+            name="expand", 
+            in_=openapi.IN_QUERY, 
+            description="Fields to expand based on their relation", 
+            type=openapi.TYPE_ARRAY, 
+            items=openapi.Items(openapi.TYPE_STRING))
+    ])
 
+@method_decorator(name="list", decorator=_product_expand_decorator())
+@method_decorator(name="retrieve", decorator=_product_expand_decorator())
 class ProductViewSet(mixins.ListModelMixin,
                      mixins.RetrieveModelMixin,
                      mixins.CreateModelMixin,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -821,6 +821,9 @@ LOGGING = {
         'simple': {
             'format': '%(levelname)s %(funcName)s %(lineno)d %(message)s'
         },
+        'json': {
+            '()': 'json_log_formatter.JSONFormatter',
+        },
     },
     'filters': {
         'require_debug_false': {
@@ -839,6 +842,11 @@ LOGGING = {
         'console': {
             'class': 'logging.StreamHandler',
         },
+        'json_console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'json'
+        },
     },
     'loggers': {
         'django.request': {
@@ -847,11 +855,15 @@ LOGGING = {
             'propagate': True,
         },
         'dojo': {
+            # specify 'json_console' to get jsonify logs (or both at once)
+            # 'handlers': ['json_console'],
             'handlers': ['console'],
             'level': 'INFO',
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
+            # specify 'json_console' to get jsonify logs (or both at once)
+            # 'handlers': ['json_console'],
             'handlers': ['console'],
             'level': 'INFO',
             'propagate': False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ django-saml2-auth==2.2.1
 cpe==1.2.1
 packageurl-python==0.9.3
 django-crum==0.7.7
+JSON-log-formatter==0.3.0


### PR DESCRIPTION
This feature is related to the discussion at : https://github.com/DefectDojo/django-DefectDojo/issues/3018

Add a new query parameter to the endpoints for product retrieval (list/retrieve) that allow the automatic expansion of the relational fields. More specifically, the endpoints can now be called with :

- `/products/?expand={array_of_fields_to_expand}`
- `/products/{id}/?expand={array_of_fields_to_expand}`

The fields to expand are provided as a comma-separated array of strings. Upon receiving the parameters, the `ProductSerializers` will try to follow the relations of the fields specified. If a field is not a relation or not existent in the model, it will simply be ignored without error to preserve the original behavior of the endpoint.

As an example, a `Product` is related to a set of regulations and a user for the technical contact. Both of these fields can be expanded by calling the endpoint

`/products/?expand=regulations,technical_contact`

This new parameter has been documented to be included in the swagger documentation.
