### PR TITLE
Fix helm rabbitMQ not grabbing secret after move to bitnami

### DIFF
--- a/helm/defectdojo/templates/secret-rabbitmq.yaml
+++ b/helm/defectdojo/templates/secret-rabbitmq.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.rabbitmq.rabbitmq.existingPasswordSecret }}
+  name: {{ .Values.rabbitmq.auth.existingPasswordSecret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -14,13 +14,13 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
-{{- if .Values.rabbitmq.rabbitmq.password }}
-  rabbitmq-password: {{ .Values.rabbitmq.rabbitmq.password | b64enc | quote }}
+{{- if .Values.rabbitmq.auth.password }}
+  rabbitmq-password: {{ .Values.rabbitmq.auth.password | b64enc | quote }}
 {{- else }}
   rabbitmq-password: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end}}
-{{- if .Values.rabbitmq.rabbitmq.erlangCookie }}
-  rabbitmq-erlang-cookie: {{ .Values.rabbitmq.rabbitmq.erlangCookie | b64enc | quote }}
+{{- if .Values.rabbitmq.auth.erlangCookie }}
+  rabbitmq-erlang-cookie: {{ .Values.rabbitmq.auth.erlangCookie | b64enc | quote }}
 {{- else }}
   rabbitmq-erlang-cookie: {{ randAlphaNum 32 | b64enc | quote }}
 {{- end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -190,7 +190,7 @@ cloudsql:
 rabbitmq:
   enabled: true
   replicas: 1
-  rabbitmq:
+  auth:
     password: ""
     erlangCookie: ""
     existingPasswordSecret: defectdojo-rabbitmq-specific


### PR DESCRIPTION
**Helm deployment option broken until this is merged.**

As we moved to Bitnami repo, the rabbitMQ chart got bumped 2 major version.

A key changed from `rabbitmq` to `auth`.

_Support: There could also be some "support" strain, where a statefulset cannot be upgraded due to k8s immutable specification around volume claims, so deleting the statefulset would be required for the upgrade_