### PR TITLE
Snyk findings: deduplication enhancements

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -778,6 +778,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'DSOP Scan': ['cve'],
     'Acunetix Scan': ['title', 'description'],
     'Trivy Scan': ['title', 'severity', 'cve', 'cwe'],
+    'Snyk Scan': ['unique_id_from_tool', 'file_path', 'component_name', 'component_version'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
@@ -842,6 +843,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'DSOP Scan': DEDUPE_ALGO_HASH_CODE,
     'Trivy Scan': DEDUPE_ALGO_HASH_CODE,
     'HackerOne Cases': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
+    'Snyk Scan': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -778,7 +778,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'DSOP Scan': ['cve'],
     'Acunetix Scan': ['title', 'description'],
     'Trivy Scan': ['title', 'severity', 'cve', 'cwe'],
-    'Snyk Scan': ['unique_id_from_tool', 'file_path', 'component_name', 'component_version'],
+    'Snyk Scan': ['vuln_id_from_tool', 'file_path', 'component_name', 'component_version'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
@@ -802,7 +802,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
 # List of fields that are known to be usable in hash_code computation)
 # 'endpoints' is a pseudo field that uses the endpoints (for dynamic scanners)
 # 'unique_id_from_tool' is often not needed here as it can be used directly in the dedupe algorithm, but it's also possible to use it for hashing
-HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'cve', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity']
+HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'cve', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
 
 # ------------------------------------
 # Deduplication configuration

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -111,6 +111,14 @@ def get_item(vulnerability, test):
     for item in vulnerability['references']:
         references += "**" + item['title'] + "**: " + item['url'] + "\n"
 
+    # Construct "file_path" removing versions
+    vulnPath = ''
+    for index, item in enumerate(vulnerability['from']):
+        if index == 0:
+            vulnPath += item.split("@")[0]
+        else:
+            vulnPath += " > " + item.split("@")[0]
+
     # create the finding object
     finding = Finding(
         title=vulnerability['from'][0] + ": " + vulnerability['title'],
@@ -136,7 +144,11 @@ def get_item(vulnerability, test):
         duplicate=False,
         out_of_scope=False,
         mitigated=None,
-        impact=severity)
+        impact=severity,
+        static_finding=True,
+        dynamic_finding=False,
+        file_path=vulnPath,
+        unique_id_from_tool=vulnerability['id'])
 
     finding.description = finding.description.strip()
 

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -148,7 +148,7 @@ def get_item(vulnerability, test):
         static_finding=True,
         dynamic_finding=False,
         file_path=vulnPath,
-        unique_id_from_tool=vulnerability['id'])
+        vuln_id_from_tool=vulnerability['id'])
 
     finding.description = finding.description.strip()
 

--- a/dojo/unittests/test_snyk_parser.py
+++ b/dojo/unittests/test_snyk_parser.py
@@ -58,6 +58,9 @@ class TestSnykParser(TestCase):
             "Issue severity of: **Medium** from a base CVSS score of: **6.5**",
             finding.severity_justification)
         self.assertEqual(
+            "SNYK-JAVA-ORGAPACHESANTUARIO-460281",
+            finding.unique_id_from_tool)
+        self.assertEqual(
             "CVE-2019-12400",
             finding.cve)
         self.assertEqual(
@@ -77,3 +80,6 @@ class TestSnykParser(TestCase):
             "504?jql=project%20%3D%20SANTUARIO\n**Security Release**: http://santuario.apache.org/secadv.data/" +
             "CVE-2019-12400.asc?version=1&modificationDate=1566573083000&api=v2\n",
             finding.references)
+        self.assertEqual(
+            "com.test:myframework > org.apache.santuario:xmlsec",
+            finding.file_path)

--- a/dojo/unittests/test_snyk_parser.py
+++ b/dojo/unittests/test_snyk_parser.py
@@ -59,7 +59,7 @@ class TestSnykParser(TestCase):
             finding.severity_justification)
         self.assertEqual(
             "SNYK-JAVA-ORGAPACHESANTUARIO-460281",
-            finding.unique_id_from_tool)
+            finding.vuln_id_from_tool)
         self.assertEqual(
             "CVE-2019-12400",
             finding.cve)


### PR DESCRIPTION
This PR addresses the following changes regarding deduplication of Snyk Findings:

- Add Snyk issues as "static_findings"
- Add "unique_id_from_tool" field
- Generate "file_path" field from the vulnerable path of the component ("from" attribute of the JSON report). We remove the versions of the components in the vulnerable path in order to allow deduplication across different version of the same PRODUCT.  
- Set Snyk deduplication algorithm to DEDUPE_ALGO_HASH_CODE
- Set fields for computing Hash Code. 
- Updated unit test