### PR TITLE
Netsparker: Fix crashing parser at method get_findings()

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ A magical, illusionary, non-existent, YMMV, wannabe, no guarantees list of thing
 - New permission model
 - Push groups of findings to a single JIRA ticket
 - Reimport matching improvements
-- New UI (SPA on top of API)
-- More parsers (CycloneDX, OVAL)
 
 
 ## Support, Bug Reports and Getting Involved

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ See [Wrappers](WRAPPERS.md)
 See [Release and branch model](BRANCHING-MODEL.md)
 
 
+## Roadmap
+A magical, illusionary, non-existent, YMMV, wannabe, no guarantees list of thing we may or may not be working on:
+- New permission model
+- Push groups of findings to a single JIRA ticket
+- Reimport matching improvements
+- New UI (SPA on top of API)
+- More parsers (CycloneDX, OVAL)
+
+
 ## Support, Bug Reports and Getting Involved
 Please come to our Slack channel first, where we can try to help you or point you in the right direction:
 

--- a/dojo/tools/netsparker/parser.py
+++ b/dojo/tools/netsparker/parser.py
@@ -79,5 +79,4 @@ class NetsparkerParser(object):
                 dupes[dupe_key] = find
                 findingdetail = ''
 
-        self.items = list(dupes.values())
-        return self.items
+        return list(dupes.values())

--- a/dojo/tools/netsparker/parser.py
+++ b/dojo/tools/netsparker/parser.py
@@ -80,3 +80,4 @@ class NetsparkerParser(object):
                 findingdetail = ''
 
         self.items = list(dupes.values())
+        return self.items


### PR DESCRIPTION
The parser is not working (TypeError: object of type 'NoneType' has no len()), which triggers an HTTP 500 response. 
This is because the get_findings(self, filename, test) method defined for the Netsparker parser (line 30) does not return the list of findings as expected in "https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/engagement/views.py#L583" (line 583) "parser_findings = parser.get_findings(file, t)"
Just adding a return statement solves the import issues.