### PR TITLE
jira: add api test for adding note/comment

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -400,8 +400,8 @@ class FindingViewSet(mixins.ListModelMixin,
             new_note = serializers.AddNewNoteOptionSerializer(data=request.data)
             if new_note.is_valid():
                 entry = new_note.validated_data['entry']
-                private = new_note.validated_data['private']
-                note_type = new_note.validated_data['note_type']
+                private = new_note.validated_data['private'] if 'private' in new_note.validated_data else False
+                note_type = new_note.validated_data['note_type'] if 'note_type' in new_note.validated_data else None
             else:
                 return Response(new_note.errors,
                     status=status.HTTP_400_BAD_REQUEST)

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -896,7 +896,7 @@ def add_comment(find, note, force_push=False):
                 j_issue = find.jira_issue
                 jira.add_comment(
                     j_issue.jira_id,
-                    '(%s): %s' % (note.author.get_full_name(), note.entry))
+                    '(%s): %s' % (note.author.get_full_name() if note.author.get_full_name() else note.author.username, note.entry))
                 return True
             except JIRAError as e:
                 log_jira_generic_alert('Jira Add Comment Error', str(e))

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -426,6 +426,23 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         response = self.do_finding_remove_tags_api(self.client.patch, finding_id, tags, *args, **kwargs)
         return response
 
+    def do_finding_notes_api(self, http_method, finding_id, note=None):
+        data = None
+        if note:
+            data = {'entry': note}
+
+        print('data:' + str(data))
+
+        response = http_method(reverse('finding-notes', args=(finding_id,)), data, format='json')
+        print(vars(response))
+        print(response.content)
+        self.assertEqual(200, response.status_code)
+        return response
+
+    def post_finding_notes_api(self, finding_id, note):
+        response = self.do_finding_notes_api(self.client.post, finding_id, note)
+        return response.data
+
     def log_finding_summary_json_api(self, findings_content_json=None):
         # print('summary')
         # print(findings_content_json)

--- a/dojo/unittests/test_jira_import_and_pushing_api.py
+++ b/dojo/unittests/test_jira_import_and_pushing_api.py
@@ -243,3 +243,18 @@ class JIRAConfigAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_issue_count_in_test(test_id, 3)
 
         self.assert_cassette_played()
+
+    def test_import_with_push_to_jira_add_comment(self):
+        import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=True)
+        test_id = import0['test']
+        self.assert_jira_issue_count_in_test(test_id, 2)
+
+        findings = self.get_test_findings_api(test_id)
+
+        finding_id = findings['results'][0]['id']
+
+        response = self.post_finding_notes_api(finding_id, 'testing note. creating it and pushing it to JIRA')
+
+        # by asserting full cassette is played we know all calls to JIRA have been made as expected
+        self.assert_cassette_played()
+        return test_id

--- a/dojo/unittests/vcr/jira/JIRAConfigAndPushTestApi.test_import_with_push_to_jira_add_comment.yaml
+++ b/dojo/unittests/vcr/jira/JIRAConfigAndPushTestApi.test_import_with_push_to_jira_add_comment.yaml
@@ -1,0 +1,1293 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA1SPT0vEMBDFv0uuttlJ+m/NTfSgIqvQ7kkWSZopVtKkNKmwLPvdTXBVvD3e/N68
+        mRNR0uN+MUSQ9xBmLzYbjQP2QbsPR2Uw0vtRWmoxkIx84uJHZyPMABgFCnm7u3lp75+7v+lunVRU
+        RLwmKIMMDhnROBt3nNCG7jhjXHBr3KpjSK2j0d8RIlKgKi7mnQwJ5MAhZzxnVceZKEFUWwoAVxDh
+        mPe4xN5unP6xdccaARHf0qIuf9l+erCDi+C15ohFzwrOlcISVQ1NDxr00JQgyy3XdVHhkA78KQgm
+        NTyOiyTpnUGuJjy5Xib7RMxFEbRv+5acz18AAAD//wMAHbVWTFoBAAA=
+    headers:
+      ATL-TraceId:
+      - 15fd2bcf7d96e10d
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:48 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 68f80a8c-9c59-4d52-9917-fe1232651b98
+      x-envoy-upstream-service-time:
+      - '52'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/field
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7SW327aMBTGXyXyNVTdboa47TQJqZqmtuouEJpMOAS3iYNshxZVfZq9z55px7Hj
+        P8RhHS0XVZXPh5zv9/lgPH8hbEWmRCqqGplTBUUt9vmG8gJW+ERG5BH2xws4rQArbtuK7MqWZFem
+        BgvyRqq6ItM1LSWMSC1WIOiyBKdwumOFUZRoUJBABfYIlLykjYTv2EqS6dza6XrZVl+1nwV+Ot9A
+        Rcn0haj9VlvTRhWrtFm5lwqqY0CvryMbCpOygfYVXQqhYrFnWsrujDZMaij+HzTs2P5L8YVFDtCL
+        nmhLBXDlcNyjZfnRPQ9zvGXHbM0BiW22cGb0jsht6CdUrKU7lLJbq53Dlu+ZSpY31RJEGKuvD2IV
+        9QPkQa7uuQvWCe9DSI5I1y3l3ztxAJ3k7a/Z8z0IyWouHUKsWYxv7DnbeXWY5dRp912TNFQIusfG
+        DEmwnlgvIV3o2xPSohBQ2FMgnrnkkuX98zs79/ylMPtDlzDp4eKz0IH15PQ5/W6s5EYeNPdfegGy
+        Lhtlds0YjSRr8ibUhv2dOmdBy9QGRI7cJgSqD994WzMoV78+XV5+/uKwUivdoUZFASrDkIQeq4Yr
+        QbksMa2Vttiv6BIwMB8QQL6et54W+PKoVyoO+zvfmSB5XV1QVVIpGeUXD9t6in9jszxugcdLKqFk
+        HMYxwQwja/sOBzgZDFCvxAEC19eL4fjM+rnCmwTh6U4fHV3ovgtu4oPz4xhd1Hpy+I3anes+1uva
+        CrrdUCqH97GDN3jOp1o8CooLDjFULN1PlLIbq52Bz7dM8fQPbF9/cJ1ETCVYHh2AiQW/aa2YqeNc
+        vUm2Jf/iSsEk3MR3ynDN0+FMq3sGT+2EGa5IskTXqGVOHCZ6y04lf1DDrim81OwFHwnmjir8rL8R
+        +edu5lpBHL8Jnc5h+uHrUxTejB85K3kCtcG55JSVjiFULMWsokX7IsvwFwAA//+0mVGPmzAMgP8K
+        2juotFKl9m2qdtrDaTrd9obugatomx5HUOC07t8vCQ5xSAzcVt4gDtj5bGI73HMNNu0fRaG2594Q
+        ew9mHPqB/7MjFOVIG1x9qlM0T9M5a2XXFZDACn/WgukqMpCvetlSuWqlchVoCa17WFlfG6fy0nmr
+        /nNjTSIL0aK68LouRHJlIt+fL3Hjmm+S1YomlpLElASIPZSy7tVuCyCzwqWYpYqZVQNX2eFSHN9e
+        +a1oXmah5DXsog5MVARIiEldfpxZlXQxlyAm6qXN/v2jbNmxV+yRTmnSa5K0kgDp7PD96/Ovl0h9
+        FxE/RQ9MyG1aZp9a9lHqYwg4YPKZu/tlUuP4hMwMn/SwgGHlZfD4OuxRtCmM+bC4tYm0X7SsOu+1
+        DqPCqQKNz9bWZ/Lz4YK1tndDA+ChJztibPA3yH8F26sLrR7Zgs4QYIyOuw0Zd0oyiDvdZbMq6nrT
+        8Xjz5i4WZ56msCBzb1E8bcLxlFfYjZOhpEKPVV1H7UXRBldgr0Vp65X+Flg/mvv7xw+oCq51sBuq
+        0rE641iCh+lI2pKRpCQmu7bqzPmJyzxExM9gxt2jBny+1ZnW1YVvsx+6WQhHRt9IjAXHRK44lTz3
+        c/GW5JuSfLXE4VurJUSy/mfv3ZZGcvZmLsQ7RbwHOucDJiqba/M7btSbY/1m7+NLR6CS50BaAlC7
+        fwdHXnJlUoClO2EphPoUCKsKkes/3LnkdK8Yu7YbcPT5T0qe/2iJyYb6X0L0yKq3MDh3wlLg9AkQ
+        VhUCN77bh06A+t8yLjR09jNEsyOhKQlAe84pWiBZCtNOYdI6ZvIhokp2GmVx47HA5ho6O9T3yoSJ
+        dh5ofd1Bw0TawioZ2NE3f6vyE+ScDjTYCX8RRhHS45gUQuOfKzmP2BU7/wdkZSbzQ156CKZmaSZ/
+        AQAA//8Cz3r4QyVpHCrE+Rm/sxGBgDQzBfEvkgDUa45paanJJcW0ncRKBFuSmkLhTBbcjQgfgovU
+        HGBBg/AjihDUl6CiKDVFAVyiE/AiAAAA//+8Wj1TwzAM/Ss9ZjqEpgtrYWLjY2RKfFyuB4QW+vvx
+        h2xJtkSTXM3URnIqvSfHsl+6EKKPqq94GTiWI9cSg5VMZLssvn0YMmfREGuIlssDS+EkXHYgn5hx
+        MOb/M7qzHupceA3ZvySDnvyU50nMHqPBt1k6V7wb0aQzRwCTLgFLcQK7IBSIJeWe0kiZg4X0x893
+        e/A2Yc8GjZGaAMCO2nQQSydTCinCyJ8SHE2QkayzZcChYotAMACyB3+hQ5pSF3HJdhlch4DxEzN5
+        ZS24WKppKxackPo/9Z6rmEHWkIvEpNqVTUq8FUvWm2N3GKISGGjgNkB/x4w67qVzkgaVkJXnc3qH
+        vgNVJXDvAXCP5st2pO/4bylpJ8pH1NqRejmcxRK56GFfbg6HMNY7MK1sM2/bw2nojCVsf3sa12E6
+        pOFxo6qr4o2qinsPkHg/Dt3K0yUySN216PPKOAYSuZtzXLQbe2N/be2loIIwXdxuVHHbeyhhfymL
+        fEAt0m4SaRBKok1+WXCGNlkabIjAnLOzUXlzHsrbThcnmL8Wa5vEWogkkbZorsnCBJFTc2ZalTPn
+        oZzpsgR112KsTYzpG/Q5R+7wZNKcI1ktP3JbtN0+FAL7PDECRc9OLSfmmMaEHgdDzjEhQc5yYX07
+        2fXib9XiOw8ge3L/dVrByx6h+sxfq/zboIeSSHjh34DJynP/CwAA///EW8FOwzAM/ZX9QKVeuHBD
+        7MgBIW6cui3AxLpWTTs+iP/hm2hdJ7ETe+s2ld2IbcX2q+OW54xHFdNUE3jnYYe+VL4IveoK5U4F
+        NleBBQ0C+wi3sxf49hWQ5QYzQZsDtNwVWb0tm6reVN97GWC5s58HsTU7eosY4c2PwKty+6Dh8DZb
+        q7QtbjAXvMDkc1dkdTt4Cctvzbpjg1oicE0AJYsncyAfM5P620S8drCzhIILZ7Qgbc7HqZeKOrEA
+        TVQqphgviBwpFmcyV7nA1CJ2xta3Kxl9vpGr8w3QcJjtiReKZDYX3DDrkBwmsnEe3q/LWgaekE9X
+        QJ/s4sAnc5KibYv1Z8nu+1MRwv1AZWec14nfI8Sn/NUfU0EsxkA3BinJkJLjCdOiaTHv35/Ffw1A
+        pLRTFkWOVz9M6twLNPwwDVTazgxH/vSJSm3nOlYwG1O9yopbHzAyarNdWRb0Ryd+7V6HXqAX1aUQ
+        OmcSBCmP5axJNQ0XO+GfQKwhv3aV4wV68FNOhBi98yZF30WTBmdLgV+1hSWDICLw0K8yJ7oufvFE
+        B49SBnFLk2dAfouQWGPqqmkh/TExIsDEXoJEz+vSovLupKzi5+KNhYZcN1X/lw1PSNKERvwchHpS
+        Fz8sKRkSRtqAvVJvvirlCxrMbDl8iVY1vsuEjrthBnO1WSB8qSsJEIEWETumhUVGtsu2+9Z8wA8+
+        9tlodN+rseWs3/22roXqJHCuksCgQVhfTVHKeKLmbCD/AAAA//8iMiDBQ79QO0BUNIjAXgvhDc4S
+        oLZiq6JcXTADdf0LSAgjxHCPAhvgHAUGy0BDzL8oPTEvswocRTjGgdGV0CoMwSPBqJZhDT/0pZOI
+        6Yh8JM24wxh5PgJJsy6SbgAAAAD//8RcwQ6CMAz9FY56MOEXjHow8eBFL8YDCYSYCCMi3Ph32WjX
+        jbVqCMYbXYG+92pYV4YOTxRabhvHYtvYeEDoddU/O/TmBV5k1z27wO7N7fHl1AsRHU1rKlqYrfR9
+        NRXpZ3m91KmAtEi7dUdpgDlA0PybwspA0Lfh22Wx3ISOxSa08UAG9kWVmEUpI7/1za49qGjazzbK
+        cPC/hbjTos7K9vZQpbcY9MdAvp03iJjCyXiqUG5QTo6wdHWvIEJp4/9FB9lAZNtk4+XLfCxSswEA
+        Y3I8ILRlgecSg6BECiuj35ZFFJAjwBVIXF2kCu9HRTZw2NgBmUKQBjjlYx4wGkcAfPWqSnIvFXgR
+        kWjVM6M8oAUEzmDK8KdnYAjFoUcQFvUwQJj1R7Z3Re+byAbcB5VH+svgt9CnKs9BHs8VhMiSwKGu
+        u74AAAD//wMADLksYH1HAAA=
+    headers:
+      ATL-TraceId:
+      - dd431afad71950b9
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:48 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 2faae567-07d1-4675-b477-7f07988e2796
+      x-envoy-upstream-service-time:
+      - '81'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xWS0/jMBD+K1EOnCpCS8WiShVCy66EdoWQKFwQB5NMqKljBz/adBH/fT2JE7vQ
+        ZbPlsgd6qWcyj28envFzDFVJeBZP4lKKR0i1igf+OLl99gJUKQN6XQKKKGC55c21LtUkSTLIrUIm
+        HsU+0YwoRQnf56ATCUonpKTJKHFWk+GB/VkTFI22xALWlrqYfbuaWYqTAix5zanW1gA6JEuiibyW
+        zKJ6jsfH1fi4j38FqZHQ+m6MnJQ0m9aO9xrGOZLjgy/WzWhcjcY7G1b0F0xVQRjbU+7/HV/Do2p4
+        9DFfVevMHd7xdjiqDkcf81ZARk1hvbnDH729DMJuwS7aoV86C3XHjMKOQSIDlUpaaiq45Z5GdQIG
+        UUaVpjzVUUkhhUjk0UrIxT5qp4Lb/umDwqVgSWG1Jf4g2MPhsSNnFui0g+x7eEbUwlKGa0m4YkRD
+        drHxRZl7jadJTpiCgb9vOQWWYeu7g217ZYqCyDUeJTwZKsEKammsmkrnUBD8UvufxEpLyh/QwVpp
+        KJDjtF86cFeO096/VmIQz4k6g5wYpm8IM9ChEyVIgjnHstqq6vguLHYvZGGWOnCe6eGdIy/CzHYI
+        Q91eGO/s6GBMrCCrhT67cVvPtTbiSW3kBWuaiqIUHDiugbCoTuVNVYmUBDuH2npaFa8fVjkw6sv8
+        1TPbMgdyPesckyxDT4D+JBRiCfGW2mNkRGuSzguEtlNkgX4QWsD1oZ2Gok1oG9q9QkPMG/3VB/Tb
+        6x+a8AjPAm4LMZTsibEbBW5t9BoErWwAsmV5gJedUAPOK/0DsLeNsNMQ+NgTxmnj3fzRjFuR6xWR
+        9RykRcmonfS+pJ8vnm2+/tcXTz0z64nLKF/sODMD/derseH6a/HT0pBF9Yr0c3PDADFa4GxloKHn
+        qnm98JKSpguQJzY/0k4sdxdt1HtqLlZX5h4XyiXBb1O85CFbNRynWgO1bT/lxlbtyYBcT3vfYZzt
+        mN+cVjcgVcPeJcHLRjvMbmjTp/c7rSIn7LMbivaF3iykZjn9ZS3ZMjxwgH6RGQUyDKPTDpZPy+pW
+        j2ds9sZvAAAA//+8l81uwjAMx19l6p1kHeUyaeI0aQf2CGgKKEoyAUVNGezQd5+dL1rSTe1ScXUT
+        +5fG8d8emxsYnFpvbLPj8IBYtZVL94BeTA0ce8dXAVFlpeqbJve33xBWdzTE2doiEpZ5FQmGCM+q
+        VQ9dfG//VBEbm+aYmcP7QLVngmuKO7R3osAglZDgnegv1Ht34jdrxAhGpOBnpMGalnca2JjUYz4l
+        Y86nwbT1vgv6bmwedZ6MWkyDChnZ5VyVZw9ZJEMuJoOMUnRlbB51kTVr7HPbLzEN/Z6pAKVme9J1
+        uTfD+gf0CHkxrIKxAxYhuzkzkw85fl+UJqLi/CDLI9Qh8qkq9izkjIMez1DfwxY7tEG0a7F7hUUP
+        2B9kYZyK0HrK3p9Vecc23DaiA050I7rxKOK8tboZa/C87nuaTOXkkVpHVJ8EXG29HClJfSNlg53e
+        uvkBAAD//wMAc91BljkVAAA=
+    headers:
+      ATL-TraceId:
+      - 408461b8d5b276fb
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:48 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 4e78ed65-8da8-436f-83eb-e934fbdf1d08
+      x-envoy-upstream-service-time:
+      - '104'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "summary": "Zap1: Cookie Without
+      Secure Flag", "description": "\n\n\n\n\n\n*Title*: [Zap1: Cookie Without Secure
+      Flag|http://localhost:8080/finding/232]\n\n*Defect Dojo link:* http://localhost:8080/finding/232\n\n*Severity:*
+      Low \n\n*CWE:* Unknown\n\n\n\n*CVE:* Unknown\n\n\n*Product/Engagement/Test:*
+      [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [ZAP Scan|http://localhost:8080/test/92]\n\n*Branch/Tag:* None\n\n*BuildID:*
+      None\n\n*Commit hash:* None\n\n*Systems/Endpoints*:    \n\n* https://mainsite.com:443\n*
+      https://mainsite.com\n* https://mainsite.com/dashboard\n\n*Description*:\nA
+      cookie has been set without the secure flag, which means that the cookie can
+      be accessed via unencrypted connections.\n\nReference: http://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\nURL:
+      https://mainsite.com/dashboard\nMethod: GET\nParameter: opvc\nEvidence: Set-Cookie:
+      opvc\n\nURL: https://mainsite.com/dashboard\nMethod: GET\nParameter: dmid\nEvidence:
+      Set-Cookie: dmid\n\nURL: https://mainsite.com\nMethod: GET\nParameter: sitevisitscookie\nEvidence:
+      Set-Cookie: sitevisitscookie\n\n\n*Mitigation*:\nWhenever a cookie contains
+      sensitive information or is a session token, then it should always be passed
+      using an encrypted channel. Ensure that the secure flag is set for cookies containing
+      such sensitive information.\n\n*Impact*:\nNo impact provided\n\n*Steps to reproduce*:\nNone\n\n*References*:\nCWE-614\nWASC-13\n\n\n*Defect
+      Dojo ID:* 232\n\n*Reporter:* [(admin) ()|mailto:]\n", "issuetype": {"name":
+      "Task"}, "priority": {"name": "Low"}}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1677'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue
+  response:
+    body:
+      string: '{"id":"10210","key":"NTEST-67","self":"https://defectdojo.atlassian.net/rest/api/2/issue/10210"}'
+    headers:
+      ATL-TraceId:
+      - 583c766894dbf746
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:49 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      timing-allow-origin:
+      - '*'
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 191cd7c8-923a-416e-b485-867fda9b89fe
+      x-envoy-upstream-service-time:
+      - '566'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-67
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6RWbW/bNhD+K4Q+DFtmWy8xEkdAMaSJ22VL08x2GqBJYdDSWWYjkQJJWfba/Pcd
+        SSlunTprU+dDxCPv/bmH/OTBqqQ89WJPAk9BQvqKQZ6qDqcFqI5KFlDQjihBUs0EVx1ImS5A006y
+        oDyDXGSdJUiFe5COoJSggGt31ut4zFgOgygMcKEgn+NyoXWpYt9PYQ6JTsVH0aM6p0oxynsctI82
+        tE9L5kc+U6oCvzVwB2vUv5gMx5PuwSEK5jZWL/7kKfRZqYRqyIRcu9hSXOH5KIiCbhh1w4NJeBgH
+        Ydw/6vWj6PcgDIxR60KvS7Bmnhmi0ccwgyDaJO0WKahEstIUBKXHRBU0zzskZUoznmhSMkiAiDmp
+        hbzrGe1E8CuZf08UCpJKgr9kUNMl1VT+odi/8KLAHlXFL050lr4Ig/1w0CwnGOiLTcodz/QZfU2o
+        ujMtqmbafMVzmivoeK0NL7ZG7jueZoiLEnvsxbzCTLxSio8Y3jOr12jb2tlutLXb6vcm0ivOtEYD
+        Bl6Ntknqb3tWibmuqTSJKVaUOUOEpFvZYHEtZPqDVX/wPeE2ZW6cNZUumSks/r6scz8wqIz6q6j/
+        bMO2hRYlv6jm/xO+woNVePBzvlats+bjCW/70Wo/+jlvDThV+7HT2/29me/VO0cu2LGbD9jBLJOQ
+        4Vw/giFiSuSVGzMnSSqlRWEpYooeosNdG4PHNhx1OKkZTMt+XtwNOx6mqd/hxBlcuQN2nAymJUtc
+        AJ8eyQziMCG1EFWenjJV5nTd4BLFNdVItI7IfnyGHEm2tOg7Y9LMh/08EZUpU2gCvTYCxjMv1rIy
+        nhMJmKoZusc0OegdHQQtTW4XLdhVzXDXRrRrY39DJUxIptfPrEOr7vd/jEZZQTNQvtFQrRGGglzU
+        PbXMNtRzLuqWovrevYHCDAyXGGRuJWWG8pvZhrtgGA5M2guqhiVLzhm/sxfxKZTmXuZJixaLodru
+        PUi44EO8lukshxFQ5RAomy/v8vzq9dnF9PzsZHgxHk6Ho9HbEaaB86MwbzwwWQC5RNLkmhi/hCki
+        eL4mOJAsN0aJFuQvJim5lFDg0JJKIb56dkS3szhCg8FnhgOtDmNva2KxshnjNMeeYdE3I2b2tmXN
+        q6Ipr8V4jtG1RIDtyzg8nK5KM7LfgWP3UHgmwpzyw2X19d3+Y6DboOolTe7wGdUiqzXufJ00L5qf
+        Crh9Fvnt6yRq71YOBtGJyIW8cNHM8gq6mUR22rwNBDkVrtmiKPGhx3XThad6+nVxbvnmb2/CdA57
+        Mbl5T8swJidC3DEg10wjO2oytncHeZXT7LPJFVPNRULzhVA6HgSDwJ8zniKJ+dF+9MEaPLWlwCg/
+        CmJAEu+R/9W0imNAmCFloAION7Gyk+shLq/4HRf1JuaTd4+ke5dSpBU+XoY8w0kqsC7+BMuA525s
+        EmiY/CnqrhY7EikbA9EH4pObUGnyT0WlBkk2JneowsZnaLXfH1+ScUL5jvPmyeQfNfV6KSlPFv6E
+        ZhjrBXbUSSuWp2enX4pORFEwTZCVFl+Kx2uloVCYeFoKhnDAZuLP7tnKG3wWlHHFNPQQNXG/v79r
+        b5fcT9HrTFCZNj1+wNNefMuPSeJgg7GRGQAnCjSpGwxppDT3BiFzxFGH1AuWLEgBlCvcpO5EYwGL
+        hhYITRKkREjJklFSIcoTuS6RU/AY5+Bu8Z4JZYRoQ7ZMIG5RVtd1T9RUlT0hMx8xBqteuSgtGhBu
+        07mQU+dMTanGN8Gswn5Mf317fTy+7I7fdPEW/M2YvhqdO6NPFeMNYJJpTF4PJ7cciRunFCETE1Eu
+        k1s+XDJzX2BwY9BdN1vt3rcc/AcAAP//7Flta9swEP4rJlBox+zaTpyXwejCXmAfNsoKG/SbYquN
+        md+w5HQjy3/vc5KiOk6dvTBKPwRCkK2T7iLdPffc5S8UJHma9CnQcwcU9G9LEqsU30KfUZ+KfTnl
+        GJ+QrW9VxUl+8W3JCwpqh9nrLVGQwg44BBmTrriTFriRXK1xypoSHsOsoHyDXPedFy/JPwoHrq8Z
+        m8OyO/aTHM2pmHKSRuBiHXhOy09QdRY88xC8gjzP+lnLE0kXOSr0G/vE1kDaTzTw0kftVJ734mNe
+        sVjS7/xcOql6cAAidFw6Sq4krwTl65prcOFa2ASudV1Br4F07jgY4dDmV2/dYGgOtI2mCg62aIn6
+        viR0IoA7Zbjx4sw5PfuFW85k+QrQss8Tgz6eGIzayV/WSIKKlxJL7opGPXv4vRN97Mu37EvdieKa
+        jwvaomCHwHSTXHfVzK6SksVLgmedKUWT54zS+OB3OY/OkEh5Wf9jzidydgEwI9qPaiq6YaNhEiym
+        Iz9awMbJZBaE4ZgohhWChgNinC54niTQgbw/eLDBNfXdG4t9tOnBIluHggeCocQU8ujheRSEwYgH
+        Ph+GyWwcD+NoEsTTKEl8Nr4J+PQiea12ORnOT8IP+Oh1bs4KkwldV78SXiPcO5yIG3oUBV7VLLI0
+        piNzK8YEnRjWI+RkCgaN4btLd+xVBdnfrd6fv8XdHsDzt7jbR3juFgOTEl2zG5bchshL0wCjeCLU
+        1rW1xrVrAC/E3zd1WfHzayBOvHwIPOpbYdZGMukxHThDsGuDuEcoePpLP0LBU1h8hIJeKLDMAybe
+        6ohbU8vbjH3sW0qWYbTPmXzwrsF6M9if6OvP+X39Od/257oTlsLxYpXWZaHpjin/G/P/i378k5+w
+        KuX/6oHqreyW0IMy8WupOkTbpis8Sxu83g4N6ObsxxcumoyeWxaqlkwt51JbS21hatuQvfb97uJw
+        Z7VZoJRsNpt7AAAA//8DAJCr3YZ7GwAA
+    headers:
+      ATL-TraceId:
+      - 53a5c1e23d43008a
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:49 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 63b0ad8e-1bd4-4b51-9e60-a015dc7e89a7
+      x-envoy-upstream-service-time:
+      - '124'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/10210
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6RWW2/bNhT+K4Qeii2zrUuMxBFQDKnjdunSNLOdBmhSGLR0LLOWSIGkfFnb/75D
+        Uopbp87a1HmIeMhz/85HfvJgXVKeerEngacgIX3JIE9Vi9MCVEslcyhoS5QgqWaCqxakTBegaSuZ
+        U55BLrLWEqTCPUiHUEpQwLU767U8ZiyHQRQGuFCQz3A517pUse+nMINEp+Kj6FCdU6UY5R0O2kcb
+        2qcl8yOfKVWB3xhYwAb1L8eD0bh9dIyCmY3Viz95Cn1WKqEaMiE3LrYUV3g+CqKgHUbt8GgcHsdB
+        GHdPOt0o+iMIA2PUutCbEqyZJ4Zo9DHMIIi2SbtFCiqRrDQFQekpUQXN8xZJmdKMJ5qUDBIgYkZW
+        Qi46RjsR/FrmPxKFgqSS4C8ZrOiSair/VOxfeF5gj6rimROdp8/D4DDs1csxBvp8m3LLM31GX2Oq
+        FqZF1VSbr3hGcwUtr7HhxdbIl5anGeKixB57Ma8wE6+U4iOG98Tq1dq2drYbTe12+r2N9JozrdGA
+        gVetbZL6255VYqZXVJrEFCvKnCFC0p1ssLgWMt3eutv7kXDrMtfO6kqXzBQWf1/XuRsYVEbdddR9
+        smHbQouSZ6r+/4iv8GgdHv2ar3XjrP54xNthtD6Mfs1bDU7VfOz19uWLme/1O0cu2LHbD9jBLJOQ
+        4Vw/gCFiSuSVGzMnSSqlRWEpYoIeouN9G72HNhx1OKkZTMt+XtwOa74wCJYsce4+PZAZfGH4ai6q
+        PD1jqszppkYhirFQ+h3OrEFm7YJqJFpHZD8/Q44kG1r0nTFp5sN+9kVlymRDvzECxjMv1rIysSQS
+        MFUzdA9pstc5OQoamtwtWrCvmuG+jWjfxuGWSpiQTG+eWIdG3e/+HI2ygmagfKOhGiMMBblYddQy
+        21LPhVg1FNX1bCOnYLjEIHMnKTOU38023AfDsGfSnlM1KFlywfjCXsRnUJp7mScNfiyqVnbvXsIF
+        H+C1TKc5DIEqh0lZf3lXF9evzi8nF+f9weVoMBkMh2+HmAbOj8K88cB4DuQKSZNrYvwSpojg+Ybg
+        QLLcGCVakNdMUnIlocChJZVCfHXsiO5mcYIGg88MB1odx97OxGJlM8Zpjj3Dom9HzOztyupXRV1e
+        i/Eco2uIANuXcbg/XZVmZH8Ax+6h8ESEOeX7y+rbu/3nQLdF1QuaLPAZ1SCrMe589esXzS8F3DyL
+        /OZ1EjV3KweD6ETkQl66aKZ5Be1MIl9t3waCnAnXbFGU+NDjuu7CYz39tjh3fPt3MGY6h4OY3L6n
+        ZRiTvhALBuSGaeRLTUb27iAvc5p9NrliqrlIaD4XSse9oBf4M8ZTJDE/Oow+WINnthQY5UdBDEji
+        A/K/mlZxBAgzpAxUwOEmVta/GeDymi+4WG1j7r97ID24kiKt8PEy4BlOUoF18cdYBjx3a5NAw+Qv
+        sWprsSeRsjYQfSA+uQ2VJv9UVGqQZGtyjypsfYZW+/3pFRkllO85b55M/kldrxeS8mTuj2mGsV5i
+        R520Ynl6fva1qC+KgmmCrDT/WjzaKA2FwsTTUjCEAzYTf3bPVt7gs6CMK6ahg6iJu93DfXv75H6K
+        XqeCyrTu8T2eDuI7fkoSBxuMjUwBOFGgyarGkEZKc28QMkMctchqzpI5KYByhZvUnagtYNHQAqFJ
+        gpQIKVkySipEeSI3JXIKHuMc3L3eMaEMEW3IlgnEDcpWq1VHrKgqO0JmPmIM1p1yXlo0INwmMyEn
+        zpmaUI2vhGmF/Zj89vbmdHTVHr1p4y34uzF9PbxwRh8rxhvAJNOYvBqM7zgSN04pQiYmolwmd3yw
+        ZOa+wOBGoNtutpq97zn4DwAA///sWW1r2zAQ/ismUGjH7FpOnJfB6MJeYB82ygob9Jtiq42Z37Ds
+        dCPLf+9zkqK6Tpy9MEo/BEKQrZPuIt0999zlLxTEWRL3KdBzBxT0b0sSqwTfUp9Rn4pdOeUYn5Ct
+        b1XFSX7xbSlyCmqH2+stUJDCDjgEGZOshJPkuJFMrXGKihIex6ykfINc913kL8k/cgeurzmcw9M7
+        /pMczSm5cpJG4mIdeE7LT1B15iL1ELySPM/6WcsTSRc5KvQb++TWQNpPNvDSvXYqz3vxMSt5VNPv
+        /Fw4iXpwACJ0XDpKrmpRSsrXldDgIrSwCVzrupJeA+ncMRvh0OZXb102NAfaRlMFB1u0RH1fEDoR
+        wJ1y3Hh+5pye/cItp3XxCtCyyxNZH09ko3byryskQcVLiTd3RcOePfzeiT725Vv2pe5Ecc39grYo
+        QLzyaElAu5fo+TMr2GY63WwomyzjlMYHv8t5dIZEyovqH3M+kbMLgBnRflRT4Q0fDWO2mI78cAGD
+        J5MZC4IxUQwrBA0HxARd8DyOoQN5f/Bgg2vquzcW+2jTg0W2DgUPBEOJKeTRw/OQBWwkmC+GQTwb
+        R8MonLBoGsaxz8c3TEwv4tdql5Ph/CT4gI9e52Y8N5nQdfUr6TXSvcOJuIFHUeCVzSJNIjoyt+Rc
+        0olhPUKuTsCgMXx36Y69Mif7u9X787e42wN4/hZ3+wjP3WJgUqyreMOS2xB5aRpgFE+E2rq21rh2
+        DeCF+PumKkpxfg3EiZYPgUd9K8zaSCY9pgNnCHZlEPcIBU9/6UcoeAqLj1DQCwWWUMDEWx1xa2p5
+        m7GPfYuapxjtciYfvGuw3gx2J/r6c35ff863/bnuhKVwIl8lVZFrkmTK/8b8/6If/+QnrIr6f/VA
+        9VZ2S+hBmfi1UB2ibRsWnqUNXm+HBnQz/uOLkE1Kzy0LVUumque1tpbawtS2IXvt+8eLg0erzQKl
+        ZLPZ3AMAAP//AwD0Q5+oexsAAA==
+    headers:
+      ATL-TraceId:
+      - 868518a58d21168d
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:49 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - df76ca55-d821-406a-8e43-281fe6ef7c56
+      x-envoy-upstream-service-time:
+      - '159'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA1SPT0vEMBDFv0uuttlJ+m/NTfSgIqvQ7kkWSZopVtKkNKmwLPvdTXBVvD3e/N68
+        mRNR0uN+MUSQ9xBmLzYbjQP2QbsPR2Uw0vtRWmoxkIx84uJHZyPMABgFCnm7u3lp75+7v+lunVRU
+        RLwmKIMMDhnROBt3nNCG7jhjXHBr3KpjSK2j0d8RIlKgKi7mnQwJ5MAhZzxnVceZKEFUWwoAVxDh
+        mPe4xN5unP6xdccaAUxUQBmwX7afHuzgInitOWLRs4JzpbBEVUPTgwY9NCXIcst1XVQ4pAN/CoJJ
+        DY/jIkl6Z5CrCU+ul8k+EXNRBO3bviXn8xcAAAD//wMAguZl01oBAAA=
+    headers:
+      ATL-TraceId:
+      - 1a64ff5abf659c76
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:50 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - ad0984cd-4040-4801-a8b2-2732146ce5d7
+      x-envoy-upstream-service-time:
+      - '26'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/field
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7SW327aMBTGXyXyNVTdboa47TQJqZqmtuouEJpMOAS3iYNshxZVfZq9z55px7Hj
+        P8RhHS0XVZXPh5zv9/lgPH8hbEWmRCqqGplTBUUt9vmG8gJW+ERG5BH2xws4rQArbtuK7MqWZFem
+        BgvyRqq6ItM1LSWMSC1WIOiyBKdwumOFUZRoUJBABfYIlLykjYTv2EqS6dza6XrZVl+1nwV+Ot9A
+        Rcn0haj9VlvTRhWrtFm5lwqqY0CvryMbCpOygfYVXQqhYrFnWsrujDZMaij+HzTs2P5L8YVFDtCL
+        nmhLBXDlcNyjZfnRPQ9zvGXHbM0BiW22cGb0jsht6CdUrKU7lLJbq53Dlu+ZSpY31RJEGKuvD2IV
+        9QPkQa7uuQvWCe9DSI5I1y3l3ztxAJ3k7a/Z8z0IyWouHUKsWYxv7DnbeXWY5dRp912TNFQIusfG
+        DEmwnlgvIV3o2xPSohBQ2FMgnrnkkuX98zs79/ylMPtDlzDp4eKz0IH15PQ5/W6s5EYeNPdfegGy
+        Lhtlds0YjSRr8ibUhv2dOmdBy9QGRI7cJgSqD994WzMoV78+XV5+/uKwUivdoUZFASrDkIQeq4Yr
+        QbksMa2Vttiv6BIwMB8QQL6et54W+PKoVyoO+zvfmSB5XV1QVVIpGeUXD9t6in9jszxugcdLKqFk
+        HMYxwQwja/sOBzgZDFCvxAEC19eL4fjM+rnCmwTh6U4fHV3ovgtu4oPz4xhd1Hpy+I3anes+1uva
+        CrrdUCqH97GDN3jOp1o8CooLDjFULN1PlLIbq52Bz7dM8fQPbF9/cJ1ETCVYHh2AiQW/aa2YqeNc
+        vUm2Jf/iSsEk3MR3ynDN0+FMq3sGT+2EGa5IskTXqGVOHCZ6y04lf1DDrim81OwFHwnmjir8rL8R
+        +edu5lpBHL8Jnc5h+uHrUxTejB85K3kCtcG55JSVjiFULMWsokX7IsvwFwAA//+0mVGPmzAMgP8K
+        2juotFKl9m2qdtrDaTrd9obugatomx5HUOC07t8vCQ5xSAzcVt4gDtj5bGI73HMNNu0fRaG2594Q
+        ew9mHPqB/7MjFOVIG1x9qlM0T9M5a2XXFZDACn/WgukqMpCvetlSuWqlchVoCa17WFlfG6fy0nmr
+        /nNjTSIL0aK68LouRHJlIt+fL3Hjmm+S1YomlpLElASIPZSy7tVuCyCzwqWYpYqZVQNX2eFSHN9e
+        +a1oXmah5DXsog5MVARIiEldfpxZlXQxlyAm6qXN/v2jbNmxV+yRTmnSa5K0kgDp7PD96/Ovl0h9
+        FxE/RQ9MyG1aZp9a9lHqYwg4YPKZu/tlUuP4hMwMn/SwgGHlZfD4OuxRtCmM+bC4tYm0X7SsOu+1
+        DqPCqQKNz9bWZ/Lz4YK1tndDA+ChJztibPA3yH8F26sLrR7Zgs4QYIyOuw0Zd0oyiDvdZbMq6nrT
+        8Xjz5i4WZ56msCBzb1E8bcLxlFfYjZOhpEKPVV1H7UXRBldgr0Vp65X+Flg/mvv7xw+oCq51sBuq
+        0rE641iCh+lI2pKRpCQmu7bqzPmJyzxExM9gxt2jBny+1ZnW1YVvsx+6WQhHRt9IjAXHRK44lTz3
+        c/GW5JuSfLXE4VurJUSy/mfv3ZZGcvZmLsQ7RbwHOucDJiqba/M7btSbY/1m7+NLR6CS50BaAlC7
+        fwdHXnJlUoClO2EphPoUCKsKkes/3LnkdK8Yu7YbcPT5T0qe/2iJyYb6X0L0yKq3MDh3wlLg9AkQ
+        VhUCN77bh06A+t8yLjR09jNEsyOhKQlAe84pWiBZCtNOYdI6ZvIhokp2GmVx47HA5ho6O9T3yoSJ
+        dh5ofd1Bw0TawioZ2NE3f6vyE+ScDjTYCX8RRhHS45gUQuOfKzmP2BU7/wdkZSbzQ156CKZmaSZ/
+        AQAA//8Cz3r4QyVpHCrE+Rm/sxGBgDQzBfEvkgDUa45paanJJcW0ncRKBFuSmkLhTBbcjQgfgovU
+        HGBBg/AjihDUl6CiKDVFAVyiE/AiAAAA//+8Wj1TwzAM/Ss9ZjqEpgtrYWLjY2RKfFyuB4QW+vvx
+        h2xJtkSTXM3URnIqvSfHsl+6EKKPqq94GTiWI9cSg5VMZLssvn0YMmfREGuIlssDS+EkXHYgn5hx
+        MOb/M7qzHupceA3ZvySDnvyU50nMHqPBt1k6V7wb0aQzRwCTLgFLcQK7IBSIJeWe0kiZg4X0x893
+        e/A2Yc8GjZGaAMCO2nQQSydTCinCyJ8SHE2QkayzZcChYotAMACyB3+hQ5pSF3HJdhlch4DxEzN5
+        ZS24WKppKxackPo/9Z6rmEHWkIvEpNqVTUq8FUvWm2N3GKISGGjgNkB/x4w67qVzkgaVkJXnc3qH
+        vgNVJXDvAXCP5st2pO/4bylpJ8pH1NqRejmcxRK56GFfbg6HMNY7MK1sM2/bw2nojCVsf3sa12E6
+        pOFxo6qr4o2qinsPkHg/Dt3K0yUySN216PPKOAYSuZtzXLQbe2N/be2loIIwXdxuVHHbeyhhfymL
+        fEAt0m4SaRBKok1+WXCGNlkabIjAnLOzUXlzHsrbThcnmL8Wa5vEWogkkbZorsnCBJFTc2ZalTPn
+        oZzpsgR112KsTYzpG/Q5R+7wZNKcI1ktP3JbtN0+FAL7PDECRc9OLSfmmMaEHgdDzjEhQc5yYX07
+        2fXib9XiOw8ge3L/dVrByx6h+sxfq/zboIeSSHjh34DJynP/CwAA///EW8FOwzAM/ZX9QKVeuHBD
+        7MgBIW6cui3AxLpWTTs+iP/hm2hdJ7ETe+s2ld2IbcX2q+OW54xHFdNUE3jnYYe+VL4IveoK5U4F
+        NleBBQ0C+wi3sxf49hWQ5QYzQZsDtNwVWb0tm6reVN97GWC5s58HsTU7eosY4c2PwKty+6Dh8DZb
+        q7QtbjAXvMDkc1dkdTt4Cctvzbpjg1oicE0AJYsncyAfM5P620S8drCzhIILZ7Qgbc7HqZeKOrEA
+        TVQqphgviBwpFmcyV7nA1CJ2xta3Kxl9vpGr8w3QcJjtiReKZDYX3DDrkBwmsnEe3q/LWgaekE9X
+        QJ/s4sAnc5KibYv1Z8nu+1MRwv1AZWec14nfI8Sn/NUfU0EsxkA3BinJkJLjCdOiaTHv35/Ffw1A
+        pLRTFkWOVz9M6twLNPwwDVTazgxH/vSJSm3nOlYwG1O9yopbHzAyarNdWRb0Ryd+7V6HXqAX1aUQ
+        OmcSBCmP5axJNQ0XO+GfQKwhv3aV4wV68FNOhBi98yZF30WTBmdLgV+1hSWDICLw0K8yJ7oufvFE
+        B49SBnFLk2dAfouQWGPqqmkh/TExIsDEXoJEz+vSovLupKzi5+KNhYZcN1X/lw1PSNKERvwchHpS
+        Fz8sKRkSRtqAvVJvvirlCxrMbDl8iVY1vsuEjrthBnO1WSB8qSsJEIEWETumhUVGtsu2+9Z8wA8+
+        9tlodN+rseWs3/22roXqJHCuksCgQVhfTVHKeKLmbCD/AAAA//8iMiDBQ79QO0BUNIjAXgvhDc4S
+        oLZiq6JcXTADdf0LSAgjxHCPAhvgHAUGy0BDzL8oPTEvswocRTjGgdGV0CoMwSPBqJZhDT/0pZOI
+        6Yh8JM24wxh5PgJJsy6SbgAAAAD//8RcwQ6CMAz9FY56MOEXjHow8eBFL8YDCYSYCCMi3Ph32WjX
+        jbVqCMYbXYG+92pYV4YOTxRabhvHYtvYeEDoddU/O/TmBV5k1z27wO7N7fHl1AsRHU1rKlqYrfR9
+        NRXpZ3m91KmAtEi7dUdpgDlA0PybwspA0Lfh22Wx3ISOxSa08UAG9kWVmEUpI7/1za49qGjazzbK
+        cPC/hbjTos7K9vZQpbcY9MdAvp03iJjCyXiqUG5QTo6wdHWvIEJp4/9FB9lAZNtk4+XLfCxSswEA
+        Y3I8ILRlgecSg6BECiuj35ZFFJAjwBVIXF2kCu9HRTZw2NgBmUKQBjjlYx4wGkcAfPWqSnIvFXgR
+        kWjVM6M8oAUEzmDK8KdnYAjFoUcQFvUwQJj1R7Z3Re+byAbcB5VH+svgt9CnKs9BHs8VhMiSwKGu
+        u74AAAD//wMADLksYH1HAAA=
+    headers:
+      ATL-TraceId:
+      - 03dc2d294dfbda28
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:50 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 1de18a35-ef7f-4d8b-80d2-e7d2c07271b3
+      x-envoy-upstream-service-time:
+      - '60'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xWS0/jMBD+K1EOnCpCS8WiShVCy66EdoWQKFwQB5NMqKljBz/adBH/fT2JE7vQ
+        ZbPlsgd6qWcyj28envFzDFVJeBZP4lKKR0i1igf+OLl99gJUKQN6XQKKKGC55c21LtUkSTLIrUIm
+        HsU+0YwoRQnf56ATCUonpKTJKHFWk+GB/VkTFI22xALWlrqYfbuaWYqTAix5zanW1gA6JEuiibyW
+        zKJ6jsfH1fi4j38FqZHQ+m6MnJQ0m9aO9xrGOZLjgy/WzWhcjcY7G1b0F0xVQRjbU+7/HV/Do2p4
+        9DFfVevMHd7xdjiqDkcf81ZARk1hvbnDH729DMJuwS7aoV86C3XHjMKOQSIDlUpaaiq45Z5GdQIG
+        UUaVpjzVUUkhhUjk0UrIxT5qp4Lb/umDwqVgSWG1Jf4g2MPhsSNnFui0g+x7eEbUwlKGa0m4YkRD
+        drHxRZl7jadJTpiCgb9vOQWWYeu7g217ZYqCyDUeJTwZKsEKammsmkrnUBD8UvufxEpLyh/QwVpp
+        KJDjtF86cFeO096/VmIQz4k6g5wYpm8IM9ChEyVIgjnHstqq6vguLHYvZGGWOnCe6eGdIy/CzHYI
+        Q91eGO/s6GBMrCCrhT67cVvPtTbiSW3kBWuaiqIUHDiugbCoTuVNVYmUBDuH2npaFa8fVjkw6sv8
+        1TPbMgdyPesckyxDT4D+JBRiCfGW2mNkRGuSzguEtlNkgX4QWsD1oZ2Gok1oG9q9QkPMG/3VB/Tb
+        6x+a8AjPAm4LMZTsibEbBW5t9BoErWwAsmV5gJedUAPOK/0DsLeNsNMQ+NgTxmnj3fzRjFuR6xWR
+        9RykRcmonfS+pJ8vnm2+/tcXTz0z64nLKF/sODMD/derseH6a/HT0pBF9Yr0c3PDADFa4GxloKHn
+        qnm98JKSpguQJzY/0k4sdxdt1HtqLlZX5h4XyiXBb1O85CFbNRynWgO1bT/lxlbtyYBcT3vfYZzt
+        mN+cVjcgVcPeJcHLRjvMbmjTp/c7rSIn7LMbivaF3iykZjn9ZS3ZMjxwgH6RGQUyDKPTDpZPy+pW
+        j2ds9sZvAAAA//+8l81uwjAMx19l6p1kHeUyaeI0aQf2CGgKKEoyAUVNGezQd5+dL1rSTe1ScXUT
+        +5fG8d8emxsYnFpvbLPj8IBYtZVL94BeTA0ce8dXAVFlpeqbJve33xBWdzTE2doiEpZ5FQmGCM+q
+        VQ9dfG//VBEbm+aYmcP7QLVngmuKO7R3osAglZDgnegv1Ht34jdrxAhGpOBnpMGalnca2JjUYz4l
+        Y86nwbT1vgv6bmwedZ6MWkyDChnZ5VyVZw9ZJEMuJoOMUnRlbB51kTVr7HPbLzEN/Z6pAKVme9J1
+        uTfD+gf0CHkxrIKxAxYhuzkzkw85fl+UJqLi/CDLI9Qh8qkq9izkjIMez1DfwxY7tEG0a7F7hUUP
+        2B9kYZyK0HrK3p9Vecc23DaiA050I7rxKOK8tboZa/C87nuaTOXkkVpHVJ8EXG29HClJfSNlg53e
+        uvkBAAD//wMAc91BljkVAAA=
+    headers:
+      ATL-TraceId:
+      - d6e0c5a02d07d958
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:50 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 8d330d68-af5e-4753-bbab-a6bb7641b3fd
+      x-envoy-upstream-service-time:
+      - '62'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "summary": "Zap2: Cookie Without
+      Secure Flag", "description": "\n\n\n\n\n\n*Title*: [Zap2: Cookie Without Secure
+      Flag|http://localhost:8080/finding/233]\n\n*Defect Dojo link:* http://localhost:8080/finding/233\n\n*Severity:*
+      Low \n\n*CWE:* Unknown\n\n\n\n*CVE:* Unknown\n\n\n*Product/Engagement/Test:*
+      [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [ZAP Scan|http://localhost:8080/test/92]\n\n*Branch/Tag:* None\n\n*BuildID:*
+      None\n\n*Commit hash:* None\n\n*Systems/Endpoints*:    \n\n* https://mainsite.com:443\n*
+      https://mainsite.com\n* https://mainsite.com/dashboard\n\n*Description*:\nA
+      cookie has been set without the secure flag, which means that the cookie can
+      be accessed via unencrypted connections.\n\nReference: http://www.owasp.org/index.php/Testing_for_cookies_attributes_(OWASP-SM-002)\n\nURL:
+      https://mainsite.com/dashboard\nMethod: GET\nParameter: opvc\nEvidence: Set-Cookie:
+      opvc\n\nURL: https://mainsite.com/dashboard\nMethod: GET\nParameter: dmid\nEvidence:
+      Set-Cookie: dmid\n\nURL: https://mainsite.com\nMethod: GET\nParameter: sitevisitscookie\nEvidence:
+      Set-Cookie: sitevisitscookie\n\n\n*Mitigation*:\nWhenever a cookie contains
+      sensitive information or is a session token, then it should always be passed
+      using an encrypted channel. Ensure that the secure flag is set for cookies containing
+      such sensitive information.\n\n*Impact*:\nNo impact provided\n\n*Steps to reproduce*:\nNone\n\n*References*:\nCWE-614\nWASC-13\n\n\n*Defect
+      Dojo ID:* 233\n\n*Reporter:* [(admin) ()|mailto:]\n", "issuetype": {"name":
+      "Task"}, "priority": {"name": "Low"}}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1677'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue
+  response:
+    body:
+      string: '{"id":"10211","key":"NTEST-68","self":"https://defectdojo.atlassian.net/rest/api/2/issue/10211"}'
+    headers:
+      ATL-TraceId:
+      - 8de286e1a895e32c
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:51 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      timing-allow-origin:
+      - '*'
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 7f2e1821-cce2-463f-8400-e50eb3409f9b
+      x-envoy-upstream-service-time:
+      - '608'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-68
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6RWW2/bNhT+K4Qehi2zrYvdxBVQDKnjdtnSNLOdBmhSGLR0LLOWSIGkfFnb/75D
+        UorTpM7a1HmIeMhz/85HfvJgU1KeerEngacgIX3FIE9Vi9MCVEslCyhoS5QgqWaCqxakTBegaStZ
+        UJ5BLrLWCqTCPUhHUEpQwLU767U8ZiyHQRSGuFCQz3G50LpUse+nMIdEp+Kj6FCdU6UY5R0O2kcb
+        2qcl8yOfKVWB3xhYwhb1zyfD8aR92EfB3MbqxZ88hT4rlVANmZBbF1uKKzwfBVHQDqN2eDgJj+Ig
+        jJ+FnSCIfg/CIDAhGhd6W4I188QQjT6GiWZ3SbtFCiqRrDQFQekxUQXN8xZJmdKMJ5qUDBIgYk7W
+        Qi47RjsR/FLm3xOFgqSS4K8YrOmKair/UOxfeFFgj6riFyc6TV+EQTfs18sJBvpil3LLM31GXxOq
+        lqZF1Uybr3hOcwUtr7HhxdbIl5anGeKixB57Ma8wE6+U4iOG98Tq1dq2drYbTe3M4k6/d5FecqY1
+        GjDwqrVNUn/bs0rM9ZpKk5hiRZkzREh6LxssroVMr7/p9b8n3LrMtbO60iUzhcXf3Tr3giP0HPU2
+        Ue/Jhm0LLUp+UfX/R3yFh5vw8Od8bRpn9ccj3rrRphv9nLcanKr52Ovtyxcz35t3jlywY9cfsINZ
+        JiHDuX4AQ8SUyCs3Zk6SVEqLwlLEFD1ER/s2+g9tOOpwUjOYlv28uB3ikmokRUc6P453R2gNhfnO
+        mDRYtp8DUZmUQkNLV0bAeObFWlaA1UCT+h3OukG0C81aM9YlS1zqnx7ITKSorBaiytMTpsqcbuuJ
+        QHEiAVM1Q/eQJoPOs95RQ5P3ixbsq2a4byPat9HdUQkTkuntE2vbqPu9H6NRVtAMlG80VGOEoSAX
+        645aZTvqORPrhqJ6nm3IDAyXGGTeS8oM5TezDffBMOybtBdUDUuWnDG+tBfxCZTmXuZJ0zPbybXd
+        u5VwwYd4LdNZDiOgyuFA1l/exdnl69Pz6dnpYHg+Hk6Ho9HbEaaB86MwbzwwWQC5QNLkmhi/hCki
+        eL4lOJAsN0aJFuQvJim5kFDg0JJKIWY7dkTvZ/EcDQafGQ60mseeuy+wRVjj3UR9NcVY7Yxxmt8/
+        VL8q6vJaVOcYXUME2L6Mw+3pqjQj+x04dg+FJyLMKd9eVl/f7T8Guh2qXtJkic+oBlmNcedrUL9o
+        firg5lnkN6+TqLlbORhEJyIX8txFM8sraGcSOWL3NhDkRLhmi6LEhx7XdRce69/Xxbnhu7+DCdM5
+        HMTk+j0to5gMhFgyIFdMI0dpMrZ3B3mV0+yzyRVTzUVC84VQOu4H/cCfM54iMfpRt/vBGjyxpcAo
+        PwpiQBIfkP/VtIpjQJghZaACDjexssHVEJeXfMnFehfz4N0D6cGFFGmFj5chz3CSCqyLP8Ey4Llr
+        mwQaJn+KdVuLPYmUtYHoA/HJdag0+aeiUoMkO5N7VGHnM7Ta748vyDihfM9582Tyn0euXi8l5cnC
+        n9AMYz3HjjppxfL09OSuaCCKgmmCrLS4Kx5vlYZCYeJpKRjCAZuJP7tnK2/wWVDGFdPQQdTEvV53
+        394+uZ+i15mgMq17fIung/iGH5PEwQZjIzMAThRosq4xpJHS3BuEzBFHLbJesGRBCqBc4SZ1J2oL
+        WDS0QGiSICVCSlaMkgpRnshtiZyCxzgHd5d2TCgjRBuyZQJxg7L1et0Ra6rKjpCZjxiDTadclBYN
+        CLfpXMipc6amVOPNPKuwH9Nf314djy/a4zdtvAV/M6YvR2fO6GPFeAOYZBqT18PJDUfixilFyMRE
+        lKvkhg9XzNwXGNwYdNvNVrP3LQf/AQAA///sWW1r2zAQ/ismUGjH7NpOnJfB6MJeYB82ygob9Jti
+        q42ZbRnLTjey/Pc+JylK6sTZC6PkQ6AU2TrpztLdc89d/kJBkqdJlwI9d0BB97YksUjxX+oz6lKx
+        K6cc4xOy9b2qOMkvvs15QUHtMHu9AgUp7IBDkDHpgjtpgRvJ1RpHVJTwGGYl5Rvkuu+8eEn+UThw
+        fc2bHJY9sJ/kaE7JlJM0EhfrwHO2/ARVZ8EzD8EryfOsn215IukiR4V+Y59cG0j7yQZeutdO5Xkv
+        PuYli2v6zs/CSdWDAxCh49JRclPzUlK+rrgGF66FTeBa15X0GkjnDoMBDm1689YNFCSqSNugqYKD
+        NVqivheETgRw5ww3Xlw45xe/cMtZLV4BWnZ5YtDFE4NB10S0nqDsUlfIjooEE4ltifpWtD3Rxb58
+        y77UnSiuuV/QFgXtiYllMXXN4jkh8J7apJ0NZZPnjNJ473c5j86QSLmo/jHnEzm7AphRKYFqKrpj
+        g34SzMYDP5rhA0ajSRCGQ6IYVggaDohxuuBpkkAH8n5vY4Nr6rs3Fvto04NFtg4FDwRDiSnk0cPL
+        KAiDAQ983g+TyTDux9EoiMdRkvhseBfw8VXyWu1y1p+ehR/wp9e5OStMJnRd/Up6jXQfcCJu6FEU
+        eGUzy9KYjswtGZN0YliPkKtTMGgM3127Q68syP529X78Frd7AMdvcbuPcOwWA3oSXTkblrwNkdem
+        AUbxRKit63UNX7cAXoi/bypR8stbIE483wQe9a0wayOZ9JgOnCHYlUHcExQ8/6WfoOA5LD5BQScU
+        WEIBE+91xC2p5W3GPvYVNcsw2kONwLt6y1Vvd6KrP+d39ed8259rT1gKx4tFWolCcyFT/jfm9xf9
+        +CefsBD1/+qr6q3sltCDMvGrUB0i2/pEbasMXq6HBnRz9uMLl01Gz1sWqpZMVU9rbS21haltQ/ba
+        908Xh09WmwVKyWq1egQAAP//AwA/Aic3exsAAA==
+    headers:
+      ATL-TraceId:
+      - 28c89942c07845c0
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:51 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 806f12a2-a505-4e5c-8ee3-1a9aa1943cb5
+      x-envoy-upstream-service-time:
+      - '159'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/10211
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6RWbVPbOBD+Kxp/6NxxSfySFFLPMDc0pC13lHJJgJlCJ6PYG0eNLXkkOU6u5b/f
+        yrIJhYZrafiAtdK+P/tIXxxY55THTuhI4DFIiN8wSGPV4jQD1VLRAjLaEjlIqpngqgUx0xlo2ooW
+        lCeQiqS1AqlwD+IR5BIUcG3POi2HGcu+F/g+LhSkc1wutM5V6LoxzCHSsfgsOlSnVClGeYeDdtGG
+        dmnO3MBlShXgNgaWsEH9s8lwPGnv91Ewr2J1wi+OQp+FiqiGRMiNjS3GFZ4PvMBr+0Hb35/4B6Hn
+        hy/9jucFf3i+55kQjQu9yaEy88wQjT6GiWa3SdtFDCqSLDcFQekRURlN0xaJmdKMR5rkDCIgYk5K
+        IZcdox0JfiHTH4lCQVRIcFcMSrqimso/FfsXDjPsUZG9sKKT+ND3un6/Xk4w0MNtyi3H9Bl9Taha
+        mhYVM22+wjlNFbScxoYTVkZuW45miIsce+yEvMBMnFyKzxjeM6tXa1e1q7rR1M4s7vV7G+kFZ1qj
+        AQOvWtsk9Xd1Vom5Lqk0iSmW5SlDhMQPssHiVpDp9de9/o+EW5e5dlZXOmemsPi7X+eed4Ceg946
+        6D3bcNXCCiUvVP3/CV/+/trf/zVf68ZZ/fGEt26w7ga/5q0Gp2o+dnq7vTXzvb605IIdu/6EHUwS
+        CQnO9SMYIqZEWtgxs5KoUFpkFUVM0UNwsGuj/9iGpQ4rNYNZsZ8Ttv2Wg2nqS5w4g6v6ANVIk5aG
+        fn4CLMU1pOZaY9Kgu/ociMIk6RuiujICxhMn1LKA25q7jC3JIpv6l0cyExceVQtRpPExU3lKN/VE
+        oDiSgKmaoXtMk17nZe+gocmHRfN2VdPftRHs2uhuqYQJyfTmmZVs1N3ez9Eoy2gCyjUaqjHCUJCK
+        sqNWyZZ6TkXZUFTPuTVQmIHhEoPMB0mZofxutv4uGPp9k/aCqmHOolPGl9VFfAy5uZd51PSs6mRZ
+        7d1JuOBDvJbpLIURUGVxIOsv5/z04u3J2fT0ZDA8Gw+nw9HowwjTwPlRmDcemCyAnCNpck2MX8IU
+        ETzdEBxIlhqjRAvyF5OUnEvIcGhJoRChnWpEH2bxCg16XxkOtJqHjr0vsEVY4+1EfTPFWO2EcZo+
+        PFS/KuryVqhOMbqGCLB9CYe700VuRvYHcGwfCs9EmFW+u6y+vdt/DnRbVL2m0RKfUQ2yGuPW16B+
+        0fxSwM2zyG1eJ0Fzt3IwiI5EKuSZjWaWFtBOJHLE9m0gyLGwzRZZjg89rusuPNW/b4tzw7d/exOm
+        U9gLyfVHmgchGQixZECumEaO0mRc3R3kTUqTryZXTDUVEU0XQumw7/U9d854jDToBt3up8rgcVUK
+        jPKzIAYk4R75X81KcQwIM6QMVMDhJpVscDXE5QVfclFuYx5cPpLunUsRF/h4GfIEJynDurgTLAOe
+        u66SQMPknSjbWuxIJK8NBJ+IS659pck/BZUaJNma3KEKW59+pf3x6JyMI8p3nDdPJvdVYOv1WlIe
+        LdwJTTDWM+yolRYsjU+O74sGIsuYJshKi/vi8UZpyBQmHueCIRywmfir9qrKG3xmlHHFNHQQNWGv
+        1921t0vuxuh1JqiM6x7f4WkvvOFHJLKwwdjIDIATBZqUNYY0Upp9g5A54qhFygWLFiQDyhVuUnui
+        toBFQwuERhFSIsRkxSgpEOWR3OTIKXiMc7B3aceEMkK0IVtGEDYoK8uyI0qq8o6QiYsYg3UnX+QV
+        GhBu07mQU+tMTanGm3lWYD+mv324Ohqft8fv23gL/m5MX4xOrdGnivEeMMk4JG+HkxuOxI1TipAJ
+        ichX0Q0frpi5LzC4Mei2na1m73sO/gMAAP//7Flta9swEP4rJlBox+xaTpyXwejCXmAfNsoKG/Sb
+        YquNmd+w7HQjy3/vc5KspG6cvTBKPwRCkK2T7iLdPffc5S8UxFkS9ynQcwcU9G9LEqsE31KfUZ+K
+        x3LKMT4hW9+qipP84ttS5BTUDrfXW6AghR1wCDImWQknyXEjmVrjFBUlPI5ZSfkGue67yF+Sf+QO
+        XF/zJoend/wnOZpTcuUkjcTFOvCcHT9B1ZmL1EPwSvI862c7nki6yFGh39gnWwNpP9nAS/faqTzv
+        xces5FFNv/Nz4STqwQGI0HHpKLmqRSkpX1dCg4vQwiZwretKeg2kc8dshEObX711mYJEFWlbNFVw
+        0KIl6vuC0IkA7pTjxvMz5/TsF245rYtXgJbHPJH18UQ26psI2wnKLnWF7KgoL5HYjqhvRbsTfezL
+        t+xL3YnimvsFbVGAeOXRkoB2L9HzZ3tZTTcbyibLOKXxwe9yHp0hkfKi+secT+TsAmBGhQOqqfCG
+        j4YxW0xHfriAwZPJjAXBmCiGFYKGA2KCLngex9CBvD/Y2uCa+u6NxT7a9GCRrUPBA8FQYgp59PA8
+        ZAEbCeaLYRDPxtEwCicsmoZx7PPxDRPTi/i12uVkOD8JPuCj17kZz00mdF39SnqNdO9wIm7gURR4
+        ZbNIk4iOzC05l3RiWI+QqxMwaAzfXbpjr8zJ/m71/vwt7vYAnr/F3T7Cc7cY0BPrytmw5F2IvDQN
+        MIonQm1dnWv4ugbwQvx9UxWlOL8G4kTLbeBR3wqzNpJJj+nAGYJdGcQ9QsHTX/oRCp7C4iMU9EJB
+        l2mASg3WG1rTMg3YfqtDcU29cDP2obCoeYrRnl36+nN+X3/Ot/257oSlcCJfJVWRa5Jkyv/G/P+i
+        H//IUhSbaod1OzQomPEfX4RsUnreWaJ6JFU9r/XyVVH/ryas3spuCU2oMr8WqsHUdk6pLUxtG1Jo
+        zXhoa/DAWLNA/abNZnMPAAD//wMAqC+m2XsbAAA=
+    headers:
+      ATL-TraceId:
+      - 95af96691ffca430
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:51 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - b056a07a-da91-48f7-81e8-98ce854c1062
+      x-envoy-upstream-service-time:
+      - '174'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA1SPT0vEMBDFv0uuttlJ+m/NTfSgIqvQ7kkWSZopVtKkNKmwLPvdTXBVvD3e/N68
+        mRNR0uN+MUSQ9xBmLzYbjQP2QbsPR2Uw0vtRWmoxkIx84uJHZyPMABgFCnm7u3lp75+7v+lunVRU
+        RLwmKIMMDhnROBt3nNCG7jhjXHBr3KpjSK2j0d8RIlKgKi7mnQwJ5MAhZzxnVceZKEFUWwoAVxDh
+        mPe4xN5unP6xdccaAUxUjG5Z8cv204MdXASvNUcselZwrhSWqGpoetCgh6YEWW65rosKh3TgT0Ew
+        qeFxXCRJ7wxyNeHJ9TLZJ2IuiqB927fkfP4CAAD//wMA/qxDA1oBAAA=
+    headers:
+      ATL-TraceId:
+      - a0dcd2e2bd439421
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:51 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - e35eb19d-60ad-4b29-819c-5f0366b4326f
+      x-envoy-upstream-service-time:
+      - '29'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/field
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7SW327aMBTGXyXyNVTdboa47TQJqZqmtuouEJpMOAS3iYNshxZVfZq9z55px7Hj
+        P8RhHS0XVZXPh5zv9/lgPH8hbEWmRCqqGplTBUUt9vmG8gJW+ERG5BH2xws4rQArbtuK7MqWZFem
+        BgvyRqq6ItM1LSWMSC1WIOiyBKdwumOFUZRoUJBABfYIlLykjYTv2EqS6dza6XrZVl+1nwV+Ot9A
+        Rcn0haj9VlvTRhWrtFm5lwqqY0CvryMbCpOygfYVXQqhYrFnWsrujDZMaij+HzTs2P5L8YVFDtCL
+        nmhLBXDlcNyjZfnRPQ9zvGXHbM0BiW22cGb0jsht6CdUrKU7lLJbq53Dlu+ZSpY31RJEGKuvD2IV
+        9QPkQa7uuQvWCe9DSI5I1y3l3ztxAJ3k7a/Z8z0IyWouHUKsWYxv7DnbeXWY5dRp912TNFQIusfG
+        DEmwnlgvIV3o2xPSohBQ2FMgnrnkkuX98zs79/ylMPtDlzDp4eKz0IH15PQ5/W6s5EYeNPdfegGy
+        Lhtlds0YjSRr8ibUhv2dOmdBy9QGRI7cJgSqD994WzMoV78+XV5+/uKwUivdoUZFASrDkIQeq4Yr
+        QbksMa2Vttiv6BIwMB8QQL6et54W+PKoVyoO+zvfmSB5XV1QVVIpGeUXD9t6in9jszxugcdLKqFk
+        HMYxwQwja/sOBzgZDFCvxAEC19eL4fjM+rnCmwTh6U4fHV3ovgtu4oPz4xhd1Hpy+I3anes+1uva
+        CrrdUCqH97GDN3jOp1o8CooLDjFULN1PlLIbq52Bz7dM8fQPbF9/cJ1ETCVYHh2AiQW/aa2YqeNc
+        vUm2Jf/iSsEk3MR3ynDN0+FMq3sGT+2EGa5IskTXqGVOHCZ6y04lf1DDrim81OwFHwnmjir8rL8R
+        +edu5lpBHL8Jnc5h+uHrUxTejB85K3kCtcG55JSVjiFULMWsokX7IsvwFwAA//+0mVGPmzAMgP8K
+        2juotFKl9m2qdtrDaTrd9obugatomx5HUOC07t8vCQ5xSAzcVt4gDtj5bGI73HMNNu0fRaG2594Q
+        ew9mHPqB/7MjFOVIG1x9qlM0T9M5a2XXFZDACn/WgukqMpCvetlSuWqlchVoCa17WFlfG6fy0nmr
+        /nNjTSIL0aK68LouRHJlIt+fL3Hjmm+S1YomlpLElASIPZSy7tVuCyCzwqWYpYqZVQNX2eFSHN9e
+        +a1oXmah5DXsog5MVARIiEldfpxZlXQxlyAm6qXN/v2jbNmxV+yRTmnSa5K0kgDp7PD96/Ovl0h9
+        FxE/RQ9MyG1aZp9a9lHqYwg4YPKZu/tlUuP4hMwMn/SwgGHlZfD4OuxRtCmM+bC4tYm0X7SsOu+1
+        DqPCqQKNz9bWZ/Lz4YK1tndDA+ChJztibPA3yH8F26sLrR7Zgs4QYIyOuw0Zd0oyiDvdZbMq6nrT
+        8Xjz5i4WZ56msCBzb1E8bcLxlFfYjZOhpEKPVV1H7UXRBldgr0Vp65X+Flg/mvv7xw+oCq51sBuq
+        0rE641iCh+lI2pKRpCQmu7bqzPmJyzxExM9gxt2jBny+1ZnW1YVvsx+6WQhHRt9IjAXHRK44lTz3
+        c/GW5JuSfLXE4VurJUSy/mfv3ZZGcvZmLsQ7RbwHOucDJiqba/M7btSbY/1m7+NLR6CS50BaAlC7
+        fwdHXnJlUoClO2EphPoUCKsKkes/3LnkdK8Yu7YbcPT5T0qe/2iJyYb6X0L0yKq3MDh3wlLg9AkQ
+        VhUCN77bh06A+t8yLjR09jNEsyOhKQlAe84pWiBZCtNOYdI6ZvIhokp2GmVx47HA5ho6O9T3yoSJ
+        dh5ofd1Bw0TawioZ2NE3f6vyE+ScDjTYCX8RRhHS45gUQuOfKzmP2BU7/wdkZSbzQ156CKZmaSZ/
+        AQAA//8Cz3r4QyVpHCrE+Rm/sxGBgDQzBfEvkgDUa45paanJJcW0ncRKBFuSmkLhTBbcjQgfgovU
+        HGBBg/AjihDUl6CiKDVFAVyiE/AiAAAA//+8Wj1TwzAM/Ss9ZjqEpgtrYWLjY2RKfFyuB4QW+vvx
+        h2xJtkSTXM3URnIqvSfHsl+6EKKPqq94GTiWI9cSg5VMZLssvn0YMmfREGuIlssDS+EkXHYgn5hx
+        MOb/M7qzHupceA3ZvySDnvyU50nMHqPBt1k6V7wb0aQzRwCTLgFLcQK7IBSIJeWe0kiZg4X0x893
+        e/A2Yc8GjZGaAMCO2nQQSydTCinCyJ8SHE2QkayzZcChYotAMACyB3+hQ5pSF3HJdhlch4DxEzN5
+        ZS24WKppKxackPo/9Z6rmEHWkIvEpNqVTUq8FUvWm2N3GKISGGjgNkB/x4w67qVzkgaVkJXnc3qH
+        vgNVJXDvAXCP5st2pO/4bylpJ8pH1NqRejmcxRK56GFfbg6HMNY7MK1sM2/bw2nojCVsf3sa12E6
+        pOFxo6qr4o2qinsPkHg/Dt3K0yUySN216PPKOAYSuZtzXLQbe2N/be2loIIwXdxuVHHbeyhhfymL
+        fEAt0m4SaRBKok1+WXCGNlkabIjAnLOzUXlzHsrbThcnmL8Wa5vEWogkkbZorsnCBJFTc2ZalTPn
+        oZzpsgR112KsTYzpG/Q5R+7wZNKcI1ktP3JbtN0+FAL7PDECRc9OLSfmmMaEHgdDzjEhQc5yYX07
+        2fXib9XiOw8ge3L/dVrByx6h+sxfq/zboIeSSHjh34DJynP/CwAA///EW8FOwzAM/ZX9QKVeuHBD
+        7MgBIW6cui3AxLpWTTs+iP/hm2hdJ7ETe+s2ld2IbcX2q+OW54xHFdNUE3jnYYe+VL4IveoK5U4F
+        NleBBQ0C+wi3sxf49hWQ5QYzQZsDtNwVWb0tm6reVN97GWC5s58HsTU7eosY4c2PwKty+6Dh8DZb
+        q7QtbjAXvMDkc1dkdTt4Cctvzbpjg1oicE0AJYsncyAfM5P620S8drCzhIILZ7Qgbc7HqZeKOrEA
+        TVQqphgviBwpFmcyV7nA1CJ2xta3Kxl9vpGr8w3QcJjtiReKZDYX3DDrkBwmsnEe3q/LWgaekE9X
+        QJ/s4sAnc5KibYv1Z8nu+1MRwv1AZWec14nfI8Sn/NUfU0EsxkA3BinJkJLjCdOiaTHv35/Ffw1A
+        pLRTFkWOVz9M6twLNPwwDVTazgxH/vSJSm3nOlYwG1O9yopbHzAyarNdWRb0Ryd+7V6HXqAX1aUQ
+        OmcSBCmP5axJNQ0XO+GfQKwhv3aV4wV68FNOhBi98yZF30WTBmdLgV+1hSWDICLw0K8yJ7oufvFE
+        B49SBnFLk2dAfouQWGPqqmkh/TExIsDEXoJEz+vSovLupKzi5+KNhYZcN1X/lw1PSNKERvwchHpS
+        Fz8sKRkSRtqAvVJvvirlCxrMbDl8iVY1vsuEjrthBnO1WSB8qSsJEIEWETumhUVGtsu2+9Z8wA8+
+        9tlodN+rseWs3/22roXqJHCuksCgQVhfTVHKeKLmbCD/AAAA//8iMiDBQ79QO0BUNIjAXgvhDc4S
+        oLZiq6JcXTADdf0LSAgjxHCPAhvgHAUGy0BDzL8oPTEvswocRTjGgdGV0CoMwSPBqJZhDT/0pZOI
+        6Yh8JM24wxh5PgJJsy6SbgAAAAD//8RcwQ6CMAz9FY56MOEXjHow8eBFL8YDCYSYCCMi3Ph32WjX
+        jbVqCMYbXYG+92pYV4YOTxRabhvHYtvYeEDoddU/O/TmBV5k1z27wO7N7fHl1AsRHU1rKlqYrfR9
+        NRXpZ3m91KmAtEi7dUdpgDlA0PybwspA0Lfh22Wx3ISOxSa08UAG9kWVmEUpI7/1za49qGjazzbK
+        cPC/hbjTos7K9vZQpbcY9MdAvp03iJjCyXiqUG5QTo6wdHWvIEJp4/9FB9lAZNtk4+XLfCxSswEA
+        Y3I8ILRlgecSg6BECiuj35ZFFJAjwBVIXF2kCu9HRTZw2NgBmUKQBjjlYx4wGkcAfPWqSnIvFXgR
+        kWjVM6M8oAUEzmDK8KdnYAjFoUcQFvUwQJj1R7Z3Re+byAbcB5VH+svgt9CnKs9BHs8VhMiSwKGu
+        u74AAAD//wMADLksYH1HAAA=
+    headers:
+      ATL-TraceId:
+      - 8d19af108ce20e9b
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:51 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      content-encoding:
+      - gzip
+      timing-allow-origin:
+      - '*'
+      vary:
+      - Accept-Encoding
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 7b45323f-fe18-4450-91b4-5b63705a05e3
+      x-envoy-upstream-service-time:
+      - '83'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"body": "(admin): testing note. creating it and pushing it to JIRA"}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.25.0
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/10210/comment
+  response:
+    body:
+      string: '{"self":"https://defectdojo.atlassian.net/rest/api/2/issue/10210/comment/10146","id":"10146","author":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5fa43d1b8405b10077912260","accountId":"5fa43d1b8405b10077912260","emailAddress":"defectdojo-project@owasp.org","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png","24x24":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png","16x16":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png","32x32":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png"},"displayName":"Defect
+        Dojo Project","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"body":"(admin):
+        testing note. creating it and pushing it to JIRA","updateAuthor":{"self":"https://defectdojo.atlassian.net/rest/api/2/user?accountId=5fa43d1b8405b10077912260","accountId":"5fa43d1b8405b10077912260","emailAddress":"defectdojo-project@owasp.org","avatarUrls":{"48x48":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png","24x24":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png","16x16":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png","32x32":"https://secure.gravatar.com/avatar/51214e10e32d96c3c571c85dd0a6f1e8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FDP-6.png"},"displayName":"Defect
+        Dojo Project","active":true,"timeZone":"Europe/Zurich","accountType":"atlassian"},"created":"2020-12-16T17:01:52.114+0100","updated":"2020-12-16T17:01:52.114+0100","jsdPublic":true}'
+    headers:
+      ATL-TraceId:
+      - 594973f6b4f6e16d
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Wed, 16 Dec 2020 16:01:52 GMT
+      Expect-CT:
+      - report-uri="https://web-security-reports.services.atlassian.com/expect-ct-report/global-proxy",
+        enforce, max-age=86400
+      Server:
+      - AtlassianProxy/1.15.8.1
+      Strict-Transport-Security:
+      - max-age=315360000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-XSS-Protection:
+      - 1; mode=block
+      cache-control:
+      - no-cache, no-store, no-transform
+      location:
+      - https://defectdojo.atlassian.net/rest/api/2/issue/10210/comment/10146
+      timing-allow-origin:
+      - '*'
+      x-aaccountid:
+      - 5fa43d1b8405b10077912260
+      x-arequestid:
+      - 80ec87d8-031f-403c-8013-148a939a464a
+      x-envoy-upstream-service-time:
+      - '249'
+    status:
+      code: 201
+      message: Created
+version: 1


### PR DESCRIPTION
#3453 showed we need a test case for adding a note to a finding and make sure it is pushed to JIRA (and doesn'r raise an exception). This PR implements that (basic) test case.

Side effects:
- note_type and private are now optional to provide in the API request when adding a note
- author text in jira comment now uses username if there is no fullname for the author