### PR TITLE
celery imports for dojo.tools.tool_issue_updater

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -677,6 +677,8 @@ CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']
 CELERY_TASK_SERIALIZER = env('DD_CELERY_TASK_SERIALIZER')
 CELERY_PASS_MODEL_BY_ID = env('DD_CELERY_PASS_MODEL_BY_ID')
 
+CELERY_IMPORTS = ('dojo.tools.tool_issue_updater', )
+
 # Celery beat scheduled tasks
 CELERY_BEAT_SCHEDULE = {
     'add-alerts': {

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -5,7 +5,7 @@ from dojo.decorators import dojo_async_task, dojo_model_to_id, dojo_model_from_i
 
 def async_tool_issue_update(finding, *args, **kwargs):
     if is_tool_issue_updater_needed(finding):
-        tool_issue_updater.delay(finding)
+        tool_issue_updater(finding)
 
 
 def is_tool_issue_updater_needed(finding, *args, **kwargs):


### PR DESCRIPTION
fixes #3413 

since 1.10.x some celery tasks are located in `dojo/tools/tool_issue_udpater.py`.
for some reason celery doesn't detect these tasks.
strange coincidence is that any changes made to that file also don't trigger any hot reloading by uwsgi.
can't figure out why, so for now we add explicit CELERY_IMPORTS to settings to detect the tasks correctly again