### PR TITLE
Celery component names renamed to be unique, to:

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}-celery-beat
   labels:
-    defectdojo.org/component: celery
+    defectdojo.org/component: celery-beat
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}-celery-worker
   labels:
-    defectdojo.org/component: celery
+    defectdojo.org/component: celery-worker
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
Minor change in helm, to have unique label for the component name from celery to:
celery-worker
celery-beat

