### PR TITLE
travis: remove non-k8s tests, reduce matrix for k8s

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,22 @@ env:
     - HELM_VERSION=v3.3.2
     - CHANGE_MINIKUBE_NONE_USER=true
   matrix:
-    - TEST=flake8
-    - TEST=docker_integration_tests
-    - BROKER=rabbitmq DATABASE=mysql
+    # - TEST=flake8
+    # - TEST=docker_integration_tests
+    # - BROKER=rabbitmq DATABASE=mysql
     - BROKER=rabbitmq DATABASE=postgresql
     - BROKER=redis DATABASE=mysql
-    - BROKER=redis DATABASE=postgresql
-    - BROKER=rabbitmq DATABASE=postgresql REPLICATION=enabled
+    # - BROKER=redis DATABASE=postgresql
+    # - BROKER=rabbitmq DATABASE=postgresql REPLICATION=enabled
     - BROKER=rabbitmq DATABASE=postgresql EXTRAVAL=enabled
-    - TEST=snyk
+    # - TEST=snyk
 matrix:
-  allow_failures:
-    - env: TEST=snyk
-jobs:
-  include:
-    - stage: deploy
-      env: TEST=deploy
+  # allow_failures:
+  #   - env: TEST=snyk
+# jobs:
+#   include:
+#     - stage: deploy
+#       env: TEST=deploy
 before_install: ['./travis/before-install.sh']
 before_script: ['./travis/before-script.sh']
 script: ['./travis/script.sh']

--- a/travis/before-install.sh
+++ b/travis/before-install.sh
@@ -8,9 +8,9 @@ sudo -H pip3 install -U setuptools pip
 sudo pip3 --version
 
 # Install Snyk
-curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-sudo apt-get install nodejs
-sudo npm install -g snyk
+# curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+# sudo apt-get install nodejs
+# sudo npm install -g snyk
 
 
 # Install Deployment

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -211,61 +211,61 @@ if [ -z "${TEST}" ]; then
   exit ${return_value}
 else
 echo "Running test ${TEST}"
-  case "${TEST}" in
-    flake8)
-      echo "${TRAVIS_BRANCH}"
-      if [[ "${TRAVIS_BRANCH}" == "dev" ]]
-      then
-          echo "Running Flake8 tests on dev branch aka pull requests"
-          # We need to checkout dev for flake8-diff to work properly
-          git checkout dev
-          sudo pip3 install pep8 flake8 flake8-diff
-          flake8-diff
-      else
-          echo "Skipping because not on dev branch"
-      fi
-      ;;
-    docker_integration_tests)
-      echo "Validating docker compose"
-      # change user id withn Docker container to user id of travis user
-      sed -i -e "s/USER\ 1001/USER\ `id -u`/g" ./Dockerfile.django
-      cp ./dojo/settings/settings.dist.py ./dojo/settings/settings.py
-      # incase of failure and you need to debug
-      # change the 'release' mode to 'dev' mode in order to activate debug=True
-      # make sure you remember to change back to 'release' before making a PR
-      source ./docker/setEnv.sh release
-      docker-compose build
+  # case "${TEST}" in
+  #   flake8)
+  #     echo "${TRAVIS_BRANCH}"
+  #     if [[ "${TRAVIS_BRANCH}" == "dev" ]]
+  #     then
+  #         echo "Running Flake8 tests on dev branch aka pull requests"
+  #         # We need to checkout dev for flake8-diff to work properly
+  #         git checkout dev
+  #         sudo pip3 install pep8 flake8 flake8-diff
+  #         flake8-diff
+  #     else
+  #         echo "Skipping because not on dev branch"
+  #     fi
+  #     ;;
+  #   docker_integration_tests)
+  #     echo "Validating docker compose"
+  #     # change user id withn Docker container to user id of travis user
+  #     sed -i -e "s/USER\ 1001/USER\ `id -u`/g" ./Dockerfile.django
+  #     cp ./dojo/settings/settings.dist.py ./dojo/settings/settings.py
+  #     # incase of failure and you need to debug
+  #     # change the 'release' mode to 'dev' mode in order to activate debug=True
+  #     # make sure you remember to change back to 'release' before making a PR
+  #     source ./docker/setEnv.sh release
+  #     docker-compose build
 
-      docker-compose up -d
-      echo "Waiting for services to start"
-      # Wait for services to become available
-      sleep 80
-      echo "Testing DefectDojo Service"
-      curl -s -o "/dev/null" http://localhost:8080 -m 120
-      CR=$(curl -s -m 10 -I http://localhost:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
-      if [ "$CR" != 200 ]; then
-        echo "ERROR: cannot display login screen; got HTTP code $CR"
-        docker-compose logs  --tail="all" uwsgi
-        exit 1
-      fi
-      echo "Docker compose container status"
-      docker-compose -f docker-compose.yml ps
+  #     docker-compose up -d
+  #     echo "Waiting for services to start"
+  #     # Wait for services to become available
+  #     sleep 80
+  #     echo "Testing DefectDojo Service"
+  #     curl -s -o "/dev/null" http://localhost:8080 -m 120
+  #     CR=$(curl -s -m 10 -I http://localhost:8080/login?next= | egrep "^HTTP" | cut  -d' ' -f2)
+  #     if [ "$CR" != 200 ]; then
+  #       echo "ERROR: cannot display login screen; got HTTP code $CR"
+  #       docker-compose logs  --tail="all" uwsgi
+  #       exit 1
+  #     fi
+  #     echo "Docker compose container status"
+  #     docker-compose -f docker-compose.yml ps
 
-      echo "run integration_test scripts"
-      source ./travis/integration_test-script.sh
-      ;;
-    snyk)
-      echo "Snyk security testing on containers"
-      build_containers
-      snyk monitor --docker defectdojo/defectdojo-django:latest
-      snyk monitor --docker defectdojo/defectdojo-nginx:latest
-      ;;
-    deploy)
-      echo "Deploy and container push"
-      build_containers
-      source ./travis/deploy.sh
-      deploy_demo
-      docker_hub
-      ;;
-  esac
+  #     echo "run integration_test scripts"
+  #     source ./travis/integration_test-script.sh
+  #     ;;
+  #   snyk)
+  #     echo "Snyk security testing on containers"
+  #     build_containers
+  #     snyk monitor --docker defectdojo/defectdojo-django:latest
+  #     snyk monitor --docker defectdojo/defectdojo-nginx:latest
+  #     ;;
+  #   deploy)
+  #     echo "Deploy and container push"
+  #     build_containers
+  #     source ./travis/deploy.sh
+  #     deploy_demo
+  #     docker_hub
+  #     ;;
+  # esac
 fi


### PR DESCRIPTION
As discussed / proposed on Slack:
- Travis tets are extremely slow
- The non-k8s tests are running fine in GitHub Actions

The plan was to let both Travis and GitHub actions run alongside eachother for a couple of weeks. But waiting times for Travis are currently up to 3-4 hours sometimes, which breaks the feedback loop we need.

This PR:
- disables/removes all non-k8s tests / steps from the travis build
- reduces the build matrix for k8s tests to alleviate the strain on travis and reduce our waiting times.

Proposed for after the release of 1.9.0