### PR TITLE
Check if Finding SLA enabled to run SLA notifications

### DIFF
--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -257,6 +257,8 @@ def celery_status():
 def async_sla_compute_and_notify_task(*args, **kwargs):
     logger.debug("Computing SLAs and notifying as needed")
     try:
-        sla_compute_and_notify(*args, **kwargs)
+        system_settings = System_Settings.objects.get()
+        if system_settings.enable_finding_sla:
+            sla_compute_and_notify(*args, **kwargs)
     except Exception as e:
         logger.error("An unexpected error was thrown calling the SLA code: {}".format(e))


### PR DESCRIPTION
The async task would still run even if the Finding SLA enabled was actually disabled.