### PR TITLE
github action release workflow: support bugfix/hotfix releases

### DIFF
--- a/.github/workflows/new-release-pr.yml
+++ b/.github/workflows/new-release-pr.yml
@@ -1,4 +1,4 @@
-name: Prepare release PR
+name: "Release: 1. create branch + PR"
 
 env:
   GIT_USERNAME: "DefectDojo release bot"
@@ -8,12 +8,15 @@ on:
     inputs:
       # the actual branch that can be chosen on the UI is made irrelevant by further steps
       # because someone will forget one day to change it.
+      from_branch:
+        description: "Select branch to release from (feature release: 'dev', bugfix or hotfix release: 'release/x.y.z')"
+        required: true
       release_number:
-        description: 'Release version (x.y.z format)'
+        description: "Release version (x.y.z format)"
         required: true
 
 jobs:
-  build:
+  create_pr:
     runs-on: ubuntu-latest
     steps:
       - name: Login to DockerHub
@@ -21,42 +24,49 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Checkout dev branch
+      - name: Checkout from_branch branch
         uses: actions/checkout@v2
         with:
-          ref: dev
+          ref: ${{ github.event.inputs.from_branch }}
       - name: Create release branch
+        if: "!startsWith('${{ github.event.inputs.from_branch }}', 'release/')"
         run: |
           echo "NEW_BRANCH=release/${{ github.event.inputs.release_number }}" >> $GITHUB_ENV
+      - name: Use existing release branch
+        if: startsWith('${{ github.event.inputs.from_branch }}', 'release/')
+        run: |
+          echo "NEW_BRANCH=${{ github.event.inputs.from_branch }}" >> $GITHUB_ENV
       - name: Configure git
         run: |
           git config --global user.name "${{ env.GIT_USERNAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
       - name: Push branch
+        if: "!startsWith('${{ github.event.inputs.from_branch }}', 'release/')"
         run: git push origin HEAD:${NEW_BRANCH}
       - name: Checkout release branch
         uses: actions/checkout@v2
         with:
-          ref: release/${{ github.event.inputs.release_number }}
+          ref: ${{ env.NEW_BRANCH }}
       - name: Update version numbers in key files
         run: |
-          # sed -ri "s/'([0-9]+(\.[0-9]+)*)'/'${{ github.event.inputs.release_number }}'/" dojo/__init__.py
           sed -ri "s/__version__ = '.*'/__version__ = '${{ github.event.inputs.release_number }}'/" dojo/__init__.py
           sed -ri "s/version='.*'/version='${{ github.event.inputs.release_number }}'/" setup.py
-          sed -ri "s/appVersion: \"([0-9]+(\.[0-9]+)*)\"/appVersion: \"${{ github.event.inputs.release_number }}\"/" helm/defectdojo/Chart.yaml
+          sed -ri "s/appVersion: \".*\"/appVersion: \"${{ github.event.inputs.release_number }}\"/" helm/defectdojo/Chart.yaml
+          sed -ri "s/\"version\": \".*\"/\"version\": \"${{ github.event.inputs.release_number }}\"/" components/package.json
       - name: Check numbers
         run: |
           grep version dojo/__init__.py
           grep version setup.py
           grep appVersion helm/defectdojo/Chart.yaml
+          grep version components/package.json
       - name: Push version changes
-        uses: stefanzweifel/git-auto-commit-action@v4.1.2
+        uses: stefanzweifel/git-auto-commit-action@v4.7.2
         with:
           commit_user_name: "${{ env.GIT_USERNAME }}"
           commit_user_email: "${{ env.GIT_EMAIL }}"
           commit_author: "${{ env.GIT_USERNAME }} <${{ env.GIT_EMAIL }}>"
           commit_message: "Update versions in application files"
-          branch: release/${{ github.event.inputs.release_number }}
+          branch: ${{ env.NEW_BRANCH }}
       - id: set-repo-org
         run: echo ::set-output name=repoorg::${GITHUB_REPOSITORY%%/*}
       - name: Create Pull Request

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -1,4 +1,4 @@
-name: Tag, release, docker
+name: "Release: 2. tag, release, docker push"
 
 env:
   GIT_USERNAME: "DefectDojo release bot"
@@ -13,7 +13,7 @@ on:
         required: true
 
 jobs:
-  tag-and-release:
+  tag-release-push:
     runs-on: ubuntu-latest
     steps:
       - name: Login to DockerHub


### PR DESCRIPTION
update workflow to allow releasing from an existing `release/x.y.z.` branch so we can do hotfix/bugfix releases.

example run for hotfix release from release/0.0.0: https://github.com/valentijnscholten/django-DefectDojo/runs/1362518559?check_suite_focus=true

example run for feature release from dev: https://github.com/valentijnscholten/django-DefectDojo/runs/1362516962?check_suite_focus=true