### PR TITLE
Fix editing of Engagement checklist

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -844,6 +844,12 @@ method to complete checklists from the engagement view
 @user_must_be_authorized(Engagement, 'staff', 'eid')
 def complete_checklist(request, eid):
     eng = get_object_or_404(Engagement, id=eid)
+    try:
+        checklist = Check_List.objects.get(engagement=eng)
+    except:
+        checklist = None
+        pass
+
     add_breadcrumb(
         parent=eng,
         title="Complete checklist",
@@ -852,7 +858,7 @@ def complete_checklist(request, eid):
     if request.method == 'POST':
         tests = Test.objects.filter(engagement=eng)
         findings = Finding.objects.filter(test__in=tests).all()
-        form = CheckForm(request.POST, findings=findings)
+        form = CheckForm(request.POST, instance=checklist, findings=findings)
         if form.is_valid():
             cl = form.save(commit=False)
             try:
@@ -861,7 +867,6 @@ def complete_checklist(request, eid):
                 cl.save()
                 form.save_m2m()
             except:
-
                 cl.engagement = eng
                 cl.save()
                 form.save_m2m()
@@ -876,7 +881,7 @@ def complete_checklist(request, eid):
     else:
         tests = Test.objects.filter(engagement=eng)
         findings = Finding.objects.filter(test__in=tests).all()
-        form = CheckForm(findings=findings)
+        form = CheckForm(instance=checklist, findings=findings)
 
     product_tab = Product_Tab(eng.product.id, title="Checklist", tab="engagements")
     product_tab.setEngagement(eng)

--- a/dojo/templates/dojo/checklist.html
+++ b/dojo/templates/dojo/checklist.html
@@ -3,12 +3,12 @@
 <head>
 </head>
 {% block content %}
-    <h3> Testing CheckList</h3>
+    <h3>Checklist</h3>
     <form class="form-horizontal" action="{% url 'complete_checklist' eid %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
-                <input class="btn btn-primary" type="submit" value="Done"/>
+                <input class="btn btn-primary" type="submit" value="Submit"/>
             </div>
         </div>
     </form>


### PR DESCRIPTION
When trying to edit a previously completed checklist, it was not loaded and instead the user had to start with an empty checklist again. With this fix, the checklist will be loaded and the user can continue where she stopped before.