### PR TITLE
debug_toolbar: add known issue + fix for static files

### DIFF
--- a/dojo/settings/template-local_settings
+++ b/dojo/settings/template-local_settings
@@ -5,8 +5,11 @@
 
 from django.conf.urls import include, url
 
+# UPDATE: Adding debug_toolbar to to INSTALLED_APPS here prevents the nginx container from generating the correct static files
+#         So add debug_toolbar to INSTALLED_APPS in settings.dist.py and rebuild to get started with the debug_toolbar.
+#         Thje middleware and other config can remain in this file (local_settings.py) to avoid chance of conflicts on upgrades.
 INSTALLED_APPS += (
-    'debug_toolbar',
+#    'debug_toolbar',
 )
 
 MIDDLEWARE = [


### PR DESCRIPTION
the debug_toolbar approach with local_settings.py doesn't work after all. It only worked on my machine because I had some previous static files from debug_Toolbar still laying around.

the nginx containers needs the settings at build time, so any apps that generate static files need to be added to INSTALLED_APPS in `settings.dist.py` for now. Maybe we can think of a better way, but we want to avoid copying `local_settings.py` into the release containers (I think), so that's way it's on the `.dockerignore` list.

if some docker expert has a better idea, let me know. For now I'd thought to get this PR so people don't get stuck on missing static files.