### PR TITLE
Set flag for auto refresh of alert/counts

### DIFF
--- a/dojo/management/commands/clear_alerts.py
+++ b/dojo/management/commands/clear_alerts.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand
+from dojo.models import Alerts, Dojo_User
+
+"""
+Author: Cody Maffucci
+This script will remove all alerts in a few different ways
+all: Remove all alerts from the database
+user: Clear alerts for a given user
+system: Clear system alert
+"""
+
+
+class Command(BaseCommand):
+    help = 'Remove alerts from the database'
+
+    def add_arguments(self, parser):
+        parser.add_argument('-a', '--all', action='store_true', help='Remove all alerts from the database')
+        parser.add_argument('-s', '--system', action='store_true', help='Remove alerts wihtout a user')
+        parser.add_argument('-u', '--users', nargs='+', type=str, help='Removes alerts from users')
+
+    def handle(self, *args, **options):
+        alls = options['all']
+        users = options['users']
+        system = options['system']
+
+        if users:
+            for user_name in users:
+                try:
+                    user = Dojo_User.objects.get(username=user_name)
+                    Alerts.objects.filter(user_id_id=user.id).delete()
+                    self.stdout.write('User Alerts for "%s" deleted with success!' % (user_name))
+                except:
+                    self.stdout.write('User "%s" does not exist.' % user_name)
+        elif alls and not system:
+            Alerts.objects.all().delete()
+        elif system and not alls:
+            Alerts.objects.filter(user_id_id=None).delete()
+        else:
+            self.stdout.write("Input is confusing...")

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -145,7 +145,7 @@ env = environ.Env(
     DD_JIRA_SSL_VERIFY=(bool, True),
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
     DD_LOGGING_HANDLER=(str, 'console'),
-    DD_ALERT_REFRESH=(bool, False)
+    DD_ALERT_REFRESH=(bool, True)
 )
 
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -139,14 +139,13 @@ env = environ.Env(
     DD_SLA_NOTIFY_WITH_JIRA_ONLY=(bool, False),
     DD_SLA_NOTIFY_PRE_BREACH=(int, 3),
     DD_SLA_NOTIFY_POST_BREACH=(int, 7),
-
     # maximum number of result in search as search can be an expensive operation
     DD_SEARCH_MAX_RESULTS=(int, 100),
     DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
     DD_JIRA_SSL_VERIFY=(bool, True),
-
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
-    DD_LOGGING_HANDLER=(str, 'console')
+    DD_LOGGING_HANDLER=(str, 'console'),
+    DD_ALERT_REFRESH=(bool, False)
 )
 
 
@@ -216,6 +215,8 @@ USE_L10N = env('DD_USE_L10N')
 USE_TZ = env('DD_USE_TZ')
 
 TEST_RUNNER = env('DD_TEST_RUNNER')
+
+ALERT_REFRESH = env('DD_ALERT_REFRESH')
 
 # ------------------------------------------------------------------------------
 # DATABASE

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -114,7 +114,7 @@
                         <div class="custom-search-form">
                             <form id="custom_search_form" role="search" method="get" action="{% url 'simple_search' %}">
                                 <div class="input-group">
-                                    <input id="simple_search" type="text" name="query" class="form-control"
+                                    <input id="simple_search" label="simple_search" aria_label="simple_search" type="text" name="query" class="form-control"
                                         placeholder="Search..." value="{{clean_query}}">
                                     <span class="input-group-btn">
                                         <button id="simple_search_submit" class="btn btn-primary" type="submit" aria-label="Search">

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -109,33 +109,33 @@
             <!-- /.navbar-header -->
 
             <ul class="nav navbar-top-links navbar-right">
-              {% if request.user.is_authenticated %}
-                <li>
-                    <div class="custom-search-form">
-                        <form id="custom_search_form" role="search" method="get" action="{% url 'simple_search' %}">
-                            <div class="input-group">
-                                <input id="simple_search" type="text" name="query" class="form-control"
-                                       placeholder="Search..." value="{{clean_query}}">
-                                <span class="input-group-btn">
-                                    <button id="simple_search_submit" class="btn btn-primary" type="submit" aria-label="Search">
-                                        <i class="fa fa-search"></i>
-                                    </button>
-                                </span>
-                            </div>
-                        </form>
-                    </div>
-                    <!-- /input-group -->
-                </li>
-                <li class="dropdown">
-                    <a class="dropdown-toggle dropdown-toggle-h{{ alert_count }}" data-toggle="dropdown" href="#" aria-expanded="false" aria-label="{{ alert_count }} Alerts">
-                        <i class="fa fa-bell fa-fw"></i>
-                        <span id="alert_count" class="badge badge-count badge-count{{ alert_count }}">{{ alert_count }}</span>
-                        <i class="fa fa-caret-down"></i>
-                    </a>
-                    <ul class="dropdown-menu dropdown-alerts">
-                    </ul>
-                    <!-- /.dropdown-alerts -->
-                </li>
+                {% if request.user.is_authenticated %}
+                    <li>
+                        <div class="custom-search-form">
+                            <form id="custom_search_form" role="search" method="get" action="{% url 'simple_search' %}">
+                                <div class="input-group">
+                                    <input id="simple_search" type="text" name="query" class="form-control"
+                                        placeholder="Search..." value="{{clean_query}}">
+                                    <span class="input-group-btn">
+                                        <button id="simple_search_submit" class="btn btn-primary" type="submit" aria-label="Search">
+                                            <i class="fa fa-search"></i>
+                                        </button>
+                                    </span>
+                                </div>
+                            </form>
+                        </div>
+                        <!-- /input-group -->
+                    </li>
+                    <li class="dropdown">
+                        <a class="dropdown-toggle dropdown-toggle-h{{ alert_count }}" data-toggle="dropdown" href="#" aria-expanded="false" aria-label="{{ alert_count }} Alerts">
+                            <i class="fa fa-bell fa-fw"></i>
+                            <span id="alert_count" class="badge badge-count badge-count{{ alert_count }}">{{ alert_count }}</span>
+                            <i class="fa fa-caret-down"></i>
+                        </a>
+                        <ul class="dropdown-menu dropdown-alerts">
+                        </ul>
+                        <!-- /.dropdown-alerts -->
+                    </li>
                 {% endif %}
                 <li class="dropdown">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="#" aria-expanded="false" aria-label="User Menu">
@@ -627,6 +627,7 @@
                 </div>
             </div>
         </div>
+        <p id="alert_refresh" class="hidden">{{ 'ALERT_REFRESH'|setting_enabled }}</p>
     </footer>
 </div>
 
@@ -643,11 +644,17 @@
     $(document).ready(function() {
         $('.has-popover').popover({'trigger':'hover'});
         {% if request.user.is_authenticated %}
-        $('.dropdown-toggle').click(function() { get_alerts(); });
-        setInterval(function() {
-            update_alertcount();
-        }, 10000);
+            $('.dropdown-toggle').click(function() { get_alerts(); });
+            refresh = document.getElementById('alert_refresh').innerHTML
+            if(refresh == 'True') {
+                setInterval(function() {
+                    update_alertcount();
+                }, 10000);
+            } else {
+                update_alertcount();
+            }
         {% endif %}
+
         function update_alertcount() {
             $.get("{% url 'alertcount' %}", function (data) {
                 if (data.count != $('#alert_count').text()) {


### PR DESCRIPTION
Add the option to disable the notification recount through the `alerts/count` endpoint. Also add a manage.py command to remove alerts from the database with the options of removing the entire table, just system alerts, or alerts belonging to specific users. They tend to add up quickly with many users!