### PR TITLE
Fix popup message on SLA displays

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2044,8 +2044,8 @@ class Finding(models.Model):
     def sla_deadline(self):
         days_remaining = self.sla_days_remaining()
         if days_remaining:
-            return None
-        return self.date + relativedelta(days=days_remaining)
+            return self.date + relativedelta(days=days_remaining)
+        return None
 
     def github(self):
         try:

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2042,9 +2042,10 @@ class Finding(models.Model):
         return sla_calculation
 
     def sla_deadline(self):
-        if self.severity == 'Info':
+        days_remaining = self.sla_days_remaining()
+        if days_remaining:
             return None
-        return self.date + relativedelta(days=self.sla_days_remaining())
+        return self.date + relativedelta(days=days_remaining)
 
     def github(self):
         try:

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -301,7 +301,7 @@ def finding_sla(finding):
                 sla_age) + ' days or less'
 
     if find_sla is not None:
-        title = '<a data-toggle="tooltip" data-placement="bottom" title="" href="#" data-original-title="' + status_text + '">' \
+        title = '<a class="has-popover" data-toggle="tooltip" data-placement="bottom" title="" href="#" data-content="' + status_text + '">' \
                                                                                                                            '<span class="label severity age-' + status + '">' + str(find_sla) + '</span></a>'
 
     return mark_safe(title)


### PR DESCRIPTION
Display tags did not correctly create the popup required to display the status of a findings SLA. Also cleaned up the logic when determining a findings SLA by removing the ugly "is Info" check.