### PR TITLE
Tweaked Fortify Parser To Handle Missing Code Snippet For Finding

### DIFF
--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -10,6 +10,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class FortifyXMLParser(object):
     language_list = []
 

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -93,7 +93,7 @@ class FortifyXMLParser(object):
 
                 issue_map.update({issue.attrib['iid']: details})
         except AttributeError:
-            logger.warning("XML Parsing error on issue number: %s" % issue_id)
+            logger.warning("XML Parsing error on issue number: %s", issue_id)
             raise
         # map created
 

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -93,7 +93,7 @@ class FortifyXMLParser(object):
 
                 issue_map.update({issue.attrib['iid']: details})
         except AttributeError:
-            logger.warning("XML Parsing error on issue number: %s", issue_id)
+            logger.warning("XML Parsing error on issue number: %s" % issue_id)
             raise
         # map created
 

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -6,7 +6,9 @@ from defusedxml import ElementTree
 from dateutil import parser
 import re
 from dojo.models import Finding
+import logging
 
+logger = logging.getLogger(__name__)
 
 class FortifyXMLParser(object):
     language_list = []
@@ -90,7 +92,7 @@ class FortifyXMLParser(object):
 
                 issue_map.update({issue.attrib['iid']: details})
         except AttributeError:
-            print("XML Parsing blew up on issue number:", issue_id)
+            logger.warning("XML Parsing blew up on issue number:", issue_id)
             raise
         # map created
 

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -73,7 +73,7 @@ class FortifyXMLParser(object):
                     "Friority": issue.find("Friority").text,
                     "FileName": issue.find("Primary").find("FileName").text,
                     "FilePath": issue.find("Primary").find("FilePath").text,
-                        "LineStart": issue.find("Primary").find("LineStart").text}
+                    "LineStart": issue.find("Primary").find("LineStart").text}
 
                 if issue.find("Primary").find("Snippet"):
                     details["Snippet"] = issue.find("Primary").find("Snippet").text

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -62,7 +62,10 @@ class FortifyXMLParser(object):
 
         # All issues obtained, create a map for reference
         issue_map = {}
+        issue_id = "N/A"
+        try:
         for issue in issues:
+                issue_id = issue.attrib['iid']
             details = {
                 "Category": issue.find("Category").text,
                 "Folder": issue.find("Folder").text, "Kingdom": issue.find("Kingdom").text,
@@ -70,8 +73,12 @@ class FortifyXMLParser(object):
                 "Friority": issue.find("Friority").text,
                 "FileName": issue.find("Primary").find("FileName").text,
                 "FilePath": issue.find("Primary").find("FilePath").text,
-                "LineStart": issue.find("Primary").find("LineStart").text,
-                "Snippet": issue.find("Primary").find("Snippet").text}
+                    "LineStart": issue.find("Primary").find("LineStart").text}
+
+                if issue.find("Primary").find("Snippet"):
+                    details["Snippet"] = issue.find("Primary").find("Snippet").text
+                else:
+                    details["Snippet"] = "n/a"
 
             if issue.find("Source"):
                 source = {
@@ -82,6 +89,10 @@ class FortifyXMLParser(object):
                 details["Source"] = source
 
             issue_map.update({issue.attrib['iid']: details})
+        except AttributeError:
+            print("XML Parsing blew up on issue number:", issue_id)
+            print("Snippet text was: ", snippet_text)
+            raise
         # map created
 
         self.items = []

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -64,34 +64,33 @@ class FortifyXMLParser(object):
         issue_map = {}
         issue_id = "N/A"
         try:
-        for issue in issues:
+            for issue in issues:
                 issue_id = issue.attrib['iid']
-            details = {
-                "Category": issue.find("Category").text,
-                "Folder": issue.find("Folder").text, "Kingdom": issue.find("Kingdom").text,
-                "Abstract": issue.find("Abstract").text,
-                "Friority": issue.find("Friority").text,
-                "FileName": issue.find("Primary").find("FileName").text,
-                "FilePath": issue.find("Primary").find("FilePath").text,
-                    "LineStart": issue.find("Primary").find("LineStart").text}
+                details = {
+                    "Category": issue.find("Category").text,
+                    "Folder": issue.find("Folder").text, "Kingdom": issue.find("Kingdom").text,
+                    "Abstract": issue.find("Abstract").text,
+                    "Friority": issue.find("Friority").text,
+                    "FileName": issue.find("Primary").find("FileName").text,
+                    "FilePath": issue.find("Primary").find("FilePath").text,
+                        "LineStart": issue.find("Primary").find("LineStart").text}
 
                 if issue.find("Primary").find("Snippet"):
                     details["Snippet"] = issue.find("Primary").find("Snippet").text
                 else:
                     details["Snippet"] = "n/a"
 
-            if issue.find("Source"):
-                source = {
-                    "FileName": issue.find("Source").find("FileName").text,
-                    "FilePath": issue.find("Source").find("FilePath").text,
-                    "LineStart": issue.find("Source").find("LineStart").text,
-                    "Snippet": issue.find("Source").find("Snippet").text}
-                details["Source"] = source
+                if issue.find("Source"):
+                    source = {
+                        "FileName": issue.find("Source").find("FileName").text,
+                        "FilePath": issue.find("Source").find("FilePath").text,
+                        "LineStart": issue.find("Source").find("LineStart").text,
+                        "Snippet": issue.find("Source").find("Snippet").text}
+                    details["Source"] = source
 
-            issue_map.update({issue.attrib['iid']: details})
+                issue_map.update({issue.attrib['iid']: details})
         except AttributeError:
             print("XML Parsing blew up on issue number:", issue_id)
-            print("Snippet text was: ", snippet_text)
             raise
         # map created
 

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -93,7 +93,7 @@ class FortifyXMLParser(object):
 
                 issue_map.update({issue.attrib['iid']: details})
         except AttributeError:
-            logger.warning("XML Parsing blew up on issue number:", issue_id)
+            logger.warning("XML Parsing error on issue number: %s", issue_id)
             raise
         # map created
 


### PR DESCRIPTION
Fixed issue with Fortify parser where the import will fail if there is no Primary.Snippet value for a given finding. Added issue id and exception handling during parsing so we know where the import failed. In some cases (ok, in my case) <Primary> stanza doesn't have a <Snippet>.