### PR TITLE
risk acceptance: fix notes bugs

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -855,6 +855,17 @@ def add_risk_acceptance(request, eid, fid=None):
     if request.method == 'POST':
         form = RiskAcceptanceForm(request.POST, request.FILES)
         if form.is_valid():
+            # first capture notes param as it cannot be saved directly as m2m
+            notes = None
+            if form.cleaned_data['notes']:
+                notes = Notes(
+                    entry=form.cleaned_data['notes'],
+                    author=request.user,
+                    date=timezone.now())
+                notes.save()
+
+            del form.cleaned_data['notes']
+
             try:
                 # we sometimes see a weird exception here, but are unable to reproduce.
                 # we add some logging in case it happens
@@ -863,16 +874,13 @@ def add_risk_acceptance(request, eid, fid=None):
                 logger.debug(vars(request.POST))
                 logger.error(vars(form))
                 logger.exception(e)
+                raise
+
+            # attach note to risk acceptance object now in database
+            if notes:
+                risk_acceptance.notes.add(notes)
 
             eng.risk_acceptance.add(risk_acceptance)
-
-            if form.cleaned_data['notes']:
-                notes = Notes(
-                    entry=form.cleaned_data['notes'],
-                    author=request.user,
-                    date=timezone.now())
-                notes.save()
-                risk_acceptance.notes.add(notes)
 
             findings = form.cleaned_data['accepted_findings']
 

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -327,35 +327,49 @@
 {% endblock %}
 
 {% block postscript %}
-<script type="application/javascript" src="{% static 'easymde/dist/easymde.min.js' %}"></script>
-<script type="text/javascript">
-    $("#edit_risk_acceptance textarea").each(function (index, elem) {
-        if (elem.hasAttribute("required")) {
-            elem.removeAttribute("required");
-            elem.id = "req"
-        }
-
-        var mde = new EasyMDE({
-            spellChecker: false,
-            element: elem,
-            autofocus: false,
-            forceSync: true,
-            toolbar: ["bold", "italic", "heading", "|",
-                "quote", "unordered-list", "ordered-list", "|",
-                "link", "image", "|",
-                "table", "horizontal-rule", "code", "|",
-                "guide"
-            ]
+{% if not edit_mode %}
+    <script type="text/javascript">
+        // keyboard shortcuts
+        document.addEventListener('keydown', function(e) {
+            console.log(e.key);
+            if (e.key == 'e') {
+                window.location.assign('{% url 'edit_risk_acceptance' eng.id risk_acceptance.id %}')
+            }
         });
-        mde.render();
-    });
 
-    // keyboard shortcuts
-    $(document).on('keypress', null, 'e', function () {
-        window.location.assign('{% url 'edit_risk_acceptance' eng.id risk_acceptance.id %}');
-    });
+        <!-- what works on every other page with the 'e' keydown, conflicts here with the textare for notes, stoppropagation 'fixes' this -->
+        $('#id_entry').keydown( function(e) {
+            e.stopPropagation();
+        });
 
-    {% include 'dojo/snippets/risk_acceptance_actions_snippet_js.html' %}
+    </script>
+{% else %}
+    <script type="application/javascript" src="{% static 'easymde/dist/easymde.min.js' %}"></script>
+    <script>
+        $("#edit_risk_acceptance textarea").each(function (index, elem) {
+            if (elem.hasAttribute("required")) {
+                elem.removeAttribute("required");
+                elem.id = "req"
+            }
 
+            var mde = new EasyMDE({
+                spellChecker: false,
+                element: elem,
+                autofocus: false,
+                forceSync: true,
+                toolbar: ["bold", "italic", "heading", "|",
+                    "quote", "unordered-list", "ordered-list", "|",
+                    "link", "image", "|",
+                    "table", "horizontal-rule", "code", "|",
+                    "guide"
+                ]
+            });
+            mde.render();
+        });
+    </script>
+{% endif %}
+
+<script type="text/javascript">
+     {% include 'dojo/snippets/risk_acceptance_actions_snippet_js.html' %}
 </script>
 {% endblock %}


### PR DESCRIPTION
two bugs fixed:
- when adding a risk acceptance with a note, a many2many relationship related error occurred
- the 'e' keydown event (to edit the risk acceptance) conflicted with the notes textarea (works fine on every other page we use the same construct)