### PR TITLE
[FIX] Remove call to old method and add call to new method for jira integration

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -412,7 +412,7 @@ class FindingViewSet(mixins.ListModelMixin,
             finding.notes.add(note)
 
             if finding.has_jira_issue:
-                jira_helper.add_comment_task(finding, note)
+                jira_helper.add_comment(finding, note)
 
             serialized_note = serializers.NoteSerializer({
                 "author": author, "entry": entry,

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -301,7 +301,7 @@ def view_finding(request, fid):
             finding.last_reviewed_by = user
             finding.save()
             if finding.has_jira_issue:
-                jira_helper.add_comment_task(finding, new_note)
+                jira_helper.add_comment(finding, new_note)
             if note_type_activation:
                 form = TypedNoteForm(available_note_types=available_note_types)
             else:


### PR DESCRIPTION
This PR is pretty straight forward, part of the code was still using the old method `add_comment_task` that has been replaced by `add_comment`. This resulted in errors when adding notes to findings. Therefore, we replace the old method by the new method which solve the problem.

Let me know if there is more to it as I'm not completely familiar with the new integration :).