### PR TITLE
Fix missing base64 import

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1,6 +1,7 @@
 # see tastypie documentation at http://django-tastypie.readthedocs.org/en
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.urls import resolve, get_script_prefix
+import base64
 from tastypie import fields
 from tastypie.fields import RelatedField
 from tastypie.authentication import ApiKeyAuthentication


### PR DESCRIPTION
The Burp plugin seems to be breaking because of the missing import.