### PR TITLE
fix anchore reimport, sync reimport logic API<->UI, add unit tests

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1270,6 +1270,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
             unchanged_count = 0
             unchanged_items = []
 
+            logger.debug('starting reimport of %i items.', len(items))
+            i = 0
             for item in items:
                 sev = item.severity
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -31,6 +31,7 @@ import dojo.finding.helper as finding_helper
 
 
 logger = logging.getLogger(__name__)
+deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 
 class TagList(list):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1317,9 +1317,9 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 # or we may need to change the matching logic here to use the same logic
                 # as the deduplication logic (hashcode fields)
 
-                # if scan_type == 'Anchore Engine Scan':
-                #     if item.file_path:
-                #         findings = findings.filter(file_path=item.file_path)
+                if scan_type == 'Anchore Engine Scan':
+                    if item.file_path:
+                        findings = findings.filter(file_path=item.file_path)
 
                 if findings:
                     # existing finding found

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -970,8 +970,6 @@ class ScanSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
-# class ImportScanSerializer(TaggitSerializer, serializers.ModelSerializer):
-# class ImportScanSerializer(TaggitSerializer, serializers.Serializer):
 class ImportScanSerializer(serializers.Serializer):
     scan_date = serializers.DateField(default=datetime.date.today)
 
@@ -1177,7 +1175,7 @@ class ImportScanSerializer(serializers.Serializer):
                     status.save()
 
                 old_finding.tags.add('stale')
-                old_finding.save()
+                old_finding.save(dedupe_option=False)
 
         logger.debug('done importing findings')
 
@@ -1313,7 +1311,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         finding.component_name = finding.component_name if finding.component_name else component_name
                         finding.component_version = finding.component_version if finding.component_version else component_version
 
-                        finding.save()
+                        finding.save(dedupe_option=False, push_to_jira=push_to_jira)
                         note = Notes(
                             entry="Re-activated by %s re-upload." % scan_type,
                             author=self.context['request'].user)
@@ -1418,7 +1416,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                             status.last_modified = timezone.now()
                             status.save()
 
-                        finding.save(push_to_jira=push_to_jira)
+                        # don't try to dedupe findings that we are closing
+                        finding.save(push_to_jira=push_to_jira, dedupe_option=False)
                         note = Notes(entry="Mitigated by %s re-upload." % scan_type,
                                     author=self.context['request'].user)
                         note.save()

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1311,7 +1311,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         finding.component_name = finding.component_name if finding.component_name else component_name
                         finding.component_version = finding.component_version if finding.component_version else component_version
 
-                        finding.save(dedupe_option=False, push_to_jira=push_to_jira)
+                        # don't dedupe before endpoints are added
+                        finding.save(dedupe_option=False)
                         note = Notes(
                             entry="Re-activated by %s re-upload." % scan_type,
                             author=self.context['request'].user)
@@ -1331,7 +1332,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                         if not finding.component_name or not finding.component_version:
                             finding.component_name = finding.component_name if finding.component_name else component_name
                             finding.component_version = finding.component_version if finding.component_version else component_version
-                            finding.save(dedupe_option=False, push_to_jira=False)
+                            finding.save(dedupe_option=False)
 
                         unchanged_items.append(finding)
                         unchanged_count += 1
@@ -1343,6 +1344,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     item.last_reviewed_by = self.context['request'].user
                     item.verified = verified
                     item.active = active
+                    # Save it. Don't dedupe before endpoints are added.
                     item.save(dedupe_option=False)
                     finding_added_count += 1
                     new_items.append(item)

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -606,9 +606,10 @@ def import_scan_results(request, eid=None, pid=None):
                 # push_to_jira = jira_helper.is_push_to_jira(new_finding, jform.cleaned_data.get('push_to_jira'))
                 push_to_jira = push_all_jira_issues or (jform and jform.cleaned_data.get('push_to_jira'))
 
-                for item in parser.items:
-                    # print("item blowup")
-                    # print(item)
+                items = parser.items
+                logger.debug('starting reimport of %i items.', len(items))
+                i = 0
+                for item in items:
                     sev = item.severity
                     if sev == 'Information' or sev == 'Informational':
                         sev = 'Info'
@@ -627,6 +628,7 @@ def import_scan_results(request, eid=None, pid=None):
                         item.verified = verified
 
                     item.save(dedupe_option=False, false_history=True)
+                    logger.debug('%i: creating new finding: %i:%s:%s:%s', i, item.id, item, item.component_name, item.component_version)
 
                     if hasattr(item, 'unsaved_req_resp') and len(
                             item.unsaved_req_resp) > 0:
@@ -692,6 +694,7 @@ def import_scan_results(request, eid=None, pid=None):
                         item.tags = item.unsaved_tags
 
                     finding_count += 1
+                    i += 1
 
                 messages.add_message(
                     request,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -754,6 +754,7 @@ if env('DD_DJANGO_METRICS_ENABLED'):
 HASHCODE_FIELDS_PER_SCANNER = {
     # In checkmarx, same CWE may appear with different severities: example "sql injection" (high) and "blind sql injection" (low).
     # Including the severity in the hash_code keeps those findings not duplicate
+    'Anchore Engine Scan': ['title', 'severity', 'component_name', 'component_version', 'file_path'],
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'Dependency Check Scan': ['cve', 'file_path'],
@@ -779,6 +780,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
 # If False and cwe = 0, then the hash_code computation will fallback to legacy algorithm for the concerned finding
 # Default is True (if scanner is not configured here but is configured in HASHCODE_FIELDS_PER_SCANNER, it allows null cwe)
 HASHCODE_ALLOWS_NULL_CWE = {
+    'Anchore Engine Scan': True,
     'Checkmarx Scan': False,
     'SonarQube Scan': False,
     'Dependency Check Scan': True,
@@ -815,6 +817,7 @@ DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE = 'unique_id_from_tool_or_hash_code
 # Key = the scan_type from factory.py (= the test_type)
 # Default is DEDUPE_ALGO_LEGACY
 DEDUPLICATION_ALGORITHM_PER_PARSER = {
+    'Anchore Engine Scan': DEDUPE_ALGO_HASH_CODE,
     'Checkmarx Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Checkmarx Scan': DEDUPE_ALGO_HASH_CODE,
     'SonarQube Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -648,8 +648,8 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'dojo.middleware.LoginRequiredMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
-    'watson.middleware.SearchContextMiddleware',
-    'auditlog.middleware.AuditlogMiddleware',
+    # 'watson.middleware.SearchContextMiddleware',
+    # 'auditlog.middleware.AuditlogMiddleware',
     'crum.CurrentRequestUserMiddleware',
 ]
 
@@ -754,6 +754,7 @@ if env('DD_DJANGO_METRICS_ENABLED'):
 HASHCODE_FIELDS_PER_SCANNER = {
     # In checkmarx, same CWE may appear with different severities: example "sql injection" (high) and "blind sql injection" (low).
     # Including the severity in the hash_code keeps those findings not duplicate
+    'Anchore Engine Scan': ['title', 'severity', 'component_name', 'component_version'],
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'Dependency Check Scan': ['cve', 'file_path'],
@@ -779,6 +780,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
 # If False and cwe = 0, then the hash_code computation will fallback to legacy algorithm for the concerned finding
 # Default is True (if scanner is not configured here but is configured in HASHCODE_FIELDS_PER_SCANNER, it allows null cwe)
 HASHCODE_ALLOWS_NULL_CWE = {
+    'Anchore Engine Scan': True,
     'Checkmarx Scan': False,
     'SonarQube Scan': False,
     'Dependency Check Scan': True,
@@ -791,6 +793,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'Acunetix Scan': True,
     'Trivy Scan': True,
 }
+
 
 # List of fields that are known to be usable in hash_code computation)
 # 'endpoints' is a pseudo field that uses the endpoints (for dynamic scanners)
@@ -815,6 +818,7 @@ DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE = 'unique_id_from_tool_or_hash_code
 # Key = the scan_type from factory.py (= the test_type)
 # Default is DEDUPE_ALGO_LEGACY
 DEDUPLICATION_ALGORITHM_PER_PARSER = {
+    'Anchore Engine Scan': DEDUPE_ALGO_HASH_CODE,
     'Checkmarx Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Checkmarx Scan': DEDUPE_ALGO_HASH_CODE,
     'SonarQube Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
@@ -904,6 +908,13 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'json'
         },
+        'file': {
+            'level': 'DEBUG',
+            'class': 'logging.FileHandler',
+            'filename': 'debug.log',
+            'formatter': 'verbose',
+            'mode': 'w',
+        },
     },
     'loggers': {
         'django.request': {
@@ -912,24 +923,24 @@ LOGGING = {
             'propagate': True,
         },
         'django.security': {
-            'handlers': [r'%s' % LOGGING_HANDLER],
+            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'celery': {
-            'handlers': [r'%s' % LOGGING_HANDLER],
+            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
             # workaround some celery logging known issue
             'worker_hijack_root_logger': False,
         },
         'dojo': {
-            'handlers': [r'%s' % LOGGING_HANDLER],
+            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
-            'handlers': [r'%s' % LOGGING_HANDLER],
+            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -648,8 +648,8 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'dojo.middleware.LoginRequiredMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
-    # 'watson.middleware.SearchContextMiddleware',
-    # 'auditlog.middleware.AuditlogMiddleware',
+    'watson.middleware.SearchContextMiddleware',
+    'auditlog.middleware.AuditlogMiddleware',
     'crum.CurrentRequestUserMiddleware',
 ]
 
@@ -754,7 +754,6 @@ if env('DD_DJANGO_METRICS_ENABLED'):
 HASHCODE_FIELDS_PER_SCANNER = {
     # In checkmarx, same CWE may appear with different severities: example "sql injection" (high) and "blind sql injection" (low).
     # Including the severity in the hash_code keeps those findings not duplicate
-    'Anchore Engine Scan': ['title', 'severity', 'component_name', 'component_version', 'file_path'],
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'Dependency Check Scan': ['cve', 'file_path'],
@@ -780,7 +779,6 @@ HASHCODE_FIELDS_PER_SCANNER = {
 # If False and cwe = 0, then the hash_code computation will fallback to legacy algorithm for the concerned finding
 # Default is True (if scanner is not configured here but is configured in HASHCODE_FIELDS_PER_SCANNER, it allows null cwe)
 HASHCODE_ALLOWS_NULL_CWE = {
-    'Anchore Engine Scan': True,
     'Checkmarx Scan': False,
     'SonarQube Scan': False,
     'Dependency Check Scan': True,
@@ -793,7 +791,6 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'Acunetix Scan': True,
     'Trivy Scan': True,
 }
-
 
 # List of fields that are known to be usable in hash_code computation)
 # 'endpoints' is a pseudo field that uses the endpoints (for dynamic scanners)
@@ -818,7 +815,6 @@ DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE = 'unique_id_from_tool_or_hash_code
 # Key = the scan_type from factory.py (= the test_type)
 # Default is DEDUPE_ALGO_LEGACY
 DEDUPLICATION_ALGORITHM_PER_PARSER = {
-    'Anchore Engine Scan': DEDUPE_ALGO_HASH_CODE,
     'Checkmarx Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Checkmarx Scan': DEDUPE_ALGO_HASH_CODE,
     'SonarQube Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
@@ -908,13 +904,6 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'json'
         },
-        'file': {
-            'level': 'DEBUG',
-            'class': 'logging.FileHandler',
-            'filename': 'debug.log',
-            'formatter': 'verbose',
-            'mode': 'w',
-        },
     },
     'loggers': {
         'django.request': {
@@ -923,24 +912,24 @@ LOGGING = {
             'propagate': True,
         },
         'django.security': {
-            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'celery': {
-            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
             # workaround some celery logging known issue
             'worker_hijack_root_logger': False,
         },
         'dojo': {
-            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'dojo.specific-loggers.deduplication': {
-            'handlers': [r'%s' % LOGGING_HANDLER, 'file'],
+            'handlers': [r'%s' % LOGGING_HANDLER],
             'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -754,7 +754,7 @@ if env('DD_DJANGO_METRICS_ENABLED'):
 HASHCODE_FIELDS_PER_SCANNER = {
     # In checkmarx, same CWE may appear with different severities: example "sql injection" (high) and "blind sql injection" (low).
     # Including the severity in the hash_code keeps those findings not duplicate
-    'Anchore Engine Scan': ['title', 'severity', 'component_name', 'component_version'],
+    'Anchore Engine Scan': ['title', 'severity', 'component_name', 'component_version', 'file_path'],
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'Dependency Check Scan': ['cve', 'file_path'],

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -737,9 +737,9 @@ def re_import_scan_results(request, tid):
                     # or we may need to change the matching logic here to use the same logic
                     # as the deduplication logic (hashcode fields)
 
-                    # if scan_type == 'Anchore Engine Scan':
-                    #     if item.file_path:
-                    #         findings = findings.filter(file_path=item.file_path)
+                    if scan_type == 'Anchore Engine Scan':
+                        if item.file_path:
+                            findings = findings.filter(file_path=item.file_path)
 
                     if findings:
                         finding = findings[0]

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -787,8 +787,8 @@ def re_import_scan_results(request, tid):
                         item.verified = verified
                         item.active = active
 
-                        # Save it. New finding may be deduplicated by dojo
-                        item.save(push_to_jira=push_to_jira, dedupe_option=True)
+                        # Save it. Don't dedupe before endpoints are added.
+                        item.save(dedupe_option=False)
                         logger.debug('%i: creating new finding: %i:%s:%s:%s', i, item.id, item, item.component_name, item.component_version)
                         deduplicationLogger.debug('reimport found multiple identical existing findings for %i, a non-exact match. these are ignored and a new finding has been created', item.id)
                         finding_added_count += 1

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -723,18 +723,22 @@ def re_import_scan_results(request, tid):
                                                       severity=sev,
                                                       numerical_severity=Finding.get_numerical_severity(sev))
 
-                        # some parsers generate 1 finding for each vulnerable file for each vulnerability
-                        # i.e
-                        # #: title                     : sev : file_path
-                        # 1: CVE-2020-1234 jquery      : 1   : /file1.jar
-                        # 2: CVE-2020-1234 jquery      : 1   : /file2.jar
-                        #
-                        # if we don't filter on file_path, we would find 2 existing findings
-                        # and the logic below will get confused and just create a new finding
-                        # and close the two existing ones. including and duplicates.
-
-                        # if item.file_path:
-                        #     finding = finding.filter(file_path=item.file_path)
+                    # some parsers generate 1 finding for each vulnerable file for each vulnerability
+                    # i.e
+                    # #: title                     : sev : file_path
+                    # 1: CVE-2020-1234 jquery      : 1   : /file1.jar
+                    # 2: CVE-2020-1234 jquery      : 1   : /file2.jar
+                    #
+                    # if we don't filter on file_path, we would find 2 existing findings
+                    # and the logic below will get confused and just create a new finding
+                    # and close the two existing ones. including and duplicates.
+                    #
+                    # for Anchore we fix this here, we may need a broader fix (and testcases)
+                    # or we may need to change the matching logic here to use the same logic
+                    # as the deduplication logic (hashcode fields)
+                    if scan_type == 'Anchore Engine Scan':
+                        if item.file_path:
+                            finding = finding.filter(file_path=item.file_path)
 
                     if len(finding) == 1:
                         finding = finding[0]

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -723,19 +723,6 @@ def re_import_scan_results(request, tid):
                                                       severity=sev,
                                                       numerical_severity=Finding.get_numerical_severity(sev))
 
-                        # some parsers generate 1 finding for each vulnerable file for each vulnerability
-                        # i.e
-                        # #: title                     : sev : file_path
-                        # 1: CVE-2020-1234 jquery      : 1   : /file1.jar
-                        # 2: CVE-2020-1234 jquery      : 1   : /file2.jar
-                        #
-                        # if we don't filter on file_path, we would find 2 existing findings
-                        # and the logic below will get confused and just create a new finding
-                        # and close the two existing ones. including and duplicates.
-
-                        # if item.file_path:
-                        #     finding = finding.filter(file_path=item.file_path)
-
                     if len(finding) == 1:
                         finding = finding[0]
                         if finding.mitigated or finding.is_Mitigated:

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -723,6 +723,19 @@ def re_import_scan_results(request, tid):
                                                       severity=sev,
                                                       numerical_severity=Finding.get_numerical_severity(sev))
 
+                        # some parsers generate 1 finding for each vulnerable file for each vulnerability
+                        # i.e
+                        # #: title                     : sev : file_path
+                        # 1: CVE-2020-1234 jquery      : 1   : /file1.jar
+                        # 2: CVE-2020-1234 jquery      : 1   : /file2.jar
+                        #
+                        # if we don't filter on file_path, we would find 2 existing findings
+                        # and the logic below will get confused and just create a new finding
+                        # and close the two existing ones. including and duplicates.
+
+                        # if item.file_path:
+                        #     finding = finding.filter(file_path=item.file_path)
+
                     if len(finding) == 1:
                         finding = finding[0]
                         if finding.mitigated or finding.is_Mitigated:
@@ -855,7 +868,7 @@ def re_import_scan_results(request, tid):
                     for finding in to_mitigate:
                         # finding = Finding.objects.get(id=finding_id)
                         if not finding.mitigated or not finding.is_Mitigated:
-                            logger.info('mitigating finding: %i:%s', finding.id, finding)
+                            logger.debug('mitigating finding: %i:%s', finding.id, finding)
                             finding.mitigated = scan_date_time
                             finding.is_Mitigated = True
                             finding.mitigated_by = request.user

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -164,7 +164,7 @@ class DojoTestUtilsMixin(object):
             self.assertEqual(response.status_code, 200)
         elif expect_redirect_to:
             self.assertEqual(response.status_code, 302)
-            print('url: ' + response.url)
+            # print('url: ' + response.url)
             try:
                 product = Product.objects.get(id=response.url.split('/')[-1])
             except:
@@ -222,14 +222,14 @@ class DojoTestUtilsMixin(object):
 
     def edit_jira_project_for_product_with_data(self, product, data, expected_delta_jira_project_db=0, expect_redirect_to=None, expect_200=None):
         jira_project_count_before = self.db_jira_project_count()
-        print('before: ' + str(jira_project_count_before))
+        # print('before: ' + str(jira_project_count_before))
 
         if not expect_redirect_to and not expect_200:
             expect_redirect_to = self.get_expected_redirect_product(product)
 
         response = self.edit_product_jira(product, data, expect_redirect_to=expect_redirect_to, expect_200=expect_200)
 
-        print('after: ' + str(self.db_jira_project_count()))
+        # print('after: ' + str(self.db_jira_project_count()))
 
         self.assertEqual(self.db_jira_project_count(), jira_project_count_before + expected_delta_jira_project_db)
         return response
@@ -242,14 +242,14 @@ class DojoTestUtilsMixin(object):
 
     def empty_jira_project_for_product(self, product, expected_delta_jira_project_db=0, expect_redirect_to=None, expect_200=False):
         jira_project_count_before = self.db_jira_project_count()
-        print('before: ' + str(jira_project_count_before))
+        # print('before: ' + str(jira_project_count_before))
 
         if not expect_redirect_to and not expect_200:
             expect_redirect_to = self.get_expected_redirect_product(product)
 
         response = self.edit_product_jira(product, self.get_product_with_empty_jira_project_data(product), expect_redirect_to=expect_redirect_to, expect_200=expect_200)
 
-        print('after: ' + str(self.db_jira_project_count()))
+        # print('after: ' + str(self.db_jira_project_count()))
 
         self.assertEqual(self.db_jira_project_count(), jira_project_count_before + expected_delta_jira_project_db)
         return response
@@ -280,13 +280,14 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
     def reimport_scan(self, payload):
         response = self.client.post(reverse('reimportscan-list'), payload)
+        # print(response.content)
         self.assertEqual(201, response.status_code)
         return json.loads(response.content)
 
     def get_test_api(self, test_id):
         response = self.client.get(reverse('test-list') + '%s/' % test_id, format='json')
         self.assertEqual(200, response.status_code)
-        print('test.content: ', response.content)
+        # print('test.content: ', response.content)
         return json.loads(response.content)
 
     def import_scan_with_params(self, filename, engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None, close_old_findings=False):

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -275,6 +275,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
     def import_scan(self, payload):
         # logger.debug('import_scan payload %s', payload)
         response = self.client.post(reverse('importscan-list'), payload)
+        print(response.content)
         self.assertEqual(201, response.status_code)
         return json.loads(response.content)
 
@@ -290,13 +291,13 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         # print('test.content: ', response.content)
         return json.loads(response.content)
 
-    def import_scan_with_params(self, filename, engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None, close_old_findings=False):
+    def import_scan_with_params(self, filename, scan_type='ZAP Scan', engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None, close_old_findings=False):
         payload = {
                 "scan_date": '2020-06-04',
                 "minimum_severity": minimum_severity,
                 "active": active,
                 "verified": verified,
-                "scan_type": 'ZAP Scan',
+                "scan_type": scan_type,
                 "file": open(filename),
                 "engagement": engagement,
                 "version": "1.0.1",
@@ -311,14 +312,14 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
         return self.import_scan(payload)
 
-    def reimport_scan_with_params(self, test_id, filename, engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None, close_old_findings=True):
+    def reimport_scan_with_params(self, test_id, filename, scan_type='ZAP Scan', engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None, close_old_findings=True):
         payload = {
                 "test": test_id,
                 "scan_date": '2020-06-04',
                 "minimum_severity": minimum_severity,
                 "active": active,
                 "verified": verified,
-                "scan_type": 'ZAP Scan',
+                "scan_type": scan_type,
                 "file": open(filename),
                 "engagement": engagement,
                 "version": "1.0.1",

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -275,7 +275,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
     def import_scan(self, payload):
         # logger.debug('import_scan payload %s', payload)
         response = self.client.post(reverse('importscan-list'), payload)
-        print(response.content)
+        # print(response.content)
         self.assertEqual(201, response.status_code)
         return json.loads(response.content)
 

--- a/dojo/unittests/scans/anchore/one_vuln_many_files.json
+++ b/dojo/unittests/scans/anchore/one_vuln_many_files.json
@@ -1,0 +1,130 @@
+{
+    "imageDigest": "sha256:91f5c377c6b3c8eabe4112057f71794a648fc7d88e06336384fb4ea1042a2dee",
+    "vulnerabilities": [
+        {
+            "feed": "nvdv2",
+            "feed_group": "nvdv2:cves",
+            "fix": "None",
+            "nvd_data": [
+                {
+                    "cvss_v2": {
+                        "base_score": 7.5,
+                        "exploitability_score": 10.0,
+                        "impact_score": 6.4
+                    },
+                    "cvss_v3": {
+                        "base_score": -1.0,
+                        "exploitability_score": -1.0,
+                        "impact_score": -1.0
+                    },
+                    "id": "CVE-2005-3906"
+                }
+            ],
+            "package": "jdk-1.4",
+            "package_cpe": "cpe:/a:-:jdk:1.4:-:-",
+            "package_cpe23": "cpe:2.3:a:-:jdk:1.4:-:-:-:-:-:-:-",
+            "package_name": "jdk",
+            "package_path": "/usr/share/contoso-petstore/contoso-petstore.war:WEB-INF/deployed-addons/jdk-tool.hpi",
+            "package_type": "java",
+            "package_version": "1.4",
+            "severity": "High",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2005-3906",
+            "vendor_data": [],
+            "vuln": "CVE-2005-3906"
+        },
+        {
+            "feed": "nvdv2",
+            "feed_group": "nvdv2:cves",
+            "fix": "None",
+            "nvd_data": [
+                {
+                    "cvss_v2": {
+                        "base_score": 7.5,
+                        "exploitability_score": 10.0,
+                        "impact_score": 6.4
+                    },
+                    "cvss_v3": {
+                        "base_score": -1.0,
+                        "exploitability_score": -1.0,
+                        "impact_score": -1.0
+                    },
+                    "id": "CVE-2005-3906"
+                }
+            ],
+            "package": "jdk-1.4",
+            "package_cpe": "cpe:/a:-:jdk:1.4:-:-",
+            "package_cpe23": "cpe:2.3:a:-:jdk:1.4:-:-:-:-:-:-:-",
+            "package_name": "jdk",
+            "package_path": "/usr/share/contoso-petstore/contoso-petstore.war:WEB-INF/deployed-addons/jdk-tool.hpi:WEB-INF/lib/jdk-tool.jar",
+            "package_type": "java",
+            "package_version": "1.4",
+            "severity": "High",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2005-3906",
+            "vendor_data": [],
+            "vuln": "CVE-2005-3906"
+        },
+        {
+            "feed": "nvdv2",
+            "feed_group": "nvdv2:cves",
+            "fix": "None",
+            "nvd_data": [
+                {
+                    "cvss_v2": {
+                        "base_score": 7.5,
+                        "exploitability_score": 10.0,
+                        "impact_score": 6.4
+                    },
+                    "cvss_v3": {
+                        "base_score": -1.0,
+                        "exploitability_score": -1.0,
+                        "impact_score": -1.0
+                    },
+                    "id": "CVE-2005-3906"
+                }
+            ],
+            "package": "jdk-1.4",
+            "package_cpe": "cpe:/a:-:jdk:1.4:-:-",
+            "package_cpe23": "cpe:2.3:a:-:jdk:1.4:-:-:-:-:-:-:-",
+            "package_name": "jdk",
+            "package_path": "/usr/share/contoso-petstore/contoso-petstore.war:WEB-INF/addons/jdk-tool.hpi",
+            "package_type": "java",
+            "package_version": "1.4",
+            "severity": "High",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2005-3906",
+            "vendor_data": [],
+            "vuln": "CVE-2005-3906"
+        },
+        {
+            "feed": "nvdv2",
+            "feed_group": "nvdv2:cves",
+            "fix": "None",
+            "nvd_data": [
+                {
+                    "cvss_v2": {
+                        "base_score": 7.5,
+                        "exploitability_score": 10.0,
+                        "impact_score": 6.4
+                    },
+                    "cvss_v3": {
+                        "base_score": -1.0,
+                        "exploitability_score": -1.0,
+                        "impact_score": -1.0
+                    },
+                    "id": "CVE-2005-3906"
+                }
+            ],
+            "package": "jdk-1.4",
+            "package_cpe": "cpe:/a:-:jdk:1.4:-:-",
+            "package_cpe23": "cpe:2.3:a:-:jdk:1.4:-:-:-:-:-:-:-",
+            "package_name": "jdk",
+            "package_path": "/usr/share/contoso-petstore/contoso-petstore.war:WEB-INF/addons/jdk-tool.hpi:WEB-INF/lib/jdk-tool.jar",
+            "package_type": "java",
+            "package_version": "1.4",
+            "severity": "High",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2005-3906",
+            "vendor_data": [],
+            "vuln": "CVE-2005-3906"
+        }
+    ],
+    "vulnerability_type": "all"
+}

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -131,8 +131,9 @@ def do_dedupe_finding(new_finding, *args, **kwargs):
             elif(deduplicationAlgorithm == settings.DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE):
                 deduplicate_uid_or_hash_code(new_finding)
             else:
+                logger.debug('dedupe legacy start')
                 deduplicate_legacy(new_finding)
-                logger.debug('done legacy')
+                logger.debug('dedupe legacy start.done.')
         else:
             deduplicationLogger.debug("no configuration per parser found; using legacy algorithm")
             deduplicate_legacy(new_finding)


### PR DESCRIPTION
```
some parsers generate 1 finding for each vulnerable file for each vulnerability
i.e
#: title                     : sev : file_path
1: CVE-2020-1234 jquery      : 1   : /file1.jar
2: CVE-2020-1234 jquery      : 1   : /file2.jar

if we don't filter on file_path, we would find 2 existing findings
and the logic below will get confused and map all incoming findings
from the reimport on the first finding
```
for Anchore we fix this here, we may need a broader fix (and testcases)
or we may need to change the matching logic here to use the same logic
as the deduplication logic (hashcode fields)

```
     if scan_type == 'Anchore Engine Scan':
           if item.file_path:
                findings = findings.filter(file_path=item.file_path)
```

I have refactored the existing 9 testscases to be run against the APIv2 and UI.

And added an extra testcase for anchore. In the first unit test run I did not yet include the fix described above and you can see the test failing. This test is using a real world anchore report: https://github.com/DefectDojo/django-DefectDojo/pull/3629/checks?check_run_id=1707458436#step:9:40351

I fixed some other things a long the way:
- There was a diffrence in logic between the API reimport and UI import when the matching found multiple existing findins for a finding in the reimported report. This is now made in sync, UI now follows API logic
- don't run dedupe on findings that we are closing
- remove some push_to_jira=False as that is the default
- use the same way to calculate differences between new items / reactivated items / closed items in API and UI
- add some DEBUG logging to help future troubles

Question for a future PR: 
- Should we add this fix for all scanners? 
- Should we use the deduplication config in reimport instead of hardcoded field matching? 
- Should we raise an error if we detect scenario's where the reimport can't handle it correctly?
- Should we add instructions for people to recalculate their hashes if they change dedupe config?