### PR TITLE
APIv2: Allow updating users and set is_superuser

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -276,7 +276,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = User
-        fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_staff')
+        fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_staff', 'is_superuser')
 
 
 class NoteHistorySerializer(serializers.ModelSerializer):

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -940,6 +940,7 @@ class RegulationsViewSet(mixins.ListModelMixin,
 
 
 class UsersViewSet(mixins.CreateModelMixin,
+                   mixins.UpdateModelMixin,
                    mixins.ListModelMixin,
                    mixins.RetrieveModelMixin,
                    viewsets.GenericViewSet):

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -581,6 +581,7 @@ class UsersTest(BaseClass.RESTEndpointTest):
             "email": "example@email.com",
             "is_active": True,
         }
+        self.update_fields = {"first_name": "test changed"}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -10,8 +10,7 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     ScansViewSet, StubFindingsViewSet, TestsViewSet, \
     ToolConfigurationsViewSet, ToolProductSettingsViewSet, ToolTypesViewSet, \
     UsersViewSet, ImportScanView, NoteTypeViewSet, AppAnalysisViewSet, \
-    EndpointStatusViewSet, SonarqubeIssueViewSet, SonarqubeIssueTransitionViewSet, \
-    SonarqubeProductViewSet, NotesViewSet
+    EndpointStatusViewSet, SonarqubeIssueViewSet, NotesViewSet
 from json import dumps
 from django.urls import reverse
 from rest_framework.authtoken.models import Token


### PR DESCRIPTION
This allows updating user profiles via the API and additionally allows setting the user's superuser status.