### PR TITLE
reimport: set component_name&version on existing findings

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1303,6 +1303,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     if item.unsaved_tags:
                         finding.tags = item.unsaved_tags
 
+                    # existing findings may be from before we had component_name/version fields
+                    finding.component_name = finding.component_name if finding.component_name else component_name
+                    finding.component_version = finding.component_version if finding.component_version else component_version
+
                     finding.save(push_to_jira=push_to_jira)
 
             to_mitigate = set(original_items) - set(reactivated_items) - set(unchanged_items)
@@ -1321,6 +1325,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         status.mitigated = True
                         status.last_modified = timezone.now()
                         status.save()
+
+                    # existing findings may be from before we had component_name/version fields
+                    finding.component_name = finding.component_name if finding.component_name else component_name
+                    finding.component_version = finding.component_version if finding.component_version else component_version
 
                     finding.save(push_to_jira=push_to_jira)
                     note = Notes(entry="Mitigated by %s re-upload." % scan_type,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -848,6 +848,11 @@ def re_import_scan_results(request, tid):
                         finding.is_Mitigated = True
                         finding.mitigated_by = request.user
                         finding.active = False
+
+                        # existing findings may be from before we had component_name/version fields
+                        finding.component_name = finding.component_name if finding.component_name else component_name
+                        finding.component_version = finding.component_version if finding.component_version else component_version
+
                         finding.save()
                         note = Notes(entry="Mitigated by %s re-upload." % scan_type,
                                     author=request.user)


### PR DESCRIPTION
in the past findings didn't have a `component_name` and `component_version` fields. when reimporting a scan these existing findings are now updated with these fields to get these populated.