### PR TITLE
Update display_tags.py

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -90,7 +90,7 @@ def url_shortner(value):
     if url.path:
         return_value = url.path
         if len(return_value) == 1:
-            return_value = value
+            return_value = str(value)
     if len(str(return_value)) > 50:
         return_value = "..." + return_value[50:]
 


### PR DESCRIPTION
As per #2226 .

When the input value is a class, like Endpoint, and the path length is one, and the input value length is greater than 50, it throws with django-DefectDojo/dojo/templatetags/display_tags.py", line 81, in url_shortner
return_value = "..." + return_value[50:]
TypeError: 'Endpoint' object is not subscriptable

Line needs a 'str' added to value.