### PR TITLE
Security fixes for reports/notes/enpoints via APIv2

### DIFF
--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -1,40 +1,6 @@
 from rest_framework import permissions
 
 
-class UserHasProductPermission(permissions.BasePermission):
-    """
-    @brief      To ensure that one user can only access authorized project
-    """
-    def has_object_permission(self, request, view, obj):
-        return request.user in \
-            (obj.authorized_users.all() | obj.prod_type.authorized_users.all()) or \
-            request.user.is_staff
-
-
-class UserHasReportGeneratePermission(permissions.BasePermission):
-    """
-    @brief      To ensure that one user can only access authorized project
-    """
-    def has_object_permission(self, request, view, obj):
-        return request.user in \
-            (obj.product.authorized_users.all() | obj.product.prod_type.authorized_users.all()) or \
-            request.user.is_staff
-
-
-class UserHasScanSettingsPermission(permissions.BasePermission):
-    def has_object_permission(self, request, view, obj):
-        return request.user in \
-            (obj.product.authorized_users.all() | obj.product.prod_type.authorized_users.all()) or \
-            request.user.is_staff
-
-
-class UserHasScanPermission(permissions.BasePermission):
-    def has_object_permission(self, request, view, obj):
-        return request.user in \
-            (obj.scan_settings.product.authorized_users.all() | obj.scan_settings.product.prod_type.authorized_users.all()) or \
-            request.user.is_staff
-
-
 class IsSuperUser(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.user and request.user.is_superuser

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -863,6 +863,11 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
 
         return data
 
+    def build_relational_field(self, field_name, relation_info):
+        if field_name == 'notes':
+            return NoteSerializer, {'many': True, 'read_only': True}
+        return super().build_relational_field(field_name, relation_info)
+
     def get_request_response(self, obj):
         burp_req_resp = BurpRawRequestResponse.objects.filter(finding=obj)
         burp_list = []

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -313,8 +313,14 @@ class UserSerializer(serializers.ModelSerializer):
         fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_staff', 'is_superuser')
 
 
+class UserStubSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'first_name', 'last_name')
+
+
 class NoteHistorySerializer(serializers.ModelSerializer):
-    current_editor = UserSerializer(read_only=True)
+    current_editor = UserStubSerializer(read_only=True)
 
     class Meta:
         model = NoteHistory
@@ -322,9 +328,9 @@ class NoteHistorySerializer(serializers.ModelSerializer):
 
 
 class NoteSerializer(serializers.ModelSerializer):
-    author = UserSerializer(
+    author = UserStubSerializer(
         many=False, read_only=True)
-    editor = UserSerializer(
+    editor = UserStubSerializer(
         read_only=True, many=False, allow_null=True)
 
     history = NoteHistorySerializer(read_only=True, many=True)
@@ -856,11 +862,6 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
                                         'be risk accepted.')
 
         return data
-
-    def build_relational_field(self, field_name, relation_info):
-        if field_name == 'notes':
-            return NoteSerializer, {'many': True, 'read_only': True}
-        return super().build_relational_field(field_name, relation_info)
 
     def get_request_response(self, obj):
         burp_req_resp = BurpRawRequestResponse.objects.filter(finding=obj)
@@ -1603,7 +1604,7 @@ class ReportGenerateSerializer(serializers.Serializer):
     endpoint = EndpointSerializer(many=False, read_only=True)
     endpoints = EndpointSerializer(many=True, read_only=True)
     findings = FindingSerializer(many=True, read_only=True)
-    user = UserSerializer(many=False, read_only=True)
+    user = UserStubSerializer(many=False, read_only=True)
     team_name = serializers.CharField(max_length=200)
     title = serializers.CharField(max_length=200)
     user_id = serializers.IntegerField()

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1297,7 +1297,7 @@ class UsersViewSet(mixins.CreateModelMixin,
     permission_classes = (IsAdminUser, DjangoModelPermissions)
 
 
-# Authorization: superuser
+# Authorization: staff
 class ImportScanView(mixins.CreateModelMixin,
                      viewsets.GenericViewSet):
     serializer_class = serializers.ImportScanSerializer
@@ -1320,7 +1320,7 @@ class ImportScanView(mixins.CreateModelMixin,
             raise ParseError(detail=e)
 
 
-# Authorization: superuser
+# Authorization: staff
 class ReImportScanView(mixins.CreateModelMixin,
                        viewsets.GenericViewSet):
     serializer_class = serializers.ReImportScanSerializer

--- a/dojo/risk_acceptance/api.py
+++ b/dojo/risk_acceptance/api.py
@@ -39,7 +39,7 @@ class AcceptedRisksMixin(ABC):
     )
     @action(methods=['post'], detail=True, permission_classes=[IsAdminUser], serializer_class=AcceptedRiskSerializer)
     def accept_risks(self, request, pk=None):
-        model = get_object_or_404(self.risk_application_model_class, pk=pk)
+        model = self.get_object()
         serializer = AcceptedRiskSerializer(data=request.data, many=True)
         if serializer.is_valid():
             accepted_risks = serializer.save()

--- a/dojo/risk_acceptance/api.py
+++ b/dojo/risk_acceptance/api.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from typing import NamedTuple, List
 
 from django.db.models import QuerySet
-from django.shortcuts import get_object_or_404
 from rest_framework import serializers, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser


### PR DESCRIPTION
### Issue
[CWE-284](https://cwe.mitre.org/data/definitions/284.html)

The API v1 and v2 are lacking appropriate access controls.

### Impact
Both APIs v1 and v2 allowed to retrieve findings, endpoints and other data for which a user was not authorized. The main endpoints affected are the ones to generate report, retrieval of notes, retrieval of endpoints as well as nested objects inside endpoints.

### Patches
We have added additional authorization checks to fix this in APIv2. APIv1 being deprecated and disabled by default since 1.12.0, it shoud no longer be used. APIv1 has not been and will not be fixed. We recommend to all users to switch to APIv2 for continued support and security fixes, and to report bugs or missing features to the project.

### Workarounds
* Disable untrusted users.
* Disable APIs. APIv1 is disabled by default since 1.12.0. APIv2 can be disabled by manually editing the configuration (not supported).

### For more information
If you have any questions or comments about this advisory:
* Visit our #defectdojo Slack channel via: https://owasp-slack.herokuapp.com/
* For sensitive issues, follow the security advisory process https://github.com/DefectDojo/django-DefectDojo/security/policy (report on hacker one)
