### PR TITLE
Helm posgreSQL, use existing secret even if postgres not enabled

### DIFF
--- a/helm/defectdojo/templates/secret-postgresql.yaml
+++ b/helm/defectdojo/templates/secret-postgresql.yaml
@@ -14,7 +14,6 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
-{{- if .Values.postgresql.enabled }}
 {{- if .Values.postgresql.postgresqlPassword }}
   postgresql-postgres-password: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
   {{ .Values.postgresql.secretKey }}: {{ .Values.postgresql.postgresqlPassword | b64enc | quote }}
@@ -23,12 +22,7 @@ data:
   postgresql-postgres-password: {{ $postgresRandomPassword }}
   {{ .Values.postgresql.secretKey }}: {{ $postgresRandomPassword }}
 {{- end }}
-{{- else }}
-  {{- $postgresRandomPassword := randAlphaNum 16 | b64enc | quote }}
-  postgresql-postgres-password: {{ $postgresRandomPassword }}
-  {{ .Values.postgresql.secretKey }}: {{ $postgresRandomPassword }}
-{{- end }}
-# TODO: check if replicatio password in injected into the values
+# TODO: check if replication password in injected into the values
 {{ if .Values.postgresql.replication.enabled -}}
 {{- if .Values.postgresql.postgresqlReplicationPassword }}
   postgresql-replication-password : {{ .Values.postgresql.postgresqlReplicationPassword | b64enc | quote }}


### PR DESCRIPTION
If you use an external postgreSQL, you'd still have a secret yet have it disabled within the helm chart.