### PR TITLE
Product Report fix extraneous user keyword arg

### DIFF
--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -757,8 +757,7 @@ def generate_report(request, obj):
                    'user_id': request.user.id}
     elif type(obj).__name__ == "QuerySet":
         findings = ReportAuthedFindingFilter(request.GET,
-                                             queryset=prefetch_related_findings_for_report(obj).distinct(),
-                                             user=request.user)
+                                             queryset=prefetch_related_findings_for_report(obj).distinct())
         filename = "finding_report.pdf"
         report_name = 'Finding'
         report_type = 'Finding'


### PR DESCRIPTION
In response to the following stacktrace
```
uwsgi_1         | Internal Server Error: /product/report
uwsgi_1         | Traceback (most recent call last):
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/handlers/exception.py", line 34, in inner
uwsgi_1         |     response = get_response(request)
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 115, in _get_response
uwsgi_1         |     response = self.process_exception_by_middleware(e, request)
uwsgi_1         |   File "/usr/local/lib/python3.6/site-packages/django/core/handlers/base.py", line 113, in _get_response
uwsgi_1         |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
uwsgi_1         |   File "./dojo/reports/views.py", line 362, in product_findings_report
uwsgi_1         |     return generate_report(request, findings)
uwsgi_1         |   File "./dojo/reports/views.py", line 761, in generate_report
uwsgi_1         |     user=request.user)
uwsgi_1         |   File "./dojo/filters.py", line 1359, in __init__
uwsgi_1         |     super(ReportAuthedFindingFilter, self).__init__(*args, **kwargs)
uwsgi_1         |   File "./dojo/filters.py", line 63, in __init__
uwsgi_1         |     super(DojoFilter, self).__init__(*args, **kwargs)
uwsgi_1         | TypeError: __init__() got an unexpected keyword argument 'user'
```