### PR TITLE
Fix gitpython version and remove jsonlines

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ titlecase==2.0.0
 social-auth-app-django==4.0.0
 social-auth-core==4.0.3
 Python-jose==3.2.0
-gitpython==2.1.13
+gitpython==3.0.7
 ptvsd==4.3.2
 python-gitlab==2.6.0
 google-auth==1.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,14 +52,13 @@ titlecase==2.0.0
 social-auth-app-django==4.0.0
 social-auth-core==4.0.3
 Python-jose==3.2.0
-gitpython>=2.1.13
+gitpython==2.1.13
 ptvsd==4.3.2
 python-gitlab==2.6.0
 google-auth==1.27.0
 google-api-python-client==1.12.8
 google-auth-oauthlib==0.4.2
 drf_yasg2==1.19.4
-jsonlines==2.0.0  # requred by yarn audit parser
 django-saml2-auth==2.2.1
 cpe==1.2.1
 packageurl-python==0.9.4


### PR DESCRIPTION
Fix 2 dependencies problems:
1. `gitpython` don't use a pinned version, switching to a pinned one
https://github.com/DefectDojo/django-DefectDojo/blob/920503f93e74b2a266a5f913283f60333ffdff48/requirements.txt#L55
2. remove useless dependency `jsonlines`
https://github.com/DefectDojo/django-DefectDojo/blob/920503f93e74b2a266a5f913283f60333ffdff48/requirements.txt#L62

### Regarding the 1)

Relevant issue upstream https://github.com/gitpython-developers/GitPython/issues/983

```
 File "/usr/local/lib/python3.6/site-packages/git/compat.py", line 16, in <module>
    from gitdb.utils.compat import (
ModuleNotFoundError: No module named 'gitdb.utils.compat'
```