### PR TITLE
Jira webhook: fixed bug for jira-in-subdir instances (error 500)

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -93,7 +93,7 @@ def webhook(request):
         if parsed.get('webhookEvent') == 'comment_created':
             comment_text = parsed['comment']['body']
             commentor = parsed['comment']['updateAuthor']['displayName']
-            jid = parsed['comment']['self'].split('/')[7]
+            jid = parsed['issue']['id']
             jissue = JIRA_Issue.objects.get(jira_id=jid)
             jira = JIRA_Conf.objects.values_list('username', flat=True)
             for jira_userid in jira:


### PR DESCRIPTION
Tested on Jira cloud.

This PR solves the issue when someone has Jira installed in a subfolder, instead of on `/` (like Jira cloud) (results in error 500).
The old code just parses the 'self' link and makes assumptions, which is now replaced by using the proper field in the JSON body.

Possibly related to 
https://github.com/DefectDojo/django-DefectDojo/issues/2976 and
https://github.com/DefectDojo/django-DefectDojo/issues/2784 .

According to https://developer.atlassian.com/cloud/jira/service-desk/webhooks/ (section `Comment shape` at the bottom) 
`.issue.id` is available, which appears to be true (tested) in the case of Jira cloud and our own instance.