### PR TITLE
Auth V2: three fixes for the new autorization system

### DIFF
--- a/dojo/authorization/authorization_decorators.py
+++ b/dojo/authorization/authorization_decorators.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
 from dojo.authorization.authorization import user_has_permission
+from dojo.user.helper import user_is_authorized as legacy_check
 
 
 def user_is_authorized(model, permission, arg, lookup="pk", func=None):
@@ -30,7 +31,10 @@ def user_is_authorized(model, permission, arg, lookup="pk", func=None):
             if not user_has_permission(request.user, obj, permission) and not request.user.is_superuser:
                 raise PermissionDenied()
         else:
-            if not request.user.is_staff:
+            if permission.name.endswith("View"):
+                if not legacy_check(request.user, 'view', obj):
+                    raise PermissionDenied()
+            elif not request.user.is_staff:
                 raise PermissionDenied()
 
         return func(request, *args, **kwargs)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -38,6 +38,7 @@ import dojo.finding.helper as finding_helper
 from dojo.authorization.roles_permissions import Permissions
 from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.product.queries import get_authorized_products
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -710,8 +711,12 @@ def new_product(request, ptid=None):
             gform = None
 
         if form.is_valid():
-            product_type = form.instance.prod_type
-            user_has_permission_or_403(request.user, product_type, Permissions.Product_Type_Add_Product)
+            if settings.FEATURE_NEW_AUTHORIZATION:
+                product_type = form.instance.prod_type
+                user_has_permission_or_403(request.user, product_type, Permissions.Product_Type_Add_Product)
+            else:
+                if not request.user.is_staff:
+                    raise PermissionDenied
             product = form.save()
             messages.add_message(request,
                                  messages.SUCCESS,

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -76,11 +76,12 @@ def add_product_type(request):
         form = Product_TypeForm(request.POST)
         if form.is_valid():
             product_type = form.save()
-            member = Product_Type_Member()
-            member.user = request.user
-            member.product_type = product_type
-            member.role = Roles.Owner
-            member.save()
+            if settings.FEATURE_NEW_AUTHORIZATION:
+                member = Product_Type_Member()
+                member.user = request.user
+                member.product_type = product_type
+                member.role = Roles.Owner
+                member.save()
             messages.add_message(request,
                                  messages.SUCCESS,
                                  'Product type added successfully.',


### PR DESCRIPTION
Further tests on the merged new authorization system showed three areas, where the behaviour was not exactly the same as before when old authorization is still active:

- dojo/authorization/authorization_decorators.py: Call legacy user authorization, otherwise non-staff users can't view product types where they are an authorized user
- dojo/product/views.py: Staff users are allowed to add new products
- dojo/product_type/views.py: Don't save product type members