### PR TITLE
aftercare: add finding from template fix

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1016,7 +1016,8 @@ class FindingForm(forms.ModelForm):
 
         # do not show checkbox if finding is not accepted and simple risk acceptance is disabled
         # if checked, always show to allow unaccept also with full risk acceptance enabled
-        if not self.instance.risk_accepted and not self.instance.test.engagement.product.enable_simple_risk_acceptance:
+        # when adding from template, we don't have access to the test. quickfix for now to just hide simple risk acceptance
+        if not hasattr(self.instance, 'test') or (not self.instance.risk_accepted and not self.instance.test.engagement.product.enable_simple_risk_acceptance):
             del self.fields['risk_accepted']
         else:
             if self.instance.risk_accepted:

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -103,6 +103,7 @@ def finding_can_be_pushed_to_jira(finding, form=None):
     logger.debug('finding_can_be_pushed_to_jira: %s, %s, %s', active, verified, severity)
 
     if not active or not verified:
+        logger.debug('Findings must be active and verified to be pushed to JIRA')
         return False, 'Findings must be active and verified to be pushed to JIRA', 'not_active_or_verified'
 
     jira_minimum_threshold = None
@@ -110,6 +111,7 @@ def finding_can_be_pushed_to_jira(finding, form=None):
         jira_minimum_threshold = Finding.get_number_severity(System_Settings.objects.get().jira_minimum_severity)
 
         if jira_minimum_threshold and jira_minimum_threshold > Finding.get_number_severity(severity):
+            logger.debug('Finding below the minimum JIRA severity threshold (%s).' % System_Settings.objects.get().jira_minimum_severity)
             return False, 'Finding below the minimum JIRA severity threshold (%s).' % System_Settings.objects.get().jira_minimum_severity, 'below_minimum_threshold'
 
     return True, None, None
@@ -471,7 +473,7 @@ def add_jira_issue(find):
     can_be_pushed_to_jira, error_message, error_code = finding_can_be_pushed_to_jira(find)
     if not can_be_pushed_to_jira:
         log_jira_alert(error_message, find)
-        logger.warn("Finding {} cannot be pushed to JIRA: %s.", find.id, error_message)
+        logger.warn("Finding %s cannot be pushed to JIRA: %s.", find.id, error_message)
         logger.warn("The JIRA issue will NOT be created.")
         return False
     logger.debug('Trying to create a new JIRA issue for finding {}...'.format(find.id))

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -934,6 +934,7 @@
                 ],
                 dom: 'Bfrtip',
                 paging: false,
+                info: false,
                 buttons: [
                     {
                         extend: 'colvis',

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -106,7 +106,7 @@ def view_test(request, tid):
     # test_imports = test.test_import_set.all()
     paged_test_imports = get_page_items_and_count(request, test.test_import_set.all(), 5, prefix='test_imports')
 
-    paged_findings = get_page_items_and_count(request, prefetch_for_findings(findings.qs), 25)
+    paged_findings = get_page_items_and_count(request, prefetch_for_findings(findings.qs), 25, prefix='findings')
     paged_stub_findings = get_page_items(request, stub_findings, 25)
     show_re_upload = any(test.test_type.name in code for code in ImportScanForm.SORTED_SCAN_TYPE_CHOICES)
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -493,13 +493,12 @@ def add_temp_finding(request, tid, fid):
     findings = Finding_Template.objects.all()
     push_all_jira_issues = jira_helper.is_push_all_issues(finding)
 
-    if jira_helper.get_jira_project(test):
-        jform = JIRAFindingForm(push_all=jira_helper.is_push_all_issues(test), prefix='jiraform', jira_project=jira_helper.get_jira_project(test), finding_form=form)
-    else:
-        jform = None
-
     if request.method == 'POST':
+
         form = FindingForm(request.POST, template=True, req_resp=None)
+        if jira_helper.get_jira_project(test):
+            jform = JIRAFindingForm(push_all=jira_helper.is_push_all_issues(test), prefix='jiraform', jira_project=jira_helper.get_jira_project(test), finding_form=form)
+
         if (form['active'].value() is False or form['false_p'].value()) and form['duplicate'].value() is False:
             closing_disabled = Note_Type.objects.filter(is_mandatory=True, is_active=True).count()
             if closing_disabled != 0:
@@ -596,6 +595,9 @@ def add_temp_finding(request, tid, fid):
                                     'impact': finding.impact,
                                     'references': finding.references,
                                     'numerical_severity': finding.numerical_severity})
+
+        if jira_helper.get_jira_project(test):
+            jform = JIRAFindingForm(push_all=jira_helper.is_push_all_issues(test), prefix='jiraform', jira_project=jira_helper.get_jira_project(test), finding_form=form)
 
     product_tab = Product_Tab(test.engagement.product.id, title="Add Finding", tab="engagements")
     product_tab.setEngagement(test.engagement)


### PR DESCRIPTION
adding a finding to a test from a template failed for two reasons:
- initialization of jira form was broken 
- initialization of finding form was broken

also the paging on view_test was broken 

all this was only in dev I believe