### PR TITLE
test.version: add missing places in UI, filters and importers

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1293,6 +1293,9 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
             scan_date_time = timezone.make_aware(scan_date_time, timezone.get_default_timezone())
         verified = data['verified']
         active = data['active']
+        version = None
+        if 'version' in data:
+            version = data['version']
 
         try:
             parser = import_parser_factory(data.get('file', None),
@@ -1511,6 +1514,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 test.target_end = max_safe([scan_date_time, test.target_end])
                 test.engagement.target_end = max_safe([scan_date, test.engagement.target_end])
 
+            if version:
+                test.version = version
             test.save()
             test.engagement.save()
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -523,6 +523,8 @@ def import_scan_results(request, eid=None, pid=None):
 
         if form.is_valid() and (jform is None or jform.is_valid()):
             # Allows for a test to be imported with an engagement created on the fly
+            version = form.cleaned_data['version']
+
             if engagement is None:
                 engagement = Engagement()
                 # product = get_object_or_404(Product, id=pid)
@@ -536,6 +538,7 @@ def import_scan_results(request, eid=None, pid=None):
                 engagement.product = product
                 engagement.active = True
                 engagement.status = 'In Progress'
+                engagement.version = version
                 engagement.save()
             file = request.FILES.get('file', None)
             scan_date = form.cleaned_data['scan_date']
@@ -544,6 +547,7 @@ def import_scan_results(request, eid=None, pid=None):
             verified = form.cleaned_data['verified']
             scan_type = request.POST['scan_type']
             tags = form.cleaned_data['tags']
+
             if not any(scan_type in code
                        for code in ImportScanForm.SCAN_TYPE_CHOICES):
                 raise Http404()
@@ -567,6 +571,7 @@ def import_scan_results(request, eid=None, pid=None):
                 target_end=scan_date,
                 environment=environment,
                 percent_complete=100,
+                version=version,
                 tags=tags)
             t.lead = user
             t.full_clean()

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -383,7 +383,7 @@ class EngagementFilter(DojoFilter):
 
     class Meta:
         model = Product
-        fields = ['name', 'prod_type']
+        fields = ['name', 'prod_type', 'version']
 
 
 class ApiEngagementFilter(DojoFilter):
@@ -1600,7 +1600,7 @@ class ApiTestFilter(DojoFilter):
         model = Test
         fields = ['id', 'title', 'test_type', 'target_start',
                      'target_end', 'notes', 'percent_complete',
-                     'actual_time', 'engagement']
+                     'actual_time', 'engagement', 'version']
 
 
 class ApiAppAnalysisFilter(DojoFilter):

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -352,6 +352,9 @@ class EngagementFilter(DojoFilter):
         queryset=User.objects.filter(
             engagement__lead__isnull=False).distinct(),
         label="Lead")
+    engagement__version = CharFilter(field_name='engagement__version', lookup_expr='icontains', label='Engagement version')
+    engagement__test__version = CharFilter(field_name='engagement__test__version', lookup_expr='icontains', label='Test version')
+
     name = CharFilter(lookup_expr='icontains')
     prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.all().order_by('name'),
@@ -383,7 +386,7 @@ class EngagementFilter(DojoFilter):
 
     class Meta:
         model = Product
-        fields = ['name', 'prod_type', 'version']
+        fields = ['name', 'prod_type']
 
 
 class ApiEngagementFilter(DojoFilter):

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -410,6 +410,8 @@ class ImportScanForm(forms.Form):
         queryset=Development_Environment.objects.all().order_by('name'))
     endpoints = forms.ModelMultipleChoiceField(Endpoint.objects, required=False, label='Systems / Endpoints',
                                                widget=MultipleSelectWithPopPlusMinus(attrs={'size': '5'}))
+    version = forms.CharField(max_length=100, required=False, help_text="Version that will be set on the Test object that will be created.")
+
     tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
@@ -462,6 +464,7 @@ class ReImportScanForm(forms.Form):
         required=False)
     close_old_findings = forms.BooleanField(help_text="Select if old findings get mitigated when importing.",
                                             required=False, initial=True)
+    version = forms.CharField(max_length=100, required=False, help_text="Version that will be set on existing Test object. Leave empty to leave existing value in place.")
 
     def __init__(self, *args, test=None, **kwargs):
         super(ReImportScanForm, self).__init__(*args, **kwargs)

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -250,7 +250,13 @@
                         {% for test in tests %}
                             <tr>
                                 <td><a title="{{ test.description }}" href="{% url 'view_test' test.id %}">{{ test }}</a>
-                                  {% if test.tags %}
+                                    {% if test.version %}
+                                        <sup>
+                                            <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ test.version }}">
+                                            {{ test.version }}</a>
+                                        </sup>
+                                    {% endif %}
+                                    {% if test.tags %}
                                       <sup>
                                           {% for tag in test.tags.all %}
                                           <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query=test-tag:{{ tag }}">{{ tag }}</a>

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -648,6 +648,8 @@ def re_import_scan_results(request, tid):
             active = form.cleaned_data['active']
             verified = form.cleaned_data['verified']
             tags = form.cleaned_data['tags']
+            if 'version' in form.cleaned_data and form.cleaned_data['version']:
+                test.version = form.cleaned_data['version']
             close_old_findings = form.cleaned_data.get('close_old_findings', True)
             # Tags are replaced, same behaviour as with django-tagging
             test.tags = tags


### PR DESCRIPTION
Continuing on #2241
The version field for Test objects was not shown in similar ways as for engagements. And it wasn't possible to set it on import/reimports via the UI and also not via reimport in the API v2.