### PR TITLE
jira: fix mailto link in description

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -306,13 +306,7 @@ class Dojo_User(User):
         proxy = True
 
     def get_full_name(self):
-        """
-        Returns the first_name plus the last_name, with a space in between.
-        """
-        full_name = '%s %s (%s)' % (self.first_name,
-                                    self.last_name,
-                                    self.username)
-        return full_name.strip()
+        return Dojo_User.generate_full_name(self)
 
     def __unicode__(self):
         return self.get_full_name()
@@ -324,6 +318,16 @@ class Dojo_User(User):
     def wants_block_execution(user):
         # this return False if there is no user, i.e. in celery processes, unittests, etc.
         return hasattr(user, 'usercontactinfo') and user.usercontactinfo.block_execution
+
+    @staticmethod
+    def generate_full_name(user):
+        """
+        Returns the first_name plus the last_name, with a space in between.
+        """
+        full_name = '%s %s (%s)' % (user.first_name,
+                                    user.last_name,
+                                    user.username)
+        return full_name.strip()
 
 
 class UserContactInfo(models.Model):

--- a/dojo/templates/issue-trackers/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira-description.tpl
@@ -49,4 +49,4 @@
 
 *Defect Dojo ID:* {{ finding.id }}
 
-*Reporter:* [{{ finding.reporter.firstname }} {{ finding.reporter.lastname }} ({{ finding.reporter.username }}) ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]
+*Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 from dojo.utils import prepare_for_view, get_system_setting, get_full_url
 from dojo.user.helper import user_is_authorized
-from dojo.models import Check_List, FindingImageAccessToken, Finding, System_Settings, Product
+from dojo.models import Check_List, FindingImageAccessToken, Finding, System_Settings, Product, Dojo_User
 import markdown
 from django.db.models import Sum, Case, When, IntegerField, Value
 from django.utils import timezone
@@ -941,3 +941,10 @@ def jira_project_tag(product_or_engagement, autoescape=True):
                                 esc(jira_project.push_all_issues),
                                 esc(jira_project.enable_engagement_epic_mapping),
                                 esc(jira_project.push_notes)))
+
+
+@register.filter
+def full_name(user):
+    # not in all templates we have access to a Dojo_User instance, so we use a filter
+    # see https://github.com/DefectDojo/django-DefectDojo/pull/3278
+    return Dojo_User.generate_full_name(user)


### PR DESCRIPTION
fixes #3271 

A more structural fix for everything around `User` vs `Dojo_User` would be better, but we ran into some issues: #3278 