### PR TITLE
Rename db migration for ipscan removal

### DIFF
--- a/dojo/db_migrations/0083_remove_ipscan.py
+++ b/dojo/db_migrations/0083_remove_ipscan.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dojo', '0079_system_settings_disclaimer'),
+        ('dojo', '0082_last_status_update_populate'),
     ]
 
     operations = [


### PR DESCRIPTION
The order of db migrations was not correct anymore after 3 parallel changes