### PR TITLE
Allow to load extra fixtures in docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,3 @@
 .gitignore
 *.md
 .env*
-docker/certs/readme.txt
-docker/extra_fixtures/readme.txt

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,10 @@ Pipfile*
 docker/certs/*
 !docker/certs/readme.txt
 
+#ignore locally added extra fixtures
+docker/extra_fixtures/*
+!docker/extra_fixtures/readme.txt
+
 # Helm dependencies
 helm/defectdojo/charts
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -49,6 +49,7 @@ or
 docker-compose build nginx
 ```
 
+> **_NOTE:_**  It's possible to add extra fixtures in folder "/docker/extra_fixtures".
 
 ## Run with Docker compose in release mode
 To run the application based on previously built image (or based on dockerhub images if none was locally built), run: 

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -80,6 +80,8 @@ RUN \
   cp dojo/settings/settings.dist.py dojo/settings/settings.py
 COPY tests/ ./tests/
 RUN \
+  rm -f /readme.txt && \
+  rm -f dojo/fixtures/readme.txt && \
   mkdir -p dojo/migrations && \
   chmod g=u dojo/migrations && \
   true

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -71,12 +71,17 @@ COPY \
   /
 COPY wsgi.py manage.py tests/unit-tests.sh ./
 COPY dojo/ ./dojo/
+
+# Add extra fixtures to docker image which are loaded by the initializer
+COPY docker/extra_fixtures/* /app/dojo/fixtures/
+
 # Legacy installs need the modified settings.py, do not remove!
 RUN \
   cp dojo/settings/settings.dist.py dojo/settings/settings.py
 COPY tests/ ./tests/
 RUN \
   rm -f /readme.txt && \
+  rm -f dojo/fixtures/readme.txt && \
   mkdir -p dojo/migrations && \
   chmod g=u dojo/migrations && \
   true

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -80,7 +80,9 @@ RUN \
   cp dojo/settings/settings.dist.py dojo/settings/settings.py
 COPY tests/ ./tests/
 RUN \
-  rm -f /readme.txt && \
+  # Remove placeholder copied from docker/certs
+  rm -f /readme.txt && \ 
+  # Remove placeholder copied from docker/extra_fixtures
   rm -f dojo/fixtures/readme.txt && \
   mkdir -p dojo/migrations && \
   chmod g=u dojo/migrations && \

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -65,6 +65,13 @@ EOD
   python3 manage.py loaddata regulation
   python3 manage.py import_surveys
   python3 manage.py loaddata initial_surveys
+
+  # If there is extra fixtures, load them
+  for i in $(ls dojo/fixtures/extra_*.json 2>/dev/null) ; do
+    echo "Loading $i"
+    python3 manage.py loaddata ${i%.*}
+  done
+
   python3 manage.py installwatson
   exec python3 manage.py buildwatson
 fi

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -67,7 +67,7 @@ EOD
   python3 manage.py loaddata initial_surveys
 
   # If there is extra fixtures, load them
-  for i in $(ls dojo/fixtures/extra_*.json 2>/dev/null) ; do
+  for i in $(ls dojo/fixtures/extra_*.json | sort -n 2>/dev/null) ; do
     echo "Loading $i"
     python3 manage.py loaddata ${i%.*}
   done

--- a/docker/extra_fixtures/readme.txt
+++ b/docker/extra_fixtures/readme.txt
@@ -1,2 +1,7 @@
 Extra JSON fixtures in this folder will be added to /app/dojo/fixtures and will be automatically loaded by the initializer.
 Files must be prefixed with "extra_" to avoid conflicts with existing default fixtures.
+
+You can define the loading order by adding some numbers to filename:
+- extra_001_fixture.json
+- extra_002_fixture.json
+- extra_003_fixture.json

--- a/docker/extra_fixtures/readme.txt
+++ b/docker/extra_fixtures/readme.txt
@@ -1,0 +1,2 @@
+Extra JSON fixtures in this folder will be added to /app/dojo/fixtures and will be automatically loaded by the initializer.
+Files must be prefixed with "extra_" to avoid conflicts with existing default fixtures.


### PR DESCRIPTION
This PR allows user to add their own fixtures to docker image that are automatically loaded by the initializer.

- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
