### PR TITLE
Fix deduplication hashcode fields for Dependency Track scanner

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -766,7 +766,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'Dependency Check Scan': ['cve', 'file_path'],
-    'Dependency Track Finding Packaging Format (FPF) Export': ['component', 'vuln_id_from_tool'],
+    'Dependency Track Finding Packaging Format (FPF) Export': ['component_name', 'vuln_id_from_tool'],
     'Nessus Scan': ['title', 'severity', 'cve', 'cwe', 'endpoints'],
     # possible improvment: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
     'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],


### PR DESCRIPTION
The Dependency Track scanner was configured to use `'component'` in its dedupe hashcode, but that field does not exist and is not in `HASHCODE_ALLOWED_FIELDS`. As a result deduplication falls back to default fields, with suboptimal results. Most likely `component` was a typo of `component_name` here (could also add the component version like other scanners, but [as the parser documents](https://github.com/DefectDojo/django-DefectDojo/blob/08bc2f906b34cd6f76f5abc4e5e6d801fa556bbd/dojo/tools/dependency_track/parser.py#L130), DT does not always supply a version).