### PR TITLE
integration tests: let celery handle dedupe again as before

### DIFF
--- a/tests/dedupe_unit_test.py
+++ b/tests/dedupe_unit_test.py
@@ -481,7 +481,8 @@ def suite():
     add_dedupe_tests_to_suite(suite)
     suite.addTest(DedupeTest('enable_jira'))
     suite.addTest(DedupeTest('enable_github'))
-    suite.addTest(DedupeTest('enable_block_execution'))
+    # block mode no longer needed, so good to actually test in non block mode so celery does the dedupe
+    # suite.addTest(DedupeTest('enable_block_execution'))
     add_dedupe_tests_to_suite(suite)
     return suite
 


### PR DESCRIPTION
a while ago we switch to block mode to run the dedupe integration tests as we thought celery was causing delays / tests to fail.
turned out it was caused by javascript (root of all evil). so we're switching back in this pr to non-block mode to let celery do the dedupe. good to have it tested that way to see of celery etc works.