### PR TITLE
Retain SLA days for mitigated findings

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2031,14 +2031,8 @@ class Finding(models.Model):
         severity = self.severity
         from dojo.utils import get_system_setting
         sla_age = get_system_setting('sla_' + self.severity.lower())
-        if sla_age and self.active:
+        if sla_age:
             sla_calculation = sla_age - self.age
-        elif sla_age and self.mitigated:
-            age = self.age
-            if age < sla_age:
-                sla_calculation = 0
-            else:
-                sla_calculation = sla_age - age
         return sla_calculation
 
     def sla_deadline(self):


### PR DESCRIPTION
Addresses https://github.com/DefectDojo/django-DefectDojo/issues/3524

![image](https://user-images.githubusercontent.com/5468769/102879973-eb3f6080-444a-11eb-93ce-2100e6e1d324.png)

Essentially, only the blue SLA would show the number instead of 0. The orange one (mitigated past SLA) already was working.