### PR TITLE
Nikto parser for scan of multiple hosts

### DIFF
--- a/dojo/tools/nikto/parser.py
+++ b/dojo/tools/nikto/parser.py
@@ -25,11 +25,11 @@ class NiktoXMLParser(object):
         root = tree.getroot()
         scan = root.find('scandetails')
 
-        if  scan is not None:
+        if scan is not None:
             self.process_scandetail(scan, test, dupes)
         else:
-        # New versions of Nikto have a new file type (nxvmlversion="1.2") which adds an additional niktoscan tag
-        # This find statement below is to support new file format while not breaking older Nikto scan files versions.
+            # New versions of Nikto have a new file type (nxvmlversion="1.2") which adds an additional niktoscan tag
+            # This find statement below is to support new file format while not breaking older Nikto scan files versions.
             for scan in root.findall('./niktoscan/scandetails'):
                 self.process_scandetail(scan, test, dupes)
 

--- a/dojo/tools/nikto/parser.py
+++ b/dojo/tools/nikto/parser.py
@@ -24,11 +24,16 @@ class NiktoXMLParser(object):
         tree = ET.parse(filename)
         root = tree.getroot()
         scan = root.find('scandetails')
+
+        if  scan is not None:
+            self.process_scandetail(scan, test, dupes)
+        else:
         # New versions of Nikto have a new file type (nxvmlversion="1.2") which adds an additional niktoscan tag
         # This find statement below is to support new file format while not breaking older Nikto scan files versions.
-        if scan is None:
-            scan = root.find('./niktoscan/scandetails')
+            for scan in root.findall('./niktoscan/scandetails'):
+                self.process_scandetail(scan, test, dupes)
 
+    def process_scandetail(self, scan, test, dupes):
         for item in scan.findall('item'):
             # Title
             titleText = None

--- a/dojo/unittests/scans/nikto/nikto-report-many-vuln.xml
+++ b/dojo/unittests/scans/nikto/nikto-report-many-vuln.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" ?>
+<!DOCTYPE niktoscan SYSTEM "docs/nikto.dtd">
+<niktoscan>
+
+<niktoscan hoststest="0" options="-Format xml -output nikto.xml -h -" version="2.1.6" scanstart="Sat Nov 14 19:00:19 2020" scanend="Thu Jan  1 01:00:00 1970" scanelapsed=" seconds" nxmlversion="1.2">
+
+<scandetails targetip="192.168.0.24" targethostname="192.168.0.24" targetport="443" targetbanner="Apache Tomcat" starttime="2020-11-14 19:24:57" sitename="https://192.168.0.24:443/" siteip="https://192.168.0.24:443/" hostheader="192.168.0.24" errors="0" checks="6953">
+<ssl ciphers="ECDHE-RSA-AES256-GCM-SHA384" issuers="/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3" info="/CN=jamf.example.com" altnames="jamf-dmz-01.mwea.de, jamf.example.com" />
+
+<item id="999970" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[CDATA[Finding 1.1]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.24:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.24:443/]]></iplink>
+</item>
+<statistics elapsed="4218" itemsfound="1" itemstested="6953" endtime="2020-11-14 20:35:15" />
+</scandetails>
+
+</niktoscan>
+
+<niktoscan hoststest="1" options="-Format xml -output nikto.xml -h -" version="2.1.6" scanstart="Sat Nov 14 19:00:19 2020" scanend="Thu Jan  1 01:00:00 1970" scanelapsed=" seconds" nxmlversion="1.2">
+
+<scandetails targetip="192.168.0.20" targethostname="192.168.0.20" targetport="443" targetbanner="Microsoft-IIS/8.5" starttime="2020-11-14 20:35:15" sitename="https://192.168.0.20:443/" siteip="https://192.168.0.20:443/" hostheader="192.168.0.20" errors="0" checks="6953">
+<ssl ciphers="TLS_AES_256_GCM_SHA384" issuers="/C=GB/ST=Greater Manchester/L=Salford/O=Sectigo Limited/CN=Sectigo RSA Domain Validation Secure Server CA" info="/CN=mail.example.com" altnames="mail.example.com, autodiscover.example.com, ehic.example.com" />
+
+<item id="999957" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 2.1]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.20:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.20:443/]]></iplink>
+</item>
+
+<item id="999100" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 2.2]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.20:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.20:443/]]></iplink>
+</item>
+
+<statistics elapsed="1895" itemsfound="2" itemstested="6953" endtime="2020-11-14 21:06:50" />
+</scandetails>
+
+</niktoscan>
+
+<niktoscan hoststest="2" options="-Format xml -output nikto.xml -h -" version="2.1.6" scanstart="Sat Nov 14 19:00:19 2020" scanend="Thu Jan  1 01:00:00 1970" scanelapsed=" seconds" nxmlversion="1.2">
+
+<scandetails targetip="192.168.0.65" targethostname="192.168.0.65" targetport="443" targetbanner="Apache" starttime="2020-11-14 21:06:50" sitename="https://192.168.0.65:443/" siteip="https://192.168.0.65:443/" hostheader="192.168.0.65" errors="0" checks="6953">
+<ssl ciphers="ECDHE-RSA-AES256-GCM-SHA384" issuers="/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3" info="/CN=issues.example.com" altnames="issues.example.com" />
+
+<item id="999961" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 3.1]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.65:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.65:443/]]></iplink>
+</item>
+
+<item id="999100" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 3.2]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.65:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.65:443/]]></iplink>
+</item>
+
+<item id="999100" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 3.3]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.65:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.65:443/]]></iplink>
+</item>
+<statistics elapsed="1291" itemsfound="3" itemstested="6953" endtime="2020-11-14 21:28:21" />
+</scandetails>
+
+</niktoscan>
+
+<niktoscan hoststest="3" options="-Format xml -output nikto.xml -h -" version="2.1.6" scanstart="Sat Nov 14 19:00:19 2020" scanend="Thu Jan  1 01:00:00 1970" scanelapsed=" seconds" nxmlversion="1.2">
+
+<scandetails targetip="192.168.0.49" targethostname="192.168.0.49" targetport="443" targetbanner="Apache" starttime="2020-11-14 21:28:21" sitename="https://192.168.0.49:443/" siteip="https://192.168.0.49:443/" hostheader="192.168.0.49" errors="0" checks="6953">
+<ssl ciphers="ECDHE-RSA-AES256-GCM-SHA384" issuers="/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3" info="/CN=software.example.com" altnames="deploy.example.com, software.example.com" />
+
+<item id="999100" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 4.1]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.49:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.49:443/]]></iplink>
+</item>
+
+<item id="999955" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 4.2]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.49:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.49:443/]]></iplink>
+</item>
+
+<item id="999993" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Finding 4.3]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.49:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.49:443/]]></iplink>
+</item>
+
+<item id="001885" osvdbid="3092" osvdblink="https://vulners.com/osvdb/OSVDB:3092" method="GET">
+<description><![CDATA[Finding 4.4]]></description>
+<uri><![CDATA[/system/]]></uri>
+<namelink><![CDATA[https://192.168.0.49:443/system/]]></namelink>
+<iplink><![CDATA[https://192.168.0.49:443/system/]]></iplink>
+</item>
+
+<statistics elapsed="1729" itemsfound="4" itemstested="6953" endtime="2020-11-14 21:57:10" />
+</scandetails>
+
+</niktoscan>
+
+</niktoscan>

--- a/dojo/unittests/scans/nikto/nikto-report-old-format.xml
+++ b/dojo/unittests/scans/nikto/nikto-report-old-format.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<!DOCTYPE niktoscan SYSTEM "docs/nikto.dtd">
+<niktoscan>
+
+<scandetails targetip="192.168.0.24" targethostname="192.168.0.24" targetport="443" targetbanner="Apache Tomcat" starttime="2020-11-14 19:24:57" sitename="https://192.168.0.24:443/" siteip="https://192.168.0.24:443/" hostheader="192.168.0.24" errors="0" checks="6953">
+<ssl ciphers="ECDHE-RSA-AES256-GCM-SHA384" issuers="/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3" info="/CN=jamf.example.com" altnames="jamf-dmz-01.mwea.de, jamf.example.com" />
+
+<item id="999970" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[CDATA[Finding 1.1]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.24:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.24:443/]]></iplink>
+</item>
+<statistics elapsed="4218" itemsfound="1" itemstested="6953" endtime="2020-11-14 20:35:15" />
+</scandetails>
+
+</niktoscan>

--- a/dojo/unittests/scans/nikto/nikto-report-one-vuln.xml
+++ b/dojo/unittests/scans/nikto/nikto-report-one-vuln.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<!DOCTYPE niktoscan SYSTEM "docs/nikto.dtd">
+<niktoscan>
+
+<niktoscan hoststest="0" options="-Format xml -output nikto.xml -h -" version="2.1.6" scanstart="Sat Nov 14 19:00:19 2020" scanend="Thu Jan  1 01:00:00 1970" scanelapsed=" seconds" nxmlversion="1.2">
+
+<scandetails targetip="192.168.0.24" targethostname="192.168.0.24" targetport="443" targetbanner="Apache Tomcat" starttime="2020-11-14 19:24:57" sitename="https://192.168.0.24:443/" siteip="https://192.168.0.24:443/" hostheader="192.168.0.24" errors="0" checks="6953">
+<ssl ciphers="ECDHE-RSA-AES256-GCM-SHA384" issuers="/C=US/O=Let's Encrypt/CN=Let's Encrypt Authority X3" info="/CN=jamf.example.com" altnames="jamf-dmz-01.mwea.de, jamf.example.com" />
+
+<item id="999970" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[CDATA[Finding 1.1]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://192.168.0.24:443/]]></namelink>
+<iplink><![CDATA[https://192.168.0.24:443/]]></iplink>
+</item>
+<statistics elapsed="4218" itemsfound="1" itemstested="6953" endtime="2020-11-14 20:35:15" />
+</scandetails>
+
+</niktoscan>
+
+</niktoscan>

--- a/dojo/unittests/scans/nikto/nikto-report-zero-vuln.xml
+++ b/dojo/unittests/scans/nikto/nikto-report-zero-vuln.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" ?>
+<!DOCTYPE niktoscan SYSTEM "docs/nikto.dtd">
+<niktoscan>
+
+</niktoscan>

--- a/dojo/unittests/test_nikto_parser.py
+++ b/dojo/unittests/test_nikto_parser.py
@@ -1,0 +1,42 @@
+from django.test import TestCase
+from dojo.tools.nikto.parser import NiktoXMLParser
+from dojo.models import Test, Engagement, Product
+
+
+class TestNiktoParser(TestCase):
+
+    def test_parse_without_file_has_no_findings(self):
+        parser = NiktoXMLParser(None, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_file_with_old_format(self):
+        test = Test()
+        engagement = Engagement()
+        engagement.product = Product()
+        test.engagement = engagement
+        testfile = open("dojo/unittests/scans/nikto/nikto-report-old-format.xml")
+        parser = NiktoXMLParser(testfile, test)
+        self.assertEqual(1, len(parser.items))
+
+    def test_parse_file_with_no_vuln_has_no_findings(self):
+        testfile = open("dojo/unittests/scans/nikto/nikto-report-zero-vuln.xml")
+        parser = NiktoXMLParser(testfile, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_parse_file_with_one_vuln_has_one_finding(self):
+        test = Test()
+        engagement = Engagement()
+        engagement.product = Product()
+        test.engagement = engagement
+        testfile = open("dojo/unittests/scans/nikto/nikto-report-one-vuln.xml")
+        parser = NiktoXMLParser(testfile, test)
+        self.assertEqual(1, len(parser.items))
+
+    def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
+        test = Test()
+        engagement = Engagement()
+        engagement.product = Product()
+        test.engagement = engagement
+        testfile = open("dojo/unittests/scans/nikto/nikto-report-many-vuln.xml")
+        parser = NiktoXMLParser(testfile, test)
+        self.assertTrue(len(parser.items) == 10)


### PR DESCRIPTION
Nikto can produce results for multiple hosts in one scan, eg. by reading nmap output to supply a list of hosts and ports to scan. The current Nikto parser reads only the result of the first host. With this pull request it will iterate over the results for all scanned hosts. This will only work for the new file type (nxvmlversion="1.2").