### PR TITLE
APIv2: allow filtering of test types by name

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -984,6 +984,7 @@ class TestTypesViewSet(mixins.ListModelMixin,
     serializer_class = serializers.TestTypeSerializer
     queryset = Test_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('name',)
 
 
 class ToolConfigurationsViewSet(mixins.ListModelMixin,


### PR DESCRIPTION
This adds the ability to filter test types by name to APIv2, which is possible in APIv1.