### PR TITLE
Add Flag for Initializer Container Entrypoint to Not Exit Upon Completion

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -111,12 +111,12 @@ EOD
   exec python3 manage.py buildwatson
 fi
 
-if [ "${KEEP_ALIVE}" = true ]
+if [ "${DD_KEEP_ALIVE}" = true ]
 then
   echo "Initializer configured to not exit after completion. Sleeping ..."
-  KEEP_ALIVE_INTERVAL=${KEEP_ALIVE_INTERVAL:-60}
+  DD_KEEP_ALIVE_INTERVAL=${DD_KEEP_ALIVE_INTERVAL:-60}
   while true;
-  do echo "Keep alive loop sleeping for ${KEEP_ALIVE_INTERVAL}";
-  sleep $KEEP_ALIVE_INTERVAL;
+  do echo "Keep alive loop sleeping for ${DD_KEEP_ALIVE_INTERVAL}";
+  sleep $DD_KEEP_ALIVE_INTERVAL;
   done
 fi

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -115,8 +115,8 @@ if [ "${DD_INITIALIZER_KEEP_ALIVE}" = true ]
 then
   echo "Initializer configured to not exit after completion. Sleeping ..."
   DD_INITIALIZER_KEEP_ALIVE_INTERVAL=${DD_INITIALIZER_KEEP_ALIVE_INTERVAL:-60}
-  while true;
-  do echo "Keep alive loop sleeping for ${DD_INITIALIZER_KEEP_ALIVE_INTERVAL}";
-  sleep $DD_INITIALIZER_KEEP_ALIVE_INTERVAL;
+  while true
+    do echo "Keep alive loop sleeping for ${DD_INITIALIZER_KEEP_ALIVE_INTERVAL}"
+    sleep $DD_INITIALIZER_KEEP_ALIVE_INTERVAL
   done
 fi

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -110,3 +110,13 @@ EOD
   python3 manage.py installwatson
   exec python3 manage.py buildwatson
 fi
+
+if [ "${KEEP_ALIVE}" = true ]
+then
+  echo "Initializer configured to not exit after completion. Sleeping ..."
+  KEEP_ALIVE_INTERVAL=${KEEP_ALIVE_INTERVAL:-60}
+  while true;
+  do echo "Keep alive loop sleeping for ${KEEP_ALIVE_INTERVAL}";
+  sleep $KEEP_ALIVE_INTERVAL;
+  done
+fi

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -111,12 +111,12 @@ EOD
   exec python3 manage.py buildwatson
 fi
 
-if [ "${DD_KEEP_ALIVE}" = true ]
+if [ "${DD_INITIALIZER_KEEP_ALIVE}" = true ]
 then
   echo "Initializer configured to not exit after completion. Sleeping ..."
-  DD_KEEP_ALIVE_INTERVAL=${DD_KEEP_ALIVE_INTERVAL:-60}
+  DD_INITIALIZER_KEEP_ALIVE_INTERVAL=${DD_INITIALIZER_KEEP_ALIVE_INTERVAL:-60}
   while true;
-  do echo "Keep alive loop sleeping for ${DD_KEEP_ALIVE_INTERVAL}";
-  sleep $DD_KEEP_ALIVE_INTERVAL;
+  do echo "Keep alive loop sleeping for ${DD_INITIALIZER_KEEP_ALIVE_INTERVAL}";
+  sleep $DD_INITIALIZER_KEEP_ALIVE_INTERVAL;
   done
 fi


### PR DESCRIPTION
Add modifications to script to use KEEP_ALIVE env var. If set, prevent
the initializer container from exiting if set.

Default to 60 seconds of sleep, unless otherwise specified with the env
var KEEP_ALIVE_INTERVAL.

Closes #3421.