### PR TITLE
Fix Accepted Risk reporter/owner in engineer metrics

### DIFF
--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -755,7 +755,7 @@ def view_engineer(request, eid):
                                  monthrange(now.year,
                                             now.month)[1],
                                  tzinfo=timezone.get_current_timezone())],
-        reporter=user)
+        owner=user)
                       for finding in ra.accepted_findings.all()]
     closed_month = []
     for f in closed_findings:


### PR DESCRIPTION
I looked through the rest of the "Accepted_Risk.objects" instances in the repo and this was the last one. Hopefully we can put this issue behind us now!