### PR TITLE
Fix SSLyze scanner: Remove unnecessary read

### DIFF
--- a/dojo/tools/sslyze/parser.py
+++ b/dojo/tools/sslyze/parser.py
@@ -21,8 +21,6 @@ class SslyzeParser(object):
         if filename is None:
             return list()
 
-        content = filename.read()
-
         if filename.name.lower().endswith('.xml'):
             return SSLyzeXMLParser().get_findings(filename, test)
         elif filename.name.lower().endswith('.json'):

--- a/dojo/unittests/tools/test_sslyze_json_parser.py
+++ b/dojo/unittests/tools/test_sslyze_json_parser.py
@@ -1,29 +1,36 @@
 from django.test import TestCase
 from dojo.tools.sslyze.parser_json import SSLyzeJSONParser
+from dojo.tools.sslyze.parser import SslyzeParser
 from dojo.models import Test
 
 
 class TestSslyzeJSONParser(TestCase):
 
-    def test_parse_file_with_one_target_has_zero_vuln(self):
+    def test_parse_file_with_one_target_has_one_vuln(self):
+        testfile = open("dojo/unittests/scans/sslyze/one_target_one_vuln.json")
+        parser = SslyzeParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+
+    def test_parse_json_file_with_one_target_has_zero_vuln(self):
         testfile = open("dojo/unittests/scans/sslyze/one_target_zero_vuln.json")
         parser = SSLyzeJSONParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(0, len(findings))
 
-    def test_parse_file_with_one_target_has_one_vuln(self):
+    def test_parse_json_file_with_one_target_has_one_vuln(self):
         testfile = open("dojo/unittests/scans/sslyze/one_target_one_vuln.json")
         parser = SSLyzeJSONParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
 
-    def test_parse_file_with_one_target_has_four_vuln(self):
+    def test_parse_json_file_with_one_target_has_four_vuln(self):
         testfile = open("dojo/unittests/scans/sslyze/one_target_many_vuln.json")
         parser = SSLyzeJSONParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(4, len(findings))
 
-    def test_parse_file_with_two_target_has_many_vuln(self):
+    def test_parse_json_file_with_two_target_has_many_vuln(self):
         testfile = open("dojo/unittests/scans/sslyze/two_targets_two_vuln.json")
         parser = SSLyzeJSONParser()
         findings = parser.get_findings(testfile, Test())

--- a/dojo/unittests/tools/test_sslyze_xml_parser.py
+++ b/dojo/unittests/tools/test_sslyze_xml_parser.py
@@ -1,23 +1,30 @@
 from django.test import TestCase
 from dojo.tools.sslyze.parser_xml import SSLyzeXMLParser
+from dojo.tools.sslyze.parser import SslyzeParser
 from dojo.models import Test
 
 
 class TestSSLyzeXMLParser(TestCase):
 
-    def test_parse_file_with_one_target_has_one_vuln(self):
+    def test_parse_file_with_one_target_has_three_vuln(self):
+        testfile = open("dojo/unittests/scans/sslyze/report_one_target_three_vuln.xml")
+        parser = SslyzeParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(3, len(findings))
+
+    def test_parse_xml_file_with_one_target_has_one_vuln(self):
         testfile = open("dojo/unittests/scans/sslyze/report_one_target_one_vuln.xml")
         parser = SSLyzeXMLParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
 
-    def test_parse_file_with_one_target_has_three_vuln(self):
+    def test_parse_xml_file_with_one_target_has_three_vuln(self):
         testfile = open("dojo/unittests/scans/sslyze/report_one_target_three_vuln.xml")
         parser = SSLyzeXMLParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(3, len(findings))
 
-    def test_parse_file_with_two_target_has_many_vuln(self):
+    def test_parse_xml_file_with_two_target_has_many_vuln(self):
         testfile = open("dojo/unittests/scans/sslyze/report_two_target_many_vuln.xml")
         parser = SSLyzeXMLParser()
         findings = parser.get_findings(testfile, Test())


### PR DESCRIPTION
There was an unnecessary read of the file with the scan results. Because of this read, the following read didn't get data anymore and therefore the scanner produced a server error.