### PR TITLE
django-debug-toolbar: add example config + required pip packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,10 @@ Or you can modify `settings.dist.py` directly, but this adds the risk of having 
         }
 ```
 
+## Debug Toolbar
+In the `dojo/settings/template-local_settings.py` you'll find instructions on how to enable the [Django Debug Toolbar](https://github.com/jazzband/django-debug-toolbar).
+This toolbar allows you to debug SQL queries, and shows some other interesting information.
+
 ## Submitting Pull Requests
 
 The following are things to consider before submitting a pull request to

--- a/dojo/settings/template-local_settings
+++ b/dojo/settings/template-local_settings
@@ -1,6 +1,7 @@
 # local_settings.py
 # this file will be included by settings.py *after* loading settings.dist.py
-# from components.base import INSTALLED_APPS
+
+# this example configures the django debug toolbar and sets some loglevels to DEBUG
 
 from django.conf.urls import include, url
 
@@ -18,8 +19,6 @@ LOGGING['loggers']['root'] = {
         }
 LOGGING['loggers']['dojo']['level'] = 'DEBUG'
 LOGGING['loggers']['dojo.specific-loggers.deduplication']['level'] = 'DEBUG'
-
-CACHALOT_UNCACHABLE_TABLES = frozenset(('django_migrations'))
 
 
 def show_toolbar(request):

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,3 +65,5 @@ packageurl-python==0.9.3
 django-crum==0.7.7
 JSON-log-formatter==0.3.0
 django-split-settings==1.0.1
+django-debug-toolbar==3.1.1
+django-debug-toolbar-request-history==0.1.3


### PR DESCRIPTION
With the new `local_settings.py` solution, people can easily add extra configuration/settings. For example to enable the Django Debug Toolbar (https://github.com/jazzband/django-debug-toolbar).

The only thing missing is the right package(s) in `requirements.txt`. Although it only requires a 1 or 2 line change, I've run into issues with as it can give conflicts. Or git requires you to stash your changes before you can pull. And before you know it you spend 5 minutes waiting for a docker build to complete and another 2-3 minutes for the initializer to complete only to find out dojo won't start because the debug toolbar is not installed.

I suggest that we inlude the debug toolbar (+1 helper package) by default in our requirements.txt.
It's only a couple of KB of space, but greatly simplifies using the toolbar. You can then even enable it in production if you want to if you have performance issues for example. Without rebuilding the images.

