### PR TITLE
JIRA: fix webhook mitigated by

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -23,7 +23,10 @@ def pre_save_finding_status_change(sender, instance, changed_fields=None, **kwar
 
     for field, (old, new) in changed_fields.items():
         logger.debug("%i: %s changed from %s to %s" % (instance.id or 0, field, old, new))
-        update_finding_status(instance, get_current_user(), changed_fields)
+        user = None
+        if get_current_user() and get_current_user().is_authenticated:
+            user = get_current_user()
+        update_finding_status(instance, user, changed_fields)
 
 
 # also get signal when id is set/changed so we can process new findings

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -108,7 +108,7 @@ def webhook(request, secret=None):
                                 finding.active = False
                                 finding.mitigated = now
                                 finding.is_Mitigated = True
-                                finding.mitigated_by = User.objects.get_or_create(username='JIRA')
+                                finding.mitigated_by, created = User.objects.get_or_create(username='JIRA')
                                 finding.endpoints.clear()
                                 finding.false_p = False
                                 ra_helper.remove_from_any_risk_acceptance(finding)

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -108,6 +108,7 @@ def webhook(request, secret=None):
                                 finding.active = False
                                 finding.mitigated = now
                                 finding.is_Mitigated = True
+                                finding.mitigated_by = User.objects.get_or_create(username='JIRA')
                                 finding.endpoints.clear()
                                 finding.false_p = False
                                 ra_helper.remove_from_any_risk_acceptance(finding)

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -108,7 +108,7 @@ def webhook(request, secret=None):
                                 finding.active = False
                                 finding.mitigated = now
                                 finding.is_Mitigated = True
-                                finding.mitigated_by, created = User.objects.get_or_create(username='JIRA')
+                                finding.mitigated_by, _ = User.objects.get_or_create(username='JIRA')
                                 finding.endpoints.clear()
                                 finding.false_p = False
                                 ra_helper.remove_from_any_risk_acceptance(finding)


### PR DESCRIPTION
Currently in dev there is an error when a finding is closed in JIRA and the webhook is closing the finding in defect dojo.
The new status helper tries to set `mitigated_by` to `get_current_user()`, but the webhook is anonymous so this fails.

Two fixes:
- make status helper robust by only using `get_current_user()` if the user is authenticated
- set `mitigated_by` to the JIRA user in the webhook.