### PR TITLE
add product via prod_type: use normal add product logic

### DIFF
--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -38,6 +38,22 @@ function success() {
     echo "Success: $1 test passed\n"
 }
 
+test="Product type integration tests"
+echo "Running: $test"
+if python3 tests/product_type_test.py ; then
+    success $test
+else
+    fail $test
+fi
+
+test="Product integration tests"
+echo "Running: $test"
+if python3 tests/product_test.py ; then
+    success $test
+else
+    fail $test
+fi
+
 test="Report Builder tests"
 echo "Running: $test"
 if python3 tests/report_builder_test.py ; then
@@ -57,22 +73,6 @@ fi
 test="Regulation integration tests"
 echo "Running: $test"
 if python3 tests/regulations_test.py ; then
-    success $test
-else
-    fail $test
-fi
-
-test="Product type integration tests"
-echo "Running: $test"
-if python3 tests/product_type_test.py ; then
-    success $test
-else
-    fail $test
-fi
-
-test="Product integration tests"
-echo "Running: $test"
-if python3 tests/product_test.py ; then
     success $test
 else
     fail $test

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -38,22 +38,6 @@ function success() {
     echo "Success: $1 test passed\n"
 }
 
-test="Product type integration tests"
-echo "Running: $test"
-if python3 tests/product_type_test.py ; then
-    success $test
-else
-    fail $test
-fi
-
-test="Product integration tests"
-echo "Running: $test"
-if python3 tests/product_test.py ; then
-    success $test
-else
-    fail $test
-fi
-
 test="Report Builder tests"
 echo "Running: $test"
 if python3 tests/report_builder_test.py ; then
@@ -73,6 +57,22 @@ fi
 test="Regulation integration tests"
 echo "Running: $test"
 if python3 tests/regulations_test.py ; then
+    success $test
+else
+    fail $test
+fi
+
+test="Product type integration tests"
+echo "Running: $test"
+if python3 tests/product_type_test.py ; then
+    success $test
+else
+    fail $test
+fi
+
+test="Product integration tests"
+echo "Running: $test"
+if python3 tests/product_test.py ; then
     success $test
 else
     fail $test

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -287,33 +287,6 @@ class DojoMetaDataForm(forms.ModelForm):
         fields = '__all__'
 
 
-class Product_TypeProductForm(forms.ModelForm):
-    name = forms.CharField(max_length=50, required=True)
-    description = forms.CharField(widget=forms.Textarea(attrs={}),
-                                  required=True)
-    # tags = forms.CharField(widget=forms.SelectMultiple(choices=[]),
-    #                        required=False,
-    #                        help_text="Add tags that help describe this product.  "
-    #                                  "Choose from the list or add new tags.  Press TAB key to add.")
-    authorized_users = forms.ModelMultipleChoiceField(
-        queryset=None,
-        required=False, label="Authorized Users")
-    prod_type = forms.ModelChoiceField(label='Product Type',
-                                       queryset=Product_Type.objects.all().order_by('name'),
-                                       required=True)
-
-    def __init__(self, *args, **kwargs):
-        non_staff = User.objects.exclude(is_staff=True) \
-            .exclude(is_active=False)
-        super(Product_TypeProductForm, self).__init__(*args, **kwargs)
-        self.fields['authorized_users'].queryset = non_staff
-
-    class Meta:
-        model = Product
-        fields = ['name', 'description', 'tags', 'product_manager', 'technical_contact', 'team_manager', 'prod_type', 'regulations',
-                  'authorized_users', 'business_criticality', 'platform', 'lifecycle', 'origin', 'user_records', 'revenue', 'external_audience', 'internet_accessible']
-
-
 class ImportScanForm(forms.Form):
     SCAN_TYPE_CHOICES = (("", "Please Select a Scan Type"),
                          ("Netsparker Scan", "Netsparker Scan"),

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1007,9 +1007,11 @@ def process_jira_project_form(request, instance=None, product=None, engagement=N
     # jform = JIRAProjectForm(request.POST, instance=instance if instance else JIRA_Project(), product=product)
     jform = JIRAProjectForm(request.POST, instance=instance, product=product, engagement=engagement)
     # logging has_changed because it sometimes doesn't do what we expect
-    logger.debug('jform has changed: ' + str(jform.has_changed()))
+    logger.debug('jform has changed: %s', str(jform.has_changed()))
 
     if jform.has_changed():  # if no data was changed, no need to do anything!
+        logger.debug('jform changed_data: %s', jform.changed_data)
+        logger.debug('jform: %s', vars(jform))
         if jform.is_valid():
             try:
                 jira_project = jform.save(commit=False)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -688,10 +688,16 @@ def import_scan_results_prod(request, pid=None):
 
 
 @user_passes_test(lambda u: u.is_staff)
-def new_product(request):
+def new_product(request, ptid=None):
     jira_project_form = None
     error = False
-    form = ProductForm()
+    initial = None
+    if ptid is not None:
+        prod_type = get_object_or_404(Product_Type, pk=ptid)
+        initial = {'prod_type': prod_type}
+
+    form = ProductForm(initial=initial)
+
     if request.method == 'POST':
         form = ProductForm(request.POST, instance=Product())
 

--- a/dojo/product_type/urls.py
+++ b/dojo/product_type/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from dojo.product_type import views
+from dojo.product import views as product_views
 
 urlpatterns = [
     #  product type
@@ -10,6 +11,6 @@ urlpatterns = [
     url(r'^product/type/add$', views.add_product_type,
         name='add_product_type'),
     url(r'^product/type/(?P<ptid>\d+)/add_product',
-        views.add_product_to_product_type,
+        product_views.new_product,
         name='add_product_to_product_type'),
 ]

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
 from dojo.filters import ProductTypeFilter
-from dojo.forms import Product_TypeForm, Product_TypeProductForm, Delete_Product_TypeForm
+from dojo.forms import Product_TypeForm, Delete_Product_TypeForm
 from dojo.models import Product_Type
 from dojo.utils import get_page_items, add_breadcrumb
 from dojo.notifications.helper import create_notification
@@ -125,13 +125,3 @@ def edit_product_type(request, ptid):
         'user': request.user,
         'pt_form': pt_form,
         'pt': pt})
-
-
-@user_passes_test(lambda u: u.is_staff)
-def add_product_to_product_type(request, ptid):
-    pt = get_object_or_404(Product_Type, pk=ptid)
-    form = Product_TypeProductForm(initial={'prod_type': pt})
-    add_breadcrumb(title="New %s Product" % pt.name, top_level=False, request=request)
-    return render(request, 'dojo/new_product.html',
-                  {'form': form,
-                   })

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -87,6 +87,10 @@ class BaseTestCase(unittest.TestCase):
         self.wait_for_datatable_if_content("no_products", "products_wrapper")
         return driver
 
+    def goto_product_type_overview(self, driver):
+        driver.get(self.base_url + "product/type")
+        return driver
+
     def goto_component_overview(self, driver):
         driver.get(self.base_url + "components")
         return driver

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -75,6 +75,17 @@ class BaseTestCase(unittest.TestCase):
     def test_login(self):
         return self.login_page()
 
+    @on_exception_html_source_logger
+    def delete_product_if_exists(self, name="QA Test"):
+        driver = self.driver
+        # Navigate to the product page
+        self.goto_product_overview(driver)
+        # Select the specific product to delete
+        qa_products = driver.find_elements(By.LINK_TEXT, name)
+
+        if len(qa_products) > 0:
+            self.test_delete_product(name)
+
     # used to load some page just to get started
     # we choose /user because it's lightweight and fast
     def goto_some_page(self):

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -14,6 +14,22 @@ dd_driver = None
 dd_driver_options = None
 
 
+def on_exception_html_source_logger(func):
+    def wrapper(self, *args, **kwargs):
+        try:
+            return func(self, *args, **kwargs)
+
+        except Exception as e:
+            print("exception occured at url:", self.driver.current_url)
+            print("page source:", self.driver.page_source)
+            f = open("selenium_page_source.html", "w", encoding='utf-8')
+            f.writelines(self.driver.page_source)
+            # time.sleep(30)
+            raise(e)
+
+    return wrapper
+
+
 class BaseTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -334,19 +350,3 @@ class WebdriverOnlyNewLogFacade(object):
         self.last_timestamp = last_timestamp
 
         return filtered
-
-
-def on_exception_html_source_logger(func):
-    def wrapper(self, *args, **kwargs):
-        try:
-            return func(self, *args, **kwargs)
-
-        except Exception as e:
-            print("exception occured at url:", self.driver.current_url)
-            print("page source:", self.driver.page_source)
-            f = open("selenium_page_source.html", "w", encoding='utf-8')
-            f.writelines(self.driver.page_source)
-            # time.sleep(30)
-            raise(e)
-
-    return wrapper

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -4,7 +4,6 @@ import unittest
 import sys
 import time
 from base_test_class import BaseTestCase, on_exception_html_source_logger
-from selenium.webdriver.common.by import By
 
 
 class WaitForPageLoad(object):
@@ -326,17 +325,6 @@ class ProductTest(BaseTestCase):
         # "Click" the dropdown option
         # driver.find_element_by_xpath("//span[contains(., 'Metrics')]").click()
         driver.find_element_by_partial_link_text('Metrics').click()
-
-    @on_exception_html_source_logger
-    def delete_product_if_exists(self, name="QA Test"):
-        driver = self.driver
-        # Navigate to the product page
-        self.goto_product_overview(driver)
-        # Select the specific product to delete
-        qa_products = driver.find_elements(By.LINK_TEXT, name)
-
-        if len(qa_products) > 0:
-            self.test_delete_product(name)
 
     @on_exception_html_source_logger
     def test_delete_product(self, name="QA Test"):

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -65,7 +65,7 @@ class ProductTest(BaseTestCase):
     @on_exception_html_source_logger
     def test_create_product_for_product_type(self):
         # make sure no left overs from previous runs are left behind
-        self.delete_product_if_exists()
+        self.delete_product_if_exists("QA Test PT")
 
         driver = self.driver
         # Navigate to the product page
@@ -74,7 +74,7 @@ class ProductTest(BaseTestCase):
         driver.find_element_by_link_text("Add Product").click()
         # Fill in th product name
         driver.find_element_by_id("id_name").clear()
-        driver.find_element_by_id("id_name").send_keys("QA Test")
+        driver.find_element_by_id("id_name").send_keys("QA Test PT")
         # Tab into the description area to fill some text
         # Couldnt find a way to get into the box with selenium
         driver.find_element_by_id("id_name").send_keys("\tThis is just a test. Be very afraid.")
@@ -351,23 +351,23 @@ class ProductTest(BaseTestCase):
         driver.find_element_by_partial_link_text('Metrics').click()
 
     @on_exception_html_source_logger
-    def delete_product_if_exists(self):
+    def delete_product_if_exists(self, name="QA Test"):
         driver = self.driver
         # Navigate to the product page
         self.goto_product_overview(driver)
         # Select the specific product to delete
-        qa_products = driver.find_elements(By.LINK_TEXT, "QA Test")
+        qa_products = driver.find_elements(By.LINK_TEXT, name)
 
         if len(qa_products) > 0:
-            self.test_delete_product()
+            self.test_delete_product(name)
 
     @on_exception_html_source_logger
-    def test_delete_product(self):
+    def test_delete_product(self, name="QA Test"):
         driver = self.driver
         # Navigate to the product page
         self.goto_product_overview(driver)
         # Select the specific product to delete
-        driver.find_element_by_link_text("QA Test").click()
+        driver.find_element_by_link_text(name).click()
         # Click the drop down menu
         # driver.execute_script("window.scrollTo(0, 0)")
         driver.find_element_by_id('dropdownMenu1').click()

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -60,6 +60,7 @@ class ProductTest(BaseTestCase):
         # Also confirm success even if Product is returned as already exists for test sake
         self.assertTrue(self.is_success_message_present(text='Product added successfully') or
             self.is_success_message_present(text='Product with this Name already exists.'))
+        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
 
     @on_exception_html_source_logger
     def test_list_products(self):
@@ -102,6 +103,7 @@ class ProductTest(BaseTestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(self.is_success_message_present(text='Product updated successfully') or
             self.is_success_message_present(text='Product with this Name already exists.'))
+        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
 
     @on_exception_html_source_logger
     def test_add_product_engagement(self):

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -63,6 +63,29 @@ class ProductTest(BaseTestCase):
             self.is_success_message_present(text='Product with this Name already exists.'))
 
     @on_exception_html_source_logger
+    def test_create_product_for_product_type(self):
+        # make sure no left overs from previous runs are left behind
+        self.delete_product_if_exists()
+
+        driver = self.driver
+        # Navigate to the product page
+        self.goto_product_type_overview(driver)
+
+        driver.find_element_by_link_text("Add Product").click()
+        # Fill in th product name
+        driver.find_element_by_id("id_name").clear()
+        driver.find_element_by_id("id_name").send_keys("QA Test")
+        # Tab into the description area to fill some text
+        # Couldnt find a way to get into the box with selenium
+        driver.find_element_by_id("id_name").send_keys("\tThis is just a test. Be very afraid.")
+        driver.find_element_by_css_selector("input.btn.btn-primary").click()
+
+        # Assert ot the query to dtermine status of failure
+        # Also confirm success even if Product is returned as already exists for test sake
+        self.assertTrue(self.is_success_message_present(text='Product added successfully'))
+        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
+
+    @on_exception_html_source_logger
     def test_list_products(self):
         driver = self.driver
         # Navigate to the product page

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -60,7 +60,7 @@ class ProductTest(BaseTestCase):
         # Also confirm success even if Product is returned as already exists for test sake
         self.assertTrue(self.is_success_message_present(text='Product added successfully') or
             self.is_success_message_present(text='Product with this Name already exists.'))
-        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
+        self.assertFalse(self.is_error_message_present())
 
     @on_exception_html_source_logger
     def test_list_products(self):
@@ -103,7 +103,7 @@ class ProductTest(BaseTestCase):
         # Assert ot the query to dtermine status of failure
         self.assertTrue(self.is_success_message_present(text='Product updated successfully') or
             self.is_success_message_present(text='Product with this Name already exists.'))
-        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
+        self.assertFalse(self.is_error_message_present())
 
     @on_exception_html_source_logger
     def test_add_product_engagement(self):

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -63,29 +63,6 @@ class ProductTest(BaseTestCase):
             self.is_success_message_present(text='Product with this Name already exists.'))
 
     @on_exception_html_source_logger
-    def test_create_product_for_product_type(self):
-        # make sure no left overs from previous runs are left behind
-        self.delete_product_if_exists("QA Test PT")
-
-        driver = self.driver
-        # Navigate to the product page
-        self.goto_product_type_overview(driver)
-
-        driver.find_element_by_link_text("Add Product").click()
-        # Fill in th product name
-        driver.find_element_by_id("id_name").clear()
-        driver.find_element_by_id("id_name").send_keys("QA Test PT")
-        # Tab into the description area to fill some text
-        # Couldnt find a way to get into the box with selenium
-        driver.find_element_by_id("id_name").send_keys("\tThis is just a test. Be very afraid.")
-        driver.find_element_by_css_selector("input.btn.btn-primary").click()
-
-        # Assert ot the query to dtermine status of failure
-        # Also confirm success even if Product is returned as already exists for test sake
-        self.assertTrue(self.is_success_message_present(text='Product added successfully'))
-        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
-
-    @on_exception_html_source_logger
     def test_list_products(self):
         driver = self.driver
         # Navigate to the product page

--- a/tests/product_type_test.py
+++ b/tests/product_type_test.py
@@ -18,6 +18,7 @@ class ProductTypeTest(BaseTestCase):
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
 
         self.assertTrue(self.is_success_message_present(text='Product type added successfully.'))
+        self.assertFalse(self.is_error_message_present())
 
     @on_exception_html_source_logger
     def test_create_product_for_product_type(self):
@@ -40,7 +41,7 @@ class ProductTypeTest(BaseTestCase):
         # Assert ot the query to dtermine status of failure
         # Also confirm success even if Product is returned as already exists for test sake
         self.assertTrue(self.is_success_message_present(text='Product added successfully'))
-        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
+        self.assertFalse(self.is_error_message_present())
 
     def test_edit_product_type(self):
         print("\n\nDebug Print Log: testing 'edit product type' \n")

--- a/tests/product_type_test.py
+++ b/tests/product_type_test.py
@@ -19,6 +19,29 @@ class ProductTypeTest(BaseTestCase):
 
         self.assertTrue(self.is_success_message_present(text='Product type added successfully.'))
 
+    @on_exception_html_source_logger
+    def test_create_product_for_product_type(self):
+        # make sure no left overs from previous runs are left behind
+        self.delete_product_if_exists("QA Test PT")
+
+        driver = self.driver
+        # Navigate to the product page
+        self.goto_product_type_overview(driver)
+
+        driver.find_element_by_link_text("Add Product").click()
+        # Fill in th product name
+        driver.find_element_by_id("id_name").clear()
+        driver.find_element_by_id("id_name").send_keys("QA Test PT")
+        # Tab into the description area to fill some text
+        # Couldnt find a way to get into the box with selenium
+        driver.find_element_by_id("id_name").send_keys("\tThis is just a test. Be very afraid.")
+        driver.find_element_by_css_selector("input.btn.btn-primary").click()
+
+        # Assert ot the query to dtermine status of failure
+        # Also confirm success even if Product is returned as already exists for test sake
+        self.assertTrue(self.is_success_message_present(text='Product added successfully'))
+        self.assertFalse(self.is_error_message_present(text='JIRA Project config not stored due to errors'))
+
     def test_edit_product_type(self):
         print("\n\nDebug Print Log: testing 'edit product type' \n")
         driver = self.driver
@@ -45,6 +68,7 @@ def suite():
     suite = unittest.TestSuite()
     suite.addTest(BaseTestCase('test_login'))
     suite.addTest(ProductTypeTest('test_create_product_type'))
+    suite.addTest(ProductTypeTest('test_create_product_for_product_type'))
     suite.addTest(ProductTypeTest('test_edit_product_type'))
     suite.addTest(ProductTypeTest('test_delete_product_type'))
     return suite

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -7,7 +7,6 @@ import unittest
 import sys
 import os
 from base_test_class import BaseTestCase
-# from base_test_class import on_exception_html_source_logger
 from product_test import ProductTest
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -131,7 +130,6 @@ class ReportBuilderTest(BaseTestCase):
 
         driver.find_element_by_name('_generate').click()
 
-    # @on_exception_html_source_logger
     def test_product_endpoint_report(self):
         driver = self.driver
         self.goto_product_overview(driver)


### PR DESCRIPTION
while investigating #3653 I noticed that adding a product via the product type view is using different logic to initialize the forms 
no jira, no github, no checks, etc.
we should reuse the add product functionality for adding a new product from the side menu.

also adds some logging to help with #3653
