### PR TITLE
duplicates: only show first 5 bug icons, link to duplicate cluste sec…

### DIFF
--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -283,18 +283,28 @@
                     <td>
                         <div class="align-top">
                             <div class="dropdown">
-                                {% for duplicate in duplicate_cluster %}
+                                {% for duplicate in duplicate_cluster|slice:"5" %}
                                     <a class="fa fa-bug" href="{% url 'view_finding' duplicate.id %}" title="{{ duplicate|finding_extended_title }}"/>
-                                {%  endfor %}                                                                
+                                {%  endfor %}            
+                                {% if duplicate_cluster|length > 5 %}                                                    
+                                    <a href="#duplicate_cluster" onclick="$('#duplicate_tree_toggle').click()">...</a>
+                                {% endif %}
                                 <a href="#" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
                                 <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
-                                {% for duplicate in duplicate_cluster %}
+                                {% for duplicate in duplicate_cluster|slice:"5" %}
                                     <li>
                                         <a class="" href="{% url 'view_finding' duplicate.id %}">
                                         <i class="fa fa-bug"></i> {{ duplicate|finding_extended_title }}</i>
                                         </a>
                                     </li>
                                 {%  endfor %}
+                                {% if duplicate_cluster|length > 5 %}                                                    
+                                    <li>
+                                        <a href="#duplicate_cluster" onclick="$('#duplicate_tree_toggle').click()">
+                                        <i class="fa fa-bug"></i>... more below ...</i>
+                                        </a>
+                                    </li>
+                                {% endif %}
                                 </ul>
                             </div>
                         </div>
@@ -527,9 +537,13 @@
     {% endif %}
     
     {% if finding.duplicate_finding_set %}
+        {% comment %}
+            little extra div to serve as anchor, with some padding and padding cancelling margin to make sure it scrolls into view correctly
+        {% endcomment %}
+        <div id="duplicate_cluster" style="padding-top: 6em; margin-top: -6em;"></div>
         <div class="panel panel-default">
             <div class="panel-heading">
-                <h4>Duplicate Cluster ({{ finding|finding_duplicate_cluster_size }})<span class="pull-right"><a data-toggle="collapse" href="#duplicate_tree"><i class="glyphicon glyphicon-chevron-down"></i></a></span></h4>
+                <h4>Duplicate Cluster ({{ finding|finding_duplicate_cluster_size }})<span class="pull-right"><a data-toggle="collapse" id="duplicate_tree_toggle" href="#duplicate_tree"><i class="glyphicon glyphicon-chevron-down"></i></a></span></h4>
             </div>
             <div id="duplicate_tree" class="panel-body collapse">
                 {% if finding.duplicate_finding %}


### PR DESCRIPTION
Currently there is a nice little bug icon on the `view_finding` page for each duplicate of the finding you are viewing. This can lead to some UI clutter if there are lots of duplicates:

![2020-10-25 09_10_03-Window](https://user-images.githubusercontent.com/4426050/97102490-44d31b00-16a6-11eb-9512-1d95d81ed82d.png)

This PR only shows the first 5 icons. A link to view the rest of the cluster is added, as the full cluster is displayed lower on the page already under the "Duplicate Cluster" panel. Clicking the will open that panel and scroll it into view.

![2020-10-25 09_39_23-Window](https://user-images.githubusercontent.com/4426050/97102513-6af8bb00-16a6-11eb-8439-87851f16447e.png)

![2020-10-25 09_39_42-Window](https://user-images.githubusercontent.com/4426050/97102518-6cc27e80-16a6-11eb-8e52-adffba93ec3d.png)

