### PR TITLE
Fix #3638 Django static import deprecated

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1,6 +1,6 @@
 {% load navigation_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}

--- a/dojo/templates/dojo/add_endpoint.html
+++ b/dojo/templates/dojo/add_endpoint.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
     .chosen-container {

--- a/dojo/templates/dojo/add_endpoint_meta_data.html
+++ b/dojo/templates/dojo/add_endpoint_meta_data.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Add Endpoint ({{ endpoint.host }}) Metadata</h3>

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/add_product_meta_data.html
+++ b/dojo/templates/dojo/add_product_meta_data.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Add {{ product.name }} Custom Fields</h3>

--- a/dojo/templates/dojo/add_related.html
+++ b/dojo/templates/dojo/add_related.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/add_tests.html
+++ b/dojo/templates/dojo/add_tests.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/add_user.html
+++ b/dojo/templates/dojo/add_user.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> {{ name }} {% if to_edit %}- {{ to_edit.username }}{% endif %}</h3>

--- a/dojo/templates/dojo/alerts.html
+++ b/dojo/templates/dojo/alerts.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block content %}
     <div class="row">
         <div class="col-md-12">

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/benchmark.html
+++ b/dojo/templates/dojo/benchmark.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load event_tags %}
 {% load display_tags %}
 

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <form method="GET" id="calfilter" action="/calendar">

--- a/dojo/templates/dojo/clear_finding_review.html
+++ b/dojo/templates/dojo/clear_finding_review.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/components.html
+++ b/dojo/templates/dojo/components.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block content %}
 <div class="row">
     <div class="col-md-12">

--- a/dojo/templates/dojo/custom_asciidoc_report.html
+++ b/dojo/templates/dojo/custom_asciidoc_report.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load event_tags %}
 {% load display_tags %}
 {% load humanize %}

--- a/dojo/templates/dojo/custom_asciidoc_report_wysiwyg_content.html
+++ b/dojo/templates/dojo/custom_asciidoc_report_wysiwyg_content.html
@@ -1,3 +1,3 @@
-{% load static from staticfiles %}
+{% load static %}
 <br/>
 {{ content|safe }}

--- a/dojo/templates/dojo/custom_html_report.html
+++ b/dojo/templates/dojo/custom_html_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
     <meta charset="UTF-8">

--- a/dojo/templates/dojo/custom_html_report_endpoint_list.html
+++ b/dojo/templates/dojo/custom_html_report_endpoint_list.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/custom_html_report_finding_list.html
+++ b/dojo/templates/dojo/custom_html_report_finding_list.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/custom_html_report_wysiwyg_content.html
+++ b/dojo/templates/dojo/custom_html_report_wysiwyg_content.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 
 <h1>{{ title }}</h1>
 <div class="wysiwyg_content">

--- a/dojo/templates/dojo/custom_html_toc.html
+++ b/dojo/templates/dojo/custom_html_toc.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 
 <div class="table_of_contents">
     <h1 id="table_of_contents">{{ title }}</h1>

--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     body{
         padding-top: 0px !important;

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     .chart {height: 300px}
     .status .panel {min-height: 140px;background-color: #f5f5f5;}

--- a/dojo/templates/dojo/edit_cred.html
+++ b/dojo/templates/dojo/edit_cred.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit Credential Configuration</h3>

--- a/dojo/templates/dojo/edit_cred_all.html
+++ b/dojo/templates/dojo/edit_cred_all.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit {{cred_type}} Credential</h3>

--- a/dojo/templates/dojo/edit_endpoint.html
+++ b/dojo/templates/dojo/edit_endpoint.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/edit_endpoint_meta_data.html
+++ b/dojo/templates/dojo/edit_endpoint_meta_data.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit Endpoint ({{ endpoint.host }}) Metadata</h3>

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/edit_jira.html
+++ b/dojo/templates/dojo/edit_jira.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit JIRA Configuration</h3>

--- a/dojo/templates/dojo/edit_note.html
+++ b/dojo/templates/dojo/edit_note.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
-{% load static from staticfiles %}
+{% load static %}
 {% block content %}
     <h3> Edit Note</h3><br></br>
     <form class="form-horizontal" action="{% url 'edit_note' note.id page objid %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/edit_object.html
+++ b/dojo/templates/dojo/edit_object.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3>Edit Tracked Files</h3>

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/edit_product_meta_data.html
+++ b/dojo/templates/dojo/edit_product_meta_data.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit {{ product.name }} Metadata</h3>

--- a/dojo/templates/dojo/edit_regulation.html
+++ b/dojo/templates/dojo/edit_regulation.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit Regulation Configuration</h3>

--- a/dojo/templates/dojo/edit_test.html
+++ b/dojo/templates/dojo/edit_test.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/edit_tool_config.html
+++ b/dojo/templates/dojo/edit_tool_config.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit Tool Configuration</h3>

--- a/dojo/templates/dojo/edit_tool_product.html
+++ b/dojo/templates/dojo/edit_tool_product.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit Product Tool Configuration</h3>

--- a/dojo/templates/dojo/edit_tool_type.html
+++ b/dojo/templates/dojo/edit_tool_type.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Edit Tool Type Configuration</h3>

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/filter_js_snippet.html
+++ b/dojo/templates/dojo/filter_js_snippet.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
 <script type="application/javascript">
     $(function () {

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -1,5 +1,5 @@
 {% load navigation_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/finding_related_actions.html
+++ b/dojo/templates/dojo/finding_related_actions.html
@@ -1,6 +1,6 @@
 {% load navigation_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% if user|is_authorized_for_change:finding %}
     {% comment %} {{ similar_finding.related_actions }} {% endcomment %}

--- a/dojo/templates/dojo/finding_related_list.html
+++ b/dojo/templates/dojo/finding_related_list.html
@@ -1,5 +1,5 @@
 {% load navigation_tags %}
-{% load static from staticfiles %}
+{% load static %}
 <table class="table table-striped table-hover centered no-bottom-margin">
     <tr>
         <th>Relationship</th>

--- a/dojo/templates/dojo/finding_related_row.html
+++ b/dojo/templates/dojo/finding_related_row.html
@@ -1,6 +1,6 @@
 {% load navigation_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 <tr>
     {% if similar_finding.duplicate_finding == finding_context %}
         <td title="The finding on the top of this page is the original for this related finding">Duplicate{% if finding_context == similar_finding %}(this){% endif %}</td>

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block content %}
     {% comment %} include inherits the current context so findings, filtered and other variables {% endcomment %}
     {% include "dojo/findings_list_snippet.html" %}

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -1,7 +1,7 @@
 {% load navigation_tags %}
 {% load display_tags %}
 {% load get_endpoint_status %}
-{% load static from staticfiles %}
+{% load static %}
 {% block findings_list %}
     <div class="row">
         <div class="col-md-12">

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/manage_images.html
+++ b/dojo/templates/dojo/manage_images.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
     <h3> Add images to {{ finding }}</h3>

--- a/dojo/templates/dojo/merge_findings.html
+++ b/dojo/templates/dojo/merge_findings.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     .tabs-below > .nav-tabs,
     .tabs-right > .nav-tabs,

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/new_object.html
+++ b/dojo/templates/dojo/new_object.html
@@ -1,5 +1,5 @@
 {% extends "base.html"%}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block content %}
  {{ block.super }}

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">

--- a/dojo/templates/dojo/notifications.html
+++ b/dojo/templates/dojo/notifications.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load event_tags %}
 
 

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     .graph {min-height: 158px;}
 {% endblock %}

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load event_tags %}

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block content %}
     <link href="{% static "google-code-prettify/src/prettify.css" %}" rel="stylesheet"/>
     <div class="row">

--- a/dojo/templates/dojo/report_cover_page.html
+++ b/dojo/templates/dojo/report_cover_page.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block content %}
     <div class="container">
         <div class="page-cover-spacer">&nbsp;</div>

--- a/dojo/templates/dojo/report_filter_snippet.html
+++ b/dojo/templates/dojo/report_filter_snippet.html
@@ -1,5 +1,5 @@
 {% load navigation_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css %}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}

--- a/dojo/templates/dojo/review_finding.html
+++ b/dojo/templates/dojo/review_finding.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load event_tags %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/snippets/endpoints.html
+++ b/dojo/templates/dojo/snippets/endpoints.html
@@ -1,5 +1,5 @@
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% load get_endpoint_status %}
 
 {% if destination == "Report" %}

--- a/dojo/templates/dojo/system_settings.html
+++ b/dojo/templates/dojo/system_settings.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
 .chosen-container {

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -1,5 +1,5 @@
 {% extends "report_base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load display_tags %}
 {% load humanize %}
 {% load get_endpoint_status %}

--- a/dojo/templates/dojo/up_risk.html
+++ b/dojo/templates/dojo/up_risk.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
     .chosen-container {

--- a/dojo/templates/dojo/view_cred_all_details.html
+++ b/dojo/templates/dojo/view_cred_all_details.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load get_config_setting %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;

--- a/dojo/templates/dojo/view_cred_details.html
+++ b/dojo/templates/dojo/view_cred_details.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load get_config_setting %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     .graph {min-height: 158px;}
     h3 { margin-top: 5px; margin-bottom: 5px; font-size: 20px; line-height: 22px;}

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -2,7 +2,7 @@
 {% load display_tags %}
 {% load humanize %}
 {% load survey_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     .tooltip-inner {
       max-width: 350px;

--- a/dojo/templates/dojo/view_engagements.html
+++ b/dojo/templates/dojo/view_engagements.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     .tooltip-inner {
       max-width: 350px;

--- a/dojo/templates/dojo/view_engineer.html
+++ b/dojo/templates/dojo/view_engineer.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% load display_tags %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     #chart_div3 .flot-x-axis .tickLabel, #chart_div4 .flot-x-axis .tickLabel
     {   top: 290px !important;

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load humanize %}
-{% load static from staticfiles %}
+{% load static %}
 {% load get_endpoint_status %}
 {% block add_styles %}
   .tooltip-inner {

--- a/dojo/templates/dojo/view_note_history.html
+++ b/dojo/templates/dojo/view_note_history.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load humanize %}
-{% load static from staticfiles %}
+{% load static %}
 {% block content %}
     <h3>Note History</h3><br></br>
     <form class="form-horizontal" action="{% url 'note_history' note.id page objid %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/view_objects.html
+++ b/dojo/templates/dojo/view_objects.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load get_config_setting %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;

--- a/dojo/templates/dojo/view_objects_eng.html
+++ b/dojo/templates/dojo/view_objects_eng.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load get_config_setting %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_styles %}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% load humanize %}
 {% load display_tags %}
 {% block add_styles %}

--- a/dojo/templates/dojo/view_risk.html
+++ b/dojo/templates/dojo/view_risk.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load humanize %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block add_styles %}
     .chosen-container {

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% load get_endpoint_status %}
-{% load static from staticfiles %}
+{% load static %}
 {% load humanize %}
 {% block add_styles %}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {

--- a/dojo/templates/report_base.html
+++ b/dojo/templates/report_base.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/dojo/templates/tastypie_swagger/index.html
+++ b/dojo/templates/tastypie_swagger/index.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load static from staticfiles %}
+{% load static %}
 {% block add_css_before %}
     <!-- TastyPie Swagger CSS -->
     <link href='{% static "tastypie_swagger/css/highlight.default.css" %}' media='screen' rel='stylesheet'


### PR DESCRIPTION
According to Django documentation, the `staticfiles` and `admin_static` template tag libraries are deprecated in 2.x and will be removed in 3.x

This pull request fixes deprecation to make migration to Django 3.x easier.

This pull request fixes #3637 

### References
[Django Deprecation Timeline](https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-3-0)