### PR TITLE
integration tests: use --disable-dev-shm-usage to start chrome

### DIFF
--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -47,7 +47,7 @@ class BaseTestCase(unittest.TestCase):
 
             # the next 2 maybe needed in some scenario's for example on WSL or other headless situations
             dd_driver_options.add_argument("--no-sandbox")
-            # dd_driver_options.add_argument("--disable-dev-shm-usage")
+            dd_driver_options.add_argument("--disable-dev-shm-usage")
             dd_driver_options.add_argument("--disable-gpu")  # on windows sometimes chrome can't start with certain gpu driver versions, even in headless mode
 
             # start maximized or at least with sufficient with because datatables will hide certain controls when the screen is too narrow


### PR DESCRIPTION
to avoid ERR_INSUFFICIENT_RESOURCES errors

![image](https://user-images.githubusercontent.com/4426050/106298951-de393c80-6254-11eb-9f45-208a178d89d7.png)

source: https://developers.google.com/web/tools/puppeteer/troubleshooting