### PR TITLE
Fix Internal Server Error when closing engagements

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -736,8 +736,12 @@ def close_epic(eng, push_to_jira):
         if push_to_jira:
             try:
                 jissue = get_jira_issue(eng)
+                if jissue is None:
+                    logger.warn("JIRA close epic failed: no issue found")
+                    return False
+
                 req_url = jira_instance.url + '/rest/api/latest/issue/' + \
-                    j_issue.jira_id + '/transitions'
+                    jissue.jira_id + '/transitions'
                 json_data = {'transition': {'id': jira_instance.close_status_key}}
                 r = requests.post(
                     url=req_url,


### PR DESCRIPTION
Closing an engagement (e.g. via the API) that has a JIRA instance associated with it leads to an Internal Server Error:

```
ERROR:django.request:Internal Server Error: /api/v2/engagements/1217/close/
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "./dojo/api_v2/views.py", line 133, in close
    close_engagement(eng)
  File "./dojo/engagement/services.py", line 17, in close_engagement
    jira_helper.close_epic(eng, True)
  File "./dojo/decorators.py", line 38, in __wrapper__
    return func(*args, **kwargs)
  File "./dojo/decorators.py", line 21, in __wrapper__
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/local.py", line 191, in __call__
    return self._get_current_object()(*a, **kw)
  File "/usr/local/lib/python3.6/site-packages/celery/app/task.py", line 393, in __call__
    return self.run(*args, **kwargs)
  File "./dojo/decorators.py", line 72, in __wrapper__
    return func(*args, **kwargs)
  File "./dojo/jira_link/helper.py", line 740, in close_epic
    j_issue.jira_id + '/transitions'
NameError: name 'j_issue' is not defined
```

Changing `j_issue` to `jissue` leads to another error:

```
ERROR:django.request:Internal Server Error: /api/v2/engagements/1217/close/
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/local/lib/python3.6/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "./dojo/api_v2/views.py", line 133, in close
    close_engagement(eng)
  File "./dojo/engagement/services.py", line 17, in close_engagement
    jira_helper.close_epic(eng, True)
  File "./dojo/decorators.py", line 38, in __wrapper__
    return func(*args, **kwargs)
  File "./dojo/decorators.py", line 21, in __wrapper__
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/celery/local.py", line 191, in __call__
    return self._get_current_object()(*a, **kw)
  File "/usr/local/lib/python3.6/site-packages/celery/app/task.py", line 393, in __call__
    return self.run(*args, **kwargs)
  File "./dojo/decorators.py", line 72, in __wrapper__
    return func(*args, **kwargs)
  File "./dojo/jira_link/helper.py", line 740, in close_epic
    jissue.jira_id + '/transitions'
AttributeError: 'NoneType' object has no attribute 'jira_id'
```

This pull request fixes both of them.
