### PR TITLE
API V2 Documentation should use URL Prefix (if set)

### DIFF
--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -212,8 +212,8 @@ urlpatterns = [
     url(r'^%shistory/(?P<cid>\d+)/(?P<oid>\d+)$' % get_system_setting('url_prefix'), views.action_history,
         name='action_history'),
     url(r'^%s' % get_system_setting('url_prefix'), include(ur)),
-    url(r'^api/v2/api-token-auth/', tokenviews.obtain_auth_token),
-    url(r'^api/v2/doc/', schema_view.with_ui('swagger', cache_timeout=0), name='api_v2_schema'),
+    url(r'^%sapi/v2/api-token-auth/' % get_system_setting('url_prefix'), tokenviews.obtain_auth_token),
+    url(r'^%sapi/v2/doc/' % get_system_setting('url_prefix'), schema_view.with_ui('swagger', cache_timeout=0), name='api_v2_schema'),
     url(r'^robots.txt', lambda x: HttpResponse("User-Agent: *\nDisallow: /", content_type="text/plain"), name="robots_file"),
     url(r'^manage_files/(?P<oid>\d+)/(?P<obj_type>\w+)$', views.manage_files, name='manage_files'),
 ]


### PR DESCRIPTION
When hosting DefectDojo under a sub-directory, the URL for API V2 documentation is broken since it doesn't use the URL_PREFIX value. 

If `DD_URL_PREFIX` is set to 'defectdojo/', then the URL should be https://example.com/defectdojo/api/v2/doc/