### PR TITLE
Snyk parser enhancements

### DIFF
--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -5,6 +5,10 @@ from dojo.models import Finding
 
 class SnykParser(object):
     def __init__(self, json_output, test):
+        self.items = []
+        
+        if json_output is None:
+            return
 
         reportTree = self.parse_json(json_output)
 

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -66,28 +66,24 @@ def get_item(vulnerability, test):
 
     if 'identifiers' in vulnerability:
         if 'CVE' in vulnerability['identifiers']:
-            if isinstance(vulnerability['identifiers']['CVE'], list):
+            cves = vulnerability['identifiers']['CVE']
+            if cves:
                 # Per the current json format, if several CVEs listed, take the first one.
-                cve = ' '.join(vulnerability['identifiers']['CVE']).split(" ")[0]
-                if len(vulnerability['identifiers']['CVE']) > 1:
-                    cve_references = ', '.join(vulnerability['identifiers']['CVE'])
+                cve = cves[0]
+                if len(cves) > 1:
+                    cve_references = ', '.join(cves)
             else:
-                # In case the structure is not a list?
-                cve = vulnerability['identifiers']['CVE']
+                cve = None
 
         if 'CWE' in vulnerability['identifiers']:
-            if isinstance(vulnerability['identifiers']['CWE'], list):
+            cwes = vulnerability['identifiers']['CWE']
+            if cwes:
                 # Per the current json format, if several CWEs, take the first one.
-                cwe = ' '.join(vulnerability['identifiers']['CWE']).split(" ")[0].split("-")[1]
+                cwe = int(cwes[0].split("-")[1])
                 if len(vulnerability['identifiers']['CVE']) > 1:
-                    cwe_references = ', '.join(vulnerability['identifiers']['CWE'])
+                    cwe_references = ', '.join(cwes)
             else:
-                # in case the structure is not a list?
-                cwe = ''.join(vulnerability['identifiers']['CWE']).split("-")[1]
-    else:
-        # If no identifiers, set to defaults
-        cve = None
-        cwe = 1035
+                cwe = 1035
 
     # Following the CVSS Scoring per https://nvd.nist.gov/vuln-metrics/cvss
     if 'cvssScore' in vulnerability:

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -6,7 +6,7 @@ from dojo.models import Finding
 class SnykParser(object):
     def __init__(self, json_output, test):
         self.items = []
-        
+
         if json_output is None:
             return
 

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -105,7 +105,7 @@ def get_item(vulnerability, test):
         severity = vulnerability['severity'].title()
 
     if 'id' in vulnerability:
-        references = "<b>Custom SNYK ID</b>: https://app.snyk.io/vuln/{}\n\n".format(vulnerability['id'])
+        references = "**SNYK ID**: https://app.snyk.io/vuln/{}\n\n".format(vulnerability['id'])
 
     if cve_references or cwe_references:
         references += "Several CVEs or CWEs were reported: \n\n{}\n{}\n".format(
@@ -113,23 +113,23 @@ def get_item(vulnerability, test):
 
     # Append vuln references to references section
     for item in vulnerability['references']:
-        references += "<b>" + item['title'] + "</b>: " + item['url'] + "\n"
+        references += "**" + item['title'] + "**: " + item['url'] + "\n"
 
     # create the finding object
     finding = Finding(
         title=vulnerability['from'][0] + ": " + vulnerability['title'],
         test=test,
         severity=severity,
-        severity_justification="Issue severity of: <b>" + severity + "</b> from a base " +
-        "CVSS score of: <b>" + str(vulnerability['cvssScore']) + "</b>",
+        severity_justification="Issue severity of: **" + severity + "** from a base " +
+        "CVSS score of: **" + str(vulnerability['cvssScore']) + "**",
         cwe=cwe,
         cve=cve,
         cvssv3=vulnerability['CVSSv3'][9:],
-        description="<h2>Details</h2><p><li><b>Vulnerable Package</b>: " +
-        vulnerability['packageName'] + "</li><li><b>Current Version</b>: " + str(
-            vulnerability['version']) + "</li><li><b>Vulnerable Version(s)</b>: " +
-        vulnerable_versions + "</li><li><b>Vulnerable Path</b>: " + " > ".join(
-            vulnerability['from']) + "</li></p>" + vulnerability['description'],
+        description="## Component Details\n - **Vulnerable Package**: " +
+        vulnerability['packageName'] + "\n- **Current Version**: " + str(
+            vulnerability['version']) + "\n- **Vulnerable Version(s)**: " +
+        vulnerable_versions + "\n- **Vulnerable Path**: " + " > ".join(
+            vulnerability['from']) + "\n" + vulnerability['description'],
         mitigation="A fix (if available) will be provided in the description.",
         references=references,
         component_name=vulnerability['packageName'],

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -6,13 +6,22 @@ from dojo.models import Finding
 class SnykParser(object):
     def __init__(self, json_output, test):
 
-        tree = self.parse_json(json_output)
+        reportTree = self.parse_json(json_output)
 
-        if tree:
-            self.items = [data for data in self.get_items(tree, test)]
+        if type(reportTree) is list:
+            temp = []
+            for moduleTree in reportTree:
+                temp += self.process_tree(moduleTree, test)
+            self.items = temp
         else:
-            self.items = []
+            self.items = self.process_tree(reportTree, test)
 
+    def process_tree(self, tree, test):
+        if tree:
+            return [data for data in self.get_items(tree, test)]
+        else:
+            return []
+            
     def parse_json(self, json_output):
         try:
             data = json_output.read()

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -21,7 +21,7 @@ class SnykParser(object):
             return [data for data in self.get_items(tree, test)]
         else:
             return []
-            
+
     def parse_json(self, json_output):
         try:
             data = json_output.read()
@@ -106,7 +106,7 @@ def get_item(vulnerability, test):
     if cve_references or cwe_references:
         references += "Several CVEs or CWEs were reported: \n\n{}\n{}\n".format(
             cve_references, cwe_references)
-    
+
     # Append vuln references to references section
     for item in vulnerability['references']:
         references += "<b>" + item['title'] + "</b>: " + item['url'] + "\n"
@@ -116,8 +116,8 @@ def get_item(vulnerability, test):
         title=vulnerability['from'][0] + ": " + vulnerability['title'],
         test=test,
         severity=severity,
-        severity_justification="Issue severity of: <b>" + severity + "</b> from a base " + 
-            "CVSS score of: <b>" + str(vulnerability['cvssScore']) + "</b>",
+        severity_justification="Issue severity of: <b>" + severity + "</b> from a base " +
+        "CVSS score of: <b>" + str(vulnerability['cvssScore']) + "</b>",
         cwe=cwe,
         cve=cve,
         cvssv3=vulnerability['CVSSv3'][9:],
@@ -144,7 +144,7 @@ def get_item(vulnerability, test):
     remediation_index = finding.description.find("## Remediation")
     references_index = finding.description.find("## References")
 
-    # Add the remediation substring to mitigation section 
+    # Add the remediation substring to mitigation section
     if (remediation_index != -1) and (references_index != -1):
         finding.mitigation = finding.description[remediation_index:references_index]
 

--- a/dojo/unittests/scans/snyk/all-projects_many_vulns.json
+++ b/dojo/unittests/scans/snyk/all-projects_many_vulns.json
@@ -1,0 +1,599 @@
+[
+  {
+    "vulnerabilities": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2020-10-02T14:16:13.342479Z",
+        "credit": [
+          "Jonathan Leitschuh"
+        ],
+        "cvssScore": 5.5,
+        "description": "## Overview\n[com.google.guava:guava](https://github.com/google/guava) is a set of core libraries that includes new collection types (such as multimap and multiset,immutable collections, a graph library, functional types, an in-memory cache and more.\n\nAffected versions of this package are vulnerable to Information Disclosure. The file permissions on the file created by com.google.common.io.Files.createTempDir allows an attacker running a malicious program co-resident on the same machine can steal secrets stored in this directory. This is because by default on unix-like operating systems the /temp directory is shared between all users, so if the correct file permissions aren't set by the directory/file creator, the file becomes readable by all other users on that system.\r\n\r\n### PoC\r\n```\r\nFile guavaTempDir = com.google.common.io.Files.createTempDir();\r\nSystem.out.println(\"Guava Temp Dir: \" + guavaTempDir.getName());\r\nrunLS(guavaTempDir.getParentFile(), guavaTempDir); // Prints the file permissions -> drwxr-xr-x\r\nFile child = new File(guavaTempDir, \"guava-child.txt\");\r\nchild.createNewFile();\r\nrunLS(guavaTempDir, child); // Prints the file permissions -> -rw-r--r--\r\n```\n## Remediation\nUpgrade `com.google.guava:guava` to version 30.0-android, 30.0-jre or higher.\n## References\n- [GitHub Commit](https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40)\n- [GitHub Issue](https://github.com/google/guava/issues/4011)\n",
+        "disclosureTime": "2020-10-02T04:56:54Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "30.0-android",
+          "30.0-jre"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "Files",
+              "filePath": "com/google/common/io/Files.java",
+              "functionName": "createTempDir"
+            },
+            "version": [
+              "[,30.0)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.google.common.io.Files",
+              "functionName": "createTempDir"
+            },
+            "version": [
+              "[,30.0)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMGOOGLEGUAVA-1015415",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8908"
+          ],
+          "CWE": [
+            "CWE-200"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "guava",
+          "groupId": "com.google.guava"
+        },
+        "modificationTime": "2020-11-05T10:11:21.061172Z",
+        "moduleName": "com.google.guava:guava",
+        "packageManager": "maven",
+        "packageName": "com.google.guava:guava",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-10-23T15:50:35Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/google/guava/issues/4011"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[, 30.0-android)",
+            "(30.0-android, 30.0-jre)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Information Disclosure",
+        "from": [
+          "com.test:version-collision@0.0.1-SNAPSHOT",
+          "com.test:project-collision@0.0.1-SNAPSHOT",
+          "com.test:project-a@0.0.1-SNAPSHOT",
+          "com.google.guava:guava@29.0-jre"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "name": "com.google.guava:guava",
+        "version": "29.0-jre"
+      }
+    ],
+    "ok": false,
+    "dependencyCount": 14,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "1 vulnerable dependency path",
+    "remediation": {
+      "unresolved": [
+        {
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N/RL:O",
+          "alternativeIds": [],
+          "creationTime": "2020-10-02T14:16:13.342479Z",
+          "credit": [
+            "Jonathan Leitschuh"
+          ],
+          "cvssScore": 5.5,
+          "description": "## Overview\n[com.google.guava:guava](https://github.com/google/guava) is a set of core libraries that includes new collection types (such as multimap and multiset,immutable collections, a graph library, functional types, an in-memory cache and more.\n\nAffected versions of this package are vulnerable to Information Disclosure. The file permissions on the file created by com.google.common.io.Files.createTempDir allows an attacker running a malicious program co-resident on the same machine can steal secrets stored in this directory. This is because by default on unix-like operating systems the /temp directory is shared between all users, so if the correct file permissions aren't set by the directory/file creator, the file becomes readable by all other users on that system.\r\n\r\n### PoC\r\n```\r\nFile guavaTempDir = com.google.common.io.Files.createTempDir();\r\nSystem.out.println(\"Guava Temp Dir: \" + guavaTempDir.getName());\r\nrunLS(guavaTempDir.getParentFile(), guavaTempDir); // Prints the file permissions -> drwxr-xr-x\r\nFile child = new File(guavaTempDir, \"guava-child.txt\");\r\nchild.createNewFile();\r\nrunLS(guavaTempDir, child); // Prints the file permissions -> -rw-r--r--\r\n```\n## Remediation\nUpgrade `com.google.guava:guava` to version 30.0-android, 30.0-jre or higher.\n## References\n- [GitHub Commit](https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40)\n- [GitHub Issue](https://github.com/google/guava/issues/4011)\n",
+          "disclosureTime": "2020-10-02T04:56:54Z",
+          "exploit": "Not Defined",
+          "fixedIn": [
+            "30.0-android",
+            "30.0-jre"
+          ],
+          "functions": [
+            {
+              "functionId": {
+                "className": "Files",
+                "filePath": "com/google/common/io/Files.java",
+                "functionName": "createTempDir"
+              },
+              "version": [
+                "[,30.0)"
+              ]
+            }
+          ],
+          "functions_new": [
+            {
+              "functionId": {
+                "className": "com.google.common.io.Files",
+                "functionName": "createTempDir"
+              },
+              "version": [
+                "[,30.0)"
+              ]
+            }
+          ],
+          "id": "SNYK-JAVA-COMGOOGLEGUAVA-1015415",
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-8908"
+            ],
+            "CWE": [
+              "CWE-200"
+            ]
+          },
+          "language": "java",
+          "mavenModuleName": {
+            "artifactId": "guava",
+            "groupId": "com.google.guava"
+          },
+          "modificationTime": "2020-11-05T10:11:21.061172Z",
+          "moduleName": "com.google.guava:guava",
+          "packageManager": "maven",
+          "packageName": "com.google.guava:guava",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2020-10-23T15:50:35Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40"
+            },
+            {
+              "title": "GitHub Issue",
+              "url": "https://github.com/google/guava/issues/4011"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "[, 30.0-android)",
+              "(30.0-android, 30.0-jre)"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "title": "Information Disclosure",
+          "from": [
+            "com.test:version-collision@0.0.1-SNAPSHOT",
+            "com.test:project-collision@0.0.1-SNAPSHOT",
+            "com.test:project-a@0.0.1-SNAPSHOT",
+            "com.google.guava:guava@29.0-jre"
+          ],
+          "upgradePath": [],
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "name": "com.google.guava:guava",
+          "version": "29.0-jre"
+        }
+      ],
+      "upgrade": {},
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    },
+    "filesystemPolicy": false,
+    "filtered": {
+      "ignore": [],
+      "patch": []
+    },
+    "uniqueCount": 1,
+    "projectName": "com.test:version-collision",
+    "foundProjectCount": 3,
+    "displayTargetFile": "pom.xml",
+    "path": "C:\\workspace"
+  },
+  {
+    "vulnerabilities": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2020-10-02T14:16:13.342479Z",
+        "credit": [
+          "Jonathan Leitschuh"
+        ],
+        "cvssScore": 5.5,
+        "description": "## Overview\n[com.google.guava:guava](https://github.com/google/guava) is a set of core libraries that includes new collection types (such as multimap and multiset,immutable collections, a graph library, functional types, an in-memory cache and more.\n\nAffected versions of this package are vulnerable to Information Disclosure. The file permissions on the file created by com.google.common.io.Files.createTempDir allows an attacker running a malicious program co-resident on the same machine can steal secrets stored in this directory. This is because by default on unix-like operating systems the /temp directory is shared between all users, so if the correct file permissions aren't set by the directory/file creator, the file becomes readable by all other users on that system.\r\n\r\n### PoC\r\n```\r\nFile guavaTempDir = com.google.common.io.Files.createTempDir();\r\nSystem.out.println(\"Guava Temp Dir: \" + guavaTempDir.getName());\r\nrunLS(guavaTempDir.getParentFile(), guavaTempDir); // Prints the file permissions -> drwxr-xr-x\r\nFile child = new File(guavaTempDir, \"guava-child.txt\");\r\nchild.createNewFile();\r\nrunLS(guavaTempDir, child); // Prints the file permissions -> -rw-r--r--\r\n```\n## Remediation\nUpgrade `com.google.guava:guava` to version 30.0-android, 30.0-jre or higher.\n## References\n- [GitHub Commit](https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40)\n- [GitHub Issue](https://github.com/google/guava/issues/4011)\n",
+        "disclosureTime": "2020-10-02T04:56:54Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "30.0-android",
+          "30.0-jre"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "Files",
+              "filePath": "com/google/common/io/Files.java",
+              "functionName": "createTempDir"
+            },
+            "version": [
+              "[,30.0)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.google.common.io.Files",
+              "functionName": "createTempDir"
+            },
+            "version": [
+              "[,30.0)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMGOOGLEGUAVA-1015415",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8908"
+          ],
+          "CWE": [
+            "CWE-200"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "guava",
+          "groupId": "com.google.guava"
+        },
+        "modificationTime": "2020-11-05T10:11:21.061172Z",
+        "moduleName": "com.google.guava:guava",
+        "packageManager": "maven",
+        "packageName": "com.google.guava:guava",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-10-23T15:50:35Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/google/guava/issues/4011"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[, 30.0-android)",
+            "(30.0-android, 30.0-jre)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Information Disclosure",
+        "from": [
+          "com.test:project-a@0.0.1-SNAPSHOT",
+          "com.google.guava:guava@22.0"
+        ],
+        "upgradePath": [
+          false,
+          "com.google.guava:guava@30.0-android"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "name": "com.google.guava:guava",
+        "version": "22.0"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2018-04-25T07:28:15.755000Z",
+        "credit": [
+          "Apostolos Giannakidis"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[com.google.guava:guava](https://github.com/google/guava) is a set of core libraries that includes new collection types (such as multimap and multiset,immutable collections, a graph library, functional types, an in-memory cache and more.\n\nAffected versions of this package are vulnerable to Deserialization of Untrusted Data. During deserialization, two Guava classes accept a caller-specified size parameter and eagerly allocate an array of that size:\r\n* `AtomicDoubleArray` (when serialized with Java serialization)\r\n* `CompoundOrdering` (when serialized with GWT serialization)\r\n\r\nAn attacker may be able to send a specially crafted request which with then cause the server to allocate all it's memory, without validation whether the data size is reasonable.\n\n## Details\n\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\n  \nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n  \n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n\n- Apache Blog\n  \n## Remediation\nUpgrade `com.google.guava:guava` to version 24.1.1-android, 24.1.1-jre or higher.\n## References\n- [GitHub Commit](https://github.com/google/guava/commit/7ec8718f1e6e2814dabaa4b9f96b6b33a813101c)\n- [Google Group Forum](https://groups.google.com/forum/#!topic/guava-announce/xqWALw4W1vs/discussion)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1573391)\n",
+        "disclosureTime": "2018-04-25T07:28:15Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "24.1.1-android",
+          "24.1.1-jre"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "AtomicDoubleArray",
+              "filePath": "com/google/common/util/concurrent/AtomicDoubleArray.java",
+              "functionName": "readObject"
+            },
+            "version": [
+              "[11.0, 24.1.1-android)",
+              "(24.1.1-android, 24.1.1-jre)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.google.common.util.concurrent.AtomicDoubleArray",
+              "functionName": "readObject"
+            },
+            "version": [
+              "[11.0, 24.1.1-android)",
+              "(24.1.1-android, 24.1.1-jre)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMGOOGLEGUAVA-32236",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-10237"
+          ],
+          "CWE": [
+            "CWE-119"
+          ],
+          "GHSA": [
+            "GHSA-mvr2-9pj6-7w5j"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "guava",
+          "groupId": "com.google.guava"
+        },
+        "modificationTime": "2020-06-12T14:37:04.235662Z",
+        "moduleName": "com.google.guava:guava",
+        "packageManager": "maven",
+        "packageName": "com.google.guava:guava",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-05-02T13:38:04Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/google/guava/commit/7ec8718f1e6e2814dabaa4b9f96b6b33a813101c"
+          },
+          {
+            "title": "Google Group Forum",
+            "url": "https://groups.google.com/forum/%23%21topic/guava-announce/xqWALw4W1vs/discussion"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1573391"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[11.0, 24.1.1-android)",
+            "(24.1.1-android, 24.1.1-jre)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Deserialization of Untrusted Data",
+        "from": [
+          "com.test:project-a@0.0.1-SNAPSHOT",
+          "com.google.guava:guava@22.0"
+        ],
+        "upgradePath": [
+          false,
+          "com.google.guava:guava@24.1.1-android"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "name": "com.google.guava:guava",
+        "version": "22.0"
+      }
+    ],
+    "ok": false,
+    "dependencyCount": 9,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "2 vulnerable dependency paths",
+    "remediation": {
+      "unresolved": [],
+      "upgrade": {
+        "com.google.guava:guava@22.0": {
+          "upgradeTo": "com.google.guava:guava@30.0-android",
+          "upgrades": [
+            "com.google.guava:guava@22.0",
+            "com.google.guava:guava@22.0"
+          ],
+          "vulns": [
+            "SNYK-JAVA-COMGOOGLEGUAVA-1015415",
+            "SNYK-JAVA-COMGOOGLEGUAVA-32236"
+          ]
+        }
+      },
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    },
+    "filesystemPolicy": false,
+    "filtered": {
+      "ignore": [],
+      "patch": []
+    },
+    "uniqueCount": 2,
+    "projectName": "com.test:project-a",
+    "foundProjectCount": 3,
+    "displayTargetFile": "project-a\\pom.xml",
+    "path": "C:\\workspace"
+  },
+  {
+    "vulnerabilities": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2020-10-02T14:16:13.342479Z",
+        "credit": [
+          "Jonathan Leitschuh"
+        ],
+        "cvssScore": 5.5,
+        "description": "## Overview\n[com.google.guava:guava](https://github.com/google/guava) is a set of core libraries that includes new collection types (such as multimap and multiset,immutable collections, a graph library, functional types, an in-memory cache and more.\n\nAffected versions of this package are vulnerable to Information Disclosure. The file permissions on the file created by com.google.common.io.Files.createTempDir allows an attacker running a malicious program co-resident on the same machine can steal secrets stored in this directory. This is because by default on unix-like operating systems the /temp directory is shared between all users, so if the correct file permissions aren't set by the directory/file creator, the file becomes readable by all other users on that system.\r\n\r\n### PoC\r\n```\r\nFile guavaTempDir = com.google.common.io.Files.createTempDir();\r\nSystem.out.println(\"Guava Temp Dir: \" + guavaTempDir.getName());\r\nrunLS(guavaTempDir.getParentFile(), guavaTempDir); // Prints the file permissions -> drwxr-xr-x\r\nFile child = new File(guavaTempDir, \"guava-child.txt\");\r\nchild.createNewFile();\r\nrunLS(guavaTempDir, child); // Prints the file permissions -> -rw-r--r--\r\n```\n## Remediation\nUpgrade `com.google.guava:guava` to version 30.0-android, 30.0-jre or higher.\n## References\n- [GitHub Commit](https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40)\n- [GitHub Issue](https://github.com/google/guava/issues/4011)\n",
+        "disclosureTime": "2020-10-02T04:56:54Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "30.0-android",
+          "30.0-jre"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "Files",
+              "filePath": "com/google/common/io/Files.java",
+              "functionName": "createTempDir"
+            },
+            "version": [
+              "[,30.0)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.google.common.io.Files",
+              "functionName": "createTempDir"
+            },
+            "version": [
+              "[,30.0)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMGOOGLEGUAVA-1015415",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8908"
+          ],
+          "CWE": [
+            "CWE-200"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "guava",
+          "groupId": "com.google.guava"
+        },
+        "modificationTime": "2020-11-05T10:11:21.061172Z",
+        "moduleName": "com.google.guava:guava",
+        "packageManager": "maven",
+        "packageName": "com.google.guava:guava",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-10-23T15:50:35Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/google/guava/issues/4011"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[, 30.0-android)",
+            "(30.0-android, 30.0-jre)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Information Disclosure",
+        "from": [
+          "com.test:project-b@0.0.1-SNAPSHOT",
+          "com.google.guava:guava@29.0-jre"
+        ],
+        "upgradePath": [
+          false,
+          "com.google.guava:guava@30.0-jre"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "name": "com.google.guava:guava",
+        "version": "29.0-jre"
+      }
+    ],
+    "ok": false,
+    "dependencyCount": 11,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "1 vulnerable dependency path",
+    "remediation": {
+      "unresolved": [],
+      "upgrade": {
+        "com.google.guava:guava@29.0-jre": {
+          "upgradeTo": "com.google.guava:guava@30.0-jre",
+          "upgrades": [
+            "com.google.guava:guava@29.0-jre"
+          ],
+          "vulns": [
+            "SNYK-JAVA-COMGOOGLEGUAVA-1015415"
+          ]
+        }
+      },
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    },
+    "filesystemPolicy": false,
+    "filtered": {
+      "ignore": [],
+      "patch": []
+    },
+    "uniqueCount": 1,
+    "projectName": "com.test:project-b",
+    "foundProjectCount": 3,
+    "displayTargetFile": "project-b\\pom.xml",
+    "path": "C:\\workspace"
+  }
+]

--- a/dojo/unittests/scans/snyk/all-projects_no_vulns.json
+++ b/dojo/unittests/scans/snyk/all-projects_no_vulns.json
@@ -1,0 +1,77 @@
+[
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 5,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "projectName": "com.test:maven-plugins",
+    "foundProjectCount": 2,
+    "displayTargetFile": "pom.xml",
+    "path": "C:\\workspace"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 42,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "projectName": "com.test:custom-rule",
+    "foundProjectCount": 2,
+    "displayTargetFile": "custom-rule\\pom.xml",
+    "path": "C:\\workspace"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 4,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "projectName": "com.test:maven-enforcer",
+    "foundProjectCount": 2,
+    "displayTargetFile": "maven-enforcer\\pom.xml",
+    "path": "C:\\workspace"
+  }
+]

--- a/dojo/unittests/scans/snyk/all-projects_one_vuln.json
+++ b/dojo/unittests/scans/snyk/all-projects_one_vuln.json
@@ -1,0 +1,174 @@
+[
+  {
+    "vulnerabilities": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-08-25T13:02:11.461178Z",
+        "credit": [
+          "Sean Mullan"
+        ],
+        "cvssScore": 6.5,
+        "description": "## Overview\n[org.apache.santuario:xmlsec](https://mvnrepository.com/artifact/org.apache.santuario/xmlsec) is a package to provide implementation of the primary security standards for XML, XML-Signature Syntax and Processing and XML Encryption Syntax and Processing.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. In version 2.0.3 a caching mechanism was introduced to speed up creating new XML documents using a static pool of DocumentBuilders. However, if some untrusted code can register a malicious implementation with the thread context class loader first, then this implementation might be cached and re-used by Apache Santuario - XML Security for Java, leading to potential security flaws when validating signed documents, etc.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387cdba6)\n- [GitHub Commit](https://github.com/apache/santuario-java/commit/c5210f77a77105fba81311d16c07ceacc21f39d5)\n- [Possible Jira Issue](https://issues.apache.org/jira/browse/SANTUARIO-504?jql=project%20%3D%20SANTUARIO)\n- [Security Release](http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2)\n",
+        "disclosureTime": "2019-05-10T21:50:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.1.4"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESANTUARIO-460281",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-12400"
+          ],
+          "CWE": [
+            "CWE-611"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xmlsec",
+          "groupId": "org.apache.santuario"
+        },
+        "modificationTime": "2020-06-12T14:36:59.920320Z",
+        "moduleName": "org.apache.santuario:xmlsec",
+        "packageManager": "maven",
+        "packageName": "org.apache.santuario:xmlsec",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-08-25T13:53:19Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387cdba6"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/santuario-java/commit/c5210f77a77105fba81311d16c07ceacc21f39d5"
+          },
+          {
+            "title": "Possible Jira Issue",
+            "url": "https://issues.apache.org/jira/browse/SANTUARIO-504?jql=project%20%3D%20SANTUARIO"
+          },
+          {
+            "title": "Security Release",
+            "url": "http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.3, 2.1.4)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "com.test:custom-rule@1.0.0-SNAPSHOT",
+          "org.apache.santuario:xmlsec@2.1.1"
+        ],
+        "upgradePath": [
+          false,
+          "org.apache.santuario:xmlsec@2.1.4"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "name": "org.apache.santuario:xmlsec",
+        "version": "2.1.1"
+      }
+    ],
+    "ok": false,
+    "dependencyCount": 5,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "1 vulnerable dependency path",
+    "remediation": {
+      "unresolved": [],
+      "upgrade": {
+        "org.apache.santuario:xmlsec@2.1.1": {
+          "upgradeTo": "org.apache.santuario:xmlsec@2.1.4",
+          "upgrades": [
+            "org.apache.santuario:xmlsec@2.1.1"
+          ],
+          "vulns": [
+            "SNYK-JAVA-ORGAPACHESANTUARIO-460281"
+          ]
+        }
+      },
+      "patch": {},
+      "ignore": {},
+      "pin": {}
+    },
+    "filesystemPolicy": false,
+    "filtered": {
+      "ignore": [],
+      "patch": []
+    },
+    "uniqueCount": 1,
+    "projectName": "com.test:custom-rule",
+    "displayTargetFile": "pom.xml",
+    "path": "C:\\workspace"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 42,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "projectName": "com.test:custom-rule",
+    "foundProjectCount": 2,
+    "displayTargetFile": "custom-rule\\pom.xml",
+    "path": "C:\\workspace"
+  },
+  {
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 4,
+    "org": "myorg",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+    },
+    "packageManager": "maven",
+    "ignoreSettings": {
+      "adminOnly": false,
+      "reasonRequired": false,
+      "disregardFilesystemIgnores": false
+    },
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "projectName": "com.test:maven-enforcer",
+    "foundProjectCount": 2,
+    "displayTargetFile": "maven-enforcer\\pom.xml",
+    "path": "C:\\workspace"
+  }
+]

--- a/dojo/unittests/scans/snyk/single_project_many_vulns.json
+++ b/dojo/unittests/scans/snyk/single_project_many_vulns.json
@@ -1,0 +1,4690 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2019-05-29T13:04:45.907245Z",
+      "credit": [
+        "JLLeitschuh"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n[com.beust:jcommander](https://github.com/cbeust/jcommander) is a Command line parsing framework for Java.\n\nAffected versions of this package are vulnerable to Unsafe Dependency Resolution due to resolving dependencies over an insecure channel (http).\r\n\r\nIf the build occurred over an insecure connection, a malicious user could have perform a Man-in-the-Middle attack during the build and alter the build artifacts that were produced.\r\nIn case that any of these artifacts were compromised, any developers using these could be altered.\r\n \r\n**Note:** In order to validate that this artifact was not compromised, the maintainer would need to confirm that none of the artifacts published to the registry were not altered with. Until this happens, we can not guarantee that this artifact was not compromised even though the probability that this happened is low. \r\n\r\nWe have chosen to alert on this issue when maintainers either decided to issue CVEs themselves, or in cases when maintainers decided against performing audits on there build to verify they had not been compromised.\n## Remediation\nUpgrade `com.beust:jcommander` to version 1.75 or higher.\n## References\n- [GitHub Commit](https://github.com/cbeust/jcommander/commit/3ae95595febbed9c13f367b6bda5c0be1c572c53)\n- [GitHub Issue](https://github.com/cbeust/jcommander/issues/465)\n- [Jonathan Leitschuh's Blog](https://medium.com/@jonathan.leitschuh/1fc329d898fb)\n",
+      "disclosureTime": "2019-02-22T12:35:55Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.75"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMBEUST-174815",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-494",
+          "CWE-829"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jcommander",
+        "groupId": "com.beust"
+      },
+      "modificationTime": "2020-06-12T14:36:55.943917Z",
+      "moduleName": "com.beust:jcommander",
+      "packageManager": "maven",
+      "packageName": "com.beust:jcommander",
+      "patches": [],
+      "proprietary": true,
+      "publicationTime": "2019-06-11T11:37:59Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/cbeust/jcommander/commit/3ae95595febbed9c13f367b6bda5c0be1c572c53"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/cbeust/jcommander/issues/465"
+        },
+        {
+          "title": "Jonathan Leitschuh's Blog",
+          "url": "https://medium.com/@jonathan.leitschuh/1fc329d898fb"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,1.75)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Unsafe Dependency Resolution",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.testng:testng@6.13.1",
+        "com.beust:jcommander@1.72"
+      ],
+      "upgradePath": [
+        false,
+        "org.testng:testng@7.3.0",
+        "com.beust:jcommander@1.78"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "com.beust:jcommander",
+      "version": "1.72"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:L",
+      "alternativeIds": [],
+      "creationTime": "2020-12-04T11:58:40.054903Z",
+      "credit": [
+        "Bartosz Baranowski"
+      ],
+      "cvssScore": 8.2,
+      "description": "## Overview\n[com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson-databind) is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. A flaw was found in FasterXML Jackson Databind, where it does not have entity expansion secured properly in the `DOMDeserializer` class. The highest threat from this vulnerability is data integrity.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `com.fasterxml.jackson.core:jackson-databind` to version 2.6.7.4, 2.9.10.7, 2.10.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/FasterXML/jackson-databind/commit/612f971b78c60202e9cd75a299050c8f2d724a59)\n- [GitHub Issue](https://github.com/FasterXML/jackson-databind/issues/2589)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1887664)\n",
+      "disclosureTime": "2020-12-04T11:54:03Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.6.7.4",
+        "2.9.10.7",
+        "2.10.5.1"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "DOMSerializer",
+            "filePath": "com/fasterxml/jackson/databind/ext/DOMSerializer.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[2.6.0,2.6.7.4)",
+            "[2.9.0,2.9.10.7)",
+            "[2.10.0, 2.10.5.1)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "com.fasterxml.jackson.databind.ext.DOMSerializer",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[2.6.0,2.6.7.4)",
+            "[2.9.0,2.9.10.7)",
+            "[2.10.0, 2.10.5.1)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-1048302",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-25649"
+        ],
+        "CWE": [
+          "CWE-611"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jackson-databind",
+        "groupId": "com.fasterxml.jackson.core"
+      },
+      "modificationTime": "2020-12-13T13:51:18.668871Z",
+      "moduleName": "com.fasterxml.jackson.core:jackson-databind",
+      "packageManager": "maven",
+      "packageName": "com.fasterxml.jackson.core:jackson-databind",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-12-04T15:22:52Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/FasterXML/jackson-databind/commit/612f971b78c60202e9cd75a299050c8f2d724a59"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/FasterXML/jackson-databind/issues/2589"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1887664"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.6.0,2.6.7.4)",
+          "[2.9.0,2.9.10.7)",
+          "[2.10.0, 2.10.5.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "com.mylib:lib-config@2.1.1",
+        "com.fasterxml.jackson.core:jackson-databind@2.10.5"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "com.fasterxml.jackson.core:jackson-databind",
+      "version": "2.10.5"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:47Z",
+      "credit": [
+        "Karl Dyszynski",
+        "Hugo Vazquez Carames"
+      ],
+      "cvssScore": 4.4,
+      "description": "## Overview\n[commons-fileupload:commons-fileupload](https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload) is a component that provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\n\nAffected versions of this package are vulnerable to Time of Check Time of Use (TOCTOU) if the attacker has write access to the /tmp directory.\r\n\r\n## Details\r\nCommons FileUpload provides file upload capability for Servlets and web applications. During the upload process, FileUpload may (depending on configuration) save the uploaded file temporarily on disk. By default this will be in the system wide tmp directory. Because the temporary files have predictable file names and are stored in a publicly writeable location they are vulnerable to a TOCTOU attack.\r\n\r\nA successful attack requires that the attacker has write access to the tmp directory. The attack can be prevented by setting the repository to a non-publicly writeable location. The documentation for FileUpload does not highlight the potential security implications of not setting a repository, nor do the provided examples set a repository. This may have caused users to use FileUpload in an insecure manner.\n## Remediation\nUpgrade `commons-fileupload:commons-fileupload` to version 1.3 or higher.\n## References\n- [Commons-user Mailing List](http://mail-archives.apache.org/mod_mbox/commons-user/201303.mbox/%3C51371C31.8020805@apache.org%3E)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L114)\n- [GitHub Commit](https://github.com/apache/commons-fileupload/commit/7d9e956627a3803c1fc5734e2b18113a033e6f60)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2013-0248)\n",
+      "disclosureTime": "2013-03-15T20:55:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30079",
+      "identifiers": {
+        "CVE": [
+          "CVE-2013-0248"
+        ],
+        "CWE": [
+          "CWE-264"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2020-06-12T14:36:47.782780Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2015-05-06T16:51:47Z",
+      "references": [
+        {
+          "title": "Commons-user Mailing List",
+          "url": "http://mail-archives.apache.org/mod_mbox/commons-user/201303.mbox/%3C51371C31.8020805@apache.org%3E"
+        },
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml%23L114"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/7d9e956627a3803c1fc5734e2b18113a033e6f60"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/CVE-2013-0248"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.3)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Time of Check Time of Use (TOCTOU)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "commons-fileupload:commons-fileupload@1.2"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.1.0.1",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:48Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 7.3,
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nAffected versions of this package are vulnerable to Arbitrary File Write.\n\n## Details\nThe DiskFileItem class in Apache Commons FileUpload, as used in Red Hat JBoss BRMS 5.3.1; JBoss Portal 4.3 CP07, 5.2.2, and 6.0.0; and Red Hat JBoss Web Server 1.0.2 allows remote attackers to write to arbitrary files via a NULL byte in a file name in a serialized instance.\n\n## References\n- [Redhat Security Advisory](https://access.redhat.com/security/cve/CVE-2013-2186)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-2186)\n",
+      "disclosureTime": "2013-06-16T16:51:48Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30080",
+      "identifiers": {
+        "CVE": [
+          "CVE-2013-2186"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-06-02T07:36:40.934521Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2013-06-16T16:51:48Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/163a6061fbc077d4b6e4787d26857c2baba495d1"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2013-2186"
+        },
+        {
+          "title": "RedHat CVE Database",
+          "url": "https://access.redhat.com/security/cve/CVE-2013-2186"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.3.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Arbitrary File Write",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "commons-fileupload:commons-fileupload@1.2"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.1.0.1",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:51Z",
+      "credit": [
+        "Mark Thomas"
+      ],
+      "cvssScore": 7.3,
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks. An attacker may send a specially crafted `Content-Type` header that bypasses a loop's intended exit conditions, causing an infinite loop and high CPU consumption.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0050)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L90)\n- [Oren Hafif Blog](http://blog.spiderlabs.com/2014/02/cve-2014-0050-exploit-with-boundaries-loops-without-boundaries.html)\n- [Apache-SVN](http://svn.apache.org/viewvc?view=revision&revision=1565143)\n- [Apache Mailing list archives](http://mail-archives.apache.org/mod_mbox/www-announce/201402.mbox/%3C52F373FC.9030907@apache.org%3E)\n- [Issue documentation](http://struts.apache.org/docs/s2-020.html)\n",
+      "disclosureTime": "2014-02-11T16:51:51Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30081",
+      "identifiers": {
+        "CVE": [
+          "CVE-2014-0050"
+        ],
+        "CWE": [
+          "CWE-264"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-06-02T07:36:41.637272Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2014-02-11T16:51:51Z",
+      "references": [
+        {
+          "title": "Apache Mailing list archives",
+          "url": "http://mail-archives.apache.org/mod_mbox/www-announce/201402.mbox/%3C52F373FC.9030907@apache.org%3E"
+        },
+        {
+          "title": "Apache-SVN",
+          "url": "http://svn.apache.org/viewvc?view=revision&revision=1565143"
+        },
+        {
+          "title": "Exploit DB",
+          "url": "https://www.exploit-db.com/exploits/31615"
+        },
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L90"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/c61ff05b3241cb14d989b67209e57aa71540417a"
+        },
+        {
+          "title": "Issue documentation",
+          "url": "http://struts.apache.org/docs/s2-020.html"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0050"
+        },
+        {
+          "title": "Oren Hafif Blog",
+          "url": "http://blog.spiderlabs.com/2014/02/cve-2014-0050-exploit-with-boundaries-loops-without-boundaries.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.3.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "commons-fileupload:commons-fileupload@1.2"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.1.0.1",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:18.753000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nThe Apache Commons FileUpload library contains a Java Object that, upon deserialization, can be manipulated to write or copy files in arbitrary locations. If integrated with [`ysoserial`](https://github.com/frohoff/ysoserial), it is possible to upload and execute binaries in a single deserialization call.\n\n# Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n- Apache Blog\n\n## Remediation\nUpgrade `commons-fileupload` to version 1.3.3 or higher.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031)\n- [Tenable Security](http://www.tenable.com/security/research/tra-2016-12)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L65)\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c)\n",
+      "disclosureTime": "2016-10-25T14:29:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "DiskFileItem",
+            "filePath": "org/apache/commons/fileupload/disk/DiskFileItem.java",
+            "functionName": "readObject"
+          },
+          "version": [
+            "[1.1,1.3.3)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.disk.DiskFileItem",
+            "functionName": "readObject"
+          },
+          "version": [
+            "[1.1,1.3.3)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30401",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-1000031"
+        ],
+        "CWE": [
+          "CWE-284"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-06-02T07:36:59.369724Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-10-26T03:04:11.895000Z",
+      "references": [
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L65"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031"
+        },
+        {
+          "title": "Tenable Security",
+          "url": "http://www.tenable.com/security/research/tra-2016-12"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.1,1.3.3)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "commons-fileupload:commons-fileupload@1.2"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.2.0.0",
+        "commons-fileupload:commons-fileupload@1.3.3"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-10-01T08:05:48.497000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\r\n[`commons-fileupload:commons-fileupload`](https://commons.apache.org/proper/commons-fileupload/) provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\r\n\r\nAffected versions of the package are vulnerable to Information Disclosure because the `InputStream` is not closed on exception.\r\n\r\n## Remediation\r\nUpgrade `commons-fileupload` to version 1.3.2 or higher.\r\n\r\n## References\r\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L56)\r\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814)",
+      "disclosureTime": "2014-02-17T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.2"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "FileUpload",
+            "filePath": "org/apache/commons/fileupload/FileUpload.java",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[,1.0-rc1)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "FileUploadBase",
+            "filePath": "org/apache/commons/fileupload/FileUploadBase.java",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[1.0-rc1,1.2.0)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "FileUploadBase$FileItemIteratorImpl",
+            "filePath": "org/apache/commons/fileupload/FileUploadBase$FileItemIteratorImpl.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[1.2.0 ,1.3.2)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.FileUpload",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[,1.0-rc1)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.FileUploadBase",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[1.0-rc1,1.2.0)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.FileUploadBase$FileItemIteratorImpl",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[1.2.0 ,1.3.2)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-31540",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-200"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2020-06-22T17:20:16.073581Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-02-17T08:05:48Z",
+      "references": [
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L56"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.3.2)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Information Exposure",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "commons-fileupload:commons-fileupload@1.2"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.2.0.0",
+        "commons-fileupload:commons-fileupload@1.3.3"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:47Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.4,
+      "description": "## Overview\n[commons-httpclient:commons-httpclient](https://mvnrepository.com/artifact/commons-httpclient/commons-httpclient) is a HttpClient component of the Apache HttpComponents project.\n\nAffected versions of this package are vulnerable to Improper Certificate Validation due to not verifying that the requesting server hostname matches a domain name in the subject's `Common Name (CN)` or `subjectAltName` field of the X.509 certificate. This allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.\n## Remediation\nThere is no fixed version for `commons-httpclient:commons-httpclient`.\n## References\n- [Jira Issue](https://issues.apache.org/jira/browse/HTTPCLIENT-1265)\n- [The University of Texas](http://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf)\n- [X-force Vulnerability Report](https://exchange.xforce.ibmcloud.com/vulnerabilities/79984)\n",
+      "disclosureTime": "2012-11-04T22:55:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [
+        {
+          "functionId": {
+            "className": "SSLProtocolSocketFactory",
+            "filePath": "org/apache/commons/httpclient/protocol/SSLProtocolSocketFactory.java",
+            "functionName": "createSocket"
+          },
+          "version": [
+            "[2.0, 3.1)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.commons.httpclient.protocol.SSLProtocolSocketFactory",
+            "functionName": "createSocket"
+          },
+          "version": [
+            "[2.0, 3.1)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMMONSHTTPCLIENT-30083",
+      "identifiers": {
+        "CVE": [
+          "CVE-2012-5783"
+        ],
+        "CWE": [
+          "CWE-295"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-httpclient",
+        "groupId": "commons-httpclient"
+      },
+      "modificationTime": "2020-06-12T14:37:02.646552Z",
+      "moduleName": "commons-httpclient:commons-httpclient",
+      "packageManager": "maven",
+      "packageName": "commons-httpclient:commons-httpclient",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2013-03-25T16:51:47Z",
+      "references": [
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/HTTPCLIENT-1265"
+        },
+        {
+          "title": "The University of Texas",
+          "url": "http://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf"
+        },
+        {
+          "title": "X-force Vulnerability Report",
+          "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/79984"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Improper Certificate Validation",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "org.owasp.antisamy:antisamy@1.4.3",
+        "commons-httpclient:commons-httpclient@3.1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "commons-httpclient:commons-httpclient",
+      "version": "3.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:21.771000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 4.3,
+      "description": "## Overview\n[commons-httpclient:commons-httpclient](https://mvnrepository.com/artifact/commons-httpclient/commons-httpclient) is a HttpClient component of the Apache HttpComponents project.\n\nAffected versions of this package are vulnerable to Man-in-the-Middle (MitM) due to not verifing the requesting server's hostname agains existing domain names in the SSL Certificate. The `AbstractVerifier` does not properly verify that the server hostname matches a domain name in the subject's `Common Name (CN)` or `subjectAltName` field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a certificate with a subject that specifies a common name in a field that is not the CN field.  \r\n\r\n**NOTE:** this issue exists because of an incomplete fix for [CVE-2012-5783](SNYK-JAVA-COMMONSHTTPCLIENT-30083).\n## Remediation\nThere is no fixed version for `commons-httpclient:commons-httpclient`.\n## References\n- [GitHub Commit](https://github.com/apache/httpcomponents-client/commit/6e14fc146a66e0f3eb362f45f95d1a58ee18886a)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-6153)\n",
+      "disclosureTime": "2014-09-04T17:55:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMMONSHTTPCLIENT-31660",
+      "identifiers": {
+        "CVE": [
+          "CVE-2012-6153"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-httpclient",
+        "groupId": "commons-httpclient"
+      },
+      "modificationTime": "2020-06-12T14:37:04.982623Z",
+      "moduleName": "commons-httpclient:commons-httpclient",
+      "packageManager": "maven",
+      "packageName": "commons-httpclient:commons-httpclient",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2018-04-08T12:56:14Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/httpcomponents-client/commit/6e14fc146a66e0f3eb362f45f95d1a58ee18886a"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-6153"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Man-in-the-Middle (MitM)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "org.owasp.antisamy:antisamy@1.4.3",
+        "commons-httpclient:commons-httpclient@3.1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "commons-httpclient:commons-httpclient",
+      "version": "3.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:N/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-12-16T11:01:31.348811Z",
+      "credit": [
+        "Liaogui Zhong"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[com.thoughtworks.xstream:xstream](https://x-stream.github.io/) is a simple library to serialize objects to XML and back again.\n\nAffected versions of this package are vulnerable to Arbitrary File Deletion. A remote attacker can delete arbitrary known files on the host as long as the executing process has sufficient rights, by manipulating the processed input stream.\n## Remediation\nUpgrade `com.thoughtworks.xstream:xstream` to version 1.4.15 or higher.\n## References\n- [CVE-2020-26259 Details](https://x-stream.github.io/CVE-2020-26259.html)\n- [GitHub Advisory](https://github.com/x-stream/xstream/security/advisories/GHSA-jfvx-7wrx-43fh)\n- [GitHub Commit](https://github.com/x-stream/xstream/commit/0bcbf50126a62dfcd65f93a0da0c6d1ae92aa738)\n",
+      "disclosureTime": "2020-12-16T10:53:35Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "1.4.15"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "XStream",
+            "filePath": "com/thoughtworks/xstream/XStream.java",
+            "functionName": "fromXML"
+          },
+          "version": [
+            "[,1.4.15)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "com.thoughtworks.xstream.XStream",
+            "functionName": "fromXML"
+          },
+          "version": [
+            "[,1.4.15)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051966",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-26259"
+        ],
+        "CWE": [
+          "CWE-22"
+        ],
+        "GHSA": [
+          "GHSA-jfvx-7wrx-43fh"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xstream",
+        "groupId": "com.thoughtworks.xstream"
+      },
+      "modificationTime": "2020-12-21T11:58:11.629188Z",
+      "moduleName": "com.thoughtworks.xstream:xstream",
+      "packageManager": "maven",
+      "packageName": "com.thoughtworks.xstream:xstream",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-12-16T17:24:55Z",
+      "references": [
+        {
+          "title": "CVE-2020-26259 Details",
+          "url": "https://x-stream.github.io/CVE-2020-26259.html"
+        },
+        {
+          "title": "GitHub Advisory",
+          "url": "https://github.com/x-stream/xstream/security/advisories/GHSA-jfvx-7wrx-43fh"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/x-stream/xstream/commit/0bcbf50126a62dfcd65f93a0da0c6d1ae92aa738"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.4.15)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Arbitrary File Deletion",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "com.thoughtworks.xstream:xstream@1.4.14"
+      ],
+      "upgradePath": [
+        false,
+        "com.thoughtworks.xstream:xstream@1.4.15"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "com.thoughtworks.xstream:xstream",
+      "version": "1.4.14"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2020-12-16T11:07:48.518257Z",
+      "credit": [
+        "Liaogui Zhong"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[com.thoughtworks.xstream:xstream](https://x-stream.github.io/) is a simple library to serialize objects to XML and back again.\n\nAffected versions of this package are vulnerable to Server-Side Request Forgery (SSRF). A remote attacker can request data from internal resources that are not publicly available by manipulating the processed input stream.\r\n\r\n*Note:* This vulnerability does not exist running Java 15 or higher, and is only relevant when using `XStream`'s default blacklist.\n## Remediation\nUpgrade `com.thoughtworks.xstream:xstream` to version 1.4.15 or higher.\n## References\n- [CVE-2020-26258 Details](https://x-stream.github.io/CVE-2020-26258.html)\n- [GitHub Advisory](https://github.com/x-stream/xstream/security/advisories/GHSA-4cch-wxpw-8p28)\n- [GitHub Commit](https://github.com/x-stream/xstream/commit/6740c04b217aef02d44fba26402b35e0f6f493ce)\n",
+      "disclosureTime": "2020-12-16T11:01:34Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.4.15"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051967",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-26258"
+        ],
+        "CWE": [
+          "CWE-918"
+        ],
+        "GHSA": [
+          "GHSA-4cch-wxpw-8p28"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xstream",
+        "groupId": "com.thoughtworks.xstream"
+      },
+      "modificationTime": "2020-12-16T17:24:55.566174Z",
+      "moduleName": "com.thoughtworks.xstream:xstream",
+      "packageManager": "maven",
+      "packageName": "com.thoughtworks.xstream:xstream",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-12-16T17:24:55Z",
+      "references": [
+        {
+          "title": "CVE-2020-26258 Details",
+          "url": "https://x-stream.github.io/CVE-2020-26258.html"
+        },
+        {
+          "title": "GitHub Advisory",
+          "url": "https://github.com/x-stream/xstream/security/advisories/GHSA-4cch-wxpw-8p28"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/x-stream/xstream/commit/6740c04b217aef02d44fba26402b35e0f6f493ce"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.4.15)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Server-Side Request Forgery (SSRF)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "com.thoughtworks.xstream:xstream@1.4.14"
+      ],
+      "upgradePath": [
+        false,
+        "com.thoughtworks.xstream:xstream@1.4.15"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "com.thoughtworks.xstream:xstream",
+      "version": "1.4.14"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-04-10T16:07:04.634619Z",
+      "credit": [
+        "Mario Areias"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[dom4j:dom4j](https://github.com/dom4j/dom4j) is a flexible XML framework for Java. *Note*: this artifact has been deprecated for `org.dom4j:dom4j`.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection due to not validating the `QName` inputs.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `dom4j:dom4j`.\n## References\n- [GitHub Commit](https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387)\n- [GitHub Issue](https://github.com/dom4j/dom4j/issues/48)\n- [Ihacktoprotect Blog](https://ihacktoprotect.com/post/dom4j-xml-injection/)\n",
+      "disclosureTime": "2018-07-01T19:12:29Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [
+        {
+          "functionId": {
+            "className": "Namespace",
+            "filePath": "org/dom4j/Namespace.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "QName",
+            "filePath": "org/dom4j/QName.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.dom4j.Namespace",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.dom4j.QName",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-DOM4J-174153",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-1000632"
+        ],
+        "CWE": [
+          "CWE-611"
+        ],
+        "GHSA": [
+          "GHSA-6pcc-3rfx-4gpm"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "dom4j",
+        "groupId": "dom4j"
+      },
+      "modificationTime": "2020-09-21T06:25:14.227405Z",
+      "moduleName": "dom4j:dom4j",
+      "packageManager": "maven",
+      "packageName": "dom4j:dom4j",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2018-08-21T14:16:13Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/dom4j/dom4j/issues/48"
+        },
+        {
+          "title": "Ihacktoprotect Blog",
+          "url": "https://ihacktoprotect.com/post/dom4j-xml-injection/"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.maven.plugins:maven-archetype-plugin@3.0.1",
+        "org.apache.maven.archetype:archetype-common@3.0.1",
+        "dom4j:dom4j@1.6.1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "dom4j:dom4j",
+      "version": "1.6.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:A/AC:H/PR:L/UI:R/S:U/C:H/I:L/A:L/E:U/RL:U/RC:R",
+      "alternativeIds": [],
+      "creationTime": "2020-11-20T15:44:58.900719Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n[io.netty:netty-handler](https://github.com/netty/netty.git/netty-handler) is a library that provides an asynchronous event-driven network application framework and tools for rapid development of maintainable high performance and high scalability protocol servers and clients. In other words, Netty is a NIO client server framework which enables quick and easy development of network applications such as protocol servers and clients. It greatly simplifies and streamlines network programming such as TCP and UDP socket server.\n\nAffected versions of this package are vulnerable to Improper Certificate Validation. Certificate hostname validation is disabled by default in `Netty 4.1.x` which makes it potentially susceptible to Man-in-the-Middle attacks.\n## Remediation\nThere is no fixed version for `io.netty:netty-handler`.\n## References\n- [GitHub Issue 1](https://github.com/netty/netty/issues/10806)\n- [GitHub Issue 2](https://github.com/netty/netty/issues/8537)\n- [GitHub Issue 2](https://github.com/netty/netty/issues/9930)\n- [GitHub Issue 3](https://github.com/netty/netty/issues/10362)\n",
+      "disclosureTime": "2020-11-19T07:07:57Z",
+      "exploit": "Unproven",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-IONETTY-1042268",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-295"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "netty-handler",
+        "groupId": "io.netty"
+      },
+      "modificationTime": "2020-11-20T16:24:16.887977Z",
+      "moduleName": "io.netty:netty-handler",
+      "packageManager": "maven",
+      "packageName": "io.netty:netty-handler",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-11-20T16:24:17.093861Z",
+      "references": [
+        {
+          "title": "GitHub Issue 1",
+          "url": "https://github.com/netty/netty/issues/10806"
+        },
+        {
+          "title": "GitHub Issue 2",
+          "url": "https://github.com/netty/netty/issues/8537"
+        },
+        {
+          "title": "GitHub Issue 2",
+          "url": "https://github.com/netty/netty/issues/9930"
+        },
+        {
+          "title": "GitHub Issue 3",
+          "url": "https://github.com/netty/netty/issues/10362"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[4.1.0.Final,]"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Improper Certificate Validation",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.infinispan:infinispan-client-hotrod@9.4.19.Final-redhat-00001",
+        "io.netty:netty-handler@4.1.53.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "io.netty:netty-handler",
+      "version": "4.1.53.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-06-18T15:47:31.144561Z",
+      "credit": [
+        "Marcio Almeida de Macedo"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[log4j:log4j](https://github.com/apache/log4j) is a the 1.x branch of the Apache Log4j project.\n\nAffected versions of this package are vulnerable to Deserialization of Untrusted Data. Included in Log4j 1.2 is a SocketServer class that is vulnerable to deserialization of untrusted data which can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data.\n\n## Details\n\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\n  \nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n  \n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n\n- Apache Blog\n  \n## Remediation\nThere is no fixed version for `log4j:log4j`.\n## References\n- [Apache Security Advisory](https://lists.apache.org/thread.html/eea03d504b36e8f870e8321d908e1def1addda16adda04327fe7c125%40%3Cdev.logging.apache.org%3E)\n",
+      "disclosureTime": "2019-12-22T09:33:11Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-LOG4J-572732",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-17571"
+        ],
+        "CWE": [
+          "CWE-502"
+        ],
+        "GHSA": [
+          "GHSA-2qrg-x229-3v8q"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "log4j",
+        "groupId": "log4j"
+      },
+      "modificationTime": "2020-06-18T15:49:24.565924Z",
+      "moduleName": "log4j:log4j",
+      "packageManager": "maven",
+      "packageName": "log4j:log4j",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-06-19T09:33:01Z",
+      "references": [
+        {
+          "title": "Apache Security Advisory",
+          "url": "https://lists.apache.org/thread.html/eea03d504b36e8f870e8321d908e1def1addda16adda04327fe7c125%40%3Cdev.logging.apache.org%3E"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Deserialization of Untrusted Data",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "log4j:log4j@1.2.16"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "log4j:log4j",
+      "version": "1.2.16"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-05-29T08:50:11.153150Z",
+      "credit": [
+        "Charles Duffy"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[org.apache.maven.shared:maven-shared-utils](https://maven.apache.org/shared/maven-shared-utils/) is a functional replacement for plexus-utils in Maven.\n\nAffected versions of this package are vulnerable to Command Injection. The `Commandline` class can emit double-quoted strings without proper escaping, allowing shell injection attacks. The `BourneShell` class should unconditionally single-quote emitted strings (including the name of the command itself being quoted), with `{{'\"'\"'}}` used for embedded single quotes, for maximum safety across shells implementing a superset of POSIX quoting rules. \r\n\r\nThis is a similar issue to [`SNYK-JAVA-ORGCODEHAUSPLEXUS-31522`](https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31522)\n## Remediation\nUpgrade `org.apache.maven.shared:maven-shared-utils` to version 3.3.3 or higher.\n## References\n- [Apache Jira Issue](https://issues.apache.org/jira/browse/MSHARED-297)\n- [GitHub PR](https://github.com/apache/maven-shared-utils/pull/40/files)\n",
+      "disclosureTime": "2020-05-29T08:43:40Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.3.3"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHEMAVENSHARED-570592",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-77"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "maven-shared-utils",
+        "groupId": "org.apache.maven.shared"
+      },
+      "modificationTime": "2020-08-05T13:31:08.299214Z",
+      "moduleName": "org.apache.maven.shared:maven-shared-utils",
+      "packageManager": "maven",
+      "packageName": "org.apache.maven.shared:maven-shared-utils",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-06-22T17:01:48Z",
+      "references": [
+        {
+          "title": "Apache Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/MSHARED-297"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/apache/maven-shared-utils/pull/40/files"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,3.3.3)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Command Injection",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.maven.shared:maven-verifier@1.6",
+        "org.apache.maven.shared:maven-shared-utils@0.8"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.maven.shared:maven-shared-utils",
+      "version": "0.8"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
+      "alternativeIds": [],
+      "creationTime": "2019-08-25T13:02:11.461178Z",
+      "credit": [
+        "Sean Mullan"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.apache.santuario:xmlsec](https://mvnrepository.com/artifact/org.apache.santuario/xmlsec) is a package to provide implementation of the primary security standards for XML, XML-Signature Syntax and Processing and XML Encryption Syntax and Processing.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. In version 2.0.3 a caching mechanism was introduced to speed up creating new XML documents using a static pool of DocumentBuilders. However, if some untrusted code can register a malicious implementation with the thread context class loader first, then this implementation might be cached and re-used by Apache Santuario - XML Security for Java, leading to potential security flaws when validating signed documents, etc.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387cdba6)\n- [GitHub Commit](https://github.com/apache/santuario-java/commit/c5210f77a77105fba81311d16c07ceacc21f39d5)\n- [Possible Jira Issue](https://issues.apache.org/jira/browse/SANTUARIO-504?jql=project%20%3D%20SANTUARIO)\n- [Security Release](http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2)\n",
+      "disclosureTime": "2019-05-10T21:50:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.1.4"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESANTUARIO-460281",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-12400"
+        ],
+        "CWE": [
+          "CWE-611"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xmlsec",
+        "groupId": "org.apache.santuario"
+      },
+      "modificationTime": "2020-06-12T14:36:59.920320Z",
+      "moduleName": "org.apache.santuario:xmlsec",
+      "packageManager": "maven",
+      "packageName": "org.apache.santuario:xmlsec",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-08-25T13:53:19Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387cdba6"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/santuario-java/commit/c5210f77a77105fba81311d16c07ceacc21f39d5"
+        },
+        {
+          "title": "Possible Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/SANTUARIO-504?jql=project%20%3D%20SANTUARIO"
+        },
+        {
+          "title": "Security Release",
+          "url": "http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.3, 2.1.4)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.santuario:xmlsec@2.1.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.santuario:xmlsec@2.1.4"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.apache.santuario:xmlsec",
+      "version": "2.1.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2018-10-12T12:12:08.269164Z",
+      "credit": [
+        "Alvaro Munoz",
+        "Christian Schneider"
+      ],
+      "cvssScore": 8.1,
+      "description": "## Overview\n[org.beanshell:bsh](https://mvnrepository.com/artifact/org.beanshell/bsh) is a Java source interpreter with object scripting language features, written in Java.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution during Deserialization. When included on the `classpat` by an application that uses Java serialization or XStream, A remote attacker could execute arbitrary code via crafted serialized data, related to XThis.Handler.\n## Remediation\nThere is no fixed version for `org.beanshell:bsh`.\n## References\n- [CVE Details](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2510)\n- [GitHub Commit](https://github.com/beanshell/beanshell/commit/1ccc66bb693d4e46a34a904db8eeff07808d2ced)\n- [GitHub Commit](https://github.com/beanshell/beanshell/commit/7c68fde2d6fc65e362f20863d868c112a90a9b49)\n- [GitHub Release](https://github.com/beanshell/beanshell/releases/tag/2.0b6)\n- [RedHat CVE Database](https://access.redhat.com/security/cve/cve-2016-2510)\n- [RSA Conference Presentation](https://www.rsaconference.com/writable/presentations/file_upload/asd-f03-serial-killer-silently-pwning-your-java-endpoints.pdf)\n",
+      "disclosureTime": "2016-02-22T16:51:56Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGBEANSHELL-72452",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-2510"
+        ],
+        "CWE": [
+          "CWE-502"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "bsh",
+        "groupId": "org.beanshell"
+      },
+      "modificationTime": "2020-06-24T13:50:41.680495Z",
+      "moduleName": "org.beanshell:bsh",
+      "packageManager": "maven",
+      "packageName": "org.beanshell:bsh",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-02-22T16:51:56Z",
+      "references": [
+        {
+          "title": "CVE Details",
+          "url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2510"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/beanshell/beanshell/commit/1ccc66bb693d4e46a34a904db8eeff07808d2ced"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/beanshell/beanshell/commit/7c68fde2d6fc65e362f20863d868c112a90a9b49"
+        },
+        {
+          "title": "GitHub Release",
+          "url": "https://github.com/beanshell/beanshell/releases/tag/2.0b6"
+        },
+        {
+          "title": "RedHat CVE Database",
+          "url": "https://access.redhat.com/security/cve/cve-2016-2510"
+        },
+        {
+          "title": "RSA Conference Presentation",
+          "url": "https://www.rsaconference.com/writable/presentations/file_upload/asd-f03-serial-killer-silently-pwning-your-java-endpoints.pdf"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Arbitrary Code Execution during Deserialization",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.maven.plugins:maven-archetype-plugin@3.0.1",
+        "org.apache.maven.shared:maven-script-interpreter@1.0",
+        "org.beanshell:bsh@2.0b4"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.beanshell:bsh",
+      "version": "2.0b4"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2020-12-06T14:48:02.848508Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[org.codehaus.groovy:groovy](https://mvnrepository.com/artifact/org.codehaus.groovy/groovy) is a language for the JVM\n\nAffected versions of this package are vulnerable to Information Disclosure. Groovy may create temporary directories within the OS temporary directory which is shared\r\nbetween all users on affected systems. This vulnerability only impacts Unix-like systems, and very old\r\nversions of Mac OSX and Windows.\n## Remediation\nUpgrade `org.codehaus.groovy:groovy` to version 2.4.21, 2.5.14, 3.0.7, 4.0.0-alpha-2 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/groovy/commit/bcbe5c4c76db83736166530647c024ac1e47ef28)\n- [Jira Issue](https://issues.apache.org/jira/browse/GROOVY-9824)\n",
+      "disclosureTime": "2020-12-06T14:40:52Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.4.21",
+        "2.5.14",
+        "3.0.7",
+        "4.0.0-alpha-2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGCODEHAUSGROOVY-1048694",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-17521"
+        ],
+        "CWE": [
+          "CWE-379"
+        ],
+        "GHSA": [
+          "GHSA-rcjj-h6gh-jf3r"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "groovy",
+        "groupId": "org.codehaus.groovy"
+      },
+      "modificationTime": "2020-12-06T16:34:08.631471Z",
+      "moduleName": "org.codehaus.groovy:groovy",
+      "packageManager": "maven",
+      "packageName": "org.codehaus.groovy:groovy",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-12-06T16:34:08Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/groovy/commit/bcbe5c4c76db83736166530647c024ac1e47ef28"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/GROOVY-9824"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[, 2.4.21)",
+          "[2.5.0, 2.5.14)",
+          "[3.0.0, 3.0.7)",
+          "[4.0.0-alpha-1, 4.0.0-alpha-2)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Information Disclosure",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.maven.plugins:maven-archetype-plugin@3.0.1",
+        "org.apache.maven.archetype:archetype-common@3.0.1",
+        "org.codehaus.groovy:groovy@2.5.13"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.codehaus.groovy:groovy",
+      "version": "2.5.13"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-11-19T11:44:30.225935Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.9,
+      "description": "## Overview\n\n[org.codehaus.jackson:jackson-mapper-asl](https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-mapper-asl) is a high-performance data binding package built on Jackson JSON processor.\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nMultiple classes including  `XmlMapper` was found to be vulnerabiltiy to XXE, which might allow attackers to have unspecified impact via unknown vectors.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n\n## Remediation\nThere is no fixed version for `org.codehaus.jackson:jackson-mapper-asl`. \n\nFor `org.codehaus.jackson:jackson-all` releases supporting `jackson-mapper-asl`. As a workaround, for 1.9.X release, the `javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING` setting can be enabled. For 2.x releases, the `\"javax.xml.stream.isSupportingExternalEntities` setting can be set to `FALSE`.\n\n## References\n\n- [CVE-2019-10172 Remediation for Jackson Databind](https://github.com/FasterXML/jackson-databind/issues/2547)\n\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1715075)\n\n- [StackOverflow CVE-2016-3720 Remediation -  jackson-all](https://stackoverflow.com/questions/38017676/small-fix-for-cve-2016-3720-with-older-versions-of-jackson-all-1-9-11-and-in-ja)\n",
+      "disclosureTime": "2019-11-18T00:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [
+        {
+          "functionId": {
+            "className": "DOMDeserializer",
+            "filePath": "org/codehaus/jackson/map/ext/DOMDeserializer.java",
+            "functionName": "parse"
+          },
+          "version": [
+            "(1.6.0,]"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.codehaus.jackson.map.ext.DOMDeserializer",
+            "functionName": "parse"
+          },
+          "version": [
+            "(1.6.0,]"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGCODEHAUSJACKSON-534878",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-10172"
+        ],
+        "CWE": [
+          "CWE-611"
+        ],
+        "GHSA": [
+          "GHSA-r6j9-8759-g62w"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jackson-mapper-asl",
+        "groupId": "org.codehaus.jackson"
+      },
+      "modificationTime": "2020-10-26T12:21:54.981287Z",
+      "moduleName": "org.codehaus.jackson:jackson-mapper-asl",
+      "packageManager": "maven",
+      "packageName": "org.codehaus.jackson:jackson-mapper-asl",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-11-19T11:56:32Z",
+      "references": [
+        {
+          "title": "CVE-2019-10172 Remediation for Jackson Databind",
+          "url": "https://github.com/FasterXML/jackson-databind/issues/2547"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1715075"
+        },
+        {
+          "title": "StackOverflow CVE-2016-3720 Remediation -  jackson-all",
+          "url": "https://stackoverflow.com/questions/38017676/small-fix-for-cve-2016-3720-with-older-versions-of-jackson-all-1-9-11-and-in-ja"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.avro:avro@1.8.1",
+        "org.codehaus.jackson:jackson-mapper-asl@1.9.13"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.codehaus.jackson:jackson-mapper-asl",
+      "version": "1.9.13"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2018-05-30T12:32:02.349000Z",
+      "credit": [
+        "Snyk Security research Team"
+      ],
+      "cvssScore": 5.5,
+      "description": "## Overview\r\n[`org.codehaus.plexus:plexus-archiver`](https://github.com/codehaus-plexus/plexus-archiver) is a Collection of Plexus components to create archives or extract files out of an archive to a directory with a unified Archiver/UnArchiver API whatever the archive format is.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip \r\nSlip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n \r\n## Remediation\r\nUpgrade `org.codehaus.plexus:plexus-archiver`to version 3.6.0 or higher.\n\n## References\n- [GitHub Commit](https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8)\n- [GitHub PR](https://github.com/codehaus-plexus/plexus-archiver/pull/87)\n- [Zip Slip Advisory](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+      "disclosureTime": "2018-04-17T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.6.0"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "AbstractUnArchiver",
+            "filePath": "org/codehaus/plexus/archiver/AbstractUnArchiver.java",
+            "functionName": "extract"
+          },
+          "version": [
+            "[,2.5.0)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "AbstractUnArchiver",
+            "filePath": "org/codehaus/plexus/archiver/AbstractUnArchiver.java",
+            "functionName": "extractFile"
+          },
+          "version": [
+            "[2.5.0, 3.6.0)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.codehaus.plexus.archiver.AbstractUnArchiver",
+            "functionName": "extract"
+          },
+          "version": [
+            "[,2.5.0)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.codehaus.plexus.archiver.AbstractUnArchiver",
+            "functionName": "extractFile"
+          },
+          "version": [
+            "[2.5.0, 3.6.0)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGCODEHAUSPLEXUS-31680",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-1002200"
+        ],
+        "CWE": [
+          "CWE-29"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "plexus-archiver",
+        "groupId": "org.codehaus.plexus"
+      },
+      "modificationTime": "2020-06-09T09:57:45.872255Z",
+      "moduleName": "org.codehaus.plexus:plexus-archiver",
+      "packageManager": "maven",
+      "packageName": "org.codehaus.plexus:plexus-archiver",
+      "patches": [],
+      "proprietary": true,
+      "publicationTime": "2018-05-31T07:32:02Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/codehaus-plexus/plexus-archiver/pull/87"
+        },
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://github.com/snyk/zip-slip-vulnerability"
+        },
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,3.6.0)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.maven.plugin-testing:maven-plugin-testing-harness@3.3.0",
+        "org.codehaus.plexus:plexus-archiver@2.2"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.codehaus.plexus:plexus-archiver",
+      "version": "2.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2020-09-21T07:39:43.834436Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[org.jboss.resteasy:resteasy-client](https://search.maven.org/artifact/org.jboss.resteasy/resteasy-client/4.5.7.Final/jar) is a RESTEasy JAX-RS Client\n\nAffected versions of this package are vulnerable to Information Exposure. It may allow client users to obtain the server's potentially sensitive information when the server got `WebApplicationException` from the RESTEasy client call.\n## Remediation\nUpgrade `org.jboss.resteasy:resteasy-client` to version 4.5.8.SP1 or higher.\n## References\n- [GitHub Commit](https://github.com/resteasy/Resteasy/commit/5c7757b6dc8972e51b6f7e97e7d2faed3378f280)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-25633)\n",
+      "disclosureTime": "2020-09-21T07:15:23Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.5.8.SP1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGJBOSSRESTEASY-1009963",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-25633"
+        ],
+        "CWE": [
+          "CWE-200"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "resteasy-client",
+        "groupId": "org.jboss.resteasy"
+      },
+      "modificationTime": "2021-01-11T10:22:31.571085Z",
+      "moduleName": "org.jboss.resteasy:resteasy-client",
+      "packageManager": "maven",
+      "packageName": "org.jboss.resteasy:resteasy-client",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-09-21T11:51:25Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/resteasy/Resteasy/commit/5c7757b6dc8972e51b6f7e97e7d2faed3378f280"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2020-25633"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,4.5.8.SP1)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Information Exposure",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.jboss.resteasy:resteasy-client@3.1.1.Final"
+      ],
+      "upgradePath": [
+        false,
+        "org.jboss.resteasy:resteasy-client@4.5.8.SP1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.jboss.resteasy:resteasy-client",
+      "version": "3.1.1.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2020-01-19T12:02:38.132243Z",
+      "credit": [
+        "Jason Shepherd"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[org.jboss.resteasy:resteasy-jaxrs](https://mvnrepository.com/artifact/org.jboss.resteasy/resteasy-jaxrs) is a JCP specification that provides a Java API for RESTful Web Services over the HTTP protocol.\n\nAffected versions of this package are vulnerable to HTTP Request Smuggling. It was discovered that the CORS Filter did not add an HTTP Vary header indicating that the response varies depending on Origin. This permitted client and server side cache poisoning in some circumstances.\n## Remediation\nUpgrade `org.jboss.resteasy:resteasy-jaxrs` to version 3.5.0.CR1, 3.0.25.Final or higher.\n## References\n- [GitHub PR](https://github.com/resteasy/Resteasy/pull/1258/files)\n- [Jira Issue](https://issues.redhat.com/browse/RESTEASY-1704)\n- [Stack Overflow Question](https://stackoverflow.com/questions/29388937/problems-resteasy-3-09-corsfilter/29390508#29390508)\n",
+      "disclosureTime": "2017-08-22T11:55:58Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.5.0.CR1",
+        "3.0.25.Final"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGJBOSSRESTEASY-542664",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-7561"
+        ],
+        "CWE": [
+          "CWE-444"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "resteasy-jaxrs",
+        "groupId": "org.jboss.resteasy"
+      },
+      "modificationTime": "2020-06-12T14:37:03.988135Z",
+      "moduleName": "org.jboss.resteasy:resteasy-jaxrs",
+      "packageManager": "maven",
+      "packageName": "org.jboss.resteasy:resteasy-jaxrs",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-01-19T11:55:50Z",
+      "references": [
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/resteasy/Resteasy/pull/1258/files"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.redhat.com/browse/RESTEASY-1704"
+        },
+        {
+          "title": "Stack Overflow Question",
+          "url": "https://stackoverflow.com/questions/29388937/problems-resteasy-3-09-corsfilter/29390508%2329390508"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[3.1.0.Beta1,3.5.0.CR1)",
+          "[,3.0.25.Final)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "HTTP Request Smuggling",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.jboss.resteasy:resteasy-client@3.1.1.Final",
+        "org.jboss.resteasy:resteasy-jaxrs@3.1.1.Final"
+      ],
+      "upgradePath": [
+        false,
+        "org.jboss.resteasy:resteasy-client@3.5.0.Final",
+        "org.jboss.resteasy:resteasy-jaxrs@3.5.0.Final"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.jboss.resteasy:resteasy-jaxrs",
+      "version": "3.1.1.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2020-09-02T13:26:31.339885Z",
+      "credit": [
+        "Mirko Selber"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[org.jboss.resteasy:resteasy-jaxrs](https://mvnrepository.com/artifact/org.jboss.resteasy/resteasy-jaxrs) is a JCP specification that provides a Java API for RESTful Web Services over the HTTP protocol.\n\nAffected versions of this package are vulnerable to Improper Input Validation in `MediaTypeHeaderDelegate.java` class results in the class returning an illegal header that will be then integrated in the server's response.\n## Remediation\nUpgrade `org.jboss.resteasy:resteasy-jaxrs` to version 3.11.0.Final or higher.\n## References\n- [GitHub Commit](https://github.com/resteasy/Resteasy/commit/acf15f2a8067f7e4cf5838342cecfa0b78a174fb)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1730462)\n",
+      "disclosureTime": "2019-07-17T09:42:55Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.11.0.Final"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "MediaTypeHeaderDelegate",
+            "filePath": "org/jboss/resteasy/plugins/delegates/MediaTypeHeaderDelegate.java",
+            "functionName": "isValid"
+          },
+          "version": [
+            "[,3.11.0.Final)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.jboss.resteasy.plugins.delegates.MediaTypeHeaderDelegate",
+            "functionName": "isValid"
+          },
+          "version": [
+            "[,3.11.0.Final)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGJBOSSRESTEASY-609370",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-1695"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "resteasy-jaxrs",
+        "groupId": "org.jboss.resteasy"
+      },
+      "modificationTime": "2020-09-30T16:27:45.201326Z",
+      "moduleName": "org.jboss.resteasy:resteasy-jaxrs",
+      "packageManager": "maven",
+      "packageName": "org.jboss.resteasy:resteasy-jaxrs",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-04-16T15:22:50Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/resteasy/Resteasy/commit/acf15f2a8067f7e4cf5838342cecfa0b78a174fb"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1730462"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,3.11.0.Final)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Improper Input Validation",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.jboss.resteasy:resteasy-client@3.1.1.Final",
+        "org.jboss.resteasy:resteasy-jaxrs@3.1.1.Final"
+      ],
+      "upgradePath": [
+        false,
+        "org.jboss.resteasy:resteasy-client@3.11.0.Final",
+        "org.jboss.resteasy:resteasy-jaxrs@3.11.0.Final"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.jboss.resteasy:resteasy-jaxrs",
+      "version": "3.1.1.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:53Z",
+      "credit": [
+        "Kaspar Brand"
+      ],
+      "cvssScore": 4.8,
+      "description": "## Overview\n\n[org.opensaml:opensaml](https://mvnrepository.com/artifact/org.opensaml/opensaml) provides tools to support developers working with the Security Assertion Markup Language (SAML).\n\n\nAffected versions of this package are vulnerable to Improper Certificate Validation.\n`HttpResource` and `FileBackedHttpResource` implementations in OpenSAML Java and Shibboleth IdP did not enable hostname verification when using TLS connections. Additionaly, OpenSAML Java makes use of Jakarta Commons HttpClient version 3.x, which does not perform verification of the server hostname against the server's X.508 certificate ([CVE-2012-5783](https://snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-30083)). This flaw can be exploited by a Man-in-the-middle (MITM) attack, where the attacker can spoof a valid certificate using a specially crafted subject.\n\n## Remediation\n\nUpgrade `org.opensaml:opensaml` to version 2.6.2 or higher.\n\n\n## References\n\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2014-3603)\n\n- [Shibboleth Advisory](http://shibboleth.net/community/advisories/secadv_20140813.txt)\n",
+      "disclosureTime": "2016-12-25T16:51:53Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.6.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGOPENSAML-30140",
+      "identifiers": {
+        "CVE": [
+          "CVE-2014-3603"
+        ],
+        "CWE": [
+          "CWE-94"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "opensaml",
+        "groupId": "org.opensaml"
+      },
+      "modificationTime": "2019-06-12T12:57:28.683262Z",
+      "moduleName": "org.opensaml:opensaml",
+      "packageManager": "maven",
+      "packageName": "org.opensaml:opensaml",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-12-25T16:51:53Z",
+      "references": [
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/CVE-2014-3603"
+        },
+        {
+          "title": "Shibboleth Advisory",
+          "url": "http://shibboleth.net/community/advisories/secadv_20140813.txt"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0,2.6.2)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Improper Certificate Validation",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.ws.security:wss4j@1.6.19",
+        "org.opensaml:opensaml@2.5.1-1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.opensaml:opensaml",
+      "version": "2.5.1-1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:30.660000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n\n[org.opensaml:opensaml](https://mvnrepository.com/artifact/org.opensaml/opensaml) provides tools to support developers working with the Security Assertion Markup Language (SAML).\n\n\nAffected versions of this package are vulnerable to Information Exposure.\nThe (1) BasicParserPool, (2) StaticBasicParserPool, (3) XML Decrypter, and (4) SAML Decrypter set the `expandEntityReferences` property to true, which allows remote attackers to conduct XML external entity (XXE) attacks via a crafted XML `DOCTYPE` declaration.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\n\nUpgrade `org.opensaml:opensaml` to version 2.6.1 or higher.\n\n\n## References\n\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-6440)\n\n- [Security Advisory](http://shibboleth.net/community/advisories/secadv_20131213.txt)\n",
+      "disclosureTime": "2014-02-14T15:55:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.6.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGOPENSAML-31267",
+      "identifiers": {
+        "CVE": [
+          "CVE-2013-6440"
+        ],
+        "CWE": [
+          "CWE-200"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "opensaml",
+        "groupId": "org.opensaml"
+      },
+      "modificationTime": "2019-10-28T09:24:49.854583Z",
+      "moduleName": "org.opensaml:opensaml",
+      "packageManager": "maven",
+      "packageName": "org.opensaml:opensaml",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2014-06-08T00:15:08Z",
+      "references": [
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-6440"
+        },
+        {
+          "title": "Security Advisory",
+          "url": "http://shibboleth.net/community/advisories/secadv_20131213.txt"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.6.1)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Information Exposure",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.ws.security:wss4j@1.6.19",
+        "org.opensaml:opensaml@2.5.1-1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.opensaml:opensaml",
+      "version": "2.5.1-1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:30.673000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 4.3,
+      "description": "## Overview\n[`org.opensaml:opensaml`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22opensaml%22)\nThe PKIX trust engines in Shibboleth Identity Provider before 2.4.4 and OpenSAML Java (OpenSAML-J) before 2.6.5 trust candidate X.509 credentials when no trusted names are available for the entityID, which allows remote attackers to impersonate an entity via a certificate issued by a shibmd:KeyAuthority trust anchor.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1796)",
+      "disclosureTime": "2015-07-08T15:59:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.6.5"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGOPENSAML-31268",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-1796"
+        ],
+        "CWE": [
+          "CWE-254"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "opensaml",
+        "groupId": "org.opensaml"
+      },
+      "modificationTime": "2019-06-12T12:56:26.492153Z",
+      "moduleName": "org.opensaml:opensaml",
+      "packageManager": "maven",
+      "packageName": "org.opensaml:opensaml",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2015-07-09T16:43:51Z",
+      "references": [
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1796"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.6.5)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Improper Certificate Validation",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.ws.security:wss4j@1.6.19",
+        "org.opensaml:opensaml@2.5.1-1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.opensaml:opensaml",
+      "version": "2.5.1-1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:50Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n\n[org.opensaml:xmltooling](https://svn.middleware.georgetown.edu/view/?root=java-opensaml2) low-level library that may be used to construct libraries that allow developers to work with XML in a Java beans manner.\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nThe (1) BasicParserPool, (2) StaticBasicParserPool, (3) XML Decrypter, and (4) SAML Decrypter set the `expandEntityReferences` property to true, which allows remote attackers to conduct XML external entity (XXE) attacks via a crafted XML `DOCTYPE` declaration.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\n\nUpgrade `org.opensaml:xmltooling` to version 1.4.4 or higher.\n\n\n## References\n\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2013-6440)\n\n- [SendSafely Blog](https://blog.sendsafely.com/web-based-single-sign-on-and-the-dangers-of-saml-xml-parsing)\n",
+      "disclosureTime": "2014-02-14T15:55:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.4.4"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGOPENSAML-30141",
+      "identifiers": {
+        "CVE": [
+          "CVE-2013-6440"
+        ],
+        "CWE": [
+          "CWE-611"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xmltooling",
+        "groupId": "org.opensaml"
+      },
+      "modificationTime": "2019-10-28T09:25:20.166092Z",
+      "moduleName": "org.opensaml:xmltooling",
+      "packageManager": "maven",
+      "packageName": "org.opensaml:xmltooling",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-12-25T16:51:50Z",
+      "references": [
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/CVE-2013-6440"
+        },
+        {
+          "title": "SendSafely Blog",
+          "url": "https://blog.sendsafely.com/web-based-single-sign-on-and-the-dangers-of-saml-xml-parsing"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.4.4)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.ws.security:wss4j@1.6.19",
+        "org.opensaml:opensaml@2.5.1-1",
+        "org.opensaml:openws@1.4.2-1",
+        "org.opensaml:xmltooling@1.3.2-1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.opensaml:xmltooling",
+      "version": "1.3.2-1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-11-21T08:28:01.581000Z",
+      "credit": [
+        "Rajesh Veerappan"
+      ],
+      "cvssScore": 6.1,
+      "description": "## Overview\n\n[org.owasp.antisamy:antisamy](https://mvnrepository.com/artifact/org.owasp.antisamy/antisamy) is a library for performing fast, configurable cleansing of HTML coming from untrusted sources.\n\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS)\nvia HTML5 entities, as demonstrated by use of `&colon;` to construct a javascript: URL.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\n\nUpgrade `org.owasp.antisamy:antisamy` to version 1.5.7 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/nahsra/antisamy/commit/82da009e733a989a57190cd6aa1b6824724f6d36)\n\n- [GitHub Issue](https://github.com/nahsra/antisamy/issues/10)\n",
+      "disclosureTime": "2017-07-05T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.5.7"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGOWASPANTISAMY-31591",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-14735"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "antisamy",
+        "groupId": "org.owasp.antisamy"
+      },
+      "modificationTime": "2018-12-30T11:24:02.966053Z",
+      "moduleName": "org.owasp.antisamy:antisamy",
+      "packageManager": "maven",
+      "packageName": "org.owasp.antisamy:antisamy",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-11-28T14:47:21Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/nahsra/antisamy/commit/82da009e733a989a57190cd6aa1b6824724f6d36"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/nahsra/antisamy/issues/10"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.5.7)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "org.owasp.antisamy:antisamy@1.4.3"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.2.0.0",
+        "org.owasp.antisamy:antisamy@1.5.8"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.owasp.antisamy:antisamy",
+      "version": "1.4.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2020-08-16T11:47:59.089849Z",
+      "credit": [
+        "Vivek Krishna"
+      ],
+      "cvssScore": 6.1,
+      "description": "## Overview\n[org.owasp.antisamy:antisamy](https://mvnrepository.com/artifact/org.owasp.antisamy/antisamy) is a library for performing fast, configurable cleansing of HTML coming from untrusted sources.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via `<style>` tag in `MagixSAXFilter.java`.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.owasp.antisamy:antisamy` to version 1.5.5 or higher.\n## References\n- [GitHub Commit](https://github.com/nahsra/antisamy/commit/7313931dc3c0d1377b010f07faef2063dd359a36#commitcomment-41485849)\n- [GitHub Issue](https://github.com/nahsra/antisamy/issues/2)\n",
+      "disclosureTime": "2020-08-15T07:20:22Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.5.5"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGOWASPANTISAMY-598767",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-10006"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "antisamy",
+        "groupId": "org.owasp.antisamy"
+      },
+      "modificationTime": "2021-01-11T10:12:00.432660Z",
+      "moduleName": "org.owasp.antisamy:antisamy",
+      "packageManager": "maven",
+      "packageName": "org.owasp.antisamy:antisamy",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-08-16T12:11:43Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/nahsra/antisamy/commit/7313931dc3c0d1377b010f07faef2063dd359a36%23commitcomment-41485849"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/nahsra/antisamy/issues/2"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.5.5)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "org.owasp.antisamy:antisamy@1.4.3"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.2.0.0",
+        "org.owasp.antisamy:antisamy@1.5.8"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.owasp.antisamy:antisamy",
+      "version": "1.4.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:50Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.4,
+      "description": "## Overview\n\n[org.owasp.esapi:esapi](https://www.owasp.org/index.php/Category:OWASP_Enterprise_Security_API) is an OWASP project to create simple strong security controls for every web platform.\n\n\nAffected versions of this package are vulnerable to MAC validation Bypass.\nThe library does not properly resist tampering with serialized ciphertext, which makes it easier for remote attackers to bypass intended cryptographic protection mechanisms via an attack against the intended cipher mode in a non-default configuration, a different vulnerability than CVE-2013-5679.\n\n## Remediation\n\nUpgrade `org.owasp.esapi:esapi` to version 2.1.0.1 or higher.\n\n\n## References\n\n- [Kevin W. Wall Blog](http://off-the-wall-security.blogspot.ca/2014/03/esapi-no-longer-owasp-flagship-project.html)\n\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-5960)\n\n- [Synacktiv Vulnerability Description](http://www.synacktiv.com/ressources/synacktiv_owasp_esapi_hmac_bypass.pdf)\n",
+      "disclosureTime": "2013-09-30T17:09:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.1.0.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGOWASPESAPI-30143",
+      "identifiers": {
+        "CVE": [
+          "CVE-2013-5960"
+        ],
+        "CWE": [
+          "CWE-310"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "esapi",
+        "groupId": "org.owasp.esapi"
+      },
+      "modificationTime": "2019-10-24T08:33:20.631190Z",
+      "moduleName": "org.owasp.esapi:esapi",
+      "packageManager": "maven",
+      "packageName": "org.owasp.esapi:esapi",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-12-25T16:51:50Z",
+      "references": [
+        {
+          "title": "Kevin W. Wall Blog",
+          "url": "http://off-the-wall-security.blogspot.ca/2014/03/esapi-no-longer-owasp-flagship-project.html"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-5960"
+        },
+        {
+          "title": "Synacktiv Vulnerability Description",
+          "url": "http://www.synacktiv.com/ressources/synacktiv_owasp_esapi_hmac_bypass.pdf"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.1.0.1)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "MAC validation Bypass",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.1.0.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.owasp.esapi:esapi",
+      "version": "2.1.0"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2019-05-30T12:27:38.286112Z",
+      "credit": [
+        "JLLeitschuh"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n[org.testng:testng](https://mvnrepository.com/artifact/org.testng/testng) is a testing framework for the JVM.\n\nAffected versions of this package are vulnerable to Unsafe Dependency Resolution due to resolving dependencies over an insecure channel (http).\r\n\r\nIf the build occurred over an insecure connection, a malicious user could have perform a Man-in-the-Middle attack during the build and alter the build artifacts that were produced.\r\nIn case that any of these artifacts were compromised, any developers using these could be altered.\r\n \r\n**Note:** In order to validate that this artifact was not compromised, the maintainer would need to confirm that none of the artifacts published to the registry were not altered with. Until this happens, we can not guarantee that this artifact was not compromised even though the probability that this happened is low. \r\n\r\nWe have chosen to alert on this issue when maintainers either decided to issue CVEs themselves, or in cases when maintainers decided against performing audits on there build to verify they had not been compromised.\n## Remediation\nUpgrade `org.testng:testng` to version 7.0.0-beta4 or higher.\n## References\n- [GitHub Commit](https://github.com/cbeust/testng/commit/40ea46dfecafb58017b221f57e90942e361fcb8d)\n- [GitHub Issue](https://github.com/cbeust/testng/issues/2022)\n- [Jonathan Leitschuh's Blog](https://medium.com/@jonathan.leitschuh/1fc329d898fb)\n",
+      "disclosureTime": "2019-02-22T12:35:55Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "7.0.0-beta4"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGTESTNG-174823",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-494",
+          "CWE-829"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "testng",
+        "groupId": "org.testng"
+      },
+      "modificationTime": "2020-06-12T14:37:01.446129Z",
+      "moduleName": "org.testng:testng",
+      "packageManager": "maven",
+      "packageName": "org.testng:testng",
+      "patches": [],
+      "proprietary": true,
+      "publicationTime": "2019-06-11T11:42:38Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/cbeust/testng/commit/40ea46dfecafb58017b221f57e90942e361fcb8d"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/cbeust/testng/issues/2022"
+        },
+        {
+          "title": "Jonathan Leitschuh's Blog",
+          "url": "https://medium.com/@jonathan.leitschuh/1fc329d898fb"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,7.0.0-beta4)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Unsafe Dependency Resolution",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.testng:testng@6.13.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.testng:testng@7.0.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.testng:testng",
+      "version": "6.13.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-06-28T12:11:08.918250Z",
+      "credit": [
+        "Yonatan Offek (poiu)"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.webjars:bootstrap](https://mvnrepository.com/artifact/org.webjars/bootstrap) is a WebJar for Bootstrap.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) in` data-template`, `data-content ` and `data-title` properties of tooltip/popover.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.webjars:bootstrap` to version 3.4.1, 4.3.1 or higher.\n## References\n- [Bootstrap Blog](https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/)\n- [GitHub Commit](https://github.com/twbs/bootstrap/pull/28236/commits/5efa9b531d25927b907e3fa24b818608bc38a2f0)\n- [GitHub Commit](https://github.com/twbs/bootstrap-rubygem/commit/a63d04c96d14e42492ccdba1d7f3d6ec1af022a9)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/28236)\n- [NPM Security Adviory](https://www.npmjs.com/advisories/891)\n",
+      "disclosureTime": "2019-02-11T19:32:59Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.4.1",
+        "4.3.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-451160",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-8331"
+        ],
+        "CWE": [
+          "CWE-79"
+        ],
+        "GHSA": [
+          "GHSA-9v3m-8fp8-mj99"
+        ],
+        "NSP": [
+          891
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "bootstrap",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2020-06-12T14:36:55.846231Z",
+      "moduleName": "org.webjars:bootstrap",
+      "packageManager": "maven",
+      "packageName": "org.webjars:bootstrap",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-02-15T19:32:59Z",
+      "references": [
+        {
+          "title": "Bootstrap Blog",
+          "url": "https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/pull/28236/commits/5efa9b531d25927b907e3fa24b818608bc38a2f0"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap-rubygem/commit/a63d04c96d14e42492ccdba1d7f3d6ec1af022a9"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/28236"
+        },
+        {
+          "title": "NPM Security Adviory",
+          "url": "https://www.npmjs.com/advisories/891"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[, 3.4.1)",
+          "[4.0.0,4.3.1)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@3.4.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:bootstrap",
+      "version": "3.3.7"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-06-28T12:13:55.956194Z",
+      "credit": [
+        "1Jesper1"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.webjars:bootstrap](https://mvnrepository.com/artifact/org.webjars/bootstrap) is a WebJar for Bootstrap.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the `tooltip`, `collapse` and `scrollspy` plugins.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.webjars:bootstrap` to version 3.4.0, 4.1.2 or higher.\n## References\n- [Bootstrap Blog](https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/)\n- [GitHub Commit](https://github.com/twbs/bootstrap/commit/149096016f70fd815540d62c0989fd99cdc809e0)\n- [GitHub Commit](https://github.com/twbs/bootstrap/pull/26630/commits/3229efc0811df29765c1d0a949c85362378b0628)\n- [GitHub Commit](https://github.com/twbs/bootstrap/pull/26630/commits/3ba186313e9e651bbd52a6a3a0305891dee0a621)\n- [GitHub Commit](https://github.com/twbs/bootstrap/pull/26630/commits/efca80bb5bb34546a2e7a9488b89f71457d2ad92)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/26625)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/26627)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/26628)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/27915#issuecomment-452140906)\n- [GitHub PR](https://github.com/twbs/bootstrap/pull/26630)\n",
+      "disclosureTime": "2018-05-29T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.4.0",
+        "4.1.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-451162",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-14040",
+          "CVE-2018-14042"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "bootstrap",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2020-06-12T14:37:03.383746Z",
+      "moduleName": "org.webjars:bootstrap",
+      "packageManager": "maven",
+      "packageName": "org.webjars:bootstrap",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2018-06-12T08:15:05Z",
+      "references": [
+        {
+          "title": "Bootstrap Blog",
+          "url": "https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/commit/149096016f70fd815540d62c0989fd99cdc809e0"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/pull/26630/commits/3229efc0811df29765c1d0a949c85362378b0628"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/pull/26630/commits/3ba186313e9e651bbd52a6a3a0305891dee0a621"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/pull/26630/commits/efca80bb5bb34546a2e7a9488b89f71457d2ad92"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/26625"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/26627"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/26628"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/27915%23issuecomment-452140906"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/twbs/bootstrap/pull/26630"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,3.4.0)",
+          "[4.0.0 ,4.1.2)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@3.4.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:bootstrap",
+      "version": "3.3.7"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-06-28T12:15:22.528355Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.webjars:bootstrap](https://mvnrepository.com/artifact/org.webjars/bootstrap) is a WebJar for Bootstrap.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the tooltip `data-viewport` attribute.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.webjars:bootstrap` to version 3.4.0 or higher.\n## References\n- [GetBootsrap Blog](https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/27044)\n- [GitHub PR](https://github.com/twbs/bootstrap/pull/27047)\n",
+      "disclosureTime": "2018-08-13T05:41:27Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.4.0"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-451164",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-20676"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "bootstrap",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2019-11-05T16:09:23.522621Z",
+      "moduleName": "org.webjars:bootstrap",
+      "packageManager": "maven",
+      "packageName": "org.webjars:bootstrap",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-01-10T09:27:20Z",
+      "references": [
+        {
+          "title": "GetBootsrap Blog",
+          "url": "https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/27044"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/twbs/bootstrap/pull/27047"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,3.4.0)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@3.4.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:bootstrap",
+      "version": "3.3.7"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-06-28T12:18:30.678974Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.webjars:bootstrap](https://mvnrepository.com/artifact/org.webjars/bootstrap) is a WebJar for Bootstrap.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the `affix` configuration target property.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.webjars:bootstrap` to version 3.4.0 or higher.\n## References\n- [GetBootstrap Blog](https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/)\n- [GitHub Commit](https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/27045)\n- [GitHub PR](https://github.com/twbs/bootstrap/pull/27047)\n",
+      "disclosureTime": "2019-01-09T05:29:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.4.0"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-451168",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-20677"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "bootstrap",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2019-11-05T16:09:20.641280Z",
+      "moduleName": "org.webjars:bootstrap",
+      "packageManager": "maven",
+      "packageName": "org.webjars:bootstrap",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-01-10T09:27:20Z",
+      "references": [
+        {
+          "title": "GetBootstrap Blog",
+          "url": "https://blog.getbootstrap.com/2018/12/13/bootstrap-3-4-0/"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/commit/2a5ba23ce8f041f3548317acc992ed8a736b609d"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/27045"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/twbs/bootstrap/pull/27047"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,3.4.0)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@3.4.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:bootstrap",
+      "version": "3.3.7"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-11-04T11:21:21.218346Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.webjars:bootstrap](https://mvnrepository.com/artifact/org.webjars/bootstrap) is a WebJar for Bootstrap.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS) via the `data-target` attribute.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.webjars:bootstrap` to version 3.4.0, 4.0.0-beta.2 or higher.\n## References\n- [Bootstrap Blog](https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/)\n- [GitHub Commit](https://github.com/twbs/bootstrap/commit/9612830701211d757ff95ceccbb494fd2e7ee17e)\n- [GitHub Commit](https://github.com/twbs/bootstrap/pull/23687/commits/d9be1da55bf0f94a81e8a2c9acf5574fb801306e)\n- [GitHub Issue](https://github.com/twbs/bootstrap/issues/20184)\n- [GitHub PR](https://github.com/twbs/bootstrap/pull/23679)\n- [GitHub PR](https://github.com/twbs/bootstrap/pull/23687)\n",
+      "disclosureTime": "2016-06-27T17:23:26Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.4.0",
+        "4.0.0-beta.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-479505",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-10735"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "bootstrap",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2019-11-05T16:09:13.431638Z",
+      "moduleName": "org.webjars:bootstrap",
+      "packageManager": "maven",
+      "packageName": "org.webjars:bootstrap",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2018-01-19T09:37:48Z",
+      "references": [
+        {
+          "title": "Bootstrap Blog",
+          "url": "https://blog.getbootstrap.com/2018/07/12/bootstrap-4-1-2/"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/commit/9612830701211d757ff95ceccbb494fd2e7ee17e"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/twbs/bootstrap/pull/23687/commits/d9be1da55bf0f94a81e8a2c9acf5574fb801306e"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/twbs/bootstrap/issues/20184"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/twbs/bootstrap/pull/23679"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/twbs/bootstrap/pull/23687"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "(,3.4.0)",
+          "[4.0.0-alpha,4.0.0-beta.2)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@3.4.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:bootstrap",
+      "version": "3.3.7"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P",
+      "alternativeIds": [],
+      "creationTime": "2019-11-04T11:39:13.365408Z",
+      "credit": [
+        "Semmle Security Research Team"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n[org.webjars:jquery](https://www.npmjs.com/package/jquery) is a JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers.\n\nAffected versions of this package are vulnerable to Prototype Pollution. The `extend` function can be tricked into modifying the prototype of `Object` when the attacker controls part of the structure passed to this function. This can let an attacker add or modify an existing property that will then exist on all objects.\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `org.webjars:jquery` to version 3.4.0 or higher.\n## References\n- [GitHub Commit](https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b)\n- [GitHub PR](https://github.com/jquery/jquery/pull/4333)\n- [Hackerone Report](https://hackerone.com/reports/454365)\n- [Snyk Blog](https://snyk.io/blog/after-three-years-of-silence-a-new-jquery-prototype-pollution-vulnerability-emerges-once-again/)\n- [Third-Party Backported Patches Repo](https://github.com/DanielRuf/snyk-js-jquery-174006)\n",
+      "disclosureTime": "2019-03-26T08:40:15Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "3.4.0"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-479774",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-11358",
+          "CVE-2019-5428"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "GHSA": [
+          "GHSA-wv67-q8rr-grjp"
+        ],
+        "NSP": [
+          796
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jquery",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2021-01-07T17:30:33.902994Z",
+      "moduleName": "org.webjars:jquery",
+      "packageManager": "maven",
+      "packageName": "org.webjars:jquery",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-03-27T08:40:08Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/jquery/jquery/commit/753d591aea698e57d6db58c9f722cd0808619b1b"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/jquery/jquery/pull/4333"
+        },
+        {
+          "title": "Hackerone Report",
+          "url": "https://hackerone.com/reports/454365"
+        },
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/after-three-years-of-silence-a-new-jquery-prototype-pollution-vulnerability-emerges-once-again/"
+        },
+        {
+          "title": "Third-Party Backported Patches Repo",
+          "url": "https://github.com/DanielRuf/snyk-js-jquery-174006"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "(,3.4.0)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7",
+        "org.webjars:jquery@1.11.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@4.4.1-1",
+        "org.webjars:jquery@3.4.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:jquery",
+      "version": "1.11.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-11-04T11:39:30.288441Z",
+      "credit": [
+        "Egor Homakov"
+      ],
+      "cvssScore": 5.4,
+      "description": "## Overview\n\n[org.webjars:jquery](https://www.npmjs.com/package/jquery) is a JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers.\n\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS)\nattacks when a cross-domain ajax request is performed without the `dataType` option causing `text/javascript` responses to be executed.\n\n## Details\n A cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## Remediation\n\nUpgrade `org.webjars:jquery` to version 1.12.2, 2.2.2, 3.0.0 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/jquery/jquery/commit/f60729f3903d17917dc351f3ac87794de379b0cc)\n\n- [GitHub Commit](https://github.com/jquery/jquery/pull/2588/commits/c254d308a7d3f1eac4d0b42837804cfffcba4bb2)\n\n- [GitHub Issue](https://github.com/jquery/jquery/issues/2432)\n\n- [GitHub PR](https://github.com/jquery/jquery/pull/2588)\n",
+      "disclosureTime": "2015-06-26T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.12.2",
+        "2.2.2",
+        "3.0.0"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-479782",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-9251",
+          "CVE-2017-16012"
+        ],
+        "CWE": [
+          "CWE-79"
+        ],
+        "GHSA": [
+          "GHSA-rmxg-73gg-4p98"
+        ],
+        "NSP": [
+          328
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jquery",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2019-11-05T16:08:37.345242Z",
+      "moduleName": "org.webjars:jquery",
+      "packageManager": "maven",
+      "packageName": "org.webjars:jquery",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-11-27T00:00:00Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/jquery/jquery/commit/f60729f3903d17917dc351f3ac87794de379b0cc"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/jquery/jquery/pull/2588/commits/c254d308a7d3f1eac4d0b42837804cfffcba4bb2"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/jquery/jquery/issues/2432"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/jquery/jquery/pull/2588"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "(,1.12.2)",
+          "[1.12.3,2.2.2)",
+          "[2.2.3,3.0.0)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7",
+        "org.webjars:jquery@1.11.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@4.0.0",
+        "org.webjars:jquery@3.0.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:jquery",
+      "version": "1.11.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-04-13T07:59:14.886750Z",
+      "credit": [
+        "Masato Kinugawa"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[org.webjars:jquery](https://www.npmjs.com/package/jquery) is a JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers.\n\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS)\nPassing HTML containing `<option>` elements from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. `.html()`, `.append()`, and others) may execute untrusted code.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\n\nUpgrade `org.webjars:jquery` to version 3.5.0 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/jquery/jquery/commit/1d61fd9407e6fbe82fe55cb0b938307aa0791f77)\n\n- [PoC](https://vulnerabledoma.in/jquery_htmlPrefilter_xss.html)\n\n- [Release Notes](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/)\n\n- [Security Blog](https://masatokinugawa.l0.cm/2020/05/jquery3.5.0-xss.html?spref=tw)\n",
+      "disclosureTime": "2020-04-10T00:00:00Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "3.5.0"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-565171",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-11023"
+        ],
+        "CWE": [
+          "CWE-79"
+        ],
+        "GHSA": [
+          "GHSA-jpcq-cgw6-v4j6"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jquery",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2020-05-05T06:46:29.512060Z",
+      "moduleName": "org.webjars:jquery",
+      "packageManager": "maven",
+      "packageName": "org.webjars:jquery",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-04-13T15:33:49Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/jquery/jquery/commit/1d61fd9407e6fbe82fe55cb0b938307aa0791f77"
+        },
+        {
+          "title": "PoC",
+          "url": "https://vulnerabledoma.in/jquery_htmlPrefilter_xss.html"
+        },
+        {
+          "title": "Release Notes",
+          "url": "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/"
+        },
+        {
+          "title": "Security Blog",
+          "url": "https://masatokinugawa.l0.cm/2020/05/jquery3.5.0-xss.html?spref=tw"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.0.3, 3.5.0)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7",
+        "org.webjars:jquery@1.11.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@4.5.0",
+        "org.webjars:jquery@3.5.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:jquery",
+      "version": "1.11.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N/E:P/RL:O/RC:R",
+      "alternativeIds": [],
+      "creationTime": "2020-04-30T12:44:35.310432Z",
+      "credit": [
+        "Masato Kinugawa"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n\n[org.webjars:jquery](https://www.npmjs.com/package/jquery) is a JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers.\n\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS).\nPassing HTML from untrusted sources - even after sanitizing it - to one of jQuery's DOM manipulation methods (i.e. `.html(), .append()`, and others) may execute untrusted code.\n\n\n## Details:\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## Remediation\n\nUpgrade `org.webjars:jquery` to version 3.5.0 or higher.\n\n\n## References\n\n- [GHSA](https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2)\n\n- [GitHub Commit](https://github.com/jquery/jquery/commit/1d61fd9407e6fbe82fe55cb0b938307aa0791f77)\n\n- [JQuery 3.5.0 Release](https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/)\n\n- [JQuery Upgrade Guide](https://jquery.com/upgrade-guide/3.5/)\n\n- [PoC](https://vulnerabledoma.in/jquery_htmlPrefilter_xss.html)\n\n- [Security Blog](https://mksben.l0.cm/2020/05/jquery3.5.0-xss.html)\n",
+      "disclosureTime": "2020-04-29T23:02:09Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "3.5.0"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGWEBJARS-567882",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-11022"
+        ],
+        "CWE": [
+          "CWE-79"
+        ],
+        "GHSA": [
+          "GHSA-v73w-r9xg-7cr9"
+        ],
+        "NSP": [
+          1518
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jquery",
+        "groupId": "org.webjars"
+      },
+      "modificationTime": "2020-05-05T06:44:17.571870Z",
+      "moduleName": "org.webjars:jquery",
+      "packageManager": "maven",
+      "packageName": "org.webjars:jquery",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-04-29T23:02:09Z",
+      "references": [
+        {
+          "title": "GHSA",
+          "url": "https://github.com/jquery/jquery/security/advisories/GHSA-gxr4-xjj5-5px2"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/jquery/jquery/commit/1d61fd9407e6fbe82fe55cb0b938307aa0791f77"
+        },
+        {
+          "title": "JQuery 3.5.0 Release",
+          "url": "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/"
+        },
+        {
+          "title": "JQuery Upgrade Guide",
+          "url": "https://jquery.com/upgrade-guide/3.5/"
+        },
+        {
+          "title": "PoC",
+          "url": "https://vulnerabledoma.in/jquery_htmlPrefilter_xss.html"
+        },
+        {
+          "title": "Security Blog",
+          "url": "https://mksben.l0.cm/2020/05/jquery3.5.0-xss.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.2.0 ,3.5.0)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.webjars:bootstrap@3.3.7",
+        "org.webjars:jquery@1.11.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.webjars:bootstrap@4.5.0",
+        "org.webjars:jquery@3.5.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.webjars:jquery",
+      "version": "1.11.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:32.257000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 7.3,
+      "description": "## Overview\n[xalan:xalan](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xalan%22) is a XSLT processor for transforming XML documents into HTML, text, or other XML document types. It implements XSL Transformations (XSLT) Version 1.0 and XML Path Language (XPath) Version 1.0 and can be used from the command line, in an applet or a servlet, or as a module in other program.\n\nAffected versions of this package are vulnerable to Arbitrary Class Load. The TransformerFactory in does not properly restrict access to certain properties when FEATURE_SECURE_PROCESSING is enabled, which allows remote attackers to bypass expected restrictions and load arbitrary classes or access external resources via a crafted  `xalan:content-header`, `xalan:entities`,  `xslt:content-header`,  `xslt:entities` property, or a Java property that is bound to the XSLT 1.0 system-property function.\n## Remediation\nUpgrade `xalan:xalan` to version 2.7.2 or higher.\n## References\n- [Apache Jira Ticket](https://issues.apache.org/jira/browse/XALANJ-2435)\n- [GitHub Commit](https://github.com/apache/xalan-j/commit/cbfd906cc5a1f1566fa1a98400c82e56077fae0c)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0107)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1080248)\n",
+      "disclosureTime": "2014-04-15T23:13:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.7.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-XALAN-31385",
+      "identifiers": {
+        "CVE": [
+          "CVE-2014-0107"
+        ],
+        "CWE": [
+          "CWE-264"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xalan",
+        "groupId": "xalan"
+      },
+      "modificationTime": "2020-06-12T14:37:00.336011Z",
+      "moduleName": "xalan:xalan",
+      "packageManager": "maven",
+      "packageName": "xalan:xalan",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2014-06-06T19:55:53Z",
+      "references": [
+        {
+          "title": "Apache Jira Ticket",
+          "url": "https://issues.apache.org/jira/browse/XALANJ-2435"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/xalan-j/commit/cbfd906cc5a1f1566fa1a98400c82e56077fae0c"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0107"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1080248"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.7.2)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Arbitrary Class Load",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.owasp.esapi:esapi@2.1.0",
+        "xom:xom@1.2.5",
+        "xalan:xalan@2.7.0"
+      ],
+      "upgradePath": [
+        false,
+        "org.owasp.esapi:esapi@2.2.0.0"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "xalan:xalan",
+      "version": "2.7.0"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 688,
+  "org": "myorg",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "41 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:L",
+        "alternativeIds": [],
+        "creationTime": "2020-12-04T11:58:40.054903Z",
+        "credit": [
+          "Bartosz Baranowski"
+        ],
+        "cvssScore": 8.2,
+        "description": "## Overview\n[com.fasterxml.jackson.core:jackson-databind](https://github.com/FasterXML/jackson-databind) is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. A flaw was found in FasterXML Jackson Databind, where it does not have entity expansion secured properly in the `DOMDeserializer` class. The highest threat from this vulnerability is data integrity.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `com.fasterxml.jackson.core:jackson-databind` to version 2.6.7.4, 2.9.10.7, 2.10.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/FasterXML/jackson-databind/commit/612f971b78c60202e9cd75a299050c8f2d724a59)\n- [GitHub Issue](https://github.com/FasterXML/jackson-databind/issues/2589)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1887664)\n",
+        "disclosureTime": "2020-12-04T11:54:03Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.6.7.4",
+          "2.9.10.7",
+          "2.10.5.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "DOMSerializer",
+              "filePath": "com/fasterxml/jackson/databind/ext/DOMSerializer.java",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[2.6.0,2.6.7.4)",
+              "[2.9.0,2.9.10.7)",
+              "[2.10.0, 2.10.5.1)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.fasterxml.jackson.databind.ext.DOMSerializer",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[2.6.0,2.6.7.4)",
+              "[2.9.0,2.9.10.7)",
+              "[2.10.0, 2.10.5.1)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMFASTERXMLJACKSONCORE-1048302",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-25649"
+          ],
+          "CWE": [
+            "CWE-611"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "jackson-databind",
+          "groupId": "com.fasterxml.jackson.core"
+        },
+        "modificationTime": "2020-12-13T13:51:18.668871Z",
+        "moduleName": "com.fasterxml.jackson.core:jackson-databind",
+        "packageManager": "maven",
+        "packageName": "com.fasterxml.jackson.core:jackson-databind",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-12-04T15:22:52Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/FasterXML/jackson-databind/commit/612f971b78c60202e9cd75a299050c8f2d724a59"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/FasterXML/jackson-databind/issues/2589"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1887664"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.6.0,2.6.7.4)",
+            "[2.9.0,2.9.10.7)",
+            "[2.10.0, 2.10.5.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "com.mylib:lib-config@2.1.1",
+          "com.fasterxml.jackson.core:jackson-databind@2.10.5"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "com.fasterxml.jackson.core:jackson-databind",
+        "version": "2.10.5"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:47Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.4,
+        "description": "## Overview\n[commons-httpclient:commons-httpclient](https://mvnrepository.com/artifact/commons-httpclient/commons-httpclient) is a HttpClient component of the Apache HttpComponents project.\n\nAffected versions of this package are vulnerable to Improper Certificate Validation due to not verifying that the requesting server hostname matches a domain name in the subject's `Common Name (CN)` or `subjectAltName` field of the X.509 certificate. This allows man-in-the-middle attackers to spoof SSL servers via an arbitrary valid certificate.\n## Remediation\nThere is no fixed version for `commons-httpclient:commons-httpclient`.\n## References\n- [Jira Issue](https://issues.apache.org/jira/browse/HTTPCLIENT-1265)\n- [The University of Texas](http://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf)\n- [X-force Vulnerability Report](https://exchange.xforce.ibmcloud.com/vulnerabilities/79984)\n",
+        "disclosureTime": "2012-11-04T22:55:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [
+          {
+            "functionId": {
+              "className": "SSLProtocolSocketFactory",
+              "filePath": "org/apache/commons/httpclient/protocol/SSLProtocolSocketFactory.java",
+              "functionName": "createSocket"
+            },
+            "version": [
+              "[2.0, 3.1)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.apache.commons.httpclient.protocol.SSLProtocolSocketFactory",
+              "functionName": "createSocket"
+            },
+            "version": [
+              "[2.0, 3.1)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMMONSHTTPCLIENT-30083",
+        "identifiers": {
+          "CVE": [
+            "CVE-2012-5783"
+          ],
+          "CWE": [
+            "CWE-295"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "commons-httpclient",
+          "groupId": "commons-httpclient"
+        },
+        "modificationTime": "2020-06-12T14:37:02.646552Z",
+        "moduleName": "commons-httpclient:commons-httpclient",
+        "packageManager": "maven",
+        "packageName": "commons-httpclient:commons-httpclient",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2013-03-25T16:51:47Z",
+        "references": [
+          {
+            "title": "Jira Issue",
+            "url": "https://issues.apache.org/jira/browse/HTTPCLIENT-1265"
+          },
+          {
+            "title": "The University of Texas",
+            "url": "http://www.cs.utexas.edu/~shmat/shmat_ccs12.pdf"
+          },
+          {
+            "title": "X-force Vulnerability Report",
+            "url": "https://exchange.xforce.ibmcloud.com/vulnerabilities/79984"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Improper Certificate Validation",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.owasp.esapi:esapi@2.1.0",
+          "org.owasp.antisamy:antisamy@1.4.3",
+          "commons-httpclient:commons-httpclient@3.1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "commons-httpclient:commons-httpclient",
+        "version": "3.1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:21.771000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 4.3,
+        "description": "## Overview\n[commons-httpclient:commons-httpclient](https://mvnrepository.com/artifact/commons-httpclient/commons-httpclient) is a HttpClient component of the Apache HttpComponents project.\n\nAffected versions of this package are vulnerable to Man-in-the-Middle (MitM) due to not verifing the requesting server's hostname agains existing domain names in the SSL Certificate. The `AbstractVerifier` does not properly verify that the server hostname matches a domain name in the subject's `Common Name (CN)` or `subjectAltName` field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a certificate with a subject that specifies a common name in a field that is not the CN field.  \r\n\r\n**NOTE:** this issue exists because of an incomplete fix for [CVE-2012-5783](SNYK-JAVA-COMMONSHTTPCLIENT-30083).\n## Remediation\nThere is no fixed version for `commons-httpclient:commons-httpclient`.\n## References\n- [GitHub Commit](https://github.com/apache/httpcomponents-client/commit/6e14fc146a66e0f3eb362f45f95d1a58ee18886a)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-6153)\n",
+        "disclosureTime": "2014-09-04T17:55:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-COMMONSHTTPCLIENT-31660",
+        "identifiers": {
+          "CVE": [
+            "CVE-2012-6153"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "commons-httpclient",
+          "groupId": "commons-httpclient"
+        },
+        "modificationTime": "2020-06-12T14:37:04.982623Z",
+        "moduleName": "commons-httpclient:commons-httpclient",
+        "packageManager": "maven",
+        "packageName": "commons-httpclient:commons-httpclient",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-04-08T12:56:14Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/httpcomponents-client/commit/6e14fc146a66e0f3eb362f45f95d1a58ee18886a"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2012-6153"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Man-in-the-Middle (MitM)",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.owasp.esapi:esapi@2.1.0",
+          "org.owasp.antisamy:antisamy@1.4.3",
+          "commons-httpclient:commons-httpclient@3.1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "commons-httpclient:commons-httpclient",
+        "version": "3.1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2019-04-10T16:07:04.634619Z",
+        "credit": [
+          "Mario Areias"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[dom4j:dom4j](https://github.com/dom4j/dom4j) is a flexible XML framework for Java. *Note*: this artifact has been deprecated for `org.dom4j:dom4j`.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection due to not validating the `QName` inputs.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `dom4j:dom4j`.\n## References\n- [GitHub Commit](https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387)\n- [GitHub Issue](https://github.com/dom4j/dom4j/issues/48)\n- [Ihacktoprotect Blog](https://ihacktoprotect.com/post/dom4j-xml-injection/)\n",
+        "disclosureTime": "2018-07-01T19:12:29Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [
+          {
+            "functionId": {
+              "className": "Namespace",
+              "filePath": "org/dom4j/Namespace.java",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "QName",
+              "filePath": "org/dom4j/QName.java",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.dom4j.Namespace",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.dom4j.QName",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-DOM4J-174153",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-1000632"
+          ],
+          "CWE": [
+            "CWE-611"
+          ],
+          "GHSA": [
+            "GHSA-6pcc-3rfx-4gpm"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "dom4j",
+          "groupId": "dom4j"
+        },
+        "modificationTime": "2020-09-21T06:25:14.227405Z",
+        "moduleName": "dom4j:dom4j",
+        "packageManager": "maven",
+        "packageName": "dom4j:dom4j",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-08-21T14:16:13Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/dom4j/dom4j/issues/48"
+          },
+          {
+            "title": "Ihacktoprotect Blog",
+            "url": "https://ihacktoprotect.com/post/dom4j-xml-injection/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.maven.plugins:maven-archetype-plugin@3.0.1",
+          "org.apache.maven.archetype:archetype-common@3.0.1",
+          "dom4j:dom4j@1.6.1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "dom4j:dom4j",
+        "version": "1.6.1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:A/AC:H/PR:L/UI:R/S:U/C:H/I:L/A:L/E:U/RL:U/RC:R",
+        "alternativeIds": [],
+        "creationTime": "2020-11-20T15:44:58.900719Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.6,
+        "description": "## Overview\n[io.netty:netty-handler](https://github.com/netty/netty.git/netty-handler) is a library that provides an asynchronous event-driven network application framework and tools for rapid development of maintainable high performance and high scalability protocol servers and clients. In other words, Netty is a NIO client server framework which enables quick and easy development of network applications such as protocol servers and clients. It greatly simplifies and streamlines network programming such as TCP and UDP socket server.\n\nAffected versions of this package are vulnerable to Improper Certificate Validation. Certificate hostname validation is disabled by default in `Netty 4.1.x` which makes it potentially susceptible to Man-in-the-Middle attacks.\n## Remediation\nThere is no fixed version for `io.netty:netty-handler`.\n## References\n- [GitHub Issue 1](https://github.com/netty/netty/issues/10806)\n- [GitHub Issue 2](https://github.com/netty/netty/issues/8537)\n- [GitHub Issue 2](https://github.com/netty/netty/issues/9930)\n- [GitHub Issue 3](https://github.com/netty/netty/issues/10362)\n",
+        "disclosureTime": "2020-11-19T07:07:57Z",
+        "exploit": "Unproven",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-IONETTY-1042268",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-295"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "netty-handler",
+          "groupId": "io.netty"
+        },
+        "modificationTime": "2020-11-20T16:24:16.887977Z",
+        "moduleName": "io.netty:netty-handler",
+        "packageManager": "maven",
+        "packageName": "io.netty:netty-handler",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-11-20T16:24:17.093861Z",
+        "references": [
+          {
+            "title": "GitHub Issue 1",
+            "url": "https://github.com/netty/netty/issues/10806"
+          },
+          {
+            "title": "GitHub Issue 2",
+            "url": "https://github.com/netty/netty/issues/8537"
+          },
+          {
+            "title": "GitHub Issue 2",
+            "url": "https://github.com/netty/netty/issues/9930"
+          },
+          {
+            "title": "GitHub Issue 3",
+            "url": "https://github.com/netty/netty/issues/10362"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[4.1.0.Final,]"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Improper Certificate Validation",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.infinispan:infinispan-client-hotrod@9.4.19.Final-redhat-00001",
+          "io.netty:netty-handler@4.1.53.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "io.netty:netty-handler",
+        "version": "4.1.53.Final"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-06-18T15:47:31.144561Z",
+        "credit": [
+          "Marcio Almeida de Macedo"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[log4j:log4j](https://github.com/apache/log4j) is a the 1.x branch of the Apache Log4j project.\n\nAffected versions of this package are vulnerable to Deserialization of Untrusted Data. Included in Log4j 1.2 is a SocketServer class that is vulnerable to deserialization of untrusted data which can be exploited to remotely execute arbitrary code when combined with a deserialization gadget when listening to untrusted network traffic for log data.\n\n## Details\n\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\n  \nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n  \n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n\n- Apache Blog\n  \n## Remediation\nThere is no fixed version for `log4j:log4j`.\n## References\n- [Apache Security Advisory](https://lists.apache.org/thread.html/eea03d504b36e8f870e8321d908e1def1addda16adda04327fe7c125%40%3Cdev.logging.apache.org%3E)\n",
+        "disclosureTime": "2019-12-22T09:33:11Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-LOG4J-572732",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-17571"
+          ],
+          "CWE": [
+            "CWE-502"
+          ],
+          "GHSA": [
+            "GHSA-2qrg-x229-3v8q"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "log4j",
+          "groupId": "log4j"
+        },
+        "modificationTime": "2020-06-18T15:49:24.565924Z",
+        "moduleName": "log4j:log4j",
+        "packageManager": "maven",
+        "packageName": "log4j:log4j",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-06-19T09:33:01Z",
+        "references": [
+          {
+            "title": "Apache Security Advisory",
+            "url": "https://lists.apache.org/thread.html/eea03d504b36e8f870e8321d908e1def1addda16adda04327fe7c125%40%3Cdev.logging.apache.org%3E"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Deserialization of Untrusted Data",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.owasp.esapi:esapi@2.1.0",
+          "log4j:log4j@1.2.16"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "log4j:log4j",
+        "version": "1.2.16"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-05-29T08:50:11.153150Z",
+        "credit": [
+          "Charles Duffy"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[org.apache.maven.shared:maven-shared-utils](https://maven.apache.org/shared/maven-shared-utils/) is a functional replacement for plexus-utils in Maven.\n\nAffected versions of this package are vulnerable to Command Injection. The `Commandline` class can emit double-quoted strings without proper escaping, allowing shell injection attacks. The `BourneShell` class should unconditionally single-quote emitted strings (including the name of the command itself being quoted), with `{{'\"'\"'}}` used for embedded single quotes, for maximum safety across shells implementing a superset of POSIX quoting rules. \r\n\r\nThis is a similar issue to [`SNYK-JAVA-ORGCODEHAUSPLEXUS-31522`](https://snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31522)\n## Remediation\nUpgrade `org.apache.maven.shared:maven-shared-utils` to version 3.3.3 or higher.\n## References\n- [Apache Jira Issue](https://issues.apache.org/jira/browse/MSHARED-297)\n- [GitHub PR](https://github.com/apache/maven-shared-utils/pull/40/files)\n",
+        "disclosureTime": "2020-05-29T08:43:40Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.3.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHEMAVENSHARED-570592",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-77"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "maven-shared-utils",
+          "groupId": "org.apache.maven.shared"
+        },
+        "modificationTime": "2020-08-05T13:31:08.299214Z",
+        "moduleName": "org.apache.maven.shared:maven-shared-utils",
+        "packageManager": "maven",
+        "packageName": "org.apache.maven.shared:maven-shared-utils",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-06-22T17:01:48Z",
+        "references": [
+          {
+            "title": "Apache Jira Issue",
+            "url": "https://issues.apache.org/jira/browse/MSHARED-297"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/apache/maven-shared-utils/pull/40/files"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,3.3.3)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Command Injection",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.maven.shared:maven-verifier@1.6",
+          "org.apache.maven.shared:maven-shared-utils@0.8"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.maven.shared:maven-shared-utils",
+        "version": "0.8"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2018-10-12T12:12:08.269164Z",
+        "credit": [
+          "Alvaro Munoz",
+          "Christian Schneider"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\n[org.beanshell:bsh](https://mvnrepository.com/artifact/org.beanshell/bsh) is a Java source interpreter with object scripting language features, written in Java.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution during Deserialization. When included on the `classpat` by an application that uses Java serialization or XStream, A remote attacker could execute arbitrary code via crafted serialized data, related to XThis.Handler.\n## Remediation\nThere is no fixed version for `org.beanshell:bsh`.\n## References\n- [CVE Details](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2510)\n- [GitHub Commit](https://github.com/beanshell/beanshell/commit/1ccc66bb693d4e46a34a904db8eeff07808d2ced)\n- [GitHub Commit](https://github.com/beanshell/beanshell/commit/7c68fde2d6fc65e362f20863d868c112a90a9b49)\n- [GitHub Release](https://github.com/beanshell/beanshell/releases/tag/2.0b6)\n- [RedHat CVE Database](https://access.redhat.com/security/cve/cve-2016-2510)\n- [RSA Conference Presentation](https://www.rsaconference.com/writable/presentations/file_upload/asd-f03-serial-killer-silently-pwning-your-java-endpoints.pdf)\n",
+        "disclosureTime": "2016-02-22T16:51:56Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGBEANSHELL-72452",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-2510"
+          ],
+          "CWE": [
+            "CWE-502"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "bsh",
+          "groupId": "org.beanshell"
+        },
+        "modificationTime": "2020-06-24T13:50:41.680495Z",
+        "moduleName": "org.beanshell:bsh",
+        "packageManager": "maven",
+        "packageName": "org.beanshell:bsh",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-02-22T16:51:56Z",
+        "references": [
+          {
+            "title": "CVE Details",
+            "url": "http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2510"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/beanshell/beanshell/commit/1ccc66bb693d4e46a34a904db8eeff07808d2ced"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/beanshell/beanshell/commit/7c68fde2d6fc65e362f20863d868c112a90a9b49"
+          },
+          {
+            "title": "GitHub Release",
+            "url": "https://github.com/beanshell/beanshell/releases/tag/2.0b6"
+          },
+          {
+            "title": "RedHat CVE Database",
+            "url": "https://access.redhat.com/security/cve/cve-2016-2510"
+          },
+          {
+            "title": "RSA Conference Presentation",
+            "url": "https://www.rsaconference.com/writable/presentations/file_upload/asd-f03-serial-killer-silently-pwning-your-java-endpoints.pdf"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Arbitrary Code Execution during Deserialization",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.maven.plugins:maven-archetype-plugin@3.0.1",
+          "org.apache.maven.shared:maven-script-interpreter@1.0",
+          "org.beanshell:bsh@2.0b4"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.beanshell:bsh",
+        "version": "2.0b4"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+        "alternativeIds": [],
+        "creationTime": "2020-12-06T14:48:02.848508Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[org.codehaus.groovy:groovy](https://mvnrepository.com/artifact/org.codehaus.groovy/groovy) is a language for the JVM\n\nAffected versions of this package are vulnerable to Information Disclosure. Groovy may create temporary directories within the OS temporary directory which is shared\r\nbetween all users on affected systems. This vulnerability only impacts Unix-like systems, and very old\r\nversions of Mac OSX and Windows.\n## Remediation\nUpgrade `org.codehaus.groovy:groovy` to version 2.4.21, 2.5.14, 3.0.7, 4.0.0-alpha-2 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/groovy/commit/bcbe5c4c76db83736166530647c024ac1e47ef28)\n- [Jira Issue](https://issues.apache.org/jira/browse/GROOVY-9824)\n",
+        "disclosureTime": "2020-12-06T14:40:52Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.4.21",
+          "2.5.14",
+          "3.0.7",
+          "4.0.0-alpha-2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGCODEHAUSGROOVY-1048694",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-17521"
+          ],
+          "CWE": [
+            "CWE-379"
+          ],
+          "GHSA": [
+            "GHSA-rcjj-h6gh-jf3r"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "groovy",
+          "groupId": "org.codehaus.groovy"
+        },
+        "modificationTime": "2020-12-06T16:34:08.631471Z",
+        "moduleName": "org.codehaus.groovy:groovy",
+        "packageManager": "maven",
+        "packageName": "org.codehaus.groovy:groovy",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-12-06T16:34:08Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/groovy/commit/bcbe5c4c76db83736166530647c024ac1e47ef28"
+          },
+          {
+            "title": "Jira Issue",
+            "url": "https://issues.apache.org/jira/browse/GROOVY-9824"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[, 2.4.21)",
+            "[2.5.0, 2.5.14)",
+            "[3.0.0, 3.0.7)",
+            "[4.0.0-alpha-1, 4.0.0-alpha-2)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Information Disclosure",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.maven.plugins:maven-archetype-plugin@3.0.1",
+          "org.apache.maven.archetype:archetype-common@3.0.1",
+          "org.codehaus.groovy:groovy@2.5.13"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.codehaus.groovy:groovy",
+        "version": "2.5.13"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2019-11-19T11:44:30.225935Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n\n[org.codehaus.jackson:jackson-mapper-asl](https://mvnrepository.com/artifact/org.codehaus.jackson/jackson-mapper-asl) is a high-performance data binding package built on Jackson JSON processor.\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nMultiple classes including  `XmlMapper` was found to be vulnerabiltiy to XXE, which might allow attackers to have unspecified impact via unknown vectors.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n\n## Remediation\nThere is no fixed version for `org.codehaus.jackson:jackson-mapper-asl`. \n\nFor `org.codehaus.jackson:jackson-all` releases supporting `jackson-mapper-asl`. As a workaround, for 1.9.X release, the `javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING` setting can be enabled. For 2.x releases, the `\"javax.xml.stream.isSupportingExternalEntities` setting can be set to `FALSE`.\n\n## References\n\n- [CVE-2019-10172 Remediation for Jackson Databind](https://github.com/FasterXML/jackson-databind/issues/2547)\n\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1715075)\n\n- [StackOverflow CVE-2016-3720 Remediation -  jackson-all](https://stackoverflow.com/questions/38017676/small-fix-for-cve-2016-3720-with-older-versions-of-jackson-all-1-9-11-and-in-ja)\n",
+        "disclosureTime": "2019-11-18T00:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [
+          {
+            "functionId": {
+              "className": "DOMDeserializer",
+              "filePath": "org/codehaus/jackson/map/ext/DOMDeserializer.java",
+              "functionName": "parse"
+            },
+            "version": [
+              "(1.6.0,]"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.codehaus.jackson.map.ext.DOMDeserializer",
+              "functionName": "parse"
+            },
+            "version": [
+              "(1.6.0,]"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGCODEHAUSJACKSON-534878",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10172"
+          ],
+          "CWE": [
+            "CWE-611"
+          ],
+          "GHSA": [
+            "GHSA-r6j9-8759-g62w"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "jackson-mapper-asl",
+          "groupId": "org.codehaus.jackson"
+        },
+        "modificationTime": "2020-10-26T12:21:54.981287Z",
+        "moduleName": "org.codehaus.jackson:jackson-mapper-asl",
+        "packageManager": "maven",
+        "packageName": "org.codehaus.jackson:jackson-mapper-asl",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-11-19T11:56:32Z",
+        "references": [
+          {
+            "title": "CVE-2019-10172 Remediation for Jackson Databind",
+            "url": "https://github.com/FasterXML/jackson-databind/issues/2547"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1715075"
+          },
+          {
+            "title": "StackOverflow CVE-2016-3720 Remediation -  jackson-all",
+            "url": "https://stackoverflow.com/questions/38017676/small-fix-for-cve-2016-3720-with-older-versions-of-jackson-all-1-9-11-and-in-ja"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.avro:avro@1.8.1",
+          "org.codehaus.jackson:jackson-mapper-asl@1.9.13"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.codehaus.jackson:jackson-mapper-asl",
+        "version": "1.9.13"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2018-05-30T12:32:02.349000Z",
+        "credit": [
+          "Snyk Security research Team"
+        ],
+        "cvssScore": 5.5,
+        "description": "## Overview\r\n[`org.codehaus.plexus:plexus-archiver`](https://github.com/codehaus-plexus/plexus-archiver) is a Collection of Plexus components to create archives or extract files out of an archive to a directory with a unified Archiver/UnArchiver API whatever the archive format is.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip \r\nSlip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n \r\n## Remediation\r\nUpgrade `org.codehaus.plexus:plexus-archiver`to version 3.6.0 or higher.\n\n## References\n- [GitHub Commit](https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8)\n- [GitHub PR](https://github.com/codehaus-plexus/plexus-archiver/pull/87)\n- [Zip Slip Advisory](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+        "disclosureTime": "2018-04-17T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.6.0"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "AbstractUnArchiver",
+              "filePath": "org/codehaus/plexus/archiver/AbstractUnArchiver.java",
+              "functionName": "extract"
+            },
+            "version": [
+              "[,2.5.0)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "AbstractUnArchiver",
+              "filePath": "org/codehaus/plexus/archiver/AbstractUnArchiver.java",
+              "functionName": "extractFile"
+            },
+            "version": [
+              "[2.5.0, 3.6.0)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.codehaus.plexus.archiver.AbstractUnArchiver",
+              "functionName": "extract"
+            },
+            "version": [
+              "[,2.5.0)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.codehaus.plexus.archiver.AbstractUnArchiver",
+              "functionName": "extractFile"
+            },
+            "version": [
+              "[2.5.0, 3.6.0)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGCODEHAUSPLEXUS-31680",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-1002200"
+          ],
+          "CWE": [
+            "CWE-29"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "plexus-archiver",
+          "groupId": "org.codehaus.plexus"
+        },
+        "modificationTime": "2020-06-09T09:57:45.872255Z",
+        "moduleName": "org.codehaus.plexus:plexus-archiver",
+        "packageManager": "maven",
+        "packageName": "org.codehaus.plexus:plexus-archiver",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-05-31T07:32:02Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/codehaus-plexus/plexus-archiver/commit/f8f4233508193b70df33759ae9dc6154d69c2ea8"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/codehaus-plexus/plexus-archiver/pull/87"
+          },
+          {
+            "title": "Zip Slip Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+          },
+          {
+            "title": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,3.6.0)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.maven.plugin-testing:maven-plugin-testing-harness@3.3.0",
+          "org.codehaus.plexus:plexus-archiver@2.2"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.codehaus.plexus:plexus-archiver",
+        "version": "2.2"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:53Z",
+        "credit": [
+          "Kaspar Brand"
+        ],
+        "cvssScore": 4.8,
+        "description": "## Overview\n\n[org.opensaml:opensaml](https://mvnrepository.com/artifact/org.opensaml/opensaml) provides tools to support developers working with the Security Assertion Markup Language (SAML).\n\n\nAffected versions of this package are vulnerable to Improper Certificate Validation.\n`HttpResource` and `FileBackedHttpResource` implementations in OpenSAML Java and Shibboleth IdP did not enable hostname verification when using TLS connections. Additionaly, OpenSAML Java makes use of Jakarta Commons HttpClient version 3.x, which does not perform verification of the server hostname against the server's X.508 certificate ([CVE-2012-5783](https://snyk.io/vuln/SNYK-JAVA-COMMONSHTTPCLIENT-30083)). This flaw can be exploited by a Man-in-the-middle (MITM) attack, where the attacker can spoof a valid certificate using a specially crafted subject.\n\n## Remediation\n\nUpgrade `org.opensaml:opensaml` to version 2.6.2 or higher.\n\n\n## References\n\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2014-3603)\n\n- [Shibboleth Advisory](http://shibboleth.net/community/advisories/secadv_20140813.txt)\n",
+        "disclosureTime": "2016-12-25T16:51:53Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.6.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGOPENSAML-30140",
+        "identifiers": {
+          "CVE": [
+            "CVE-2014-3603"
+          ],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "opensaml",
+          "groupId": "org.opensaml"
+        },
+        "modificationTime": "2019-06-12T12:57:28.683262Z",
+        "moduleName": "org.opensaml:opensaml",
+        "packageManager": "maven",
+        "packageName": "org.opensaml:opensaml",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-12-25T16:51:53Z",
+        "references": [
+          {
+            "title": "Redhat Bugzilla",
+            "url": "https://bugzilla.redhat.com/CVE-2014-3603"
+          },
+          {
+            "title": "Shibboleth Advisory",
+            "url": "http://shibboleth.net/community/advisories/secadv_20140813.txt"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0,2.6.2)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Improper Certificate Validation",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.ws.security:wss4j@1.6.19",
+          "org.opensaml:opensaml@2.5.1-1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.opensaml:opensaml",
+        "version": "2.5.1-1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:30.660000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n\n[org.opensaml:opensaml](https://mvnrepository.com/artifact/org.opensaml/opensaml) provides tools to support developers working with the Security Assertion Markup Language (SAML).\n\n\nAffected versions of this package are vulnerable to Information Exposure.\nThe (1) BasicParserPool, (2) StaticBasicParserPool, (3) XML Decrypter, and (4) SAML Decrypter set the `expandEntityReferences` property to true, which allows remote attackers to conduct XML external entity (XXE) attacks via a crafted XML `DOCTYPE` declaration.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\n\nUpgrade `org.opensaml:opensaml` to version 2.6.1 or higher.\n\n\n## References\n\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-6440)\n\n- [Security Advisory](http://shibboleth.net/community/advisories/secadv_20131213.txt)\n",
+        "disclosureTime": "2014-02-14T15:55:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.6.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGOPENSAML-31267",
+        "identifiers": {
+          "CVE": [
+            "CVE-2013-6440"
+          ],
+          "CWE": [
+            "CWE-200"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "opensaml",
+          "groupId": "org.opensaml"
+        },
+        "modificationTime": "2019-10-28T09:24:49.854583Z",
+        "moduleName": "org.opensaml:opensaml",
+        "packageManager": "maven",
+        "packageName": "org.opensaml:opensaml",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2014-06-08T00:15:08Z",
+        "references": [
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2013-6440"
+          },
+          {
+            "title": "Security Advisory",
+            "url": "http://shibboleth.net/community/advisories/secadv_20131213.txt"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,2.6.1)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Information Exposure",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.ws.security:wss4j@1.6.19",
+          "org.opensaml:opensaml@2.5.1-1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.opensaml:opensaml",
+        "version": "2.5.1-1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:30.673000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 4.3,
+        "description": "## Overview\n[`org.opensaml:opensaml`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22opensaml%22)\nThe PKIX trust engines in Shibboleth Identity Provider before 2.4.4 and OpenSAML Java (OpenSAML-J) before 2.6.5 trust candidate X.509 credentials when no trusted names are available for the entityID, which allows remote attackers to impersonate an entity via a certificate issued by a shibmd:KeyAuthority trust anchor.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1796)",
+        "disclosureTime": "2015-07-08T15:59:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.6.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGOPENSAML-31268",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-1796"
+          ],
+          "CWE": [
+            "CWE-254"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "opensaml",
+          "groupId": "org.opensaml"
+        },
+        "modificationTime": "2019-06-12T12:56:26.492153Z",
+        "moduleName": "org.opensaml:opensaml",
+        "packageManager": "maven",
+        "packageName": "org.opensaml:opensaml",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2015-07-09T16:43:51Z",
+        "references": [
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1796"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,2.6.5)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Improper Certificate Validation",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.ws.security:wss4j@1.6.19",
+          "org.opensaml:opensaml@2.5.1-1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.opensaml:opensaml",
+        "version": "2.5.1-1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:50Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n\n[org.opensaml:xmltooling](https://svn.middleware.georgetown.edu/view/?root=java-opensaml2) low-level library that may be used to construct libraries that allow developers to work with XML in a Java beans manner.\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nThe (1) BasicParserPool, (2) StaticBasicParserPool, (3) XML Decrypter, and (4) SAML Decrypter set the `expandEntityReferences` property to true, which allows remote attackers to conduct XML external entity (XXE) attacks via a crafted XML `DOCTYPE` declaration.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\n\nUpgrade `org.opensaml:xmltooling` to version 1.4.4 or higher.\n\n\n## References\n\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2013-6440)\n\n- [SendSafely Blog](https://blog.sendsafely.com/web-based-single-sign-on-and-the-dangers-of-saml-xml-parsing)\n",
+        "disclosureTime": "2014-02-14T15:55:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.4.4"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGOPENSAML-30141",
+        "identifiers": {
+          "CVE": [
+            "CVE-2013-6440"
+          ],
+          "CWE": [
+            "CWE-611"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xmltooling",
+          "groupId": "org.opensaml"
+        },
+        "modificationTime": "2019-10-28T09:25:20.166092Z",
+        "moduleName": "org.opensaml:xmltooling",
+        "packageManager": "maven",
+        "packageName": "org.opensaml:xmltooling",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-12-25T16:51:50Z",
+        "references": [
+          {
+            "title": "Redhat Bugzilla",
+            "url": "https://bugzilla.redhat.com/CVE-2013-6440"
+          },
+          {
+            "title": "SendSafely Blog",
+            "url": "https://blog.sendsafely.com/web-based-single-sign-on-and-the-dangers-of-saml-xml-parsing"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,1.4.4)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "com.test:myframework@1.0.0-SNAPSHOT",
+          "org.apache.ws.security:wss4j@1.6.19",
+          "org.opensaml:opensaml@2.5.1-1",
+          "org.opensaml:openws@1.4.2-1",
+          "org.opensaml:xmltooling@1.3.2-1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.opensaml:xmltooling",
+        "version": "1.3.2-1"
+      }
+    ],
+    "upgrade": {
+      "com.thoughtworks.xstream:xstream@1.4.14": {
+        "upgradeTo": "com.thoughtworks.xstream:xstream@1.4.15",
+        "upgrades": [
+          "com.thoughtworks.xstream:xstream@1.4.14",
+          "com.thoughtworks.xstream:xstream@1.4.14"
+        ],
+        "vulns": [
+          "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051966",
+          "SNYK-JAVA-COMTHOUGHTWORKSXSTREAM-1051967"
+        ]
+      },
+      "org.apache.santuario:xmlsec@2.1.1": {
+        "upgradeTo": "org.apache.santuario:xmlsec@2.1.4",
+        "upgrades": [
+          "org.apache.santuario:xmlsec@2.1.1"
+        ],
+        "vulns": [
+          "SNYK-JAVA-ORGAPACHESANTUARIO-460281"
+        ]
+      },
+      "org.jboss.resteasy:resteasy-client@3.1.1.Final": {
+        "upgradeTo": "org.jboss.resteasy:resteasy-client@4.5.8.SP1",
+        "upgrades": [
+          "org.jboss.resteasy:resteasy-client@3.1.1.Final",
+          "org.jboss.resteasy:resteasy-jaxrs@3.1.1.Final",
+          "org.jboss.resteasy:resteasy-jaxrs@3.1.1.Final"
+        ],
+        "vulns": [
+          "SNYK-JAVA-ORGJBOSSRESTEASY-1009963",
+          "SNYK-JAVA-ORGJBOSSRESTEASY-609370",
+          "SNYK-JAVA-ORGJBOSSRESTEASY-542664"
+        ]
+      },
+      "org.owasp.esapi:esapi@2.1.0": {
+        "upgradeTo": "org.owasp.esapi:esapi@2.2.0.0",
+        "upgrades": [
+          "commons-fileupload:commons-fileupload@1.2",
+          "commons-fileupload:commons-fileupload@1.2",
+          "org.owasp.antisamy:antisamy@1.4.3",
+          "org.owasp.antisamy:antisamy@1.4.3",
+          "xalan:xalan@2.7.0",
+          "commons-fileupload:commons-fileupload@1.2",
+          "commons-fileupload:commons-fileupload@1.2",
+          "commons-fileupload:commons-fileupload@1.2",
+          "org.owasp.esapi:esapi@2.1.0"
+        ],
+        "vulns": [
+          "SNYK-JAVA-COMMONSFILEUPLOAD-30401",
+          "SNYK-JAVA-COMMONSFILEUPLOAD-31540",
+          "SNYK-JAVA-ORGOWASPANTISAMY-31591",
+          "SNYK-JAVA-ORGOWASPANTISAMY-598767",
+          "SNYK-JAVA-XALAN-31385",
+          "SNYK-JAVA-COMMONSFILEUPLOAD-30079",
+          "SNYK-JAVA-COMMONSFILEUPLOAD-30080",
+          "SNYK-JAVA-COMMONSFILEUPLOAD-30081",
+          "SNYK-JAVA-ORGOWASPESAPI-30143"
+        ]
+      },
+      "org.testng:testng@6.13.1": {
+        "upgradeTo": "org.testng:testng@7.3.0",
+        "upgrades": [
+          "com.beust:jcommander@1.72",
+          "org.testng:testng@6.13.1"
+        ],
+        "vulns": [
+          "SNYK-JAVA-COMBEUST-174815",
+          "SNYK-JAVA-ORGTESTNG-174823"
+        ]
+      },
+      "org.webjars:bootstrap@3.3.7": {
+        "upgradeTo": "org.webjars:bootstrap@4.5.0",
+        "upgrades": [
+          "org.webjars:jquery@1.11.1",
+          "org.webjars:jquery@1.11.1",
+          "org.webjars:jquery@1.11.1",
+          "org.webjars:jquery@1.11.1",
+          "org.webjars:bootstrap@3.3.7",
+          "org.webjars:bootstrap@3.3.7",
+          "org.webjars:bootstrap@3.3.7",
+          "org.webjars:bootstrap@3.3.7",
+          "org.webjars:bootstrap@3.3.7"
+        ],
+        "vulns": [
+          "SNYK-JAVA-ORGWEBJARS-565171",
+          "SNYK-JAVA-ORGWEBJARS-567882",
+          "SNYK-JAVA-ORGWEBJARS-479774",
+          "SNYK-JAVA-ORGWEBJARS-479782",
+          "SNYK-JAVA-ORGWEBJARS-451160",
+          "SNYK-JAVA-ORGWEBJARS-451162",
+          "SNYK-JAVA-ORGWEBJARS-451164",
+          "SNYK-JAVA-ORGWEBJARS-451168",
+          "SNYK-JAVA-ORGWEBJARS-479505"
+        ]
+      }
+    },
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 41,
+  "projectName": "com.test:myframework",
+  "displayTargetFile": "pom.xml",
+  "path": "C:\\workspace"
+}

--- a/dojo/unittests/scans/snyk/single_project_no_vulns.json
+++ b/dojo/unittests/scans/snyk/single_project_no_vulns.json
@@ -1,0 +1,24 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 0,
+  "org": "myorg",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "No known vulnerabilities",
+  "filesystemPolicy": false,
+  "uniqueCount": 0,
+  "projectName": "com.test:maven-profiles",
+  "displayTargetFile": "pom.xml",
+  "path": "C:\\workspace"
+}

--- a/dojo/unittests/scans/snyk/single_project_one_vuln.json
+++ b/dojo/unittests/scans/snyk/single_project_one_vuln.json
@@ -1,0 +1,122 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
+      "alternativeIds": [],
+      "creationTime": "2019-08-25T13:02:11.461178Z",
+      "credit": [
+        "Sean Mullan"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.apache.santuario:xmlsec](https://mvnrepository.com/artifact/org.apache.santuario/xmlsec) is a package to provide implementation of the primary security standards for XML, XML-Signature Syntax and Processing and XML Encryption Syntax and Processing.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. In version 2.0.3 a caching mechanism was introduced to speed up creating new XML documents using a static pool of DocumentBuilders. However, if some untrusted code can register a malicious implementation with the thread context class loader first, then this implementation might be cached and re-used by Apache Santuario - XML Security for Java, leading to potential security flaws when validating signed documents, etc.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387cdba6)\n- [GitHub Commit](https://github.com/apache/santuario-java/commit/c5210f77a77105fba81311d16c07ceacc21f39d5)\n- [Possible Jira Issue](https://issues.apache.org/jira/browse/SANTUARIO-504?jql=project%20%3D%20SANTUARIO)\n- [Security Release](http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2)\n",
+      "disclosureTime": "2019-05-10T21:50:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.1.4"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESANTUARIO-460281",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-12400"
+        ],
+        "CWE": [
+          "CWE-611"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xmlsec",
+        "groupId": "org.apache.santuario"
+      },
+      "modificationTime": "2020-06-12T14:36:59.920320Z",
+      "moduleName": "org.apache.santuario:xmlsec",
+      "packageManager": "maven",
+      "packageName": "org.apache.santuario:xmlsec",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-08-25T13:53:19Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387cdba6"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/santuario-java/commit/c5210f77a77105fba81311d16c07ceacc21f39d5"
+        },
+        {
+          "title": "Possible Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/SANTUARIO-504?jql=project%20%3D%20SANTUARIO"
+        },
+        {
+          "title": "Security Release",
+          "url": "http://santuario.apache.org/secadv.data/CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.3, 2.1.4)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "com.test:myframework@1.0.0-SNAPSHOT",
+        "org.apache.santuario:xmlsec@2.1.1"
+      ],
+      "upgradePath": [
+        false,
+        "org.apache.santuario:xmlsec@2.1.4"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "org.apache.santuario:xmlsec",
+      "version": "2.1.1"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 5,
+  "org": "myorg",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "maven",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "1 vulnerable dependency path",
+  "remediation": {
+    "unresolved": [],
+    "upgrade": {
+      "org.apache.santuario:xmlsec@2.1.1": {
+        "upgradeTo": "org.apache.santuario:xmlsec@2.1.4",
+        "upgrades": [
+          "org.apache.santuario:xmlsec@2.1.1"
+        ],
+        "vulns": [
+          "SNYK-JAVA-ORGAPACHESANTUARIO-460281"
+        ]
+      }
+    },
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 1,
+  "projectName": "com.test:myframework",
+  "displayTargetFile": "pom.xml",
+  "path": "C:\\workspace"
+}

--- a/dojo/unittests/test_snyk_parser.py
+++ b/dojo/unittests/test_snyk_parser.py
@@ -55,7 +55,7 @@ class TestSnykParser(TestCase):
         self.assertEqual(
             "Medium", finding.severity)
         self.assertEqual(
-            "Issue severity of: <b>Medium</b> from a base CVSS score of: <b>6.5</b>",
+            "Issue severity of: **Medium** from a base CVSS score of: **6.5**",
             finding.severity_justification)
         self.assertEqual(
             "CVE-2019-12400",
@@ -70,10 +70,10 @@ class TestSnykParser(TestCase):
             "## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n",
             finding.mitigation)
         self.assertEqual(
-            "<b>Custom SNYK ID</b>: https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHESANTUARIO-460281\n\n<b>GitHub " +
-            "Commit</b>: https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387" +
-            "cdba6\n<b>GitHub Commit</b>: https://github.com/apache/santuario-java/commit/c5210f77a77105fba81" +
-            "311d16c07ceacc21f39d5\n<b>Possible Jira Issue</b>: https://issues.apache.org/jira/browse/SANTUARIO-" +
-            "504?jql=project%20%3D%20SANTUARIO\n<b>Security Release</b>: http://santuario.apache.org/secadv.data/" +
+            "**SNYK ID**: https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHESANTUARIO-460281\n\n**GitHub " +
+            "Commit**: https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387" +
+            "cdba6\n**GitHub Commit**: https://github.com/apache/santuario-java/commit/c5210f77a77105fba81" +
+            "311d16c07ceacc21f39d5\n**Possible Jira Issue**: https://issues.apache.org/jira/browse/SANTUARIO-" +
+            "504?jql=project%20%3D%20SANTUARIO\n**Security Release**: http://santuario.apache.org/secadv.data/" +
             "CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2\n",
             finding.references)

--- a/dojo/unittests/test_snyk_parser.py
+++ b/dojo/unittests/test_snyk_parser.py
@@ -1,0 +1,79 @@
+from django.test import TestCase
+from dojo.tools.snyk.parser import SnykParser
+from dojo.models import Test
+
+
+class TestSnykParser(TestCase):
+    def test_snykParser_without_file_has_no_finding(self):
+        parser = SnykParser(None, Test())
+        self.assertEqual(0, len(parser.items))
+
+    def test_snykParser_single_has_no_finding(self):
+        testfile = open("dojo/unittests/scans/snyk/single_project_no_vulns.json")
+        parser = SnykParser(testfile, Test())
+        self.assertEqual(0, len(parser.items))
+        testfile.close()
+
+    def test_snykParser_allprojects_has_no_finding(self):
+        testfile = open("dojo/unittests/scans/snyk/all-projects_no_vulns.json")
+        parser = SnykParser(testfile, Test())
+        self.assertEqual(0, len(parser.items))
+        testfile.close()
+
+    def test_snykParser_single_has_one_finding(self):
+        testfile = open("dojo/unittests/scans/snyk/single_project_one_vuln.json")
+        parser = SnykParser(testfile, Test())
+        self.assertEqual(1, len(parser.items))
+        testfile.close()
+
+    def test_snykParser_allprojects_has_one_finding(self):
+        testfile = open("dojo/unittests/scans/snyk/all-projects_one_vuln.json")
+        parser = SnykParser(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(parser.items))
+
+    def test_snykParser_single_has_many_findings(self):
+        testfile = open("dojo/unittests/scans/snyk/single_project_many_vulns.json")
+        parser = SnykParser(testfile, Test())
+        testfile.close()
+        self.assertEqual(41, len(parser.items))
+
+    def test_snykParser_allprojects_has_many_findings(self):
+        testfile = open("dojo/unittests/scans/snyk/all-projects_many_vulns.json")
+        parser = SnykParser(testfile, Test())
+        testfile.close()
+        self.assertEqual(4, len(parser.items))
+
+    def test_snykParser_finding_has_fields(self):
+        testfile = open("dojo/unittests/scans/snyk/single_project_one_vuln.json")
+        parser = SnykParser(testfile, Test())
+        testfile.close()
+        finding = parser.items[0]
+        self.assertEqual(
+          "com.test:myframework@1.0.0-SNAPSHOT: XML External Entity (XXE) Injection",
+          finding.title)
+        self.assertEqual(
+          "Medium", finding.severity)
+        self.assertEqual(
+          "Issue severity of: <b>Medium</b> from a base CVSS score of: <b>6.5</b>",
+          finding.severity_justification)
+        self.assertEqual(
+          "CVE-2019-12400",
+          finding.cve)
+        self.assertEqual(
+          "611",
+          finding.cwe)
+        self.assertEqual(
+          "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
+          finding.cvssv3)
+        self.assertEqual(
+          "## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n",
+          finding.mitigation)
+        self.assertEqual(
+          "<b>Custom SNYK ID</b>: https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHESANTUARIO-460281\n\n<b>GitHub " +
+          "Commit</b>: https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387" +
+          "cdba6\n<b>GitHub Commit</b>: https://github.com/apache/santuario-java/commit/c5210f77a77105fba81" +
+          "311d16c07ceacc21f39d5\n<b>Possible Jira Issue</b>: https://issues.apache.org/jira/browse/SANTUARIO-" +
+          "504?jql=project%20%3D%20SANTUARIO\n<b>Security Release</b>: http://santuario.apache.org/secadv.data/" +
+          "CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2\n",
+          finding.references)

--- a/dojo/unittests/test_snyk_parser.py
+++ b/dojo/unittests/test_snyk_parser.py
@@ -61,7 +61,7 @@ class TestSnykParser(TestCase):
             "CVE-2019-12400",
             finding.cve)
         self.assertEqual(
-            "611",
+            611,
             finding.cwe)
         self.assertEqual(
             "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",

--- a/dojo/unittests/test_snyk_parser.py
+++ b/dojo/unittests/test_snyk_parser.py
@@ -50,30 +50,30 @@ class TestSnykParser(TestCase):
         testfile.close()
         finding = parser.items[0]
         self.assertEqual(
-          "com.test:myframework@1.0.0-SNAPSHOT: XML External Entity (XXE) Injection",
-          finding.title)
+            "com.test:myframework@1.0.0-SNAPSHOT: XML External Entity (XXE) Injection",
+            finding.title)
         self.assertEqual(
-          "Medium", finding.severity)
+            "Medium", finding.severity)
         self.assertEqual(
-          "Issue severity of: <b>Medium</b> from a base CVSS score of: <b>6.5</b>",
-          finding.severity_justification)
+            "Issue severity of: <b>Medium</b> from a base CVSS score of: <b>6.5</b>",
+            finding.severity_justification)
         self.assertEqual(
-          "CVE-2019-12400",
-          finding.cve)
+            "CVE-2019-12400",
+            finding.cve)
         self.assertEqual(
-          "611",
-          finding.cwe)
+            "611",
+            finding.cwe)
         self.assertEqual(
-          "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
-          finding.cvssv3)
+            "AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L",
+            finding.cvssv3)
         self.assertEqual(
-          "## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n",
-          finding.mitigation)
+            "## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n",
+            finding.mitigation)
         self.assertEqual(
-          "<b>Custom SNYK ID</b>: https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHESANTUARIO-460281\n\n<b>GitHub " +
-          "Commit</b>: https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387" +
-          "cdba6\n<b>GitHub Commit</b>: https://github.com/apache/santuario-java/commit/c5210f77a77105fba81" +
-          "311d16c07ceacc21f39d5\n<b>Possible Jira Issue</b>: https://issues.apache.org/jira/browse/SANTUARIO-" +
-          "504?jql=project%20%3D%20SANTUARIO\n<b>Security Release</b>: http://santuario.apache.org/secadv.data/" +
-          "CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2\n",
-          finding.references)
+            "<b>Custom SNYK ID</b>: https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHESANTUARIO-460281\n\n<b>GitHub " +
+            "Commit</b>: https://github.com/apache/santuario-java/commit/52ae824cf5f5c873a0e37bb33fedcc3b387" +
+            "cdba6\n<b>GitHub Commit</b>: https://github.com/apache/santuario-java/commit/c5210f77a77105fba81" +
+            "311d16c07ceacc21f39d5\n<b>Possible Jira Issue</b>: https://issues.apache.org/jira/browse/SANTUARIO-" +
+            "504?jql=project%20%3D%20SANTUARIO\n<b>Security Release</b>: http://santuario.apache.org/secadv.data/" +
+            "CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2\n",
+            finding.references)


### PR DESCRIPTION
This PR addresses the following features:

* Support for Snyk JSON reports generated with the --all-projects (e.g: Maven multi module projects). 

* Added the following missing fields for each Finding generated from a report:
  * CVSS3
  * Severity justification 
  * Mitigation
  * References
 
* Minor visual changes:
  * Added link to the Snyk Vulnerability Database for the referenced Snyk IDs.
  * Added bold format to the details section within the issue description.
  
  
TODO:
- [x] Add unit test 