### PR TITLE
FIX APIv2 : Add exception when parser fail to avoid error 500 without error info

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1188,6 +1188,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                                            data['scan_type'],)
         except ValueError:
             raise Exception("Parser ValueError")
+        except:
+            raise Exception('Error while parsing the report, did you specify the correct scan type ?')
 
         try:
             items = parser.items

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1002,6 +1002,8 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
                                            data['scan_type'],)
         except ValueError:
             raise Exception('FileParser ValueError')
+        except:
+            raise Exception('Error while parsing the report, did you specify the correct scan type ?')
 
         new_findings = []
         skipped_hashcodes = []

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1082,7 +1082,10 @@ class ReImportScanView(mixins.CreateModelMixin,
             push_to_jira = push_to_jira or jira_project.push_all_issues
 
         logger.debug('push_to_jira: %s', serializer.validated_data.get('push_to_jira'))
-        serializer.save(push_to_jira=push_to_jira)
+        try:
+            serializer.save(push_to_jira=push_to_jira)
+        except Exception as e:
+            raise ParseError(detail=e)
 
 
 class NoteTypeViewSet(mixins.ListModelMixin,

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -7,6 +7,7 @@ from rest_framework.response import Response
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
+from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 from django.utils.decorators import method_decorator
 from drf_yasg2 import openapi
@@ -1060,7 +1061,10 @@ class ImportScanView(mixins.CreateModelMixin,
             push_to_jira = push_to_jira or jira_project.push_all_issues
 
         logger.debug('push_to_jira: %s', serializer.validated_data.get('push_to_jira'))
-        serializer.save(push_to_jira=push_to_jira)
+        try:
+            serializer.save(push_to_jira=push_to_jira)
+        except Exception as e:
+            raise ParseError(detail=e)
 
 
 class ReImportScanView(mixins.CreateModelMixin,


### PR DESCRIPTION
The method `save` in the serializers for import scan and re-import scan can fail if the file parsed is not of the type given by scan type. As a result, the client gets an error 500 without any error message. Therefore, this PR aim at solving that issue by raising an exception which is catched in the viewset and transformed into a ParseError that yields an HTTP error 400 with an error message.

Currently, I wrote a generic message since there is not error handling in the `import_parser_factory` that would yield a more specific error message. Let me know if you think that something else would be more appropriate.