### PR TITLE
Helm mount ca volume, ingress spec

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: "1.13.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.5.0
+version: 1.5.1
 icon: https://www.defectdojo.org/img/favicon.ico

--- a/helm/defectdojo/requirements.lock
+++ b/helm/defectdojo/requirements.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 1.6.9
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 9.8.11
+  version: 10.3.5
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 8.7.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 12.0.0
-digest: sha256:9fce637d96f0c9be7835159b717cc1373af5403873205fea67eed89220e3387e
-generated: "2020-12-01T14:45:19.341437819+01:00"
+digest: sha256:971488f759f2dc91f38b92a281bca1ecec1cbfa51870655cfd20667c6078e201
+generated: "2021-02-22T20:25:51.156231357+01:00"

--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: "@stable"
     condition: mysql.enabled
   - name: postgresql
-    version: 9.8.11
+    version: 10.3.5
     repository: "@bitnami"
     condition: postgresql.enabled
   - name: rabbitmq

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -39,7 +39,7 @@ data:
   NGINX_METRICS_ENABLED: '{{ .Values.monitoring.enabled }}'
   METRICS_HTTP_AUTH_USER: {{ .Values.monitoring.user | default "monitoring" }}
 {{- if  .Values.django.uwsgi.certificates.enabled }}
-  REQUESTS_CA_BUNDLE: {{ .Values.django.uwsgi.certificates.certMountPath }}
+  REQUESTS_CA_BUNDLE: {{ .Values.django.uwsgi.certificates.certMountPath }}{{ .Values.django.uwsgi.certificates.certFileName }}
 {{- end }}
 {{- if  .Values.extraConfigs  }}
 {{ toYaml .Values.extraConfigs | indent 2 }}{{- end }}

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -38,5 +38,8 @@ data:
   DD_DJANGO_METRICS_ENABLED: '{{ .Values.monitoring.enabled }}'
   NGINX_METRICS_ENABLED: '{{ .Values.monitoring.enabled }}'
   METRICS_HTTP_AUTH_USER: {{ .Values.monitoring.user | default "monitoring" }}
+{{- if  .Values.django.uwsgi.certificates.enabled }}
+  REQUESTS_CA_BUNDLE: {{ .Values.django.uwsgi.certificates.certMountPath }}
+{{- end }}
 {{- if  .Values.extraConfigs  }}
 {{ toYaml .Values.extraConfigs | indent 2 }}{{- end }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -88,7 +88,7 @@ spec:
         {{- if  .Values.django.uwsgi.certificates.enabled }}
         - name: cert-mount
           mountPath: {{ .Values.django.uwsgi.certificates.certMountPath }}
-        {{- end }}   
+        {{- end }}
         ports:
         - name: http
           protocol: TCP

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -41,6 +41,11 @@ spec:
       volumes:
       - name: run
         emptyDir: {}
+      {{- if  .Values.django.uwsgi.certificates.enabled }}
+      - name: cert-mount
+        configMap:
+          name: {{ .Values.django.uwsgi.certificates.configName }}
+      {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy
@@ -80,6 +85,10 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run/defectdojo
+        {{- if  .Values.django.uwsgi.certificates.enabled }}
+        - name: cert-mount
+          mountPath: {{ .Values.django.uwsgi.certificates.certMountPath }}
+        {{- end }}   
         ports:
         - name: http
           protocol: TCP

--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.django.ingress.enabled -}}
 {{- $fullName := include "defectdojo.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -36,8 +36,11 @@ spec:
   - host: {{ .Values.host }}
     http:
       paths:
-        - path: /
+        - pathType: Prefix
+          path: "/"
           backend:
-            serviceName: {{ $fullName }}-django
-            servicePort: http
+            service:
+              name: {{ $fullName }}-django
+              port:
+                name: http
 {{- end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -150,7 +150,13 @@ django:
       processes: 2
       threads: 2
     enable_ptvsd: false  # this also requires DD_DEBUG to be set to True
-
+    certificates:
+    # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
+    # to create configMap `kubectl create  cm defect-dojo-certs --from-file=file_path`
+      enabled: false
+      configName: defect-dojo-certs
+      certMountPath: /certs/cacert.crt
+      
 initializer:
   run: true
   keepSeconds: 60

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -155,8 +155,8 @@ django:
     # to create configMap `kubectl create  cm defect-dojo-certs --from-file=file_path`
       enabled: false
       configName: defect-dojo-certs
-      certMountPath: /certs/cacert.crt
-      
+      certMountPath: /certs/
+
 initializer:
   run: true
   keepSeconds: 60

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -152,7 +152,7 @@ django:
     enable_ptvsd: false  # this also requires DD_DEBUG to be set to True
     certificates:
     # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
-    # to create configMap `kubectl create  cm defect-dojo-certs --from-file=ca.crt`
+    # to create configMap `kubectl create  cm defectdojo-certs --from-file=ca.crt`
       enabled: false
       configName: defectdojo-ca-certs
       certMountPath: /certs/

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -152,7 +152,7 @@ django:
     enable_ptvsd: false  # this also requires DD_DEBUG to be set to True
     certificates:
     # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
-    # to create configMap `kubectl create  cm defectdojo-certs --from-file=ca.crt`
+    # to create configMap `kubectl create  cm defectdojo-ca-certs --from-file=ca.crt`
       enabled: false
       configName: defectdojo-ca-certs
       certMountPath: /certs/

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -154,7 +154,7 @@ django:
     # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
     # to create configMap `kubectl create  cm defect-dojo-certs --from-file=ca.crt`
       enabled: false
-      configName: defect-dojo-ca-certs
+      configName: defectdojo-ca-certs
       certMountPath: /certs/
       certFileName: ca.crt
 

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -152,10 +152,11 @@ django:
     enable_ptvsd: false  # this also requires DD_DEBUG to be set to True
     certificates:
     # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
-    # to create configMap `kubectl create  cm defect-dojo-certs --from-file=file_path`
+    # to create configMap `kubectl create  cm defect-dojo-certs --from-file=ca.crt`
       enabled: false
-      configName: defect-dojo-certs
+      configName: defect-dojo-ca-certs
       certMountPath: /certs/
+      certFileName: ca.crt
 
 initializer:
   run: true


### PR DESCRIPTION
This PR contains:
-  option to mount CA cert as volume
-  updated values.yaml
- updates ingress to networking.k8s.io/v1 spec
- Updates postgres helm (to respect: postgresql.shmVolume.enabled=false)
