### PR TITLE
Updated UI product name max chars to match model and API

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -197,7 +197,7 @@ class Delete_Dev_EnvironmentForm(forms.ModelForm):
 
 
 class ProductForm(forms.ModelForm):
-    name = forms.CharField(max_length=50, required=True)
+    name = forms.CharField(max_length=255, required=True)
     description = forms.CharField(widget=forms.Textarea(attrs={}),
                                   required=True)
 


### PR DESCRIPTION
The max characters in the UI form element for Product name was 50 but the model and API is 255 - see [here](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/models.py#L617).

This PR makes the UI max the same as the others.

Docker image mtesauro/defectdojo-django:test-pr was built successfully to test the PR and ensure the UI worked as expected.