### PR TITLE
set mitigation related fields correctly at close_old_findings

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1262,6 +1262,7 @@ class ImportScanSerializer(serializers.Serializer):
 
             for old_finding in old_findings:
                 old_finding.active = False
+                old_finding.is_Mitigated = True
                 old_finding.mitigated = datetime.datetime.combine(
                     test.target_start,
                     timezone.now().time())

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1263,14 +1263,7 @@ class ImportScanSerializer(serializers.Serializer):
             for old_finding in old_findings:
                 old_finding.active = False
                 old_finding.is_Mitigated = True
-                old_finding.mitigated = datetime.datetime.combine(
-                    test.target_start,
-                    timezone.now().time())
-                if settings.USE_TZ:
-                    old_finding.mitigated = timezone.make_aware(
-                        old_finding.mitigated,
-                        timezone.get_default_timezone())
-                old_finding.mitigated_by = self.context['request'].user
+                finding_helper.update_finding_status(old_finding, self.context['request'].user)
                 old_finding.notes.create(author=self.context['request'].user,
                                          entry="This finding has been automatically closed"
                                          " as it is not present anymore in recent scans.")


### PR DESCRIPTION
Fixed a bug where the 'is_Mitigated' field is not updated when findings are automatically closed, which leads to them not been considered closed internally by DefectDojo (although on the UI it appears "Mitigated"). This causes these findings not to appear on metrics nor at the 'View Closed Findings' option.