### PR TITLE
celery: allow forced synchronous execution

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -10,9 +10,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def we_want_async():
+def we_want_async(*args, **kwargs):
     from dojo.utils import get_current_user
     from dojo.models import Dojo_User
+
+    sync = kwargs.get('sync', False)
+    if sync:
+        logger.debug('dojo_async_task: running task in the foreground as sync=True has been found as kwarg')
+        return False
 
     user = get_current_user()
 
@@ -28,7 +33,7 @@ def we_want_async():
 def dojo_async_task(func):
     @wraps(func)
     def __wrapper__(*args, **kwargs):
-        if we_want_async():
+        if we_want_async(*args, **kwargs):
             return func.delay(*args, **kwargs)
         else:
             return func(*args, **kwargs)


### PR DESCRIPTION
Currently our `dojo_async_task` decorator looks at the `block_execution` field in the users profile to determine if a task (deduplication, push to jira, send email, etc) should be performed synchronously, or asynchronously using celery.

There can be situation where this is the right default approach, for example when using the API. But sometimes in the UI you want direct feedback to see if that push to JIRA (or other task) was succesful.

I am going to use this in a future PR, but didn't want to sneak it in there. So here is the `sync=True` flag in its own PR.

example: `jira_helper.push_to_jira(finding, sync=True)` will ensure it's always performed synchronously in the current request/thread and the task won't get posted to celery.