### PR TITLE
dependency track parser: fix dedupe, set hash code fields

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -438,7 +438,7 @@ class ImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx"}),
+        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt"}),
         label="Choose report file",
         required=False)
 
@@ -482,7 +482,7 @@ class ReImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Modify existing tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx"}),
+        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt"}),
         label="Choose report file",
         required=False)
     close_old_findings = forms.BooleanField(help_text="Select if old findings get mitigated when importing.",

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -482,7 +482,7 @@ class ReImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Modify existing tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt"}),
+        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt, .sarif"}),
         label="Choose report file",
         required=False)
     close_old_findings = forms.BooleanField(help_text="Select if old findings get mitigated when importing.",

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -438,7 +438,7 @@ class ImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt"}),
+        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt, .sarif"}),
         label="Choose report file",
         required=False)
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -762,6 +762,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'Dependency Check Scan': ['cve', 'file_path'],
+    'Dependency Track Finding Packaging Format (FPF) Export': ['component', 'vuln_id_from_tool'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
     'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
@@ -801,7 +802,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
 # List of fields that are known to be usable in hash_code computation)
 # 'endpoints' is a pseudo field that uses the endpoints (for dynamic scanners)
 # 'unique_id_from_tool' is often not needed here as it can be used directly in the dedupe algorithm, but it's also possible to use it for hashing
-HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'cve', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity']
+HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'cve', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
 
 # ------------------------------------
 # Deduplication configuration
@@ -824,6 +825,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Anchore Engine Scan': DEDUPE_ALGO_HASH_CODE,
     'Checkmarx Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Checkmarx Scan': DEDUPE_ALGO_HASH_CODE,
+    'Dependency Track Finding Packaging Format (FPF) Export': DEDUPE_ALGO_HASH_CODE,
     'SonarQube Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'SonarQube Scan': DEDUPE_ALGO_HASH_CODE,
     'Dependency Check Scan': DEDUPE_ALGO_HASH_CODE,

--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -134,10 +134,11 @@ class DependencyTrackParser(object):
         else:
             component_version = None
         if component_version is not None:
-            version_description = 'version {component_version} of '.format(component_version=component_version)
+            version_description = component_version
         else:
             version_description = ''
-        title = "Vulnerability Id {vuln_id} from {source} affecting {version_description}the {component_name} component"\
+
+        title = "{component_name}:{version_description} affected by: {vuln_id} ({source})"\
             .format(vuln_id=vuln_id, source=source, version_description=version_description, component_name=component_name)
 
         # The vulnId is not always a CVE (e.g. if the vulnerability is not from the NVD source)
@@ -165,6 +166,11 @@ class DependencyTrackParser(object):
         if 'purl' in dependency_track_finding['component'] and dependency_track_finding['component']['purl'] is not None:
             component_purl = dependency_track_finding['component']['purl']
             vulnerability_description = vulnerability_description + "\nThe purl of the affected component is: {purl}.".format(purl=component_purl)
+            # there is no file_path in the report, but defect dojo needs it otherwise it skips deduplication:
+            # see https://github.com/DefectDojo/django-DefectDojo/issues/3647
+            # might be no longer needed in the future, and is not needed if people use the default
+            # hash code dedupe config for this parser
+            file_path = component_purl
         # Append other info about vulnerability description info if it is present
         if 'title' in dependency_track_finding['vulnerability'] and dependency_track_finding['vulnerability']['title'] is not None:
             vulnerability_description = vulnerability_description + "\nVulnerability Title: {title}".format(title=dependency_track_finding['vulnerability']['title'])
@@ -172,6 +178,8 @@ class DependencyTrackParser(object):
             vulnerability_description = vulnerability_description + "\nVulnerability Subtitle: {subtitle}".format(subtitle=dependency_track_finding['vulnerability']['subtitle'])
         if 'description' in dependency_track_finding['vulnerability'] and dependency_track_finding['vulnerability']['description'] is not None:
             vulnerability_description = vulnerability_description + "\nVulnerability Description: {description}".format(description=dependency_track_finding['vulnerability']['description'])
+        if 'uuid' in dependency_track_finding['vulnerability'] and dependency_track_finding['vulnerability']['uuid'] is not None:
+            vuln_id_from_tool = dependency_track_finding['vulnerability']['uuid']
 
         # Get severity according to Dependency Track and convert it to a severity DefectDojo understands
         dependency_track_severity = dependency_track_finding['vulnerability']['severity']
@@ -198,6 +206,8 @@ class DependencyTrackParser(object):
             false_p=is_false_positive,
             component_name=component_name,
             component_version=component_version,
+            file_path=file_path,
+            vuln_id_from_tool=vuln_id_from_tool,
             static_finding=True,
             dynamic_finding=False)
 

--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -171,6 +171,9 @@ class DependencyTrackParser(object):
             # might be no longer needed in the future, and is not needed if people use the default
             # hash code dedupe config for this parser
             file_path = component_purl
+        else:
+            file_path = 'unknown'
+
         # Append other info about vulnerability description info if it is present
         if 'title' in dependency_track_finding['vulnerability'] and dependency_track_finding['vulnerability']['title'] is not None:
             vulnerability_description = vulnerability_description + "\nVulnerability Title: {title}".format(title=dependency_track_finding['vulnerability']['title'])

--- a/dojo/unittests/scans/dependency_track_samples/dependency_track_3.8.0_2021-01-18.json
+++ b/dojo/unittests/scans/dependency_track_samples/dependency_track_3.8.0_2021-01-18.json
@@ -1,0 +1,224 @@
+{
+   "meta":{
+      "application":"Dependency-Track",
+      "version":"3.8.0",
+      "timestamp":"2021-01-18T15:08:59Z"
+   },
+   "findings":[
+      {
+         "component":{
+            "name":"jquery-ui",
+            "purl":"pkg:maven/org.webjars/jquery-ui@1.11.4?type=jar",
+            "uuid":"28902b39-d4cc-4072-b752-3614cf421867",
+            "version":"1.11.4",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"CVE-2016-7103",
+            "cweId":79,
+            "description":"Cross-site scripting (XSS) vulnerability in jQuery UI before 1.12.0 might allow remote attackers to inject arbitrary web script or HTML via the closeText parameter of the dialog function.",
+            "source":"NVD",
+            "uuid":"9e5b0aff-f4d8-4a7a-88a8-20326d5cfbe0"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:28902b39-d4cc-4072-b752-3614cf421867:9e5b0aff-f4d8-4a7a-88a8-20326d5cfbe0"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"3e831af5-428b-4712-874f-8f6ff932e2b2",
+            "cweId":79,
+            "description":"The software does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users.",
+            "source":"OSSINDEX",
+            "title":"CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "uuid":"d16f59db-6cff-43fa-9941-72fe4e1c820d"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:d16f59db-6cff-43fa-9941-72fe4e1c820d"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"CVE-2016-10735",
+            "cweId":79,
+            "description":"In Bootstrap 3.x before 3.4.0 and 4.x-beta before 4.0.0-beta.2, XSS is possible in the data-target attribute, a different vulnerability than CVE-2018-14041.",
+            "source":"NVD",
+            "uuid":"02ac4593-9aee-407d-9e2b-81d08cdf8603"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:02ac4593-9aee-407d-9e2b-81d08cdf8603"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"CVE-2018-14040",
+            "cweId":79,
+            "description":"In Bootstrap before 4.1.2, XSS is possible in the collapse data-parent attribute.",
+            "source":"NVD",
+            "uuid":"e26f418a-3833-4ded-9e57-6eb0bf86087e"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:e26f418a-3833-4ded-9e57-6eb0bf86087e"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"6dd9e321-93cd-4d79-b33a-ff7e01b15ad9",
+            "cweId":79,
+            "description":"The software does not neutralize or incorrectly neutralizes user-controllable input before it is placed in output that is used as a web page that is served to other users.",
+            "source":"OSSINDEX",
+            "title":"CWE-79: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "uuid":"e7a95d30-9e5e-49cb-b175-7da2c4a3e42a"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:e7a95d30-9e5e-49cb-b175-7da2c4a3e42a"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"CVE-2018-20676",
+            "cweId":79,
+            "description":"In Bootstrap before 3.4.0, XSS is possible in the tooltip data-viewport attribute.",
+            "source":"NVD",
+            "uuid":"eb039a1b-443c-4e6a-8385-2063d7c93c49"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:eb039a1b-443c-4e6a-8385-2063d7c93c49"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"CVE-2018-14042",
+            "cweId":79,
+            "description":"In Bootstrap before 4.1.2, XSS is possible in the data-container property of tooltip.",
+            "source":"NVD",
+            "uuid":"e11b6826-784a-430b-8aa0-3e165eaaa03e"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:e11b6826-784a-430b-8aa0-3e165eaaa03e"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"CVE-2019-8331",
+            "cweId":79,
+            "description":"In Bootstrap before 3.4.1 and 4.3.x before 4.3.1, XSS is possible in the tooltip or popover data-template attribute.",
+            "source":"NVD",
+            "uuid":"d10dbcd5-2776-46ac-b7db-e3ce25c22bd7"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:d10dbcd5-2776-46ac-b7db-e3ce25c22bd7"
+      },
+      {
+         "component":{
+            "name":"bootstrap",
+            "purl":"pkg:maven/org.webjars/bootstrap@3.3.6?type=jar",
+            "uuid":"856773f1-67e4-4e3b-b07b-c60bf8a4f364",
+            "version":"3.3.6",
+            "group":"org.webjars"
+         },
+         "vulnerability":{
+            "severity":"MEDIUM",
+            "severityRank":2,
+            "cweName":"Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+            "vulnId":"CVE-2018-20677",
+            "cweId":79,
+            "description":"In Bootstrap before 3.4.0, XSS is possible in the affix configuration target property.",
+            "source":"NVD",
+            "uuid":"3715d188-7fe1-49fd-99df-9f8b8204b18a"
+         },
+         "analysis":{
+            "isSuppressed":false
+         },
+         "matrix":"cb028f91-4e76-417f-9659-f98bbdab46f1:856773f1-67e4-4e3b-b07b-c60bf8a4f364:3715d188-7fe1-49fd-99df-9f8b8204b18a"
+      }
+   ],
+   "project":{
+      "name":"project",
+      "uuid":"cb028f91-4e76-417f-9659-f98bbdab46f1",
+      "version":"CI"
+   },
+   "version":"1.0"
+}

--- a/dojo/unittests/test_dependency_track_parser.py
+++ b/dojo/unittests/test_dependency_track_parser.py
@@ -37,3 +37,11 @@ class TestDependencyTrackParser(TestCase):
         parser = DependencyTrackParser(testfile, Test())
         testfile.close()
         self.assertEqual(1, len(parser.items))
+
+    def test_dependency_track_parser_v3_8_0(self):
+        testfile = open("dojo/unittests/scans/dependency_track_samples/dependency track 3.8.0 2021-01-18.json")
+        parser = DependencyTrackParser(testfile, Test())
+        testfile.close()
+        self.assertEqual(9, len(parser.items))
+        self.assertTrue(all(item.file_path is not None for item in parser.items))
+        self.assertTrue(all(item.vuln_id_from_tool is not None for item in parser.items))

--- a/dojo/unittests/test_dependency_track_parser.py
+++ b/dojo/unittests/test_dependency_track_parser.py
@@ -39,7 +39,7 @@ class TestDependencyTrackParser(TestCase):
         self.assertEqual(1, len(parser.items))
 
     def test_dependency_track_parser_v3_8_0(self):
-        testfile = open("dojo/unittests/scans/dependency_track_samples/dependency track 3.8.0 2021-01-18.json")
+        testfile = open("dojo/unittests/scans/dependency_track_samples/dependency_track_3.8.0_2021-01-18.json")
         parser = DependencyTrackParser(testfile, Test())
         testfile.close()
         self.assertEqual(9, len(parser.items))


### PR DESCRIPTION
fixes #3647

- add dedupe hash code config
- add file_path to make legacy dedupe happy
- add vuln_id_from_tool field
- make title format/value more useful
- allow .txt file uploads
- extend unit tests