### PR TITLE
Remove usage of django.utils.six vendored library version of six

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -5,7 +5,7 @@ from datetime import timedelta, datetime
 from django.apps import apps
 from auditlog.models import LogEntry
 from django.contrib.auth.models import User
-from django.utils import six
+import six
 from django.utils.translation import ugettext_lazy as _
 from django_filters import FilterSet, CharFilter, OrderingFilter, \
     ModelMultipleChoiceFilter, ModelChoiceFilter, MultipleChoiceFilter, \


### PR DESCRIPTION
`django.utils.six` is a vendored version of the package `six` that we already have as a dependency.

As it is only used 1 time in `filters.py`, this import is completely useless.

(!) This simple reference break compatibility with Django 3.x as Django project cleaned there vendoring by removing it of 3.x branch.

Reference [https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis)