### PR TITLE
feat(alerts): automated cleanup of alerts per user

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -154,6 +154,8 @@ env = environ.Env(
     DD_LOGGING_HANDLER=(str, 'console'),
     DD_ALERT_REFRESH=(bool, True),
     DD_DISABLE_ALERT_COUNTER=(bool, False),
+    # to disable deleting alerts per user set value to -1
+    DD_MAX_ALERTS_PER_USER=(int, 999),
     DD_TAG_PREFETCHING=(bool, True),
 
     # when enabled in sytem settings,  every minute a job run to delete excess duplicates
@@ -235,6 +237,7 @@ TEST_RUNNER = env('DD_TEST_RUNNER')
 
 ALERT_REFRESH = env('DD_ALERT_REFRESH')
 DISABLE_ALERT_COUNTER = env("DD_DISABLE_ALERT_COUNTER")
+MAX_ALERTS_PER_USER = env("DD_MAX_ALERTS_PER_USER")
 
 TAG_PREFETCHING = env('DD_TAG_PREFETCHING')
 
@@ -697,6 +700,10 @@ CELERY_BEAT_SCHEDULE = {
         'task': 'dojo.tasks.add_alerts',
         'schedule': timedelta(hours=1),
         'args': [timedelta(hours=1)]
+    },
+    'cleanup-alerts': {
+        'task': 'dojo.tasks.async_dupe_delete',
+        'schedule': timedelta(hours=8),
     },
     'dedupe-delete': {
         'task': 'dojo.tasks.async_dupe_delete',

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -702,7 +702,7 @@ CELERY_BEAT_SCHEDULE = {
         'args': [timedelta(hours=1)]
     },
     'cleanup-alerts': {
-        'task': 'dojo.tasks.async_dupe_delete',
+        'task': 'dojo.tasks.cleanup_alerts',
         'schedule': timedelta(hours=8),
     },
     'dedupe-delete': {

--- a/dojo/unittests/test_cleanup_alerts.py
+++ b/dojo/unittests/test_cleanup_alerts.py
@@ -10,14 +10,12 @@ logger = logging.getLogger(__name__)
 class TestCleanupAlerts(TestCase):
     fixtures = ['dojo_testdata.json']
 
-
     def setUp(self):
         testuser = User.objects.get(username='admin')
         Alerts.objects.filter(user_id=testuser).delete()
         Alerts.objects.create(title="B", user_id=testuser, created=datetime(2021, 1, 8, 16, 54, 23, 597051, tzinfo=timezone.utc))
         Alerts.objects.create(title="A", user_id=testuser, created=datetime(2021, 1, 7, 16, 54, 23, 597051, tzinfo=timezone.utc))
         Alerts.objects.create(title="C", user_id=testuser, created=datetime(2021, 1, 9, 16, 54, 23, 597051, tzinfo=timezone.utc))
-
 
     def test_delete_alerts_disabled(self):
         settings.MAX_ALERTS_PER_USER = -1
@@ -27,14 +25,12 @@ class TestCleanupAlerts(TestCase):
         alerts_after = Alerts.objects.filter(user_id=testuser).count()
         self.assertEquals(alerts_before, alerts_after)
 
-
     def test_delete_all_alerts(self):
         settings.MAX_ALERTS_PER_USER = 0
         testuser = User.objects.get(username='admin')
         cleanup_alerts()
         alerts_after = Alerts.objects.filter(user_id=testuser).count()
         self.assertEquals(alerts_after, 0)
-
 
     def test_delete_more_than_two_alerts(self):
         settings.MAX_ALERTS_PER_USER = 2

--- a/dojo/unittests/test_cleanup_alerts.py
+++ b/dojo/unittests/test_cleanup_alerts.py
@@ -1,0 +1,51 @@
+from dojo.tasks import cleanup_alerts
+from django.test import TestCase
+from django.conf import settings
+from dojo.models import User, Alerts
+from datetime import datetime, timezone
+import logging
+logger = logging.getLogger(__name__)
+
+
+class TestCleanupAlerts(TestCase):
+    fixtures = ['dojo_testdata.json']
+
+
+    def setUp(self):
+        testuser = User.objects.get(username='admin')
+        Alerts.objects.filter(user_id=testuser).delete()
+        Alerts.objects.create(title="B", user_id=testuser, created=datetime(2021, 1, 8, 16, 54, 23, 597051, tzinfo=timezone.utc))
+        Alerts.objects.create(title="A", user_id=testuser, created=datetime(2021, 1, 7, 16, 54, 23, 597051, tzinfo=timezone.utc))
+        Alerts.objects.create(title="C", user_id=testuser, created=datetime(2021, 1, 9, 16, 54, 23, 597051, tzinfo=timezone.utc))
+
+
+    def test_delete_alerts_disabled(self):
+        settings.MAX_ALERTS_PER_USER = -1
+        testuser = User.objects.get(username='admin')
+        alerts_before = Alerts.objects.filter(user_id=testuser).count()
+        cleanup_alerts()
+        alerts_after = Alerts.objects.filter(user_id=testuser).count()
+        self.assertEquals(alerts_before, alerts_after)
+
+
+    def test_delete_all_alerts(self):
+        settings.MAX_ALERTS_PER_USER = 0
+        testuser = User.objects.get(username='admin')
+        cleanup_alerts()
+        alerts_after = Alerts.objects.filter(user_id=testuser).count()
+        self.assertEquals(alerts_after, 0)
+
+
+    def test_delete_more_than_two_alerts(self):
+        settings.MAX_ALERTS_PER_USER = 2
+        testuser = User.objects.get(username='admin')
+        cleanup_alerts()
+        alerts_after = Alerts.objects.filter(user_id=testuser).count()
+        self.assertEquals(alerts_after, 2)
+        self.assertEquals(Alerts.objects.filter(user_id=testuser, title="A").count(), 0)
+        self.assertEquals(Alerts.objects.filter(user_id=testuser, title="B").count(), 1)
+        self.assertEquals(Alerts.objects.filter(user_id=testuser, title="C").count(), 1)
+
+        cleanup_alerts()
+        alerts_after = Alerts.objects.filter(user_id=testuser).count()
+        self.assertEquals(alerts_after, 2)


### PR DESCRIPTION
Some users receives a lot of alerts but never reads or deletes them. This feature deletes the oldest x (default 999) alerts per user. The feature can be disabled by set DD_MAX_ALERTS_PER_USER to -1.

On behalf of DB Systel GmbH