### PR TITLE
Metrics query optimizations

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1412,6 +1412,10 @@ class MetricsFindingFilter(FilterSet):
     start_date = DateFilter(field_name='date', label='Start Date', lookup_expr=('gt'))
     end_date = DateFilter(field_name='date', label='End Date', lookup_expr=('lt'))
     date = MetricsDateRangeFilter()
+    test__test_type = ModelMultipleChoiceFilter(
+        queryset=Test_Type.objects.all().order_by('name'),
+        label="Test Type"
+    )
     test__engagement__product__prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.all().order_by('name'),
         label="Product Type")

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -127,13 +127,17 @@ def finding_querys(prod_type, request):
             Q(test__engagement__product__authorized_users__in=[request.user]) |
             Q(test__engagement__product__prod_type__authorized_users__in=[request.user]))
 
-    active_findings_query = Finding.objects.filter(verified=True, active=True,
-                                      severity__in=('Critical', 'High', 'Medium', 'Low', 'Info')).prefetch_related(
+    active_findings_query = Finding.objects.filter(
+        verified=True,
+        active=True,
+        severity__in=('Critical', 'High', 'Medium', 'Low', 'Info')
+    ).prefetch_related(
         'test__engagement__product',
         'test__engagement__product__prod_type',
         'test__engagement__risk_acceptance',
         'risk_acceptance_set',
-        'reporter')
+        'reporter'
+    )
 
     if not request.user.is_staff:
         active_findings_query = active_findings_query.filter(

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -1118,23 +1118,9 @@ def research_metrics(request):
         test__test_type__name='Security Research')
     findings = findings.filter(date__year=now.year, date__month=now.month)
     verified_month = findings.filter(verified=True)
-    month_all_by_product, month_all_aggregate = count_findings(findings)
-    month_verified_by_product, month_verified_aggregate = count_findings(
+    month_all_by_product, _ = count_findings(findings)
+    month_verified_by_product, _ = count_findings(
         verified_month)
-
-    end_of_week = now + relativedelta(weekday=6, hour=23, minute=59, second=59)
-    day_list = [end_of_week - relativedelta(weeks=1, weekday=x,
-                                            hour=0, minute=0, second=0)
-                for x in range(end_of_week.weekday())]
-    q_objects = (Q(date=d) for d in day_list)
-    week_findings = Finding.objects.filter(reduce(operator.or_, q_objects))
-    open_week = week_findings.exclude(mitigated__isnull=False)
-    verified_week = week_findings.filter(verified=True)
-    week_all_by_product, week_all_aggregate = count_findings(week_findings)
-    week_verified_by_product, week_verified_aggregate = count_findings(
-        verified_week)
-    week_remaining_by_product, week_remaining_aggregate = count_findings(
-        open_week)
 
     remaining_by_product, remaining_aggregate = count_findings(
         Finding.objects.filter(mitigated__isnull=True,

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -412,13 +412,7 @@ def get_in_period_details(findings):
         if obj.test.engagement.product.name not in in_period_details:
             in_period_details[obj.test.engagement.product.name] = {
                 'path': reverse('product_open_findings', args=(obj.test.engagement.product.id,)),
-                'Critical': 0,
-                'High': 0,
-                'Medium': 0,
-                'Low': 0,
-                'Info': 0,
-                'Total': 0
-            }
+                'Critical': 0, 'High': 0, 'Medium': 0, 'Low': 0, 'Info': 0, 'Total': 0}
         in_period_details[obj.test.engagement.product.name][obj.severity] += 1
         in_period_details[obj.test.engagement.product.name]['Total'] += 1
 
@@ -431,13 +425,7 @@ def get_accepted_in_period_details(findings):
         if obj.test.engagement.product.name not in accepted_in_period_details:
             accepted_in_period_details[obj.test.engagement.product.name] = {
                 'path': reverse('accepted_findings') + '?test__engagement__product=' + str(obj.test.engagement.product.id),
-                'Critical': 0,
-                'High': 0,
-                'Medium': 0,
-                'Low': 0,
-                'Info': 0,
-                'Total': 0
-            }
+                'Critical': 0, 'High': 0, 'Medium': 0, 'Low': 0, 'Info': 0, 'Total': 0}
         accepted_in_period_details[
             obj.test.engagement.product.name
         ][obj.severity] += 1
@@ -459,13 +447,7 @@ def get_closed_in_period_details(findings):
             closed_in_period_details[obj.test.engagement.product.name] = {
                 'path': reverse('closed_findings') + '?test__engagement__product=' + str(
                     obj.test.engagement.product.id),
-                'Critical': 0,
-                'High': 0,
-                'Medium': 0,
-                'Low': 0,
-                'Info': 0,
-                'Total': 0
-            }
+                'Critical': 0, 'High': 0, 'Medium': 0, 'Low': 0, 'Info': 0, 'Total': 0}
         closed_in_period_details[
             obj.test.engagement.product.name
         ][obj.severity] += 1
@@ -525,7 +507,7 @@ def metrics(request, mtype):
     punchcard = list()
     ticks = list()
 
-    if request.GET.get('view') == 'dashboard':
+    if 'view' in request.GET and 'dashboard' == request.GET['view']:
         punchcard, ticks = get_punchcard_data(queryset_check(filters['all']), filters['start_date'], filters['weeks_between'], view)
         page_name = (get_system_setting('team_name')) + " Metrics"
         template = 'dojo/dashboard-metrics.html'
@@ -1160,8 +1142,8 @@ def research_metrics(request):
         test__test_type__name='Security Research')
     findings = findings.filter(date__year=now.year, date__month=now.month)
     verified_month = findings.filter(verified=True)
-    month_all_by_product, _ = count_findings(findings)
-    month_verified_by_product, _ = count_findings(
+    month_all_by_product, month_all_aggregate = count_findings(findings)
+    month_verified_by_product, month_verified_aggregate = count_findings(
         verified_month)
 
     remaining_by_product, remaining_aggregate = count_findings(

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -450,7 +450,7 @@ def metrics(request, mtype):
 
     for obj in filters['accepted']:
         if view == 'Endpoint':
-            obj = finding.finding
+            obj = obj.finding
 
         if obj.test.engagement.product.name not in accepted_in_period_details:
             accepted_in_period_details[obj.test.engagement.product.name] = {

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2217,6 +2217,15 @@ class Finding(models.Model):
         return self.references
 
 
+class FindingAdmin(admin.ModelAdmin):
+    # For efficiency with large databases, display many-to-many fields with raw
+    # IDs rather than multi-select
+    raw_id_fields = (
+        'endpoints',
+        'endpoint_status',
+    )
+
+
 Finding.endpoints.through.__unicode__ = lambda \
     x: "Endpoint: " + x.endpoint.host
 
@@ -3499,7 +3508,7 @@ admin.site.register(Languages)
 admin.site.register(Language_Type)
 admin.site.register(App_Analysis)
 admin.site.register(Test)
-admin.site.register(Finding)
+admin.site.register(Finding, FindingAdmin)
 admin.site.register(FindingImage)
 admin.site.register(FindingImageAccessToken)
 admin.site.register(Stub_Finding)

--- a/dojo/unittests/test_metrics_queries.py
+++ b/dojo/unittests/test_metrics_queries.py
@@ -32,7 +32,7 @@ class FindingQueriesTest(TestCase):
         mock_timezone.return_value = mock_datetime
 
         # Queries over Finding and Risk_Acceptance
-        with self.assertNumQueries(41):
+        with self.assertNumQueries(29):
             product_types = []
             finding_queries = views.finding_querys(
                 product_types,

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -35,7 +35,6 @@ import crum
 from celery.decorators import task
 from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
 
-
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -645,7 +645,7 @@ def get_punchcard_data(objs, start_date, weeks, view='Finding'):
                                         .annotate(count=Count('id')) \
                                         .order_by('date')
         # return empty stuff if no findings to be statted
-        if severities_by_day.count() <= 0:
+        if len(severities_by_day) == 0:
             return None, None
 
         # day of the week numbers:

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -35,6 +35,7 @@ import crum
 from celery.decorators import task
 from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
 
+
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
@@ -644,7 +645,7 @@ def get_punchcard_data(objs, start_date, weeks, view='Finding'):
                                         .annotate(count=Count('id')) \
                                         .order_by('date')
         # return empty stuff if no findings to be statted
-        if len(severities_by_day) == 0:
+        if severities_by_day.count() <= 0:
             return None, None
 
         # day of the week numbers:


### PR DESCRIPTION
This PR builds on the unit tests merged in #3743 (which assert on the number of ORM queries made in the metrics endpoint), and updates the implementation to decrease the count of queries. This is aided by splitting the queries in to separate functions from the main view function, which might be a technique to use on the additional metrics views.

(This builds on original PR #3438. Since several of the changes in #3438 were addressed in #3549, this separates out the remaining changes into a new clean PR.)