### PR TITLE
DSOP parser: remove pandas and fix twistlock CVE

### DIFF
--- a/dojo/tools/dsop/parser.py
+++ b/dojo/tools/dsop/parser.py
@@ -1,141 +1,180 @@
 import re
-
-import pandas as pd
+from openpyxl import load_workbook
 
 from dojo.models import Finding
-
-__author__ = 'Matt Sicker'
 
 
 class DsopParser:
     def get_findings(self, file, test):
+        book = load_workbook(file)
         items = list()
-        f = pd.ExcelFile(file)
-        self.__parse_disa(pd.read_excel(f, sheet_name='OpenSCAP - DISA Compliance', parse_dates=['scanned_date'],
-                                        dtype={'result': 'category', 'severity': 'category'}), test, items)
-        self.__parse_oval(pd.read_excel(f, sheet_name='OpenSCAP - OVAL Results'), test, items)
-        self.__parse_twistlock(
-            pd.read_excel(f, sheet_name='Twistlock Vulnerability Results', dtype={'severity': 'category'}), test, items)
-        self.__parse_anchore(pd.read_excel(f, sheet_name='Anchore CVE Results', dtype={'severity': 'category'}), test, items)
-        self.__parse_anchore_compliance(
-            pd.read_excel(f, sheet_name='Anchore Compliance Results', dtype={'severity': 'category'}), test, items)
+        self.__parse_disa(test, items, book['OpenSCAP - DISA Compliance'])
+        self.__parse_oval(test, items, book['OpenSCAP - OVAL Results'])
+        self.__parse_twistlock(test, items, book['Twistlock Vulnerability Results'])
+        self.__parse_anchore(test, items, book['Anchore CVE Results'])
+        self.__parse_anchore_compliance(test, items, book['Anchore Compliance Results'])
         return items
 
-    def __parse_disa(self, df: pd.DataFrame, test, items):
-        for row in df.itertuples(index=False):
-            if row.result not in ('fail', 'notchecked'):
-                continue
-            title = row.title
-            unique_id = row.ruleid
-            if row.severity == 'unknown':
-                severity = 'Info'
+    def __parse_disa(self, test, items, sheet):
+        headers = dict()
+        first = True
+        for row in sheet.iter_rows(min_row=1, values_only=True):
+            if first:
+                first = False
+                # store the headers
+                for i in range(len(row)):
+                    headers[row[i]] = i
             else:
-                severity = row.severity.title()
-            cve = row.identifiers
-            references = row.refs
-            description = row.desc
-            impact = row.rationale
-            date = row.scanned_date.date()
-            tags = "disa"
-
-            finding = Finding(title=title, date=date, cve=cve, severity=severity, description=description,
-                        impact=impact, references=references, test=test, unique_id_from_tool=unique_id,
-                         static_finding=True, dynamic_finding=False)
-            finding.unsaved_tags = tags
-            items.append(finding)
-
-    def __parse_oval(self, df: pd.DataFrame, test, items):
-        severity_pattern = re.compile(r'\((.*)\)')
-        for row in df.itertuples(index=False):
-            if not row.result or row.result in ('false'):
-                continue
-            title = row.title
-            match = severity_pattern.search(title)
-            if match:
-                sev = match.group(1)
-                if sev == 'Important':
-                    severity = 'High'
-                elif sev == 'Moderate':
-                    severity = 'Medium'
-                elif sev == 'None':
+                if row[headers['result']] not in ('fail', 'notchecked'):
+                    continue
+                title = row[headers['title']]
+                unique_id = row[headers['ruleid']]
+                if row[headers['severity']] == 'unknown':
                     severity = 'Info'
                 else:
-                    severity = sev
+                    severity = row[headers['severity']].title()
+                cve = row[headers['identifiers']]
+                references = row[headers['refs']]
+                description = row[headers['desc']]
+                impact = row[headers['rationale']]
+                date = row[headers['scanned_date']]
+                tags = "disa"
+
+                finding = Finding(title=title, date=date, cve=cve, severity=severity, description=description,
+                            impact=impact, references=references, test=test, unique_id_from_tool=unique_id,
+                            static_finding=True, dynamic_finding=False)
+                finding.unsaved_tags = tags
+                items.append(finding)
+
+    def __parse_oval(self, test, items, sheet):
+        severity_pattern = re.compile(r'\((.*)\)')
+        headers = dict()
+        first = True
+        for row in sheet.iter_rows(min_row=1, values_only=True):
+            if first:
+                first = False
+                # store the headers
+                for i in range(len(row)):
+                    headers[row[i]] = i
             else:
-                severity = 'Info'
-            unique_id = row.id
-            cve = row.ref
-            tags = "oval"
+                if not row[headers['result']] or row[headers['result']] in ('false'):
+                    continue
+                title = row[headers['title']]
+                match = severity_pattern.search(title)
+                if match:
+                    sev = match.group(1)
+                    if sev == 'Important':
+                        severity = 'High'
+                    elif sev == 'Moderate':
+                        severity = 'Medium'
+                    elif sev == 'None':
+                        severity = 'Info'
+                    else:
+                        severity = sev
+                else:
+                    severity = 'Info'
+                unique_id = row[headers['id']]
+                cve = row[headers['ref']]
+                tags = "oval"
 
-            finding = Finding(title=title, cve=cve, severity=severity, unique_id_from_tool=unique_id,
-                    test=test, static_finding=True, dynamic_finding=False)
-            finding.unsaved_tags = tags
-            items.append(finding)
+                finding = Finding(title=title, cve=cve, severity=severity, unique_id_from_tool=unique_id,
+                        test=test, static_finding=True, dynamic_finding=False)
+                finding.unsaved_tags = tags
+                items.append(finding)
 
-    def __parse_twistlock(self, df: pd.DataFrame, test, items):
-        for row in df.itertuples(index=False):
-            cve = row.id
-            description = row.desc
-            mitigation = row.status
-            url = row.link
-            component_name = row.packageName
-            component_version = row.packageVersion
-            title = '{}: {} - {}'.format(cve, component_name, component_version)
-            if row.severity == 'important':
-                severity = 'High'
-            elif row.severity == 'moderate':
-                severity = 'Medium'
+    def __parse_twistlock(self, test, items, sheet):
+        headers = dict()
+        first = True
+        for row in sheet.iter_rows(min_row=1, values_only=True):
+            if first:
+                first = False
+                # store the headers
+                for i in range(len(row)):
+                    headers[row[i]] = i
             else:
-                severity = row.severity.title()
-            severity_justification = row.vecStr
-            tags = "twistlock"
+                if row[headers['severity']] is None:
+                    continue
+                cve = row[headers['cve']]
+                description = row[headers['desc']]
+                mitigation = row[headers['status']]
+                url = row[headers['link']]
 
-            finding = Finding(title=title, cve=cve, url=url, severity=severity, description=description,
-                                    component_name=component_name, component_version=component_version,
-                                    severity_justification=severity_justification, test=test,
-                                    static_finding=True, dynamic_finding=False)
-            finding.unsaved_tags = tags
-            items.append(finding)
+                component_name = row[headers['packageName']]
+                component_version = row[headers['packageVersion']]
+                title = '{}: {} - {}'.format(cve, component_name, component_version)
+                if row[headers['severity']] == 'important':
+                    severity = 'High'
+                elif row[headers['severity']] == 'moderate':
+                    severity = 'Medium'
+                else:
+                    severity = row[headers['severity']].title()
+                severity_justification = row[headers['vecStr']]
+                tags = "twistlock"
 
-    def __parse_anchore(self, df: pd.DataFrame, test, items):
-        for row in df.itertuples(index=False):
-            cve = row.cve
-            severity = row.severity
-            component = row.package
-            file_path = row.package_path
-            mitigation = row.fix
-            description = "Image affected: {}".format(row.tag)
-            title = '{}: {}'.format(cve, component)
-            tags = "anchore"
+                finding = Finding(title=title, cve=cve, url=url, severity=severity, description=description,
+                                        component_name=component_name, component_version=component_version,
+                                        severity_justification=severity_justification, test=test,
+                                        static_finding=True, dynamic_finding=False)
+                finding.unsaved_tags = tags
+                items.append(finding)
 
-            finding = Finding(title=title, cve=cve, severity=severity,
-                                    mitigation=mitigation, component_name=component,
-                                    description=description, test=test,
-                                    static_finding=True, dynamic_finding=False,
-                                    file_path=file_path)
-            finding.unsaved_tags = tags
-            items.append(finding)
-
-    def __parse_anchore_compliance(self, df: pd.DataFrame, test, items):
-        for row in df.itertuples(index=False):
-            if row.policy_id != "DoDFileChecks":
-                continue
-
-            if row.gate_action == "warn":
-                severity = "Medium"
-            elif row.gate_action == "stop":
-                severity = "Critical"
+    def __parse_anchore(self, test, items, sheet):
+        headers = dict()
+        first = True
+        for row in sheet.iter_rows(min_row=1, values_only=True):
+            if first:
+                first = False
+                # store the headers
+                for i in range(len(row)):
+                    headers[row[i]] = i
             else:
-                severity = "Info"
-            severity = severity
-            mitigation = "To be investigated"
-            description = "Gate: {} (Trigger: {}): {}".format(row.gate, row.trigger, row.check_output)
-            title = '{}: {}'.format(row.policy_id, row.trigger_id)
-            tags = "anchore_compliance"
+                if row[0] is None:
+                    continue
+                cve = row[headers['cve']]
+                severity = row[headers['severity']]
+                component = row[headers['package']]
+                file_path = row[headers['package_path']]
+                mitigation = row[headers['fix']]
+                description = "Image affected: {}".format(row[headers['tag']])
+                title = '{}: {}'.format(cve, component)
+                tags = "anchore"
 
-            finding = Finding(title=title, severity=severity,
-                                    mitigation=mitigation,
-                                    description=description, test=test,
-                                    static_finding=True, dynamic_finding=False)
-            finding.unsaved_tags = tags
-            items.append(finding)
+                finding = Finding(title=title, cve=cve, severity=severity,
+                                        mitigation=mitigation, component_name=component,
+                                        description=description, test=test,
+                                        static_finding=True, dynamic_finding=False,
+                                        file_path=file_path)
+                finding.unsaved_tags = tags
+                items.append(finding)
+
+    def __parse_anchore_compliance(self, test, items, sheet):
+        headers = dict()
+        first = True
+        for row in sheet.iter_rows(min_row=1, values_only=True):
+            if first:
+                first = False
+                # store the headers
+                for i in range(len(row)):
+                    headers[row[i]] = i
+            else:
+                if row[headers['policy_id']] != "DoDFileChecks":
+                    continue
+
+                if row[headers['gate_action']] == "warn":
+                    severity = "Medium"
+                elif row[headers['gate_action']] == "stop":
+                    severity = "Critical"
+                else:
+                    severity = "Info"
+                severity = severity
+                mitigation = "To be investigated"
+                description = "Gate: {} (Trigger: {}): {}".format(row[headers['gate']], row[headers['trigger']], row[headers['check_output']])
+                title = '{}: {}'.format(row[headers['policy_id']], row[headers['trigger_id']])
+                tags = "anchore_compliance"
+
+                finding = Finding(title=title, severity=severity,
+                                        mitigation=mitigation,
+                                        description=description, test=test,
+                                        static_finding=True, dynamic_finding=False)
+                finding.unsaved_tags = tags
+                items.append(finding)

--- a/dojo/unittests/tools/test_dsop_parser.py
+++ b/dojo/unittests/tools/test_dsop_parser.py
@@ -16,3 +16,6 @@ class TestDsopParser(TestCase):
         parser = DsopParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEquals(len(findings), 4)
+        finding = findings[0]
+        self.assertEqual("CVE-2019-15587", finding.cve)
+        self.assertEqual("Low", finding.severity)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ PyGithub==1.54.1
 lxml==4.6.2
 Markdown==3.3.3
 mysqlclient==2.0.3
-pandas==1.1.5
+openpyxl==3.0.6
 xlrd==1.2.0
 pdfkit==0.6.1
 Pillow==8.1.0  # required by django-imagekit


### PR DESCRIPTION
Refactor DSOP parser to not use pandas.

Fix one bug that don't detect CVE for Twistlock CVE data.

Need https://github.com/DefectDojo/django-DefectDojo/pull/3763 first