### PR TITLE
Reduce default loglevel values to INFO

### DIFF
--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -41,7 +41,7 @@ annotations: {}
 # Components
 celery:
   broker: rabbitmq
-  logLevel: DEBUG
+  logLevel: INFO
   beat:
     annotations: {}
     affinity: {}
@@ -58,7 +58,7 @@ celery:
   worker:
     annotations: {}
     affinity: {}
-    logLevel: DEBUG
+    logLevel: INFO
     nodeSelector: {}
     replicas: 1
     resources:


### PR DESCRIPTION
Unsure why `DEBUG` was the default, `INFO` seems like a better start.