### PR TITLE
api: fix authorized product allowance for Test retrieval

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1050,7 +1050,9 @@ class TestsViewSet(mixins.ListModelMixin,
     def get_queryset(self):
         if not self.request.user.is_staff:
             return Test.objects.filter(
-                engagement__product__authorized_users__in=[self.request.user])
+                Q(engagement__product__authorized_users__in=[self.request.user]) |
+                Q(engagement__product__prod_type_authorized_users__in=[self.request.user])
+            )
         else:
             return Test.objects.all()
 


### PR DESCRIPTION
check for authorized products was missing the product_Type claus for the TestsViewset endpoint on the api leading to some tests not being returned even though authorized on the product_type level