### PR TITLE
Add bitnami to helm repo list

### DIFF
--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -150,6 +150,7 @@ jobs:
       - name: Configure HELM repos
         run: |-
              helm repo add stable https://charts.helm.sh/stable
+             helm repo add bitnami https://charts.bitnami.com/bitnami
              helm dependency update ./helm/defectdojo
       - name: Set confings into Outputs
         id: set


### PR DESCRIPTION
to support testing and eventually passing of https://github.com/DefectDojo/django-DefectDojo/pull/2859

This add should not change anything, since the actual chart taken into consideration is in requirements.yaml