### PR TITLE
system setting: set random secret when jira secret is disabled and empty

### DIFF
--- a/dojo/templates/dojo/system_settings.html
+++ b/dojo/templates/dojo/system_settings.html
@@ -72,24 +72,30 @@ Django forms are very rigid so without crispy-forms we're forced to use javascri
             $(generate_secret).css('padding-left', '5px')
             $(generate_secret).popover()
 
-            $(generate_secret).click(function () {
-                $('#id_jira_webhook_secret').val(generateGUID())
-            });
+            $(generate_secret).click(generate_new_secret)
 
             $('#id_disable_jira_webhook_secret').change(show_hide_jira_webhook_secret)
 
             show_hide_jira_webhook_secret()
         });
 
+        function generate_new_secret() {
+            $('#id_jira_webhook_secret').val(generateGUID())
+        }
+
         function show_hide_jira_webhook_secret() {
             if ($('#id_disable_jira_webhook_secret').is(':checked')) {
                 <!-- alert('checked') -->
                 $('#id_jira_webhook_secret').css('display', 'none');
                 $('#id_generate_secret').css('display', 'none');
+                if (!$('#id_jira_webhook_secret').val()){
+                    <!-- field is mandatory so generat a value even if using secret is disabled -->
+                    generate_new_secret()
+                }
             } else {
                 <!-- alert('not checked')                 -->
                 $('#id_jira_webhook_secret').css('display', 'inline-block');
-                $('#id_generate_secret').css('display', 'inline-block');                    
+                $('#id_generate_secret').css('display', 'inline-block');
             }
         }
 


### PR DESCRIPTION
fixes #3211 

error happened when the jira secret was empty and the jira secret disable checkbox was checked.

It's because the field is mandatory but empty. The django javascript tries to focus the field and display the error. Not sure how to fix it. Workaround is to put some value in there.