### PR TITLE
Reimport (UI): Preserve existing tags when reimporting scan/test

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -474,7 +474,7 @@ class ReImportScanForm(forms.Form):
     verified = forms.BooleanField(help_text="Select if these findings have been verified.", required=False)
     endpoints = forms.ModelMultipleChoiceField(Endpoint.objects, required=False, label='Systems / Endpoints',
                                                widget=MultipleSelectWithPopPlusMinus(attrs={'size': '5'}))
-    tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
+    tags = TagField(required=False, help_text="Modify existing tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
         attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx"}),
@@ -483,9 +483,12 @@ class ReImportScanForm(forms.Form):
     close_old_findings = forms.BooleanField(help_text="Select if old findings get mitigated when importing.",
                                             required=False, initial=True)
 
-    def __init__(self, *args, scan_type=None, **kwargs):
+    def __init__(self, *args, test=None, **kwargs):
         super(ReImportScanForm, self).__init__(*args, **kwargs)
-        self.scan_type = scan_type
+        self.scan_type = None
+        if test:
+            self.scan_type = test.test_type.name
+            self.fields['tags'].initial = test.tags.all()
 
     def clean(self):
         cleaned_data = super().clean()

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -622,7 +622,7 @@ def re_import_scan_results(request, tid):
     test = get_object_or_404(Test, id=tid)
     scan_type = test.test_type.name
     engagement = test.engagement
-    form = ReImportScanForm()
+    form = ReImportScanForm(test=test)
     jform = None
     jira_project = jira_helper.get_jira_project(test)
     push_all_jira_issues = jira_helper.is_push_all_issues(test)
@@ -633,7 +633,7 @@ def re_import_scan_results(request, tid):
 
     # form.initial['tags'] = [tag.name for tag in test.tags.all()]
     if request.method == "POST":
-        form = ReImportScanForm(request.POST, request.FILES, scan_type=scan_type)
+        form = ReImportScanForm(request.POST, request.FILES, test=test)
         if jira_project:
             jform = JIRAImportScanForm(request.POST, push_all=push_all_jira_issues, prefix='jiraform')
         if form.is_valid() and (jform is None or jform.is_valid()):


### PR DESCRIPTION
fixes #3563 

only affects UI.
In the API the reimport doesn't allow to modify tags. We could add it, but it would result in lots of glue code to either replace existing tags or add to existing tags or find a way to delete them and add new ones etc. It's easier to let the user decide and use the API to modify any tags straight on the test object if needed.