### PR TITLE
make build image for nginx the same as django

### DIFF
--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -21,8 +21,7 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 COPY requirements.txt ./
-RUN pip3 install --no-cache-dir --upgrade pip
-RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt --use-deprecated=legacy-resolver
+RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
 FROM build AS collectstatic
 

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -15,12 +15,14 @@ RUN \
     postgresql-client \
     xmlsec1 \
     git \
+    uuid-runtime \
     && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
   true
 COPY requirements.txt ./
-RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
+RUN pip3 install --no-cache-dir --upgrade pip
+RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt --use-deprecated=legacy-resolver
 
 FROM build AS collectstatic
 


### PR DESCRIPTION
In the Dockerfile it says:

># The code for the build image should be idendical with the code in
># Dockerfile.django to use the caching mechanism of Docker.

this PR makes Dockerfile.nginx back in sync with Dockerfile.django again