### PR TITLE
Fix CWE URL on the finding page.

### DIFF
--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -337,7 +337,7 @@
                     {% endif %}
                         <td>
                         {% if finding.cwe > 0 %}
-                            <a target="_blank" href={{ finding.cwe|cwe_url }}">
+                            <a target="_blank" href="{{ finding.cwe|cwe_url }}">
                                 <i class="fa fa-external-link"></i> {{ finding.cwe }}
                             </a>
                         {% endif %}


### PR DESCRIPTION
The CWE link on the finding page is missing a `"`, which causes the link to go to the wrong location and also malforms the HTML on the page.