### PR TITLE
tags: add testcases

### DIFF
--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -225,6 +225,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
     def get_finding_tags_api(self, finding_id):
         response = self.do_finding_tags_api(self.client.get, finding_id)
+        print(response.data)
         return response.data
 
     def post_finding_tags_api(self, finding_id, tags):

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -120,7 +120,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         # print('test.content: ', response.content)
         return json.loads(response.content)
 
-    def import_scan_with_params(self, filename, engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None):
+    def import_scan_with_params(self, filename, engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None):
         payload = {
                 "scan_date": '2020-06-04',
                 "minimum_severity": minimum_severity,
@@ -135,9 +135,12 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         if push_to_jira is not None:
             payload['push_to_jira'] = push_to_jira
 
+        if tags is not None:
+            payload['tags'] = tags
+
         return self.import_scan(payload)
 
-    def reimport_scan_with_params(self, test_id, filename, engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None):
+    def reimport_scan_with_params(self, test_id, filename, engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None):
         payload = {
                 "test": test_id,
                 "scan_date": '2020-06-04',
@@ -152,6 +155,9 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
         if push_to_jira is not None:
             payload['push_to_jira'] = push_to_jira
+
+        if tags is not None:
+            payload['tags'] = tags
 
         return self.reimport_scan(payload)
 

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -2,7 +2,8 @@ from vcr_unittest import VCRTestCase
 from dojo.models import User, Endpoint, Notes, Finding, Endpoint_Status, Test, JIRA_Issue
 from dojo.models import System_Settings, Engagement
 from django.urls import reverse
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase, APIClient
+from rest_framework.authtoken.models import Token
 import json
 from django.test import TestCase
 from itertools import chain
@@ -95,6 +96,12 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
     def __init__(self, *args, **kwargs):
         APITestCase.__init__(self, *args, **kwargs)
+
+    def login_as_admin(self):
+        testuser = self.get_test_admin()
+        token = Token.objects.get(user=testuser)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
 
     def import_scan(self, payload):
         # logger.debug('import_scan payload %s', payload)
@@ -196,6 +203,46 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         self.assertEqual(200, response.status_code)
         # print('findings.content: ', response.content)
         return json.loads(response.content)
+
+    def do_finding_tags_api(self, http_method, finding_id, tags=None):
+        data = None
+        if tags:
+            data = {'tags': tags}
+
+        # print('data:' + str(data))
+
+        response = http_method(reverse('finding-tags', args=(finding_id,)), data, format='json')
+        # print(vars(response))
+        # print(response.content)
+        self.assertEqual(200, response.status_code)
+        return response
+
+    def get_finding_tags_api(self, finding_id):
+        response = self.do_finding_tags_api(self.client.get, finding_id)
+        return response.data
+
+    def post_finding_tags_api(self, finding_id, tags):
+        response = self.do_finding_tags_api(self.client.post, finding_id, tags)
+        return response.data
+
+    def do_finding_remove_tags_api(self, http_method, finding_id, tags=None, expected_response_status_code=200):
+        data = None
+        if tags:
+            data = {'tags': tags}
+
+        response = http_method(reverse('finding-remove-tags', args=(finding_id,)), data, format='json')
+        # print(response)
+        # print(response.content)
+        self.assertEqual(expected_response_status_code, response.status_code)
+        return response.data
+
+    def put_finding_remove_tags_api(self, finding_id, tags, *args, **kwargs):
+        response = self.do_finding_remove_tags_api(self.client.put, finding_id, tags, *args, **kwargs)
+        return response
+
+    def patch_finding_remove_tags_api(self, finding_id, tags, *args, **kwargs):
+        response = self.do_finding_remove_tags_api(self.client.patch, finding_id, tags, *args, **kwargs)
+        return response
 
     def log_finding_summary_json_api(self, findings_content_json=None):
         # print('summary')

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -15,6 +15,10 @@ from json import dumps
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APITestCase, APIClient
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 def skipIfNotSubclass(baseclass_name):
@@ -44,20 +48,30 @@ class BaseClass():
 
         @skipIfNotSubclass('ListModelMixin')
         def test_list(self):
-            if hasattr(self.endpoint_model, 'tags') and self.payload:
+            check_for_tags = False
+            if hasattr(self.endpoint_model, 'tags') and self.payload and self.payload.get('tags', None):
                 # create a new instance first to make sure there's at least 1 instance with tags set by payload to trigger tag handling code
+                logger.debug('creating model with endpoints: %s', self.payload)
                 response = self.client.post(self.url, self.payload)
+                # print('response:', response.data)
+                check_for_id = response.data['id']
+                # print('id: ', check_for_id)
+                check_for_tags = self.payload.get('tags', None)
 
             response = self.client.get(self.url, format='json')
-            # print("RESPONSE[0]:", response.data['results'])
-            # print("RESPONSE[0]:", response.data['results'][0])
-            # print("RESPONSE[0]:", response.data['results'][0]['id'])
-            # finding = Finding.objects.get(id=response.data['results'][0]['id'])
-            # print("RESPONSE.age:", response.data['results'][0]['age'])
-            # print("finding.age:", finding.age)
+            # tags must be present in last entry, the one we created
+            if check_for_tags:
+                tags_found = False
+                for result in response.data['results']:
+                    if result['id'] == check_for_id:
+                        # logger.debug('result.tags: %s', result.get('tags', ''))
+                        self.assertEqual(len(check_for_tags), len(result.get('tags', None)))
+                        for tag in check_for_tags:
+                            # logger.debug('looking for tag %s in tag list %s', tag, result['tags'])
+                            self.assertTrue(tag in result['tags'])
+                        tags_found = True
+                self.assertTrue(tags_found)
 
-            # print("RESPONSE.sla_days_remaining:", response.data['results'][0]['sla_days_remaining'])
-            # print("finding.sla_days_remaining:", finding.sla_days_remaining())
             self.assertEqual(200, response.status_code)
 
         @skipIfNotSubclass('CreateModelMixin')
@@ -66,6 +80,12 @@ class BaseClass():
             response = self.client.post(self.url, self.payload)
             self.assertEqual(201, response.status_code, response.data)
             self.assertEqual(self.endpoint_model.objects.count(), length + 1)
+
+            if hasattr(self.endpoint_model, 'tags') and self.payload and self.payload.get('tags', None):
+                self.assertEqual(len(self.payload.get('tags')), len(response.data.get('tags', None)))
+                for tag in self.payload.get('tags'):
+                    # logger.debug('looking for tag %s in tag list %s', tag, response.data['tags'])
+                    self.assertTrue(tag in response.data['tags'])
 
         @skipIfNotSubclass('RetrieveModelMixin')
         def test_detail(self):
@@ -101,6 +121,13 @@ class BaseClass():
             self.assertFalse('ssh' in response.data)
             self.assertFalse('password' in response.data)
             self.assertFalse('api_key' in response.data)
+
+            if hasattr(self.endpoint_model, 'tags') and self.update_fields and self.update_fields.get('tags', None):
+                self.assertEqual(len(self.update_fields.get('tags')), len(response.data.get('tags', None)))
+                for tag in self.update_fields.get('tags'):
+                    logger.debug('looking for tag %s in tag list %s', tag, response.data['tags'])
+                    self.assertTrue(tag in response.data['tags'])
+
             response = self.client.put(
                 relative_url, self.payload)
             self.assertEqual(200, response.status_code)
@@ -164,7 +191,7 @@ class EndpointTest(BaseClass.RESTEndpointTest):
             'product': 1,
             "tags": ["mytag", "yourtag"]
         }
-        self.update_fields = {'protocol': 'ftp'}
+        self.update_fields = {'protocol': 'ftp', 'tags': ['one_new_tag']}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -253,8 +280,10 @@ class FindingsTest(BaseClass.RESTEndpointTest):
             "static_finding": False,
             "dynamic_finding": False,
             "endpoints": [1, 2],
-            "images": []}
-        self.update_fields = {'active': True, "push_to_jira": "True"}
+            "images": [],
+            "tags": ['tag1', 'tag_2']
+        }
+        self.update_fields = {'active': True, "push_to_jira": "True", 'tags': ['finding_tag_new']}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -14,7 +14,8 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
 from json import dumps
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
-from rest_framework.test import APITestCase, APIClient
+from rest_framework.test import APIClient
+from .dojo_test_case import DojoAPITestCase
 import logging
 
 
@@ -33,9 +34,9 @@ def skipIfNotSubclass(baseclass_name):
 
 
 class BaseClass():
-    class RESTEndpointTest(APITestCase):
+    class RESTEndpointTest(DojoAPITestCase):
         def __init__(self, *args, **kwargs):
-            APITestCase.__init__(self, *args, **kwargs)
+            DojoAPITestCase.__init__(self, *args, **kwargs)
             self.view_mixins = list(map(
                 (lambda x: x.__name__), self.viewset.__bases__))
 
@@ -219,7 +220,7 @@ class EngagementTest(BaseClass.RESTEndpointTest):
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
-class FindingRequestResponseTest(APITestCase):
+class FindingRequestResponseTest(DojoAPITestCase):
     fixtures = ['dojo_testdata.json']
 
     def setUp(self):
@@ -622,7 +623,7 @@ class UsersTest(BaseClass.RESTEndpointTest):
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
-class ProductPermissionTest(APITestCase):
+class ProductPermissionTest(DojoAPITestCase):
     fixtures = ['dojo_testdata.json']
 
     def setUp(self):
@@ -642,7 +643,7 @@ class ProductPermissionTest(APITestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class ScanSettingsPermissionTest(APITestCase):
+class ScanSettingsPermissionTest(DojoAPITestCase):
     fixtures = ['dojo_testdata.json']
 
     def setUp(self):
@@ -662,7 +663,7 @@ class ScanSettingsPermissionTest(APITestCase):
         self.assertEqual(response.status_code, 404)
 
 
-class ScansPermissionTest(APITestCase):
+class ScansPermissionTest(DojoAPITestCase):
     fixtures = ['dojo_testdata.json']
 
     def setUp(self):
@@ -704,7 +705,7 @@ class ImportScanTest(BaseClass.RESTEndpointTest):
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
-class ReimportScanTest(APITestCase):
+class ReimportScanTest(DojoAPITestCase):
     fixtures = ['dojo_testdata.json']
 
     def setUp(self):

--- a/dojo/unittests/test_taggit_tags.py
+++ b/dojo/unittests/test_taggit_tags.py
@@ -180,6 +180,36 @@ class TaggitTests(DojoAPITestCase):
     def test_finding_patch_remove_tags_non_existent(self):
         return self.test_finding_put_remove_tags_non_existent()
 
+    def test_finding_create_tags_with_comma(self):
+        tags = ['one,two']
+        finding_id = self.create_finding_with_tags(tags)
+        response = self.get_finding_tags_api(finding_id)
+
+        # via API the tag gets split into two tags (via the UI no splitting happens)
+        self.assertEqual(2, len(response.get('tags')))
+        self.assertTrue('one' in response['tags'])
+        self.assertTrue('two' in response['tags'])
+
+    def test_finding_create_tags_with_spaces(self):
+        tags = ['one two']
+        finding_id = self.create_finding_with_tags(tags)
+        response = self.get_finding_tags_api(finding_id)
+
+        # via API the tag gets split into two tags (via the UI no splitting happens)
+        self.assertEqual(2, len(response.get('tags')))
+        self.assertTrue('one' in response['tags'])
+        self.assertTrue('two' in response['tags'])
+
+    def test_finding_create_tags_with_slashes(self):
+        tags = ['a/b/c']
+        finding_id = self.create_finding_with_tags(tags)
+        response = self.get_finding_tags_api(finding_id)
+
+        self.assertEqual(len(tags), len(response.get('tags', None)))
+        for tag in tags:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag in response['tags'])
+
     def test_import_and_reimport_with_tags(self):
         tags = ['tag1', 'tag2']
         import0 = self.import_scan_with_params(self.zap_sample5_filename, tags=tags)

--- a/dojo/unittests/test_taggit_tags.py
+++ b/dojo/unittests/test_taggit_tags.py
@@ -1,12 +1,16 @@
-from django.test import TestCase
-from dojo.models import Product
+from dojo.models import Product, Finding
+from .dojo_test_case import DojoAPITestCase
+import logging
+
+logger = logging.getLogger(__name__)
 
 
-class TaggitTests(TestCase):
+class TaggitTests(DojoAPITestCase):
     fixtures = ['dojo_testdata.json']
 
     def setUp(self, *args, **kwargs):
-        pass
+        super().setUp()
+        self.login_as_admin()
 
     def test_tags_prefetching(self):
         # print('\nadding tags')
@@ -53,3 +57,123 @@ class TaggitTests(TestCase):
                     self.assertEqual('eng_' + str(eng.id + 1) in [tag.name for tag in eng.tags], False)
                     self.assertEqual('test_' + str(test.id) in [tag.name for tag in test.tags], True)
                     self.assertEqual('test_' + str(test.id + 1) in [tag.name for tag in test.tags], False)
+
+    def create_finding_with_tags(self, tags):
+        finding_id = Finding.objects.all().first().id
+        finding_details = self.get_finding_api(finding_id)
+
+        del finding_details['id']
+
+        finding_details['title'] = 'tags test 1'
+        finding_details['tags'] = tags
+        response = self.post_new_finding_api(finding_details)
+
+        return response['id']
+
+    def test_finding_get_tags(self):
+        tags = ['tag1', 'tag2']
+        finding_id = self.create_finding_with_tags(tags)
+        response = self.get_finding_tags_api(finding_id)
+
+        self.assertEqual(len(tags), len(response.get('tags', None)))
+        for tag in tags:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag in response['tags'])
+
+    def test_finding_post_tags(self):
+        # create finding
+        tags = ['tag1', 'tag2']
+        finding_id = self.create_finding_with_tags(tags)
+
+        # post tags. POST will ADD tags to existing tags (which is possibly not REST compliant?)
+        tags_new = ['tag3', 'tag4']
+        response = self.post_finding_tags_api(finding_id, tags_new)
+        tags_merged = list(set(tags) | set(tags_new))
+        self.assertEqual(len(tags_merged), len(response.get('tags')))
+        for tag in tags_merged:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag in response['tags'])
+
+    def test_finding_post_tags_overlap(self):
+        # create finding
+        tags = ['tag1', 'tag2']
+        finding_id = self.create_finding_with_tags(tags)
+
+        # post tags. POST will ADD tags to existing tags (which is possibly not REST compliant?)
+        tags_new = ['tag2', 'tag3']
+        response = self.post_finding_tags_api(finding_id, tags_new)
+        tags_merged = list(set(tags) | set(tags_new))
+        self.assertEqual(len(tags_merged), len(response.get('tags')))
+        for tag in tags_merged:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag in response['tags'])
+
+    def test_finding_put_remove_tags(self):
+        # create finding
+        tags = ['tag1', 'tag2']
+        finding_id = self.create_finding_with_tags(tags)
+
+        # post tags. PUT will remove any tags that exist
+        tags_remove = ['tag1']
+        response = self.put_finding_remove_tags_api(finding_id, tags_remove)
+
+        # for some reason this method returns just a message, not the remaining tags
+        self.assertEquals(response['success'], 'Tag(s) Removed')
+
+        # retrieve finding and check
+        tags_merged = list(set(tags) - set(tags_remove))
+        response = self.get_finding_tags_api(finding_id)
+        self.assertEqual(len(tags_merged), len(response.get('tags')))
+        for tag in tags_merged:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag in response['tags'])
+
+    def test_finding_put_remove_tags_all(self):
+        # create finding
+        tags = ['tag1', 'tag2']
+        finding_id = self.create_finding_with_tags(tags)
+
+        # post tags. PUT will remove any tags that exist
+        tags_remove = tags
+        response = self.put_finding_remove_tags_api(finding_id, tags_remove)
+
+        # for some reason this method returns just a message, not the remaining tags
+        self.assertEquals(response['success'], 'Tag(s) Removed')
+
+        # retrieve finding and check
+        tags_merged = list(set(tags) - set(tags_remove))
+        response = self.get_finding_tags_api(finding_id)
+        self.assertEqual(len(tags_merged), len(response.get('tags')))
+        for tag in tags_merged:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag in response['tags'])
+
+    def test_finding_put_remove_tags_non_existent(self):
+        # create finding
+        tags = ['tag1', 'tag2']
+        finding_id = self.create_finding_with_tags(tags)
+
+        # post tags. PUT will throw an error on non-existent tag to be removed (which is maybe not what we want?)
+        tags_remove = ['tag5']
+        response = self.put_finding_remove_tags_api(finding_id, tags_remove, expected_response_status_code=400)
+
+        # for some reason this method returns just a message, not the remaining tags
+        self.assertEquals(response['error'], '\'tag5\' is not a valid tag in list')
+
+        # retrieve finding and check
+        tags_merged = list(set(tags) - set(tags_remove))
+        response = self.get_finding_tags_api(finding_id)
+        self.assertEqual(len(tags_merged), len(response.get('tags')))
+        for tag in tags_merged:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag in response['tags'])
+
+    def test_finding_patch_remove_tags(self):
+        # has same logic as PUT
+        return self.test_finding_put_remove_tags()
+
+    def test_finding_patch_remove_tags_all(self):
+        return self.test_finding_put_remove_tags_all()
+
+    def test_finding_patch_remove_tags_non_existent(self):
+        return self.test_finding_put_remove_tags_non_existent()

--- a/dojo/unittests/test_taggit_tags.py
+++ b/dojo/unittests/test_taggit_tags.py
@@ -210,6 +210,7 @@ class TaggitTests(DojoAPITestCase):
         self.assertEqual(2, len(response.get('tags')))
         self.assertTrue('one' in response['tags'])
         self.assertTrue('two' in response['tags'])
+        # finding.tags: [<Tag: one>, <Tag: two>]
 
     def test_finding_create_tags_with_spaces_quoted(self):
         tags = ['"one two"']
@@ -221,6 +222,8 @@ class TaggitTests(DojoAPITestCase):
         for tag in tags:
             logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
             self.assertTrue(tag.strip('\"') in response['tags'])
+
+        # finding.tags: <QuerySet [<Tag: one two>]>
 
     def test_finding_create_tags_with_slashes(self):
         tags = ['a/b/c']

--- a/dojo/unittests/test_taggit_tags.py
+++ b/dojo/unittests/test_taggit_tags.py
@@ -180,7 +180,7 @@ class TaggitTests(DojoAPITestCase):
     def test_finding_patch_remove_tags_non_existent(self):
         return self.test_finding_put_remove_tags_non_existent()
 
-    def test_finding_create_tags_with_comma(self):
+    def test_finding_create_tags_with_commas(self):
         tags = ['one,two']
         finding_id = self.create_finding_with_tags(tags)
         response = self.get_finding_tags_api(finding_id)
@@ -189,6 +189,17 @@ class TaggitTests(DojoAPITestCase):
         self.assertEqual(2, len(response.get('tags')))
         self.assertTrue('one' in response['tags'])
         self.assertTrue('two' in response['tags'])
+
+    def test_finding_create_tags_with_commas_quoted(self):
+        tags = ['"one,two"']
+        finding_id = self.create_finding_with_tags(tags)
+        response = self.get_finding_tags_api(finding_id)
+
+        # no splitting due to quotes
+        self.assertEqual(len(tags), len(response.get('tags', None)))
+        for tag in tags:
+            # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag.strip('\"') in response['tags'])
 
     def test_finding_create_tags_with_spaces(self):
         tags = ['one two']
@@ -199,6 +210,17 @@ class TaggitTests(DojoAPITestCase):
         self.assertEqual(2, len(response.get('tags')))
         self.assertTrue('one' in response['tags'])
         self.assertTrue('two' in response['tags'])
+
+    def test_finding_create_tags_with_spaces_quoted(self):
+        tags = ['"one two"']
+        finding_id = self.create_finding_with_tags(tags)
+        response = self.get_finding_tags_api(finding_id)
+
+        # no splitting due to quotes
+        self.assertEqual(len(tags), len(response.get('tags', None)))
+        for tag in tags:
+            logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
+            self.assertTrue(tag.strip('\"') in response['tags'])
 
     def test_finding_create_tags_with_slashes(self):
         tags = ['a/b/c']


### PR DESCRIPTION
in the near future I am going to work on replacing the `django-taggit` library with `django-tagulous`.

to capture the current behavior, I have added some more test cases around tags. this will help with regression testing after the move to `django-tagulous`