### PR TITLE
logging: add DD_LOG_LEVEL setting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,29 +21,6 @@ For changes that require additional settings, you can now use local_settings.py 
 ## Python3 version
 For compatibility reasons, the code in dev branch should be python3.6 compliant.
 
-## Logging
-Logging is configured in `settings.dist.py` and can be tuned using a `local_settings.py`, see [template for local_settings.py](dojo/settings/template-local_settings)
-Specific logger can be added. For example to activate logs related to the deduplication, change the level from DEBUG to INFO in `local_settings.py`:
-
-
-```
-LOGGING['loggers']['dojo.specific-loggers.deduplication']['level'] = 'DEBUG'
-```
-
-Or you can modify `settings.dist.py` directly, but this adds the risk of having conflicts when `settings.dist.py` gets updated upstream. 
-
-```
-          'dojo.specific-loggers.deduplication': {
-            'handlers': ['console'],
-            'level': 'DEBUG',
-            'propagate': False,
-        }
-```
-
-## Debug Toolbar
-In the `dojo/settings/template-local_settings.py` you'll find instructions on how to enable the [Django Debug Toolbar](https://github.com/jazzband/django-debug-toolbar).
-This toolbar allows you to debug SQL queries, and shows some other interesting information.
-
 ## Submitting Pull Requests
 
 The following are things to consider before submitting a pull request to
@@ -70,5 +47,3 @@ DefectDojo.
 [setup_bash]: /setup.bash "Bash setup script"
 [pep8]: https://www.python.org/dev/peps/pep-0008/ "PEP8"
 [flake8 built-in commit hooks]: https://flake8.pycqa.org/en/latest/user/using-hooks.html#built-in-hook-integration
-
-   

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -152,7 +152,7 @@ docker-compose logs initializer | grep "Admin password:"
 
 Make sure you write down the first password generated as you'll need it when re-starting the application.
 
-# Option to change the password 
+## Option to change the password 
 * If you dont have admin password use the below command to change the password. 
 * After starting the container and open another tab in the same folder.  
 * django-defectdojo_uwsgi_1 -- name obtained from running containers using ```zsh docker ps ``` command
@@ -160,6 +160,29 @@ Make sure you write down the first password generated as you'll need it when re-
 ```zsh
 docker exec -it django-defectdojo_uwsgi_1 ./manage.py changepassword admin
 ```
+
+# Logging
+For docker-compose release mode the log level is INFO. In the other modes the log level is DEBUG. Logging is configured in `settings.dist.py` and can be tuned using a `local_settings.py`, see [template for local_settings.py](dojo/settings/template-local_settings). For example the deduplication logger can be set to DEBUG in a local_settings.py file:
+
+
+```
+LOGGING['loggers']['dojo.specific-loggers.deduplication']['level'] = 'DEBUG'
+```
+
+Or you can modify `settings.dist.py` directly, but this adds the risk of having conflicts when `settings.dist.py` gets updated upstream. 
+
+```
+          'dojo.specific-loggers.deduplication': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+            'propagate': False,
+        }
+```
+
+## Debug Toolbar
+In the `dojo/settings/template-local_settings.py` you'll find instructions on how to enable the [Django Debug Toolbar](https://github.com/jazzband/django-debug-toolbar).
+This toolbar allows you to debug SQL queries, and shows some other interesting information.
+
 
 # Exploitation, versioning
 ## Disable the database initialization

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -12,6 +12,7 @@ env = environ.Env(
     DD_SITE_URL=(str, 'http://localhost:8080'),
     DD_DEBUG=(bool, False),
     DD_TEMPLATE_DEBUG=(bool, False),
+    DD_LOG_LEVEL=(str, ''),
     DD_DJANGO_METRICS_ENABLED=(bool, False),
     DD_LOGIN_REDIRECT_URL=(str, '/'),
     DD_DJANGO_ADMIN_ENABLED=(bool, False),
@@ -841,6 +842,11 @@ JIRA_SSL_VERIFY = env('DD_JIRA_SSL_VERIFY')
 # See http://docs.djangoproject.com/en/dev/topics/logging for
 # more details on how to customize your logging configuration.
 LOGGING_HANDLER = env('DD_LOGGING_HANDLER')
+
+LOG_LEVEL = env('DD_LOG_LEVEL')
+if not LOG_LEVEL:
+    LOG_LEVEL = 'DEBUG' if DEBUG else 'INFO'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -887,24 +893,24 @@ LOGGING = {
         },
         'django.security': {
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': 'INFO',
+            'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'celery': {
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': 'INFO',
+            'level': '%s' % LOG_LEVEL,
             'propagate': False,
             # workaround some celery logging known issue
             'worker_hijack_root_logger': False,
         },
         'dojo': {
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': 'INFO',
+            'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': 'INFO',
+            'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'MARKDOWN': {

--- a/dojo/settings/template-local_settings
+++ b/dojo/settings/template-local_settings
@@ -16,12 +16,16 @@ MIDDLEWARE = [
     'debug_toolbar.middleware.DebugToolbarMiddleware',
 ] + MIDDLEWARE
 
+# adding DEBUG logging for all of Django.
 LOGGING['loggers']['root'] = {
             'handlers': ['console'],
             'level': 'DEBUG',
         }
-LOGGING['loggers']['dojo']['level'] = 'DEBUG'
-LOGGING['loggers']['dojo.specific-loggers.deduplication']['level'] = 'DEBUG'
+# setting log level WARN for defect dojo
+# LOGGING['loggers']['dojo']['level'] = 'WARN'
+
+# output DEBUG logging for deduplication
+# LOGGING['loggers']['dojo.specific-loggers.deduplication']['level'] = 'DEBUG'
 
 
 def show_toolbar(request):


### PR DESCRIPTION
Whenever people report bugs / issues, it's good to have DEBUG logs available. This PR allows to easily turn on DEBUG logging without having to rebuild containers or modifying settings files.

- adjust log level based on DEBUG value. DEBUG=True -> log level DEBUG, otherwise log level INFO
- add DD_LOG_LEVEL setting to allow finetuning / overriding
- update docs