### PR TITLE
api v2: remove try-catch that swallows all exceptions

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -8,7 +8,6 @@ from django.db import IntegrityError
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.decorators import action
 from rest_framework.parsers import MultiPartParser
-from rest_framework.exceptions import ParseError
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg2 import openapi
 from drf_yasg2.utils import swagger_auto_schema, no_body
@@ -1260,10 +1259,7 @@ class ImportScanView(mixins.CreateModelMixin,
             push_to_jira = push_to_jira or jira_project.push_all_issues
 
         logger.debug('push_to_jira: %s', serializer.validated_data.get('push_to_jira'))
-        try:
-            serializer.save(push_to_jira=push_to_jira)
-        except Exception as e:
-            raise ParseError(detail=e)
+        serializer.save(push_to_jira=push_to_jira)
 
 
 class ReImportScanView(mixins.CreateModelMixin,
@@ -1281,10 +1277,7 @@ class ReImportScanView(mixins.CreateModelMixin,
             push_to_jira = push_to_jira or jira_project.push_all_issues
 
         logger.debug('push_to_jira: %s', serializer.validated_data.get('push_to_jira'))
-        try:
-            serializer.save(push_to_jira=push_to_jira)
-        except Exception as e:
-            raise ParseError(detail=e)
+        serializer.save(push_to_jira=push_to_jira)
 
 
 class NoteTypeViewSet(mixins.ListModelMixin,


### PR DESCRIPTION
fixes #3679

a recent PR changed the error handling of the api v2 to catch everything and wrap it in a parseerror.
this leads to all exceptions being turned into a 400 error which means:
- the exception is not logged
- the exception is not returned in the api response
- the response code is 400 instead of 500 leading to wrong conclusions by users / log parsers

I tried to contact the original author of the reason for this try-catch, but I am not getting any reponse.

This PR reverses it, which will help us and others, for example in #3725 

 