### PR TITLE
Moving away from kubernetes to charts repo 

### DIFF
--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -149,7 +149,7 @@ jobs:
              docker images
       - name: Configure HELM repos
         run: |-
-             helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+             helm repo add stable https://charts.helm.sh/stable
              helm dependency update ./helm/defectdojo
       - name: Set confings into Outputs
         id: set


### PR DESCRIPTION
kubernetes helm repo is not available anymore, so we are going to  use charts.helm.sh/stable