### PR TITLE
fix typo in setup.py for jsonlines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'whitenoise==4.1.4',
         'django-environ==0.4.5',
         'titlecase',
-        'jsonlines=2.0.0'  # requred by yarn audit parser
+        'jsonlines==2.0.0'  # requred by yarn audit parser
     ],
 
     extras_require={'mysql': ['mysqlclient==2.0.3']},

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'whitenoise==4.1.4',
         'django-environ==0.4.5',
         'titlecase',
-        'jsonlines==1.2.0'  # requred by yarn audit parser
+        'jsonlines=2.0.0'  # requred by yarn audit parser
     ],
 
     extras_require={'mysql': ['mysqlclient==2.0.3']},

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'whitenoise==4.1.4',
         'django-environ==0.4.5',
         'titlecase',
-        'json-lines==1.2.0'  # requred by yarn audit parser
+        'jsonlines==1.2.0'  # requred by yarn audit parser
     ],
 
     extras_require={'mysql': ['mysqlclient==2.0.3']},


### PR DESCRIPTION
Related slack thread: https://owasp.slack.com/archives/C014H3ZV9U6/p1613934621008200

[jsonlines](https://pypi.org/project/jsonlines/) - it looks like this is the package that was intended. That is the one referenced in requirements.txt

[json-lines](https://pypi.org/project/json-lines/) - this is the one that it currently points to in the master branch.

This PR updates to the proper package and most recent version.