### PR TITLE
Correct filter for findings for non-staff users

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -147,7 +147,7 @@ django_filter=open_findings_filter):
         add_breadcrumb(title="Findings", top_level=not len(request.GET), request=request)
 
     if not request.user.is_staff:
-        findings = Finding.objects.filter(
+        findings = findings.filter(
             Q(test__engagement__product__authorized_users__in=[request.user]) |
             Q(test__engagement__product__prod_type__authorized_users__in=[request.user])
         )


### PR DESCRIPTION
When a non-staff user opens the list of finding in one of the products, he sees not only the findings of this particular product but all findings for all products he is allowed to see. This is due to a bug, where the queryset for the findings doesn't get a new filter to limit the findings to his products but a new filter is created, which disregards the initial selection.

This bug fix uses the previously defined filter and uses it for the authorization.