### PR TITLE
API_V2 : Add metadata operation on findings endpoints

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -580,7 +580,7 @@ class FindingViewSet(mixins.ListModelMixin,
         responses={status.HTTP_200_OK: ""},
         methods=['delete'],
         manual_parameters=[openapi.Parameter(
-            name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING, 
+            name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING,
             description="name of the metadata to retrieve. If name is empty, return all the \
                             metadata associated with the finding")]
     )
@@ -588,7 +588,7 @@ class FindingViewSet(mixins.ListModelMixin,
         responses={status.HTTP_200_OK: ""},
         methods=['put'],
         manual_parameters=[openapi.Parameter(
-            name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING, 
+            name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING,
             description="name of the metadata to edit")],
         request_body=serializers.FindingMetaSerializer
     )
@@ -609,7 +609,7 @@ class FindingViewSet(mixins.ListModelMixin,
             return self._edit_metadata(request, pk)
         elif request.method == "DELETE":
             return self._remove_metadata(request, pk)
-        
+
         return Response({"error", "unsupported method"}, status=status.HTTP_400_BAD_REQUEST)
 
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -605,8 +605,6 @@ class FindingViewSet(mixins.ListModelMixin,
             return self._add_metadata(request, pk)
         elif request.method == "PUT":
             return self._edit_metadata(request, pk)
-        elif request.method == "PATCH":
-            return self._edit_metadata(request, pk)
         elif request.method == "DELETE":
             return self._remove_metadata(request, pk)
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1,6 +1,7 @@
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from django.core.exceptions import ValidationError
 from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
 from rest_framework.permissions import DjangoModelPermissions
@@ -513,6 +514,103 @@ class FindingViewSet(mixins.ListModelMixin,
         data = report_generate(request, findings, options)
         report = serializers.ReportGenerateSerializer(data)
         return Response(report.data)
+
+    def _get_metadata(self, request, pk=None):
+        finding = get_object_or_404(Finding.objects, id=pk)
+
+        metadata = DojoMeta.objects.filter(finding=finding)
+        serializer = serializers.FindingMetaSerializer(instance=metadata, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def _edit_metadata(self, request, pk=None):
+        finding = get_object_or_404(Finding.objects, id=pk)
+        metadata_name = request.query_params.get("name", None)
+        if metadata_name is None:
+            return Response({"error": "Metadata name is required"},
+                status=status.HTTP_400_BAD_REQUEST)
+
+        metadata = get_object_or_404(DojoMeta.objects, name=metadata_name, finding=finding)
+        metadata.name = request.data.get("name", metadata.name)
+        metadata.value = request.data.get("value", metadata.value)
+
+        metadata.save()
+        return Response({"success": "Metadata updated"},
+            status=status.HTTP_200_OK)
+
+    def _add_metadata(self, request, pk=None):
+        finding = get_object_or_404(Finding.objects, id=pk)
+        metadata_data = serializers.FindingMetaSerializer(data=request.data)
+
+        if metadata_data.is_valid():
+            name = metadata_data.validated_data["name"]
+            value = metadata_data.validated_data["value"]
+
+            metadata = DojoMeta(finding=finding, name=name, value=value)
+            try:
+                metadata.validate_unique()
+                metadata.save()
+            except ValidationError as err:
+                return Response({"error": err},
+                status=status.HTTP_400_BAD_REQUEST)
+
+            return Response({"success": "Metadata updated"},
+                status=status.HTTP_200_OK)
+        else:
+            return Response(metadata_data.errors,
+                status=status.HTTP_400_BAD_REQUEST)
+
+    def _remove_metadata(self, request, pk=None):
+        finding = get_object_or_404(Finding.objects, id=pk)
+        name = request.query_params.get("name", None)
+        if name is None:
+            return Response({"error": "A metadata name must be provided"},
+                status=status.HTTP_400_BAD_REQUEST)
+
+        metadata = get_object_or_404(DojoMeta.objects, finding=finding, name=name)
+        metadata.delete()
+
+        return Response({"success": "Metadata deleted"},
+            status=status.HTTP_200_OK)
+
+    @swagger_auto_schema(
+        responses={status.HTTP_200_OK: serializers.FindingMetaSerializer(many=True)},
+        methods=['get']
+    )
+    @swagger_auto_schema(
+        responses={status.HTTP_200_OK: ""},
+        methods=['delete'],
+        manual_parameters=[openapi.Parameter(
+            name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING, 
+            description="name of the metadata to retrieve. If name is empty, return all the \
+                            metadata associated with the finding")]
+    )
+    @swagger_auto_schema(
+        responses={status.HTTP_200_OK: ""},
+        methods=['put'],
+        manual_parameters=[openapi.Parameter(
+            name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING, 
+            description="name of the metadata to edit")],
+        request_body=serializers.FindingMetaSerializer
+    )
+    @swagger_auto_schema(
+        responses={status.HTTP_200_OK: ""},
+        methods=['post'],
+        request_body=serializers.FindingMetaSerializer
+    )
+    @action(detail=True, methods=["post", "put", "delete", "get"])
+    def metadata(self, request, pk=None):
+        if request.method == "GET":
+            return self._get_metadata(request, pk)
+        elif request.method == "POST":
+            return self._add_metadata(request, pk)
+        elif request.method == "PUT":
+            return self._edit_metadata(request, pk)
+        elif request.method == "PATCH":
+            return self._edit_metadata(request, pk)
+        elif request.method == "DELETE":
+            return self._remove_metadata(request, pk)
+        
+        return Response({"error", "unsupported method"}, status=status.HTTP_400_BAD_REQUEST)
 
 
 class JiraConfigurationsViewSet(mixins.ListModelMixin,

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -270,12 +270,12 @@ class FindingMetadataTest(BaseClass.RESTEndpointTest):
         self.current_findings = self.client.get(self.url, format='json').data["results"]
         finding = Finding.objects.get(id=self.current_findings[0]['id'])
 
-        self.base_url = f"%s%s/metadata/" % (self.url, self.current_findings[0]['id'])
+        self.base_url = f"{self.url}{self.current_findings[0]['id']}/metadata/"
         metadata = DojoMeta(finding=finding, name="test_meta", value="20")
         metadata.save()
 
     def test_create(self):
-        self.client.post(self.base_url, data={ "name":"test_meta2", "value":"40"})
+        self.client.post(self.base_url, data={"name": "test_meta2", "value": "40"})
         results = self.client.get(self.base_url).data
         for result in results:
             if result["name"] == "test_meta2" and result["value"] == "40":
@@ -284,7 +284,7 @@ class FindingMetadataTest(BaseClass.RESTEndpointTest):
         assert False, "Metadata was not created correctly"
 
     def test_create_duplicate(self):
-        result = self.client.post(self.base_url, data={ "name":"test_meta", "value":"40"})
+        result = self.client.post(self.base_url, data={"name": "test_meta", "value": "40"})
         assert result.status_code == status.HTTP_400_BAD_REQUEST, "Metadata creation did not failed on duplicate"
 
     def test_get(self):
@@ -296,7 +296,7 @@ class FindingMetadataTest(BaseClass.RESTEndpointTest):
         assert False, "Metadata was not created correctly"
 
     def test_update(self):
-        self.client.put(self.base_url + "?name=test_meta", data={ "name": "test_meta", "value":"40" })
+        self.client.put(self.base_url + "?name=test_meta", data={"name": "test_meta", "value": "40"})
         result = self.client.get(self.base_url).data[0]
         assert result["name"] == "test_meta" and result["value"] == "40", "Metadata not edited correctly"
 

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -3,7 +3,7 @@ from dojo.models import Product, Engagement, Test, Finding, \
     User, ScanSettings, Scan, Stub_Finding, Endpoint, JIRA_PKey, JIRA_Conf, \
     Finding_Template, Note_Type, App_Analysis, Endpoint_Status, \
     Sonarqube_Issue, Sonarqube_Issue_Transition, Sonarqube_Product, Notes, \
-    BurpRawRequestResponse
+    BurpRawRequestResponse, DojoMeta
 from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     FindingTemplatesViewSet, FindingViewSet, JiraConfigurationsViewSet, \
     JiraIssuesViewSet, JiraViewSet, ProductViewSet, ScanSettingsViewSet, \
@@ -13,6 +13,7 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     EndpointStatusViewSet, SonarqubeIssueViewSet, NotesViewSet
 from json import dumps
 from django.urls import reverse
+from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase, APIClient
 
@@ -247,6 +248,62 @@ class FindingsTest(BaseClass.RESTEndpointTest):
             "images": []}
         self.update_fields = {'active': True, "push_to_jira": "True"}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+
+class FindingMetadataTest(BaseClass.RESTEndpointTest):
+    fixtures = ['dojo_testdata.json']
+
+    def __init__(self, *args, **kwargs):
+        self.endpoint_model = Finding
+        self.viewname = 'finding'
+        self.viewset = FindingViewSet
+        self.payload = {}
+        BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+    def setUp(self):
+        testuser = User.objects.get(username='admin')
+        token = Token.objects.get(user=testuser)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        self.url = reverse(self.viewname + '-list')
+
+        self.current_findings = self.client.get(self.url, format='json').data["results"]
+        finding = Finding.objects.get(id=self.current_findings[0]['id'])
+
+        self.base_url = f"%s%s/metadata/" % (self.url, self.current_findings[0]['id'])
+        metadata = DojoMeta(finding=finding, name="test_meta", value="20")
+        metadata.save()
+
+    def test_create(self):
+        self.client.post(self.base_url, data={ "name":"test_meta2", "value":"40"})
+        results = self.client.get(self.base_url).data
+        for result in results:
+            if result["name"] == "test_meta2" and result["value"] == "40":
+                return
+
+        assert False, "Metadata was not created correctly"
+
+    def test_create_duplicate(self):
+        result = self.client.post(self.base_url, data={ "name":"test_meta", "value":"40"})
+        assert result.status_code == status.HTTP_400_BAD_REQUEST, "Metadata creation did not failed on duplicate"
+
+    def test_get(self):
+        results = self.client.get(self.base_url, format="json").data
+        for result in results:
+            if result["name"] == "test_meta" and result["value"] == "20":
+                return
+
+        assert False, "Metadata was not created correctly"
+
+    def test_update(self):
+        self.client.put(self.base_url + "?name=test_meta", data={ "name": "test_meta", "value":"40" })
+        result = self.client.get(self.base_url).data[0]
+        assert result["name"] == "test_meta" and result["value"] == "40", "Metadata not edited correctly"
+
+    def test_delete(self):
+        self.client.delete(self.base_url + "?name=test_meta")
+        result = self.client.get(self.base_url).data
+        assert len(result) == 0, "Metadata not deleted correctly"
 
 
 class FindingTemplatesTest(BaseClass.RESTEndpointTest):


### PR DESCRIPTION
The goal of this PR is to support metadata operations directly on the findings endpoints to avoid having to perform double queries. More specifically, by introducing `/findings/{id}/metadata` we can directly interact with the metadata of a given findings without having to first retrieve its id and then perform the operation. This is quite similar to what is already done with the notes and the tags.

Concretely, we introduce the methods `POST`, `GET`, `PUT`, `DELETE` on `/findings/{id}/metadata`. We decided to not support `PATCH` as a metadata, for a given finding, is only a tuple (name, value) and the name is required to identify the metadata on which we want to perform the operation. Hence, we don't think that there is any advantage is supporting `PATCH` at the moment.

This PR also add the correct swagger doc for the new endpoints as well as a new test case in `test_rest_framework.py`.