### PR TITLE
Swtich to official django-tagulous release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,5 +69,5 @@ django-debug-toolbar==3.2
 django-debug-toolbar-request-history==0.1.3
 vcrpy==4.1.1
 vcrpy-unittest==0.1.7
-git+https://github.com/radiac/django-tagulous.git@develop#egg=django-tagulous
+django-tagulous==1.1.0
 PyJWT==1.7.1


### PR DESCRIPTION
As temporary fix, we switch to the `dev` version of `django-tagulous`. With their 1.1.0 release, this is no longer needed.