### PR TITLE
settings.dist.py: reduce default log level from DEBUG to INFO

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -880,7 +880,7 @@ LOGGING = {
         },
         'dojo': {
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {


### PR DESCRIPTION
fixing my left over mistake in settings.dist.py