### PR TITLE
Fix helm chart

### DIFF
--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -12,9 +12,9 @@ metadata:
     helm.sh/chart: {{ include "defectdojo.chart" . }}
 {{- if or .Values.django.ingress.annotations .Values.gke.useGKEIngress }}
   annotations:
-  {{- with .Values.django.ingress.annotations }}
-  {{ toYaml . | indent 2 }}
-  {{- end }}
+{{- with .Values.django.ingress.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
   {{- if .Values.gke.useGKEIngress }}
     kubernetes.io/ingress.class: gce
     {{- if .Values.gke.useManagedCertificate }}


### PR DESCRIPTION
I got some 

```  unknown field "kubernetes.io/ingress.class" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta, ValidationError(Ingress.metadata): unknown field "kubernetes.io/tls-acme" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta, ValidationError(Ingress.metadata): unknown field "nginx.ingress.kubernetes.io/proxy-body-size" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta, ValidationError(Ingress.metadata): unknown field "nginx.ingress.kubernetes.io/proxy-read-timeout" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta, ValidationError(Ingress.metadata): unknown field "nginx.ingress.kubernetes.io/ssl-redirect" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta]```

When updating the chart. 

The `annotations` is already with 2 indents, so below needs to be `4` and the leading spaces throw things off, e.g. relative indents do not seem to work.

Thanks @ccojocar for the hand :+1: 