### PR TITLE
Include local_settings in celery containers if present

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,10 @@ services:
       DD_CELERY_BROKER_PASSWORD: ${DD_CELERY_BROKER_USER:-guest}
       DD_SECRET_KEY: ${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}
       DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}
+    volumes:
+        - type: bind
+          source: ./docker/extra_settings
+          target: /app/docker/extra_settings
   celeryworker:
     image: defectdojo/defectdojo-django:latest
     depends_on:
@@ -64,6 +68,10 @@ services:
       DD_CELERY_BROKER_PASSWORD: ${DD_CELERY_BROKER_USER:-guest}
       DD_SECRET_KEY: ${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}
       DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}
+    volumes:
+        - type: bind
+          source: ./docker/extra_settings
+          target: /app/docker/extra_settings
   initializer:
     image: defectdojo/defectdojo-django:latest
     depends_on:
@@ -81,7 +89,7 @@ services:
     volumes:
         - type: bind
           source: ./docker/extra_settings
-          target: /app/docker/extra_settings      
+          target: /app/docker/extra_settings
   mysql:
     image: mysql:5.7.32@sha256:ec6742af6625f76f98162b17fd62d22e1824d13fd80f214ab9184c7b6b50bad5
     environment:

--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -11,6 +11,15 @@ do
 done
 echo
 
+# Allow for bind-mount setting.py overrides
+FILE=/app/docker/extra_settings/local_settings.py
+if test -f "$FILE"; then
+    echo "============================================================"
+    echo "     Overriding DefectDojo's local_settings.py with $FILE."
+    echo "============================================================"
+    cp "$FILE" /app/dojo/settings/local_settings.py
+fi
+
 exec celery beat \
   --app=dojo \
   --pidfile=/var/run/defectdojo/celery-beat.pid \

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -11,6 +11,15 @@ do
 done
 echo
 
+# Allow for bind-mount setting.py overrides
+FILE=/app/docker/extra_settings/local_settings.py
+if test -f "$FILE"; then
+    echo "============================================================"
+    echo "     Overriding DefectDojo's local_settings.py with $FILE."
+    echo "============================================================"
+    cp "$FILE" /app/dojo/settings/local_settings.py
+fi
+
 if [ "${DD_CELERY_WORKER_POOL_TYPE}" = "prefork" ]; then
   EXTRA_PARAMS="--autoscale=${DD_CELERY_WORKER_AUTOSCALE_MAX},${DD_CELERY_WORKER_AUTOSCALE_MIN}
     --prefetch-multiplier=${DD_CELERY_WORKER_PREFETCH_MULTIPLIER}"


### PR DESCRIPTION
If you want to add a new CELERY_BEAT_SCHEDULE or override deduplication algorythms by way of HASHCODE_FIELDS_PER_SCANNER and friends, the configuration needs to also be propagated to the celery containers and not only uWSGI.