### PR TITLE
Revert "release workflow: simplify matrix"

### DIFF
--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -46,13 +46,20 @@ jobs:
             Fill in with release drafter information manually for now, then publish.
           draft: true
           prerelease: false
-
-  job-build-and-push:
+  job-build-matrix:
     needs: tag-and-release
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        # ref should be the tag name
+        run: echo "::set-output name=matrix::{\"docker-image\":[\"django\",\"nginx\"],\"docker-tag\":[\"latest\",\"${{ github.event.inputs.release_number }}\"]}"
+  job-build-and-push:
+    needs: job-build-matrix
+    runs-on: ubuntu-latest
     strategy:
-      matrix: 
-          docker-image: [django, nginx]
+      matrix: ${{fromJson(needs.job-build-matrix.outputs.matrix)}}
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -75,7 +82,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:latest
+          tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ matrix.docker-tag }}
           file: ./Dockerfile.${{ matrix.docker-image }}
           context: .
       - name: Image digest


### PR DESCRIPTION
Reverts DefectDojo/django-DefectDojo#3416

Although unrelated, we're seeing unti test failures after merging this. Just reverting to see if it is related to this PR or not.

```
uwsgi_1         | ======================================================================
uwsgi_1         | ERROR: test_zero_findings (dojo.unittests.test_dsop_parser.TestDsopParser)
uwsgi_1         | ----------------------------------------------------------------------
uwsgi_1         | Traceback (most recent call last):
uwsgi_1         |   File "/app/dojo/unittests/test_dsop_parser.py", line 11, in test_zero_findings
uwsgi_1         |     parser = DsopParser(file, Test())
uwsgi_1         |   File "/app/dojo/tools/dsop/parser.py", line 14, in __init__
uwsgi_1         |     f = pd.ExcelFile(file)
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/pandas/io/excel/_base.py", line 867, in __init__
uwsgi_1         |     self._reader = self._engines[engine](self._io)
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/pandas/io/excel/_xlrd.py", line 22, in __init__
uwsgi_1         |     super().__init__(filepath_or_buffer)
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/pandas/io/excel/_base.py", line 351, in __init__
uwsgi_1         |     self.book = self.load_workbook(filepath_or_buffer)
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/pandas/io/excel/_xlrd.py", line 35, in load_workbook
uwsgi_1         |     return open_workbook(file_contents=data)
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/xlrd/__init__.py", line 170, in open_workbook
uwsgi_1         |     raise XLRDError(FILE_FORMAT_DESCRIPTIONS[file_format]+'; not supported')
uwsgi_1         | xlrd.biffh.XLRDError: Excel xlsx file; not supported
```
