### PR TITLE
GHA: Docker build caching and other speed improvements

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,6 +2,7 @@ name: Flake8
 # pull requests:
 #      run on pull_request_target instead of just pull_request as we need write access to update the status check
 on:
+  workflow_dispatch:
   pull_request_target:
   push:
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,7 +91,7 @@ jobs:
         run: |-
              docker load -i nginx/nginx_img
              docker load -i django/django_img
-             docker load -i django/integration-tests_img
+             docker load -i integration-tests/integration-tests_img
              docker images
 
       - name: Set integration-test mode

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,18 +22,51 @@ jobs:
       - name: Set integration-test mode
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
 
-      # Pull the latest image to build, and avoid caching pull-only images.
-      # (docker pull is faster than caching in most cases.)
-      - run: docker-compose pull
-      # In this step, this action saves a list of existing images,
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
-      - uses: satackey/action-docker-layer-caching@master
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
 
-      - name: Build the stack
-        run: docker-compose build
+      # - name: Get Date
+      #   id: get-date
+      #   run: |
+      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      #   shell: bash
+
+      # build with docker so we can use layer caching
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-django-${{ github.sha }
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: defectdojo/defectdojo-django:latest
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile.django
+          context: .
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: defectdojo/defectdojo-nginx:latest
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile.nginx
+          context: .
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      # but run with docker-compose
 
       # phased startup so we can use the exit code from integrationtest container
       - name: Start MySQL

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,14 +34,23 @@ jobs:
       #   shell: bash
 
       # build with docker so we can use layer caching
+      # each image needs its own cache
 
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
+          path: /tmp/.buildx-cache-django
+          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-django-
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-nginx
+          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-nginx-
 
       - name: Build
         uses: docker/build-push-action@v2
@@ -52,8 +61,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile.django
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-django
+          cache-to: type=local,dest=/tmp/.buildx-cache-django
 
       - name: Build
         uses: docker/build-push-action@v2
@@ -64,8 +73,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile.nginx
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-nginx
+          cache-to: type=local,dest=/tmp/.buildx-cache-nginx
 
       # but run with docker-compose
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,12 +13,13 @@ on:
       - hotfix/**
 
 jobs:
-  build_image:
+  build:
+    # build with docker so we can use layer caching
     name: Build Docker Image
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker-image: [django, nginx]
+        docker-image: [django, nginx, integrationtest]
     steps:
       # - name: Login to DockerHub
       #   uses: docker/login-action@v1
@@ -35,20 +36,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # - name: Log into containers
-        # uses: docker/login-action@v1
-        # with:
-        #   registry: ${{ env.GITHUB_CACHE_REPO }}
-        #   username: ${{ github.actor }}
-        #   password: ${{ secrets.PAT }}
-
-      # - name: Get Date
-      #   id: get-date
-      #   run: |
-      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      #   shell: bash
-
-      # build with docker so we can use layer caching
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -68,12 +55,13 @@ jobs:
           push: false
           tags: |
             ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
+            defectdojo/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img
           cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
 
+      # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact
         uses:  actions/upload-artifact@v2
         with:
@@ -81,104 +69,28 @@ jobs:
           path: ${{matrix.docker-image}}_img
           retention-days: 1
 
-
   integration_tests:
+    # run tests with docker-compose
+    name: integration tests
+    needs: build
     runs-on: ubuntu-latest
     steps:
 
       - name: Checkout
         uses: actions/checkout@v2
 
+      # load docker images from build jobs
+      - name: Load images from artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Load docker images
+        run: |-
+             docker load -i nginx/nginx_img
+             docker load -i django/django_img
+             docker images
+
       - name: Set integration-test mode
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
-
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
-
-      # - name: Get Date
-      #   id: get-date
-      #   run: |
-      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      #   shell: bash
-
-      # build with docker so we can use layer caching
-      # each image needs its own cache
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        env:
-          docker-image: django
-        with:
-          path: /tmp/.buildx-cache-$${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
-
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        env:
-          docker-image: nginx
-        with:
-          path: /tmp/.buildx-cache-$${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        env:
-          docker-image: integration-tests
-        with:
-          path: /tmp/.buildx-cache-$${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
-
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          load: true
-          tags: defectdojo/defectdojo-django:latest
-          builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile.django
-          context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-django
-          cache-to: type=local,dest=/tmp/.buildx-cache-django
-
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          load: true
-          tags: defectdojo/defectdojo-nginx:latest
-          builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile.nginx
-          context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-nginx
-          cache-to: type=local,dest=/tmp/.buildx-cache-nginx
-
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          load: true
-          tags: defectdojo/defectdojo-integration-tests:latest
-          builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile.integration-tests
-          context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-integration-tests
-          cache-to: type=local,dest=/tmp/.buildx-cache-integration-tests
-
-      # but run with docker-compose
 
       # phased startup so we can use the exit code from integrationtest container
       - name: Start MySQL

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,7 +91,7 @@ jobs:
           load: true
           tags: defectdojo/defectdojo-integration-tests:latest
           builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile.integrationtests
+          file: ./Dockerfile.integration-tests
           context: .
           cache-from: type=local,src=/tmp/.buildx-cache-integration-tests
           cache-to: type=local,dest=/tmp/.buildx-cache-integration-tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker-image: [django, nginx, integrationtest]
+        docker-image: [django, nginx, integration-tests]
     steps:
       # - name: Login to DockerHub
       #   uses: docker/login-action@v1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,7 +19,9 @@ jobs:
   build:
     # build with docker so we can use layer caching
     name: Build Image
+
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         docker-image: [django, nginx, integration-tests]
@@ -43,12 +45,12 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-$${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-$${{ matrix.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}
 
       - name: Build
         id: docker_build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v1
 
       # - name: Get Date
       #   id: get-date

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-django-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,24 +40,30 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache-django
-          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-django-${{ github.workflow }}
             ${{ runner.os }}-buildx-django-
 
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache-nginx
-          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}
             ${{ runner.os }}-buildx-nginx-
 
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache-integration-tests
-          key: ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}
             ${{ runner.os }}-buildx-integration-tests-
 
       - name: Build

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,6 +52,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-nginx-
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-integration-tests
+          key: ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-integration-tests-
+
       - name: Build
         uses: docker/build-push-action@v2
         with:
@@ -75,6 +83,18 @@ jobs:
           context: .
           cache-from: type=local,src=/tmp/.buildx-cache-nginx
           cache-to: type=local,dest=/tmp/.buildx-cache-nginx
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: defectdojo/defectdojo-integration-tests:latest
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile.integrationtests
+          context: .
+          cache-from: type=local,src=/tmp/.buildx-cache-integration-tests
+          cache-to: type=local,dest=/tmp/.buildx-cache-integration-tests
 
       # but run with docker-compose
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-$${{ matrix.docker-image }}
+          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
           key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,75 @@ on:
       - hotfix/**
 
 jobs:
+  build_image:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker-image: [django, nginx]
+    steps:
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Read Docker Image Identifiers
+        id: read-docker-image-identifiers
+        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # - name: Log into containers
+        # uses: docker/login-action@v1
+        # with:
+        #   registry: ${{ env.GITHUB_CACHE_REPO }}
+        #   username: ${{ github.actor }}
+        #   password: ${{ secrets.PAT }}
+
+      # - name: Get Date
+      #   id: get-date
+      #   run: |
+      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      #   shell: bash
+
+      # build with docker so we can use layer caching
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-$${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
+
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
+            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
+          file: Dockerfile.${{ matrix.docker-image }}
+          outputs: type=docker,dest=${{ matrix.docker-image }}_img
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
+
+      - name: Upload image ${{ matrix.docker-image }} as artifact
+        uses:  actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.docker-image }}
+          path: ${{matrix.docker-image}}_img
+          retention-days: 1
+
+
   integration_tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,33 +38,40 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: django
         with:
-          path: /tmp/.buildx-cache-django
-          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-$${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-django-${{ github.workflow }}
-            ${{ runner.os }}-buildx-django-
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
+
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: nginx
         with:
-          path: /tmp/.buildx-cache-nginx
-          key: ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-$${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}
-            ${{ runner.os }}-buildx-nginx-
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: integration-tests
         with:
-          path: /tmp/.buildx-cache-integration-tests
-          key: ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-$${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-integration-tests-${{ github.workflow }}
-            ${{ runner.os }}-buildx-integration-tests-
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Build
         uses: docker/build-push-action@v2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
         uses:  actions/upload-artifact@v2
         with:
           name: ${{ matrix.docker-image }}
-          path: ${{matrix.docker-image}}_img
+          path: ${{ matrix.docker-image }}_img
           retention-days: 1
 
   integration_tests:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-django-${{ github.sha }
+          key: ${{ runner.os }}-buildx-django-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,7 +54,6 @@ jobs:
           context: .
           push: false
           tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
             defectdojo/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -91,24 +91,23 @@ jobs:
         run: |-
              docker load -i nginx/nginx_img
              docker load -i django/django_img
+             docker load -i django/integration-tests_img
              docker images
 
       - name: Set integration-test mode
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
 
       # phased startup so we can use the exit code from integrationtest container
-      - name: Start MySQL
-        run: docker-compose up -d
+
+      - name: Start Dojo
+        # implicity starts uwsgi and rabbitmq
+        run: docker-compose up -d mysql nginx celerybeat celeryworker
 
       - name: Initialize
         run: docker-compose up --exit-code-from initializer initializer
 
-      - name: Start Dojo
-        # implicity starts uwsgi and rabbitmq
-        run: docker-compose up -d nginx celerybeat celeryworker
-
       - name: Integration tests
-        run: docker-compose up --exit-code-from integrationtest integrationtest
+        run: docker-compose up --exit-code-from integration-tests integration-tests
 
       - name: Logs
         if: failure()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,26 +44,30 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: ${{ matrix.docker-image }}
         with:
-          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
+        env:
+          docker-image: ${{ matrix.docker-image }}
         with:
           context: .
           push: false
           tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-          file: Dockerfile.${{ matrix.docker-image }}
-          outputs: type=docker,dest=${{ matrix.docker-image }}_img
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ env.docker-image }}:latest
+          file: Dockerfile.${{ env.docker-image }}
+          outputs: type=docker,dest=${{ env.docker-image }}_img
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
       # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,7 @@ name: Integration tests
 # push:
 #      run on every push, which is when something gets merged also
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   build:
     # build with docker so we can use layer caching
-    name: Build Docker Image
+    name: Build Image
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,6 +12,9 @@ on:
       - release/**
       - hotfix/**
 
+env:
+  DD_DOCKER_REPO: defectdojo
+
 jobs:
   build:
     # build with docker so we can use layer caching
@@ -54,7 +57,7 @@ jobs:
           context: .
           push: false
           tags: |
-            defectdojo/defectdojo-${{ matrix.docker-image }}:latest
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img
           cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -90,11 +90,14 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
+      - name: Compress
+        run: gzip ${{ matrix.docker-image }}_img
+
       - name: Upload image ${{ env.docker-image }} as artifact
         uses:  actions/upload-artifact@v2
         with:
           name: ${{ matrix.docker-image }}
-          path: ${{ matrix.docker-image }}_img
+          path: ${{ matrix.docker-image }}_img.gz
           retention-days: 1
 
   setting_minikube_cluster:
@@ -131,6 +134,11 @@ jobs:
 
       - name: Load images from artifacts
         uses: actions/download-artifact@v2
+
+      - name: Decompress
+        run: |-
+            gunzip nginx/nginx_img.gz
+            gunzip django/django.gz
 
       - name: Load docker images
         run: |-

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -180,9 +180,6 @@ jobs:
       - name: Check Application
         run: |-
              to_complete () {
-               set -x
-               set -e
-               set -v
                kubectl wait  --for=$1 $2 --timeout=500s --selector=$3
                if [[ ${?} != 0 ]]; then
                  echo "ERROR: $2"

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -58,7 +58,7 @@ jobs:
         run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v1
       # - name: Log into containers
         # uses: docker/login-action@v1
         # with:

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -77,8 +77,7 @@ jobs:
           context: .
           push: false
           tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
+            defectdojo/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img
           cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -90,14 +90,11 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
-      - name: Compress
-        run: gzip ${{ matrix.docker-image }}_img
-
       - name: Upload image ${{ env.docker-image }} as artifact
         uses:  actions/upload-artifact@v2
         with:
           name: ${{ matrix.docker-image }}
-          path: ${{ matrix.docker-image }}_img.gz
+          path: ${{ matrix.docker-image }}_img
           retention-days: 1
 
   setting_minikube_cluster:
@@ -121,6 +118,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Load images from artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Load docker images
+        run: |-
+             eval $(minikube docker-env)
+             docker load -i nginx/nginx_img
+             docker load -i django/django_img
+             docker images
+
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.3.0
         with:
@@ -131,21 +138,6 @@ jobs:
 
       - name: Status of minikube
         run: minikube status
-
-      - name: Load images from artifacts
-        uses: actions/download-artifact@v2
-
-      - name: Decompress
-        run: |-
-            gunzip nginx/nginx_img.gz
-            gunzip django/django.gz
-
-      - name: Load docker images
-        run: |-
-             eval $(minikube docker-env)
-             docker load -i nginx/nginx_img
-             docker load -i django/django_img
-             docker images
 
       - name: Configure HELM repos
         run: |-

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -38,7 +38,7 @@ env:
    "
 jobs:
   build_image:
-    name: Docker image build
+    name: Build Docker Image
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        component: [django, nginx]
+        docker-image: [django, nginx]
     steps:
       # - name: Login to DockerHub
       #   uses: docker/login-action@v1
@@ -77,10 +77,10 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
+          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-
 
       - name: Build
         id: docker_build
@@ -89,18 +89,18 @@ jobs:
           context: .
           push: false
           tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.component }}:latest
-            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.component }}:cache
-          file: Dockerfile.${{ matrix.component }}
-          outputs: type=docker,dest=${{ matrix.component }}_img
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
+            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
+          file: Dockerfile.${{ matrix.docker-image }}
+          outputs: type=docker,dest=${{ matrix.docker-image }}_img
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
 
-      - name: Upload image ${{ matrix.component }} as artifact
+      - name: Upload image ${{ matrix.docker-image }} as artifact
         uses:  actions/upload-artifact@v2
         with:
-          name: ${{ matrix.component }}
-          path: ${{matrix.component}}_img
+          name: ${{ matrix.docker-image }}
+          path: ${{matrix.docker-image}}_img
           retention-days: 1
 
   setting_minikube_cluster:

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -123,7 +123,6 @@ jobs:
 
       - name: Load docker images
         run: |-
-             eval $(minikube docker-env)
              docker load -i nginx/nginx_img
              docker load -i django/django_img
              docker images
@@ -137,7 +136,9 @@ jobs:
           start args: '--addons=ingress'
 
       - name: Status of minikube
-        run: minikube status
+        run: |-
+          eval $(minikube docker-env)
+          minikube status
 
       - name: Configure HELM repos
         run: |-

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -180,6 +180,9 @@ jobs:
       - name: Check Application
         run: |-
              to_complete () {
+               set -x
+               set -e
+               set -v
                kubectl wait  --for=$1 $2 --timeout=500s --selector=$3
                if [[ ${?} != 0 ]]; then
                  echo "ERROR: $2"

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-$${{ matrix.docker-image }}
+          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
           key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -39,10 +39,13 @@ env:
 jobs:
   build:
     name: Build Image
+
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         docker-image: [django, nginx]
+
     steps:
       # - name: Login to DockerHub
       #   uses: docker/login-action@v1
@@ -63,12 +66,12 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-$${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-$${{ matrix.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}
 
       - name: Build
         id: docker_build
@@ -92,12 +95,16 @@ jobs:
 
   setting_minikube_cluster:
     name: Kubernetes Deployment
+
     runs-on: ubuntu-latest
+
     needs: build
+
     strategy:
       matrix:
         databases: [pgsql, mysql]
         brokers: [redis, rabbit]
+
     steps:
 #      - name: Login to DockerHub
 #        uses: docker/login-action@v1

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -78,8 +78,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache-${{ matrix.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
             ${{ runner.os }}-buildx-${{ matrix.docker-image }}-
 
       - name: Build

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -93,8 +93,8 @@ jobs:
       - name: Upload image ${{ env.docker-image }} as artifact
         uses:  actions/upload-artifact@v2
         with:
-          name: ${{ env.docker-image }}
-          path: ${{ env.docker-image }}_img
+          name: ${{ matrix.docker-image }}
+          path: ${{ matrix.docker-image }}_img
           retention-days: 1
 
   setting_minikube_cluster:

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -37,7 +37,7 @@ env:
     --set createPostgresqlSecret=true \
    "
 jobs:
-  build_image:
+  build:
     name: Build Docker Image
     runs-on: ubuntu-latest
     strategy:
@@ -59,20 +59,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # - name: Log into containers
-        # uses: docker/login-action@v1
-        # with:
-        #   registry: ${{ env.GITHUB_CACHE_REPO }}
-        #   username: ${{ github.actor }}
-        #   password: ${{ secrets.PAT }}
-
-      # - name: Get Date
-      #   id: get-date
-      #   run: |
-      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      #   shell: bash
-
-      # build with docker so we can use layer caching
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -92,7 +78,7 @@ jobs:
           push: false
           tags: |
             ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img
           cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
@@ -106,13 +92,13 @@ jobs:
           retention-days: 1
 
   setting_minikube_cluster:
-    name: Kubernetes Deployment
+    name: Test Kubernetes Deployment
     runs-on: ubuntu-latest
-    needs: build_image
+    needs: build
     strategy:
       matrix:
-        databases: [pgsql,mysql]
-        brokers: [redis,rabbit]
+        databases: [pgsql, mysql]
+        brokers: [redis, rabbit]
     steps:
 #      - name: Login to DockerHub
 #        uses: docker/login-action@v1

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -49,21 +49,39 @@ jobs:
       #   with:
       #     username: ${{ secrets.DOCKERHUB_USERNAME }}
       #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Read Docker Image Identifiers
         id: read-docker-image-identifiers
         run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       # - name: Log into containers
         # uses: docker/login-action@v1
         # with:
         #   registry: ${{ env.GITHUB_CACHE_REPO }}
         #   username: ${{ github.actor }}
         #   password: ${{ secrets.PAT }}
+
+      # - name: Get Date
+      #   id: get-date
+      #   run: |
+      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      #   shell: bash
+
+      # build with docker so we can use layer caching
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
@@ -75,8 +93,9 @@ jobs:
             ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.component }}:cache
           file: Dockerfile.${{ matrix.component }}
           outputs: type=docker,dest=${{ matrix.component }}_img
-          # cache-to: type=registry,ref=${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.component }}:cache,mode=max
-          # cache-from: type=registry,ref=${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.component }}:cache
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
       - name: Upload image ${{ matrix.component }} as artifact
         uses:  actions/upload-artifact@v2
         with:
@@ -100,6 +119,7 @@ jobs:
 #          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.3.0
         with:
@@ -107,22 +127,27 @@ jobs:
           kubernetes version: 'v1.19.2'
           driver: docker
           start args: '--addons=ingress'
+
       - name: Status of minikube
         run: minikube status
+
       - name: Load images from artifacts
         uses: actions/download-artifact@v2
+
       - name: Load docker images
         run: |-
              eval $(minikube docker-env)
              docker load -i nginx/nginx_img
              docker load -i django/django_img
              docker images
+
       - name: Configure HELM repos
         run: |-
              helm repo add stable https://charts.helm.sh/stable
              helm repo add bitnami https://charts.bitnami.com/bitnami
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
+
       - name: Set confings into Outputs
         id: set
         run: |-
@@ -130,6 +155,7 @@ jobs:
               echo ::set-output name=mysql:: "${{ env.HELM_MYSQL_DATABASE_SETTINGS }}"
               echo ::set-output name=redis:: "${{ env.HELM_REDIS_BROKER_SETTINGS }}"
               echo ::set-output name=rabbit:: "${{ env.HELM_RABBIT_BROKER_SETTINGS }}"
+
       # - name: Create image pull Secrets
       #   run: |-
       #         kubectl create secret docker-registry defectdojoregistrykey --docker-username=${{ secrets.DOCKERHUB_USERNAME }} --docker-password=${{ secrets.DOCKERHUB_TOKEN }}
@@ -145,11 +171,13 @@ jobs:
                ${{ steps.set.outputs[matrix.brokers] }} \
                --set createSecret=true \
               #  --set imagePullSecrets=defectdojoregistrykey
+
       - name: Check deployment status
         run: |-
              kubectl get pods
              kubectl get ingress
              kubectl get services
+
       - name: Check Application
         run: |-
              to_complete () {

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -38,7 +38,7 @@ env:
    "
 jobs:
   build:
-    name: Build Docker Image
+    name: Build Image
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -91,7 +91,7 @@ jobs:
           retention-days: 1
 
   setting_minikube_cluster:
-    name: Test Kubernetes Deployment
+    name: Kubernetes Deployment
     runs-on: ubuntu-latest
     needs: build
     strategy:

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -77,12 +77,12 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-$${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Build
         id: docker_build

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -118,15 +118,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Load images from artifacts
-        uses: actions/download-artifact@v2
-
-      - name: Load docker images
-        run: |-
-             docker load -i nginx/nginx_img
-             docker load -i django/django_img
-             docker images
-
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.3.0
         with:
@@ -137,8 +128,17 @@ jobs:
 
       - name: Status of minikube
         run: |-
-          eval $(minikube docker-env)
           minikube status
+
+      - name: Load images from artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Load docker images
+        run: |-
+             eval $(minikube docker-env)
+             docker load -i nginx/nginx_img
+             docker load -i django/django_img
+             docker images
 
       - name: Configure HELM repos
         run: |-

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -77,7 +77,7 @@ jobs:
           context: .
           push: false
           tags: |
-            defectdojo/defectdojo-${{ matrix.docker-image }}:latest
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img
           cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -65,32 +65,36 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: ${{ matrix.docker-image }}
         with:
-          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
+        env:
+          docker-image: ${{ matrix.docker-image }}
         with:
           context: .
           push: false
           tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-          file: Dockerfile.${{ matrix.docker-image }}
-          outputs: type=docker,dest=${{ matrix.docker-image }}_img
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ env.docker-image }}:latest
+          file: Dockerfile.${{ env.docker-image }}
+          outputs: type=docker,dest=${{ env.docker-image }}_img
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
-      - name: Upload image ${{ matrix.docker-image }} as artifact
+      - name: Upload image ${{ env.docker-image }} as artifact
         uses:  actions/upload-artifact@v2
         with:
-          name: ${{ matrix.docker-image }}
-          path: ${{matrix.docker-image}}_img
+          name: ${{ env.docker-image }}
+          path: ${{ env.docker-image }}_img
           retention-days: 1
 
   setting_minikube_cluster:

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-django-${{ github.sha }
+          key: ${{ runner.os }}-buildx-django-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -47,74 +47,6 @@ jobs:
           draft: true
           prerelease: false
 
-  build_image:
-    name: Build Docker Image
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        docker-image: [django, nginx]
-    steps:
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Read Docker Image Identifiers
-        id: read-docker-image-identifiers
-        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      # - name: Log into containers
-        # uses: docker/login-action@v1
-        # with:
-        #   registry: ${{ env.GITHUB_CACHE_REPO }}
-        #   username: ${{ github.actor }}
-        #   password: ${{ secrets.PAT }}
-
-      # - name: Get Date
-      #   id: get-date
-      #   run: |
-      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      #   shell: bash
-
-      # build with docker so we can use layer caching
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache-$${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
-
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          push: false
-          tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
-          file: Dockerfile.${{ matrix.docker-image }}
-          outputs: type=docker,dest=${{ matrix.docker-image }}_img
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
-
-      - name: Upload image ${{ matrix.docker-image }} as artifact
-        uses:  actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.docker-image }}
-          path: ${{matrix.docker-image}}_img
-          retention-days: 1
-
 
   job-build-and-push:
     needs: tag-and-release
@@ -140,14 +72,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-
-      # - name: Get Date
-      #   id: get-date
-      #   run: |
-      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      #   shell: bash
-
-      # build with docker so we can use layer caching
 
       - name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v1
 
       # - name: Get Date
       #   id: get-date

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -84,8 +84,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache-${{ matrix.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
             ${{ runner.os }}-buildx-${{ matrix.docker-image }}-
 
       - name: Build and push images

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -47,6 +47,75 @@ jobs:
           draft: true
           prerelease: false
 
+  build_image:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker-image: [django, nginx]
+    steps:
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Read Docker Image Identifiers
+        id: read-docker-image-identifiers
+        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # - name: Log into containers
+        # uses: docker/login-action@v1
+        # with:
+        #   registry: ${{ env.GITHUB_CACHE_REPO }}
+        #   username: ${{ github.actor }}
+        #   password: ${{ secrets.PAT }}
+
+      # - name: Get Date
+      #   id: get-date
+      #   run: |
+      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      #   shell: bash
+
+      # build with docker so we can use layer caching
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-$${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
+
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
+            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
+          file: Dockerfile.${{ matrix.docker-image }}
+          outputs: type=docker,dest=${{ matrix.docker-image }}_img
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
+
+      - name: Upload image ${{ matrix.docker-image }} as artifact
+        uses:  actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.docker-image }}
+          path: ${{matrix.docker-image}}_img
+          retention-days: 1
+
+
   job-build-and-push:
     needs: tag-and-release
     runs-on: ubuntu-latest

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -79,10 +79,10 @@ jobs:
           docker-image: ${{ matrix.docker-image }}
         with:
           path: /tmp/.buildx-cache-${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ GITHUB_ACTION }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ GITHUB_ACTION}}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ GITHUB_ACTION }}
             ${{ runner.os }}-buildx-${{ env.docker-image }}-
 
       - name: Build and push images

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -75,25 +75,28 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: ${{ matrix.docker-image }}
         with:
-          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-
 
       - name: Build and push images
+        uses: docker/build-push-action@v2
         env:
           REPO_ORG: ${{ steps.set-repo-org.outputs.repoorg }}
-        uses: docker/build-push-action@v2
+          docker-image: ${{ matrix.docker-image }}
         with:
           push: true
-          tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:latest
-          file: ./Dockerfile.${{ matrix.docker-image }}
+          tags: ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:latest
+          file: ./Dockerfile.${{ env.docker-image }}
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -79,10 +79,10 @@ jobs:
           docker-image: ${{ matrix.docker-image }}
         with:
           path: /tmp/.buildx-cache-${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ GITHUB_ACTION }}-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.GITHUB_ACTION }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ GITHUB_ACTION}}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ GITHUB_ACTION }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.GITHUB_ACTION}}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.GITHUB_ACTION }}
             ${{ runner.os }}-buildx-${{ env.docker-image }}-
 
       - name: Build and push images

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -3,6 +3,7 @@ name: "Release: 2. tag, release, docker push"
 env:
   GIT_USERNAME: "DefectDojo release bot"
   GIT_EMAIL: "dojo-release-bot@users.noreply.github.com"
+  workflow_name: 'release 2 tag release docker push' # needed in cache key, which doesn't support comma's
 on:
   workflow_dispatch:
     inputs:
@@ -79,10 +80,10 @@ jobs:
           docker-image: ${{ matrix.docker-image }}
         with:
           path: /tmp/.buildx-cache-${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.GITHUB_ACTION }}-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.workflow_name }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.GITHUB_ACTION}}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.GITHUB_ACTION }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.workflow_name}}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ env.workflow_name }}
             ${{ runner.os }}-buildx-${{ env.docker-image }}-
 
       - name: Build and push images

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -83,10 +83,10 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
+          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-
 
       - name: Build and push images
         env:
@@ -97,8 +97,8 @@ jobs:
           tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:latest
           file: ./Dockerfile.${{ matrix.docker-image }}
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -51,7 +51,7 @@ jobs:
     needs: tag-and-release
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
+      matrix:
           docker-image: [django, nginx]
     steps:
       - name: Login to DockerHub
@@ -59,16 +59,35 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Checkout tag
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.release_number }}
+
       - id: set-repo-org
         run: echo ::set-output name=repoorg::${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]'
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      # - name: Get Date
+      #   id: get-date
+      #   run: |
+      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      #   shell: bash
+
+      # build with docker so we can use layer caching
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-django-${{ github.sha }
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build and push images
         env:
           REPO_ORG: ${{ steps.set-repo-org.outputs.repoorg }}
@@ -78,5 +97,8 @@ jobs:
           tags: ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ matrix.docker-image}}:latest
           file: ./Dockerfile.${{ matrix.docker-image }}
           context: .
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/new-release-tag-docker.yml
+++ b/.github/workflows/new-release-tag-docker.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-django-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,77 @@ on:
       - dev
 
 jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker-image: [django, nginx]
+    steps:
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v1
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Read Docker Image Identifiers
+        id: read-docker-image-identifiers
+        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      # - name: Log into containers
+        # uses: docker/login-action@v1
+        # with:
+        #   registry: ${{ env.GITHUB_CACHE_REPO }}
+        #   username: ${{ github.actor }}
+        #   password: ${{ secrets.PAT }}
+
+      # - name: Get Date
+      #   id: get-date
+      #   run: |
+      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      #   shell: bash
+
+      # build with docker so we can use layer caching
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-$${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
+
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
+            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
+          file: Dockerfile.${{ matrix.docker-image }}
+          outputs: type=docker,dest=${{ matrix.docker-image }}_img
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
+
+      - name: Upload image ${{ matrix.docker-image }} as artifact
+        uses:  actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.docker-image }}
+          path: ${{matrix.docker-image}}_img
+          retention-days: 1
+
   unit_tests:
+    name: unit tests
+    needs: build
     runs-on: ubuntu-latest
     steps:
       # disabled login as it leaves plain text credentials behind
@@ -27,78 +97,24 @@ jobs:
       - name: Set unit-test mode
         run: docker/setEnv.sh unit_tests_cicd
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v1
+      - name: Load images from artifacts
+        uses: actions/download-artifact@v2
 
-      # - name: Get Date
-      #   id: get-date
-      #   run: |
-      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      #   shell: bash
-
-      # build with docker so we can use layer caching
-      # each image needs its own cache
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        env:
-          docker-image: django
-        with:
-          path: /tmp/.buildx-cache-django
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        env:
-          docker-image: nginx
-        with:
-          path: /tmp/.buildx-cache-django
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
-
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          load: true
-          tags: defectdojo/defectdojo-django:latest
-          builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile.django
-          context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-django
-          cache-to: type=local,dest=/tmp/.buildx-cache-django
-
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          load: true
-          tags: defectdojo/defectdojo-nginx:latest
-          builder: ${{ steps.buildx.outputs.name }}
-          file: ./Dockerfile.nginx
-          context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-nginx
-          cache-to: type=local,dest=/tmp/.buildx-cache-nginx
-
-      # but run with docker-compose
+      - name: Load docker images
+        run: |-
+             docker load -i nginx/nginx_img
+             docker load -i django/django_img
+             docker images
 
       # phased startup so we can use the exit code from integrationtest container
       - name: Start MySQL
         run: docker-compose up -d
 
-      - name: Initialize
-        run: docker-compose up --exit-code-from initializer initializer
+      # - name: Initialize
+      #   run: docker-compose up --exit-code-from initializer initializer
 
       - name: Unit tests
-        run: docker-compose up --exit-code-from uwsgi uwsgi
+        run: docker-compose up --no-deps  --exit-code-from uwsgi uwsgi
 
       - name: Logs
         if: failure()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-django-${{ github.sha }
+          key: ${{ runner.os }}-buildx-django-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -97,7 +97,7 @@ jobs:
 
       # no celery or initializer needed for unit tests
       - name: Unit tests
-        run: docker-compose up --no-deps  --exit-code-from uwsgi uwsgi
+        run: docker-compose up --no-deps --exit-code-from uwsgi uwsgi
 
       - name: Logs
         if: failure()

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-$GITHUB_WORKFLOW-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,16 +44,20 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache-django
-          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-django-${{ github.workflow }}
             ${{ runner.os }}-buildx-django-
 
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache-nginx
-          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
+            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}
             ${{ runner.os }}-buildx-nginx-
 
       - name: Build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,7 @@ name: Unit tests
 # push:
 #      run on every push, which is when something gets merged also
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -52,7 +52,6 @@ jobs:
           context: .
           push: false
           tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
             defectdojo/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v1
 
       # - name: Get Date
       #   id: get-date

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,14 +38,23 @@ jobs:
       #   shell: bash
 
       # build with docker so we can use layer caching
+      # each image needs its own cache
 
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.workflow }}-${{ github.sha }}
+          path: /tmp/.buildx-cache-django
+          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-buildx-
+            ${{ runner.os }}-buildx-django-
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache-nginx
+          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-nginx-
 
       - name: Build
         uses: docker/build-push-action@v2
@@ -56,8 +65,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile.django
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-django
+          cache-to: type=local,dest=/tmp/.buildx-cache-django
 
       - name: Build
         uses: docker/build-push-action@v2
@@ -68,8 +77,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile.nginx
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache-nginx
+          cache-to: type=local,dest=/tmp/.buildx-cache-nginx
 
       # but run with docker-compose
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,9 @@ on:
       - master
       - dev
 
+env:
+  DD_DOCKER_REPO: defectdojo
+
 jobs:
   build:
     # build with docker so we can use layer caching
@@ -52,7 +55,7 @@ jobs:
           context: .
           push: false
           tags: |
-            defectdojo/defectdojo-${{ matrix.docker-image }}:latest
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img
           cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,13 +42,15 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: django
         with:
           path: /tmp/.buildx-cache-django
-          key: ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ runner.os }}-buildx-$docker-image-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-django-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-django-${{ github.workflow }}
-            ${{ runner.os }}-buildx-django-
+            ${{ runner.os }}-buildx-$docker-image-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-$docker-image-${{ github.workflow }}
+            ${{ runner.os }}-buildx-$docker-image-
 
       - name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,22 +26,51 @@ jobs:
       - name: Set unit-test mode
         run: docker/setEnv.sh unit_tests_cicd
 
-      # Pull the latest image to build, and avoid caching pull-only images.
-      # (docker pull is faster than caching in most cases.)
-      - run: docker-compose pull
-      # In this step, this action saves a list of existing images,
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      # - name: Get Date
+      #   id: get-date
+      #   run: |
+      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      #   shell: bash
+
+      # build with docker so we can use layer caching
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
         with:
-          key: docker-layer-caching-Unit-tests-{hash}
-          restore-keys: docker-layer-caching-Unit-tests-
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-django-${{ github.sha }
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: defectdojo/defectdojo-django:latest
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile.django
+          context: .
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
-      - name: Build the stack
-        run: docker-compose build
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          tags: defectdojo/defectdojo-nginx:latest
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile.nginx
+          context: .
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      # but run with docker-compose
 
       # phased startup so we can use the exit code from integrationtest container
       - name: Start MySQL

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    # build with docker so we can use layer caching
     name: Build Docker Image
     runs-on: ubuntu-latest
     strategy:
@@ -33,20 +34,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      # - name: Log into containers
-        # uses: docker/login-action@v1
-        # with:
-        #   registry: ${{ env.GITHUB_CACHE_REPO }}
-        #   username: ${{ github.actor }}
-        #   password: ${{ secrets.PAT }}
-
-      # - name: Get Date
-      #   id: get-date
-      #   run: |
-      #     echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
-      #   shell: bash
-
-      # build with docker so we can use layer caching
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -66,12 +53,13 @@ jobs:
           push: false
           tags: |
             ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-            ${{ env.GITHUB_CACHE_REPO }}/${{ env.IMAGE_REPOSITORY }}/${{ matrix.docker-image }}:cache
+            defectdojo/defectdojo-${{ matrix.docker-image }}:latest
           file: Dockerfile.${{ matrix.docker-image }}
           outputs: type=docker,dest=${{ matrix.docker-image }}_img
           cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
 
+      # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact
         uses:  actions/upload-artifact@v2
         with:
@@ -80,23 +68,15 @@ jobs:
           retention-days: 1
 
   unit_tests:
+    # run tests with docker-compose
     name: unit tests
     needs: build
     runs-on: ubuntu-latest
     steps:
-      # disabled login as it leaves plain text credentials behind
-
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set unit-test mode
-        run: docker/setEnv.sh unit_tests_cicd
-
+      # load docker images from build jobs
       - name: Load images from artifacts
         uses: actions/download-artifact@v2
 
@@ -106,13 +86,14 @@ jobs:
              docker load -i django/django_img
              docker images
 
-      # phased startup so we can use the exit code from integrationtest container
+      - name: Set unit-test mode
+        run: docker/setEnv.sh unit_tests_cicd
+
+      # phased startup so we can use the exit code from unit test container
       - name: Start MySQL
         run: docker-compose up -d
 
-      # - name: Initialize
-      #   run: docker-compose up --exit-code-from initializer initializer
-
+      # no celery or initializer needed for unit tests
       - name: Unit tests
         run: docker-compose up --no-deps  --exit-code-from uwsgi uwsgi
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -46,11 +46,11 @@ jobs:
           docker-image: django
         with:
           path: /tmp/.buildx-cache-django
-          key: ${{ runner.os }}-buildx-$docker-image-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-$docker-image-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-$docker-image-${{ github.workflow }}
-            ${{ runner.os }}-buildx-$docker-image-
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Cache Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   DD_DOCKER_REPO: defectdojo
-  docker-image: django
+  docker-image: django # we only need to build the django image for unit tests
 
 jobs:
   unit_tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,14 +14,9 @@ env:
   DD_DOCKER_REPO: defectdojo
 
 jobs:
-  build:
-    # build with docker so we can use layer caching
-    name: Build Image
+  unit_tests:
+    name: unit tests
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        docker-image: [django, nginx]
 
     steps:
       # - name: Login to DockerHub
@@ -33,13 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Read Docker Image Identifiers
-        id: read-docker-image-identifiers
-        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      # - name: Read Docker Image Identifiers
+      #   id: read-docker-image-identifiers
+      #   run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
+      # build with docker so we can use layer caching
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -53,43 +49,20 @@ jobs:
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
+        env:
+          docker-image: ${{ matrix.docker-image }}
         with:
           context: .
           push: false
+          load: true
           tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:latest
-          file: Dockerfile.${{ matrix.docker-image }}
-          outputs: type=docker,dest=${{ matrix.docker-image }}_img
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ matrix.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ matrix.docker-image }}
+            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ env.docker-image }}:latest
+          file: Dockerfile.${{ env.docker-image }}
 
-      # export docker images to be used in next jobs below
-      - name: Upload image ${{ matrix.docker-image }} as artifact
-        uses:  actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.docker-image }}
-          path: ${{matrix.docker-image}}_img
-          retention-days: 1
+          cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
+          cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
-  unit_tests:
-    # run tests with docker-compose
-    name: unit tests
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      # load docker images from build jobs
-      - name: Load images from artifacts
-        uses: actions/download-artifact@v2
-
-      - name: Load docker images
-        run: |-
-             docker load -i nginx/nginx_img
-             docker load -i django/django_img
-             docker images
-
+      # run tests with docker-compose
       - name: Set unit-test mode
         run: docker/setEnv.sh unit_tests_cicd
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -54,13 +54,15 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        env:
+          docker-image: nginx
         with:
-          path: /tmp/.buildx-cache-nginx
-          key: ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-django
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-nginx-${{ github.workflow }}
-            ${{ runner.os }}-buildx-nginx-
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Build
         uses: docker/build-push-action@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-$${{ matrix.docker-image }}
+          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
           key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,9 +18,11 @@ jobs:
     # build with docker so we can use layer caching
     name: Build Image
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         docker-image: [django, nginx]
+
     steps:
       # - name: Login to DockerHub
       #   uses: docker/login-action@v1
@@ -41,12 +43,12 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-$${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-$${{ matrix.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ matrix.docker-image }}
 
       - name: Build
         id: docker_build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   DD_DOCKER_REPO: defectdojo
+  docker-image: django
 
 jobs:
   unit_tests:
@@ -39,18 +40,16 @@ jobs:
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache-${{ matrix.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
+          path: /tmp/.buildx-cache-${{ env.docker-image }}
+          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ matrix.docker-image }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}-${{ github.sha }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ github.workflow }}
+            ${{ runner.os }}-buildx-${{ env.docker-image }}
 
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
-        env:
-          docker-image: ${{ matrix.docker-image }}
         with:
           context: .
           push: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     # build with docker so we can use layer caching
-    name: Build Docker Image
+    name: Build Image
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-django-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          key: ${{ runner.os }}-buildx-${{ GITHUB_WORKFLOW }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 

--- a/Dockerfile.busybox
+++ b/Dockerfile.busybox
@@ -1,2 +1,0 @@
-FROM busybox:1.32.0-musl
-ENTRYPOINT ["/bin/echo", "hello world"]

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -44,7 +44,7 @@ RUN \
     libmariadb3 \
     xmlsec1 \
     git \
-    uuid-runtime \    
+    uuid-runtime \
     # only required for the dbshell (used by the initializer job)
     postgresql-client \
     curl \
@@ -59,7 +59,7 @@ RUN pip3 install \
 	--no-index \
   --find-links=/tmp/wheels \
   -r ./requirements.txt
-  
+
 COPY \
   docker/entrypoint-celery-beat.sh \
   docker/entrypoint-celery-worker.sh \
@@ -78,17 +78,18 @@ COPY dojo/ ./dojo/
 # Add extra fixtures to docker image which are loaded by the initializer
 COPY docker/extra_fixtures/* /app/dojo/fixtures/
 
+# Fallback for safety parser, if installation does't allow internet connectivity
+RUN curl -sS -o dojo/tools/safety/insecure_full.json https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json
+
 COPY tests/ ./tests/
 RUN \
   # Remove placeholder copied from docker/certs
-  rm -f /readme.txt && \ 
+  rm -f /readme.txt && \
   # Remove placeholder copied from docker/extra_fixtures
   rm -f dojo/fixtures/readme.txt && \
   mkdir -p dojo/migrations && \
   chmod g=u dojo/migrations && \
   true
-# Fallback for safety parser, if installation does't allow internet connectivity
-RUN curl -sS -o dojo/tools/safety/insecure_full.json https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json
 USER root
 RUN \
     adduser --system --no-create-home --disabled-password --gecos '' \

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -28,6 +28,8 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 
+RUN pip install --no-cache-dir selenium requests
+
 # Installing Chromium Driver and Selenium for test automation
 RUN LATEST_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
     wget -O /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/$LATEST_VERSION/chromedriver_linux64.zip && \
@@ -35,12 +37,11 @@ RUN LATEST_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_
     rm /tmp/chromedriver.zip && \
     chmod 777 /usr/local/bin/chromedriver;
 
-RUN pip install --no-cache-dir selenium requests
-
-COPY tests/ ./tests/
 COPY docker/wait-for-it.sh \
   docker/entrypoint-integration-tests.sh \
   /
+
+COPY tests/ ./tests/
 
 RUN chmod -R 0777 /app
 USER 1001

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -1,8 +1,8 @@
 ---
 version: '3.7'
 services:
-  integrationtest:
-    build: 
+  integration-tests:
+    build:
       context: ./
       dockerfile: Dockerfile.integration-tests
     image: defectdojo/integration-tests:${INTEGRATION_TESTS_VERSION:-latest}

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.integration-tests
-    image: defectdojo/integration-tests:${INTEGRATION_TESTS_VERSION:-latest}
+    image: defectdojo/defectdojo-integration-tests:${INTEGRATION_TESTS_VERSION:-latest}
     depends_on:
       - nginx
       - uwsgi

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   nginx:
-    build: 
+    build:
       context: ./
       dockerfile: Dockerfile.busybox
     image: defectdojo/defectdojo-busybox:${NGINX_VERSION:-latest}
@@ -21,8 +21,8 @@ services:
     environment:
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
   initializer:
-    environment:
-      DD_INITIALIZE: 'false'
+    image: busybox:1.32.0-musl
+
   mysql:
     ports:
       - target: 3306

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -22,6 +22,7 @@ services:
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
   initializer:
     image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'initializer']
 
   mysql:
     ports:

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -2,10 +2,8 @@
 version: '3.7'
 services:
   nginx:
-    build:
-      context: ./
-      dockerfile: Dockerfile.busybox
-    image: defectdojo/defectdojo-busybox:${NGINX_VERSION:-latest}
+    image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'nginx']
   uwsgi:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/app/docker/entrypoint-unit-tests-devDocker.sh']
     volumes:

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -15,11 +15,11 @@ services:
       DD_TEST_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
       DD_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
   celerybeat:
-    environment:
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
+    image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'celery beat']
   celeryworker:
-    environment:
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
+    image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'celery worker']
   initializer:
     image: busybox:1.32.0-musl
     entrypoint: ['echo', 'skipping', 'initializer']

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -2,7 +2,7 @@
 version: '3.7'
 services:
   nginx:
-    build: 
+    build:
       context: ./
       dockerfile: Dockerfile.busybox
     image: defectdojo/defectdojo-busybox:${NGINX_VERSION:-latest}
@@ -21,8 +21,7 @@ services:
     environment:
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
   initializer:
-    environment:
-      DD_INITIALIZE: 'false'
+    image: busybox:1.32.0-musl
   mysql:
     ports:
       - target: 3306

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -15,11 +15,11 @@ services:
       DD_TEST_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
       DD_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
   celerybeat:
-    environment:
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
+    image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'celery beat']
   celeryworker:
-    environment:
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
+    image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'celery worker']
   initializer:
     image: busybox:1.32.0-musl
     entrypoint: ['echo', 'skipping', 'initializer']

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -2,10 +2,8 @@
 version: '3.7'
 services:
   nginx:
-    build:
-      context: ./
-      dockerfile: Dockerfile.busybox
-    image: defectdojo/defectdojo-busybox:${NGINX_VERSION:-latest}
+    image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'nginx']
   uwsgi:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/app/docker/entrypoint-unit-tests.sh']
     volumes:

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -22,6 +22,7 @@ services:
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
   initializer:
     image: busybox:1.32.0-musl
+    entrypoint: ['echo', 'skipping', 'initializer']
   mysql:
     ports:
       - target: 3306

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -9,6 +9,7 @@ while [  $COUNTER -lt 10 ]; do
     curl -s -o "/dev/null" $DD_BASE_URL -m 120
     CR=$(curl --insecure -s -m 10 -I "${DD_BASE_URL}login?next=/" | egrep "^HTTP" | cut  -d' ' -f2)
     if [ "$CR" == 200 ]; then
+        echo "Succesfully displayed login page, starting integration tests"
         break
     fi
     echo "Waiting: cannot display login screen; got HTTP code $CR"

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -1,15 +1,26 @@
 #!/bin/bash
 
-echo "Waiting 60s for services to start"
-# Wait for services to become available
-sleep 60
 echo "Testing DefectDojo Service"
-curl -s -o "/dev/null" $DD_BASE_URL -m 120
-CR=$(curl --insecure -s -m 10 -I "${DD_BASE_URL}login?next=/" | egrep "^HTTP" | cut  -d' ' -f2)
-if [ "$CR" != 200 ]; then
+
+echo "Waiting max 60s for services to start"
+# Wait for services to become available
+COUNTER=0
+while [  $COUNTER -lt 10 ]; do
+    curl -s -o "/dev/null" $DD_BASE_URL -m 120
+    CR=$(curl --insecure -s -m 10 -I "${DD_BASE_URL}login?next=/" | egrep "^HTTP" | cut  -d' ' -f2)
+    if [ "$CR" == 200 ]; then
+        break
+    fi
+    echo "Waiting: cannot display login screen; got HTTP code $CR"
+    sleep 10
+    let COUNTER=COUNTER+1
+done
+
+if [ $COUNTER -gt 10 ]; then
     echo "ERROR: cannot display login screen; got HTTP code $CR"
     exit 1
 fi
+
 
 # Run available unittests with a simple setup
 # All available Integrationtest Scripts are activated below
@@ -60,7 +71,7 @@ fi
 
 test="Product integration tests"
 echo "Running: $test"
-if python3 tests/product_test.py ; then 
+if python3 tests/product_test.py ; then
     success $test
 else
     fail $test
@@ -84,7 +95,7 @@ fi
 
 test="Environment integration tests"
 echo "Running: $test"
-if python3 tests/environment_test.py ; then 
+if python3 tests/environment_test.py ; then
     success $test
 else
     fail $test
@@ -152,7 +163,7 @@ fi
 
 # echo "Import Scanner integration test"
 # if python3 tests/import_scanner_test.py ; then
-#     echo "Success: Import Scanner integration tests passed" 
+#     echo "Success: Import Scanner integration tests passed"
 # else
 #     echo "Error: Import Scanner integration test failed"; exit 1
 # fi

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -39,4 +39,4 @@ python3 manage.py migrate
 
 # --parallel fails on GitHub Actions
 #python3 manage.py test dojo.unittests -v 3 --no-input --parallel
-python3 manage.py test dojo.unittests -v 3 --no-input --parallel
+python3 manage.py test dojo.unittests -v 3 --no-input

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -37,4 +37,4 @@ EOF
 
 python3 manage.py migrate
 
-python3 manage.py test dojo.unittests -v 3 --no-input
+python3 manage.py test dojo.unittests -v 3 --no-input --parallel

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -2,9 +2,9 @@
 # Run available unittests with a setup for CI/CD:
 # - Fail if migrations are not created
 # - Exit container after running tests to allow exit code to propagate as test result
-set -x
-set -e
-set -v
+# set -x
+# set -e
+# set -v
 
 cd /app
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -37,4 +37,6 @@ EOF
 
 python3 manage.py migrate
 
+# --parallel fails on GitHub Actions
+#python3 manage.py test dojo.unittests -v 3 --no-input --parallel
 python3 manage.py test dojo.unittests -v 3 --no-input --parallel


### PR DESCRIPTION
TL;DR;
All tests in GitHub Actions have become a lot faster. 

Integration tests before:
![image](https://user-images.githubusercontent.com/4426050/105097193-80646200-5aa8-11eb-9478-237016e84ab6.png)


After:
![image](https://user-images.githubusercontent.com/4426050/105097178-75a9cd00-5aa8-11eb-98eb-b105ea4c3e10.png)

Others are also a couple of minutes faster each.

Changes:
- Use Docker Layer Caching. If we only change some code, all the expensive build steps are cached (pip install -r requirements.txt etc)
- Build images in parallel and use artifact upload/download to pass on to the next job (in the same workflow)
- Use dummy image for initializer, celery(worker|beat) and nginx on unit tests
- Finetune Dockerfile.xxxx to make sure as much layers as possible can be cached
- Don't start any containers that are not needed for unit tests