### PR TITLE
Centralize logic to decide on async or foreground tasks

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -1,0 +1,21 @@
+from functools import wraps
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+# Defect Dojo performs all tasks asynchrnonously using celery
+# *unless* the user initiating the task has set block_execution to True in their usercontactinfo profile
+def dojo_async_task(func):
+    @wraps(func)
+    def __wrapper__(*args, **kwargs):
+        from dojo.utils import get_current_user
+        user = get_current_user()
+        from dojo.models import Dojo_User
+        if Dojo_User.wants_block_execution(user):
+            logger.debug('dojo_async_task: running task in the foreground as block_execution is set to True for %s', user)
+            return func(*args, **kwargs)
+        else:
+            return func.delay(*args, **kwargs)
+    return __wrapper__

--- a/dojo/engagement/services.py
+++ b/dojo/engagement/services.py
@@ -3,8 +3,7 @@ import logging
 
 from django.utils import timezone
 from dojo.models import JIRA_PKey
-from dojo.utils import get_system_setting
-from dojo.tasks import close_epic_task
+from dojo.utils import get_system_setting, close_epic
 
 logger = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ def close_engagement(eng):
     if get_system_setting('enable_jira'):
         jpkey_set = JIRA_PKey.objects.filter(product=eng.product)
         if jpkey_set.count() >= 1:
-            close_epic_task(eng, True)
+            close_epic(eng, True)
 
 
 def reopen_engagement(eng):

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -34,7 +34,6 @@ from dojo.tools.factory import import_parser_factory
 from dojo.utils import get_page_items, add_breadcrumb, handle_uploaded_threat, \
     FileIterWrapper, get_cal_event, message, get_system_setting, Product_Tab, is_scan_file_too_large, update_epic, add_epic
 from dojo.notifications.helper import create_notification
-from dojo.tasks import update_epic_task, add_epic_task
 from dojo.finding.views import find_available_notetypes
 from functools import reduce
 from django.db.models.query import QuerySet
@@ -193,18 +192,11 @@ def edit_engagement(request, eid):
             if 'jiraform-push_to_jira' in request.POST:
                 logger.debug('push_to_jira true')
                 if JIRA_Issue.objects.filter(engagement=eng).exists():
-                    if Dojo_User.wants_block_execution(request.user):
-                        update_epic(
-                            eng, jform.cleaned_data.get('push_to_jira'))
-                    else:
-                        update_epic_task.delay(
-                            eng, jform.cleaned_data.get('push_to_jira'))
+                    update_epic(
+                        eng, jform.cleaned_data.get('push_to_jira'))
 
                 else:
-                    if Dojo_User.wants_block_execution(request.user):
-                        add_epic(eng, jform.cleaned_data.get('push_to_jira'))
-                    else:
-                        add_epic_task.delay(eng, jform.cleaned_data.get('push_to_jira'))
+                    add_epic(eng, jform.cleaned_data.get('push_to_jira'))
 
             temp_form = form.save(commit=False)
             if (temp_form.status == "Cancelled" or temp_form.status == "Completed"):

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -44,8 +44,6 @@ from dojo.utils import get_page_items, add_breadcrumb, FileIterWrapper, process_
     jira_get_issue, get_words_for_field
 from dojo.notifications.helper import create_notification
 
-from dojo.tasks import add_jira_issue_task, update_external_issue_task, add_comment_task, \
-    add_external_issue_task, close_external_issue_task, reopen_external_issue_task
 from django.template.defaultfilters import pluralize
 from django.db.models import Q, QuerySet, Prefetch, Count
 
@@ -733,15 +731,9 @@ def edit_finding(request, fid):
                     request.POST, prefix='githubform', enabled=github_enabled)
                 if gform.is_valid():
                     if GITHUB_Issue.objects.filter(finding=new_finding).exists():
-                        if Dojo_User.wants_block_execution(request.user):
-                            update_external_issue(new_finding, old_status, 'github')
-                        else:
-                            update_external_issue_task.delay(new_finding, old_status, 'github')
+                        update_external_issue(new_finding, old_status, 'github')
                     else:
-                        if Dojo_User.wants_block_execution(request.user):
-                            add_external_issue(new_finding, 'github')
-                        else:
-                            add_external_issue_task.delay(new_finding, 'github')
+                        add_external_issue(new_finding, 'github')
 
             new_finding.save(push_to_jira=push_to_jira)
 
@@ -1261,10 +1253,7 @@ def promote_to_finding(request, fid):
                     enabled=GITHUB_PKey.objects.get(
                         product=test.engagement.product).push_all_issues)
                 if gform.is_valid():
-                    if Dojo_User.wants_block_execution(request.user):
-                        add_external_issue(new_finding, 'github')
-                    else:
-                        add_external_issue_task.delay(new_finding, 'github')
+                    add_external_issue(new_finding, 'github')
 
             messages.add_message(
                 request,
@@ -1839,15 +1828,9 @@ def finding_bulk_update_all(request, pid=None):
                         old_status = finding.status()
                         if form.cleaned_data['push_to_github']:
                             if GITHUB_Issue.objects.filter(finding=finding).exists():
-                                if Dojo_User.wants_block_execution(request.user):
-                                    update_external_issue(finding, old_status, 'github')
-                                else:
-                                    update_external_issue_task.delay(finding, old_status, 'github')
+                                update_external_issue(finding, old_status, 'github')
                             else:
-                                if Dojo_User.wants_block_execution(request.user):
-                                    add_external_issue(finding, 'github')
-                                else:
-                                    add_external_issue_task.delay(finding, 'github')
+                                add_external_issue(finding, 'github')
 
                 if form.cleaned_data['tags']:
                     for finding in finds:
@@ -1882,15 +1865,9 @@ def finding_bulk_update_all(request, pid=None):
                             log_jira_alert('Finding cannot be pushed to jira as there is no jira configuration for this product.', finding)
                         else:
                             if JIRA_Issue.objects.filter(finding=finding).exists():
-                                if Dojo_User.wants_block_execution(request.user):
-                                    update_jira_issue(finding, True)
-                                else:
-                                    update_jira_issue.delay(finding, True)
+                                update_jira_issue(finding, True)
                             else:
-                                if Dojo_User.wants_block_execution(request.user):
-                                    add_jira_issue(finding, True)
-                                else:
-                                    add_jira_issue_task.delay(finding, True)
+                                add_jira_issue(finding, True)
 
                 messages.add_message(request,
                                      messages.SUCCESS,
@@ -2119,20 +2096,12 @@ def push_to_jira(request, fid):
     try:
         if finding.jira():
             logger.info('trying to push %d:%s to JIRA to update JIRA issue', finding.id, finding.title)
-            if Dojo_User.wants_block_execution(request.user):
-                update_jira_issue(finding, True)
-                message = 'Linked JIRA issue succesfully updated.'
-            else:
-                update_jira_issue.delay(finding, True)
-                message = 'Action queued to update linked JIRA issue, check alerts for background errors.'
+            update_jira_issue(finding, True)
+            message = 'Action queued to update linked JIRA issue, check alerts for background errors.'
         else:
             logger.info('trying to push %d:%s to JIRA to create a new JIRA issue', finding.id, finding.title)
-            if Dojo_User.wants_block_execution(request.user):
-                add_jira_issue(finding, True)
-                message = 'JIRA issue created succesfully'
-            else:
-                add_jira_issue_task.delay(finding, True)
-                message = 'Action queued to created linked JIRA issue, check alerts for background errors.'
+            add_jira_issue(finding, True)
+            message = 'Action queued to created linked JIRA issue, check alerts for background errors.'
 
         # it may look like succes here, but the add_jira_issue and update_jira_issue are swallowing exceptions
         # but cant't change too much now without having a test suite, so leave as is for now with the addition warning message to check alerts for background errors.

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -26,6 +26,7 @@ from django.views.decorators.http import require_POST
 from tagging.models import Tag
 from itertools import chain
 from dojo.user.helper import user_must_be_authorized, check_auth_users_list
+from dojo.utils import close_external_issue, reopen_external_issue
 
 from dojo.filters import OpenFindingFilter, \
     OpenFindingSuperFilter, AcceptedFindingSuperFilter, \
@@ -356,7 +357,7 @@ def close_finding(request, fid):
     if request.method == 'POST':
         form = CloseFindingForm(request.POST, missing_note_types=missing_note_types)
 
-        close_external_issue_task.delay(finding, 'Closed by defectdojo', 'github')
+        close_external_issue(finding, 'Closed by defectdojo', 'github')
 
         if form.is_valid():
             now = timezone.now()
@@ -515,7 +516,7 @@ def reopen_finding(request, fid):
     except JIRA_PKey.DoesNotExist:
         finding.save()
 
-    reopen_external_issue_task.delay(finding, 're-opened by defectdojo', 'github')
+    reopen_external_issue(finding, 're-opened by defectdojo', 'github')
 
     messages.add_message(
         request,

--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -22,10 +22,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         findings = Finding.objects.all()
-        logger.info("######## Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
-        deduplicationLogger.info("######## Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
+        logger.info("######## Updating Hashcodes (deduplication is done in the background  upon finding save ########")
+        deduplicationLogger.info("######## Updating Hashcodes (deduplication is done in the background  upon finding save ########")
         for finding in findings:
             finding.hash_code = finding.compute_hash_code()
             finding.save()
-        logger.info("######## Done Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
-        deduplicationLogger.info("######## Done Updating Hashcodes (deduplication is done in background using django signals upon finding save ########")
+        logger.info("######## Done Updating Hashcodes (deduplication is done in the background upon finding save ########")
+        deduplicationLogger.info("######## Done Updating Hashcodes (deduplication is done in the background upon finding save ########")

--- a/dojo/management/commands/rename_whitesource_findings.py
+++ b/dojo/management/commands/rename_whitesource_findings.py
@@ -22,7 +22,7 @@ def rename_whitesource_finding():
     whitesource_id = Test_Type.objects.get(name="Whitesource Scan").id
     findings = Finding.objects.filter(found_by=whitesource_id)
     findings = findings.order_by('-pk')
-    logger.info("######## Updating Hashcodes - deduplication is done in background using django signals upon finding save ########")
+    logger.info("######## Updating Hashcodes - deduplication is done in the background upon finding save ########")
     for finding in findings:
         logger.info("Updating Whitesource Finding with id: %d" % finding.id)
         lib_name_begin = re.search('\\*\\*Library Filename\\*\\* : ', finding.description).span(0)[1]

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -1,0 +1,70 @@
+
+from django.core.management.base import BaseCommand
+
+from dojo.models import Finding
+# from dojo.utils import get_system_setting, do_dedupe_finding, dojo_async_task
+from celery import task
+from functools import wraps
+
+
+class Command(BaseCommand):
+    help = "Command to do some tests with celery and decorators. Just committing it so 'we never forget'"
+
+    def handle(self, *args, **options):
+        finding = Finding.objects.all().first()
+
+        finding.save(dedupe_option=True)
+
+        # print('sync')
+        # my_test_task(finding)
+
+        # sync
+        # outside before
+        # inside before
+        # oh la la what a nice task
+        # inside after
+        # outside after
+
+        # print('async')
+        # my_test_task.delay(finding)
+
+        # async
+        # outside before
+        # outside after
+
+        # this will print in celery:
+        # inside before
+        # oh la la what a nice task
+        # inside after
+        #
+        # so the inside decorator only executes inside the celery task
+        # the outside decorator only outside
+
+
+def my_decorator_outside(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        print("outside before")
+        func(*args, **kwargs)
+        print("outside after")
+
+    if getattr(func, 'delay', None):
+        wrapper.delay = my_decorator_outside(func.delay)
+
+    return wrapper
+
+
+def my_decorator_inside(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        print("inside before")
+        func(*args, **kwargs)
+        print("inside after")
+    return wrapper
+
+
+@my_decorator_outside
+@task
+@my_decorator_inside
+def my_test_task(new_finding, *args, **kwargs):
+    print('oh la la what a nice task')

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -26,7 +26,6 @@ from tagging.registry import register as tag_register
 from multiselectfield import MultiSelectField
 from django import forms
 from django.utils.translation import gettext as _
-from dojo.signals import dedupe_signal
 from dojo.tag.prefetching_tag_descriptor import PrefetchingTagDescriptor
 from django.contrib.contenttypes.fields import GenericRelation
 from tagging.models import TaggedItem
@@ -2141,42 +2140,27 @@ class Finding(models.Model):
         self.found_by.add(self.test.test_type)
 
         if rules_option:
-            from dojo.tasks import async_rules
-            from dojo.utils import sync_rules
-            if Dojo_User.wants_block_execution(user):
-                sync_rules(self, *args, **kwargs)
-            else:
-                async_rules(self, *args, **kwargs)
+            from dojo.utils import do_apply_rules
+            do_apply_rules(self, *args, **kwargs)
+
         from dojo.utils import calculate_grade
         calculate_grade(self.test.engagement.product)
+
         # Assign the numerical severity for correct sorting order
         self.numerical_severity = Finding.get_numerical_severity(self.severity)
         super(Finding, self).save()
         system_settings = System_Settings.objects.get()
+
         if dedupe_option and self.hash_code is not None:
             if system_settings.enable_deduplication:
-                from dojo.tasks import async_dedupe
-                try:
-                    if Dojo_User.wants_block_execution(user):
-                        dedupe_signal.send(sender=self.__class__, new_finding=self)
-                    else:
-                        async_dedupe.delay(self, *args, **kwargs)
-                except:
-                    async_dedupe.delay(self, *args, **kwargs)
-                    pass
+                from dojo.utils import do_dedupe_finding
+                do_dedupe_finding(self, *args, **kwargs)
             else:
                 deduplicationLogger.debug("skipping dedupe because it's disabled in system settings")
+
         if system_settings.false_positive_history and false_history:
-            from dojo.tasks import async_false_history
-            from dojo.utils import sync_false_history
-            try:
-                if Dojo_User.wants_block_execution(user):
-                    sync_false_history(self, *args, **kwargs)
-                else:
-                    async_false_history.delay(self, *args, **kwargs)
-            except:
-                async_false_history.delay(self, *args, **kwargs)
-                pass
+            from dojo.utils import do_false_positive_history
+            do_false_positive_history(self, *args, **kwargs)
         else:
             deduplicationLogger.debug("skipping false positive history because it's disabled in system settings or false_history param is False")
 
@@ -2190,18 +2174,11 @@ class Finding(models.Model):
         # Adding a snippet here for push to JIRA so that it's in one place
         if push_to_jira:
             logger.debug('pushing to jira from finding.save()')
-            from dojo.tasks import add_jira_issue_task
             from dojo.utils import add_jira_issue, update_jira_issue
             if jira_issue_exists:
-                if Dojo_User.wants_block_execution(user):
-                    update_jira_issue(self, True)
-                else:
-                    update_jira_issue.delay(self, True)
+                update_jira_issue(self, True)
             else:
-                if Dojo_User.wants_block_execution(user):
-                    add_jira_issue(self, True)
-                else:
-                    add_jira_issue_task.delay(self, True)
+                add_jira_issue(self, True)
 
     def delete(self, *args, **kwargs):
         for find in self.original_finding.all():

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -24,12 +24,11 @@ from dojo.forms import ProductForm, EngForm, DeleteProductForm, DojoMetaDataForm
                        GITHUB_Product_Form, GITHUBFindingForm, App_AnalysisTypeForm, JIRAEngagementForm
 from dojo.models import Product_Type, Note_Type, Finding, Product, Engagement, ScanSettings, Risk_Acceptance, Test, JIRA_PKey, GITHUB_PKey, Finding_Template, \
                         Test_Type, System_Settings, Languages, App_Analysis, Benchmark_Type, Benchmark_Product_Summary, Endpoint_Status, \
-                        Endpoint, Engagement_Presets, DojoMeta, Sonarqube_Product, Notifications, Dojo_User, BurpRawRequestResponse
+                        Endpoint, Engagement_Presets, DojoMeta, Sonarqube_Product, Notifications, BurpRawRequestResponse
 
 from dojo.utils import get_page_items, add_breadcrumb, get_system_setting, Product_Tab, get_punchcard_data, add_epic, queryset_check
 from dojo.notifications.helper import create_notification
 from custom_field.models import CustomFieldValue, CustomField
-from dojo.tasks import add_epic_task, add_external_issue_task, add_external_issue
 from tagging.models import Tag
 from tagging.utils import get_tag_list
 from django.db.models import Prefetch, F
@@ -935,12 +934,7 @@ def new_eng_for_app(request, pid, cicd=False):
 
             if form.is_valid() and (jform is None or jform.is_valid()):
                 if 'jiraform-push_to_jira' in request.POST:
-                    if Dojo_User.wants_block_execution(request.user):
-                        logger.debug('calling add_epic')
-                        add_epic(new_eng, jform.cleaned_data.get("push_to_jira"))
-                    else:
-                        logger.debug('calling add_epic_task')
-                        add_epic_task.delay(new_eng, jform.cleaned_data.get("push_to_jira"))
+                    add_epic(new_eng, jform.cleaned_data.get("push_to_jira"))
 
             messages.add_message(request,
                                  messages.SUCCESS,
@@ -1196,10 +1190,7 @@ def ad_hoc_finding(request, pid):
             if 'githubform-push_to_github' in request.POST:
                 gform = GITHUBFindingForm(request.POST, prefix='jiragithub', enabled=push_all_jira_issues)
                 if gform.is_valid():
-                    if Dojo_User.wants_block_execution(request.user):
-                        add_external_issue(new_finding, 'github')
-                    else:
-                        add_external_issue_task.delay(new_finding, 'github')
+                    add_external_issue(new_finding, 'github')
 
             new_finding.save(push_to_jira=push_to_jira)
 

--- a/dojo/signals.py
+++ b/dojo/signals.py
@@ -1,3 +1,0 @@
-from django.dispatch import Signal
-
-dedupe_signal = Signal(providing_args=["new_finding"])

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -1,4 +1,6 @@
+import logging
 import tempfile
+import pdfkit
 from datetime import timedelta
 from django.db.models import Count
 from django.conf import settings
@@ -11,18 +13,11 @@ from celery.utils.log import get_task_logger
 from celery.decorators import task
 from dojo.models import Product, Finding, Engagement, System_Settings
 from django.utils import timezone
-from dojo.signals import dedupe_signal
-
-import pdfkit
-from dojo.tools.tool_issue_updater import tool_issue_updater, update_findings_from_source_issues
-from dojo.utils import sync_false_history, calculate_grade
+from dojo.utils import calculate_grade
 from dojo.reports.widgets import report_widget_factory
-from dojo.utils import add_comment, add_epic, add_jira_issue, update_epic, \
-                       close_epic, sync_rules, \
-                       update_external_issue, add_external_issue, \
-                       close_external_issue, reopen_external_issue, sla_compute_and_notify
+from dojo.utils import sla_compute_and_notify
 from dojo.notifications.helper import create_notification
-import logging
+
 
 fmt = getattr(settings, 'LOG_FORMAT', None)
 lvl = getattr(settings, 'LOG_LEVEL', logging.DEBUG)
@@ -224,96 +219,6 @@ def async_custom_pdf_report(self,
             temp.close()
 
     return True
-
-
-@task(name='add_external_issue_task')
-def add_external_issue_task(find, external_issue_provider):
-    logger.info("add external issue task")
-    add_external_issue(find, external_issue_provider)
-
-
-@task(name='update_external_issue_task')
-def update_external_issue_task(find, old_status, external_issue_provider):
-    logger.info("update external issue task")
-    update_external_issue(find, old_status, external_issue_provider)
-
-
-@task(name='close_external_issue_task')
-def close_external_issue_task(find, note, external_issue_provider):
-    logger.info("close external issue task")
-    close_external_issue(find, note, external_issue_provider)
-
-
-@task(name='reopen_external_issue_task')
-def reopen_external_issue_task(find, note, external_issue_provider):
-    logger.info("reopen external issue task")
-    reopen_external_issue(find, note, external_issue_provider)
-
-
-@task(name='add_jira_issue_task')
-def add_jira_issue_task(find, push_to_jira):
-    logger.info("add issue task")
-    add_jira_issue(find, push_to_jira)
-
-
-# @task(name='update_jira_issue_task')
-# def update_jira_issue_task(find, push_to_jira):
-#     logger.info("update issue task")
-#     update_jira_issue(find, push_to_jira)
-
-
-@task(name='add_epic_task')
-def add_epic_task(eng, push_to_jira):
-    logger.info("add epic task")
-    add_epic(eng, push_to_jira)
-
-
-@task(name='update_epic_task')
-def update_epic_task(eng, push_to_jira):
-    logger.info("update epic task")
-    update_epic(eng, push_to_jira)
-
-
-@task(name='close_epic_task')
-def close_epic_task(eng, push_to_jira):
-    logger.info("close epic task")
-    close_epic(eng, push_to_jira)
-
-
-@task(name='add comment')
-def add_comment_task(find, note):
-    logger.info("add comment")
-    add_comment(find, note)
-
-
-@app.task(name='async_dedupe')
-def async_dedupe(new_finding, *args, **kwargs):
-    deduplicationLogger.debug("running async deduplication")
-    dedupe_signal.send(sender=new_finding.__class__, new_finding=new_finding)
-
-
-@app.task(name='applying rules')
-def async_rules(new_finding, *args, **kwargs):
-    logger.info("applying rules")
-    sync_rules(new_finding, *args, **kwargs)
-
-
-@app.task(name='async_false_history')
-def async_false_history(new_finding, *args, **kwargs):
-    logger.info("running false_history")
-    sync_false_history(new_finding, *args, **kwargs)
-
-
-@app.task(name='tool_issue_updater')
-def async_tool_issue_updater(finding, *args, **kwargs):
-    logger.info("running tool_issue_updater")
-    tool_issue_updater(finding, *args, **kwargs)
-
-
-@app.task(bind=True)
-def async_update_findings_from_source_issues(*args, **kwargs):
-    logger.info("running update_findings_from_source_issues")
-    update_findings_from_source_issues()
 
 
 @app.task(bind=True)

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -32,7 +32,6 @@ from dojo.tools.factory import import_parser_factory
 from dojo.utils import get_page_items, get_page_items_and_count, add_breadcrumb, get_cal_event, message, process_notifications, get_system_setting, \
     Product_Tab, max_safe, is_scan_file_too_large, add_jira_issue, get_words_for_field
 from dojo.notifications.helper import create_notification
-from dojo.tasks import add_jira_issue_task
 from dojo.finding.views import find_available_notetypes
 from functools import reduce
 from dojo.finding.views import finding_link_jira, finding_unlink_jira
@@ -522,10 +521,7 @@ def add_temp_finding(request, tid, fid):
             if 'jiraform-push_to_jira' in request.POST:
                 jform = JIRAFindingForm(request.POST, prefix='jiraform', push_all=push_all_jira_issues, jira_pkey=test.engagement.product.jira_pkey)
                 if jform.is_valid():
-                    if Dojo_User.wants_block_execution(request.user):
-                        add_jira_issue(new_finding, jform.cleaned_data.get('push_to_jira'))
-                    else:
-                        add_jira_issue_task.delay(new_finding, jform.cleaned_data.get('push_to_jira'))
+                    add_jira_issue(new_finding, jform.cleaned_data.get('push_to_jira'))
 
             messages.add_message(request,
                                  messages.SUCCESS,

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -3,8 +3,7 @@ from dojo.tools import SCAN_SONARQUBE_API
 
 def async_tool_issue_update(finding, *args, **kwargs):
     if is_tool_issue_updater_needed(finding):
-        from dojo.tasks import async_tool_issue_updater
-        async_tool_issue_updater.delay(finding)
+        tool_issue_updater.delay(finding)
 
 
 def is_tool_issue_updater_needed(finding, *args, **kwargs):

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -12,6 +12,8 @@ def is_tool_issue_updater_needed(finding, *args, **kwargs):
     return test_type.name == SCAN_SONARQUBE_API
 
 
+@dojo_async_task
+@task
 def tool_issue_updater(finding, *args, **kwargs):
 
     test_type = finding.test.test_type
@@ -21,6 +23,8 @@ def tool_issue_updater(finding, *args, **kwargs):
         SonarQubeApiUpdater().update_sonarqube_finding(finding)
 
 
+@dojo_async_task
+@task
 def update_findings_from_source_issues():
     from dojo.tools.sonarqube_api.updater_from_source import SonarQubeApiUpdaterFromSource
 

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -1,4 +1,6 @@
 from dojo.tools import SCAN_SONARQUBE_API
+from celery.decorators import task
+from dojo.decorators import dojo_async_task
 
 
 def async_tool_issue_update(finding, *args, **kwargs):


### PR DESCRIPTION
Currently the code is "scattered" with logic to decide if a task should be handled asyncrhonously by celery, or in the foreground:

```
if Dojo_User.wants_block_execution(request.user):
    update_jira_issue(finding, True)	
else:	
    update_jira_issue.delay(finding, True)
```

There were 18 ocurrences. and this PR brings that down to 2 occurrences. This done by implementing a decorator `dojo_async_task` that decides if the underlying task (function) should be executed asynchronously or in the foreground.

This PR also removes all wrapping / glue code from tasks.py as that is not needed.

```
@app.task(name='applying rules')	
def async_rules(new_finding, *args, **kwargs):	
    logger.info("applying rules")	
    sync_rules(new_finding, *args, **kwargs)
```

This PR also removes the dedupe_signal. It was called manually from finding.save() which makes it no different from a normal method/function call. 

A file `test_celery_decorators.py` is added for further testing in the future and to capture some initial results regarding decorators inside and outside celery tasks which may become helpful in the future.