### PR TITLE
report: fix report from products list and more

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -700,7 +700,7 @@ class ClosedFindingFilter(DojoFilter):
         exclude = ['url', 'description', 'mitigation', 'impact',
                    'endpoint', 'references', 'test', 'is_template',
                    'active', 'verified', 'out_of_scope', 'false_p',
-                   'duplicate', 'thread_id', 'date', 'notes',
+                   'duplicate', 'duplicate_finding', 'thread_id', 'date', 'notes',
                    'numerical_severity', 'reporter', 'endpoints', 'endpoint_status',
                    'last_reviewed', 'review_requested_by', 'defect_review_requested_by',
                    'last_reviewed_by', 'created', 'jira_creation', 'jira_change']
@@ -783,7 +783,7 @@ class AcceptedFindingFilter(DojoFilter):
         exclude = ['url', 'description', 'mitigation', 'impact',
                    'endpoint', 'references', 'test', 'is_template',
                    'active', 'verified', 'out_of_scope', 'false_p',
-                   'duplicate', 'thread_id', 'mitigated', 'notes',
+                   'duplicate', 'duplicate_finding', 'thread_id', 'mitigated', 'notes',
                    'numerical_severity', 'reporter', 'endpoints', 'endpoint_status',
                    'last_reviewed', 'o', 'jira_creation', 'jira_change']
 
@@ -1090,6 +1090,7 @@ class MetricsFindingFilter(FilterSet):
         model = Finding
         exclude = ['url',
                    'description',
+                   'duplicate_finding',
                    'mitigation',
                    'unsaved_endpoints',
                    'unsaved_request',
@@ -1182,6 +1183,7 @@ class ProductMetricsFindingFilter(FilterSet):
         model = Finding
         exclude = ['url',
                    'description',
+                   'duplicate_finding'
                    'mitigation',
                    'unsaved_endpoints',
                    'unsaved_request',
@@ -1297,7 +1299,7 @@ class ReportFindingFilter(DojoFilter):
         label="Risk Accepted")
     # queryset will be restricted in __init__, here we don't have access to the logged in user
     duplicate = ReportBooleanFilter()
-    duplicate_finding = ModelChoiceFilter(queryset=Finding.objects.filter(original_finding__isnull=False))
+    duplicate_finding = ModelChoiceFilter(queryset=Finding.objects.filter(original_finding__isnull=False).distinct())
     out_of_scope = ReportBooleanFilter()
 
     class Meta:
@@ -1353,6 +1355,7 @@ class ReportAuthedFindingFilter(DojoFilter):
     test__engagement__risk_acceptance = ReportRiskAcceptanceFilter(
         label="Risk Accepted")
     duplicate = ReportBooleanFilter()
+    duplicate_finding = ModelChoiceFilter(queryset=Finding.objects.filter(original_finding__isnull=False).distinct())
     out_of_scope = ReportBooleanFilter()
 
     def __init__(self, *args, **kwargs):

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -757,8 +757,7 @@ def generate_report(request, obj):
                    'user_id': request.user.id}
     elif type(obj).__name__ == "QuerySet":
         findings = ReportAuthedFindingFilter(request.GET,
-                                             queryset=prefetch_related_findings_for_report(obj).distinct(),
-                                             user=request.user)
+                                             queryset=prefetch_related_findings_for_report(obj).distinct())
         filename = "finding_report.pdf"
         report_name = 'Finding'
         report_type = 'Finding'

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -26,7 +26,7 @@
 
                                 <li role="presentation">
                                     <a href="{% url 'product_findings_report' %}">
-                                        <i class="fa fa-file-text-o"></i> Product Report
+                                        <i class="fa fa-file-text-o"></i> Findings Report
                                     </a>
                                 </li>
                             </ul>

--- a/tests/Report_builder_unit_test.py
+++ b/tests/Report_builder_unit_test.py
@@ -160,6 +160,23 @@ class ReportBuilderTest(BaseTestCase):
 
         driver.find_element_by_name('_generate').click()
 
+    def test_product_list_report(self):
+        driver = self.driver
+        self.goto_product_overview(driver)
+        driver.find_element_by_id("dropdownMenu1").click()
+        driver.find_element_by_link_text("Findings Report").click()
+
+        my_select = Select(driver.find_element_by_id("id_include_finding_notes"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_executive_summary"))
+        my_select.select_by_index(1)
+
+        my_select = Select(driver.find_element_by_id("id_include_table_of_contents"))
+        my_select.select_by_index(1)
+
+        driver.find_element_by_name('_generate').click()
+
 
 def add_report_tests_to_suite(suite):
     # Add each test the the suite to be run


### PR DESCRIPTION
fixes #3446 

also fixes one other place where the `duplicate_finding` field in filters was retrieving *all* findings.

in other places I removed that field from the filters. That field was added later to defect dojo and I think it was missed when excluding fields that are not really useful to filter on. I doubt anyone is using it (especially since the reports seem a bit shaky anyway).

if really needed, people can add it back in easily.