### PR TITLE
JIRAError doesn't include message. .text will provide the content.

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -272,7 +272,7 @@ def get_jira_connection_raw(jira_server, jira_username, jira_password):
         else:
             log_jira_generic_alert('Unknown JIRA Connection Error', e)
 
-        add_error_message_to_response('Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + e.message)
+        add_error_message_to_response('Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + e.text)
         raise e
 
     except requests.exceptions.RequestException as re:

--- a/dojo/tools/semgrep/models.py
+++ b/dojo/tools/semgrep/models.py
@@ -34,10 +34,12 @@ class SemgrepJSONResult:
             return
 
         # parse CWE
-        if metadata.get("cwe").partition(':')[2]:
-            self.title = metadata.get("cwe").partition(':')[2]
+        cwe = metadata.get("cwe")
+        if cwe != None:
+            if  cwe.partition(':')[2]:
+                self.title = cwe.partition(':')[2]
+            self.cwe = cwe.partition(':')[0].partition('-')[2]
 
-        self.cwe = metadata.get("cwe").partition(':')[0].partition('-')[2]
         # Convert Semgrep severity to defectDojo Severity
         semSeverity = extra.get('severity')
 


### PR DESCRIPTION
(resubmitting to dev) 

Based on the JIRA docs there's no .message attribute on the JIRAError Exception. This was causing an error if the request failed. Changing this to .text will provide the content of the error.

https://jira.readthedocs.io/en/master/_modules/jira/exceptions.html

