### PR TITLE
Allow to specify the `Environment` when importing data from the APIv2 and the UI

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -947,6 +947,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
     tags = TagListSerializerField(required=False)
     close_old_findings = serializers.BooleanField(required=False, default=False)
     push_to_jira = serializers.BooleanField(default=False)
+    environment = serializers.CharField(required=False)
 
     def save(self, push_to_jira=False):
         data = self.validated_data
@@ -956,8 +957,6 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         test_type, created = Test_Type.objects.get_or_create(
             name=data.get('test_type', data['scan_type']))
         endpoint_to_add = data['endpoint_to_add']
-        environment, created = Development_Environment.objects.get_or_create(
-            name='Development')
         scan_date = data['scan_date']
         scan_date_time = datetime.datetime.combine(scan_date, timezone.now().time())
         if settings.USE_TZ:
@@ -966,6 +965,9 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
         version = ''
         if 'version' in data:
             version = data['version']
+        # Will save in the provided environment or in the `Development` one if absent
+        environment_name = data.get('environment', 'Development')
+        environment = Development_Environment.objects.get(name=environment_name)
 
         test = Test(
             engagement=data['engagement'],

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -557,9 +557,11 @@ def import_scan_results(request, eid=None, pid=None):
                 return HttpResponseRedirect(reverse('import_scan_results', args=(engagement,)))
 
             tt, t_created = Test_Type.objects.get_or_create(name=scan_type)
-            # will save in development environment
-            environment, env_created = Development_Environment.objects.get_or_create(
-                name="Development")
+
+            # Will save in the provided environment or in the `Development` one if absent
+            environment_id = request.POST.get('environment', 'Development')
+            environment = Development_Environment.objects.get(id=environment_id)
+
             t = Test(
                 engagement=engagement,
                 test_type=tt,

--- a/dojo/fixtures/development_environment.json
+++ b/dojo/fixtures/development_environment.json
@@ -40,5 +40,12 @@
     },
     "model": "dojo.development_environment",
     "pk": 6
+  },
+  {
+    "fields": {
+      "name": "Default"
+    },
+    "model": "dojo.development_environment",
+    "pk": 7
   }
 ]

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -731,7 +731,7 @@
     "pk": 1,
     "model": "dojo.development_environment",
     "fields": {
-      "name": "Ad officia praesentium sequi suscipit error iste qui nihil illum q"
+      "name": "Development"
     }
   },
   {

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -433,6 +433,8 @@ class ImportScanForm(forms.Form):
     active = forms.BooleanField(help_text="Select if these findings are currently active.", required=False)
     verified = forms.BooleanField(help_text="Select if these findings have been verified.", required=False)
     scan_type = forms.ChoiceField(required=True, choices=SORTED_SCAN_TYPE_CHOICES)
+    environment = forms.ModelChoiceField(
+        queryset=Development_Environment.objects.all().order_by('name'))
     endpoints = forms.ModelMultipleChoiceField(Endpoint.objects, required=False, label='Systems / Endpoints',
                                                widget=MultipleSelectWithPopPlusMinus(attrs={'size': '5'}))
     tags = forms.CharField(widget=forms.SelectMultiple(choices=[]),

--- a/tests/Finding_unit_test.py
+++ b/tests/Finding_unit_test.py
@@ -274,8 +274,10 @@ class FindingTest(BaseTestCase):
         driver.find_element_by_partial_link_text("Findings").click()
         # Click on `Import Scan Results` link text
         driver.find_element_by_link_text("Import Scan Results").click()
-        # Select `ZAP Scan' as Scan Type
+        # Select `ZAP Scan` as Scan Type
         Select(driver.find_element_by_id("id_scan_type")).select_by_visible_text('ZAP Scan')
+        # Select `Default` as the Environment
+        Select(driver.find_element_by_id("id_environment")).select_by_visible_text('Development')
         # upload scan file
         file_path = os.path.join(dir_path, 'zap_sample.xml')
         driver.find_element_by_name("file").send_keys(file_path)

--- a/tests/ibm_appscan_test.py
+++ b/tests/ibm_appscan_test.py
@@ -26,6 +26,8 @@ class IBMAppScanTest(BaseTestCase):
         driver.find_element_by_link_text("Import Scan Results").click()
         # Select scan type
         Select(driver.find_element_by_id("id_scan_type")).select_by_visible_text("IBM AppScan DAST")
+        # Select `Default` as the Environment
+        Select(driver.find_element_by_id("id_environment")).select_by_visible_text('Development')
         # Upload Scan result file
         scanner_file = os.path.join(dir_path, "ibm_appscan_xml_file.xml")
         driver.find_element_by_name("file").send_keys(scanner_file)


### PR DESCRIPTION
### What

This commit add the ability to specify the `Environment` (prod, dev, ...) when importing scan data from both the APIv2 and the UI.

The current behavior of DDJ is to put everything inside the `Development` environment (APIv2+UI) when importing data without being able to specify it. I modified this logic and it'll put everything inside the `Default` environment if not specified when importing data from the APIv2, and when uploading data from the UI the user will need to specify it manually.

### Notes

* I haven't added the ability to edit the `Environment` when using the `reimport_scan` endpoint, I didn't think that it was relevant and it's still possible to edit the environment afterwards by editing the associated `test`. Let me know what you think.
* I wasn't sure if it was best to specify the `environment_name` or the `environment_id` when uploading a scan from the APIv2, I went with the first as I thought that it was more convenient (as we do for specifying the scanner name).