### PR TITLE
Revert "unit tests: don't build & start unneeded services"

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       # phased startup so we can use the exit code from unit test container
       - name: Start MySQL
-        run: docker-compose up --no-deps -d mysql
+        run: docker-compose up -d
 
       # no celery or initializer needed for unit tests
       - name: Unit tests


### PR DESCRIPTION
Reverts DefectDojo/django-DefectDojo#3992
It was merged with failing tests and now all unit tests are hanging in GHA