### PR TITLE
Fix tag migration for legacy products

### DIFF
--- a/dojo/db_migrations/0066_django_tagulous.py
+++ b/dojo/db_migrations/0066_django_tagulous.py
@@ -36,9 +36,18 @@ class Migration(migrations.Migration):
                     #     obj.save(dedupe_option=False, rules_option=False, issue_updater_option=False, push_to_jira=False)
                     # else:
                     try:
+                        if hasattr(obj, 'prod_type_id') and obj.prod_type_id == 0:
+                            logger.warning('product found without product type (prod_type==0), changing to: "_tag migration lost and found" product type')
+                            prod_type_lost_and_found, created = Product_Type.objects.get_or_create(name='_tag migration lost and found')
+                            obj.prod_type = prod_type_lost_and_found
+                            obj.save()
+                            logger.warning('product type succesfully changed to %i', prod_type_lost_and_found.id)
+
                         obj.save()
                     except Exception as e:
                         logger.error('Error saving old existing django-tagging tags to new string field')
+                        logger.error('Known errors are products with prod_type equal to 0. ')
+                        logger.error('Run UPDATE dojo_product set prod_type=<valid_id> to fix this problem')
                         logger.error('Details of object:')
                         logger.error(vars(obj))
                         logger.error('Model to dict:')

--- a/dojo/db_migrations/0066_django_tagulous.py
+++ b/dojo/db_migrations/0066_django_tagulous.py
@@ -3,7 +3,7 @@
 from django.db import migrations, models
 # import django.db.models.deletion
 from tagging.registry import register as tag_register
-
+from django.forms.models import model_to_dict
 import tagulous.models.fields
 import tagulous.models.models
 import logging
@@ -35,7 +35,14 @@ class Migration(migrations.Migration):
                     # if model_name == 'finding2':
                     #     obj.save(dedupe_option=False, rules_option=False, issue_updater_option=False, push_to_jira=False)
                     # else:
-                    obj.save()
+                    try:
+                        obj.save()
+                    except Exception as e:
+                        logger.error('Error saving old existing django-tagging tags to new string field')
+                        logger.error('Details of object:')
+                        logger.error(vars(obj))
+                        logger.error('Model to dict:')
+                        logger.error(model_to_dict(obj))
 
     def copy_tags_from_django_tagging_field_to_new_tagulous_tags_field(apps, schema_editor):
         # We can't import the models directly as it may be a newer
@@ -50,9 +57,15 @@ class Migration(migrations.Migration):
                 if obj.tags_from_django_tagging:
                     logger.debug('%s:%s:%s: found tags: %s', model_class, obj.id, obj, obj.tags_from_django_tagging)
                     obj.tags = obj.tags_from_django_tagging
-                    obj.save()
 
-        # raise ValueError('fake error to fail migration')
+                    try:
+                        obj.save()
+                    except Exception as e:
+                        logger.error('Error saving tags to new tagulous m2m field')
+                        logger.error('Details of object:')
+                        logger.error(vars(obj))
+                        logger.error('Model to dict:')
+                        logger.error(model_to_dict(obj))
 
     dependencies = [
         ('dojo', '0065_delete_empty_jira_project_configs'),

--- a/dojo/db_migrations/0066_django_tagulous.py
+++ b/dojo/db_migrations/0066_django_tagulous.py
@@ -46,8 +46,6 @@ class Migration(migrations.Migration):
                         obj.save()
                     except Exception as e:
                         logger.error('Error saving old existing django-tagging tags to new string field')
-                        logger.error('Known errors are products with prod_type equal to 0. ')
-                        logger.error('Run UPDATE dojo_product set prod_type=<valid_id> to fix this problem')
                         logger.error('Details of object:')
                         logger.error(vars(obj))
                         logger.error('Model to dict:')


### PR DESCRIPTION
make tagulous migration work with (legacy) products without a product type. (fixes #3683)

if a product is found without a product type (prod_type==0), we create a `_tag migration lost and found` product type and attach the product to it.

this a rare case where updating an existing migration is harmless as we're not changing the database schema, just the data migration. this will only affect people for which the migration was failing.

for those people, you need to comment out the following part in `dojo/db_migrations/0066_django_tagulous.py`:

``` 
    #     migrations.AddField(
    #         model_name='app_analysis',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),
    #     migrations.AddField(
    #         model_name='endpoint',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),
    #     migrations.AddField(
    #         model_name='engagement',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),
    #     migrations.AddField(
    #         model_name='finding',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),
    #     migrations.AddField(
    #         model_name='objects',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),
    #     migrations.AddField(
    #         model_name='test',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),
    #     migrations.AddField(
    #         model_name='product',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),
    #     migrations.AddField(
    #         model_name='finding_template',
    #         name='tags_from_django_tagging',
    #         field=models.TextField(blank=True, editable=False, help_text='Temporary archive with tags from the previous tagging library we used'),
    #     ),

        migrations.RunPython(copy_existing_tags_to_tags_from_django_tagging_field, migrations.RunPython.noop),

```

So basically everything before the first RunPython command.