### PR TITLE
Improve GitLab dependency scanning parser

### DIFF
--- a/dojo/tools/gitlab_dep_scan/parser.py
+++ b/dojo/tools/gitlab_dep_scan/parser.py
@@ -66,8 +66,13 @@ def get_item(vuln, test):
 
     location = vuln['location']
     file_path = location['file'] if 'file' in location else None
-    component_name = location['dependency']['package']['name']
-    component_version = location['dependency']['version']
+
+    component_name = None
+    component_version = None
+    if 'dependency' in location:
+        component_version = location['dependency']['version'] if 'version' in location['dependency'] else None
+        if 'package' in location['dependency']:
+            component_name = location['dependency']['package']['name'] if 'name' in location['dependency']['package'] else None
 
     severity = vuln['severity']
     if severity == 'Undefined' or severity == 'Unknown':

--- a/dojo/tools/gitlab_dep_scan/parser.py
+++ b/dojo/tools/gitlab_dep_scan/parser.py
@@ -66,21 +66,8 @@ def get_item(vuln, test):
 
     location = vuln['location']
     file_path = location['file'] if 'file' in location else None
-    sourcefile = location['file'] if 'file' in location else None
-
-    line = location['start_line'] if 'start_line' in location else None
-    if 'end_line' in location:
-        line = location['end_line']
-
-    sast_source_line = location['start_line'] if 'start_line' in location else None
-
-    sast_object = None
-    if 'class' in location and 'method' in location:
-        sast_object = '{}#{}'.format(location['class'], location['method'])
-    elif 'class' in location:
-        sast_object = location['class']
-    elif 'method' in location:
-        sast_object = location['method']
+    component_name = location['dependency']['package']['name']
+    component_version = location['dependency']['version']
 
     severity = vuln['severity']
     if severity == 'Undefined' or severity == 'Unknown':
@@ -126,12 +113,8 @@ def get_item(vuln, test):
                       unique_id_from_tool=unique_id_from_tool,
                       references=references,
                       file_path=file_path,
-                      sourcefile=sourcefile,
-                      line=line,
-                      sast_source_object=sast_object,
-                      sast_sink_object=sast_object,
-                      sast_source_file_path=file_path,
-                      sast_source_line=sast_source_line,
+                      component_name=component_name,
+                      component_version=component_version,
                       cwe=cwe,
                       cve=cve,
                       static_finding=True,

--- a/dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-1-vuln-missing-component.json
+++ b/dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-1-vuln-missing-component.json
@@ -1,0 +1,74 @@
+{
+  "version": "3.0.0",
+  "vulnerabilities": [
+    {
+      "id": "2d8b607cb56d9866c73cdcf33a016f64b4fa37d909c1dd300037b1ac026a3ca5",
+      "category": "dependency_scanning",
+      "name": "XML Entity Expansion",
+      "message": "XML Entity Expansion in gopkg.in/yaml.v2",
+      "description": "go-yaml is vulnerable to a Billion Laughs Attack.",
+      "cve": "service/go.sum:gopkg.in/yaml.v2:gemnasium:7368f513-0aa9-4e34-a08d-40ea81f48e0e",
+      "severity": "Unknown",
+      "solution": "Upgrade to version 2.2.3 or above.",
+      "scanner": {
+        "id": "gemnasium",
+        "name": "Gemnasium"
+      },
+      "location": {
+        "file": "service/go.sum",
+        "dependency": {
+          "package": { }
+        }
+      },
+      "identifiers": [
+        {
+          "type": "gemnasium",
+          "name": "Gemnasium-7368f513-0aa9-4e34-a08d-40ea81f48e0e",
+          "value": "7368f513-0aa9-4e34-a08d-40ea81f48e0e",
+          "url": "https://gitlab.com/gitlab-org/security-products/gemnasium-db/-/blob/master/go/gopkg.in/yaml.v2/GMS-2019-2.yml"
+        }
+      ],
+      "links": [
+        {
+          "url": "https://github.com/docker/cli/pull/2117"
+        }
+      ]
+    }
+  ],
+  "remediations": [],
+  "dependency_files": [
+    {
+      "path": "service/go.sum",
+      "package_manager": "go",
+      "dependencies": [
+        {
+          "package": {
+            "name": "gopkg.in/yaml.v2"
+          },
+          "version": "v2.2.2"
+        },
+        {
+          "package": {
+            "name": "gopkg.in/yaml.v2"
+          },
+          "version": "v2.2.4"
+        }
+      ]
+    }
+  ],
+  "scan": {
+    "scanner": {
+      "id": "gemnasium",
+      "name": "Gemnasium",
+      "url": "https://gitlab.com/gitlab-org/security-products/analyzers/gemnasium",
+      "vendor": {
+        "name": "GitLab"
+      },
+      "version": "2.24.1"
+    },
+    "type": "dependency_scanning",
+    "start_time": "2020-12-23T13:43:48",
+    "end_time": "2020-12-23T13:43:49",
+    "status": "success"
+  }
+}

--- a/dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-2-vuln-missing-component.json
+++ b/dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-2-vuln-missing-component.json
@@ -33,6 +33,54 @@
           "url": "https://github.com/docker/cli/pull/2117"
         }
       ]
+    },
+    {   
+      "id": "e4f855103139f6af7b2ac8c83aa6779fc97a168e06a45235fb6f072cf707c1b5",
+      "category": "dependency_scanning",
+      "name": "Nil Pointer Dereference",
+      "message": "Nil Pointer Dereference in golang.org/x/crypto",
+      "description": "A nil pointer dereference in the `golang.org/x/crypto/ssh` component allows remote attackers to cause a denial of service against SSH servers.",
+      "cve": "service/go.sum:golang.org/x/crypto:gemnasium:ffb814a0-404c-11eb-b378-0242ac130002",
+      "severity": "High",
+      "solution": "Upgrade to version v0.0.0-20201216223049-8b5274cf687f or above.",
+      "scanner": {
+        "id": "gemnasium",
+        "name": "Gemnasium"
+      },  
+      "location": {
+        "file": "service/go.sum",
+        "dependency": {
+          "package": {
+            "name": "golang.org/x/crypto"
+          },  
+          "version": "v0.0.0-20190308221718-c2843e01d9a2"
+        }   
+      },  
+      "identifiers": [
+        {   
+          "type": "gemnasium",
+          "name": "Gemnasium-ffb814a0-404c-11eb-b378-0242ac130002",
+          "value": "ffb814a0-404c-11eb-b378-0242ac130002",
+          "url": "https://gitlab.com/gitlab-org/security-products/gemnasium-db/-/blob/master/go/golang.org/x/crypto/CVE-2020-29652.yml"
+        },  
+        {   
+          "type": "cve",
+          "name": "CVE-2020-29652",
+          "value": "CVE-2020-29652",
+          "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-29652"
+        }   
+      ],  
+      "links": [
+        {   
+          "url": "https://go-review.googlesource.com/c/crypto/+/278852"
+        },  
+        {   
+          "url": "https://groups.google.com/g/golang-announce/c/ouZIlBimOsE?pli=1"
+        },  
+        {   
+          "url": "https://nvd.nist.gov/vuln/detail/CVE-2020-29652"
+        }
+      ]
     }
   ],
   "remediations": [],

--- a/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
+++ b/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
@@ -23,14 +23,17 @@ class TestGitlabDepScanReportParser(TestCase):
 
     def test_parse_file_with_one_vuln_missing_component_has_one_finding(self):
         testfile = open(
-            "dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-1-vuln-missing-component.json"
+            "dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-2-vuln-missing-component.json"
         )
         parser = GitlabDepScanReportParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertEqual(1, len(findings))
+        self.assertEqual(2, len(findings))
         finding = findings[0]
         self.assertEqual(None, finding.component_name)
         self.assertEqual(None, finding.component_version)
+        finding = findings[1]
+        self.assertEqual("golang.org/x/crypto", finding.component_name)
+        self.assertEqual("v0.0.0-20190308221718-c2843e01d9a2", finding.component_version)
 
     def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
         testfile = open(

--- a/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
+++ b/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
@@ -21,6 +21,14 @@ class TestGitlabDepScanReportParser(TestCase):
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
 
+    def test_parse_file_with_one_vuln_missing_component_has_one_finding(self):
+        testfile = open(
+            "dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-1-vuln-missing-component.json"
+        )
+        parser = GitlabDepScanReportParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+
     def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
         testfile = open(
             "dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-many-vuln.json"

--- a/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
+++ b/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
@@ -28,6 +28,9 @@ class TestGitlabDepScanReportParser(TestCase):
         parser = GitlabDepScanReportParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
+        finding = findings[0]
+        self.assertEqual(None, finding.component_name)
+        self.assertEqual(None, finding.component_version)
 
     def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
         testfile = open(

--- a/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
+++ b/dojo/unittests/tools/test_gitlab_dep_scan_parser.py
@@ -21,7 +21,7 @@ class TestGitlabDepScanReportParser(TestCase):
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
 
-    def test_parse_file_with_one_vuln_missing_component_has_one_finding(self):
+    def test_parse_file_with_two_vuln_has_one_missing_component_(self):
         testfile = open(
             "dojo/unittests/scans/gitlab_dep_scan/gl-dependency-scanning-report-2-vuln-missing-component.json"
         )


### PR DESCRIPTION
1. Improve GitLab dependency scanning parser, adding component name and version for the findings.
2. Removed SAST components, since they are not present in this kind of report.

Current findings from GitLab dependency scanning have this structure:
![image](https://user-images.githubusercontent.com/17654553/106728667-f8846900-660c-11eb-9563-61f4cce315df.png)

Now they will appear as:
![image](https://user-images.githubusercontent.com/17654553/106728734-089c4880-660d-11eb-9abb-7f8c4b66f7ec.png)
