### PR TITLE
jira: fix add/edit engagement if no jira config used

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -155,7 +155,7 @@ def edit_engagement(request, eid):
         jira_project_form = JIRAProjectForm(request.POST, prefix='jira-project-form', instance=jira_project, target='engagement')
         jira_epic_form = JIRAEngagementForm(request.POST, prefix='jira-epic-form', instance=engagement)
 
-        if (form.is_valid() and jira_project_form.is_valid() and jira_epic_form.is_valid()):
+        if (form.is_valid() and (jira_project_form is None or jira_project_form.is_valid()) and (jira_epic_form is None or jira_epic_form.is_valid())):
 
             # first save engagement details
             new_status = form.cleaned_data.get('status')

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -916,7 +916,7 @@ def new_eng_for_app(request, pid, cicd=False):
         jira_project_form = JIRAProjectForm(request.POST, prefix='jira-project-form', target='engagement', product=product)
         jira_epic_form = JIRAEngagementForm(request.POST, prefix='jira-epic-form')
 
-        if (form.is_valid() and jira_project_form.is_valid() and jira_epic_form.is_valid()):
+        if (form.is_valid() and (jira_project_form is None or jira_project_form.is_valid()) and (jira_epic_form is None or jira_epic_form.is_valid())):
 
             # first create the new engagement
             engagement = form.save(commit=False)


### PR DESCRIPTION
engagements without JIRA config would not get updated on form submit due to a similar bug as in #3295 

add/edit product is not suffering from this.