### PR TITLE
[APIv2] Update put semantic and doc for endpoint /finding/{id}/metadata

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.core.exceptions import ValidationError
 from rest_framework import viewsets, mixins, status
 from rest_framework.response import Response
+from django.db import IntegrityError
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
@@ -514,30 +515,31 @@ class FindingViewSet(mixins.ListModelMixin,
         report = serializers.ReportGenerateSerializer(data)
         return Response(report.data)
 
-    def _get_metadata(self, request, pk=None):
-        finding = get_object_or_404(Finding.objects, id=pk)
-
+    def _get_metadata(self, request, finding):
         metadata = DojoMeta.objects.filter(finding=finding)
         serializer = serializers.FindingMetaSerializer(instance=metadata, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-    def _edit_metadata(self, request, pk=None):
-        finding = get_object_or_404(Finding.objects, id=pk)
+    def _edit_metadata(self, request, finding):
         metadata_name = request.query_params.get("name", None)
         if metadata_name is None:
-            return Response({"error": "Metadata name is required"},
+            return Response("Metadata name is required", status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            DojoMeta.objects.update_or_create(
+                name=metadata_name, finding=finding,
+                defaults={
+                    "name": request.data.get("name"),
+                    "value": request.data.get("value")
+                }
+            )
+
+            return Response(data=request.data, status=status.HTTP_200_OK)
+        except IntegrityError:
+            return Response("Update failed because the new name already exists",
                 status=status.HTTP_400_BAD_REQUEST)
 
-        metadata = get_object_or_404(DojoMeta.objects, name=metadata_name, finding=finding)
-        metadata.name = request.data.get("name", metadata.name)
-        metadata.value = request.data.get("value", metadata.value)
-
-        metadata.save()
-        return Response({"success": "Metadata updated"},
-            status=status.HTTP_200_OK)
-
-    def _add_metadata(self, request, pk=None):
-        finding = get_object_or_404(Finding.objects, id=pk)
+    def _add_metadata(self, request, finding):
         metadata_data = serializers.FindingMetaSerializer(data=request.data)
 
         if metadata_data.is_valid():
@@ -548,35 +550,37 @@ class FindingViewSet(mixins.ListModelMixin,
             try:
                 metadata.validate_unique()
                 metadata.save()
-            except ValidationError as err:
-                return Response({"error": err},
-                status=status.HTTP_400_BAD_REQUEST)
+            except ValidationError:
+                return Response("Create failed because the name of the metadata already exists", status=status.HTTP_400_BAD_REQUEST)
 
-            return Response({"success": "Metadata updated"},
-                status=status.HTTP_200_OK)
+            return Response(data=metadata_data.data, status=status.HTTP_200_OK)
         else:
             return Response(metadata_data.errors,
                 status=status.HTTP_400_BAD_REQUEST)
 
-    def _remove_metadata(self, request, pk=None):
-        finding = get_object_or_404(Finding.objects, id=pk)
+    def _remove_metadata(self, request, finding):
         name = request.query_params.get("name", None)
         if name is None:
-            return Response({"error": "A metadata name must be provided"},
-                status=status.HTTP_400_BAD_REQUEST)
+            return Response("A metadata name must be provided", status=status.HTTP_400_BAD_REQUEST)
 
         metadata = get_object_or_404(DojoMeta.objects, finding=finding, name=name)
         metadata.delete()
 
-        return Response({"success": "Metadata deleted"},
-            status=status.HTTP_200_OK)
+        return Response("Metadata deleted", status=status.HTTP_200_OK)
 
     @swagger_auto_schema(
-        responses={status.HTTP_200_OK: serializers.FindingMetaSerializer(many=True)},
+        responses={
+            status.HTTP_200_OK: serializers.FindingMetaSerializer(many=True),
+            status.HTTP_404_NOT_FOUND: "Returned if finding does not exist"
+        },
         methods=['get']
     )
     @swagger_auto_schema(
-        responses={status.HTTP_200_OK: ""},
+        responses={
+            status.HTTP_200_OK: "Returned if the metadata was correctly deleted",
+            status.HTTP_404_NOT_FOUND: "Returned if finding does not exist",
+            status.HTTP_400_BAD_REQUEST: "Returned if there was a problem with the metadata information"
+        },
         methods=['delete'],
         manual_parameters=[openapi.Parameter(
             name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING,
@@ -584,7 +588,11 @@ class FindingViewSet(mixins.ListModelMixin,
                             metadata associated with the finding")]
     )
     @swagger_auto_schema(
-        responses={status.HTTP_200_OK: ""},
+        responses={
+            status.HTTP_200_OK: serializers.FindingMetaSerializer,
+            status.HTTP_404_NOT_FOUND: "Returned if finding does not exist",
+            status.HTTP_400_BAD_REQUEST: "Returned if there was a problem with the metadata information"
+        },
         methods=['put'],
         manual_parameters=[openapi.Parameter(
             name="name", in_=openapi.IN_QUERY, required=True, type=openapi.TYPE_STRING,
@@ -592,20 +600,28 @@ class FindingViewSet(mixins.ListModelMixin,
         request_body=serializers.FindingMetaSerializer
     )
     @swagger_auto_schema(
-        responses={status.HTTP_200_OK: ""},
+        responses={
+            status.HTTP_200_OK: serializers.FindingMetaSerializer,
+            status.HTTP_404_NOT_FOUND: "Returned if finding does not exist",
+            status.HTTP_400_BAD_REQUEST: "Returned if there was a problem with the metadata information"
+        },
         methods=['post'],
         request_body=serializers.FindingMetaSerializer
     )
     @action(detail=True, methods=["post", "put", "delete", "get"])
     def metadata(self, request, pk=None):
+        finding = get_object_or_404(Finding.objects, id=pk)
+
         if request.method == "GET":
-            return self._get_metadata(request, pk)
+            return self._get_metadata(request, finding)
         elif request.method == "POST":
-            return self._add_metadata(request, pk)
+            return self._add_metadata(request, finding)
         elif request.method == "PUT":
-            return self._edit_metadata(request, pk)
+            return self._edit_metadata(request, finding)
+        elif request.method == "PATCH":
+            return self._edit_metadata(request, finding)
         elif request.method == "DELETE":
-            return self._remove_metadata(request, pk)
+            return self._remove_metadata(request, finding)
 
         return Response({"error", "unsupported method"}, status=status.HTTP_400_BAD_REQUEST)
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -551,7 +551,7 @@ class FindingViewSet(mixins.ListModelMixin,
                 metadata.validate_unique()
                 metadata.save()
             except ValidationError:
-                return Response("Create failed because the name of the metadata already exists", status=status.HTTP_400_BAD_REQUEST)
+                return Response("Create failed probably because the name of the metadata already exists", status=status.HTTP_400_BAD_REQUEST)
 
             return Response(data=metadata_data.data, status=status.HTTP_200_OK)
         else:


### PR DESCRIPTION
This PR is an improvement of the (sub)endpoint recently added, `/finding/{id}/metadata`. In the current implementation, the semantic of PUT is only an update semantic, meaning that if the given metadata does not exist, it will not create it. However, since we are in the particular case where a metadata can be uniquely identified by a pair `(finding_id, metadata_name)` we think it makes sense to change the semantic to that of update or create. Note that this does not contradict the original semantic intended for the PUT operation in the context of REST API since we are not identifying the metadata with an ID.

The main advantage of this improvement is to reduce the number of queries from two to one in the case where we want to do an update or create. We also kept the POST operation to still support a create only that could fail instead of updating the metadata if it already exists.

We also took advantage of this improvement to enhance the documentation of that endpoint, more specifically the responses that the endpoint could return.