### PR TITLE
calendar: speedup and security fix

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -60,6 +60,9 @@ def engagement_calendar(request):
         filters.append(Q(lead__in=leads))
         engagements = Engagement.objects.filter(reduce(operator.or_, filters))
 
+    engagements = engagements.select_related('lead')
+    engagements = engagements.prefetch_related('product')
+
     add_breadcrumb(
         title="Engagement Calendar", top_level=True, request=request)
     return render(

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -40,7 +40,7 @@ from functools import reduce
 from django.db.models.query import QuerySet
 from dojo.user.helper import user_must_be_authorized, user_is_authorized, check_auth_users_list
 import dojo.jira_link.helper as jira_helper
-
+from django.views.decorators.vary import vary_on_cookie
 
 logger = logging.getLogger(__name__)
 parse_logger = logging.getLogger('dojo')
@@ -48,6 +48,7 @@ parse_logger = logging.getLogger('dojo')
 
 @user_passes_test(lambda u: u.is_staff)
 @cache_page(60 * 5)  # cache for 5 minutes
+@vary_on_cookie
 def engagement_calendar(request):
     if 'lead' not in request.GET or '0' in request.GET.getlist('lead'):
         engagements = Engagement.objects.all()

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -263,6 +263,9 @@ def test_calendar(request):
             filters.append(Q(lead__isnull=True))
         filters.append(Q(lead__in=leads))
         tests = Test.objects.filter(reduce(operator.or_, filters))
+
+    tests = tests.prefetch_related('test_type', 'lead', 'engagement__product')
+
     add_breadcrumb(title="Test Calendar", top_level=True, request=request)
     return render(request, 'dojo/calendar.html', {
         'caltype': 'tests',

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -36,7 +36,7 @@ from dojo.finding.views import find_available_notetypes
 from functools import reduce
 from dojo.user.helper import user_must_be_authorized
 import dojo.jira_link.helper as jira_helper
-
+from django.views.decorators.vary import vary_on_cookie
 
 logger = logging.getLogger(__name__)
 parse_logger = logging.getLogger('dojo')

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -252,6 +252,7 @@ def delete_test(request, tid):
 
 @user_passes_test(lambda u: u.is_staff)
 @cache_page(60 * 5)  # cache for 5 minutes
+@vary_on_cookie
 def test_calendar(request):
     if 'lead' not in request.GET or '0' in request.GET.getlist('lead'):
         tests = Test.objects.all()


### PR DESCRIPTION
prefetch engagement / test data to avoid slow calendar rendering

also fixes #3550 by making sure caching happens on a per user basis