### PR TITLE
pin all python / pip dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ lxml==4.6.2
 Markdown==3.3.3
 mysqlclient==2.0.2
 pandas==1.1.2
-xlrd==1.0.0
+xlrd==1.2.0
 pdfkit==0.6.1
 Pillow==8.0.1  # required by django-imagekit
 psycopg2-binary==2.8.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements.txt for DefectDojo using Python 3.x
 asteval==0.9.21
-bleach>=3.1.0
+bleach==3.1.0
 celery==4.4.7
 coverage==5.3
 defusedxml==0.6.0
@@ -32,8 +32,8 @@ PyGithub==1.54
 lxml==4.6.2
 Markdown==3.3.3
 mysqlclient==2.0.2
-pandas>=0.25
-xlrd>=1.0.0
+pandas==1.1.2
+xlrd==1.0.0
 pdfkit==0.6.1
 Pillow==8.0.1  # required by django-imagekit
 psycopg2-binary==2.8.6
@@ -42,18 +42,18 @@ python-dateutil==2.8.1
 python-nmap==0.6.1
 pytz==2020.4
 redis==3.5.3
-requests>=2.22.0
+requests==2.25.0
 sqlalchemy  # Required by Celery broker transport
 supervisor==4.2.1
 urllib3==1.26.2
 uWSGI==2.0.19.1
 vobject==0.9.6.1
-whitenoise>=4.1.2
+whitenoise==5.2.0
 titlecase==1.1.1
 social-auth-app-django==4.0.0
 Python-jose==3.2.0
 gitpython>=2.1.13
-ptvsd>=4.2.7
+ptvsd==4.3.2
 google-auth==1.23.0
 google-api-python-client==1.12.8
 google-auth-oauthlib==0.4.2


### PR DESCRIPTION
fixes #3455 by pinning xlrd and pandas.
pins some other dependencies as well to the version currently installed by pip.
pinning ensures stability and triggers dependabot to create PRs to keep up to date.