### PR TITLE
Update open finding definition on product level

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -439,9 +439,9 @@
                     <span class="hidden-xs"> Findings{% if product_tab.findings > 0 %} <span class="badge">{{ product_tab.findings }}</span>{% endif %}</span>
                     <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&verified=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-list-alt"></i> View Open Findings</a></li>
-                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&verified=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}&severity=Critical"><i class="fa fa-exclamation-triangle"></i> View Critical Findings</a></li>
-                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&verified=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}&date=2"><i class="fa fa-calendar"></i> View Findings from Last 7 Days </a></li>
+                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-list-alt"></i> View Open Findings</a></li>
+                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}&severity=Critical"><i class="fa fa-exclamation-triangle"></i> View Critical Findings</a></li>
+                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}&date=2"><i class="fa fa-calendar"></i> View Findings from Last 7 Days </a></li>
                       <li role="separator" class="divider"></li>
                       <li><a href="{% url 'product_accepted_findings' product_tab.product.id %}?test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-check"></i> View Risk Accepted Findings</a></li>
                       <li><a href="{% url 'product_all_findings' product_tab.product.id %}?test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-search"></i> View All Findings</a></li>

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1979,7 +1979,6 @@ class Product_Tab():
             product=self.product, active=True).count()
         self.open_findings_count = Finding.objects.filter(test__engagement__product=self.product,
                                                           false_p=False,
-                                                          verified=True,
                                                           duplicate=False,
                                                           out_of_scope=False,
                                                           active=True,
@@ -2031,7 +2030,6 @@ def tab_view_count(product_id):
         product=product, active=True).count()
     open_findings = Finding.objects.filter(test__engagement__product=product,
                                            false_p=False,
-                                           verified=True,
                                            duplicate=False,
                                            out_of_scope=False,
                                            active=True,


### PR DESCRIPTION
At the product level, the number of findings displayed in the product tabs only counted active AND verified findings. It now counts findings that are active regardless fo verification status. Additionally, the the "View Open Findings" tab now queries findings that are active instead of active and verified.

<img width="1058" alt="image" src="https://user-images.githubusercontent.com/46459665/99211837-e96ce800-278e-11eb-912f-3cf48cf9ab1c.png">

