### PR TITLE
UWSGI json logging option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ dojo/fixtures/initial_surveys.json
 *.db
 celerybeat.pid
 *.env*
+dojo/uwsgi.ini
 
 weekly.txt
 Monthly.txt
@@ -122,3 +123,5 @@ docker/certs/*
 # Helm dependencies
 helm/defectdojo/charts
 
+# pre-commit
+.pre-commit-config.yaml

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -9,14 +9,29 @@ if [ ! -f ${TARGET_SETTINGS_FILE} ]; then
   cp dojo/settings/settings.dist.py dojo/settings/settings.py
 fi
 
-exec uwsgi \
-  "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
-  --protocol uwsgi \
-  --wsgi dojo.wsgi:application \
-  --enable-threads \
-  --processes ${DD_UWSGI_NUM_OF_PROCESSES:-2} \
-  --threads ${DD_UWSGI_NUM_OF_THREADS:-2} \
-  --reload-mercy 1 \
-  --worker-reload-mercy 1 \
-  --py-autoreload 1 \
-  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-4096}"
+UWSGI_INIFILE=dojo/uwsgi.ini
+cat > $UWSGI_INIFILE<<EOF
+[uwsgi]
+$DD_UWSGI_MODE = $DD_UWSGI_ENDPOINT
+protocol = uwsgi
+module = dojo.wsgi:application
+py-autoreload = 1
+enable-threads
+processes = ${DD_UWSGI_NUM_OF_PROCESSES:-2}
+threads = ${DD_UWSGI_NUM_OF_THREADS:-2}
+reload-mercy = 1
+worker-reload-mercy = 1
+threaded-logger
+buffer-size = ${DD_UWSGI_BUFFER_SIZE:-4096}
+EOF
+
+if [ "${DD_LOGGING_FORMAT}" = "json_console" ]; then
+    cat >> $UWSGI_INIFILE <<'EOF'
+; logging as json does not offer full tokenization for requests, everything will be in message.
+logger = stdio
+log-encoder = json {"timestamp":${strftime:%%Y-%%m-%%d %%H:%%M:%%S%%z}, "source": "uwsgi", "message":"${msg}"}
+log-encoder = nl
+EOF
+fi
+
+exec uwsgi --ini $UWSGI_INIFILE


### PR DESCRIPTION
Companion PR for doc at https://github.com/DefectDojo/Documentation/pull/146

Piggy back on variable, `DD_LOGGING_FORMAT` used to have celery log as JSON. That same value `json` will have uwsgi log in json format with all its known limitations. If the variable is not set, then everything is as usual. Also, `threaded-logger` is introduced, as a helper for performance.

To make it easier moving forward to have uwsgi options set, the entrypoints were reworked to create a `uwsgi.ini` file on the fly.

Example of uwsgi server messages:
```
uwsgi_1         | wait-for-it.sh: waiting 30 seconds for mysql:3306
uwsgi_1         | wait-for-it.sh: mysql:3306 is available after 0 seconds
uwsgi_1         | [uWSGI] getting INI configuration from dojo/uwsgi.ini
uwsgi_1         | [log-encoder] registered json {"timestamp":${strftime:%Y-%m-%d%z %H:%M:%S}, "source": "uwsgi", "message":"${msg}"}
uwsgi_1         | [log-encoder] registered nl
uwsgi_1         | {"timestamp":2020-10-26+0000 14:11:52, "source": "uwsgi", "message":"*** Starting uWSGI 2.0.19.1 (64bit) on [Mon Oct 26 14:11:52 2020] ***"}
uwsgi_1         | {"timestamp":2020-10-26+0000 14:11:52, "source": "uwsgi", "message":"compiled with version: 8.3.0 on 23 October 2020 15:10:53"}
uwsgi_1         | {"timestamp":2020-10-26+0000 14:11:52, "source": "uwsgi", "message":"os: Linux-5.8.15-1-default #1 SMP Thu Oct 15 08:10:08 UTC 2020 (c680e93)"}
```

Example of request json (as you can see, all request info are within the `message` field, which is a known uwsgi "issue")
```
uwsgi_1         | {"time":"1603721045306548", "source":"uwsgi", "message":"[pid: 15|app: 0|req: 33/33] 172.90.2.1 () {54 vars in 1887 bytes} [Mon Oct 26 14:04:05 2020] GET /product/1/new_engagement => generated 47065 bytes in 293 msecs (HTTP/1.1 200) 7 headers in 369 bytes (1 switches on core 0)"}
```

The main advantage of json logging, however, is that stracktrace will be part of a single message instead of being spread over multiple lines. This makes it easy on log processing platforms without having to transform the log messages with some wise regexes to match multiline patterns.

```
uwsgi_1         | {"time":"1603721096833326", "source":"uwsgi", "message":"Internal Server Error: /engagement/1/import_scan_results\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py\", line 84, in _execute\n    return self.cursor.execute(sql, params)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/mysql/base.py\", line 71, in execute\n    return self.cursor.execute(query, args)\n  File \"/usr/local/lib/python3.6/site-packages/MySQLdb/cursors.py\", line 206, in execute\n    res = self._query(query)\n  File \"/usr/local/lib/python3.6/site-packages/MySQLdb/cursors.py\", line 319, in _query\n    db.query(q)\n  File \"/usr/local/lib/python3.6/site-packages/MySQLdb/connections.py\", line 259, in query\n    _mysql.connection.query(self, query)\nMySQLdb._exceptions.OperationalError: (2006, 'MySQL server has gone away')\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py\", line 34, in inner\n    response = get_response(request)\n  File \"/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py\", line 115, in _get_response\n    response = self.process_exception_by_middleware(e, request)\n  File \"/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py\", line 113, in _get_response\n    response = wrapped_callback(request, *callback_args, **callback_kwargs)\n  File \"./dojo/engagement/views.py\", line 690, in import_scan_results\n    burp_rr.save()\n  File \"/usr/local/lib/python3.6/site-packages/django/db/models/base.py\", line 744, in save\n    force_update=force_update, update_fields=update_fields)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/models/base.py\", line 782, in save_base\n    force_update, using, update_fields,\n  File \"/usr/local/lib/python3.6/site-packages/django/db/models/base.py\", line 873, in _save_table\n    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/models/base.py\", line 911, in _do_insert\n    using=using, raw=raw)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/models/manager.py\", line 82, in manager_method\n    return getattr(self.get_queryset(), name)(*args, **kwargs)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/models/query.py\", line 1186, in _insert\n    return query.get_compiler(using=using).execute_sql(return_id)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/models/sql/compiler.py\", line 1377, in execute_sql\n    cursor.execute(sql, params)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py\", line 99, in execute\n    return super().execute(sql, params)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py\", line 67, in execute\n    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py\", line 76, in _execute_with_wrappers\n    return executor(sql, params, many, context)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py\", line 84, in _execute\n    return self.cursor.execute(sql, params)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/utils.py\", line 89, in __exit__\n    raise dj_exc_value.with_traceback(traceback) from exc_value\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/utils.py\", line 84, in _execute\n    return self.cursor.execute(sql, params)\n  File \"/usr/local/lib/python3.6/site-packages/django/db/backends/mysql/base.py\", line 71, in execute\n    return self.cursor.execute(query, args)\n  File \"/usr/local/lib/python3.6/site-packages/MySQLdb/cursors.py\", line 206, in execute\n    res = self._query(query)\n  File \"/usr/local/lib/python3.6/site-packages/MySQLdb/cursors.py\", line 319, in _query\n    db.query(q)\n  File \"/usr/local/lib/python3.6/site-packages/MySQLdb/connections.py\", line 259, in query\n    _mysql.connection.query(self, query)\ndjango.db.utils.OperationalError: (2006, 'MySQL server has gone away')"}
```