### PR TITLE
apiv2: fix endpoint status creation during scan import

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1065,7 +1065,7 @@ class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     eps, created = Endpoint_Status.objects.get_or_create(
                             finding=item,
                             endpoint=endpoint_to_add)
-                    ep.endpoint_status.add(eps)
+                    endpoint_to_add.endpoint_status.add(eps)
                     item.endpoint_status.add(eps)
                 if item.unsaved_tags is not None:
                     item.tags = item.unsaved_tags


### PR DESCRIPTION
https://github.com/DefectDojo/django-DefectDojo/pull/2983 introduced bug (maybe a typo?) which caused a server error when importing a scan with an additional endpoint.

On behalf of DB Systel GmbH