### PR TITLE
Update Qualys_Infrascan_Webgui parser.py

### DIFF
--- a/dojo/tools/qualys_infrascan_webgui/parser.py
+++ b/dojo/tools/qualys_infrascan_webgui/parser.py
@@ -54,7 +54,9 @@ def issue_r(raw_row, vuln, scan_date):
 
     # FQDN
     issue_row['fqdn'] = raw_row.get('name')
-
+    if issue_row['fqdn'] == "No registered hostname"
+        issue_row['fqdn'] = False
+        
     # Create Endpoint
     if issue_row['fqdn']:
         ep = Endpoint(host=issue_row['fqdn'])


### PR DESCRIPTION
Catching "No registered hostname" as non-valid value for fqdn, falling back to IP address to be used for the endpoint; otherwise you get an endpoint called "No registered hostname" and findings are aggregated incorrectly.

Raw XML report extract example (actual public IP has been replaced with 127.0.0.1):

`<IP value="127.0.0.1" name="No registered hostname">`
`  <OS><![CDATA[Linux 2.6]]></OS>`
`  <INFOS>`
`    <CAT value="Information gathering">`
`      <INFO number="6" severity="1">`
`        <TITLE><![CDATA[DNS Host Name]]></TITLE>`
`        <LAST_UPDATE><![CDATA[2018-01-04T17:39:37Z]]></LAST_UPDATE>`
`        <PCI_FLAG>0</PCI_FLAG>`
`        <DIAGNOSIS><![CDATA[The fully qualified domain name of this host, if it was obtained from a DNS server, is displayed in the RESULT section.]]></DIAGNOSIS>`
`        <CONSEQUENCE><![CDATA[N/A]]></CONSEQUENCE>`
`        <SOLUTION><![CDATA[N/A]]></SOLUTION>`
`        <RESULT format="table"><![CDATA[IP address	Host name
127.0.0.1	No registered hostname]]></RESULT>`
`      </INFO>`