### PR TITLE
reports: fix performance issues and small bugs

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -24,7 +24,7 @@ from dojo.models import Product, Product_Type, Engagement, Test, Test_Type, Find
     BurpRawRequestResponse
 
 from dojo.endpoint.views import get_endpoint_ids
-from dojo.reports.views import report_url_resolver
+from dojo.reports.views import report_url_resolver, prefetch_related_findings_for_report
 from dojo.finding.views import set_finding_as_original_internal, reset_finding_duplicate_status_internal, \
     duplicate_cluster
 from dojo.filters import ReportFindingFilter, ReportAuthedFindingFilter, ApiFindingFilter, ApiProductFilter
@@ -1206,10 +1206,8 @@ def report_generate(request, obj, options):
         report_title = "Product Type Report"
         report_subtitle = str(product_type)
 
-        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
-            test__engagement__product__prod_type=product_type).distinct().prefetch_related('test',
-                                                                                           'test__engagement__product',
-                                                                                           'test__engagement__product__prod_type'))
+        findings = ReportFindingFilter(request.GET, prod_type=prod_type, queryset=prefetch_related_findings_for_report(Finding.objects.filter(
+            test__engagement__product__prod_type=product_type)))
         products = Product.objects.filter(prod_type=product_type,
                                           engagement__test__finding__in=findings.qs).distinct()
         engagements = Engagement.objects.filter(product__prod_type=product_type,
@@ -1238,10 +1236,8 @@ def report_generate(request, obj, options):
         report_name = "Product Report: " + str(product)
         report_title = "Product Report"
         report_subtitle = str(product)
-        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
-            test__engagement__product=product).distinct().prefetch_related('test',
-                                                                           'test__engagement__product',
-                                                                           'test__engagement__product__prod_type'))
+        findings = ReportFindingFilter(request.GET, product=product, queryset=prefetch_related_findings_for_report(Finding.objects.filter(
+            test__engagement__product=product)))
         ids = set(finding.id for finding in findings.qs)
         engagements = Engagement.objects.filter(test__finding__id__in=ids).distinct()
         tests = Test.objects.filter(finding__id__in=ids).distinct()
@@ -1250,13 +1246,8 @@ def report_generate(request, obj, options):
 
     elif type(obj).__name__ == "Engagement":
         engagement = obj
-        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
-            test__engagement=engagement,
-        ).prefetch_related(
-            'test',
-            'test__engagement__product',
-            'test__engagement__product__prod_type'
-        ).distinct())
+        findings = ReportFindingFilter(request.GET, engagement=engagement,
+                                       queryset=prefetch_related_findings_for_report(Finding.objects.filter(test__engagement=engagement)))
         report_name = "Engagement Report: " + str(engagement)
 
         report_title = "Engagement Report"
@@ -1269,11 +1260,10 @@ def report_generate(request, obj, options):
 
     elif type(obj).__name__ == "Test":
         test = obj
-        findings = ReportFindingFilter(request.GET,
-                                       queryset=Finding.objects.filter(test=test).prefetch_related(
-                                            'test',
-                                            'test__engagement__product',
-                                            'test__engagement__product__prod_type').distinct())
+        findings = ReportFindingFilter(request.GET, engagement=test.engagement,
+                                       queryset=prefetch_related_findings_for_report(Finding.objects.filter(test=test)))
+        filename = "test_finding_report.pdf"
+        template = "dojo/test_pdf_report.html"
         report_name = "Test Report: " + str(test)
         report_title = "Test Report"
         report_subtitle = str(test)
@@ -1288,23 +1278,13 @@ def report_generate(request, obj, options):
         report_title = "Endpoint Report"
         report_subtitle = host
         findings = ReportFindingFilter(request.GET,
-            queryset=Finding.objects.filter(
-                endpoints__in=endpoints,
-            ).prefetch_related(
-                'test',
-                'test__engagement__product',
-                'test__engagement__product__prod_type'
-            ).distinct())
+                                       queryset=prefetch_related_findings_for_report(Finding.objects.filter(endpoints__in=endpoints)))
 
     elif type(obj).__name__ == "QuerySet":
         findings = ReportAuthedFindingFilter(request.GET,
-            queryset=obj.prefetch_related(
-                'test',
-                'test__engagement__product',
-                'test__engagement__product__prod_type'
-            ).distinct(),
-            user=request.user
-        )
+                                             queryset=prefetch_related_findings_for_report(obj).distinct(),
+                                             user=request.user)
+
         report_name = 'Finding'
         report_type = 'Finding'
         report_title = "Finding Report"

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2231,18 +2231,18 @@ class Finding(models.Model):
 
     def get_report_requests(self):
         if self.burprawrequestresponse_set.count() >= 3:
-            return BurpRawRequestResponse.objects.filter(finding=self)[0:3]
+            return self.burprawrequestresponse_set.all()[0:3]
         elif self.burprawrequestresponse_set.count() > 0:
-            return BurpRawRequestResponse.objects.filter(finding=self)
+            return self.burprawrequestresponse_set.all()
 
     def get_request(self):
         if self.burprawrequestresponse_set.count() > 0:
-            reqres = BurpRawRequestResponse.objects.filter(finding=self)[0]
+            reqres = self.burprawrequestresponse_set().first()
         return base64.b64decode(reqres.burpRequestBase64)
 
     def get_response(self):
         if self.burprawrequestresponse_set.count() > 0:
-            reqres = BurpRawRequestResponse.objects.filter(finding=self)[0]
+            reqres = self.burprawrequestresponse_set.first()
         res = base64.b64decode(reqres.burpResponseBase64)
         # Removes all blank lines
         res = re.sub(r'\n\s*\n', '\n', res)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -218,6 +218,7 @@ def finding_querys(request, prod):
                                       severity__in=('Critical', 'High', 'Medium', 'Low', 'Info')).prefetch_related(
         'test__engagement',
         'test__engagement__risk_acceptance',
+        'test__test_type',
         'risk_acceptance_set',
         'reporter').extra(
         select={

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -383,18 +383,18 @@ def endpoint_report(request, eid):
 @user_must_be_authorized(Product, 'view', 'pid')
 def product_endpoint_report(request, pid):
     user = Dojo_User.objects.get(id=request.user.id)
-    product = get_object_or_404(Product, id=pid)
-    endpoints = Endpoint.objects.filter(product=product,
-                                        finding__active=True,
-                                        finding__verified=True,
-                                        finding__false_p=False,
-                                        finding__duplicate=False,
-                                        finding__out_of_scope=False,
-                                        )
+    product = get_object_or_404(Product.objects.all().prefetch_related('engagement_set__test_set__test_type', 'engagement_set__test_set__environment'), id=pid)
+    endpoint_ids = Endpoint.objects.filter(product=product,
+                                           finding__active=True,
+                                           finding__verified=True,
+                                           finding__false_p=False,
+                                           finding__duplicate=False,
+                                           finding__out_of_scope=False,
+                                           ).values_list('id', flat=True)
 
-    ids = get_endpoint_ids(endpoints)
+    # ids = get_endpoint_ids(endpoints)
 
-    endpoints = Endpoint.objects.filter(id__in=ids)
+    endpoints = prefetch_related_endpoints_for_report(Endpoint.objects.filter(id__in=endpoint_ids))
     endpoints = EndpointReportFilter(request.GET, queryset=endpoints)
 
     paged_endpoints = get_page_items(request, endpoints.qs, 25)
@@ -601,10 +601,8 @@ def generate_report(request, obj):
         report_title = "Product Type Report"
         report_subtitle = str(product_type)
 
-        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
-            test__engagement__product__prod_type=product_type).distinct().prefetch_related('test',
-                                                                                           'test__engagement__product',
-                                                                                           'test__engagement__product__prod_type'))
+        findings = ReportFindingFilter(request.GET, prod_type=product_type, queryset=prefetch_related_findings_for_report(Finding.objects.filter(
+            test__engagement__product__prod_type=product_type)))
         products = Product.objects.filter(prod_type=product_type,
                                           engagement__test__finding__in=findings.qs).distinct()
         engagements = Engagement.objects.filter(product__prod_type=product_type,
@@ -653,10 +651,8 @@ def generate_report(request, obj):
         report_name = "Product Report: " + str(product)
         report_title = "Product Report"
         report_subtitle = str(product)
-        findings = ReportFindingFilter(request.GET, queryset=Finding.objects.filter(
-            test__engagement__product=product).distinct().prefetch_related('test',
-                                                                           'test__engagement__product',
-                                                                           'test__engagement__product__prod_type'))
+        findings = ReportFindingFilter(request.GET, product=product, queryset=prefetch_related_findings_for_report(Finding.objects.filter(
+            test__engagement__product=product)))
         ids = set(finding.id for finding in findings.qs)
         engagements = Engagement.objects.filter(test__finding__id__in=ids).distinct()
         tests = Test.objects.filter(finding__id__in=ids).distinct()
@@ -679,12 +675,10 @@ def generate_report(request, obj):
                    'user_id': request.user.id}
 
     elif type(obj).__name__ == "Engagement":
+        logger.debug('generating report for Engagement')
         engagement = obj
-        findings = ReportFindingFilter(request.GET,
-                                       queryset=Finding.objects.filter(test__engagement=engagement,
-                                                                       ).prefetch_related('test',
-                                                                                          'test__engagement__product',
-                                                                                          'test__engagement__product__prod_type').distinct())
+        findings = ReportFindingFilter(request.GET, engagement=engagement,
+                                       queryset=prefetch_related_findings_for_report(Finding.objects.filter(test__engagement=engagement)))
         report_name = "Engagement Report: " + str(engagement)
         filename = "engagement_finding_report.pdf"
         template = 'dojo/engagement_pdf_report.html'
@@ -695,6 +689,7 @@ def generate_report(request, obj):
         tests = Test.objects.filter(finding__id__in=ids).distinct()
         ids = get_endpoint_ids(Endpoint.objects.filter(product=engagement.product).distinct())
         endpoints = Endpoint.objects.filter(id__in=ids)
+
         context = {'engagement': engagement,
                    'tests': tests,
                    'report_name': report_name,
@@ -712,10 +707,8 @@ def generate_report(request, obj):
 
     elif type(obj).__name__ == "Test":
         test = obj
-        findings = ReportFindingFilter(request.GET,
-                                       queryset=Finding.objects.filter(test=test).prefetch_related('test',
-                                                                                                   'test__engagement__product',
-                                                                                                   'test__engagement__product__prod_type').distinct())
+        findings = ReportFindingFilter(request.GET, engagement=test.engagement,
+                                       queryset=prefetch_related_findings_for_report(Finding.objects.filter(test=test)))
         filename = "test_finding_report.pdf"
         template = "dojo/test_pdf_report.html"
         report_name = "Test Report: " + str(test)
@@ -747,10 +740,7 @@ def generate_report(request, obj):
         report_title = "Endpoint Report"
         report_subtitle = host
         findings = ReportFindingFilter(request.GET,
-                                       queryset=Finding.objects.filter(endpoints__in=endpoints,
-                                                                       ).prefetch_related('test',
-                                                                                          'test__engagement__product',
-                                                                                          'test__engagement__product__prod_type').distinct())
+                                       queryset=prefetch_related_findings_for_report(Finding.objects.filter(endpoints__in=endpoints)))
 
         context = {'endpoint': endpoint,
                    'endpoints': endpoints,
@@ -767,9 +757,7 @@ def generate_report(request, obj):
                    'user_id': request.user.id}
     elif type(obj).__name__ == "QuerySet":
         findings = ReportAuthedFindingFilter(request.GET,
-                                             queryset=obj.prefetch_related('test',
-                                                                           'test__engagement__product',
-                                                                           'test__engagement__product__prod_type').distinct(),
+                                             queryset=prefetch_related_findings_for_report(obj).distinct(),
                                              user=request.user)
         filename = "finding_report.pdf"
         report_name = 'Finding'
@@ -899,3 +887,26 @@ def generate_report(request, obj):
                    'report_form': report_form,
                    'context': context,
                    })
+
+
+def prefetch_related_findings_for_report(findings):
+    return findings.prefetch_related('test',
+                                     'test__engagement__product',
+                                     'test__engagement__product__prod_type',
+                                     'risk_acceptance_set',
+                                     'risk_acceptance_set__accepted_findings',
+                                     'burprawrequestresponse_set',
+                                     'endpoints',
+                                     'notes',
+                                     'images',
+                                     'tagged_items',
+                                     'reporter',
+                                     'mitigated_by'
+                                     )
+
+
+def prefetch_related_endpoints_for_report(endpoints):
+    return endpoints.prefetch_related(
+                                      'product',
+                                      'tagged_items',
+                                     )

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -207,15 +207,14 @@
                     {% if finding.get_report_requests %}
                         <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
                         {% for req in finding.get_report_requests %}
-                           <h6>Request {{forloop.counter}} </h6>
-                           <pre>{{ req.get_request }}</pre>
-                        {% if req.get_response %}
-                           <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
-                        {% endif %}
+                            <h6>Request {{forloop.counter}} </h6>
+                            <pre>{{ req.get_request }}</pre>
+                            {% if req.get_response %}
+                             <h6>Response {{forloop.counter}}</h6>
+                             <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
+                            {% endif %}
                         {% endfor %}
-                        {% endif %}
-
+                    {% endif %}
                     <h6>Impact</h6>
                     <pre>{{ finding.impact }}</pre>
                     <h6>References</h6>
@@ -226,62 +225,65 @@
                             {% for pic in finding.images.all %}
                                 <p><img src="{{ host }}{% pic_token pic 'original' %}" style="max-width: 85%"></p>
                             {% endfor %}
-                            {% endif %}
-
-                        <h6>Impact</h6>
-                        <pre>{{ finding.impact }}</pre>
-                        <h6>References</h6>
-                        <pre>{{ finding.references }}</pre>
-                        {% if include_finding_images %}
-                            <h6>Images</h6>
-                            {% if finding.images.all.count > 0 %}
-                                {% for pic in finding.images.all %}
-                                    <p><img src="{{ host }}{% pic_token pic 'original' %}" style="max-width: 85%" alt="finding_image"></p>
-                                {% endfor %}
-                            {% else %}
-                                <p class="text-center">No images found.</p>
-                            {% endif %}
                         {% endif %}
+                    {% endif %}
+
+                    <h6>Impact</h6>
+                    <pre>{{ finding.impact }}</pre>
+                    <h6>References</h6>
+                    <pre>{{ finding.references }}</pre>
+
+                    {% if include_finding_images %}
+                        <h6>Images</h6>
+                        {% if finding.images.all.count > 0 %}
+                            {% for pic in finding.images.all %}
+                                <p><img src="{{ host }}{% pic_token pic 'original' %}" style="max-width: 85%" alt="finding_image"></p>
+                            {% endfor %}
+                        {% else %}
+                            <p class="text-center">No images found.</p>
+                        {% endif %}
+                    {% endif %}
+
                         {% if include_finding_notes %}
                             {% with notes=finding.notes.all|get_public_notes %}
                                 {% if notes.count > 0 %}
-                                    <h6>Notes</h6>
-                                    <table id="notes" class="tablesorter-bootstrap table table-condensed table-striped">
-                                        <thead>
-                                            <tr>
-                                                <th>User</th>
-                                                <th>Date</th>
-                                                {% with notes_with_type=notes|get_notetype_notes_count %}
-                                                {% if notes_with_type > 0 %}
-                                                    <th>Note Type</th>
-                                                {% endif %}
-                                                <th>Note</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                            {% for note in notes reversed %}
+                                    {% with notes_with_type=notes|get_notetype_notes_count %}
+                                        <h6>Notes</h6>
+                                        <table id="notes" class="tablesorter-bootstrap table table-condensed table-striped">
+                                            <thead>
                                                 <tr>
-                                                    <td>
-                                                        {{ note.author.username }}
-                                                    </td>
-                                                    <td>
-                                                        {{ note.date }}
-                                                    </td>
-                                                    {% if notes_with_type > 0 %}
-                                                    <td>
-                                                        {% if note.note_type != None %}
-                                                        {{ note.note_type }}
+                                                    <th>User</th>
+                                                    <th>Date</th>
+                                                        {% if notes_with_type > 0 %}
+                                                            <th>Note Type</th>
                                                         {% endif %}
-                                                    </td>
-                                                    {% endif %}
-                                                    <td>
-                                                        {{ note|linebreaks }}
-                                                    </td>
+                                                    <th>Note</th>
                                                 </tr>
-                                            {% endfor %}
-                                        </tbody>
+                                            </thead>
+                                            <tbody>
+                                                {% for note in notes reversed %}
+                                                    <tr>
+                                                        <td>
+                                                            {{ note.author.username }}
+                                                        </td>
+                                                        <td>
+                                                            {{ note.date }}
+                                                        </td>
+                                                        {% if notes_with_type > 0 %}
+                                                        <td>
+                                                            {% if note.note_type != None %}
+                                                                {{ note.note_type }}
+                                                            {% endif %}
+                                                        </td>
+                                                        {% endif %}
+                                                        <td>
+                                                            {{ note|linebreaks }}
+                                                        </td>
+                                                    </tr>
+                                                {% endfor %}
+                                            </tbody>
+                                        </table>
                                     {% endwith %}
-                                    </table>
                                 {% endif %}
                             {% endwith %}
                         {% endif %}
@@ -513,75 +515,77 @@
             }
         {%  endif %}
 
-        window.onload = function () {
-            var toc = "";
-            var level = 3;
+        {% if include_table_of_contents%}        
+            window.onload = function () {
+                var toc = "";
+                var level = 3;
 
-            document.getElementById("contents").innerHTML =
-                document.getElementById("contents").innerHTML.replace(
-                    /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
-                    function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
-                        if (openLevel != closeLevel || openLevel > 5) {
-                            return str;
-                        }
-
-                        if(tags)
-                        {
-                            openLevel = openLevel_t;
-                            id = id_t;
-                            titleText = titleText_t;
-                            closeLevel = closeLevel_t;
-                        }
-
-                        if (openLevel > level) {
-                            toc += (new Array(openLevel - level + 1)).join("<ul>");
-                        } else if (openLevel < level) {
-                            toc += (new Array(level - openLevel + 1)).join("</ul>");
-                        }
-
-                        level = parseInt(openLevel);
-                        
-                        var anchor = titleText.trim().replace(/ /g, "_");
-
-                        if(tags)
-                        {
-                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                document.getElementById("contents").innerHTML =
+                    document.getElementById("contents").innerHTML.replace(
+                        /<h([\d])([^<]*)>([^<]+)<\/h([\d])>|<h([\d])([^>]*)>([^<]+)<sup>([^<]*)<\/sup>([^<]*)<\/h([\d])>/gi,
+                        function (str, openLevel, id, titleText, closeLevel, openLevel_t, id_t, titleText_t, tags, junk, closeLevel_t) {
+                            if (openLevel != closeLevel || openLevel > 5) {
+                                return str;
                             }
-                            else {
-                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                titleText + "<sup>" + tags + "</sup></a></li>";
+
+                            if(tags)
+                            {
+                                openLevel = openLevel_t;
+                                id = id_t;
+                                titleText = titleText_t;
+                                closeLevel = closeLevel_t;
+                            }
+
+                            if (openLevel > level) {
+                                toc += (new Array(openLevel - level + 1)).join("<ul>");
+                            } else if (openLevel < level) {
+                                toc += (new Array(level - openLevel + 1)).join("</ul>");
+                            }
+
+                            level = parseInt(openLevel);
+                            
+                            var anchor = titleText.trim().replace(/ /g, "_");
+
+                            if(tags)
+                            {
+                                if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                    toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li>";
+                                }
+                                else {
+                                    toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    titleText + "<sup>" + tags + "</sup></a></li>";
+                                }
+
+                                return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                    + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
+                            }
+                            else
+                            {
+                                if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
+                                    toc += "<br><li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li><br>";
+                                }
+                                else {
+                                    toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
+                                    titleText + "</a></li>";
+                                }
+
+                                return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
+                                    + titleText + "</h" + closeLevel + "></a>";
                             }
 
                             return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
                                 + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
                         }
-                        else
-                        {
-                            if (['Info', 'Low', 'Medium', 'High', 'Critical'].indexOf(titleText) >= 0) {
-                                toc += "<br><li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                "<span class=\"label severity severity-" + titleText + "\">" + titleText + "</span></a></li><br>";
-                            }
-                            else {
-                                toc += "<li><a style=\"font-size:" + (160 - (level * 7)) + "%; color:black;\" href=\"#" + anchor + "\">" + 
-                                titleText + "</a></li>";
-                            }
+                    );
+                    
+                if (level) {
+                    toc += (new Array(level + 1)).join("</ul>");
+                }
 
-                            return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                                + titleText + "</h" + closeLevel + "></a>";
-                        }
-
-                        return "<a style=\"color:black;\" name=\"" + anchor + "\"><h" + openLevel + "" + id + ">"
-                            + titleText + "<sup>" + tags + "</sup></h" + closeLevel + "></a>";
-                    }
-                );
-                
-            if (level) {
-                toc += (new Array(level + 1)).join("</ul>");
-            }
-
-            document.getElementById("toc").innerHTML += toc;
-        };
+                document.getElementById("toc").innerHTML += toc;
+            };
+        {% endif %}
     </script>
 {% endblock %}

--- a/tests/Product_unit_test.py
+++ b/tests/Product_unit_test.py
@@ -402,7 +402,6 @@ class ProductTest(BaseTestCase):
         # Navigate to the product page
         driver.get(self.base_url + "metrics/product/type/counts")
 
-        from selenium.webdriver.support.select import Select
         my_select = Select(driver.find_element_by_id("id_product_type"))
         my_select.select_by_index(1)
 

--- a/tests/Report_builder_unit_test.py
+++ b/tests/Report_builder_unit_test.py
@@ -1,10 +1,13 @@
 from selenium.webdriver.support.ui import Select
 from selenium.webdriver.common.action_chains import ActionChains
-
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 import unittest
 import sys
 import os
 from base_test_class import BaseTestCase
+# from base_test_class import on_exception_html_source_logger
 from Product_unit_test import ProductTest
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -51,22 +54,137 @@ class ReportBuilderTest(BaseTestCase):
         driver.find_elements_by_class_name("run_report")[1].click()
         self.assertTrue(driver.current_url == self.base_url + "reports/custom")
 
+    def test_product_type_report(self):
+        driver = self.driver
+        driver.get(self.base_url + "product/type")
+        driver.find_element_by_partial_link_text('Report').click()
+        my_select = Select(driver.find_element_by_id("id_include_finding_notes"))
+        my_select.select_by_index(1)
 
-def add_finding_tests_to_suite(suite):
+        my_select = Select(driver.find_element_by_id("id_include_executive_summary"))
+        my_select.select_by_index(1)
 
+        my_select = Select(driver.find_element_by_id("id_include_executive_summary"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_table_of_contents"))
+        my_select.select_by_index(1)
+
+        driver.find_element_by_name('_generate').click()
+
+    def test_product_report(self):
+        driver = self.driver
+        self.goto_product_overview(driver)
+        driver.find_element_by_link_text("QA Test").click()
+        driver.find_element_by_id("dropdownMenu1").click()
+        driver.find_element_by_partial_link_text('Product Report').click()
+
+        my_select = Select(driver.find_element_by_id("id_include_finding_notes"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_executive_summary"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_table_of_contents"))
+        my_select.select_by_index(1)
+
+        driver.find_element_by_name('_generate').click()
+
+    def test_engagement_report(self):
+        driver = self.driver
+        self.goto_product_overview(driver)
+        driver.find_element_by_link_text("QA Test").click()
+        driver.find_element_by_partial_link_text('Engagements').click()
+        driver.find_element_by_link_text("View Engagements").click()
+        driver.find_element_by_link_text("Ad Hoc Engagement").click()
+        driver.find_element_by_id("dropdownMenu1").click()
+        driver.find_element_by_partial_link_text('Report').click()
+        my_select = Select(driver.find_element_by_id("id_include_finding_notes"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_executive_summary"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_table_of_contents"))
+        my_select.select_by_index(1)
+
+        driver.find_element_by_name('_generate').click()
+
+    def test_test_report(self):
+        driver = self.driver
+        self.goto_product_overview(driver)
+        driver.find_element_by_link_text("QA Test").click()
+        driver.find_element_by_partial_link_text('Engagements').click()
+        driver.find_element_by_link_text("View Engagements").click()
+        driver.find_element_by_link_text("Ad Hoc Engagement").click()
+        driver.find_element_by_link_text("Pen Test").click()
+        driver.find_element_by_id("dropdownMenu1").click()
+        driver.find_element_by_partial_link_text('Report').click()
+        my_select = Select(driver.find_element_by_id("id_include_finding_notes"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_executive_summary"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_table_of_contents"))
+        my_select.select_by_index(1)
+
+        driver.find_element_by_name('_generate').click()
+
+    # @on_exception_html_source_logger
+    def test_product_endpoint_report(self):
+        driver = self.driver
+        self.goto_product_overview(driver)
+        driver.find_element_by_link_text("QA Test").click()
+        driver.find_element_by_partial_link_text('Endpoints').click()
+        driver.find_element_by_link_text("Endpoint Report").click()
+
+        # extra dropdown click
+        # print('waiting for show-filters to appear due to the amazing javascript we have...')
+        dropdown = WebDriverWait(driver, 20).until(EC.visibility_of_element_located((By.ID, "show-filters")))
+
+        dropdown = driver.find_element_by_id("show-filters")
+        dropdown.click()
+
+        # print('waiting for filter section to expand...')
+        my_select = WebDriverWait(driver, 20).until(EC.visibility_of_element_located((By.ID, "id_include_finding_notes")))
+
+        my_select = Select(driver.find_element_by_id("id_include_finding_notes"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_executive_summary"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_table_of_contents"))
+        my_select.select_by_index(1)
+
+        driver.find_element_by_name('_generate').click()
+
+
+def add_report_tests_to_suite(suite):
     # Add each test the the suite to be run
     # success and failure is output by the test
     suite.addTest(ProductTest('test_create_product'))
-    suite.addTest(ProductTest('test_add_product_finding'))
-    suite.addTest(ReportBuilderTest('generate_HTML_report'))
-    suite.addTest(ReportBuilderTest('generate_AsciiDoc_report'))
+    # suite.addTest(ProductTest('test_add_product_finding'))
+    # suite.addTest(ProductTest('test_add_product_endpoints'))
+
+    # suite.addTest(ReportBuilderTest('generate_HTML_report'))
+    # suite.addTest(ReportBuilderTest('generate_AsciiDoc_report'))
+
+    # we add reports here as we now have a product that triggers some logic inside reports
+    # suite.addTest(ReportBuilderTest('test_product_type_report'))
+    # suite.addTest(ReportBuilderTest('test_product_report'))
+    # suite.addTest(ReportBuilderTest('test_engagement_report'))
+    # suite.addTest(ReportBuilderTest('test_test_report'))
+    suite.addTest(ReportBuilderTest('test_product_endpoint_report'))
+
     suite.addTest(ProductTest('test_delete_product'))
     return suite
 
 
 def suite():
     suite = unittest.TestSuite()
-    add_finding_tests_to_suite(suite)
+    add_report_tests_to_suite(suite)
     return suite
 
 


### PR DESCRIPTION
The reports for ProductType, Product, Engagement and Test are trying to load all findings into a dropdown in a filter.
This causes severe performance issues once you start having a somewhat larger instance. And it discloses finding titles to unauthorized users.

This PR fixes that and along the way I ran into two bugs in the product type report that are now fixed (#3431)

This PR also adds a basic selenium test for each report.