### PR TITLE
Findings list: Display jira key instead of jira bug icon

### DIFF
--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -38,7 +38,7 @@
                             <form action="{% url 'finding_bulk_update_all' %}" method="post" id="bulk_change_form">
                           {% endif %}
                                 {% csrf_token %}
-                                <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />                                            
+                                <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
                                 <label style="display: block" for="severity">Severity</label>
                                 <select name="severity" id="severity" style="font-size: 80%">
                                     <option value="">Choose...</option>
@@ -95,10 +95,10 @@
                                 {% endif %}
                                 <label style="display: block">Tags</label>
                                 {% comment %}
-                                    Quick hack to make bulk edit work without refactoring the whole bulk edit form                                
+                                    Quick hack to make bulk edit work without refactoring the whole bulk edit form
                                     {{ bulk_edit_form.media.css }}
                                     {{ bulk_edit_form.media.js }}
-                                {% endcomment %}                                
+                                {% endcomment %}
                                 {{ bulk_edit_form.tags }}
                                 <input type="submit" class="btn btn-sm btn-primary" value="Submit"/>
                             </form>
@@ -155,7 +155,7 @@
                             <th class="nowrap centered">{% dojo_sort request 'Severity' 'numerical_severity' 'asc' %}</th>
                             <th class="nowrap">{% dojo_sort request 'Name' 'title' %}</th>
                             <th>CWE</th>
-                            <th>CVE</th>                            
+                            <th>CVE</th>
                             {% if filter_name == 'Closed' %}
                             <th class="nowrap">{% dojo_sort request 'Closed Date' 'mitigated'%}</th>
                             {% else %}
@@ -229,14 +229,14 @@
                                               </li>
                                           {% endif %}
                                        {% endif %}
-                                       {% if user|is_authorized_for_change:finding %}                                       
+                                       {% if user|is_authorized_for_change:finding %}
                                           <li role="presentation">
                                               <a href="{% url 'touch_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
                                                   <i class="fa fa-clock-o"></i> Touch Finding
                                               </a>
                                           </li>
-                                       {% endif %}                                       
-                                       {% if user.is_staff %}                                       
+                                       {% endif %}
+                                       {% if user.is_staff %}
                                           <li role="presentation">
                                               <a href="{% url 'mktemplate' finding.id %}">
                                                   <i class="fa fa-copy"></i> Make Finding a Template
@@ -247,7 +247,7 @@
                                                   <i class="fa fa-copy"></i> Apply Template to Finding
                                               </a>
                                           </li>
-                                       {% endif %}                                       
+                                       {% endif %}
                                        {% if user|is_authorized_for_change:finding %}
                                         {% if finding.active %}
                                             <li role="presentation">
@@ -262,7 +262,7 @@
                                                 </a>
                                             </li>
                                         {% endif %}
-                                       {% endif %}                                       
+                                       {% endif %}
                                        <li class="divider"></li>
                                         {% if user|is_authorized_for_staff:finding %}
                                           {% if finding.risk_acceptance_set.all %}
@@ -356,14 +356,14 @@
                                         <i class="fa fa-external-link"></i> {{ finding.cwe|default:"" }}
                                     </a>
                                   {% endif %}
-                                </td> 
+                                </td>
                                 <td class="nowrap">
                                   {% if finding.cve %}
                                     <a target="_blank" href="{{ finding.cve|cve_url }}">
                                         <i class="fa fa-external-link"></i> {{ finding.cve|default:"" }}
                                     </a>
                                   {% endif %}
-                                </td>                               
+                                </td>
                                 {% if filter_name == 'Closed' %}
                                   <td class="nowrap">{{ finding.mitigated|date }}</td>
                                 {% else %}
@@ -391,16 +391,16 @@
                                   {% if jira_project and product_tab or not product_tab %}
                                     <td class="nowrap">
                                       {% if finding.has_jira_issue %}
-                                        <a href="{{ finding | jira_issue_url }}" target="_blank" 
-                                            alt="Jira Bug - {{finding | jira_key}}" data-toggle="tooltip" data-placement="bottom" title="{{finding | jira_key}}"><i class="fa fa-bug fa-fw"></i></a>
+                                        <a href="{{ finding | jira_issue_url }}" target="_blank"
+                                            alt="Jira Bug - {{finding | jira_key}}" data-toggle="tooltip" data-placement="bottom" title="{{finding | jira_key}}">{{finding | jira_key}}</a>
                                       {% endif %}
                                     </td>
                                     <td class="nowrap">
-                                      {{ finding | jira_creation | timesince }} 
+                                      {{ finding | jira_creation | timesince }}
                                     </td>
                                     <td class="nowrap">
-                                      {{ finding | jira_change | timesince }} 
-                                    </td> 
+                                      {{ finding | jira_change | timesince }}
+                                    </td>
                                   {% endif %}
                                 {% endif %}
                                 {% if show_product_column and product_tab is None %}
@@ -418,7 +418,7 @@
                     {% include "dojo/paging_snippet.html" with page=findings page_size=True%}
                 </div>
             {% else %}
-                <div id="no_findings"><p class="text-center">No findings found.</p></div>                
+                <div id="no_findings"><p class="text-center">No findings found.</p></div>
             {% endif %}
         </div>
     </div>
@@ -489,11 +489,11 @@
                 drawCallback: function(){
                       $('.has-popover').popover({'trigger':'hover'});
                 },
-                colReorder: true,                
+                colReorder: true,
                 "columns": columns,
                 order: [],
                 columnDefs: [
-                    { 
+                    {
                         "orderable": false,
                         "targets": [0, 1]
                     },

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -200,7 +200,7 @@
         </div>
 
         <div class="dropdown hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
-            {% if user|is_authorized_for_change:test %}            
+            {% if user|is_authorized_for_change:test %}
                 <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     Bulk Edit
@@ -221,7 +221,7 @@
                             <i class="fa fa-trash"></i>
                         </a>
                     </button>
-                {% endif %}                
+                {% endif %}
             </div>
             <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
                 <li class="dropdown-header">Choose wisely...</li>
@@ -271,8 +271,8 @@
                         {% endif %}
                         <label style="display: block">Tags</label>
                         {% comment %}
-                            Quick hack to make bulk edit work without refactoring the whole bulk edit form                                
-                        {% endcomment %}                                
+                            Quick hack to make bulk edit work without refactoring the whole bulk edit form
+                        {% endcomment %}
                         {{ bulk_edit_form.media.css }}
                         {{ bulk_edit_form.media.js }}
                         {{ bulk_edit_form.tags }}
@@ -378,14 +378,14 @@
                                             </li>
                                         {% endif %}
                                     {% endif %}
-                                    {% if user|is_authorized_for_change:finding %}                                       
+                                    {% if user|is_authorized_for_change:finding %}
                                         <li role="presentation">
                                             <a href="{% url 'touch_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}">
                                                 <i class="fa fa-clock-o"></i> Touch Finding
                                             </a>
                                         </li>
-                                    {% endif %}             
-                                    {% if user.is_staff %}                                                                 
+                                    {% endif %}
+                                    {% if user.is_staff %}
                                         <li role="presentation">
                                             <a href="{% url 'mktemplate' finding.id %}">
                                                 <i class="fa fa-copy"></i> Make Finding a Template
@@ -454,7 +454,7 @@
                                 </ul>
                             </div>
                             </div>
-                        </td>                        
+                        </td>
                         <td class="centered">
                             <span class="label severity severity-{{ finding.severity }}">
                             {{ finding.severity_display }}
@@ -522,8 +522,8 @@
                             {% if jira_project and product_tab or not product_tab %}
                                 <td>
                                     {% if finding.has_jira_issue %}
-                                        <a href="{{ finding | jira_issue_url }}" target="_blank" 
-                                            alt="Jira Bug - {{finding | jira_key}}" data-toggle="tooltip" data-placement="bottom" title="{{finding | jira_key}}"><i class="fa fa-bug fa-fw"></i></a>
+                                        <a href="{{ finding | jira_issue_url }}" target="_blank"
+                                            alt="Jira Bug - {{finding | jira_key}}" data-toggle="tooltip" data-placement="bottom" title="{{finding | jira_key}}">{{finding | jira_key}}</a>
                                     {% endif %}
                                     </td>
 
@@ -791,7 +791,7 @@
                 colReorder: true,
                 "columns": columns,
                 columnDefs: [
-                    { 
+                    {
                         "orderable": false,
                         "targets": [0]
                     },
@@ -905,14 +905,14 @@
                       checkbox_count++;
                     }
                   }
-  
+
                   if ($(this).prop("checked")) {
                     $('div#bulk_edit_menu').removeClass('hidden');
                   } else {
                     checkbox_count--;
                     var checkbox_values = $("input[type=checkbox][name^='select_']");
                     var checked = false;
-  
+
                     for (var i = 0; i < checkbox_values.length; i++) {
                       if ($(checkbox_values[i]).prop("checked")) {
                         checked = true;
@@ -922,7 +922,7 @@
                       $('div#bulk_edit_menu').addClass('hidden');
                     }
                   }
-  
+
                 }
               });
             $('a.merge').on('click', function (e) {
@@ -1085,5 +1085,5 @@
         });
 
     </script>
-    {% include "dojo/filter_js_snippet.html" %}    
+    {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}


### PR DESCRIPTION
When wanting to look at a glance or eventually take a screenshot, seeing the jira bug does not help much.

This PR reverts to the old display we used to have.

![image](https://user-images.githubusercontent.com/5468769/104105959-50e87500-52b2-11eb-90b7-17fb15f004b7.png)
