### PR TITLE
Fix the new dirs for parser test and supress the need to modify facto…

### DIFF
--- a/docs/content/contributing/how-to-write-a-parser.md
+++ b/docs/content/contributing/how-to-write-a-parser.md
@@ -35,8 +35,8 @@ You'd want to build your docker images locally, and eventually pass in your loca
 |`dojo/tools/<parser_dir>/__init__.py`          | Empty file for class initialization
 |`dojo/tools/<parser_dir>/parser.py`            | The meat. This is where you write your actual parser
 |`dojo/unittests/scans/<parser_dir>/{many_vulns,no_vuln,one_vuln}.json` | Sample files containing meaningful data for unit tests. The minimal set.
-|`dojo/unittests/test_<parser_dir>_parser.py`   | The unittest class, holding unit tests definitions
-|`dojo/tools/factory.py`                        | Import there your new parser class and add it to the long list of `register_parser`  statement
+|`dojo/unittests/tools/test_<parser_dir>_parser.py`   | The unittest class, holding unit tests definitions
+
 
 ## Things to pay attention to
 


### PR DESCRIPTION
Seems the docs is not really update actually. 
The tests shoudl go to  `dojo/unittests/tools/test_<parser_dir>_parser.py` and it seems we do not need to modify factory.py 


