### PR TITLE
APIv1: disable by default

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -2,7 +2,6 @@
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.http import HttpResponse
 from django.urls import resolve, get_script_prefix
-from django.utils.html import escape
 import base64
 from tastypie import fields
 from tastypie import http
@@ -13,7 +12,7 @@ from tastypie.authorization import DjangoAuthorization
 from tastypie.constants import ALL, ALL_WITH_RELATIONS
 from tastypie.exceptions import Unauthorized, ImmediateHttpResponse, NotFound
 from tastypie.http import HttpCreated
-from tastypie.resources import ModelResource, Resource
+from tastypie.resources import ModelResource, Resource, sanitize
 from tastypie.serializers import Serializer
 from tastypie.validation import FormValidation, Validation
 from tastypie.exceptions import BadRequest
@@ -93,12 +92,6 @@ class ModelFormValidation(FormValidation):
                 kwargs['data'][name] = pk
 
         return kwargs
-
-
-def sanitize(text):
-    # We put the single quotes back, due to their frequent usage in exception
-    # messages.
-    return escape(text).replace('&#39;', "'").replace('&quot;', '"').replace('&#x27;', "'")
 
 
 class BaseModelResource(ModelResource):

--- a/dojo/api.py
+++ b/dojo/api.py
@@ -110,9 +110,9 @@ class BaseModelResource(ModelResource):
         @csrf_exempt
         def wrapper(request, *args, **kwargs):
             try:
-                api_v1_deprecation_warning = 'APIv1 is deprecated and may contain vulnerabilities. It\'s disabled by default. '
+                api_v1_deprecation_warning = 'APIv1 is deprecated and may contain vulnerabilities. It is disabled by default. '
                 if not settings.LEGACY_API_V1_ENABLE:
-                    raise BadRequest({'code': 666, 'message': api_v1_deprecation_warning + 'At your own risk it can be enabled by setting DD_LEGACY_API_V1_ENABLE to True, or by setting LEGACY_API_V1_ENABLE to True in  settings(.dist).py or local_settings.py'})
+                    raise BadRequest({'code': 666, 'message': api_v1_deprecation_warning + 'It can be enabled at your own risk by setting DD_LEGACY_API_V1_ENABLE to True, or by setting LEGACY_API_V1_ENABLE to True in  settings(.dist).py or local_settings.py'})
 
                 callback = getattr(self, view)
                 response = callback(request, *args, **kwargs)

--- a/dojo/api.py
+++ b/dojo/api.py
@@ -110,8 +110,9 @@ class BaseModelResource(ModelResource):
         @csrf_exempt
         def wrapper(request, *args, **kwargs):
             try:
+                api_v1_deprecation_warning = 'APIv1 is deprecated and may contain vulnerabilities. It\'s disabled by default. '
                 if not settings.LEGACY_API_V1_ENABLE:
-                    raise BadRequest({'code': 666, 'message': 'APIv1 is deprecated and may contain vulnerabilities. It\'s disabled by default. At your own risk it can be enabled by setting DD_LEGACY_API_V1_ENABLE to True, or by setting LEGACY_API_V1_ENABLE to True in  settings(.dist).py or local_settings.py'})
+                    raise BadRequest({'code': 666, 'message': api_v1_deprecation_warning + 'At your own risk it can be enabled by setting DD_LEGACY_API_V1_ENABLE to True, or by setting LEGACY_API_V1_ENABLE to True in  settings(.dist).py or local_settings.py'})
 
                 callback = getattr(self, view)
                 response = callback(request, *args, **kwargs)
@@ -135,6 +136,12 @@ class BaseModelResource(ModelResource):
                     # the browser cache here.
                     # See http://www.enhanceie.com/ie/bugs.asp for details.
                     patch_cache_control(response, no_cache=True)
+
+                # official header for deprecation
+                response['Deprecation'] = 'true'
+
+                # official header for warning (666 is not official)
+                response['Warning'] = '666 APIv1 ' + api_v1_deprecation_warning + 'At your own or your admins risk it has been enabled.'
 
                 return response
             except (BadRequest, fields.ApiFieldError) as e:

--- a/dojo/api.py
+++ b/dojo/api.py
@@ -112,7 +112,7 @@ class BaseModelResource(ModelResource):
             try:
                 api_v1_deprecation_warning = 'APIv1 is deprecated and may contain vulnerabilities. It is disabled by default. '
                 if not settings.LEGACY_API_V1_ENABLE:
-                    raise BadRequest({'code': 666, 'message': api_v1_deprecation_warning + 'It can be enabled at your own risk by setting DD_LEGACY_API_V1_ENABLE to True, or by setting LEGACY_API_V1_ENABLE to True in  settings(.dist).py or local_settings.py'})
+                    raise BadRequest({'code': 666, 'message': api_v1_deprecation_warning + 'It can be enabled at your own risk by setting DD_LEGACY_API_V1_ENABLE to True, or by setting LEGACY_API_V1_ENABLE to True in  settings(.dist).py or local_settings.py. APIv1 will be removed at 2021-06-30'})
 
                 callback = getattr(self, view)
                 response = callback(request, *args, **kwargs)
@@ -141,7 +141,7 @@ class BaseModelResource(ModelResource):
                 response['Deprecation'] = 'true'
 
                 # official header for warning (666 is not official)
-                response['Warning'] = '666 APIv1 ' + api_v1_deprecation_warning + 'At your own or your admins risk it has been enabled.'
+                response['Warning'] = '666 APIv1 ' + api_v1_deprecation_warning + 'At your own or your admins risk it has been enabled. APIv1 will be removed at 2021-06-30'
 
                 return response
             except (BadRequest, fields.ApiFieldError) as e:

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -162,6 +162,7 @@ env = environ.Env(
     # we limit the amount of duplicates that can be deleted in a single run of that job
     # to prevent overlapping runs of that job from occurrring
     DD_DUPE_DELETE_MAX_PER_RUN=(int, 200),
+    # APIv1 is depreacted and will be removed 30/06/2021
     DD_LEGACY_API_V1_ENABLE=(bool, False),
 )
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -162,7 +162,7 @@ env = environ.Env(
     # we limit the amount of duplicates that can be deleted in a single run of that job
     # to prevent overlapping runs of that job from occurrring
     DD_DUPE_DELETE_MAX_PER_RUN=(int, 200),
-    # APIv1 is depreacted and will be removed 30/06/2021
+    # APIv1 is depreacted and will be removed at 2021-06-30
     DD_LEGACY_API_V1_ENABLE=(bool, False),
 )
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -161,7 +161,8 @@ env = environ.Env(
     # when enabled in sytem settings,  every minute a job run to delete excess duplicates
     # we limit the amount of duplicates that can be deleted in a single run of that job
     # to prevent overlapping runs of that job from occurrring
-    DD_DUPE_DELETE_MAX_PER_RUN=(int, 200)
+    DD_DUPE_DELETE_MAX_PER_RUN=(int, 200),
+    DD_LEGACY_API_V1_ENABLE=(bool, False),
 )
 
 
@@ -462,6 +463,8 @@ LOGIN_EXEMPT_URLS = (
     r'saml2/acs',
     r'empty_questionnaire/([\d]+)/answer'
 )
+
+LEGACY_API_V1_ENABLE = env('DD_LEGACY_API_V1_ENABLE')
 
 # ------------------------------------------------------------------------------
 # SECURITY DIRECTIVES


### PR DESCRIPTION
Now that APIv1 is deprecated, it might be best to disable it by default. It can be enabled by setting `DD_LEGACY_API_V1_ENABLE` environment variable to `True`. Or by setting `LEGACY_API_V1_ENABLE` to `True` in a `local_settings.py` file.

By default all apiv1 request return a 400 message with an error:

```
BadRequest at /api/v1/findings/1234/
{"error": "{'code': 666, 'message': \"APIv1 is deprecated and may contain vulnerabilities. It's disabled by default. At your own risk it can be enabled by setting DD_LEGACY_API_V1_ENABLE to True, or by setting LEGACY_API_V1_ENABLE to True in  settings(.dist).py or local_settings.py\"}"}
```

When APIv1 is enabled again, it will work, but will also return some warnings:
```
Response Headers
{
  ...
  "deprecation": "true",
  "warning": "666 APIv1 APIv1 is deprecated and may contain vulnerabilities. It's disabled by default. At your own or your admins risk it has been enabled.",
  ...
}
```

With unit test! And existing unit tests still work using a override_settings decorator.