### PR TITLE
fix(qualys-parser): map qid to vuln_id_from_tool

### DIFF
--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -208,7 +208,7 @@ def issue_r(raw_row, vuln):
                               references=refs,
                               impact=_temp['IMPACT'],
                               date=_temp['date'],
-                              unique_id_from_tool=_gid,
+                              vuln_id_from_tool=_gid,
                               )
 
         else:
@@ -219,7 +219,7 @@ def issue_r(raw_row, vuln):
                               references=_gid,
                               impact=_temp['IMPACT'],
                               date=_temp['date'],
-                              unique_id_from_tool=_gid,
+                              vuln_id_from_tool=_gid,
                               )
         finding.mitigated = _temp['mitigation_date']
         finding.is_Mitigated = _temp['mitigated']


### PR DESCRIPTION
The qid in Qualys is not unique.

On behalf of DB Systel GmbH