### PR TITLE
import_scan: add test response field to swagger docs

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1067,6 +1067,7 @@ class ImportScanSerializer(serializers.Serializer):
     push_to_jira = serializers.BooleanField(default=False)
     environment = serializers.CharField(required=False)
     version = serializers.CharField(required=False)
+    test = serializers.IntegerField(read_only=True)  # not a modelserializer, so can't use related fields
 
     # class Meta:
     #     model = Test


### PR DESCRIPTION
in the api the test.id field was already returned, but in a way that it didn't show up in the swagger docs. now we add it as a serializer field officially so the docs are correct.

![image](https://user-images.githubusercontent.com/4426050/107846475-5a4e8b00-6de4-11eb-8af8-7788230aa432.png)
