### PR TITLE
remove left over risk acceptance jira comment code

### DIFF
--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -26,9 +26,6 @@ def expire_now(risk_acceptance):
                 if risk_acceptance.restart_sla_expired:
                     finding.sla_start_date = timezone.now().date()
 
-                if finding.has_jira_issue:
-                    jira_helper.add_simple_jira_comment(jira_instance, finding.jira_issue, jira_comment)
-
                 finding.save(dedupe_option=False)
                 reactivated_findings.append(finding)
                 # findings remain in this risk acceptance for reporting / metrics purposes


### PR DESCRIPTION
comments were refactored at some point and are now handled by: https://github.com/DefectDojo/django-DefectDojo/blob/ebca1322fef7fb47a651b96525f80c7b82a2abd6/dojo/risk_acceptance/helper.py#L39

the line removed references 2 variables that don't exist, so need to remove that.