### PR TITLE
[APIv2] Prefetch Mixins + Composable Swagger Schema

### DIFF
--- a/dojo/api_v2/prefetch/__init__.py
+++ b/dojo/api_v2/prefetch/__init__.py
@@ -1,2 +1,4 @@
 from .mixins import PrefetchListMixin, PrefetchRetrieveMixin
 from .schema import get_prefetch_schema
+
+__all__ = ['PrefetchListMixin', 'PrefetchRetrieveMixin', 'get_prefetch_schema']

--- a/dojo/api_v2/prefetch/__init__.py
+++ b/dojo/api_v2/prefetch/__init__.py
@@ -1,0 +1,2 @@
+from .mixins import PrefetchListMixin, PrefetchRetrieveMixin
+from .schema import get_prefetch_schema

--- a/dojo/api_v2/prefetch/mixins.py
+++ b/dojo/api_v2/prefetch/mixins.py
@@ -1,0 +1,42 @@
+from rest_framework.response import Response
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from .prefetcher import _Prefetcher
+
+
+class PrefetchListMixin(ListModelMixin):
+    def list(self, request, *args, **kwargs):
+        prefetch_params = request.GET.get("prefetch", "").split(",")
+        prefetcher = _Prefetcher()
+
+        # Apply the same operations as the standard list method defined in the django rest framework
+        queryset = self.filter_queryset(self.get_queryset())
+        queryset = self.paginate_queryset(queryset)
+
+        serializer = self.get_serializer()
+        # Stores the final JSON object
+        results = []
+
+        for entry in queryset:
+            results.append(serializer.to_representation(entry))
+            prefetcher._prefetch(entry, prefetch_params)
+
+        # Done in the original list method so we do it as well
+        response = self.get_paginated_response(results)
+        response.data["prefetch"] = prefetcher.prefetched_data
+        return response
+
+
+class PrefetchRetrieveMixin(RetrieveModelMixin):
+    def retrieve(self, request, *args, **kwargs):
+        prefetch_params = request.GET.get("prefetch", "").split(",")
+        prefetcher = _Prefetcher()
+
+        entry = self.get_object()
+        serializer = self.get_serializer()
+
+        # Get the queried object representation
+        result = serializer.to_representation(entry)
+        prefetcher._prefetch(entry, prefetch_params)
+        result["prefetch"] = prefetcher.prefetched_data
+
+        return Response(result)

--- a/dojo/api_v2/prefetch/prefetcher.py
+++ b/dojo/api_v2/prefetch/prefetcher.py
@@ -1,0 +1,96 @@
+from rest_framework.serializers import ModelSerializer
+from . import utils
+import inspect
+import sys
+
+# Reduce the scope of search for serializers.
+SERIALIZER_DEFS_MODULE = "dojo.api_v2.serializers"
+
+
+class _Prefetcher():
+    @staticmethod
+    def _build_serializers():
+        """Returns a map model -> serializer where model is a django model and serializer is the corresponding
+        serializer used to serialize the model
+
+        Returns:
+            dict[model, serializer]: map of model to their serializer
+        """
+        def _is_model_serializer(obj):
+            return inspect.isclass(obj) and issubclass(obj, ModelSerializer)
+
+        serializers = dict()
+        # We process all the serializers found in the module SERIALIZER_DEFS_MODULE. We restrict the scope to avoid
+        # processing all the classes in the symbol table
+        available_serializers = inspect.getmembers(sys.modules[SERIALIZER_DEFS_MODULE], _is_model_serializer)
+
+        for _, serializer in available_serializers:
+            model = serializer.Meta.model
+            serializers[model] = serializer
+        # We add object->None to have a more uniform processing later on
+        serializers[object] = None
+
+        return serializers
+
+    def __init__(self):
+        self._serializers = _Prefetcher._build_serializers()
+        self._prefetch_data = dict()
+
+    def _find_serializer(self, field_type):
+        """Find the best suited serializer for the given type.
+
+        Args:
+            field_type (django.db.models.fields): the field type for which we need to find a serializer
+
+        Returns:
+            rest_framework.serializers.ModelSerializer: The serializer if one has been found or None
+        """
+        # If the type is represented in the map then return the serializer
+        if field_type in self._serializers:
+            return self._serializers[field_type]
+
+        # Otherwise we get the direct parent class and we recursively call the method
+        # Note that this process will always terminate has we have a decreasing measure
+        # with a lower bound taking the form of the object class which is referenced
+        # in our serializers.
+        parent_class = field_type.__mro__[1]
+        return self._find_serializer(parent_class)
+
+    def _prefetch(self, entry, fields_to_fetch):
+        """Apply prefetching for the given field on the given entry
+
+        Args:
+            entry (ModelInstance): Instance of a model as returned by a django queryset
+            field_to_fetch (list[string]): fields to prefetch
+        """
+        for field_to_fetch in fields_to_fetch:
+            # Get the field from the instance
+            field_value = getattr(entry, field_to_fetch, None)
+            if field_value is None:
+                continue
+
+            # Get the model related to the field
+            model_type = getattr(field_value, "model", type(field_value))
+            extra_serializer = self._find_serializer(model_type)
+            if extra_serializer is None:
+                continue
+
+            # Get the concrete field type
+            field_meta = getattr(type(entry), field_to_fetch, None)
+            # Check if the field represents a many-to-many relationship as we need to instantiate
+            # the serializer accordingly
+            many = utils._is_many_to_many_relation(field_meta)
+            field_data = extra_serializer(many=many).to_representation(field_value)
+            # For convenience in processing we store the field data in a list
+            field_data_list = field_data if type(field_data) is list else [field_data]
+
+            if field_to_fetch not in self._prefetch_data:
+                self._prefetch_data[field_to_fetch] = dict()
+
+            # Should not fail as django always generate an id field
+            for data in field_data_list:
+                self._prefetch_data[field_to_fetch][data["id"]] = data
+
+    @property
+    def prefetched_data(self):
+        return self._prefetch_data

--- a/dojo/api_v2/prefetch/schema.py
+++ b/dojo/api_v2/prefetch/schema.py
@@ -1,0 +1,34 @@
+from drf_yasg2 import openapi, utils
+from .prefetcher import _Prefetcher
+from .utils import _get_prefetchable_fields
+from ..schema import extra_schema
+from ..schema.utils import LazySchemaRef
+
+
+def get_prefetch_schema(methods, serializer):
+    """ Return a composable swagger schema that contains in the query the fields that can be prefetch from the model
+        supported by the serializer and in the reponse the structure of these fields in a new top-level attribute
+        named prefetch.
+
+        Returns:
+            ComposableSchema: A swagger schema
+    """
+    prefetcher = _Prefetcher()
+    fields = _get_prefetchable_fields(serializer())
+
+    field_to_serializer = dict([(name, prefetcher._find_serializer(field)) for name, field in fields])
+    fields_to_refname = dict([(name, utils.get_serializer_ref_name(serializer())) for name, serializer in field_to_serializer.items()])
+    fields_name = [name for name, _ in fields]
+
+    # New openapi parameter corresponding to the prefetchable fields
+    prefetch_params = [openapi.Parameter("prefetch", in_=openapi.IN_QUERY, required=False, type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_STRING, enum=fields_name))]
+
+    additional_props = dict([(name, openapi.Schema(type=openapi.TYPE_OBJECT, read_only=True, additional_properties=LazySchemaRef(fields_to_refname[name], True))) for name in fields_name])
+    prefetch_response = {"200": {"prefetch": openapi.Schema(type=openapi.TYPE_OBJECT, properties=additional_props)}}
+
+    schema = extra_schema.IdentitySchema()
+    for method in methods:
+        schema = schema.composeWith(extra_schema.ExtraParameters(method, prefetch_params))
+        schema = schema.composeWith(extra_schema.ExtraResponseField(method, prefetch_response))
+
+    return schema

--- a/dojo/api_v2/prefetch/utils.py
+++ b/dojo/api_v2/prefetch/utils.py
@@ -1,0 +1,56 @@
+from django.db.models.fields import related
+
+
+def _is_many_to_many_relation(field):
+    """Check if a field specified a many-to-many relationship as defined by django.
+    This is the case if the field is an instance of the ManyToManyDescriptor as generated
+    by the django framework
+
+    Args:
+        field (django.db.models.fields): The field to check
+
+    Returns:
+        bool: true if the field is a many-to-many relationship
+    """
+    return isinstance(field, related.ManyToManyDescriptor)
+
+
+def _is_one_to_one_relation(field):
+    """Check if a field specified a one-to-one relationship as defined by django.
+    This is the case if the field is an instance of the ForwardManyToOne as generated
+    by the django framework
+
+    Args:
+        field (django.db.models.fields): The field to check
+
+    Returns:
+        bool: true if the field is a one-to-one relationship
+    """
+    return isinstance(field, related.ForwardManyToOneDescriptor)
+
+
+def _get_prefetchable_fields(serializer):
+    """Get the fields that are prefetchable according to the serializer description.
+    Method mainly used by for automatic schema generation.
+
+    Args:
+        serializer (Serializer): [description]
+    """
+    def _is_field_prefetchable(field):
+        return _is_one_to_one_relation(field) or _is_many_to_many_relation(field)
+
+    meta = getattr(serializer, "Meta", None)
+    if meta is None:
+        return []
+
+    model = getattr(meta, "model", None)
+    if model is None:
+        return []
+
+    fields = []
+    for field_name in dir(model):
+        field = getattr(model, field_name)
+        if _is_field_prefetchable(field):
+            fields.append((field_name, field.field.related_model))
+
+    return fields

--- a/dojo/api_v2/schema/__init__.py
+++ b/dojo/api_v2/schema/__init__.py
@@ -1,2 +1,10 @@
 from .extra_schema import IdentitySchema, ExtraParameters, ExtraResponseField, ComposableSchema
 from .utils import LazySchemaRef, try_apply, resolve_lazy_ref
+
+__all__ = ['IdentitySchema',
+            'ExtraParameters',
+            'ExtraResponseField',
+            'ComposableSchema',
+            'LazySchemaRef',
+            'try_apply',
+            'resolve_lazy_ref']

--- a/dojo/api_v2/schema/__init__.py
+++ b/dojo/api_v2/schema/__init__.py
@@ -1,0 +1,2 @@
+from .extra_schema import IdentitySchema, ExtraParameters, ExtraResponseField, ComposableSchema
+from .utils import LazySchemaRef, try_apply, resolve_lazy_ref

--- a/dojo/api_v2/schema/extra_schema.py
+++ b/dojo/api_v2/schema/extra_schema.py
@@ -1,0 +1,132 @@
+from drf_yasg2.inspectors.view import SwaggerAutoSchema
+from drf_yasg2.openapi import resolve_ref, Schema
+from .utils import resolve_lazy_ref
+import copy
+
+
+class ComposableSchema:
+    """A composable schema defines a transformation on drf_yasg2 Operation. These
+    schema can then be composed with another composable schema using the composeWith method
+    yielding a new composable schema whose transformation is defined as the function composition
+    of the transformation of the two source schema.
+    """
+    def transform_operation(self, operation, resolver):
+        """Defines an operation transformation
+
+        Args:
+            operation (Operation): the operation to transform
+            resolver (Resolver): the schema refs resolver
+        """
+        pass
+
+    def composeWith(self, schema):
+        """Allow two schema to be composed into a new schema.
+        Given the caller schema 'self' and another schema 'schema',
+        this operation yields a new composable schema whose transform_operation
+        if defined as
+            transform_operation(op, res) = schema.transform_operation(self.transform_operation(op, res), res)
+
+        Args:
+            schema (ComposableSchema): The schema to compose with
+
+        Returns:
+            ComposableSchema: the newly composed schema
+        """
+        op = self.transform_operation
+
+        class _Wrapper(ComposableSchema):
+            def transform_operation(self, operation, resolver):
+                return schema.transform_operation(op(operation, resolver), resolver)
+
+        return _Wrapper()
+
+    def to_schema(self):
+        """Convert the composable schema into a SwaggerAutoSchema that
+        can be used with the drf_yasg library code
+
+        Returns:
+            SwaggerAutoSchema: the swagger auto schema derived from the composable schema
+        """
+        op = self.transform_operation
+
+        class _Schema(SwaggerAutoSchema):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+            def get_operation(self, operation_keys):
+                operation = super().get_operation(operation_keys)
+                return op(operation, self.components)
+
+        return _Schema
+
+
+class IdentitySchema(ComposableSchema):
+    def transform_operation(self, operation, resolver):
+        return operation
+
+
+class ExtraParameters(ComposableSchema):
+    """Define a schema that can add parameters to the operation
+    """
+    def __init__(self, operation_name, extra_parameters, *args, **kwargs):
+        """Initialize the schema
+
+        Args:
+            operation_name (string): the name of the operation to transform
+            extra_parameters (list[Parameter]): list of openapi parameters to add
+        """
+        super().__init__(*args, **kwargs)
+        self._extra_parameters = extra_parameters
+        self._operation_name = operation_name
+
+    def transform_operation(self, operation, resolver):
+        operation_id = operation["operationId"]
+        if not operation_id.endswith(self._operation_name):
+            return operation
+
+        for param in self._extra_parameters:
+            operation["parameters"].append(resolve_lazy_ref(param, resolver))
+        return operation
+
+
+class ExtraResponseField(ComposableSchema):
+    """Define a schema that can add fields to the responses of the operation
+    """
+    def __init__(self, operation_name, extra_fields, *args, **kwargs):
+        """Initialize the schema
+
+        Args:
+            operation_name (string): the name of the operation to transform
+            extra_fields (dict()): description of the fields to add to the responses. The format is
+            {
+                parameters: list[openapi.Parameter](params1, params2, ...),
+                responses: {
+                    code1: {
+                        field1: openapi.Schema,
+                        field2: openapi.Schema,
+                        ...
+                    },
+                    code2: ...
+                }
+            }
+        """
+        super().__init__(*args, **kwargs)
+        self._extra_fields = extra_fields
+        self._operation_name = operation_name
+
+    def transform_operation(self, operation, resolver):
+        operation_id = operation["operationId"]
+        if not operation_id.endswith(self._operation_name):
+            return operation
+
+        responses = operation["responses"]
+        for code, params in self._extra_fields.items():
+            if code in responses:
+                original_schema = responses[code]["schema"]
+                schema = original_schema if type(original_schema) is Schema else resolve_ref(original_schema, resolver)
+                schema = copy.deepcopy(schema)
+
+                for name, param in params.items():
+                    schema["properties"][name] = resolve_lazy_ref(param, resolver)
+                responses[code]["schema"] = schema
+        return operation

--- a/dojo/api_v2/schema/utils.py
+++ b/dojo/api_v2/schema/utils.py
@@ -1,0 +1,58 @@
+from drf_yasg2.openapi import SchemaRef, Schema
+
+
+class LazySchemaRef:
+    """Utility class to support SchemaRef definition without knowing the resolver.
+    The reference can be evaluated later in the context of a swagger generator
+    """
+    def __init__(self, schema_name, ignore_unresolved=False):
+        # Bind curried version of the SchemaRef init
+        self.schema_ref = lambda resolver: SchemaRef(resolver, schema_name, ignore_unresolved)
+
+    def apply(self, resolver):
+        """Resolve the LazySchemaRef with the given resolver
+
+        Args:
+            resolver (ReferenceResolver): resolver containing the schema refs
+
+        Returns:
+            SchemaRef: the corresponding SchemaRef
+        """
+        return self.schema_ref(resolver)
+
+
+def try_apply(obj, resolver):
+    """Try to resolve a LazySchemaRef
+
+    Args:
+        obj (object): the object to resolve
+        resolver (resolver): the resolver to use
+
+    Returns:
+        object: the original object if it was not resolve otherwise the resolved LazySchemaRef
+    """
+    if type(obj) is LazySchemaRef:
+        return obj.apply(resolver)
+    else:
+        return obj
+
+
+def resolve_lazy_ref(schema, resolver):
+    """Recursively evaluate the schema to unbox LazySchemaRef based on the underlying resolvers.
+
+    Args:
+        schema (object): the schema to evaluate
+
+    Returns:
+        object: the schema without LazySchemaRef
+    """
+    if type(schema) is not Schema:
+        return try_apply(schema, resolver)
+
+    if "properties" in schema:
+        for prop_name, prop in schema["properties"].items():
+            schema["properties"][prop_name] = resolve_lazy_ref(prop, resolver)
+    if "additionalProperties" in schema:
+        schema["additionalProperties"] = resolve_lazy_ref(schema["additionalProperties"], resolver)
+
+    return schema

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -10,7 +10,6 @@ from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
 from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
-from django.utils.decorators import method_decorator
 from drf_yasg2 import openapi
 from drf_yasg2.utils import swagger_auto_schema, no_body
 import base64
@@ -250,7 +249,7 @@ def _finding_related_fields_decorator():
                 description="Expand finding external relations (engagement, environment, product, product_type, test, test_type)",
                 type=openapi.TYPE_BOOLEAN)
         ])
-        
+
 
 class FindingViewSet(prefetch.PrefetchListMixin,
                      prefetch.PrefetchRetrieveMixin,

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -17,6 +17,7 @@ from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 from .dojo_test_case import DojoAPITestCase
+from dojo.api_v2.prefetch.utils import _get_prefetchable_fields
 import logging
 # from unittest import skip
 
@@ -136,6 +137,56 @@ class BaseClass():
             response = self.client.put(
                 relative_url, self.payload)
             self.assertEqual(200, response.status_code)
+
+    @skipIfNotSubclass("PrefetchRetrieveMixin")
+    def test_detail_prefetch(self):
+        prefetchable_fields = [x[0] for x in _get_prefetchable_fields(self.viewset.serializer_class)]
+
+        current_objects = self.client.get(self.url, format='json').data
+        relative_url = self.url + '%s/' % current_objects['results'][0]['id']
+        response = self.client.get(relative_url, data={
+            "prefetch": ','.join(prefetchable_fields)
+        })
+
+        self.assertEqual(200, response.status_code)
+        obj = response.data
+        self.assertTrue("prefetch" in obj)
+
+        for field in prefetchable_fields:
+            field_value = obj.get(field, None)
+            if field_value is None:
+                continue
+            
+            self.assertTrue(field in obj["prefetch"])
+            values = field_value if type(field_value) is list else [field_value]
+
+            for value in values:
+                self.assertTrue(value in obj["prefetch"][field])
+
+    @skipIfNotSubclass("PrefetchListMixin")
+    def test_list_prefetch(self):
+        prefetchable_fields = [x[0] for x in _get_prefetchable_fields(self.viewset.serializer_class)]
+        
+        response = self.client.get(self.url, data={
+            "prefetch": ','.join(prefetchable_fields)
+        })
+
+        self.assertEqual(200, response.status_code)
+        objs = response.data
+        self.assertTrue("results" in objs)
+        self.assertTrue("prefetch" in objs)
+
+        for obj in objs:
+            for field in prefetchable_fields:
+                field_value = obj.get(field, None)
+                if field_value is None:
+                    continue
+                
+                self.assertTrue(field in obj["prefetch"])
+                values = field_value if type(field_value) is list else [field_value]
+
+                for value in values:
+                    self.assertTrue(value in obj["prefetch"][field])
 
 
 class AppAnalysisTest(BaseClass.RESTEndpointTest):
@@ -526,6 +577,63 @@ class ProductTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'prod_type': 2}
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+    @skipIfNotSubclass('PrefetchRetrieveMixin')
+    def test_detail_prefetch(self):
+        current_objects = self.client.get(self.url, format='json').data
+        relative_url = self.url + '%s/' % current_objects['results'][0]['id']
+        response = self.client.get(relative_url, data={
+            "prefetch": [
+                "product_manager",
+                "technical_contact",
+                "authorized_users"
+            ]
+        })
+
+        self.assertEqual(200, response.status_code)
+        obj = response.data
+    
+        for user in obj.get("authorized_users", []):
+            self.assertTrue("authorized_users" in obj["prefetch"])
+            self.assertTrue(user in obj["prefetch"]["authorized_users"])
+
+        if obj.product_manager is not None:
+            self.assertTrue("product_manager" in obj["prefetch"])
+            self.assertTrue(obj.product_manager in obj.prefetch["product_manager"])
+
+        if obj.technical_contact is not None:
+            self.assertTrue("technical_contact" in obj["prefetch"])
+            self.assertTrue(obj.technical_contact in obj.prefetch["technical_contact"])
+        
+        self.assertTrue("prod_type" not in obj.prefetch)
+
+    @skipIfNotSubclass('PrefetchListMixin')
+    def test_list_prefetch(self):
+        response = self.client.get(self.url, data={
+            "prefetch": [
+                "product_manager",
+                "technical_contact",
+                "authorized_users"
+            ]
+        })
+
+        self.assertEqual(200, response.status_code)
+        objs = response.data
+
+        for obj in objs:
+            for user in obj.authorized_users:
+                self.assertTrue("authorized_users" in obj.prefetch)
+                self.assertTrue(user in obj.prefetch["authorized_users"])
+
+            if obj.product_manager is not None:
+                self.assertTrue("product_manager" in obj.prefetch)
+                self.assertTrue(obj.product_manager in obj.prefetch["product_manager"])
+
+            if obj.technical_contact is not None:
+                self.assertTrue("technical_contact" in obj.prefetch)
+                self.assertTrue(obj.technical_contact in obj.prefetch["technical_contact"])
+        
+        self.assertTrue("prod_type" not in obj.prefetch)
 
 
 class ScanSettingsTest(BaseClass.RESTEndpointTest):


### PR DESCRIPTION
**Note**
Follow-up to #3154. I decided to open a new PR as mentioned since we changed a lot since then and it was easier (avoiding rebasing, etc.). Feel free to close the old PR when you think that it's not useful anymore.

**Summary**
This PR add two new components to the APIv2

1. Prefetching Mixins : We introduce two new mixins that can be used in place of their standard counterparts found in the django API. Both mixins add to the endpoints they target (read and list) the support for prefetching fields at relational depth 1. The fields that can be prefetched are those that are represented by One-to-One and One-to-Many relationships. Invalid field are simply ignored. 

    The prefetched data is returned in the response under the top-level attribute `prefetch`. This attribute acts as a form a cache where the corresponding data is stored under two level of indirection, more specifically the name of the field referencing it and its primary key. This two level indirection allow us to easily reconstruct the object on the client-side while avoiding duplicated data.

     Here is a example to illustrate prefetching on `/findings/{id}`. Here we queried the endpoint with the query parameter `?prefetch=defect_review_requested_by,found_by`
```
{
  "id": 2,
  "severity": "Critical",
  "description": "It's possible to by-pass the authentication by sending xyz payload par of a GET request.",
  "mitigation": "Implement proper input sanitization.",
  "impact": "Critical, it's possible to access the application without credentials.",
  "defect_review_requested_by": 2,
  "found_by": [
    3
  ],
  ...,
  "prefetch": {
    "defect_review_requested_by": {
      "2": {
        "id": 2,
        "username": "techmanager",
        "first_name": "Technical",
        "last_name": "Manager",
        "email": "tech.manager@company1.com",
        "last_login": null,
        "is_active": true,
        "is_staff": false,
        "is_superuser": true
      }
    },
    "found_by": {
      "3": {
        "id": 3,
        "name": "Pen Test",
        "static_tool": false,
        "dynamic_tool": false
      }
    }
  }
}

```

2. ComposableSchema : drf_yasl2 offers support for swagger schema but it is not flexible enough for our application. In our case, we would like to easily add documentation for prefetching and other fields (related_fields, etc.). The main problem is that, a ViewSet expects a single swagger schema generator and we cannot compose multiple ones that would add different parameters or fields in the response. Therefore, we introduce wrappers around the structure defined in the drf_yasl2 library that allow easy schema composition and also the ability to add new query parameters and new fields in the response of an endpoint. Currently we have the following structure

     - ComposableSchema : base class for composable schema, each composable structure must inherit from it
     - IdentitySchema : An empty schema whose only purpose is to easily chain schema composition operation
     - ExtraParameters : schema that adds new parameters inside the query structure
     - ExtraResponseField : schema that adds new fields inside the specified responses
    
     With these classes we add automatic documentation for endpoints supporting prefetching.

As a final note, this PR also add prefetching to the finding and product endpoints as they are the main reason why this mechanism is introduced.