### PR TITLE
products: only prefetch github data if enabled

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -106,8 +106,8 @@ def prefetch_for_product(prods):
         if get_system_setting('enable_github'):
             prefetched_prods = prefetched_prods.prefetch_related(
                 Prefetch('github_pkey_set', queryset=GITHUB_PKey.objects.all().select_related('git_conf'),
-                        to_attr='github_confs'))        
-        
+                        to_attr='github_confs'))
+
     else:
         logger.debug('unable to prefetch because query was already executed')
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -96,9 +96,6 @@ def prefetch_for_product(prods):
                                                                                     engagement__test__finding__active=True,
                                                                                     engagement__test__finding__verified=True)))
         prefetched_prods = prefetched_prods.prefetch_related('jira_project_set__jira_instance')
-        prefetched_prods = prefetched_prods.prefetch_related(
-            Prefetch('github_pkey_set', queryset=GITHUB_PKey.objects.all().select_related('git_conf'),
-                     to_attr='github_confs'))
         active_endpoint_query = Endpoint.objects.filter(
             finding__active=True,
             finding__mitigated__isnull=True)
@@ -106,6 +103,11 @@ def prefetch_for_product(prods):
             Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
         prefetched_prods = prefetched_prods.prefetch_related('tags')
 
+        if get_system_setting('enable_github'):
+            prefetched_prods = prefetched_prods.prefetch_related(
+                Prefetch('github_pkey_set', queryset=GITHUB_PKey.objects.all().select_related('git_conf'),
+                        to_attr='github_confs'))        
+        
     else:
         logger.debug('unable to prefetch because query was already executed')
 


### PR DESCRIPTION
the products list should only prefetch github config data if github integration is enabled.