### PR TITLE
jira_webhook: improve error handling

### DIFF
--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -1699,7 +1699,7 @@
       "jira_key": "222",
       "finding": 5,
       "jira_id": "2",
-      "engagement": 3
+      "engagement": null
     }
   },
   {
@@ -1707,9 +1707,19 @@
     "model": "dojo.jira_issue",
     "fields": {
       "jira_key": "333",
-      "finding": 6,
-      "jira_id": "3",
+      "finding": null,
+      "jira_id": "333",
       "engagement": 1
+    }
+  },
+  {
+    "pk": 4,
+    "model": "dojo.jira_issue",
+    "fields": {
+      "jira_key": "666",
+      "finding": null,
+      "jira_id": "666",
+      "engagement": null
     }
   },
   {

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -127,7 +127,8 @@ def webhook(request, secret=None):
         if parsed.get('webhookEvent') == 'comment_created':
             comment_text = parsed['comment']['body']
             commentor = parsed['comment']['updateAuthor']['displayName']
-            jid = parsed['comment']['self'].split('/')[7]
+            # example: body['comment']['self'] = "http://www.testjira.com/jira_under_a_path/rest/api/2/issue/666/comment/456843"
+            jid = parsed['comment']['self'].split('/')[-3]
             jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
             logger.debug('jissue: %s', vars(jissue))
             if jissue.finding:

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -57,7 +57,7 @@ def webhook(request, secret=None):
         if parsed.get('webhookEvent') == 'jira:issue_updated':
             jid = parsed['issue']['id']
             jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
-            if jissue.finding is not None:
+            if jissue.finding:
                 finding = jissue.finding
                 jira_instance = jira_helper.get_jira_instance(finding)
                 resolved = True
@@ -115,34 +115,43 @@ def webhook(request, secret=None):
                     finding.jira_issue.jira_change = timezone.now()
                     finding.jira_issue.save()
                     finding.save()
-            """
-            if jissue.engagement is not None:
-                eng = jissue.engagement
-                if parsed['issue']['fields']['resolution'] != None:
-                    eng.active = False
-                    eng.status = 'Completed'
-                    eng.save()
-           """
+            elif jissue.engagement:
+                # if parsed['issue']['fields']['resolution'] != None:
+                #     eng.active = False
+                #     eng.status = 'Completed'
+                #     eng.save()
+                return HttpResponse('Update for engagement ignored')
+            else:
+                raise Http404('No finding or engagement found for this JIRA issue')
+
         if parsed.get('webhookEvent') == 'comment_created':
             comment_text = parsed['comment']['body']
             commentor = parsed['comment']['updateAuthor']['displayName']
             jid = parsed['comment']['self'].split('/')[7]
-            jissue = JIRA_Issue.objects.get(jira_id=jid)
-            jira_usernames = JIRA_Instance.objects.values_list('username', flat=True)
-            for jira_userid in jira_usernames:
-                if jira_userid.lower() in commentor.lower():
-                    return HttpResponse('')
-                    break
-            finding = jissue.finding
-            new_note = Notes()
-            new_note.entry = '(%s): %s' % (commentor, comment_text)
-            new_note.author, created = User.objects.get_or_create(username='JIRA')
-            new_note.save()
-            finding.notes.add(new_note)
-            finding.jira_issue.jira_change = timezone.now()
-            finding.jira_issue.save()
-            finding.save()
-            create_notification(event='other', title='JIRA incoming comment - %s' % (jissue.finding), url=reverse("view_finding", args=(jissue.finding.id, )), icon='check')
+            jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
+            logger.debug('jissue: %s', vars(jissue))
+            if jissue.finding:
+                logger.debug('finding: %s', vars(jissue.finding))
+                jira_usernames = JIRA_Instance.objects.values_list('username', flat=True)
+                for jira_userid in jira_usernames:
+                    if jira_userid.lower() in commentor.lower():
+                        logger.debug('skipping incoming JIRA comment as the user id of the comment mathces the JIRA user in Defect Dojo')
+                        return HttpResponse('')
+                        break
+                finding = jissue.finding
+                new_note = Notes()
+                new_note.entry = '(%s): %s' % (commentor, comment_text)
+                new_note.author, created = User.objects.get_or_create(username='JIRA')
+                new_note.save()
+                finding.notes.add(new_note)
+                finding.jira_issue.jira_change = timezone.now()
+                finding.jira_issue.save()
+                finding.save()
+                create_notification(event='other', title='JIRA incoming comment - %s' % (jissue.finding), url=reverse("view_finding", args=(jissue.finding.id, )), icon='check')
+            elif jissue.engagement:
+                return HttpResponse('Comment for engagement ignored')
+            else:
+                raise Http404('No finding or engagement found for this JIRA issue')
 
         if parsed.get('webhookEvent') not in ['comment_created', 'jira:issue_updated']:
             logger.info('Unrecognized JIRA webhook event received: {}'.format(parsed.get('webhookEvent')))

--- a/dojo/unittests/test_jira_webhook.py
+++ b/dojo/unittests/test_jira_webhook.py
@@ -441,6 +441,29 @@ class JIRAWebhookTest(DojoTestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(notes_count_after, notes_count_before + 1)
 
+    def test_webhook_comment_on_finding_jira_under_path(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # finding 5 has a JIRA issue in the initial fixture for unit tests with id=2
+
+        body = json.loads(json.dumps(self.jira_issue_comment_template_json))
+        body['comment']['self'] = "http://www.testjira.com/my_little_happy_path_for_jira/rest/api/2/issue/2/comment/456843"
+
+        jira_issue = JIRA_Issue.objects.get(jira_id=2)
+        finding = jira_issue.finding
+        notes_count_before = finding.notes.count()
+
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
+                                    self.jira_issue_comment_template_json,
+                                    content_type="application/json")
+
+        jira_issue = JIRA_Issue.objects.get(jira_id=2)
+        finding = jira_issue.finding
+        notes_count_after = finding.notes.count()
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(notes_count_after, notes_count_before + 1)
+
     def test_webhook_comment_on_engagement(self):
         self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
 

--- a/dojo/unittests/test_jira_webhook.py
+++ b/dojo/unittests/test_jira_webhook.py
@@ -11,125 +11,47 @@ logger = logging.getLogger(__name__)
 class JIRAWebhookTest(DojoTestCase):
     fixtures = ['dojo_testdata.json']
 
-    def __init__(self, *args, **kwargs):
-        DojoTestCase.__init__(self, *args, **kwargs)
-
-    def setUp(self):
-        self.correct_secret = '12345'
-        self.incorrect_secret = '1234567890'
-
-    def test_webhook_get(self):
-        response = self.client.get(reverse('jira_web_hook'))
-        self.assertEqual(405, response.status_code)
-
-    def test_webhook_jira_disabled(self):
-        self.system_settings(enable_jira=False)
-        response = self.client.post(reverse('jira_web_hook'))
-        self.assertEqual(404, response.status_code)
-
-    def test_webhook_disabled(self):
-        self.system_settings(enable_jira=False, enable_jira_web_hook=False)
-        response = self.client.post(reverse('jira_web_hook'))
-        self.assertEqual(404, response.status_code)
-
-    def test_webhook_invalid_content_type(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=True)
-        response = self.client.post(reverse('jira_web_hook'))
-        # 400 due to incorrect content_type
-        self.assertEqual(400, response.status_code)
-
-    def test_webhook_secret_disabled_no_secret(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=True)
-        response = self.client.post(reverse('jira_web_hook'))
-        # 400 due to incorrect content_type
-        self.assertEqual(400, response.status_code)
-
-    def test_webhook_secret_disabled_secret(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=True)
-        response = self.client.post(reverse('jira_web_hook_secret', args=(self.incorrect_secret, )))
-        # 400 due to incorrect content_type
-        self.assertEqual(400, response.status_code)
-
-    def test_webhook_secret_enabled_no_secret(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
-        response = self.client.post(reverse('jira_web_hook'))
-        self.assertEqual(403, response.status_code)
-
-    def test_webhook_secret_enabled_incorrect_secret(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
-        response = self.client.post(reverse('jira_web_hook_secret', args=(self.incorrect_secret, )))
-        self.assertEqual(403, response.status_code)
-
-    def test_webhook_secret_enabled_correct_secret(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
-        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )))
-        # 400 due to incorrect content_type
-        self.assertEqual(400, response.status_code)
-
-    def test_webhook_comment_on_finding(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
-
-        body = {
-            "timestamp": 1605117321425,
-            "webhookEvent": "comment_created",
-            "comment": {
-                        "self": "http://www.testjira.com/rest/api/2/issue/2/comment/456843",
-                        "id": "456843",
-                        "author": {
-                            "self": "http://www.testjira.com/rest/api/2/user?username=valentijn",
-                            "name": "valentijn",
-                            "key": "valentijn",
-                            "avatarUrls": {
-                                "48x48": "http://www.testjira.com/secure/useravatar?ownerId=valentijn&avatarId=11101",
-                                "24x24": "http://www.testjira.com/secure/useravatar?size=small&ownerId=valentijn&avatarId=11101",
-                                "16x16": "http://www.testjira.com/secure/useravatar?size=x small&ownerId=valentijn&avatarId=11101",
-                                "32x32": "http://www.testjira.com/secure/useravatar?size=medium&ownerId=valentijn&avatarId=11101"
-                            },
-                            "displayName": "Valentijn Scholten",
-                            "active": "true",
-                            "timeZone": "Europe/Amsterdam"
+    jira_issue_comment_template_json = {
+        "timestamp": 1605117321425,
+        "webhookEvent": "comment_created",
+        "comment": {
+                    "self": "http://www.testjira.com/rest/api/2/issue/2/comment/456843",
+                    "id": "456843",
+                    "author": {
+                        "self": "http://www.testjira.com/rest/api/2/user?username=valentijn",
+                        "name": "valentijn",
+                        "key": "valentijn",
+                        "avatarUrls": {
+                            "48x48": "http://www.testjira.com/secure/useravatar?ownerId=valentijn&avatarId=11101",
+                            "24x24": "http://www.testjira.com/secure/useravatar?size=small&ownerId=valentijn&avatarId=11101",
+                            "16x16": "http://www.testjira.com/secure/useravatar?size=x small&ownerId=valentijn&avatarId=11101",
+                            "32x32": "http://www.testjira.com/secure/useravatar?size=medium&ownerId=valentijn&avatarId=11101"
                         },
-                        "body": "test2",
-                        "updateAuthor": {
-                            "self": "http://www.testjira.com/rest/api/2/user?username=valentijn",
-                            "name": "valentijn",
-                            "key": "valentijn",
-                            "avatarUrls": {
-                                "48x48": "http://www.testjira.com/secure/useravatar?ownerId=valentijn&avatarId=11101",
-                                "24x24": "http://www.testjira.com/secure/useravatar?size=small&ownerId=valentijn&avatarId=11101",
-                                "16x16": "http://www.testjira.com/secure/useravatar?size=xsmall&ownerId=valentijn&avatarId=11101",
-                                "32x32": "http://www.testjira.com/secure/useravatar?size=medium&ownerId=valentijn&avatarId=11101"
-                            },
-                            "displayName": "Valentijn Scholten",
-                            "active": "true",
-                            "timeZone": "Europe/Amsterdam"
+                        "displayName": "Valentijn Scholten",
+                        "active": "true",
+                        "timeZone": "Europe/Amsterdam"
+                    },
+                    "body": "test2",
+                    "updateAuthor": {
+                        "self": "http://www.testjira.com/rest/api/2/user?username=valentijn",
+                        "name": "valentijn",
+                        "key": "valentijn",
+                        "avatarUrls": {
+                            "48x48": "http://www.testjira.com/secure/useravatar?ownerId=valentijn&avatarId=11101",
+                            "24x24": "http://www.testjira.com/secure/useravatar?size=small&ownerId=valentijn&avatarId=11101",
+                            "16x16": "http://www.testjira.com/secure/useravatar?size=xsmall&ownerId=valentijn&avatarId=11101",
+                            "32x32": "http://www.testjira.com/secure/useravatar?size=medium&ownerId=valentijn&avatarId=11101"
                         },
-                        "created": "2020-11-11T18:55:21.425+0100",
-                        "updated": "2020-11-11T18:55:21.425+0100"
-            }
+                        "displayName": "Valentijn Scholten",
+                        "active": "true",
+                        "timeZone": "Europe/Amsterdam"
+                    },
+                    "created": "2020-11-11T18:55:21.425+0100",
+                    "updated": "2020-11-11T18:55:21.425+0100"
         }
+    }
 
-        # finding 5 has a JIRA issue in the initial fixture for unit tests
-
-        jira_issue = JIRA_Issue.objects.get(jira_id=2)
-        finding = jira_issue.finding
-        notes_count_before = finding.notes.count()
-
-        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
-                                    body,
-                                    content_type="application/json")
-
-        jira_issue = JIRA_Issue.objects.get(jira_id=2)
-        finding = jira_issue.finding
-        notes_count_after = finding.notes.count()
-
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(notes_count_after, notes_count_before + 1)
-
-    def test_webhook_update_finding(self):
-        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
-
-        body = json.dumps(json.loads("""
+    jira_issue_update_template_string = """
 {
    "timestamp":1605117321475,
    "webhookEvent":"jira:issue_updated",
@@ -442,14 +364,74 @@ class JIRAWebhookTest(DojoTestCase):
       "updated":"2020-11-11T18:55:21.425+0100"
    }
 }
-"""))
-        # finding 5 has a JIRA issue in the initial fixture for unit tests
+"""
+
+    def __init__(self, *args, **kwargs):
+        DojoTestCase.__init__(self, *args, **kwargs)
+
+    def setUp(self):
+        self.correct_secret = '12345'
+        self.incorrect_secret = '1234567890'
+
+    def test_webhook_get(self):
+        response = self.client.get(reverse('jira_web_hook'))
+        self.assertEqual(405, response.status_code)
+
+    def test_webhook_jira_disabled(self):
+        self.system_settings(enable_jira=False)
+        response = self.client.post(reverse('jira_web_hook'))
+        self.assertEqual(404, response.status_code)
+
+    def test_webhook_disabled(self):
+        self.system_settings(enable_jira=False, enable_jira_web_hook=False)
+        response = self.client.post(reverse('jira_web_hook'))
+        self.assertEqual(404, response.status_code)
+
+    def test_webhook_invalid_content_type(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=True)
+        response = self.client.post(reverse('jira_web_hook'))
+        # 400 due to incorrect content_type
+        self.assertEqual(400, response.status_code)
+
+    def test_webhook_secret_disabled_no_secret(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=True)
+        response = self.client.post(reverse('jira_web_hook'))
+        # 400 due to incorrect content_type
+        self.assertEqual(400, response.status_code)
+
+    def test_webhook_secret_disabled_secret(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=True)
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.incorrect_secret, )))
+        # 400 due to incorrect content_type
+        self.assertEqual(400, response.status_code)
+
+    def test_webhook_secret_enabled_no_secret(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+        response = self.client.post(reverse('jira_web_hook'))
+        self.assertEqual(403, response.status_code)
+
+    def test_webhook_secret_enabled_incorrect_secret(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.incorrect_secret, )))
+        self.assertEqual(403, response.status_code)
+
+    def test_webhook_secret_enabled_correct_secret(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )))
+        # 400 due to incorrect content_type
+        self.assertEqual(400, response.status_code)
+
+    def test_webhook_comment_on_finding(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # finding 5 has a JIRA issue in the initial fixture for unit tests with id=2
+
         jira_issue = JIRA_Issue.objects.get(jira_id=2)
         finding = jira_issue.finding
         notes_count_before = finding.notes.count()
 
         response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
-                                    body,
+                                    self.jira_issue_comment_template_json,
                                     content_type="application/json")
 
         jira_issue = JIRA_Issue.objects.get(jira_id=2)
@@ -457,7 +439,85 @@ class JIRAWebhookTest(DojoTestCase):
         notes_count_after = finding.notes.count()
 
         self.assertEqual(200, response.status_code)
-        self.assertEqual(notes_count_after, notes_count_before)
-        self.assertTrue(finding.is_Mitigated)
-        self.assertFalse(finding.active)
-        self.assertIsNotNone(finding.mitigated)
+        self.assertEqual(notes_count_after, notes_count_before + 1)
+
+    def test_webhook_comment_on_engagement(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # 333 = engagement
+        body = json.loads(json.dumps(self.jira_issue_comment_template_json))
+        body['comment']['self'] = "http://www.testjira.com/rest/api/2/issue/333/comment/456843"
+
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
+                                    body,
+                                    content_type="application/json")
+        print(response.content)
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(b'Comment for engagement ignored', response.content)
+
+    def test_webhook_update_engagement(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # 333 = engagement
+        body = json.loads(self.jira_issue_update_template_string)
+        body['issue']['id'] = 333
+
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
+                                    body,
+                                    content_type="application/json")
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(b'Update for engagement ignored', response.content)
+
+    def test_webhook_comment_no_finding_no_engagement(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # 666 = nothing attached to JIRA_Issue
+        body = json.loads(json.dumps(self.jira_issue_comment_template_json))
+        body['comment']['self'] = "http://www.testjira.com/rest/api/2/issue/666/comment/456843"
+
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
+                                    body,
+                                    content_type="application/json")
+
+        self.assertEqual(404, response.status_code)
+
+    def test_webhook_update_no_finding_no_engagement(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # 666 = nothing attached to JIRA_Issue
+        body = json.loads(self.jira_issue_update_template_string)
+        body['issue']['id'] = 999
+
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
+                                    body,
+                                    content_type="application/json")
+
+        self.assertEqual(404, response.status_code)
+
+    def test_webhook_comment_no_jira_issue_at_all(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # 666 = nothing attached to JIRA_Issue
+        body = json.loads(json.dumps(self.jira_issue_comment_template_json))
+        body['comment']['self'] = "http://www.testjira.com/rest/api/2/issue/999/comment/456843"
+
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
+                                    body,
+                                    content_type="application/json")
+
+        self.assertEqual(404, response.status_code)
+
+    def test_webhook_update_no_jira_issue_at_all(self):
+        self.system_settings(enable_jira=True, enable_jira_web_hook=True, disable_jira_webhook_secret=False, jira_webhook_secret=self.correct_secret)
+
+        # 666 = nothing attached to JIRA_Issue
+        body = json.loads(self.jira_issue_update_template_string)
+        body['issue']['id'] = 666
+
+        response = self.client.post(reverse('jira_web_hook_secret', args=(self.correct_secret, )),
+                                    body,
+                                    content_type="application/json")
+
+        self.assertEqual(404, response.status_code)


### PR DESCRIPTION
I discussed #3290 with @madchap and we decided I should put my money where my mouth is.
So this is my take a improving error handling of the JIRA webhook, and fix #3290 

Has updated unit tests to test scenarios with missing JIRA_Issue or missing Finding or missing Engagement.

Will also correctly ignore comments/udpates for engagements, as these have no findings attached in Defect Dojo.

Any exceptions that are not anticipated are not catched same as we do not catch those on any other page / view / api endpoint in Defect Dojo.

also added a fix for #3217 while I was at it