### PR TITLE
node/yarn: update to v14 and 1.22.10

### DIFF
--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -19,7 +19,6 @@ RUN \
 # Installing Google Chrome browser
 RUN \
   curl -sS -o - https://dl.google.com/linux/linux_signing_key.pub | apt-key add && \
-  # only update chrome repo, not all other repo's again
   apt-get -y update && \
   apt-get -y install \
     google-chrome-stable \

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -19,8 +19,10 @@ RUN \
 # Installing Google Chrome browser
 RUN \
   curl -sS -o - https://dl.google.com/linux/linux_signing_key.pub | apt-key add && \
+  # only update chrome repo, not all other repo's again
   echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
-  apt-get -y update && \
+  apt-get update -y -o Dir::Etc::sourcelist="sources.list.d/google-chrome.list" \
+  -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
   apt-get -y install \
     google-chrome-stable \
   && \

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -20,9 +20,7 @@ RUN \
 RUN \
   curl -sS -o - https://dl.google.com/linux/linux_signing_key.pub | apt-key add && \
   # only update chrome repo, not all other repo's again
-  echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
-  apt-get update -y -o Dir::Etc::sourcelist="sources.list.d/google-chrome.list" \
-  -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
+  apt-get -y update && \
   apt-get -y install \
     google-chrome-stable \
   && \

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -19,6 +19,7 @@ RUN \
 # Installing Google Chrome browser
 RUN \
   curl -sS -o - https://dl.google.com/linux/linux_signing_key.pub | apt-key add && \
+  echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
   apt-get -y update && \
   apt-get -y install \
     google-chrome-stable \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -34,16 +34,18 @@ RUN \
   apt-get -y update && \
   apt-get -y install apt-transport-https ca-certificates curl wget && \
   curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add --no-tty - && \
-  curl -sL https://deb.nodesource.com/setup_12.x | bash - && \
+  echo 'deb https://deb.nodesource.com/node_14.x buster main' > /etc/apt/sources.list.d/nodesource.list && \
+  echo 'deb-src https://deb.nodesource.com/node_14.x buster main' >> /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update -y -o Dir::Etc::sourcelist="sources.list.d/nodesource.list" \
+  -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
   curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  wget https://github.com/yarnpkg/yarn/releases/download/v1.21.0/yarn_1.21.0_all.deb && \
-  dpkg -i yarn_1.21.0_all.deb && \
-  apt-get -y update && \
+  wget https://github.com/yarnpkg/yarn/releases/download/v1.22.10/yarn_1.22.10_all.deb && \
+  dpkg -i yarn_1.22.10_all.deb && \
   echo "$(yarn --version)" && \
   apt-get -y install nodejs && \
   echo "$(node --version)" && \
   apt-get clean && \
-  rm yarn_1.21.0_all.deb && \
+  rm yarn_1.22.10_all.deb && \
   rm -rf /var/lib/apt/lists && \
   true
 


### PR DESCRIPTION
node v14 is the current/active LTS version, so we should start using that.
also bumps yarn to the latest version
includes a small optimization to only update the newly added APT repositories and not update ALL apt repositories again