### PR TITLE
Bugfix at close_old_findings

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1262,6 +1262,7 @@ class ImportScanSerializer(serializers.Serializer):
 
             for old_finding in old_findings:
                 old_finding.active = False
+                old_finding.is_Mitigated = True
                 old_finding.mitigated = datetime.datetime.combine(
                     test.target_start,
                     timezone.now().time())


### PR DESCRIPTION
Fixed a bug where the 'is_Mitigated' field is not updated when findings are automatically closed, which leads to them not been considered closed internally by DefectDojo (although on the UI it appears "Mitigated"). This causes these findings not to appear on metrics nor at the 'View Closed Findings' option.