### PR TITLE
Handle null LAST_FIXED date in Qualys VM/OS report.

### DIFF
--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -133,7 +133,11 @@ def issue_r(raw_row, vuln):
         else:
             _temp['active'] = False
             _temp['mitigated'] = True
-            _temp['mitigation_date'] = datetime.datetime.strptime(vuln_details.findtext('LAST_FIXED'), "%Y-%m-%dT%H:%M:%SZ").date()
+            last_fixed = vuln_details.findtext('LAST_FIXED')
+            if last_fixed is not None:
+                _temp['mitigation_date'] = datetime.datetime.strptime(last_fixed, "%Y-%m-%dT%H:%M:%SZ").date()
+            else:
+                _temp['mitigation_date'] = None
         search = "//GLOSSARY/VULN_DETAILS_LIST/VULN_DETAILS[@id='{}']".format(_gid)
         vuln_item = vuln.find(search)
         if vuln_item is not None:


### PR DESCRIPTION
Some Qualys VM/OS reports do not have a LAST_FIXED date in the report. This handles the problem by using None instead as the LAST_FIXED instead of failing to import.