### PR TITLE
Snyk parser fixes

### DIFF
--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -81,9 +81,9 @@ def get_item(vulnerability, test):
         # If we're dealing with a license finding, there will be no cvssScore
         if vulnerability['cvssScore'] <= 3.9:
             severity = "Low"
-        elif vulnerability['cvssScore'] > 4.0 and vulnerability['cvssScore'] <= 6.9:
+        elif vulnerability['cvssScore'] >= 4.0 and vulnerability['cvssScore'] <= 6.9:
             severity = "Medium"
-        elif vulnerability['cvssScore'] > 7.0 and vulnerability['cvssScore'] <= 8.9:
+        elif vulnerability['cvssScore'] >= 7.0 and vulnerability['cvssScore'] <= 8.9:
             severity = "High"
         else:
             severity = "Critical"

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -34,7 +34,7 @@ class SnykParser(object):
 
                 item = get_item(node, test)
                 unique_key = node['title'] + str(node['packageName'] + str(
-                    node['version']) + str(node['from']))
+                    node['version']) + str(node['from']) + str(node['id']))
                 items[unique_key] = item
 
         return list(items.values())


### PR DESCRIPTION
This PR addresses two minor bugs:

* **unique_id** param can generate duplicated values for two different Findings when different Snyk issues with the same "title" affect the same component in a project. E.g: 
  * https://snyk.io/vuln/SNYK-JAVA-ORGOWASPANTISAMY-31591 
  * https://snyk.io/vuln/SNYK-JAVA-ORGOWASPANTISAMY-598767
  
* **Severity** level extractor ranges are missing CVSS values 4.0 and 7.0 as stated in https://nvd.nist.gov/vuln-metrics/cvss 