### PR TITLE
Fix date format on Fortify parser

### DIFF
--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -21,9 +21,9 @@ class FortifyXMLParser(object):
         # Get Date
         date_string = root.getchildren()[5].getchildren()[1].getchildren()[2].text
         date_list = date_string.split()[1:4]
-        date_act = "".join(date_list)
+        date_list = [item.replace(',', '') for item in date_list]
+        date_act = ".".join(date_list)
         find_date = parser.parse(date_act)
-
         # Get Language
         lang_string = root[8][4][2].text
         lang_need_string = re.findall("^.*com.fortify.sca.Phase0HigherOrder.Languages.*$",

--- a/dojo/unittests/test_fortify_parser.py
+++ b/dojo/unittests/test_fortify_parser.py
@@ -1,6 +1,7 @@
 from django.test import TestCase
 from dojo.tools.fortify.parser import FortifyXMLParser
 from dojo.models import Test
+from datetime import datetime
 
 
 class TestFortifyParser(TestCase):
@@ -9,13 +10,16 @@ class TestFortifyParser(TestCase):
         testfile = "dojo/unittests/scans/fortify/fortify_many_findings.xml"
         parser = FortifyXMLParser(testfile, Test())
         self.assertEqual(324, len(parser.items))
+        self.assertEqual(parser.items[0].date, datetime(2019, 12, 17))
 
     def test_fortify_few_findings(self):
         testfile = "dojo/unittests/scans/fortify/fortify_few_findings.xml"
         parser = FortifyXMLParser(testfile, Test())
         self.assertEqual(2, len(parser.items))
+        self.assertEqual(parser.items[0].date, datetime(2019, 5, 7))
 
     def test_fortify_few_findings_count_chart(self):
         testfile = "dojo/unittests/scans/fortify/fortify_few_findings_count_chart.xml"
         parser = FortifyXMLParser(testfile, Test())
         self.assertEqual(3, len(parser.items))
+        self.assertEqual(parser.items[0].date, datetime(2019, 5, 7))


### PR DESCRIPTION
The date parser on the Fortify parser was not totally accurate because of the punctuation used within the report. The `dateutil` parser would receive an input like `Oct31,2020,` and it would record the date in dojo as October 21, 2021. Instead, the parser will get an input of `Oct.31.2020` and the date will be recorded on the finding correctly. 