### PR TITLE
store tags for new (ad hoc) findings

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -1155,6 +1155,7 @@ def ad_hoc_finding(request, pid):
             create_template = new_finding.is_template
             # always false now since this will be deprecated soon in favor of new Finding_Template model
             new_finding.is_template = False
+            new_finding.tags = form.cleaned_data['tags']
             new_finding.save()
             new_finding.endpoints.set(form.cleaned_data['endpoints'])
             for endpoint in form.cleaned_data['endpoints']:

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -359,6 +359,7 @@ def add_findings(request, tid):
             create_template = new_finding.is_template
             # always false now since this will be deprecated soon in favor of new Finding_Template model
             new_finding.is_template = False
+            new_finding.tags = form.cleaned_data['tags']
             new_finding.save(dedupe_option=False, push_to_jira=False)
             for ep in form.cleaned_data['endpoints']:
                 eps, created = Endpoint_Status.objects.get_or_create(


### PR DESCRIPTION
tags were not stored for findings created manually via the UI