### PR TITLE
Fix Placeholder Text in New Product Type Form

### DIFF
--- a/dojo/templates/dojo/new_product_type.html
+++ b/dojo/templates/dojo/new_product_type.html
@@ -13,7 +13,7 @@
 {% block postscript %}
     <script type="application/javascript">
         $(function () {
-            $('#id_authorized_users').chosen({'placeholder_text_multiple': 'Select some product types...'});
+            $('#id_authorized_users').chosen({'placeholder_text_multiple': 'Select some users...'});
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Noticed a small typo in the placeholder text of the "new product type" form.
This was newly added in 1.9 via #3007