### PR TITLE
Celery: only send model ids and not full instances

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -1,4 +1,6 @@
 from functools import wraps
+from dojo.models import Finding
+from django.db import models
 import logging
 
 
@@ -19,3 +21,103 @@ def dojo_async_task(func):
         else:
             return func.delay(*args, **kwargs)
     return __wrapper__
+
+
+# decorator with parameters needs another wrapper layer
+# example usage: @dojo_model_to_id(parameter=0) but defaults to parameter=0
+def dojo_model_to_id(_func=None, *, parameter=0):
+    # logger.debug('dec_args:' + str(dec_args))
+    # logger.debug('dec_kwargs:' + str(dec_kwargs))
+    logger.debug('_func:%s', _func)
+
+    def dojo_model_from_id_internal(func, *args, **kwargs):
+        @wraps(func)
+        def __wrapper__(*args, **kwargs):
+            # logger.debug('args:' + str(args))
+            # logger.debug('kwargs:' + str(kwargs))
+
+            # parameter = dec_kwargs.get('parameter', 0)
+
+            model_or_id = get_parameter_froms_args_kwargs(args, kwargs, parameter)
+
+            if model_or_id:
+                if isinstance(model_or_id, models.Model):
+                    logger.debug('converting model_or_id to id: %s', model_or_id)
+                    id = model_or_id.id
+                    args = list(args)
+                    args[parameter] = id
+
+            return func(*args, **kwargs)
+
+        return __wrapper__
+
+    if _func is None:
+        # decorator called without parameters
+        return dojo_model_from_id_internal
+    else:
+        return dojo_model_from_id_internal(_func)
+
+
+# decorator with parameters needs another wrapper layer
+# example usage: @dojo_model_from_id(parameter=0, model=Finding) but defaults to parameter 0 and model Finding
+def dojo_model_from_id(_func=None, *, model=Finding, parameter=0):
+    # logger.debug('dec_args:' + str(dec_args))
+    # logger.debug('dec_kwargs:' + str(dec_kwargs))
+    logger.debug('_func:%s', _func)
+    logger.debug('model: %s', model)
+
+    def dojo_model_from_id_internal(func, *args, **kwargs):
+        # logger.debug('args:' + str(args))
+        # logger.debug('kwargs:' + str(kwargs))
+
+        @wraps(func)
+        def __wrapper__(*args, **kwargs):
+            logger.debug('args:' + str(args))
+            logger.debug('kwargs:' + str(kwargs))
+
+            logger.debug('checking if we need to convert id to model: %s for parameter: %s', model.__name__, parameter)
+
+            model_or_id = get_parameter_froms_args_kwargs(args, kwargs, parameter)
+
+            if model_or_id:
+                if not isinstance(model_or_id, models.Model):
+                    logger.debug('instantiating model_or_id: %s for model: %s', model_or_id, model)
+                    try:
+                        instance = model.objects.get(id=model_or_id)
+                    except model.DoesNotExist:
+                        logger.debug('error instantiating model_or_id: %s for model: %s: DoesNotExist', model_or_id, model)
+                        instance = None
+                    args = list(args)
+                    args[parameter] = instance
+                else:
+                    logger.debug('model_or_id already a model instance %s for model: %s', model_or_id, model)
+
+            return func(*args, **kwargs)
+
+        return __wrapper__
+
+    if _func is None:
+        # decorator called without parameters
+        return dojo_model_from_id_internal
+    else:
+        return dojo_model_from_id_internal(_func)
+
+
+def get_parameter_froms_args_kwargs(args, kwargs, parameter):
+    model_or_id = None
+    if isinstance(parameter, int):
+        # Lookup value came as a positional argument
+        args = list(args)
+        if parameter >= len(args):
+            raise ValueError('parameter index invalid: ' + str(parameter))
+        model_or_id = args[parameter]
+    else:
+        # Lookup value was passed as keyword argument
+        model_or_id = kwargs.get(parameter, None)
+
+    logger.debug('model_or_id: %s', model_or_id)
+
+    if not model_or_id:
+        logger.error('unable to get parameter: ' + parameter)
+
+    return model_or_id

--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from dojo.models import Finding
 from django.db import models
+from django.conf import settings
 import logging
 
 
@@ -28,15 +29,13 @@ def dojo_async_task(func):
 def dojo_model_to_id(_func=None, *, parameter=0):
     # logger.debug('dec_args:' + str(dec_args))
     # logger.debug('dec_kwargs:' + str(dec_kwargs))
-    logger.debug('_func:%s', _func)
+    # logger.debug('_func:%s', _func)
 
     def dojo_model_from_id_internal(func, *args, **kwargs):
         @wraps(func)
         def __wrapper__(*args, **kwargs):
-            # logger.debug('args:' + str(args))
-            # logger.debug('kwargs:' + str(kwargs))
-
-            # parameter = dec_kwargs.get('parameter', 0)
+            if not settings.CELERY_PASS_MODEL_BY_ID:
+                return func(*args, **kwargs)
 
             model_or_id = get_parameter_froms_args_kwargs(args, kwargs, parameter)
 
@@ -63,15 +62,15 @@ def dojo_model_to_id(_func=None, *, parameter=0):
 def dojo_model_from_id(_func=None, *, model=Finding, parameter=0):
     # logger.debug('dec_args:' + str(dec_args))
     # logger.debug('dec_kwargs:' + str(dec_kwargs))
-    logger.debug('_func:%s', _func)
-    logger.debug('model: %s', model)
+    # logger.debug('_func:%s', _func)
+    # logger.debug('model: %s', model)
 
     def dojo_model_from_id_internal(func, *args, **kwargs):
-        # logger.debug('args:' + str(args))
-        # logger.debug('kwargs:' + str(kwargs))
-
         @wraps(func)
         def __wrapper__(*args, **kwargs):
+            if not settings.CELERY_PASS_MODEL_BY_ID:
+                return func(*args, **kwargs)
+
             logger.debug('args:' + str(args))
             logger.debug('kwargs:' + str(kwargs))
 

--- a/dojo/github.py
+++ b/dojo/github.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 def reopen_external_issue_github(find, note, prod, eng):
 
+    from dojo.utils import get_system_setting
+    if not get_system_setting('enable_github'):
+        return
+
     # Check if we have github info related to the product
     if GITHUB_PKey.objects.filter(product=prod).count() == 0:
         return
@@ -41,6 +45,10 @@ def reopen_external_issue_github(find, note, prod, eng):
 
 
 def close_external_issue_github(find, note, prod, eng):
+
+    from dojo.utils import get_system_setting
+    if not get_system_setting('enable_github'):
+        return
 
     # Check if we have github info related to the product
     if GITHUB_PKey.objects.filter(product=prod).count() == 0:
@@ -69,6 +77,10 @@ def close_external_issue_github(find, note, prod, eng):
 
 def update_external_issue_github(find, prod, eng):
 
+    from dojo.utils import get_system_setting
+    if not get_system_setting('enable_github'):
+        return
+
     # Check if we have github info related to the product
     if GITHUB_PKey.objects.filter(product=prod).count() == 0:
         return
@@ -92,6 +104,10 @@ def update_external_issue_github(find, prod, eng):
 
 
 def add_external_issue_github(find, prod, eng):
+
+    from dojo.utils import get_system_setting
+    if not get_system_setting('enable_github'):
+        return
 
     # Check if we have github info related to the product
     if GITHUB_PKey.objects.filter(product=prod).count() == 0:

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -1,7 +1,7 @@
 
 from django.core.management.base import BaseCommand
 
-from dojo.models import Finding
+from dojo.models import Finding, Notes
 # from dojo.utils import get_system_setting, do_dedupe_finding, dojo_async_task
 from celery import task
 from functools import wraps
@@ -16,8 +16,8 @@ class Command(BaseCommand):
 
         # test2(Finding, 100)
         # finding.save(dedupe_option=True)
-        # test_valentijn(finding)
-        test_valentijn(1)
+        test_valentijn(finding, Notes.objects.all().first())
+        # test_valentijn(1)
 
         # print('sync')
         # my_test_task(finding)
@@ -77,3 +77,16 @@ def my_decorator_inside(func):
 @my_decorator_inside
 def my_test_task(new_finding, *args, **kwargs):
     print('oh la la what a nice task')
+
+
+# example working with multiple parameters...
+@dojo_model_to_id(parameter=1)
+@dojo_model_to_id
+@dojo_async_task
+@task
+@dojo_model_from_id(model=Notes, parameter=1)
+@dojo_model_from_id
+def test_valentijn_task(new_finding, note):
+    logger.debug('test_valentijn:')
+    logger.debug(new_finding)
+    logger.debug(note)

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -5,6 +5,7 @@ from dojo.models import Finding
 # from dojo.utils import get_system_setting, do_dedupe_finding, dojo_async_task
 from celery import task
 from functools import wraps
+from dojo.utils import test_valentijn
 
 
 class Command(BaseCommand):
@@ -13,7 +14,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         finding = Finding.objects.all().first()
 
-        finding.save(dedupe_option=True)
+        # test2(Finding, 100)
+        # finding.save(dedupe_option=True)
+        # test_valentijn(finding)
+        test_valentijn(1)
 
         # print('sync')
         # my_test_task(finding)
@@ -39,6 +43,11 @@ class Command(BaseCommand):
         #
         # so the inside decorator only executes inside the celery task
         # the outside decorator only outside
+
+
+def test2(clazz, id):
+    model = clazz.objects.get(id=id)
+    print(model)
 
 
 def my_decorator_outside(func):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -61,6 +61,8 @@ env = environ.Env(
     DD_CELERY_BEAT_SCHEDULE_FILENAME=(str, root('dojo.celery.beat.db')),
     DD_CELERY_TASK_SERIALIZER=(str, 'pickle'),
     DD_FOOTER_VERSION=(str, ''),
+    # models should be passed to celery by ID, default is False (for now)
+    DD_CELERY_PASS_MODEL_BY_ID=(str, False),
     DD_FORCE_LOWERCASE_TAGS=(bool, True),
     DD_MAX_TAG_LENGTH=(int, 25),
     DD_DATABASE_ENGINE=(str, 'django.db.backends.mysql'),
@@ -662,6 +664,7 @@ CELERY_RESULT_EXPIRES = env('DD_CELERY_RESULT_EXPIRES')
 CELERY_BEAT_SCHEDULE_FILENAME = env('DD_CELERY_BEAT_SCHEDULE_FILENAME')
 CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = env('DD_CELERY_TASK_SERIALIZER')
+CELERY_PASS_MODEL_BY_ID = env('DD_CELERY_PASS_MODEL_BY_ID')
 
 # Celery beat scheduled tasks
 CELERY_BEAT_SCHEDULE = {

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -1,6 +1,6 @@
 from dojo.tools import SCAN_SONARQUBE_API
 from celery.decorators import task
-from dojo.decorators import dojo_async_task
+from dojo.decorators import dojo_async_task, dojo_model_to_id, dojo_model_from_id
 
 
 def async_tool_issue_update(finding, *args, **kwargs):
@@ -13,8 +13,10 @@ def is_tool_issue_updater_needed(finding, *args, **kwargs):
     return test_type.name == SCAN_SONARQUBE_API
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def tool_issue_updater(finding, *args, **kwargs):
 
     test_type = finding.test.test_type

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -38,7 +38,7 @@ from django.contrib import messages
 from django.http import HttpResponseRedirect
 import crum
 from celery.decorators import task
-from dojo.decorators import dojo_async_task
+from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
@@ -355,6 +355,15 @@ def set_duplicate_reopen(new_finding, existing_finding):
     existing_finding.notes.create(author=existing_finding.reporter,
                                     entry="This finding has been automatically re-openend as it was found in recent scans.")
     existing_finding.save()
+
+
+@dojo_model_to_id
+@dojo_async_task
+@task
+@dojo_model_from_id
+def test_valentijn(new_finding):
+    logger.debug('test_valentijn:')
+    logger.debug(new_finding)
 
 
 @dojo_async_task

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -49,8 +49,10 @@ Helper functions for DefectDojo
 """
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def do_false_positive_history(new_finding, *args, **kwargs):
     logger.debug('%s: sync false positive history', new_finding.id)
     if new_finding.endpoints.count() == 0:
@@ -104,8 +106,10 @@ def is_deduplication_on_engagement_mismatch(new_finding, to_duplicate_finding):
     return not new_finding.test.engagement.deduplication_on_engagement and to_duplicate_finding.test.engagement.deduplication_on_engagement
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def do_dedupe_finding(new_finding, *args, **kwargs):
     try:
         enabled = System_Settings.objects.get(no_cache=True).enable_deduplication
@@ -361,13 +365,6 @@ def set_duplicate_reopen(new_finding, existing_finding):
 @dojo_async_task
 @task
 @dojo_model_from_id
-def test_valentijn(new_finding):
-    logger.debug('test_valentijn:')
-    logger.debug(new_finding)
-
-
-@dojo_async_task
-@task
 def do_apply_rules(new_finding, *args, **kwargs):
     rules = Rule.objects.filter(applies_to='Finding', parent_rule=None)
     for rule in rules:
@@ -1321,8 +1318,10 @@ def jira_description(find):
     return render_to_string(template, kwargs)
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def add_external_issue(find, external_issue_provider):
     eng = Engagement.objects.get(test=find.test)
     prod = Product.objects.get(engagement=eng)
@@ -1332,8 +1331,10 @@ def add_external_issue(find, external_issue_provider):
         add_external_issue_github(find, prod, eng)
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def update_external_issue(find, old_status, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
     eng = Engagement.objects.get(test=find.test)
@@ -1342,8 +1343,10 @@ def update_external_issue(find, old_status, external_issue_provider):
         update_external_issue_github(find, prod, eng)
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def close_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
     eng = Engagement.objects.get(test=find.test)
@@ -1352,8 +1355,10 @@ def close_external_issue(find, note, external_issue_provider):
         close_external_issue_github(find, note, prod, eng)
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def reopen_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
     eng = Engagement.objects.get(test=find.test)
@@ -1362,8 +1367,10 @@ def reopen_external_issue(find, note, external_issue_provider):
         reopen_external_issue_github(find, note, prod, eng)
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def add_jira_issue(find, push_to_jira):
     logger.info('trying to create a new jira issue for %d:%s', find.id, find.title)
 
@@ -1525,8 +1532,10 @@ def jira_check_attachment(issue, source_file_name):
     return file_exists
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def update_jira_issue(find, push_to_jira):
     logger.info('trying to update a linked jira issue for %d:%s', find.id, find.title)
     prod = Product.objects.get(
@@ -1622,8 +1631,10 @@ def update_jira_issue(find, push_to_jira):
             find.save()
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def close_epic(eng, push_to_jira):
     engagement = eng
     prod = Product.objects.get(engagement=engagement)
@@ -1647,8 +1658,10 @@ def close_epic(eng, push_to_jira):
             pass
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def update_epic(eng, push_to_jira):
     engagement = eng
     prod = Product.objects.get(engagement=engagement)
@@ -1668,8 +1681,10 @@ def update_epic(eng, push_to_jira):
             pass
 
 
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id
 def add_epic(eng, push_to_jira):
     logger.info('trying to create a new jira EPIC for %d:%s', eng.id, eng.name)
     engagement = eng
@@ -1728,8 +1743,12 @@ def jira_get_issue(jpkey, issue_key):
         return None
 
 
+@dojo_model_to_id(parameter=1)
+@dojo_model_to_id
 @dojo_async_task
 @task
+@dojo_model_from_id(model=Notes, parameter=1)
+@dojo_model_from_id
 def add_comment(find, note, force_push=False):
     logger.debug('trying to add a comment to a linked jira issue for: %d:%s', find.id, find.title)
     if not note.private:


### PR DESCRIPTION
based on 3091, so merge that first. there's also a quickfix (but not complete fix) for #3099 

Currently Defect Dojo is sending the full model instances to celery. These can be fairly large, especially if there are fields stored such as `unsaved_request` and `unsaved_response`. These can be large base64 encoded "blobs" putting straing on celery / rabbitmq. The current approach only works because we are using the "insecure" `pickle` serializer, which at some point we have to get rid of (#3093)

This PR adds a setting / environment variable (DD_)CELERY_PASS_MODEL_BY_ID to convert all models to ids before calling celery. Inside the celery tasks the models will be loaded from the database based on this id.
This is done using 2 decorators that can be transparently used on celery tasks to make sure only the id is passed to celery.
And on the celery side the 2nd decorator will load the model instance from the database from that id and transparently injects it into the function parameters again.

So no code changes needed, apart from applying these two decorators on celery tasks. The alternative was to use ids everywhere instead of model instances. This would make for ugly code and probably people will forget it etc.

The DD_CELERY_PASS_MODEL_BY_ID is *disabled*  by default. So people must make a conscious decision to start using this feature, i.e. it's a feature flag. For now I think it's good to do some testing, but at some point I think we should make it default to True. Passing ids instead of model instances is a best practices and helps with stability of celery/rabbitmq.

![image](https://user-images.githubusercontent.com/4426050/97225356-d6d84200-17d2-11eb-9620-e68082d1ba03.png)

Old:
```
@dojo_async_task
@task
def test_valentijn(new_finding):
    logger.debug('test_valentijn:')
    logger.debug(new_finding)
```

New:
```
@dojo_model_to_id
@dojo_async_task
@task
@dojo_model_from_id
def test_valentijn(new_finding):
    logger.debug('test_valentijn:')
    logger.debug(new_finding)
```

Celery tasks almost always have a single finding as parameter, so those are the defaults. But you can tweak 2 settings:

Will convert parameter 1 (product) to id before sending to celery and convert back into a Product before execution in celery starts.
```
@dojo_model_to_id
@dojo_async_task
@task
@dojo_model_from_id(model=Product, parameter=1)
def test_valentijn(dummy_parameter_not_convert, product):
    logger.debug('test_valentijn:')
    logger.debug(product)
```

This approach works will because almost always we are only sending 1 parameter: the finding on which some logic should occur. If we were to have lots of different parameters all the time, it might be better to force ourselves to pass ids instead of instances. 
Or to make a more generic decorator that converts all parameters that are model instances into ids (and the reverse inside celery)