### PR TITLE
Security: Prevent XEE in parsers, Prevent open redirect

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -18,7 +18,8 @@ from dojo.filters import EndpointFilter
 from dojo.forms import EditEndpointForm, \
     DeleteEndpointForm, AddEndpointForm, DojoMetaDataForm
 from dojo.models import Product, Endpoint, Finding, System_Settings, DojoMeta, Endpoint_Status
-from dojo.utils import get_page_items, add_breadcrumb, get_period_counts, get_system_setting, Product_Tab, calculate_grade
+from dojo.utils import get_page_items, add_breadcrumb, get_period_counts, get_system_setting, Product_Tab, \
+    calculate_grade, redirect
 from dojo.notifications.helper import create_notification
 from dojo.user.helper import user_must_be_authorized
 
@@ -441,7 +442,7 @@ def endpoint_status_bulk_update(request, fid):
                                     messages.ERROR,
                                     'Unable to process bulk update. Required fields were not selected.',
                                     extra_tags='alert-danger')
-    return HttpResponseRedirect(post['return_url'])
+    return redirect(post['return_url'])
 
 
 def prefetch_for_endpoints(endpoints):

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -200,7 +200,7 @@ def identify_view(request):
         # although any XSS should be catch by django autoescape, we see people sometimes using '|safe'...
         if view in ['Endpoint', 'Finding']:
             return view
-        raise ValueError('invalid view, view must Endpoint or Finding')
+        raise ValueError('invalid view, view must be "Endpoint" or "Finding"')
     else:
         if get_data.get('finding__severity', None):
             return 'Endpoint'

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -196,7 +196,11 @@ def identify_view(request):
     get_data = request.GET
     view = get_data.get('type', None)
     if view:
-        return view
+        # value of view is reflected in the template, make sure it's valid
+        # although any XSS should be catch by django autoescape, we see people sometimes using '|safe'...
+        if view in ['Endpoint', 'Finding']:
+            return view
+        raise ValueError('invalid view, view must Endpoint or Finding')
     else:
         if get_data.get('finding__severity', None):
             return 'Endpoint'

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -27,7 +27,7 @@ from dojo.reports.widgets import CoverPage, PageBreak, TableOfContents, WYSIWYGC
     CustomReportJsonForm, ReportOptions, report_widget_factory
 from dojo.tasks import async_pdf_report, async_custom_pdf_report
 from dojo.utils import get_page_items, add_breadcrumb, get_system_setting, get_period_counts_legacy, Product_Tab, \
-    get_words_for_field
+    get_words_for_field, redirect
 from dojo.user.helper import user_must_be_authorized, check_auth_users_list
 
 logger = logging.getLogger(__name__)
@@ -318,7 +318,7 @@ def reports(request):
 def regen_report(request, rid):
     report = get_object_or_404(Report, id=rid)
     if report.type != 'Custom':
-        return HttpResponseRedirect(report.options + "&regen=" + rid)
+        return redirect(report.options + "&regen=" + rid)
     else:
         report.datetime = timezone.now()
         report.status = 'requested'

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -212,7 +212,7 @@ def add_questionnaire(request, eid):
                 return HttpResponseRedirect(reverse(
                     'answer_questionnaire', args=(eid, survey.id)))
 
-            return HttpResponseRedirect('/engagement/%s' % eid)
+            return HttpResponseRedirect(reverse('view_engagement', args=(eid,)))
         else:
             messages.add_message(request,
                                  messages.ERROR,

--- a/dojo/tools/acunetix/parser_helper.py
+++ b/dojo/tools/acunetix/parser_helper.py
@@ -6,8 +6,6 @@ from .parser_models import DefectDojoFinding
 # from memory_profiler import profile #Comment out this and profile in defectdojo repo
 import html2text
 
-logging.basicConfig(level=logging.ERROR)
-
 SCAN_NODE_TAG_NAME = "Scan"
 ACUNETIX_XML_SCAN_IGNORE_NODES = ['Technologies', 'Crawler']
 ACUNETIX_XML_REPORTITEM_IGNORE_NODES = ['CVEList', 'CVSS', 'CVSS3']
@@ -21,7 +19,7 @@ def get_root_node(filename):
     :return:
     """
     try:
-        tree = etree.parse(filename)
+        tree = etree.parse(filename, etree.XMLParser(resolve_entities=False))
         return tree.getroot()
     except XMLSyntaxError as xse:
         logging.error("ERROR : error parsing XML file {filename}".format(filename=filename))

--- a/dojo/tools/qualys_webapp/parser.py
+++ b/dojo/tools/qualys_webapp/parser.py
@@ -232,6 +232,7 @@ def qualys_webapp_parser(qualys_xml_file, test):
     if qualys_xml_file is None:
         return []
 
+    # supposed to be safe against XEE: https://docs.python.org/3/library/xml.html#xml-vulnerabilities
     tree = xml.etree.ElementTree.parse(qualys_xml_file)
     is_app_report = tree.getroot().tag == 'WAS_WEBAPP_REPORT'
 

--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -27,7 +27,7 @@ class VeracodeXMLParser(object):
             self.items = list()
             return
         try:
-            xml = etree.parse(filename)
+            xml = etree.parse(filename, etree.XMLParser(resolve_entities=False))
         except:
             raise NamespaceErr('Cannot parse this report. Make sure to upload a proper Veracode Detailed XML report.')
 

--- a/dojo/unittests/test_deduplication_logic.py
+++ b/dojo/unittests/test_deduplication_logic.py
@@ -6,9 +6,6 @@ import logging
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
-loglevel = logging.DEBUG
-logging.basicConfig(level=loglevel)
-
 # things to consider:
 # - cross scanner deduplication is still flaky as if some scanners don't provide severity, but another doesn, the hashcode will be different so no deduplication happens.
 #   so I couldn't create any good tests

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -11,6 +11,7 @@ from math import pi, sqrt
 import vobject
 from dateutil.relativedelta import relativedelta, MO, SU
 from django.conf import settings
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
 from django.urls import get_resolver, reverse
@@ -1643,13 +1644,22 @@ def get_return_url(request):
 
 def redirect_to_return_url_or_else(request, or_else):
     return_url = get_return_url(request)
+
     if return_url:
-        return HttpResponseRedirect(return_url.strip())
+        # logger.debug('redirecting to %s: ', return_url.strip())
+        return redirect(return_url.strip())
     elif or_else:
-        return HttpResponseRedirect(or_else)
+        return redirect(or_else)
     else:
         messages.add_message(request, messages.ERROR, 'Unable to redirect anywhere.', extra_tags='alert-danger')
-        return HttpResponseRedirect(request.get_full_path())
+        return redirect(request.get_full_path())
+
+
+# only allow redirects to allowed_hosts to prevent open redirects
+def redirect(request, redirect_to):
+    if url_has_allowed_host_and_scheme(redirect_to):
+        return HttpResponseRedirect(redirect_to)
+    raise ValueError('invalid redirect, host and scheme not in allowed_hosts')
 
 
 def file_size_mb(file_obj):

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1630,7 +1630,7 @@ def merge_sets_safe(set1, set2):
     # return {*set1, *set2}
 
 
-def is_safe_url(self, url):
+def is_safe_url(url):
     try:
         # available in django 3+
         from django.utils.http import url_has_allowed_host_and_scheme

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1658,12 +1658,12 @@ def redirect_to_return_url_or_else(request, or_else):
 
     if return_url:
         # logger.debug('redirecting to %s: ', return_url.strip())
-        return redirect(return_url.strip())
+        return redirect(request, return_url.strip())
     elif or_else:
-        return redirect(or_else)
+        return redirect(request, or_else)
     else:
         messages.add_message(request, messages.ERROR, 'Unable to redirect anywhere.', extra_tags='alert-danger')
-        return redirect(request.get_full_path())
+        return redirect(request, request.get_full_path())
 
 
 # only allow redirects to allowed_hosts to prevent open redirects

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -11,7 +11,6 @@ from math import pi, sqrt
 import vobject
 from dateutil.relativedelta import relativedelta, MO, SU
 from django.conf import settings
-from django.utils.http import url_has_allowed_host_and_scheme
 from django.core.mail import send_mail
 from django.core.paginator import Paginator
 from django.urls import get_resolver, reverse
@@ -1631,6 +1630,18 @@ def merge_sets_safe(set1, set2):
     # return {*set1, *set2}
 
 
+def is_safe_url(self, url):
+    try:
+        # available in django 3+
+        from django.utils.http import url_has_allowed_host_and_scheme
+    except ImportError:
+        # django < 3
+        from django.utils.http import \
+            is_safe_url as url_has_allowed_host_and_scheme
+
+    return url_has_allowed_host_and_scheme(url, allowed_hosts=None)
+
+
 def get_return_url(request):
     return_url = request.POST.get('return_url', None)
     # print('return_url from POST: ', return_url)
@@ -1657,7 +1668,7 @@ def redirect_to_return_url_or_else(request, or_else):
 
 # only allow redirects to allowed_hosts to prevent open redirects
 def redirect(request, redirect_to):
-    if url_has_allowed_host_and_scheme(redirect_to):
+    if is_safe_url(redirect_to):
         return HttpResponseRedirect(redirect_to)
     raise ValueError('invalid redirect, host and scheme not in allowed_hosts')
 

--- a/tests/validate_acunetix_scan_xml.py
+++ b/tests/validate_acunetix_scan_xml.py
@@ -12,7 +12,7 @@ def get_root_node(filename):
     :return:
     """
     try:
-        tree = etree.parse(filename)
+        tree = etree.parse(filename, etree.XMLParser(resolve_entities=False))
         return tree.getroot()
     except XMLSyntaxError as xse:
         logging.error("ERROR : error parsing XML file {filename}".format(filename=filename))


### PR DESCRIPTION
the old lxml parser is not safe against XEE out of the box, so we have to disable entity resolution.

also fixes an open redirect

includes fixes for suggestions from sonar:
- remove hardcoded logging config changes
- check user controlled view parameter that is reflected in templates
