### PR TITLE
fix dates and reimport history for similar / duplicate findings

### DIFF
--- a/dojo/templates/dojo/finding_related_row.html
+++ b/dojo/templates/dojo/finding_related_row.html
@@ -30,8 +30,8 @@
             ({{ note_count }} note{{ note_count|pluralize }})
         {% endwith %}
     </td>
-    <td class="nowrap">{{ finding.date|date }}</td>
-    <td>{{ similar_finding|finding_display_status|safe }}&nbsp;{{ finding|import_history }}</td>
+    <td class="nowrap">{{ similar_finding.date|date }}</td>
+    <td>{{ similar_finding|finding_display_status|safe }}&nbsp;{{ similar_finding|import_history }}</td>
     <td><a href="{% url 'view_test' similar_finding.test_id %}">{{ similar_finding.test }}</a></td>
     <td><a href="{% url 'view_engagement' similar_finding.test.engagement_id %}">{{ similar_finding.test.engagement.name }}</a>
     {% if similar_finding.test.engagement.version %}


### PR DESCRIPTION
fixes #3955 
similar findings list and duplicate cluster now shows the correct date and reimport history for each finding