### PR TITLE
Fixes mouse-over help for product notifications includes a non-rendered link (unclickable) #2905

### DIFF
--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -335,7 +335,7 @@
   <div class="panel-heading">
     {% url 'notifications' as notifications_url %}
     <h3 class="panel-title"><span class="fa fa-users fa-fw" aria-hidden="true"></span> Notifications
-      <i class="fa fa-question-circle has-popover" data-trigger="hover" data-content="These are your personal settings for this product, next to your <a href='{{notifications_url}}'>global notifications</a>." data-placement="right" data-container="body"></i>
+      <i class="fa fa-question-circle has-popover" data-trigger="hover" data-content="These are your personal settings for this product." data-placement="right" data-container="body"></i>
     </h3>
   </div>
   <form id="edit_notifications_form" class="form-horizontal" method="post" action="{% url 'edit_notifications' prod.id %}">{% csrf_token %}


### PR DESCRIPTION
Fixes #2905 