### PR TITLE
Reimport: keep false positive and out of scope history #3848

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1438,8 +1438,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 if findings:
                     # existing finding found
                     finding = findings[0]
-                    if finding.false_p or finding.out_of_scope:
-                        logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.id, finding, finding.component_name, finding.component_version)
+                    if finding.false_p or finding.out_of_scope or finding.risk_accepted:
+                        logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
                     elif finding.mitigated or finding.is_Mitigated:
                         logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                         finding.mitigated = None

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1438,7 +1438,9 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 if findings:
                     # existing finding found
                     finding = findings[0]
-                    if finding.mitigated or finding.is_Mitigated:
+                    if finding.false_p or finding.out_of_scope:
+                        logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.id, finding, finding.component_name, finding.component_version)
+                    elif finding.mitigated or finding.is_Mitigated:
                         logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                         finding.mitigated = None
                         finding.is_Mitigated = False

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -776,8 +776,8 @@ def re_import_scan_results(request, tid):
 
                     if findings:
                         finding = findings[0]
-                        if finding.false_p or finding.out_of_scope:
-                            logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.id, finding, finding.component_name, finding.component_version)
+                        if finding.false_p or finding.out_of_scope or finding.risk_accepted:
+                            logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
                         elif finding.mitigated or finding.is_Mitigated:
                             logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                             # it was once fixed, but now back

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -776,7 +776,9 @@ def re_import_scan_results(request, tid):
 
                     if findings:
                         finding = findings[0]
-                        if finding.mitigated or finding.is_Mitigated:
+                        if finding.false_p or finding.out_of_scope:
+                            logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.id, finding, finding.component_name, finding.component_version)
+                        elif finding.mitigated or finding.is_Mitigated:
                             logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                             # it was once fixed, but now back
                             finding.mitigated = None

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -37,6 +37,12 @@ class DojoTestUtilsMixin(object):
         product = Product(name=name, description=description, prod_type=prod_type)
         product.save()
 
+    def patch_product_api(self, product_id, product_details):
+        payload = copy.deepcopy(product_details)
+        response = self.client.patch(reverse('product-list') + '%s/' % product_id, payload, format='json')
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        return response.data
+
     def create_engagement(self, name, product, *args, description=None, **kwargs):
         engagement = Engagement(name=name, description=description, product=product)
         engagement.save()
@@ -44,8 +50,18 @@ class DojoTestUtilsMixin(object):
     def get_test(self, id):
         return Test.objects.get(id=id)
 
+    def get_test_api(self, test_id):
+        response = self.client.patch(reverse('engagement-list') + '%s/' % test_id)
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        return response.data
+
     def get_engagement(self, id):
         return Engagement.objects.get(id=id)
+
+    def get_engagement_api(self, engagement_id):
+        response = self.client.patch(reverse('engagement-list') + '%s/' % engagement_id)
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        return response.data
 
     def assert_jira_issue_count_in_test(self, test_id, count):
         test = self.get_test(test_id)
@@ -398,6 +414,11 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
         response = self.client.put(reverse('finding-list') + '%s/' % finding_id, payload, format='json')
         self.assertEqual(200, response.status_code, response.content[:1000])
+        return response.data
+
+    def delete_finding_api(self, finding_id):
+        response = self.client.delete(reverse('finding-list') + '%s/' % finding_id)
+        self.assertEqual(204, response.status_code, response.content[:1000])
         return response.data
 
     def patch_finding_api(self, finding_id, finding_details, push_to_jira=None):

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -552,8 +552,10 @@ class ImportReimportMixin(object):
                                                        "out_of_scope": True,
                                                        "is_Mitigated": True})
 
-        reimport0 = self.reimport_scan_with_params(test_id, self.zap_sample0_filename)
-        test_id = reimport0['test']
+        with assertTestImportModelsCreated(self, reimports=1):
+            reimport0 = self.reimport_scan_with_params(test_id, self.zap_sample0_filename)
+
+        self.assertEqual(reimport0['test'], test_id)
 
         active_findings_after = self.get_test_findings_api(test_id, active=True)
         self.assert_finding_count_json(1, active_findings_after)

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -517,17 +517,24 @@ class ImportReimportMixin(object):
         # reimporting the exact same scan shouldn't create any notes
         self.assertEqual(notes_count_before, self.db_notes_count())
 
-    # import 0 with 4 findings
+    # import Zap0 with 4 findings
     # set 1 finding to active=False and false_positve=True
     # set 1 finding to active=False and out_of_scope=True
-    # set 1 finding to active=False and false_positve=True and out_of_scope=True
-    # reimport 0 and only 1 finding must be active
+    # set 1 finding to active=False and risk_accepted=True
+    # delete 1 finding
+    # reimport Zap0 and only 1 finding must be active
     # the other 3 findings manually set to active=False must remain False
     def test_import_reimport_keep_false_positive_and_out_of_scope(self):
         logger.debug('importing zap0 with 4 findings, manually setting 3 findings to active=False, reimporting zap0 must return only 1 finding active=True')
 
         import0 = self.import_scan_with_params(self.zap_sample0_filename)
         test_id = import0['test']
+
+        test_api_response = self.get_test_api(test_id)
+        product_api_response = self.get_engagement_api(test_api_response['engagement'])
+        product_id = product_api_response['product']
+
+        self.patch_product_api(product_id, {"enable_simple_risk_acceptance": True})
 
         active_findings_before = self.get_test_findings_api(test_id, active=True)
         self.assert_finding_count_json(4, active_findings_before)
@@ -538,21 +545,34 @@ class ImportReimportMixin(object):
                                                        "verified": False,
                                                        "false_p": True,
                                                        "out_of_scope": False,
+                                                       "risk_accepted": False,
                                                        "is_Mitigated": True})
             elif 'Zap2' in finding['title']:
                 self.patch_finding_api(finding['id'], {"active": False,
                                                        "verified": False,
                                                        "false_p": False,
                                                        "out_of_scope": True,
+                                                       "risk_accepted": False,
                                                        "is_Mitigated": True})
             elif 'Zap3' in finding['title']:
                 self.patch_finding_api(finding['id'], {"active": False,
                                                        "verified": False,
-                                                       "false_p": True,
-                                                       "out_of_scope": True,
+                                                       "false_p": False,
+                                                       "out_of_scope": False,
+                                                       "risk_accepted": True,
                                                        "is_Mitigated": True})
 
-        with assertTestImportModelsCreated(self, reimports=1):
+        active_findings_before = self.get_test_findings_api(test_id, active=True)
+        self.assert_finding_count_json(1, active_findings_before)
+
+        for finding in active_findings_before['results']:
+            if 'Zap5' in finding['title']:
+                self.delete_finding_api(finding['id'])
+
+        active_findings_before = self.get_test_findings_api(test_id, active=True)
+        self.assert_finding_count_json(0, active_findings_before)
+
+        with assertTestImportModelsCreated(self, reimports=1, affected_findings=1, created=1):
             reimport0 = self.reimport_scan_with_params(test_id, self.zap_sample0_filename)
 
         self.assertEqual(reimport0['test'], test_id)
@@ -569,19 +589,29 @@ class ImportReimportMixin(object):
                 self.assertFalse(finding['verified'])
                 self.assertTrue(finding['false_p'])
                 self.assertFalse(finding['out_of_scope'])
+                self.assertFalse(finding['risk_accepted'])
                 self.assertTrue(finding['is_Mitigated'])
             elif 'Zap2' in finding['title']:
                 self.assertFalse(finding['active'])
                 self.assertFalse(finding['verified'])
                 self.assertFalse(finding['false_p'])
                 self.assertTrue(finding['out_of_scope'])
+                self.assertFalse(finding['risk_accepted'])
                 self.assertTrue(finding['is_Mitigated'])
             elif 'Zap3' in finding['title']:
                 self.assertFalse(finding['active'])
                 self.assertFalse(finding['verified'])
-                self.assertTrue(finding['false_p'])
-                self.assertTrue(finding['out_of_scope'])
+                self.assertFalse(finding['false_p'])
+                self.assertFalse(finding['out_of_scope'])
+                self.assertTrue(finding['risk_accepted'])
                 self.assertTrue(finding['is_Mitigated'])
+            elif 'Zap5' in finding['title']:
+                self.assertTrue(finding['active'])
+                self.assertTrue(finding['verified'])
+                self.assertFalse(finding['false_p'])
+                self.assertFalse(finding['out_of_scope'])
+                self.assertFalse(finding['risk_accepted'])
+                self.assertFalse(finding['is_Mitigated'])
 
 
 @override_settings(TRACK_IMPORT_HISTORY=True)

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -517,6 +517,70 @@ class ImportReimportMixin(object):
         # reimporting the exact same scan shouldn't create any notes
         self.assertEqual(notes_count_before, self.db_notes_count())
 
+    # import 0 with 4 findings
+    # set 1 finding to active=False and false_positve=True
+    # set 1 finding to active=False and out_of_scope=True
+    # set 1 finding to active=False and false_positve=True and out_of_scope=True
+    # reimport 0 and only 1 finding must be active
+    # the other 3 findings manually set to active=False must remain False
+    def test_import_reimport_keep_false_positive_and_out_of_scope(self):
+        logger.debug('importing zap0 with 4 findings, manually setting 3 findings to active=False, reimporting zap0 must return only 1 finding active=True')
+
+        import0 = self.import_scan_with_params(self.zap_sample0_filename)
+        test_id = import0['test']
+
+        active_findings_before = self.get_test_findings_api(test_id, active=True)
+        self.assert_finding_count_json(4, active_findings_before)
+
+        for finding in active_findings_before['results']:
+            if 'Zap1' in finding['title']:
+                self.patch_finding_api(finding['id'], {"active": False,
+                                                       "verified": False,
+                                                       "false_p": True,
+                                                       "out_of_scope": False,
+                                                       "is_Mitigated": True})
+            elif 'Zap2' in finding['title']:
+                self.patch_finding_api(finding['id'], {"active": False,
+                                                       "verified": False,
+                                                       "false_p": False,
+                                                       "out_of_scope": True,
+                                                       "is_Mitigated": True})
+            elif 'Zap3' in finding['title']:
+                self.patch_finding_api(finding['id'], {"active": False,
+                                                       "verified": False,
+                                                       "false_p": True,
+                                                       "out_of_scope": True,
+                                                       "is_Mitigated": True})
+
+        reimport0 = self.reimport_scan_with_params(test_id, self.zap_sample0_filename)
+        test_id = reimport0['test']
+
+        active_findings_after = self.get_test_findings_api(test_id, active=True)
+        self.assert_finding_count_json(1, active_findings_after)
+
+        active_findings_after = self.get_test_findings_api(test_id, active=False)
+        self.assert_finding_count_json(3, active_findings_after)
+
+        for finding in active_findings_after['results']:
+            if 'Zap1' in finding['title']:
+                self.assertFalse(finding['active'])
+                self.assertFalse(finding['verified'])
+                self.assertTrue(finding['false_p'])
+                self.assertFalse(finding['out_of_scope'])
+                self.assertTrue(finding['is_Mitigated'])
+            elif 'Zap2' in finding['title']:
+                self.assertFalse(finding['active'])
+                self.assertFalse(finding['verified'])
+                self.assertFalse(finding['false_p'])
+                self.assertTrue(finding['out_of_scope'])
+                self.assertTrue(finding['is_Mitigated'])
+            elif 'Zap3' in finding['title']:
+                self.assertFalse(finding['active'])
+                self.assertFalse(finding['verified'])
+                self.assertTrue(finding['false_p'])
+                self.assertTrue(finding['out_of_scope'])
+                self.assertTrue(finding['is_Mitigated'])
+
 
 @override_settings(TRACK_IMPORT_HISTORY=True)
 class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):


### PR DESCRIPTION
Fix issue https://github.com/DefectDojo/django-DefectDojo/issues/3848 regarding the reimport of reports where previous findings marked as false positive and/or out of scope are re-activated instead of ignored. Now the history of false positive and out of scope findings is properly preserved.