### PR TITLE
aftercare: fix datatables viewing duplicate findings

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -353,7 +353,7 @@ def view_finding(request, fid):
     similar_findings_filter = SimilarFindingFilter(request.GET, queryset=Finding.objects.all(), user=request.user, finding=finding)
     logger.debug('similar query: %s', similar_findings_filter.qs.query)
 
-    similar_findings = get_page_items(request, similar_findings_filter.qs, settings.SIMILAR_FINDINGS_MAX_RESULTS)
+    similar_findings = get_page_items(request, similar_findings_filter.qs, settings.SIMILAR_FINDINGS_MAX_RESULTS, prefix='similar')
 
     similar_findings.object_list = prefetch_for_similar_findings(similar_findings.object_list)
 

--- a/dojo/templates/dojo/finding_related_list.html
+++ b/dojo/templates/dojo/finding_related_list.html
@@ -1,9 +1,9 @@
 {% load navigation_tags %}
 {% load static %}
 <div class="clearfix">
-    {% include "dojo/paging_snippet.html" with page=finding_list prefix=similar page_size=True %}
+    {% include "dojo/paging_snippet.html" with page=finding_list prefix=prefix page_size=True %}
 </div>
-<table id="similar_findings_table" class="table table-striped table-hover centered no-bottom-margin">
+<table id="{{prefix}}_findings_table" class="table table-striped table-hover centered no-bottom-margin">
     <tr>
         <th>Relationship</th>
         <th>Severity</th>
@@ -30,98 +30,3 @@
         {% include "dojo/finding_related_row.html" with similar_finding=similar_finding finding_context=finding %}
     {% endfor %}
 </table>
-<script type="application/javascript">
-    // DataTables Setup
-    $(document).ready(function() {
-        date =  new Date().toISOString().slice(0, 10);
-        var fileDated = 'Findings_List_' + date;
-        var columns = [
-            { "data": "relationship" },
-            { "data": "severity" },
-            { "data": "finding" , render: function (data, type, row) {
-                    return type === 'export' ? getDojoExportValueFromTag(data, 'a') :  data;
-            }},
-            { "data": "found_date" },
-            { "data": "status" },
-            { "data": "test" },
-            { "data": "engagement" },
-            { "data": "product" },
-            { "data": "cwe" },
-            { "data": "cve" },
-            { "data": "file_path" },
-            {% if system_settings.enable_jira %}
-                { "data": "jira_id" },
-            {% endif %}
-            { "data": "action" },
-          ];
-
-        // Filter the list of items to display based on what is shown.
-        var disallowed_entries = new Set(["checkbox", "action"]);
-        var data_column_list = [];
-        for (var i = 0; i < columns.length; i++) {
-            if (!disallowed_entries.has(columns[i]["data"])) {
-                data_column_list.push(i);
-            }
-        }
-
-        var buttonCommon = {
-            exportOptions: {
-                columns: data_column_list,
-                stripHtml: true,
-                stripNewlines: true,
-                trim: true,
-                orthogonal: 'export'
-            },
-            filename: fileDated,
-            title: 'Similar Findings List'
-        };
-
-        // Mapping of table columns to objects for proper cleanup and data formatting
-        var dojoTable = $('#similar_findings_table').DataTable({
-            drawCallback: function(){
-                  $('.has-popover').popover({'trigger':'hover'});
-            },
-            colReorder: true,
-            "columns": columns,
-            order: [],
-            columnDefs: [
-                {
-                    "orderable": false,
-                    "targets": [0, 1]
-                },
-                {
-                    targets: [0, 1],
-                    className: 'noVis'
-                }
-            ],
-            dom: 'Bfrtip',
-            paging: false,
-            info: false,
-            buttons: [
-                {
-                    extend: 'colvis',
-                    columns: ':not(.noVis)'
-                },
-                $.extend( true, {}, buttonCommon, {
-                    extend: 'copy'
-                }),
-                $.extend( true, {}, buttonCommon, {
-                    extend: 'excel',
-                    autoFilter: true,
-                    sheetName: 'Exported data',
-                }),
-                $.extend( true, {}, buttonCommon, {
-                    extend: 'csv'
-                }),
-                $.extend( true, {}, buttonCommon, {
-                    extend: 'pdf',
-                    orientation: 'landscape',
-                    pageSize: 'LETTER'
-                }),
-                $.extend( true, {}, buttonCommon, {
-                    extend: 'print'
-                }),
-            ],
-        });
-    });
-</script>

--- a/dojo/templates/dojo/paging_snippet.html
+++ b/dojo/templates/dojo/paging_snippet.html
@@ -1,6 +1,7 @@
 {% load navigation_tags %}
 {% with page_param=prefix|add:'page' %}
 {% with page_size_param=prefix|add:'page_size' %}
+{% if page.paginator %}
 <div class="pull-left pagination  pagination-sm">
     Showing entries {{ page.start_index }} to {{ page.end_index }} of {{ page.paginator.count }}
 </div>
@@ -43,7 +44,7 @@
                 </li>
             {% endif %}
         </ul>
-
     </nav>
-    {% endwith %}
-    {% endwith %}
+{% endif %}
+{% endwith %}
+{% endwith %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -565,9 +565,9 @@
             </div>
             <div id="duplicate_tree" class="panel-body collapse">
                 {% if finding.duplicate_finding %}
-                    {% include "dojo/finding_related_list.html" with finding_context=finding finding_first_related=finding.duplicate_finding finding_list=duplicate_cluster %}
+                    {% include "dojo/finding_related_list.html" with finding_context=finding finding_first_related=finding.duplicate_finding finding_list=duplicate_cluster prefix='duplicate' %}
                 {% else %}
-                    {% include "dojo/finding_related_list.html" with finding_context=finding finding_first_related=finding finding_list=duplicate_cluster %}
+                    {% include "dojo/finding_related_list.html" with finding_context=finding finding_first_related=finding finding_list=duplicate_cluster prefix='duplicate' %}
                 {% endif %}
             </div>
         </div>
@@ -594,11 +594,11 @@
             <span id="the-filters-wrapper" class="collapse {% if similar_findings_filter.has_changed %}in{% endif %}">
                 <div id="the-filters" class="is-filters panel-body similar-filters">
                     {% url 'view_finding' finding.id as finding_url %}
-                    {% include "dojo/filter_snippet.html" with form=similar_findings_filter.form form_id="similar" clear_js=True restart_link=finding_url%}
+                    {% include "dojo/filter_snippet.html" with form=similar_findings_filter.form form_id="similar" clear_js=True restart_link=finding_url %}
                 </div>
                 {% if similar_findings_filter %}
                     <div id="similar_findings" class="panel-body">
-                        {% include "dojo/finding_related_list.html" with finding_context=finding finding_list=similar_findings %}
+                        {% include "dojo/finding_related_list.html" with finding_context=finding finding_list=similar_findings prefix='similar' %}
                     </div>
                 {% endif %}
             </span>
@@ -1284,6 +1284,102 @@
 
         $(".dojo-filter-set :input").not("button").addClass("form-control input-sm"); {% endcomment %}
 
+    </script>
+
+    <script type="application/javascript">
+        // DataTables Setup
+        $(document).ready(function() {
+            date =  new Date().toISOString().slice(0, 10);
+            var fileDated = 'Findings_List_' + date;
+            var columns = [
+                { "data": "relationship" },
+                { "data": "severity" },
+                { "data": "finding" , render: function (data, type, row) {
+                        return type === 'export' ? getDojoExportValueFromTag(data, 'a') :  data;
+                }},
+                { "data": "found_date" },
+                { "data": "status" },
+                { "data": "test" },
+                { "data": "engagement" },
+                { "data": "product" },
+                { "data": "cwe" },
+                { "data": "cve" },
+                { "data": "file_path" },
+                {% if system_settings.enable_jira %}
+                    { "data": "jira_id" },
+                {% endif %}
+                { "data": "action" },
+              ];
+
+            // Filter the list of items to display based on what is shown.
+            var disallowed_entries = new Set(["checkbox", "action"]);
+            var data_column_list = [];
+            for (var i = 0; i < columns.length; i++) {
+                if (!disallowed_entries.has(columns[i]["data"])) {
+                    data_column_list.push(i);
+                }
+            }
+
+            var buttonCommon = {
+                exportOptions: {
+                    columns: data_column_list,
+                    stripHtml: true,
+                    stripNewlines: true,
+                    trim: true,
+                    orthogonal: 'export'
+                },
+                filename: fileDated,
+                title: 'Similar Findings List'
+            };
+
+            // Mapping of table columns to objects for proper cleanup and data formatting
+            var dojoTable = $('#similar_findings_table').DataTable({
+                drawCallback: function(){
+                      $('.has-popover').popover({'trigger':'hover'});
+                },
+                colReorder: true,
+                "columns": columns,
+                order: [],
+                columnDefs: [
+                    {
+                        "orderable": false,
+                        "targets": [0, 1]
+                    },
+                    {
+                        targets: [0, 1],
+                        className: 'noVis'
+                    }
+                ],
+                dom: 'Bfrtip',
+                paging: false,
+                info: false,
+                buttons: [
+                    {
+                        extend: 'colvis',
+                        columns: ':not(.noVis)'
+                    },
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'copy'
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'excel',
+                        autoFilter: true,
+                        sheetName: 'Exported data',
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'csv'
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'pdf',
+                        orientation: 'landscape',
+                        pageSize: 'LETTER'
+                    }),
+                    $.extend( true, {}, buttonCommon, {
+                        extend: 'print'
+                    }),
+                ],
+            });
+        });
     </script>
 
     {% include "dojo/filter_js_snippet.html" %}


### PR DESCRIPTION
small bugfix after #3812 to avoid duplicate initialization of similar findings table when viewing duplicate or original findings.