### PR TITLE
jira: add logging of metadata

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -21,6 +21,7 @@ from dojo.forms import JIRAForm, DeleteJIRAConfForm, ExpressJIRAForm
 from dojo.models import User, JIRA_Conf, JIRA_Issue, Notes, Risk_Acceptance
 from dojo.utils import add_breadcrumb, get_system_setting
 from dojo.notifications.helper import create_notification
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -131,7 +131,8 @@ def express_new_jira(request):
                     jira = JIRA(server=jira_server,
                         basic_auth=(jira_username, jira_password),
                         options={"verify": settings.JIRA_SSL_VERIFY})
-                except Exception:
+                except Exception as e:
+                    logger.exception(e)
                     messages.add_message(request,
                                      messages.ERROR,
                                      'Unable to authenticate. Please check the URL, username, and password.',
@@ -228,7 +229,8 @@ def new_jira(request):
                                     url=request.build_absolute_uri(reverse('jira')),
                                     )
                 return HttpResponseRedirect(reverse('jira', ))
-            except Exception:
+            except Exception as e:
+                logger.exception(e)
                 messages.add_message(request,
                                      messages.ERROR,
                                      'Unable to authenticate. Please check the URL, username, and password.',
@@ -279,7 +281,7 @@ def edit_jira(request, jid):
                                     )
                 return HttpResponseRedirect(reverse('jira', ))
             except Exception as e:
-                logger.error(e)
+                logger.exception(e)
                 messages.add_message(request,
                                      messages.ERROR,
                                      'Unable to authenticate. Please check the URL, username, and password.',

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -103,7 +103,7 @@ def create_notification_message(event, user, notification_type, *args, **kwargs)
             kwargs["description"] = create_description(event, *args, **kwargs)
             notification_message = render_to_string('notifications/other.tpl', kwargs)
 
-    return notification_message
+    return notification_message if notification_message else ''
 
 
 def process_notifications(event, notifications=None, *args, **kwargs):
@@ -272,7 +272,7 @@ def send_alert_notification(event, user=None, *args, **kwargs):
         alert = Alerts(
             user_id=user,
             title=kwargs.get('title')[:100],
-            description=create_notification_message(event, user, 'alert', *args, **kwargs),
+            description=create_notification_message(event, user, 'alert', *args, **kwargs)[:2000],
             url=kwargs.get('url', reverse('alerts')),
             icon=icon[:25],
             source=Notifications._meta.get_field(event).verbose_name.title()[:100]

--- a/dojo/tool_type/views.py
+++ b/dojo/tool_type/views.py
@@ -10,7 +10,7 @@ from dojo.utils import add_breadcrumb
 from dojo.forms import ToolTypeForm
 from dojo.models import Tool_Type, JIRA_Issue
 from jira import JIRA
-
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -3,6 +3,7 @@ import binascii
 import os
 import hashlib
 import io
+import json
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.backends import default_backend
 from calendar import monthrange
@@ -1465,7 +1466,9 @@ def add_jira_issue(find, push_to_jira):
 
 
 def jira_meta(jira, jpkey):
-    return jira.createmeta(projectKeys=jpkey.project_key, issuetypeNames=jpkey.conf.default_issue_type, expand="projects.issuetypes.fields")
+    meta = jira.createmeta(projectKeys=jpkey.project_key, issuetypeNames=jpkey.conf.default_issue_type, expand="projects.issuetypes.fields")
+    logger.debug("jira_meta: %s", json.dumps(meta, indent=4))
+    return meta
 
 
 def jira_attachment(finding, jira, issue, file, jira_filename=None):

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1467,7 +1467,7 @@ def add_jira_issue(find, push_to_jira):
 
 def jira_meta(jira, jpkey):
     meta = jira.createmeta(projectKeys=jpkey.project_key, issuetypeNames=jpkey.conf.default_issue_type, expand="projects.issuetypes.fields")
-    logger.debug("jira_meta: %s", json.dumps(meta, indent=4))
+    logger.debug("jira_meta: %s", json.dumps(meta, indent=4))  # this is None safe
     return meta
 
 


### PR DESCRIPTION
we see recurring issues around exceptions on missing meta data. this PR logs meta data to DEBUG to help troubleshooting support tickets.