### PR TITLE
Fix risk acceptance celery handler + align @task decorators

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -421,9 +421,9 @@ def push_to_jira(obj):
         logger.error('unsupported object passed to push_to_jira: %s %i %s', obj.__name__, obj.id, obj)
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def add_jira_issue(find):
     logger.info('trying to create a new jira issue for %d:%s', find.id, find.title)
@@ -551,9 +551,9 @@ def add_jira_issue(find):
         return False
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def update_jira_issue(find):
     logger.debug('trying to update a linked jira issue for %d:%s', find.id, find.title)
@@ -745,9 +745,9 @@ def jira_check_attachment(issue, source_file_name):
     return file_exists
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id(model=Engagement)
 def close_epic(eng, push_to_jira):
     engagement = eng
@@ -787,9 +787,9 @@ def close_epic(eng, push_to_jira):
         return False
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id(model=Engagement)
 def update_epic(engagement):
     logger.debug('trying to update jira EPIC for %d:%s', engagement.id, engagement.name)
@@ -818,9 +818,9 @@ def update_epic(engagement):
         return False
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id(model=Engagement)
 def add_epic(engagement):
     logger.debug('trying to create a new jira EPIC for %d:%s', engagement.id, engagement.name)
@@ -890,10 +890,10 @@ def jira_get_issue(jira_project, issue_key):
         return None
 
 
+@app.task
 @dojo_model_to_id(parameter=1)
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
 def add_comment(find, note, force_push=False):

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -421,9 +421,9 @@ def push_to_jira(obj):
         logger.error('unsupported object passed to push_to_jira: %s %i %s', obj.__name__, obj.id, obj)
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def add_jira_issue(find):
     logger.info('trying to create a new jira issue for %d:%s', find.id, find.title)
@@ -551,9 +551,9 @@ def add_jira_issue(find):
         return False
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def update_jira_issue(find):
     logger.debug('trying to update a linked jira issue for %d:%s', find.id, find.title)
@@ -745,9 +745,9 @@ def jira_check_attachment(issue, source_file_name):
     return file_exists
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id(model=Engagement)
 def close_epic(eng, push_to_jira):
     engagement = eng
@@ -787,9 +787,9 @@ def close_epic(eng, push_to_jira):
         return False
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id(model=Engagement)
 def update_epic(engagement):
     logger.debug('trying to update jira EPIC for %d:%s', engagement.id, engagement.name)
@@ -818,9 +818,9 @@ def update_epic(engagement):
         return False
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id(model=Engagement)
 def add_epic(engagement):
     logger.debug('trying to create a new jira EPIC for %d:%s', engagement.id, engagement.name)
@@ -890,10 +890,10 @@ def jira_get_issue(jira_project, issue_key):
         return None
 
 
-@app.task
 @dojo_model_to_id(parameter=1)
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
 def add_comment(find, note, force_push=False):

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -14,7 +14,7 @@ from dojo.models import Finding, Test, Engagement, Product, JIRA_Issue, JIRA_Pro
 from requests.auth import HTTPBasicAuth
 from dojo.notifications.helper import create_notification
 from django.contrib import messages
-from celery.decorators import task
+from dojo.celery import app
 from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
 from dojo.utils import get_current_request, truncate_with_dots
 from django.urls import reverse
@@ -423,7 +423,7 @@ def push_to_jira(obj):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def add_jira_issue(find):
     logger.info('trying to create a new jira issue for %d:%s', find.id, find.title)
@@ -553,7 +553,7 @@ def add_jira_issue(find):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def update_jira_issue(find):
     logger.debug('trying to update a linked jira issue for %d:%s', find.id, find.title)
@@ -747,7 +747,7 @@ def jira_check_attachment(issue, source_file_name):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id(model=Engagement)
 def close_epic(eng, push_to_jira):
     engagement = eng
@@ -789,7 +789,7 @@ def close_epic(eng, push_to_jira):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id(model=Engagement)
 def update_epic(engagement):
     logger.debug('trying to update jira EPIC for %d:%s', engagement.id, engagement.name)
@@ -820,7 +820,7 @@ def update_epic(engagement):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id(model=Engagement)
 def add_epic(engagement):
     logger.debug('trying to create a new jira EPIC for %d:%s', engagement.id, engagement.name)
@@ -893,7 +893,7 @@ def jira_get_issue(jira_project, issue_key):
 @dojo_model_to_id(parameter=1)
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
 def add_comment(find, note, force_push=False):

--- a/dojo/management/commands/rename_whitesource_findings.py
+++ b/dojo/management/commands/rename_whitesource_findings.py
@@ -1,6 +1,6 @@
 from django.core.management.base import BaseCommand
 from pytz import timezone
-from celery.decorators import task
+from dojo.celery import app
 
 locale = timezone(get_system_setting('time_zone'))
 
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         rename_whitesource_finding()
 
 
-@task(name='rename_whitesource_finding_task')
+@app.task(name='rename_whitesource_finding_task')
 def rename_whitesource_finding():
     whitesource_id = Test_Type.objects.get(name="Whitesource Scan").id
     findings = Finding.objects.filter(found_by=whitesource_id)

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 
 from dojo.models import Finding, Notes
 # from dojo.utils import get_system_setting, do_dedupe_finding, dojo_async_task
-from celery import task
+from dojo.celery import app
 from functools import wraps
 from dojo.utils import test_valentijn
 
@@ -73,7 +73,7 @@ def my_decorator_inside(func):
 
 
 @my_decorator_outside
-@task
+@app.task
 @my_decorator_inside
 def my_test_task(new_finding, *args, **kwargs):
     print('oh la la what a nice task')
@@ -83,7 +83,7 @@ def my_test_task(new_finding, *args, **kwargs):
 @dojo_model_to_id(parameter=1)
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
 def test_valentijn_task(new_finding, note):

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -72,18 +72,18 @@ def my_decorator_inside(func):
     return wrapper
 
 
-@app.task
 @my_decorator_outside
+@app.task
 @my_decorator_inside
 def my_test_task(new_finding, *args, **kwargs):
     print('oh la la what a nice task')
 
 
 # example working with multiple parameters...
-@app.task
 @dojo_model_to_id(parameter=1)
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
 def test_valentijn_task(new_finding, note):

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -72,18 +72,18 @@ def my_decorator_inside(func):
     return wrapper
 
 
-@my_decorator_outside
 @app.task
+@my_decorator_outside
 @my_decorator_inside
 def my_test_task(new_finding, *args, **kwargs):
     print('oh la la what a nice task')
 
 
 # example working with multiple parameters...
+@app.task
 @dojo_model_to_id(parameter=1)
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
 def test_valentijn_task(new_finding, note):

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -145,7 +145,7 @@ def process_notifications(event, notifications=None, **kwargs):
 # notifications are made synchronous again due to serialization bug in django-tagulous
 # see https://github.com/DefectDojo/django-DefectDojo/issues/3677
 # @dojo_async_task
-@app.task(name='send_slack_notification')
+@app.task
 def send_slack_notification(event, user=None, *args, **kwargs):
     from dojo.utils import get_system_setting
 
@@ -205,7 +205,7 @@ def send_slack_notification(event, user=None, *args, **kwargs):
 # notifications are made synchronous again due to serialization bug in django-tagulous
 # see https://github.com/DefectDojo/django-DefectDojo/issues/3677
 # @dojo_async_task
-@app.task(name='send_msteams_notification')
+@app.task
 def send_msteams_notification(event, user=None, *args, **kwargs):
     from dojo.utils import get_system_setting
 
@@ -233,7 +233,7 @@ def send_msteams_notification(event, user=None, *args, **kwargs):
 # notifications are made synchronous again due to serialization bug in django-tagulous
 # see https://github.com/DefectDojo/django-DefectDojo/issues/3677
 # @dojo_async_task
-@app.task(name='send_mail_notification')
+@app.task
 def send_mail_notification(event, user=None, *args, **kwargs):
     from dojo.utils import get_system_setting
 

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -121,7 +121,7 @@ def add_findings_to_risk_acceptance(risk_acceptance, findings):
     post_jira_comments(risk_acceptance, findings, accepted_message_creator)
 
 
-@task(name='risk_acceptance_expiration_handler')
+@task(name='dojo.risk_acceptance.helper.expiration_handler')
 def expiration_handler(*args, **kwargs):
     """
     Creates a notification upon risk expiration and X days beforehand if configured.

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -5,7 +5,7 @@ import dojo.jira_link.helper as jira_helper
 from dojo.jira_link.helper import escape_for_jira
 from dojo.notifications.helper import create_notification
 from django.urls import reverse
-from celery.decorators import task
+from dojo.celery import app
 from dojo.models import System_Settings, Risk_Acceptance
 import logging
 
@@ -121,7 +121,7 @@ def add_findings_to_risk_acceptance(risk_acceptance, findings):
     post_jira_comments(risk_acceptance, findings, accepted_message_creator)
 
 
-@task
+@app.task
 def expiration_handler(*args, **kwargs):
     """
     Creates a notification upon risk expiration and X days beforehand if configured.

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -121,7 +121,7 @@ def add_findings_to_risk_acceptance(risk_acceptance, findings):
     post_jira_comments(risk_acceptance, findings, accepted_message_creator)
 
 
-@task(name='dojo.risk_acceptance.helper.expiration_handler')
+@task
 def expiration_handler(*args, **kwargs):
     """
     Creates a notification upon risk expiration and X days beforehand if configured.

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -727,7 +727,7 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': timedelta(hours=3),
     },
     'compute-sla-age-and-notify': {
-        'task': 'dojo.tasks.async_sla_compute_and_notify',
+        'task': 'dojo.tasks.async_sla_compute_and_notify_task',
         'schedule': crontab(hour=7, minute=30),
     },
     'risk_acceptance_expiration_handler': {

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -10,7 +10,6 @@ from django.template.loader import render_to_string
 from django.utils.http import urlencode
 from dojo.celery import app
 from celery.utils.log import get_task_logger
-from celery.decorators import task
 from dojo.models import Alerts, Product, Finding, Engagement, System_Settings, User
 from django.utils import timezone
 from dojo.utils import calculate_grade
@@ -290,7 +289,7 @@ def async_dupe_delete(*args, **kwargs):
         logger.info('total number of excess duplicates deleted: %s', total_deleted_count)
 
 
-@task(ignore_result=False)
+@app.task(ignore_result=False)
 def celery_status():
     return True
 

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -290,12 +290,12 @@ def async_dupe_delete(*args, **kwargs):
         logger.info('total number of excess duplicates deleted: %s', total_deleted_count)
 
 
-@task(name='celery_status', ignore_result=False)
+@task(ignore_result=False)
 def celery_status():
     return True
 
 
-@app.task(name='dojo.tasks.async_sla_compute_and_notify')
+@app.task
 def async_sla_compute_and_notify_task(*args, **kwargs):
     logger.debug("Computing SLAs and notifying as needed")
     try:

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -1,4 +1,4 @@
-from celery.decorators import task
+from dojo.celery import app
 
 from dojo.decorators import (dojo_async_task, dojo_model_from_id,
                              dojo_model_to_id)
@@ -17,7 +17,7 @@ def is_tool_issue_updater_needed(finding, *args, **kwargs):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def tool_issue_updater(finding, *args, **kwargs):
 
@@ -29,7 +29,7 @@ def tool_issue_updater(finding, *args, **kwargs):
 
 
 @dojo_async_task
-@task
+@app.task
 def update_findings_from_source_issues():
     from dojo.tools.sonarqube_api.updater_from_source import \
         SonarQubeApiUpdaterFromSource

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -15,9 +15,9 @@ def is_tool_issue_updater_needed(finding, *args, **kwargs):
     return test_type.name == SCAN_SONARQUBE_API
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def tool_issue_updater(finding, *args, **kwargs):
 
@@ -28,8 +28,8 @@ def tool_issue_updater(finding, *args, **kwargs):
         SonarQubeApiUpdater().update_sonarqube_finding(finding)
 
 
-@app.task
 @dojo_async_task
+@app.task
 def update_findings_from_source_issues():
     from dojo.tools.sonarqube_api.updater_from_source import \
         SonarQubeApiUpdaterFromSource

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -15,9 +15,9 @@ def is_tool_issue_updater_needed(finding, *args, **kwargs):
     return test_type.name == SCAN_SONARQUBE_API
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def tool_issue_updater(finding, *args, **kwargs):
 
@@ -28,8 +28,8 @@ def tool_issue_updater(finding, *args, **kwargs):
         SonarQubeApiUpdater().update_sonarqube_finding(finding)
 
 
-@dojo_async_task
 @app.task
+@dojo_async_task
 def update_findings_from_source_issues():
     from dojo.tools.sonarqube_api.updater_from_source import \
         SonarQubeApiUpdaterFromSource

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -102,9 +102,9 @@ def is_deduplication_on_engagement_mismatch(new_finding, to_duplicate_finding):
     return not new_finding.test.engagement.deduplication_on_engagement and to_duplicate_finding.test.engagement.deduplication_on_engagement
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def do_dedupe_finding(new_finding, *args, **kwargs):
     try:
@@ -360,9 +360,9 @@ def set_duplicate_reopen(new_finding, existing_finding):
     existing_finding.save()
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def do_apply_rules(new_finding, *args, **kwargs):
     rules = Rule.objects.filter(applies_to='Finding', parent_rule=None)
@@ -1222,9 +1222,9 @@ def handle_uploaded_selenium(f, cred):
     cred.save()
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def add_external_issue(find, external_issue_provider):
     eng = Engagement.objects.get(test=find.test)
@@ -1235,9 +1235,9 @@ def add_external_issue(find, external_issue_provider):
         add_external_issue_github(find, prod, eng)
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def update_external_issue(find, old_status, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
@@ -1247,9 +1247,9 @@ def update_external_issue(find, old_status, external_issue_provider):
         update_external_issue_github(find, prod, eng)
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def close_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
@@ -1259,9 +1259,9 @@ def close_external_issue(find, note, external_issue_provider):
         close_external_issue_github(find, note, prod, eng)
 
 
+@app.task
 @dojo_model_to_id
 @dojo_async_task
-@app.task
 @dojo_model_from_id
 def reopen_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -102,9 +102,9 @@ def is_deduplication_on_engagement_mismatch(new_finding, to_duplicate_finding):
     return not new_finding.test.engagement.deduplication_on_engagement and to_duplicate_finding.test.engagement.deduplication_on_engagement
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def do_dedupe_finding(new_finding, *args, **kwargs):
     try:
@@ -360,9 +360,9 @@ def set_duplicate_reopen(new_finding, existing_finding):
     existing_finding.save()
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def do_apply_rules(new_finding, *args, **kwargs):
     rules = Rule.objects.filter(applies_to='Finding', parent_rule=None)
@@ -1222,9 +1222,9 @@ def handle_uploaded_selenium(f, cred):
     cred.save()
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def add_external_issue(find, external_issue_provider):
     eng = Engagement.objects.get(test=find.test)
@@ -1235,9 +1235,9 @@ def add_external_issue(find, external_issue_provider):
         add_external_issue_github(find, prod, eng)
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def update_external_issue(find, old_status, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
@@ -1247,9 +1247,9 @@ def update_external_issue(find, old_status, external_issue_provider):
         update_external_issue_github(find, prod, eng)
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def close_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
@@ -1259,9 +1259,9 @@ def close_external_issue(find, note, external_issue_provider):
         close_external_issue_github(find, note, prod, eng)
 
 
-@app.task
 @dojo_model_to_id
 @dojo_async_task
+@app.task
 @dojo_model_from_id
 def reopen_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -32,7 +32,7 @@ import itertools
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 import crum
-from celery.decorators import task
+from dojo.celery import app
 from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
 
 
@@ -47,7 +47,7 @@ Helper functions for DefectDojo
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def do_false_positive_history(new_finding, *args, **kwargs):
     logger.debug('%s: sync false positive history', new_finding.id)
@@ -104,7 +104,7 @@ def is_deduplication_on_engagement_mismatch(new_finding, to_duplicate_finding):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def do_dedupe_finding(new_finding, *args, **kwargs):
     try:
@@ -362,7 +362,7 @@ def set_duplicate_reopen(new_finding, existing_finding):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def do_apply_rules(new_finding, *args, **kwargs):
     rules = Rule.objects.filter(applies_to='Finding', parent_rule=None)
@@ -1224,7 +1224,7 @@ def handle_uploaded_selenium(f, cred):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def add_external_issue(find, external_issue_provider):
     eng = Engagement.objects.get(test=find.test)
@@ -1237,7 +1237,7 @@ def add_external_issue(find, external_issue_provider):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def update_external_issue(find, old_status, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
@@ -1249,7 +1249,7 @@ def update_external_issue(find, old_status, external_issue_provider):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def close_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
@@ -1261,7 +1261,7 @@ def close_external_issue(find, note, external_issue_provider):
 
 @dojo_model_to_id
 @dojo_async_task
-@task
+@app.task
 @dojo_model_from_id
 def reopen_external_issue(find, note, external_issue_provider):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))


### PR DESCRIPTION
Fixes https://github.com/DefectDojo/django-DefectDojo/issues/3865

Now shows

```
$ docker-compose exec celerybeat sh -c 'celery -A dojo inspect registered'
[15/Feb/2021 09:12:31] INFO [dojo.models:3356] disabling audit logging
-> celery@9f983fab23f5: OK
  [...]
    * dojo.risk_acceptance.helper.expiration_handler
  [...]
```

and command runs

```
$ docker-compose exec uwsgi /bin/bash -c 'python manage.py risk_acceptance_handle_expiration'
[15/Feb/2021 09:12:55] INFO [dojo.models:3356] disabling audit logging
[15/Feb/2021 09:12:58] INFO [dojo.risk_acceptance.helper:141] expiring 0 risk acceptances that are past expiration date
[15/Feb/2021 09:12:58] INFO [dojo.risk_acceptance.helper:150] notifying for 0 risk acceptances that are expiring within 10 days
```