### PR TITLE
Add json logging to Django

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -821,6 +821,9 @@ LOGGING = {
         'simple': {
             'format': '%(levelname)s %(funcName)s %(lineno)d %(message)s'
         },
+        'json': {
+            '()': 'json_log_formatter.JSONFormatter',
+        },
     },
     'filters': {
         'require_debug_false': {
@@ -839,6 +842,11 @@ LOGGING = {
         'console': {
             'class': 'logging.StreamHandler',
         },
+        'json_console': {
+            'level': 'INFO',
+            'class': 'logging.StreamHandler',
+            'formatter': 'json'
+        },
     },
     'loggers': {
         'django.request': {
@@ -847,11 +855,15 @@ LOGGING = {
             'propagate': True,
         },
         'dojo': {
+            # specify 'json_console' to get jsonify logs (or both at once)
+            # 'handlers': ['json_console'],
             'handlers': ['console'],
             'level': 'INFO',
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
+            # specify 'json_console' to get jsonify logs (or both at once)
+            # 'handlers': ['json_console'],
             'handlers': ['console'],
             'level': 'INFO',
             'propagate': False,

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,3 +63,4 @@ django-saml2-auth==2.2.1
 cpe==1.2.1
 packageurl-python==0.9.3
 django-crum==0.7.7
+JSON-log-formatter==0.3.0


### PR DESCRIPTION
For monitoring purposes and automatic tokenization by logging systems, the json format is much better.
This PR introduces the ability to turn on JSON logging instead of/in parallel of standard console logging.

As the requirement will be in there, users can also tweak the `LOGGING` variable to their liking.


When submitting a pull request, please make sure you have completed the following checklist:

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.