### PR TITLE
security: correct incomplete fix for #3410 / GHSA-96vq-gqr9-vf2c

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1257,6 +1257,17 @@ class EndpointFilter(DojoFilter):
                 Q(authorized_users__in=[self.user]) |
                 Q(prod_type__authorized_users__in=[self.user])).distinct().order_by('name')
 
+    @property
+    def qs(self):
+        parent = super(EndpointFilter, self).qs
+        if get_current_user() and not get_current_user().is_staff:
+            return parent.filter(
+                Q(product__authorized_users__in=[get_current_user()]) |
+                Q(product__prod_type__authorized_users__in=[get_current_user()])
+            )
+        else:
+            return parent
+
     class Meta:
         model = Endpoint
         exclude = ['mitigated', 'endpoint_status']


### PR DESCRIPTION
After #3410 there was still an instance where unauthorzed endpoints were shown.

Original security release:

Adresses: Security Advistory [GHSA-96vq-gqr9-vf2c](https://github.com/DefectDojo/django-DefectDojo/security/advisories/GHSA-96vq-gqr9-vf2c)

### Impact
A user can see vulnerable endpoints and details about their findings in a report, when he is not autorized for these products.
A user can see products, product types and details about their findings in metrics reports, when he is not autorized for these products.

This information about products and findings should only be revealed, when a user is explicitly allowed seen them or he is set as staff or superuser.

Similar data leakage could occur due to Django caching metrics globally instead of per user.

### CWE
[CWE-200](https://cwe.mitre.org/data/definitions/200.html) Disclosure of Sensitive Information.

### Fix
Affected reports / queries / pages have been adjusted to only show data related to authorized products and product types.
Caching of metrics has been configured to cache "per user" (vary_on_cookie).

### For more information
If you have any questions or comments about this advisory:
* Open an issue in [the DefectDojo issue tracker](https://github.com/DefectDojo/django-DefectDojo/issues)
* Slack us in the [OWASP #defectdojo](https://owasp.slack.com/archives/C2P5BA8MN) channel.

Please see our [security policy](https://github.com/DefectDojo/django-DefectDojo/security/policy) for more information. Disclose responsibly any vulnerabilities that you may find.