### PR TITLE
enable search tests

### DIFF
--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -122,14 +122,14 @@ else
     fail $test
 fi
 
-# all smoke tests are already covered by other testcases above/below
-# test="Smoke integration test"
-# echo "Running: $test"
-# if python3 tests/smoke_test.py ; then
-#     success $test
-# else
-#     fail $test
-# fi
+
+test="Search integration test"
+echo "Running: $test"
+if python3 tests/search_test.py ; then
+    success $test
+else
+    fail $test
+fi
 
 test="Check Status test"
 echo "Running: $test"

--- a/entrypoint_scripts/test/travis-integration-test.sh
+++ b/entrypoint_scripts/test/travis-integration-test.sh
@@ -67,7 +67,7 @@ travis_fold end travis_integration_install
 travis_fold start travis_integration_tests
 
 python tests/check_status.py -v
-python tests/smoke_test.py
+python tests/search_test.py
 python tests/dedupe_unit_test.py
 
 travis_fold end travis_integration_tests

--- a/setup/scripts/test/travis-integration-test.sh
+++ b/setup/scripts/test/travis-integration-test.sh
@@ -67,7 +67,7 @@ travis_fold end travis_integration_install
 travis_fold start travis_integration_tests
 
 python tests/check_status.py -v
-python tests/smoke_test.py
+python tests/search_test.py
 python tests/dedupe_unit_test.py
 
 travis_fold end travis_integration_tests

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -77,13 +77,16 @@ class BaseTestCase(unittest.TestCase):
     def goto_some_page(self):
         driver = self.driver
         driver.get(self.base_url + "user")
+        return driver
 
     def goto_product_overview(self, driver):
         driver.get(self.base_url + "product")
         self.wait_for_datatable_if_content("no_products", "products_wrapper")
+        return driver
 
     def goto_component_overview(self, driver):
         driver.get(self.base_url + "components")
+        return driver
 
     def goto_active_engagements_overview(self, driver):
         # return self.goto_engagements_internal(driver, 'engagement')
@@ -104,6 +107,7 @@ class BaseTestCase(unittest.TestCase):
     def goto_all_findings_list(self, driver):
         driver.get(self.base_url + "finding")
         self.wait_for_datatable_if_content("no_findings", "open_findings_wrapper")
+        return driver
 
     def wait_for_datatable_if_content(self, no_content_id, wrapper_id):
         no_content = None

--- a/tests/local-integration-tests.bat
+++ b/tests/local-integration-tests.bat
@@ -38,9 +38,8 @@ echo "Running Ibm Appscan integration test"
 python tests/ibm_appscan_test.py
 if %ERRORLEVEL% NEQ 0 GOTO END
 
-everything in the smoke test is already covered by the other tests
-echo "Running Smoke integration test"
-python tests/smoke_test.py
+echo "Running Search integration test"
+python tests/search_test.py
 if %ERRORLEVEL% NEQ 0 GOTO END
 
 echo "Running Check Status test"

--- a/tests/local-integration-tests.sh
+++ b/tests/local-integration-tests.sh
@@ -106,14 +106,13 @@ else
     echo "Error: Report Builder integration test failed."; exit 1
 fi
 
-# everything in the smoke test is already covered by the other tests
-# echo "Running Smoke integration test"
-# if python3 tests/smoke_test.py ; then
-#     echo "Success: Smoke integration tests passed"
-# else
-#     docker-compose logs uwsgi --tail=120
-#     echo "Error: Smoke integration test failed"; exit 1
-# fi
+echo "Running Search integration test"
+if python3 tests/search_test.py ; then
+    echo "Success: Search integration tests passed"
+else
+    docker-compose logs uwsgi --tail=120
+    echo "Error: Search integration test failed"; exit 1
+fi
 
 echo "Running Check Status test"
 if python3 tests/check_status.py ; then

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -10,6 +10,7 @@ class SearchTests(BaseTestCase):
 
     def test_search(self):
         # very basic search test to see if it doesn't 500
+        driver = self.goto_some_page()
         driver.find_element_by_id("simple_search").clear()
         driver.find_element_by_id("simple_search").send_keys('finding')
         driver.find_element_by_id("simple_search_submit").click()

--- a/tests/search_test.py
+++ b/tests/search_test.py
@@ -3,7 +3,7 @@ import sys
 from base_test_class import BaseTestCase
 
 
-class DojoTests(BaseTestCase):
+class SearchTests(BaseTestCase):
 
     def test_login(self):
         driver = self.login_page()
@@ -91,19 +91,18 @@ class DojoTests(BaseTestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(DojoTests('test_login'))
-    suite.addTest(DojoTests('test_search'))
-    suite.addTest(DojoTests('test_search_cve'))
-    suite.addTest(DojoTests('test_search_tag'))
-    suite.addTest(DojoTests('test_search_product_tag'))
-    suite.addTest(DojoTests('test_search_engagement_tag'))
-    suite.addTest(DojoTests('test_search_test_tag'))
-    suite.addTest(DojoTests('test_search_tags'))
-    suite.addTest(DojoTests('test_search_product_tags'))
-    suite.addTest(DojoTests('test_search_engagement_tags'))
-    suite.addTest(DojoTests('test_search_test_tags'))
-    suite.addTest(DojoTests('test_search_id'))
-    test_search_product_tag
+    suite.addTest(SearchTests('test_login'))
+    suite.addTest(SearchTests('test_search'))
+    suite.addTest(SearchTests('test_search_cve'))
+    suite.addTest(SearchTests('test_search_tag'))
+    suite.addTest(SearchTests('test_search_product_tag'))
+    suite.addTest(SearchTests('test_search_engagement_tag'))
+    suite.addTest(SearchTests('test_search_test_tag'))
+    suite.addTest(SearchTests('test_search_tags'))
+    suite.addTest(SearchTests('test_search_product_tags'))
+    suite.addTest(SearchTests('test_search_engagement_tags'))
+    suite.addTest(SearchTests('test_search_test_tags'))
+    suite.addTest(SearchTests('test_search_id'))
     return suite
 
 

--- a/travis/integration_test-script.sh
+++ b/travis/integration_test-script.sh
@@ -136,9 +136,9 @@ else
     fail $test
 fi
 
-test="Smoke integration test"
+test="Search integration test"
 echo "Running: $test"
-if python3 tests/smoke_test.py ; then
+if python3 tests/search_test.py ; then
     success $test
 else
     fail $test


### PR DESCRIPTION
In #3449 I added some integration tests for search, but turns out they weren't enable in the entrypoint scripts. This PR corrects that.