### PR TITLE
APIv2: Use serializers instead of direct access to fields of model instance

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1,3 +1,4 @@
+from drf_yasg2.utils import swagger_serializer_method
 from dojo.models import Product, Engagement, Test, Finding, \
     User, ScanSettings, IPScan, Scan, Stub_Finding, Risk_Acceptance, \
     Finding_Template, Test_Type, Development_Environment, NoteHistory, \
@@ -629,6 +630,50 @@ class FindingMetaSerializer(serializers.ModelSerializer):
         fields = ('name', 'value')
 
 
+class FindingProdTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product_Type
+        fields = ["id", "name"]
+
+
+class FindingProductSerializer(serializers.ModelSerializer):
+    prod_type = FindingProdTypeSerializer(required=False)
+
+    class Meta:
+        model = Product
+        fields = ["id", "name", "prod_type"]
+
+
+class FindingEngagementSerializer(serializers.ModelSerializer):
+    product = FindingProductSerializer(required=False)
+
+    class Meta:
+        model = Engagement
+        fields = ["id", "name", "product"]
+
+
+class FindingEnvironmentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Development_Environment
+        fields = ["id", "name"]
+
+
+class FindingTestTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Test_Type
+        fields = ["id", "name"]
+
+
+class FindingTestSerializer(serializers.ModelSerializer):
+    engagement = FindingEngagementSerializer(required=False)
+    environment = FindingEnvironmentSerializer(required=False)
+    test_type = FindingTestTypeSerializer(required=False)
+
+    class Meta:
+        model = Test
+        fields = ["id", "title", "test_type", "engagement", "environment"]
+
+
 class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
     images = FindingImageSerializer(many=True, read_only=True)
     tags = TagListSerializerField(required=False)
@@ -644,38 +689,13 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
         model = Finding
         fields = '__all__'
 
+    @swagger_serializer_method(FindingTestSerializer)
     def get_related_fields(self, obj):
         query_params = self.context['request'].query_params
-        if 'related_fields' in query_params and query_params['related_fields'] == 'true':
-            related_fields = {
-                'product_type': {
-                    'id': obj.test.engagement.product.prod_type.id,
-                    'name': obj.test.engagement.product.prod_type.name
-                },
-                'product': {
-                    'id': obj.test.engagement.product.id,
-                    'name': obj.test.engagement.product.name
-                },
-                'engagement': {
-                    'id': obj.test.engagement.id,
-                    'name': obj.test.engagement.name,
-                    'branch': obj.test.engagement.branch_tag
-                },
-                'test': {
-                    'id': obj.test.id,
-                    'title': obj.test.title
-                },
-                'test_type': {
-                    'id': obj.test.test_type.id,
-                    'name': obj.test.test_type.name
-                },
-                'environment': {
-                    'id': obj.test.environment.id,
-                    'name': obj.test.environment.name
-                },
-                'display_status': obj.status()
-            }
-            return related_fields
+        if 'related_fields' in query_params:
+            return FindingTestSerializer(required=False).to_representation(obj.test)
+        else:
+            return None
 
     # Overriding this to push add Push to JIRA functionality
     def update(self, instance, validated_data):


### PR DESCRIPTION
Fix the issue raised in #3100. 

Introduce serializers for the related fields instead of accessing the fields directly from the model. While this follows the design principles of django it also changes a bit the structure of the returned object. More specifically, we don't have all the referred fields as direct children of the parent JSON object `related_fields`. Instead, we have an object with the same structure as defined in the models.

This fix also adds the swagger documentation for the response as it was missing from the current implementation.

Note : I kept the name `related_fields`, however, we might want to rename it ?