### PR TITLE
[GHA] Push image in one's org

### DIFF
--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -82,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: defectdojo/defectdojo-${{ matrix.docker-image}}:${{ matrix.docker-tag }}
+          tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ matrix.docker-tag }}
           file: ./Dockerfile.${{ matrix.docker-image }}
           context: .
       - name: Image digest


### PR DESCRIPTION
I didn't want to try it live when doing 1.9.0, now tested manually, works fine.

If someone take the workflow and try on his own GH org, then the docker push will push to the org of the same name on dockerhub.