### PR TITLE
Show boolean fields in product types as icons

### DIFF
--- a/dojo/templates/dojo/product_type.html
+++ b/dojo/templates/dojo/product_type.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
+{% load display_tags %}
+
 {% block content %}
     <div class="row">
         <div class="col-md-12">
@@ -46,8 +48,8 @@
                             <th>{% dojo_sort request 'Product Type' 'name' 'asc' %}</th>
                             <th>Product count</th>
                             <th>Active (Verified) findings</th>
-                            <th>Critical product</th>
-                            <th>Key product</th>
+                            <th class="text-center">Critical product</th>
+                            <th class="text-center">Key product</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -98,8 +100,20 @@
                                     <a href="{% url 'open_findings' %}?test__engagement__product__prod_type={{ pt.id }}"><b>{{ pt.active_findings_count }}</b></a>
                                     &nbsp;(<a href="{% url 'verified_findings' %}?test__engagement__product__prod_type={{ pt.id }}">{{ pt.active_verified_findings_count }}</a>)
                                 </td>
-                                <td>{{ pt.critical_product }}</td>
-                                <td>{{ pt.key_product }}</td>
+                                <td class="text-center">
+                                    {% if pt.critical_product %}
+                                        <i class="text-success fa fa-check"></i>
+                                    {% else %}
+                                        <i class="text-danger fa fa-times"></i>
+                                    {% endif %}
+								</td>
+                                    <td class="text-center">
+                                    {% if pt.key_product %}
+                                        <i class="text-success fa fa-check"></i>
+                                    {% else %}
+                                        <i class="text-danger fa fa-times"></i>
+                                    {% endif %}
+								</td>
                             </tr>
                         {% endfor %}
                         </tbody>

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -133,11 +133,23 @@
                       <tbody>
                         <tr>
                           <td style="width: 150px;"><strong>Critical product</strong></td>
-                          <td>{{ pt.critical_product }}</td>
-                        </tr>
+                          <td>
+                            {% if pt.critical_product %}
+                            <i class="text-success fa fa-check"></i>
+                            {% else %}
+                            <i class="text-danger fa fa-times"></i>
+                            {% endif %}
+                        </td>
+                    </tr>
                         <tr>
                             <td style="width: 150px;"><strong>Key product</strong></td>
-                            <td>{{ pt.key_product }}</td>
+                            <td>
+                                {% if pt.key_product %}
+                                <i class="text-success fa fa-check"></i>
+                                {% else %}
+                                <i class="text-danger fa fa-times"></i>
+                                {% endif %}
+                            </td>
                         </tr>
                         <tr>
                             <td style="width: 150px;"><strong>Authorized Users</strong></td>


### PR DESCRIPTION
This PR makes the UI for product types nicer. The attributes for critical product and key product have been shown as True or False in the list of product types and when viewing a single product type. With this PR they are shown as a red cross or a green tick, similar to the boolean fields in the list of users.