### PR TITLE
performance: optimize a bit view_finding, max similar findings=25

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -255,11 +255,11 @@ def view_finding(request, fid):
     try:
         prev_finding_id = findings[(list(findings).index(finding.id)) - 1]
     except AssertionError:
-        prev_finding_id = finding
+        prev_finding_id = finding.id
     try:
         next_finding_id = findings[(list(findings).index(finding.id)) + 1]
     except IndexError:
-        next_finding_id = finding
+        next_finding_id = finding.id
 
     cred_finding = Cred_Mapping.objects.filter(
         finding=finding.id).select_related('cred_id').order_by('cred_id')

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -25,7 +25,7 @@ from django.utils import timezone
 from django.views.decorators.http import require_POST
 from tagging.models import Tag
 from itertools import chain
-from dojo.user.helper import user_must_be_authorized, check_auth_users_list
+from dojo.user.helper import user_must_be_authorized
 from dojo.utils import close_external_issue, reopen_external_issue
 
 from dojo.filters import OpenFindingFilter, \
@@ -192,12 +192,15 @@ def prefetch_for_findings(findings):
     prefetched_findings = findings
     if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
         prefetched_findings = prefetched_findings.select_related('reporter')
-        prefetched_findings = prefetched_findings.prefetch_related('jira_issue')
+        prefetched_findings = prefetched_findings.prefetch_related('jira_issue__jira_project__jira_instance')
         prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__jira_project__jira_instance')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_project_set__jira_instance')
         prefetched_findings = prefetched_findings.prefetch_related('found_by')
         prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
+        prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set__accepted_findings')
+        prefetched_findings = prefetched_findings.prefetch_related('original_finding')
+
         # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
         prefetched_findings = prefetched_findings.prefetch_related('notes')
         prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
@@ -214,19 +217,50 @@ def prefetch_for_findings(findings):
     return prefetched_findings
 
 
+def prefetch_for_similar_findings(findings):
+    prefetched_findings = findings
+    if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_findings = prefetched_findings.select_related('reporter')
+        prefetched_findings = prefetched_findings.prefetch_related('jira_issue__jira_project__jira_instance')
+        prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
+        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__jira_project__jira_instance')
+        prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__jira_project_set__jira_instance')
+        prefetched_findings = prefetched_findings.prefetch_related('found_by')
+        prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set')
+        prefetched_findings = prefetched_findings.prefetch_related('risk_acceptance_set__accepted_findings')
+        prefetched_findings = prefetched_findings.prefetch_related('original_finding')
+
+        # we could try to prefetch only the latest note with SubQuery and OuterRef, but I'm getting that MySql doesn't support limits in subqueries.
+        prefetched_findings = prefetched_findings.prefetch_related('notes')
+        prefetched_findings = prefetched_findings.prefetch_related('tagged_items__tag')
+        # prefetched_findings = prefetched_findings.prefetch_related('endpoints')
+        # prefetched_findings = prefetched_findings.prefetch_related('endpoint_status')
+        # prefetched_findings = prefetched_findings.prefetch_related('endpoint_status__endpoint')
+        # prefetched_findings = prefetched_findings.annotate(active_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=False)))
+        # prefetched_findings = prefetched_findings.annotate(mitigated_endpoint_count=Count('endpoint_status__id', filter=Q(endpoint_status__mitigated=True)))
+        # prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__authorized_users')
+        # prefetched_findings = prefetched_findings.prefetch_related('test__engagement__product__prod_type__authorized_users')
+    else:
+        logger.debug('unable to prefetch because query was already executed')
+
+    return prefetched_findings
+
+
 @user_must_be_authorized(Finding, 'view', 'fid')
 def view_finding(request, fid):
-    finding = get_object_or_404(Finding, id=fid)
-    findings = Finding.objects.filter(test=finding.test).order_by('numerical_severity')
+    finding_qs = prefetch_for_findings(Finding.objects.all())
+    finding = get_object_or_404(finding_qs, id=fid)
+    findings = Finding.objects.filter(test=finding.test).order_by('numerical_severity').values_list('id', flat=True)
+    logger.debug(findings)
     try:
-        prev_finding = findings[(list(findings).index(finding)) - 1]
+        prev_finding_id = findings[(list(findings).index(finding.id)) - 1]
     except AssertionError:
-        prev_finding = finding
+        prev_finding_id = finding
     try:
-        next_finding = findings[(list(findings).index(finding)) + 1]
+        next_finding_id = findings[(list(findings).index(finding.id)) + 1]
     except IndexError:
-        next_finding = finding
-    findings = [finding.id for finding in findings]
+        next_finding_id = finding
+
     cred_finding = Cred_Mapping.objects.filter(
         finding=finding.id).select_related('cred_id').order_by('cred_id')
     creds = Cred_Mapping.objects.filter(
@@ -242,10 +276,6 @@ def view_finding(request, fid):
         pass
 
     dojo_user = get_object_or_404(Dojo_User, id=user.id)
-    if user.is_staff or check_auth_users_list(user, finding):
-        pass  # user is authorized for this product
-    else:
-        raise PermissionDenied
 
     notes = finding.notes.all()
     note_type_activation = Note_Type.objects.filter(is_active=True).count()
@@ -310,7 +340,7 @@ def view_finding(request, fid):
     # similar_findings = get_similar_findings(request, finding)
     similar_findings_filter = SimilarFindingFilter(request.GET, queryset=Finding.objects.all(), user=request.user, finding=finding)
     logger.debug('similar query: %s', similar_findings_filter.qs.query)
-    similar_findings = prefetch_for_findings(similar_findings_filter.qs[:10])
+    similar_findings = prefetch_for_similar_findings(similar_findings_filter.qs[:settings.SIMILAR_FINDINGS_MAX_RESULTS])
     for similar_finding in similar_findings:
         similar_finding.related_actions = calculate_possible_related_actions_for_similar_finding(request, finding, similar_finding)
 
@@ -333,8 +363,8 @@ def view_finding(request, fid):
             'found_by': finding.found_by.all().distinct(),
             'findings_list': findings,
             'findings_list_lastElement': findings[lastPos],
-            'prev_finding': prev_finding,
-            'next_finding': next_finding,
+            'prev_finding_id': prev_finding_id,
+            'next_finding_id': next_finding_id,
             'duplicate_cluster': duplicate_cluster(request, finding),
             'similar_findings': similar_findings,
             'similar_findings_filter': similar_findings_filter

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2009,7 +2009,7 @@ class Finding(models.Model):
             status += ['Out Of Scope']
         if self.duplicate:
             status += ['Duplicate']
-        if self.risk_acceptance_set.exists():
+        if len(self.risk_acceptance_set.all()) > 0:  # this is normally prefetched so works better than count() or exists()
             status += ['Risk Accepted']
         if not len(status):
             status += ['Initial']

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -141,6 +141,7 @@ env = environ.Env(
     DD_SLA_NOTIFY_POST_BREACH=(int, 7),
     # maximum number of result in search as search can be an expensive operation
     DD_SEARCH_MAX_RESULTS=(int, 100),
+    DD_SIMILAR_FINDINGS_MAX_RESULTS=(int, 25),
     DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
     DD_JIRA_SSL_VERIFY=(bool, True),
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
@@ -419,6 +420,7 @@ SLA_NOTIFY_PRE_BREACH = env('DD_SLA_NOTIFY_PRE_BREACH')  # in days, notify betwe
 SLA_NOTIFY_POST_BREACH = env('DD_SLA_NOTIFY_POST_BREACH')  # in days, skip notifications for findings that go past dayofbreach plus this number
 
 SEARCH_MAX_RESULTS = env('DD_SEARCH_MAX_RESULTS')
+SIMILAR_FINDINGS_MAX_RESULTS = env('DD_SIMILAR_FINDINGS_MAX_RESULTS')
 MAX_AUTOCOMPLETE_WORDS = env('DD_MAX_AUTOCOMPLETE_WORDS')
 
 LOGIN_EXEMPT_URLS = (

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -266,7 +266,7 @@
                                        {% endif %}                                       
                                        <li class="divider"></li>
                                         {% if user|is_authorized_for_staff:finding %}
-                                          {% if finding.risk_acceptance_set.exists %}
+                                          {% if finding.risk_acceptance_set.all %}
                                               <li role="presentation">
                                               <a href="{% url 'simple_risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
                                                   <i class="fa fa-exclamation-circle"></i> Unaccept Risk

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -129,7 +129,7 @@
                                 {% endif %}
                             {% endif %}                                  
                             {% if user|is_authorized_for_change:finding %}
-                                {% if finding.risk_acceptance_set.exists %}
+                                {% if finding.risk_acceptance_set.all %}
                                     <li role="presentation">
                                     <a href="{% url 'simple_risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
                                         <i class="fa fa-exclamation-circle"></i> Unaccept Risk
@@ -419,7 +419,7 @@
         </div>
         {% endif %}
     {% endif %}
-    {% if finding.static_finding or finding.line > 0 or finding.has_jira_configured or finding.jira_issue or finding.github_issue or finding.github_conf_new %}
+    {% if finding.static_finding or finding.line > 0 or finding.has_jira_configured or finding.has_jira_issue or finding.github_issue or finding.github_conf_new %}
     <div class="panel panel-default">
         <table id="error_notes" class="table-striped table table-condensed table-hover centered">
             <tr>
@@ -920,11 +920,11 @@
         var lastID = {{findings_list_lastElement}};
         if(currentID != firstID)
         {
-            $('.PrevAndNext_Buttons').append('<a href="{% url 'view_finding' prev_finding.id %}" class="btn btn-primary">Previous Finding</a> ');
+            $('.PrevAndNext_Buttons').append('<a href="{% url 'view_finding' prev_finding_id %}" class="btn btn-primary">Previous Finding</a> ');
         }
         if(currentID != lastID)
         {
-            $('.PrevAndNext_Buttons').append('<a href="{% url 'view_finding' next_finding.id %}" class="btn btn-primary">Next Finding</a>');
+            $('.PrevAndNext_Buttons').append('<a href="{% url 'view_finding' next_finding_id %}" class="btn btn-primary">Next Finding</a>');
         }
         //Ensures dropdown has proper zindex
         $('.table-responsive').on('show.bs.dropdown', function () {
@@ -964,11 +964,11 @@
         });
         
         $(document).on('keypress', null, 'p', function () {
-            window.location.assign('{% url 'view_finding' prev_finding.id %}');
+            window.location.assign('{% url 'view_finding' prev_finding_id %}');
         });
         
         $(document).on('keypress', null, 'n', function () {
-            window.location.assign('{% url 'view_finding' next_finding.id %}');
+            window.location.assign('{% url 'view_finding' next_finding_id %}');
         });
 
         $('a.delete-finding').on('click', function (e) {

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -414,7 +414,7 @@
                                         {% endif %}
                                     {% endif %}
                                     {% if user|is_authorized_for_staff:finding %}
-                                        {% if finding.risk_acceptance_set.exists %}
+                                        {% if finding.risk_acceptance_set.all %}
                                             <li role="presentation">
                                             <a href="{% url 'simple_risk_unaccept_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
                                                 <i class="fa fa-exclamation-circle"></i> Unaccept Risk


### PR DESCRIPTION
the view_finding page is quite slow due to the amount of queries executed and data retrieved.
this PR optimizes it a bit, but the real gain must come from #3236 

also adds a `settings.DD_SIMILAR_FINDINGS_MAX_RESULTS` setting to tune the max number of similar findings returned (default 25 instead of previous 10).