### PR TITLE
Fix sonarqube 3-hourly sync job

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -711,7 +711,7 @@ CELERY_BEAT_SCHEDULE = {
         'args': [timedelta(minutes=1)]
     },
     'update-findings-from-source-issues': {
-        'task': 'dojo.tasks.async_update_findings_from_source_issues',
+        'task': 'dojo.tools.tool_issue_updater.update_findings_from_source_issues',
         'schedule': timedelta(hours=3),
     },
     'compute-sla-age-and-notify': {


### PR DESCRIPTION
during one of the bigger revamp PRs we broke the 3-hourly job that syncs data from sonarqube into defect dojo for findings originally imported from sonarqube: `dojo.tools.tool_issue_updater.update_findings_from_source_issues`

