### PR TITLE
pip: use old legacy resolver

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -23,7 +23,8 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 COPY requirements.txt ./
-RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt --use-deprecated=legacy-resolver
 
 FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c
 WORKDIR /app
@@ -59,7 +60,8 @@ RUN pip3 install \
 	--no-cache-dir \
 	--no-index \
   --find-links=/tmp/wheels \
-  -r ./requirements.txt
+  -r ./requirements.txt \
+  --use-deprecated=legacy-resolver
 COPY \
   docker/entrypoint-celery-beat.sh \
   docker/entrypoint-celery-worker.sh \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -20,7 +20,8 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 COPY requirements.txt ./
-RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt --use-deprecated=legacy-resolver
 
 FROM build AS collectstatic
 
@@ -46,11 +47,13 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 
+RUN pip3 install --no-cache-dir --upgrade pip
 RUN pip3 install \
 	--no-cache-dir \
 	--no-index \
   --find-links=/tmp/wheels \
-	-r ./requirements.txt
+	-r ./requirements.txt \
+    --use-deprecated=legacy-resolver
 
 COPY components/ ./components/
 COPY manage.py ./


### PR DESCRIPTION
switch to old legacy resolver due to pip now using a new more strict resolver that we cannot use yet