### PR TITLE
Align Qualys WAS severities with the those in the UI

### DIFF
--- a/dojo/tools/qualys_webapp/parser.py
+++ b/dojo/tools/qualys_webapp/parser.py
@@ -9,12 +9,19 @@ from datetime import datetime
 from dojo.models import Finding, Endpoint
 from urllib.parse import urlparse
 
-
-SEVERITY_MATCH = ['Info',
+# Severities are listed under WAS_SCAN_REPORT/APPENDIX/SEVERITY_CATEGORY_LIST
+# Since Info findings are not recroded in the Confirmed Vulnerability or
+# Potential Vulnerability categories, a severity of 1 is shown as low
+# in the portal.
+SEVERITY_MATCH = ['Low',
                    'Low',
                    'Medium',
                    'High',
                    'Critical']
+# All QIDs in this category will be info because they only carry
+# three levels of severity (Minimal, Medium, Serious)
+INFO_CATEGORIES = ['Sensitive Content',
+                   'Information Gathered']
 
 
 def truncate_str(value: str, maxlen: int):
@@ -169,7 +176,8 @@ def get_glossary_item(glossary, finding):
     severity = glossary.findtext('SEVERITY')
     if severity is not None:
         group = glossary.findtext('GROUP')
-        if group == "DIAG":
+        category = glossary.findtext('CATEGORY')
+        if category in INFO_CATEGORIES or group == "DIAG":
             # Scan Diagnostics are always Info.
             finding.severity = "Info"
         else:

--- a/dojo/unittests/test_qualys_webapp_parser.py
+++ b/dojo/unittests/test_qualys_webapp_parser.py
@@ -14,7 +14,7 @@ class TestPhpSymfonySecurityCheckerParser(TestCase):
         parser = QualysWebAppParser(testfile, Test())
         testfile.close()
         # 6 non-info findings, 17 total
-        self.assertEqual(6, len([x for x in parser.items if x.severity != "Info"]))
+        self.assertEqual(0, len([x for x in parser.items if x.severity != "Info"]))
         self.assertEqual(17, len(parser.items))
 
     def test_qualys_webapp_parser_with_one_criticle_vuln_has_one_findings(self):
@@ -22,7 +22,7 @@ class TestPhpSymfonySecurityCheckerParser(TestCase):
         parser = QualysWebAppParser(testfile, Test())
         testfile.close()
         # 8 non-info findings, 14 total
-        self.assertEqual(8, len([x for x in parser.items if x.severity != "Info"]))
+        self.assertEqual(1, len([x for x in parser.items if x.severity != "Info"]))
         self.assertEqual(14, len(parser.items))
 
     def test_qualys_webapp_parser_with_many_vuln_has_many_findings(self):
@@ -30,5 +30,5 @@ class TestPhpSymfonySecurityCheckerParser(TestCase):
         parser = QualysWebAppParser(testfile, Test())
         testfile.close()
         # 9 non-info findings, 21 total
-        self.assertEqual(9, len([x for x in parser.items if x.severity != "Info"]))
+        self.assertEqual(3, len([x for x in parser.items if x.severity != "Info"]))
         self.assertEqual(21, len(parser.items))


### PR DESCRIPTION
Severities for issue recorded in Dojo from Qualys did not reflect the same number of vulnerabilities. Since all "information gathered" and "Sensitive Content" categories have a different severity scale,  they will be marked as informational. Additionally, Low severity items were being marked as Info in Dojo. The mapping is very strange, so this is a stab 