### PR TITLE
Add DD_LOGGING_FORMAT variable, celery logger section

### DIFF
--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -1,6 +1,6 @@
-
 import os
 from celery import Celery
+from celery.signals import setup_logging
 from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
@@ -11,6 +11,12 @@ app = Celery('dojo')
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings', namespace='CELERY')
+
+
+@setup_logging.connect
+def config_loggers(*args, **kwags):
+    from logging.config import dictConfig
+    dictConfig(settings.LOGGING)
 
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 

--- a/dojo/celery.py
+++ b/dojo/celery.py
@@ -12,15 +12,15 @@ app = Celery('dojo')
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
-
-@setup_logging.connect
-def config_loggers(*args, **kwags):
-    from logging.config import dictConfig
-    dictConfig(settings.LOGGING)
-
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 
 @app.task(bind=True)
 def debug_task(self):
     print(('Request: {0!r}'.format(self.request)))
+
+
+@setup_logging.connect
+def config_loggers(*args, **kwags):
+    from logging.config import dictConfig
+    dictConfig(settings.LOGGING)

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -211,6 +211,9 @@ USE_TZ = env('DD_USE_TZ')
 
 TEST_RUNNER = env('DD_TEST_RUNNER')
 
+# grabs the celery log level from environment
+CELERY_LOG_LEVEL = env('DD_CELERY_LOG_LEVEL')
+
 # ------------------------------------------------------------------------------
 # DATABASE
 # ------------------------------------------------------------------------------
@@ -861,7 +864,7 @@ LOGGING = {
         },
         'celery': {
             'handlers': [r'%s' % LOGGING_FORMAT],
-            'level': 'INFO',
+            'level': r'%s' % CELERY_LOG_LEVEL,
             'propagate': False,
             # does not seem to work?
             # 'worker_hijack_root_logger': False,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -855,7 +855,7 @@ LOGGING = {
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
-            'propagate': False,
+            'propagate': True,
         },
         'django.security': {
             'handlers': [r'%s' % LOGGING_FORMAT],

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -211,9 +211,6 @@ USE_TZ = env('DD_USE_TZ')
 
 TEST_RUNNER = env('DD_TEST_RUNNER')
 
-# grabs the celery log level from environment
-CELERY_LOG_LEVEL = env('DD_CELERY_LOG_LEVEL')
-
 # ------------------------------------------------------------------------------
 # DATABASE
 # ------------------------------------------------------------------------------
@@ -864,7 +861,7 @@ LOGGING = {
         },
         'celery': {
             'handlers': [r'%s' % LOGGING_FORMAT],
-            'level': r'%s' % CELERY_LOG_LEVEL,
+            'level': 'INFO',
             'propagate': False,
             # does not seem to work?
             # 'worker_hijack_root_logger': False,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -138,7 +138,10 @@ env = environ.Env(
     # maximum number of result in search as search can be an expensive operation
     DD_SEARCH_MAX_RESULTS=(int, 100),
     DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
-    DD_JIRA_SSL_VERIFY=(bool, True)
+    DD_JIRA_SSL_VERIFY=(bool, True),
+
+    # if you want to keep logging to the console but in json format, change this here to 'json_console'
+    DD_LOGGING_FORMAT=(str, 'console')
 )
 
 
@@ -800,14 +803,12 @@ JIRA_ISSUE_TYPE_CHOICES_CONFIG = (
 )
 
 JIRA_SSL_VERIFY = env('DD_JIRA_SSL_VERIFY')
+LOGGING_FORMAT = env('DD_LOGGING_FORMAT')
 
 
 # ------------------------------------------------------------------------------
 # LOGGING
 # ------------------------------------------------------------------------------
-# A sample logging configuration. The only tangible logging
-# performed by this configuration is to send an email to
-# the site admins on every HTTP 500 error when DEBUG=False.
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING = {
@@ -843,7 +844,6 @@ LOGGING = {
             'class': 'logging.StreamHandler',
         },
         'json_console': {
-            'level': 'INFO',
             'class': 'logging.StreamHandler',
             'formatter': 'json'
         },
@@ -852,31 +852,39 @@ LOGGING = {
         'django.request': {
             'handlers': ['mail_admins'],
             'level': 'ERROR',
-            'propagate': True,
+            'propagate': False,
+        },
+        'django.security': {
+            'handlers': [r'%s' % LOGGING_FORMAT],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'celery': {
+            'handlers': [r'%s' % LOGGING_FORMAT],
+            'level': 'INFO',
+            'propagate': False,
+            # does not seem to work?
+            # 'worker_hijack_root_logger': False,
         },
         'dojo': {
-            # specify 'json_console' to get jsonify logs (or both at once)
-            # 'handlers': ['json_console'],
-            'handlers': ['console'],
+            'handlers': [r'%s' % LOGGING_FORMAT],
             'level': 'INFO',
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
-            # specify 'json_console' to get jsonify logs (or both at once)
-            # 'handlers': ['json_console'],
-            'handlers': ['console'],
+            'handlers': [r'%s' % LOGGING_FORMAT],
             'level': 'INFO',
             'propagate': False,
         },
         'MARKDOWN': {
             # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
-            'handlers': ['console'],
+            'handlers': [r'%s' % LOGGING_FORMAT],
             'level': 'WARNING',
             'propagate': False,
         },
         'titlecase': {
             # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
-            'handlers': ['console'],
+            'handlers': [r'%s' % LOGGING_FORMAT],
             'level': 'WARNING',
             'propagate': False,
         },

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -803,14 +803,13 @@ JIRA_ISSUE_TYPE_CHOICES_CONFIG = (
 )
 
 JIRA_SSL_VERIFY = env('DD_JIRA_SSL_VERIFY')
-LOGGING_FORMAT = env('DD_LOGGING_FORMAT')
-
 
 # ------------------------------------------------------------------------------
 # LOGGING
 # ------------------------------------------------------------------------------
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
+LOGGING_FORMAT = env('DD_LOGGING_FORMAT')
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,


### PR DESCRIPTION
Follow-up from #3062

It turns out that celery hijacks the logger settings from django, so logging was not following what was set.
This PR fixes that. Without it celery continues to log as it wishes without considering our logging settings.

Also, the PR introduces a new variable called `DD_LOGGING_FORMAT` to be able to override the console logging format.

I also added a `django.security` logger, because I stumbled upon it and thought it would not hurt.

When submitting a pull request, please make sure you have completed the following checklist:

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.