### PR TITLE
release workflow: simplify matrix

### DIFF
--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -46,20 +46,13 @@ jobs:
             Fill in with release drafter information manually for now, then publish.
           draft: true
           prerelease: false
-  job-build-matrix:
+
+  job-build-and-push:
     needs: tag-and-release
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        # ref should be the tag name
-        run: echo "::set-output name=matrix::{\"docker-image\":[\"django\",\"nginx\"],\"docker-tag\":[\"latest\",\"${{ github.event.inputs.release_number }}\"]}"
-  job-build-and-push:
-    needs: job-build-matrix
-    runs-on: ubuntu-latest
     strategy:
-      matrix: ${{fromJson(needs.job-build-matrix.outputs.matrix)}}
+      matrix: 
+          docker-image: [django, nginx]
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -82,7 +75,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ matrix.docker-tag }}
+          tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:latest
           file: ./Dockerfile.${{ matrix.docker-image }}
           context: .
       - name: Image digest


### PR DESCRIPTION
the current workflow builds all images twice. once to push version `x.y.z` and once to push `latest`
this workflow simplifies this, which also results in the sha's for both tags being the same (which is good).