### PR TITLE
Quick report based on current finding filters

### DIFF
--- a/dojo/reports/urls.py
+++ b/dojo/reports/urls.py
@@ -40,4 +40,6 @@ urlpatterns = [
         views.report_endpoints, name='report_endpoints'),
     url(r'^reports/custom$',
         views.custom_report, name='custom_report'),
+    url(r'^reports/quick$',
+        views.quick_report, name='quick_report'),
 ]

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -1109,7 +1109,7 @@ def quick_report(request):
              'false_positive', 'inactive']
     request.path = url
     obj_name = obj_id = view = query = None
-    path_items = list(filter(None, re.split('/|\?', url)))
+    path_items = list(filter(None, re.split('/|\?', url))) # noqa W605
     try:
         finding_index = path_items.index('finding')
     except ValueError:

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -1,8 +1,9 @@
 import logging
 import mimetypes
 import os
+import re
 import urllib.parse
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -12,6 +13,7 @@ from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect, HttpResponseForbidden, JsonResponse
 from django.http import HttpResponse
+from django_filters.filters import _truncate
 from django.shortcuts import render, get_object_or_404
 from django.utils import timezone
 from django.db.models import Q
@@ -19,7 +21,7 @@ from django.db.models import Q
 from dojo.celery import app
 from dojo.endpoint.views import get_endpoint_ids
 from dojo.filters import ReportFindingFilter, ReportAuthedFindingFilter, EndpointReportFilter, ReportFilter, \
-    EndpointFilter
+    EndpointFilter, now
 from dojo.forms import ReportOptionsForm, DeleteReportForm
 from dojo.models import Product_Type, Finding, Product, Engagement, Test, \
     Dojo_User, Endpoint, Report, Risk_Acceptance
@@ -939,3 +941,204 @@ def prefetch_related_endpoints_for_report(endpoints):
                                       'product',
                                       'tags'
                                      )
+
+
+def generate_quick_report(request, findings, obj=None):
+    product = engagement = test = None
+
+    if obj:
+        if type(obj).__name__ == "Product":
+            product = obj
+        elif type(obj).__name__ == "Engagement":
+            engagement = obj
+        elif type(obj).__name__ == "Test":
+            test = obj
+
+    return render(request, 'dojo/finding_pdf_report.html', {
+                    'report_name': 'Finding Report',
+                    'product': product,
+                    'engagement': engagement,
+                    'test': test,
+                    'findings': findings,
+                    'user': request.user,
+                    'team_name': settings.TEAM_NAME,
+                    'title': 'Finding Report',
+                    'user_id': request.user.id,
+                  })
+
+
+def validate_date(date, filter_lookup):
+    # Today
+    if date == 1:
+        filter_lookup['date__year'] = now().year
+        filter_lookup['date__month'] = now().month
+        filter_lookup['date__day'] = now().day
+    # Past 7 Days
+    elif date == 2:
+        filter_lookup['date__gte'] = _truncate(now() - timedelta(days=7))
+        filter_lookup['date__lt'] = _truncate(now() + timedelta(days=1))
+    # Past 30 Days
+    elif date == 3:
+        filter_lookup['date__gte'] = _truncate(now() - timedelta(days=30))
+        filter_lookup['date__lt'] = _truncate(now() + timedelta(days=1))
+    # Past 90 Days
+    elif date == 4:
+        filter_lookup['date__gte'] = _truncate(now() - timedelta(days=90))
+        filter_lookup['date__lt'] = _truncate(now() + timedelta(days=1))
+    # Current Month
+    elif date == 5:
+        filter_lookup['date__year'] = now().year
+        filter_lookup['date__month'] = now().month
+    # Current Year
+    elif date == 6:
+        filter_lookup['date__year'] = now().year
+    # Past Year
+    elif date == 7:
+        filter_lookup['date__gte'] = _truncate(now() - timedelta(days=365))
+        filter_lookup['date__lt'] = _truncate(now() + timedelta(days=1))
+
+
+def validate(field, value):
+    validated_field = field
+    validated_value = None
+    # Boolean values
+    if value in ['true', 'false', 'unknown']:
+        if value == 'true':
+            validated_value = True
+        elif value == 'false':
+            validated_value = False
+    # Tags (lists)
+    elif 'tags' in field:
+        validated_field = value.split(', ')
+        validated_field = field + '__in'
+    else:
+        # Integer (ID) values
+        try:
+            validated_value = int(value)
+            if field not in ['nb_occurences', 'nb_occurences', 'date', 'cwe']:
+                validated_field = field + '__id'
+        except ValueError:
+            # Okay it must be a string
+            validated_value = None if not len(value) else value
+    return (validated_field, validated_value)
+
+
+def parse_query(filter_lookup, query):
+    if query:
+        split_items = query.split('&')
+        items = []
+        for item in split_items:
+            query_split = item.split('=')
+            items.append((query_split[0], urllib.parse.unquote(query_split[1]).replace('+', ' ')))
+            field = query_split[0]
+            value = urllib.parse.unquote(query_split[1]).replace('+', ' ')
+            validated_data = validate(field, value)
+            # value could be False
+            if validated_data[1] is not None:
+                filter_lookup[validated_data[0]] = validated_data[1]
+        # Handle the date if specified
+        date = filter_lookup.pop('date', None)
+        if date:
+            validated_date = validate_date(date, filter_lookup)
+        # Handle the ordering if specified
+        order = filter_lookup.pop('o', None)
+        findings = Finding.objects.filter(**filter_lookup)
+        if order:
+            findings = findings.order_by(order)
+    else:
+        findings = Finding.objects.filter(**filter_lookup)
+    return findings
+
+
+def get_view(filter_lookup, obj_name, obj_id, view):
+    obj = None
+    if obj_id:
+        if 'product' in obj_name:
+            obj = Product.objects.get(pk=obj_id)
+            filter_lookup['test__engagement__product__id'] = obj_id
+        elif 'engagement' in obj_name:
+            obj = Engagement.objects.get(pk=obj_id)
+            filter_lookup['test__engagement__id'] = obj_id
+        elif 'test' in obj_name:
+            obj = Test.objects.get(pk=obj_id)
+            filter_lookup['test__id'] = obj_id
+
+    if view:
+        if view == 'open':
+            filter_lookup['active'] = True
+        elif view == 'inactive':
+            filter_lookup['active'] = True
+        elif view == 'verified':
+            filter_lookup['verified'] = True
+        elif view == 'closed':
+            filter_lookup['is_Mitigated'] = True
+        elif view == 'accepted':
+            filter_lookup['risk_accepted'] = True
+        elif view == 'out_of_scope':
+            filter_lookup['out_of_scope'] = True
+            filter_lookup['active'] = False
+        elif view == 'false_positive':
+            filter_lookup['false_positive'] = True
+            filter_lookup['active'] = False
+            filter_lookup['duplicate'] = False
+        elif view == 'inactive':
+            filter_lookup['false_positive'] = False
+            filter_lookup['active'] = False
+            filter_lookup['duplicate'] = False
+            filter_lookup['is_Mitigated'] = False
+            filter_lookup['out_of_scope'] = False
+
+    return obj
+
+
+def get_list_index(list, index):
+    try:
+        element = list[index]
+    except Exception as e:
+        element = None
+    return element
+
+
+def quick_report(request):
+    url = request.GET.get('url', None)
+    if not url:
+        raise Http404('Please use the report button when viewing findings')
+
+    views = ['all', 'open', 'inactive', 'verified',
+             'closed', 'accepted', 'out_of_scope',
+             'false_positive', 'inactive']
+    request.path = url
+    obj_name = obj_id = view = query = None
+    path_items = list(filter(None, re.split('/|\?', url)))
+    try:
+        finding_index = path_items.index('finding')
+    except ValueError:
+        finding_index = -1
+    filter_lookup = {}
+    # There is a engagement or product here
+    if finding_index > 0:
+        # path_items ['product', '1', 'finding', 'closed', 'test__engagement__product=1']
+        obj_name = get_list_index(path_items, 0)
+        obj_id = get_list_index(path_items, 1)
+        view = get_list_index(path_items, 3)
+        query = get_list_index(path_items, 4)
+        # Try to catch a mix up
+        query = query if view in views else view
+    # This is findings only. Accomodate view and query
+    elif finding_index == 0:
+        # path_items ['finding', 'closed', 'title=blah']
+        obj_name = get_list_index(path_items, 0)
+        view = get_list_index(path_items, 1)
+        query = get_list_index(path_items, 2)
+        # Try to catch a mix up
+        query = query if view in views else view
+    # This is a test or engagement only
+    elif finding_index == -1:
+        # path_items ['test', '1', 'test__engagement__product=1']
+        obj_name = get_list_index(path_items, 0)
+        obj_id = get_list_index(path_items, 1)
+        query = get_list_index(path_items, 2)
+
+    obj = get_view(filter_lookup, obj_name, obj_id, view)
+    findings = parse_query(filter_lookup, query)
+    return generate_quick_report(request, findings, obj)

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -424,14 +424,14 @@
                     <span class="hidden-xs"> Findings{% if product_tab.findings > 0 %} <span class="badge">{{ product_tab.findings }}</span>{% endif %}</span>
                     <span class="caret"></span></a>
                     <ul class="dropdown-menu">
-                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=20&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-list-alt"></i> View Active Findings</a></li>
-                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&verified=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-list-alt"></i> View Active Verified Findings</a></li>
-                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}&severity=Critical"><i class="fa fa-exclamation-triangle"></i> View Critical Findings</a></li>
-                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?active=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement__product={{ product_tab.product.id }}&date=2"><i class="fa fa-calendar"></i> View Findings from Last 7 Days </a></li>
+                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}"><i class="fa fa-list-alt"></i> View Active Findings</a></li>
+                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?verified=true"><i class="fa fa-list-alt"></i> View Active Verified Findings</a></li>
+                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?severity=Critical"><i class="fa fa-exclamation-triangle"></i> View Critical Findings</a></li>
+                      <li><a href="{% url 'product_open_findings' product_tab.product.id %}?date=2"><i class="fa fa-calendar"></i> View Findings from Last 7 Days </a></li>
                       <li role="separator" class="divider"></li>
-                      <li><a href="{% url 'product_accepted_findings' product_tab.product.id %}?test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-check"></i> View Risk Accepted Findings</a></li>
-                      <li><a href="{% url 'product_all_findings' product_tab.product.id %}?test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-search"></i> View All Findings</a></li>
-                      <li><a href="{% url 'product_closed_findings' product_tab.product.id %}?test__engagement__product={{ product_tab.product.id }}"><i class="fa fa-fire-extinguisher"></i>&nbsp;&nbsp;View Closed Findings </a></li>
+                      <li><a href="{% url 'product_accepted_findings' product_tab.product.id %}"><i class="fa fa-check"></i> View Risk Accepted Findings</a></li>
+                      <li><a href="{% url 'product_all_findings' product_tab.product.id %}"><i class="fa fa-search"></i> View All Findings</a></li>
+                      <li><a href="{% url 'product_closed_findings' product_tab.product.id %}"><i class="fa fa-fire-extinguisher"></i>&nbsp;&nbsp;View Closed Findings </a></li>
                       {% if user|is_authorized_for_staff:product_tab.product %}
                       <li role="separator" class="divider"></li>
                       <li><a href="{% url 'ad_hoc_finding' product_tab.product.id %}"><i class="fa fa-plus"></i> Add New Finding</a></li>

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -12,6 +12,13 @@
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
                         </div>
+                        <form method="get" action="{% url 'quick_report' %}" class="pull-right">
+                            <input type="hidden" name="url" value="{{ request.get_full_path }}">
+                            <input type="hidden" name="_generate" value="_generate">
+                            <button class="btn btn-primary" type="submit" id="quick_report" aria-expanded="true">
+                                <i class="fa fa-file-text-o"></i>
+                            </button>
+                        </form>
                     </h3>
                 </div>
                 <div id="the-filters" class="is-filters panel-body collapse" >

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -13,9 +13,9 @@
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
                         </div>
                         <form method="get" action="{% url 'quick_report' %}" class="pull-right">
-                            <input type="hidden" name="url" value="{{ request.get_full_path }}">
-                            <input type="hidden" name="_generate" value="_generate">
-                            <button class="btn btn-primary" type="submit" id="quick_report" aria-expanded="true">
+                            <input type="hidden" label="url" name="url" value="{{ request.get_full_path }}">
+                            <input type="hidden" label="_generate" name="_generate" value="_generate">
+                            <button class="btn btn-primary" type="submit" label="quick_report" id="quick_report" aria-expanded="true">
                                 <i class="fa fa-file-text-o"></i>
                             </button>
                         </form>

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -217,12 +217,12 @@
                                 <li class="divider"></li>
                                 {% endif %}
                                 <li role="presentation">
-                                    <a href="{% url 'engagment_open_findings' eng.id %}?active=2&verified=2&false_p=3&duplicate=2&out_of_scope=1&test__engagement={{ eng.id }}">
+                                    <a href="{% url 'engagment_open_findings' eng.id %}?active=true">
                                         <i class="fa fa-file-text-o"></i> View Open Findings
                                     </a>
                                 </li>
                                 <li role="presentation">
-                                    <a href="{% url 'engagment_all_findings' eng.id %}?test__engagement={{ eng.id }}">
+                                    <a href="{% url 'engagment_all_findings' eng.id %}">
                                         <i class="fa fa-file-text-o"></i> View All Findings
                                     </a>
                                 </li>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -274,9 +274,9 @@
                         </ul>
                     </div>
                     <form method="get" action="{% url 'quick_report' %}" class="pull-right">
-                        <input type="hidden" name="url" value="{{ request.get_full_path }}">
-                        <input type="hidden" name="_generate" value="_generate">
-                        <button class="btn btn-primary" type="submit" id="quick_report" aria-expanded="true">
+                        <input type="hidden" label="url" name="url" value="{{ request.get_full_path }}">
+                        <input type="hidden" label="_generate" name="_generate" value="_generate">
+                        <button class="btn btn-primary" type="submit" label="quick_report" id="quick_report" aria-expanded="true">
                             <i class="fa fa-file-text-o"></i>
                         </button>
                     </form>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -273,6 +273,13 @@
                             </li>
                         </ul>
                     </div>
+                    <form method="get" action="{% url 'quick_report' %}" class="pull-right">
+                        <input type="hidden" name="url" value="{{ request.get_full_path }}">
+                        <input type="hidden" name="_generate" value="_generate">
+                        <button class="btn btn-primary" type="submit" id="quick_report" aria-expanded="true">
+                            <i class="fa fa-file-text-o"></i>
+                        </button>
+                    </form>
                 </h4>
             </div>
         </div>


### PR DESCRIPTION
Generate a finding report very quickly with the current findings displayed on a given page with the current filters applied. No need redo the current filter options on the report tab any longer.
<img width="1728" alt="Screen Shot 2021-02-25 at 1 52 07 AM" src="https://user-images.githubusercontent.com/46459665/109120913-2e98a280-770c-11eb-8a21-13d2ae7d3d0e.png">
