### PR TITLE
endpoint_status: prefetch part1

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -204,6 +204,7 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
         prefetched_findings = prefetched_findings.prefetch_related('endpoints')
         prefetched_findings = prefetched_findings.prefetch_related('endpoint_status')
+        prefetched_findings = prefetched_findings.prefetch_related('endpoint_status__endpoint')
         prefetched_findings = prefetched_findings.annotate(active_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=False)))
         prefetched_findings = prefetched_findings.annotate(mitigated_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=True)))
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__authorized_users')

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -324,11 +324,11 @@
                                   {% else %}
                                     {% if finding.endpoints.all %}
                                       <i class="fa fa-sitemap has-popover dojo-sup" data-html="true" data-trigger="hover" data-content="
-                                      {% for endpoint in finding.endpoints.all %}
-                                        {% if endpoint|endpoint_check_active:finding %}
-                                          &#10005; {{ endpoint }}<br/>
+                                      {% for endpoint_status in finding.endpoint_status.all %}
+                                        {% if endpoint_status.mitigated %}
+                                          &#10003; {{ endpoint_status.endpoint }}<br/>
                                         {% else %}
-                                          &#10003; {{ endpoint }}<br/>
+                                          &#10005; {{ endpoint_status.endpoint }}<br/>
                                         {% endif %}
                                       {% endfor %}
                                       " data-placement="right" data-container="body" data-original-title="Endpoints ({{finding.active_endpoint_count}} Active, {{finding.mitigated_endpoint_count}} Mitigated)" title=""></i>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -472,11 +472,11 @@
                             {% else %}
                               {% if finding.endpoints.all %}
                                 <i class="fa dojo-sup fa-sitemap has-popover" data-html="true" data-trigger="hover" data-content="
-                                    {% for endpoint in finding.endpoints.all %}
-                                        {% if endpoint|endpoint_check_active:finding %}
-                                            &#10005; {{ endpoint }}<br/>
+                                    {% for endpoint_status in finding.endpoint_status.all %}
+                                        {% if endpoint_status.mitigated %}
+                                            &#10003; {{ endpoint_status.endpoint }}<br/>
                                         {% else %}
-                                            &#10003; {{ endpoint }}<br/>
+                                            &#10005; {{ endpoint_status.endpoint }}<br/>
                                         {% endif %}
                                     {% endfor %}
                                 " data-placement="right" data-container="body" data-original-title="Endpoints ({{finding.active_endpoint_count}} Active, {{finding.mitigated_endpoint_count}} Mitigated)" title=""></i>

--- a/dojo/templatetags/get_endpoint_status.py
+++ b/dojo/templatetags/get_endpoint_status.py
@@ -56,9 +56,3 @@ def endpoint_mitigator(endpoint, finding):
 def endpoint_mitigated_time(endpoint, finding):
     status = Endpoint_Status.objects.get(endpoint=endpoint, finding=finding)
     return status.mitigated_time
-
-
-@register.filter
-def endpoint_check_active(endpoint, finding):
-    status = Endpoint_Status.objects.get(endpoint=endpoint, finding=finding)
-    return not status.mitigated

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -171,6 +171,7 @@ def prefetch_for_findings(findings):
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
         prefetched_findings = prefetched_findings.prefetch_related('endpoints')
         prefetched_findings = prefetched_findings.prefetch_related('endpoint_status')
+        prefetched_findings = prefetched_findings.prefetch_related('endpoint_status__endpoint')
         prefetched_findings = prefetched_findings.annotate(active_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=False)))
         prefetched_findings = prefetched_findings.annotate(mitigated_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=True)))
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__authorized_users')


### PR DESCRIPTION
fixes #3234
endpointstatus querying was inefficient resulting in slow page loads and 600+ queries.