### PR TITLE
jira: split url handling for issues and projects

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2087,7 +2087,7 @@ class JIRAProjectForm(forms.ModelForm):
         self.product = kwargs.pop('product', None)
         super().__init__(*args, **kwargs)
 
-        logger.debug('self.target: %s, self.product: %s, self.instance: %s', self.target, self.product, self.instance)
+        # logger.debug('self.target: %s, self.product: %s, self.instance: %s', self.target, self.product, self.instance)
         if self.target == 'engagement':
             if not self.product and self.instance and self.instance.engagement and self.instance.engagement.product:
                 self.product = self.instance.engagement.product

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -152,11 +152,15 @@ def get_jira_issue_url(obj):
 
 
 def get_jira_project_url(obj):
-    # jira_url can be called for a JIRA_Project, i.e. http://jira.com/browser/SEC
+
     logger.debug('getting jira project url')
-    if isinstance(obj, JIRA_Project):
-        logger.debug('getting jira project url2')
+    if not isinstance(obj, JIRA_Project):
+        jira_project = get_jira_project(obj)
+    else:
         jira_project = obj
+
+    if jira_project:
+        logger.debug('getting jira project url2')
         jira_instance = get_jira_instance(obj)
         if jira_project and jira_instance:
             logger.debug('getting jira project url3')

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -28,8 +28,8 @@
                     </label>
                     <div class="col-sm-10 form-control-static">
                         {% if product_tab.product.has_jira_configured %}
-                            <a href="{{ product_tab.product|jira_url }}"
-                            target="_blank"> {{ product_tab.product|jira_url }} </a>
+                            <a href="{{ product_tab.product|jira_project_url }}"
+                            target="_blank"> {{ product_tab.product|jira_project_url }} </a>
                         {% else %}
                         None
                         {% endif %}

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -33,8 +33,8 @@
                         </label>
                         <div class="col-sm-10 form-control-static">
                             {% if product_tab.product.has_jira_configured %}
-                                <a href="{{ product_tab.product|jira_url }}"
-                                target="_blank"> {{ product_tab.product|jira_url }} </a>
+                                <a href="{{ product_tab.product|jira_project_url }}"
+                                target="_blank"> {{ product_tab.product|jira_project_url }} </a>
                             {% else %}
                             None
                             {% endif %}
@@ -64,8 +64,8 @@
                         </label>
                         <div class="col-sm-10 form-control-static">
                             {% if product_tab.product.has_jira_configured %}
-                                <a href="{{ product_tab.product|jira_url }}"
-                                target="_blank"> {{ product_tab.product|jira_url }} </a>
+                                <a href="{{ product_tab.product|jira_project_url }}"
+                                target="_blank"> {{ product_tab.product|jira_project_url }} </a>
                             {% else %}
                             None
                             {% endif %}

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -62,8 +62,8 @@
                         <a href="{{finding.duplicate_finding.cwe|cwe_url}}">(CWE-{{finding.duplicate_finding.cwe}})</a>
                     {% endif %}
                     {% if finding.duplicate_finding.jira_issue %}
-                        <a href="{{ finding.duplicate_finding | jira_url }}"
-                        target="_blank" title="{{ finding.duplicate_finding | jira_url }}">{{ finding.duplicate_finding | jira_key }}</a>
+                        <a href="{{ finding.duplicate_finding | jira_issue_url }}"
+                        target="_blank" title="{{ finding.duplicate_finding | jira_issue_url }}">{{ finding.duplicate_finding | jira_key }}</a>
                     {% endif %}
                     ]
                 {% endif %}
@@ -78,11 +78,12 @@
                         </i>
                     </label>
                     <div class="col-sm-10 form-control-static">
-                        {% if finding.has_jira_configured %}
-                            <a href="{{ finding | jira_url }}"
-                            target="_blank"> {{ finding | jira_url }} </a>
+                        {% if finding.has_jira_issue %}                        
+                            <a href="{{ finding | jira_issue_url }}"
+                            target="_blank"> {{ finding | jira_issue_url }} </a>
                         {% else %}
-                        None
+                            <a href="{{ finding | jira_project_url }}"
+                            target="_blank"> {{ finding | jira_project_url }} </a>
                         {% endif %}
                     </div>
                 </div>

--- a/dojo/templates/dojo/finding_related_row.html
+++ b/dojo/templates/dojo/finding_related_row.html
@@ -62,8 +62,8 @@
     {% if system_settings.enable_jira %} 
         <td>
             {% if similar_finding.jira_issue %}
-                <a href="{{ similar_finding | jira_url }}"
-                target="_blank" title="{{similar_finding | jira_url }}">{{ similar_finding | jira_key }}</a>
+                <a href="{{ similar_finding | jira_issue_url }}"
+                target="_blank" title="{{similar_finding | jira_issue_url }}">{{ similar_finding | jira_key }}</a>
             {% endif %}
         </td>
     {% endif %}

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -392,7 +392,7 @@
                                   {% if jira_project and product_tab or not product_tab %}
                                     <td class="nowrap">
                                       {% if finding.has_jira_issue %}
-                                        <a href="{{ finding | jira_url }}" target="_blank" 
+                                        <a href="{{ finding | jira_issue_url }}" target="_blank" 
                                             alt="Jira Bug - {{finding | jira_key}}" data-toggle="tooltip" data-placement="bottom" title="{{finding | jira_key}}"><i class="fa fa-bug fa-fw"></i></a>
                                       {% endif %}
                                     </td>

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -22,8 +22,8 @@
 			</label>
 			<div class="col-sm-10 form-control-static">
 				{% if product_tab.product.has_jira_configured %}
-					<a href="{{ engagement_or_product|jira_url }}"
-					target="_blank"> {{ engagement_or_product|jira_url }} </a>
+					<a href="{{ engagement_or_product|jira_project_url }}"
+					target="_blank"> {{ engagement_or_product|jira_project_url }} </a>
 				{% else %}
 				None
 				{% endif %}

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -31,25 +31,6 @@
         {%  if jira_epic_form %}
                 <h4> JIRA Epic</h4>
                 <hr>
-                <!-- <div class="form-group">
-                    <label class="col-sm-2 control-label" for="id_jira_issue">JIRA URL
-                        <i class="fa fa-question-circle has-popover" data-trigger="hover" data-content="JIRA URL connected to this product or engagement" data-placement="right" data-container="body" data-original-title="" title="">
-                        </i>
-                    </label>
-                    <div class="col-sm-10 form-control-static">
-                        {% if product_tab.product.has_jira_configured %}
-                            {% if eng %}
-                                <a href="{{ eng | jira_url }}"
-                                target="_blank"> {{ eng | jira_url }} </a>
-                            {% else %}
-                                <a href="{{ product_tab.product|jira_url }}"
-                                target="_blank"> {{ product_tab.product|jira_url }} </a>
-                            {% endif %}
-                        {% else %}
-                        None
-                        {% endif %}
-                    </div>
-                </div> -->
                 {% include "dojo/form_fields.html" with form=jira_epic_form %}
             {% endif %}
         <div class="form-group">

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -717,14 +717,14 @@
         {% if jissue and jira_project %}
         <tr>
             <td><strong>Jira</strong></td>
-            <td><a href="{{ eng | jira_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
+            <td><a href="{{ eng | jira_issue_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
             <small>(epic)</small>
             </a></td>
         </tr>
         {% elif jira_project %}
         <tr>
             <td><strong>JIRA</strong></td>
-            <td><a href="{{ eng | jira_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
+            <td><a href="{{ eng | jira_project_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
             {% if jira_project.engagement is not eng %}
             <small>(inherited)</small>
             {% else %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -486,8 +486,8 @@
                 {% if finding.has_jira_configured or finding.jira_issue %}
                     <td id="jira">
                     {% if finding.jira_issue %}
-                        <a href="{{ finding | jira_url }}"
-                        target="_blank" title="{{ finding | jira_url }}">{{ finding | jira_key }}</a>
+                        <a href="{{ finding | jira_issue_url }}"
+                        target="_blank" title="{{ finding | jira_issue_url }}">{{ finding | jira_key }}</a>
                         <i id="unlink_jira" class="fa fa-trash" title="Unlink JIRA issue from this finding."></i>
                         <i id="push_to_jira" class="fa fa-share-square" title="Push finding data to linked JIRA issue."></i>
                     {% else %}

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -237,7 +237,7 @@
             {% if jira_project %}
             <tr>
               <td><strong>JIRA</strong></td>
-              <td><a href="{{ prod | jira_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ prod | jira_key }}</a></td>
+              <td><a href="{{ prod | jira_project_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ prod | jira_key }}</a></td>
             </tr>
             {% endif %}
           {% endwith %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -523,7 +523,7 @@
                             {% if jira_project and product_tab or not product_tab %}
                                 <td>
                                     {% if finding.has_jira_issue %}
-                                        <a href="{{ finding | jira_url }}" target="_blank" 
+                                        <a href="{{ finding | jira_issue_url }}" target="_blank" 
                                             alt="Jira Bug - {{finding | jira_key}}" data-toggle="tooltip" data-placement="bottom" title="{{finding | jira_key}}"><i class="fa fa-bug fa-fw"></i></a>
                                     {% endif %}
                                     </td>

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -836,8 +836,13 @@ def jira_project(obj, use_inheritance=True):
 
 
 @register.filter
-def jira_url(obj):
-    return jira_helper.get_jira_url(obj)
+def jira_issue_url(obj):
+    return jira_helper.get_jira_issue_url(obj)
+
+
+@register.filter
+def jira_project_url(obj):
+    return jira_helper.get_jira_project_url(obj)
 
 
 @register.filter


### PR DESCRIPTION
in #3200 there was a `jira_url` filter that was (supposed to be) "smart". Turns out there are many variations of findings with a jira issue or findings wanting to display a jira project url if they have no issue, but only on the edit screen, but not in the findings list, etc. etc. 

so this PR splits out the `jira_url` filter into two seperate filters so it's clear what it does and will or will not display.

thanks @madchap for reporting.