### PR TITLE
Allow Info findings to be pushed to JIRA without SLA

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -453,7 +453,7 @@ def add_jira_issue(find):
 
             if System_Settings.objects.get().enable_finding_sla:
 
-                if 'duedate' in meta['projects'][0]['issuetypes'][0]['fields']:
+                if 'duedate' in meta['projects'][0]['issuetypes'][0]['fields'] and Finding.get_number_severity(find.severity):
                     # jira wants YYYY-MM-DD
                     duedate = find.sla_deadline().strftime('%Y-%m-%d')
                     fields['duedate'] = duedate

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -453,10 +453,11 @@ def add_jira_issue(find):
 
             if System_Settings.objects.get().enable_finding_sla:
 
-                if 'duedate' in meta['projects'][0]['issuetypes'][0]['fields'] and Finding.get_number_severity(find.severity):
+                if 'duedate' in meta['projects'][0]['issuetypes'][0]['fields']:
                     # jira wants YYYY-MM-DD
-                    duedate = find.sla_deadline().strftime('%Y-%m-%d')
-                    fields['duedate'] = duedate
+                    duedate = find.sla_deadline()
+                    if duedate:
+                        fields['duedate'] = duedate.strftime('%Y-%m-%d')
 
             if len(find.endpoints.all()) > 0:
                 if not meta:

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2045,6 +2045,8 @@ class Finding(models.Model):
         return sla_calculation
 
     def sla_deadline(self):
+        if self.severity == 'Info':
+            return None
         return self.date + relativedelta(days=self.sla_days_remaining())
 
     def github(self):


### PR DESCRIPTION
Findings with an Info severity do not get an SLA. When creating new issues to push to JIRA, a findings SLA is used to set the due date on the JIRA issue. Since Info findings don't have an SLA, trying to add one results in an exception and the issue is not pushed. This added check just ignores that field if it is an Info finding.