### PR TITLE
add datetime to logformat (use verbose)

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -841,6 +841,7 @@ LOGGING = {
         },
         'console': {
             'class': 'logging.StreamHandler',
+            'formatter': 'verbose'
         },
         'json_console': {
             'class': 'logging.StreamHandler',


### PR DESCRIPTION
By default the log output from DD is not displaying any date or time. Personally I prefer to have the default to use the `verbose` logformat which basically only adds a datetimestamp at the beginning of the line. 