### PR TITLE
Revoke access to authorized users after removal

### DIFF
--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -87,11 +87,13 @@ def add_product_type(request):
 @user_passes_test(lambda u: u.is_staff)
 def edit_product_type(request, ptid):
     pt = get_object_or_404(Product_Type, pk=ptid)
-    pt_form = Product_TypeForm(instance=pt)
+    authed_users = pt.authorized_users.all()
+    pt_form = Product_TypeForm(instance=pt, initial={'authorized_users': authed_users})
     delete_pt_form = Delete_Product_TypeForm(instance=pt)
     if request.method == "POST" and request.POST.get('edit_product_type'):
         pt_form = Product_TypeForm(request.POST, instance=pt)
         if pt_form.is_valid():
+            pt.authorized_users.set(pt_form.cleaned_data['authorized_users'])
             pt = pt_form.save()
             messages.add_message(
                 request,

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -310,6 +310,12 @@ def edit_user(request, uid):
 
         if form.is_valid() and contact_form.is_valid():
             form.save()
+            for init_auth_prods in authed_products:
+                init_auth_prods.authorized_users.remove(user)
+                init_auth_prods.save()
+            for init_auth_prod_types in authed_product_types:
+                init_auth_prod_types.authorized_users.remove(user)
+                init_auth_prod_types.save()
             if 'authorized_products' in form.cleaned_data and len(form.cleaned_data['authorized_products']) > 0:
                 for p in form.cleaned_data['authorized_products']:
                     p.authorized_users.add(user)


### PR DESCRIPTION
Fixed a bug introduced in #3007. Users were not being removed as an authorized user in the database, but were shown as being removed from the form. This obviously carries quite a bit of risk. 

- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.6 compliant (specific python >3.6 syntax is currently not accepted).
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the ReadTheDocs documentation folder. https://github.com/DefectDojo/Documentation/tree/master/docs or provide feature documentation in the PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.