### PR TITLE
integration tests: wait for findings datatable

### DIFF
--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -85,6 +85,11 @@ class DedupeTest(BaseTestCase):
         except TimeoutException:
             self.fail('Confirmation dialogue not shown, cannot delete previous findings')
 
+        # not sure if this is needed. the datatables js logic only kicks in
+        # if the dev with id "findings" is present
+        # so if it isn't, the no_findings div is available straight after
+        # the page load. but we see some errors here about the div not being there
+        # but when we log the page source, the no_findings div is present
         self.wait_for_datatable_if_content("no_findings", "findings_wrapper")
 
         text = None

--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -79,11 +79,13 @@ class DedupeTest(BaseTestCase):
         driver.find_element_by_css_selector("i.fa.fa-trash").click()
         try:
             WebDriverWait(driver, 1).until(EC.alert_is_present(),
-                                        'Timed out waiting for PA creation ' +
+                                        'Timed out waiting for finding delete ' +
                                         'confirmation popup to appear.')
             driver.switch_to.alert.accept()
         except TimeoutException:
             self.fail('Confirmation dialogue not shown, cannot delete previous findings')
+
+        self.wait_for_datatable_if_content("no_findings", "findings_wrapper")
 
         text = None
         if self.element_exists_by_id("no_findings"):

--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -91,6 +91,7 @@ class DedupeTest(BaseTestCase):
         if self.element_exists_by_id("no_findings"):
             text = driver.find_element_by_id("no_findings").text
 
+        self.assertIsNotNone(text)
         self.assertTrue('No findings found.' in text)
         # check that user was redirect back to url where it came from based on return_url
         self.assertTrue(driver.current_url.endswith('page=1'))


### PR DESCRIPTION
in the dedupe test there could be cases where the integration test was failing because it couldn't find the "No findings" text because the datatables initialization wasn't finished