### PR TITLE
finding.save() + add logging of the JIRA issue key to jira webhook

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -78,7 +78,7 @@ def webhook(request, secret=None):
 
                     if resolution is None:
                         resolved = False
-                    if finding.active == resolved:
+                    if finding.active is resolved:
                         if finding.active:
                             if jira_instance and resolution['name'] in jira_instance.accepted_resolutions:
                                 logger.debug("Marking related finding of {} as accepted. Creating risk acceptance.".format(jissue.jira_key))

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -58,6 +58,7 @@ def webhook(request, secret=None):
             if parsed.get('webhookEvent') == 'jira:issue_updated':
                 # xml examples at the end of file
                 jid = parsed['issue']['id']
+                logging.info("Received issue update for {}".format(jid))
                 jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
                 if jissue.finding:
                     finding = jissue.finding
@@ -132,7 +133,7 @@ def webhook(request, secret=None):
                     #     eng.save()
                     return HttpResponse('Update for engagement ignored')
                 else:
-                    raise Http404('No finding or engagement found for this JIRA issue')
+                    raise Http404('No finding or engagement found for JIRA issue {}'.format(jid))
 
             if parsed.get('webhookEvent') == 'comment_created':
                 """
@@ -189,6 +190,7 @@ def webhook(request, secret=None):
                 commentor_display_name = parsed['comment']['updateAuthor']['displayName']
                 # example: body['comment']['self'] = "http://www.testjira.com/jira_under_a_path/rest/api/2/issue/666/comment/456843"
                 jid = parsed['comment']['self'].split('/')[-3]
+                logging.info("Received issue comment for {}".format(jid))
                 jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
                 logger.debug('jissue: %s', vars(jissue))
                 if jissue.finding:
@@ -213,7 +215,7 @@ def webhook(request, secret=None):
                 elif jissue.engagement:
                     return HttpResponse('Comment for engagement ignored')
                 else:
-                    raise Http404('No finding or engagement found for this JIRA issue')
+                    raise Http404('No finding or engagement found for JIRA issue {}'.format(jid))
 
             if parsed.get('webhookEvent') not in ['comment_created', 'jira:issue_updated']:
                 logger.info('Unrecognized JIRA webhook event received: {}'.format(parsed.get('webhookEvent')))

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -58,8 +58,8 @@ def webhook(request, secret=None):
             if parsed.get('webhookEvent') == 'jira:issue_updated':
                 # xml examples at the end of file
                 jid = parsed['issue']['id']
-                logging.info("Received issue update for {}".format(jid))
                 jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
+                logging.info("Received issue update for {}".format(jissue.jira_key))
                 if jissue.finding:
                     finding = jissue.finding
                     jira_instance = jira_helper.get_jira_instance(finding)
@@ -133,7 +133,7 @@ def webhook(request, secret=None):
                     #     eng.save()
                     return HttpResponse('Update for engagement ignored')
                 else:
-                    raise Http404('No finding or engagement found for JIRA issue {}'.format(jid))
+                    raise Http404('No finding or engagement found for JIRA issue {}'.format(jissue.jira_key))
 
             if parsed.get('webhookEvent') == 'comment_created':
                 """
@@ -190,8 +190,8 @@ def webhook(request, secret=None):
                 commentor_display_name = parsed['comment']['updateAuthor']['displayName']
                 # example: body['comment']['self'] = "http://www.testjira.com/jira_under_a_path/rest/api/2/issue/666/comment/456843"
                 jid = parsed['comment']['self'].split('/')[-3]
-                logging.info("Received issue comment for {}".format(jid))
                 jissue = get_object_or_404(JIRA_Issue, jira_id=jid)
+                logging.info("Received issue comment for {}".format(jissue.jira_key))
                 logger.debug('jissue: %s', vars(jissue))
                 if jissue.finding:
                     # logger.debug('finding: %s', vars(jissue.finding))
@@ -215,7 +215,7 @@ def webhook(request, secret=None):
                 elif jissue.engagement:
                     return HttpResponse('Comment for engagement ignored')
                 else:
-                    raise Http404('No finding or engagement found for JIRA issue {}'.format(jid))
+                    raise Http404('No finding or engagement found for JIRA issue {}'.format(jissue.jira_key))
 
             if parsed.get('webhookEvent') not in ['comment_created', 'jira:issue_updated']:
                 logger.info('Unrecognized JIRA webhook event received: {}'.format(parsed.get('webhookEvent')))

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -65,7 +65,6 @@ def webhook(request, secret=None):
                     jira_instance = jira_helper.get_jira_instance(finding)
                     resolved = True
                     resolution = parsed['issue']['fields']['resolution']
-                    logger.debug("JIRA resolution for {} is {}".format(jissue.jira_key, resolution['name']))
 
                     #         "resolution":{
                     #             "self":"http://www.testjira.com/rest/api/2/resolution/11",
@@ -81,6 +80,7 @@ def webhook(request, secret=None):
                         resolved = False
                         logger.debug("JIRA resolution is None, therefore resolved is now False")
                     if finding.active is resolved:
+                        logger.debug("JIRA resolution for {} is {}".format(jissue.jira_key, resolution['name']))
                         if finding.active:
                             if jira_instance and resolution['name'] in jira_instance.accepted_resolutions:
                                 logger.debug("Marking related finding of {} as accepted. Creating risk acceptance.".format(jissue.jira_key))

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -102,7 +102,6 @@ def webhook(request, secret=None):
                                 finding.is_Mitigated = False
                                 finding.false_p = True
                                 ra_helper.remove_from_any_risk_acceptance(finding)
-                                finding.save(dedupe_option=False)
                             else:
                                 # Mitigated by default as before
                                 logger.debug("Marking related finding of {} as mitigated (default)".format(jissue.jira_key))
@@ -113,7 +112,6 @@ def webhook(request, secret=None):
                                 finding.endpoints.clear()
                                 finding.false_p = False
                                 ra_helper.remove_from_any_risk_acceptance(finding)
-                                finding.save(dedupe_option=False)
                         else:
                             # Reopen / Open Jira issue
                             logger.debug("Re-opening related finding of {}".format(jissue.jira_key))
@@ -122,7 +120,6 @@ def webhook(request, secret=None):
                             finding.is_Mitigated = False
                             finding.false_p = False
                             ra_helper.remove_from_any_risk_acceptance(finding)
-                            finding.save()
                     else:
                         # Reopen / Open Jira issue
                         finding.active = True
@@ -131,9 +128,9 @@ def webhook(request, secret=None):
                         finding.false_p = False
                         ra_helper.remove_from_any_risk_acceptance(finding)
 
-                        finding.jira_issue.jira_change = timezone.now()
-                        finding.jira_issue.save()
-                        finding.save()
+                    finding.jira_issue.jira_change = timezone.now()
+                    finding.jira_issue.save()
+                    finding.save()
 
                 elif jissue.engagement:
                     # if parsed['issue']['fields']['resolution'] != None:

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -81,6 +81,7 @@ def webhook(request, secret=None):
                     if finding.active == resolved:
                         if finding.active:
                             if jira_instance and resolution['name'] in jira_instance.accepted_resolutions:
+                                logger.debug("Marking related finding of {} as accepted. Creating risk acceptance.".format(jissue.jira_key))
                                 finding.active = False
                                 finding.mitigated = None
                                 finding.is_Mitigated = False
@@ -92,6 +93,7 @@ def webhook(request, secret=None):
                                     owner=finding.reporter,
                                 ).accepted_findings.set([finding])
                             elif jira_instance and resolution['name'] in jira_instance.false_positive_resolutions:
+                                logger.debug("Marking related finding of {} as false-positive".format(jissue.jira_key))
                                 finding.active = False
                                 finding.verified = False
                                 finding.mitigated = None
@@ -100,6 +102,7 @@ def webhook(request, secret=None):
                                 ra_helper.remove_from_any_risk_acceptance(finding)
                             else:
                                 # Mitigated by default as before
+                                logger.debug("Marking related finding of {} as mitigated (default)".format(jissue.jira_key))
                                 now = timezone.now()
                                 finding.active = False
                                 finding.mitigated = now
@@ -109,6 +112,7 @@ def webhook(request, secret=None):
                                 ra_helper.remove_from_any_risk_acceptance(finding)
                         else:
                             # Reopen / Open Jira issue
+                            logger.debug("Re-opening related finding of {}".format(jissue.jira_key))
                             finding.active = True
                             finding.mitigated = None
                             finding.is_Mitigated = False

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -80,7 +80,6 @@ def webhook(request, secret=None):
                         resolved = False
                         logger.debug("JIRA resolution is None, therefore resolved is now False")
                     if finding.active is resolved:
-                        logger.debug("JIRA resolution for {} is {}".format(jissue.jira_key, resolution['name']))
                         if finding.active:
                             if jira_instance and resolution['name'] in jira_instance.accepted_resolutions:
                                 logger.debug("Marking related finding of {} as accepted. Creating risk acceptance.".format(jissue.jira_key))

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -93,6 +93,7 @@ def webhook(request, secret=None):
                                     accepted_by=assignee_name,
                                     owner=finding.reporter,
                                 ).accepted_findings.set([finding])
+                                finding.save(dedupe_option=False)
                             elif jira_instance and resolution['name'] in jira_instance.false_positive_resolutions:
                                 logger.debug("Marking related finding of {} as false-positive".format(jissue.jira_key))
                                 finding.active = False

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -65,7 +65,7 @@ def webhook(request, secret=None):
                     jira_instance = jira_helper.get_jira_instance(finding)
                     resolved = True
                     resolution = parsed['issue']['fields']['resolution']
-                    logger.debug("JIRA resolution for {} is {}".format(jissue.jira_key, resolution))
+                    logger.debug("JIRA resolution for {} is {}".format(jissue.jira_key, resolution['name']))
 
                     #         "resolution":{
                     #             "self":"http://www.testjira.com/rest/api/2/resolution/11",

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -65,6 +65,7 @@ def webhook(request, secret=None):
                     jira_instance = jira_helper.get_jira_instance(finding)
                     resolved = True
                     resolution = parsed['issue']['fields']['resolution']
+                    logger.debug("JIRA resolution for {} is {}".format(jissue.jira_key, resolution))
 
                     #         "resolution":{
                     #             "self":"http://www.testjira.com/rest/api/2/resolution/11",
@@ -78,6 +79,7 @@ def webhook(request, secret=None):
 
                     if resolution is None:
                         resolved = False
+                        logger.debug("JIRA resolution is None, therefore resolved is now False")
                     if finding.active is resolved:
                         if finding.active:
                             if jira_instance and resolution['name'] in jira_instance.accepted_resolutions:

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -102,6 +102,7 @@ def webhook(request, secret=None):
                                 finding.is_Mitigated = False
                                 finding.false_p = True
                                 ra_helper.remove_from_any_risk_acceptance(finding)
+                                finding.save(dedupe_option=False)
                             else:
                                 # Mitigated by default as before
                                 logger.debug("Marking related finding of {} as mitigated (default)".format(jissue.jira_key))
@@ -112,6 +113,7 @@ def webhook(request, secret=None):
                                 finding.endpoints.clear()
                                 finding.false_p = False
                                 ra_helper.remove_from_any_risk_acceptance(finding)
+                                finding.save(dedupe_option=False)
                         else:
                             # Reopen / Open Jira issue
                             logger.debug("Re-opening related finding of {}".format(jissue.jira_key))
@@ -120,6 +122,7 @@ def webhook(request, secret=None):
                             finding.is_Mitigated = False
                             finding.false_p = False
                             ra_helper.remove_from_any_risk_acceptance(finding)
+                            finding.save()
                     else:
                         # Reopen / Open Jira issue
                         finding.active = True


### PR DESCRIPTION
Adding a few lines to help in debugging without full debug turned on.

As it turns out, the findings were not saved? I could reproduce that with `finding.save()` calls, the finding status did reflect the jira status, but not without.