### PR TITLE
Various Bug Fixes. Make 'Active' Default On Scan Import Forms

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1358,6 +1358,10 @@ class MetricsFindingFilter(FilterSet):
             'numerical_severity'
         ).values_list('severity', 'severity').distinct()
         if get_current_user() is not None and not get_current_user().is_staff:
+            logger.debug('*******************')
+            logger.debug('FORM FIELDS ARE')
+            logger.debug(self.form.fields)
+            logger.debug('*******************')
             self.form.fields[
                 'test__engagement__product__prod_type'].queryset = Product_Type.objects.filter(
                 authorized_users__in=[get_current_user()])
@@ -1366,7 +1370,7 @@ class MetricsFindingFilter(FilterSet):
                 Q(engagement__product__authorized_users__in=[get_current_user()]) |
                 Q(engagement__product__prod_type__authorized_users__in=[get_current_user()]))
             self.form.fields[
-                'duplicate_finding'].queryset = Finding.objects.filter(
+                'duplicate'].queryset = Finding.objects.filter(
                 Q(test__engagement__product__authorized_users__in=[get_current_user()]) |
                 Q(test__engagement__product__prod_type__authorized_users__in=[get_current_user()]))
 

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1365,10 +1365,6 @@ class MetricsFindingFilter(FilterSet):
                 'test'].queryset = Test.objects.filter(
                 Q(engagement__product__authorized_users__in=[get_current_user()]) |
                 Q(engagement__product__prod_type__authorized_users__in=[get_current_user()]))
-            self.form.fields[
-                'duplicate'].queryset = Finding.objects.filter(
-                Q(test__engagement__product__authorized_users__in=[get_current_user()]) |
-                Q(test__engagement__product__prod_type__authorized_users__in=[get_current_user()]))
 
     class Meta:
         model = Finding

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1358,10 +1358,6 @@ class MetricsFindingFilter(FilterSet):
             'numerical_severity'
         ).values_list('severity', 'severity').distinct()
         if get_current_user() is not None and not get_current_user().is_staff:
-            logger.debug('*******************')
-            logger.debug('FORM FIELDS ARE')
-            logger.debug(self.form.fields)
-            logger.debug('*******************')
             self.form.fields[
                 'test__engagement__product__prod_type'].queryset = Product_Type.objects.filter(
                 authorized_users__in=[get_current_user()])

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -422,7 +422,7 @@ class ImportScanForm(forms.Form):
     minimum_severity = forms.ChoiceField(help_text='Minimum severity level to be imported',
                                          required=True,
                                          choices=SEVERITY_CHOICES)
-    active = forms.BooleanField(help_text="Select if these findings are currently active.", required=False)
+    active = forms.BooleanField(help_text="Select if these findings are currently active.", required=False, initial=True)
     verified = forms.BooleanField(help_text="Select if these findings have been verified.", required=False)
     scan_type = forms.ChoiceField(required=True, choices=SORTED_SCAN_TYPE_CHOICES)
     environment = forms.ModelChoiceField(
@@ -469,7 +469,7 @@ class ReImportScanForm(forms.Form):
     minimum_severity = forms.ChoiceField(help_text='Minimum severity level to be imported',
                                          required=True,
                                          choices=SEVERITY_CHOICES[0:4])
-    active = forms.BooleanField(help_text="Select if these findings are currently active.", required=False)
+    active = forms.BooleanField(help_text="Select if these findings are currently active.", required=False, initial=True)
     verified = forms.BooleanField(help_text="Select if these findings have been verified.", required=False)
     endpoints = forms.ModelMultipleChoiceField(Endpoint.objects, required=False, label='Systems / Endpoints',
                                                widget=MultipleSelectWithPopPlusMinus(attrs={'size': '5'}))

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -18,7 +18,7 @@ def create_notification(event=None, **kwargs):
         logger.debug('creating notifications for recipients')
         for recipient_notifications in Notifications.objects.filter(user__username__in=kwargs['recipients'], user__is_active=True, product=None):
             # kwargs.update({'user': recipient_notifications.user})
-            process_notifications(event, recipient_notifications, *args, **kwargs)
+            process_notifications(event, recipient_notifications, **kwargs)
     else:
         logger.debug('creating system notifications for event: %s', event)
         # send system notifications to all admin users

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -577,7 +577,7 @@ def generate_report(request, obj):
             pass  # user is authorized for this product
         else:
             raise PermissionDenied
-    elif type(obj).__name__ == "QuerySet":
+    elif type(obj).__name__ == "QuerySet" or type(obj).__name__ == "CastTaggedQuerySet":
         # authorization taken care of by only selecting findings from product user is authed to see
         pass
     else:
@@ -755,7 +755,7 @@ def generate_report(request, obj):
                    'title': report_title,
                    'host': report_url_resolver(request),
                    'user_id': request.user.id}
-    elif type(obj).__name__ == "QuerySet":
+    elif type(obj).__name__ == "QuerySet" or type(obj).__name__ == "CastTaggedQuerySet":
         findings = ReportAuthedFindingFilter(request.GET,
                                              queryset=prefetch_related_findings_for_report(obj).distinct())
         filename = "finding_report.pdf"

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -676,7 +676,7 @@ def re_import_scan_results(request, tid):
 
             try:
                 items = parser.items
-                original_items = test.finding_set.all().values_list("id", flat=True)
+                original_items = test.finding_set.all()
                 new_items = []
                 mitigated_count = 0
                 finding_count = 0

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -676,7 +676,7 @@ def re_import_scan_results(request, tid):
 
             try:
                 items = parser.items
-                original_items = test.finding_set.all()
+                original_items = test.finding_set.all().values_list("id", flat=True)
                 new_items = []
                 mitigated_count = 0
                 finding_count = 0
@@ -752,7 +752,7 @@ def re_import_scan_results(request, tid):
                                 status.last_modified = timezone.now()
                                 status.save()
 
-                            reactivated_items.append(finding)
+                            reactivated_items.append(finding.id)
                             reactivated_count += 1
                         else:
                             # existing findings may be from before we had component_name/version fields
@@ -760,7 +760,7 @@ def re_import_scan_results(request, tid):
                                 finding.component_name = finding.component_name if finding.component_name else component_name
                                 finding.component_version = finding.component_version if finding.component_version else component_version
                                 finding.save(dedupe_option=False, push_to_jira=False)
-                            unchanged_items.append(finding)
+                            unchanged_items.append(finding.id)
                             unchanged_count += 1
 
                     else:

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -839,8 +839,16 @@ def re_import_scan_results(request, tid):
                     finding.save(push_to_jira=push_to_jira)
                 # calculate the difference
                 to_mitigate = set(original_items) - set(reactivated_items) - set(unchanged_items)
+                logger.debug('QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ')
+                logger.debug('to_mitigate is')
+                logger.debug(to_mitigate)
                 mitigated_findings = []
                 for finding_id in to_mitigate:
+                    logger.debug('QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ')
+                    logger.debug('finding_id')
+                    logger.debug(finding_id)
+                    logger.debug('finding_id type')
+                    logger.debug(type(finding_id))
                     finding = Finding.objects.get(id=finding_id)
                     if not finding.mitigated or not finding.is_Mitigated:
                         finding.mitigated = scan_date_time

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -839,16 +839,8 @@ def re_import_scan_results(request, tid):
                     finding.save(push_to_jira=push_to_jira)
                 # calculate the difference
                 to_mitigate = set(original_items) - set(reactivated_items) - set(unchanged_items)
-                logger.debug('QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ')
-                logger.debug('to_mitigate is')
-                logger.debug(to_mitigate)
                 mitigated_findings = []
                 for finding_id in to_mitigate:
-                    logger.debug('QQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQQ')
-                    logger.debug('finding_id')
-                    logger.debug(finding_id)
-                    logger.debug('finding_id type')
-                    logger.debug(type(finding_id))
                     finding = Finding.objects.get(id=finding_id)
                     if not finding.mitigated or not finding.is_Mitigated:
                         finding.mitigated = scan_date_time

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,4 @@ django-debug-toolbar-request-history==0.1.3
 vcrpy==4.1.1
 vcrpy-unittest==0.1.7
 git+https://github.com/radiac/django-tagulous.git@develop#egg=django-tagulous
+PyJWT==1.6.1


### PR DESCRIPTION
BugFix 1. I **believe** from tagulous, a notion of a ‘CastTaggedQuerySet' is introduced. When Googling, I only saw this type with reference to tagulous. Our report generator does not know how to handle this. QuerySets are only referenced in two locations in the generate report method and only come from a few sources. There maybe a more eloquent fix, but to keep consistent with other if else logic.  I simply added an 'or' in the same style which seems to have corrected the issues. I believe we want to treat CastTaggedQuerySet in the same fashion as QuerySets.

BugFix 2. Function not updated to reflect removal of args parameter. Line 21 helper/notifications still has args even though it appears all other functions were rewritten to use kwargs. create_notification causes closing engagements / tests / findings / to throw an error. I've removed the args to make the methods consistent, which seems to resolve my issue.

Enhancement 1. Setting default for scan import status to active. This seems to be consistent with our current usage. 2. Not having by default makes it easy to create many inactive / mitigated findings from reupload usage.