### PR TITLE
logging: improve variable naming for HANDLERs

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -144,7 +144,7 @@ env = environ.Env(
     DD_JIRA_SSL_VERIFY=(bool, True),
 
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
-    DD_LOGGING_FORMAT=(str, 'console')
+    DD_LOGGING_HANDLER=(str, 'console')
 )
 
 
@@ -685,7 +685,6 @@ CELERY_BEAT_SCHEDULE = {
     }
 }
 
-
 # ------------------------------------
 # Monitoring Metrics
 # ------------------------------------
@@ -819,7 +818,7 @@ JIRA_SSL_VERIFY = env('DD_JIRA_SSL_VERIFY')
 # ------------------------------------------------------------------------------
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
-LOGGING_FORMAT = env('DD_LOGGING_FORMAT')
+LOGGING_HANDLER = env('DD_LOGGING_HANDLER')
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -864,36 +863,36 @@ LOGGING = {
             'propagate': True,
         },
         'django.security': {
-            'handlers': [r'%s' % LOGGING_FORMAT],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': 'INFO',
             'propagate': False,
         },
         'celery': {
-            'handlers': [r'%s' % LOGGING_FORMAT],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': 'INFO',
             'propagate': False,
             # does not seem to work?
             # 'worker_hijack_root_logger': False,
         },
         'dojo': {
-            'handlers': [r'%s' % LOGGING_FORMAT],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': 'INFO',
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
-            'handlers': [r'%s' % LOGGING_FORMAT],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': 'INFO',
             'propagate': False,
         },
         'MARKDOWN': {
             # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
-            'handlers': [r'%s' % LOGGING_FORMAT],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': 'WARNING',
             'propagate': False,
         },
         'titlecase': {
             # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
-            'handlers': [r'%s' % LOGGING_FORMAT],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': 'WARNING',
             'propagate': False,
         },


### PR DESCRIPTION
Recently somebody (from Switzerland ;-)) introduced a DD_LOGGING_FORMAT variable.
The variable is used to configure *handlers*  and not formatters, so this PR renames it to DD_LOGGING_HANDLER.
I considered making it backwards compatible, but couldn't find a straigforward way. The variable is new in 1.9.0 and I don't think may people are using it.
With the new `local_settings.py` setup people will have to review their settings anyway when upgrading.