### PR TITLE
Hide reports list behind a feature flag

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1644,7 +1644,10 @@ class CustomReportOptionsForm(forms.Form):
     report_name = forms.CharField(required=False, max_length=100)
     include_finding_notes = forms.ChoiceField(required=False, choices=yes_no)
     include_finding_images = forms.ChoiceField(choices=yes_no, label="Finding Images")
-    report_type = forms.ChoiceField(choices=(('HTML', 'HTML'), ('AsciiDoc', 'AsciiDoc')))
+    if settings.FEATURE_REPORTS_PDF_LIST:
+        report_type = forms.ChoiceField(choices=(('HTML', 'HTML'), ('AsciiDoc', 'AsciiDoc'), ('PDF', 'PDF')))
+    else:
+        report_type = forms.ChoiceField(choices=(('HTML', 'HTML'), ('AsciiDoc', 'AsciiDoc')))
 
 
 class DeleteReportForm(forms.ModelForm):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -175,6 +175,10 @@ env = environ.Env(
     # When enabled, staff users have full access to all product types and products
     DD_AUTHORIZATION_STAFF_OVERRIDE=(bool, False),
 
+    # Feature toggle to show legacy list of PDF reports
+    # You need to have wkhtmltopdf installed on your system to generate PDF reports
+    DD_FEATURE_REPORTS_PDF_LIST=(bool, False),
+
     DD_JIRA_TEMPLATE_DIR=(str, 'dojo/templates/issue-trackers'),
     DD_TEMPLATE_DIR_PREFIX=(str, 'dojo/templates/')
 )
@@ -1026,6 +1030,10 @@ TAGULOUS_AUTOCOMPLETE_SETTINGS = {'placeholder': "Enter some tags (comma separat
 FEATURE_AUTHORIZATION_V2 = env('DD_FEATURE_AUTHORIZATION_V2')
 # When enabled, staff users have full access to all product types and products
 AUTHORIZATION_STAFF_OVERRIDE = env('DD_AUTHORIZATION_STAFF_OVERRIDE')
+
+# Feature toggle to show legacy list of PDF reports
+# You need to have wkhtmltopdf installed on your system to generate PDF reports
+FEATURE_REPORTS_PDF_LIST = env('DD_FEATURE_REPORTS_PDF_LIST')
 
 EDITABLE_MITIGATED_DATA = env('DD_EDITABLE_MITIGATED_DATA')
 

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -280,7 +280,10 @@
                                     <span class="glyphicon arrow"></span>
                                 </a>
                                 <ul class="nav nav-second-level">
-                                    <li><a href="{% url 'reports' %}"> All Reports </a></li>
+                                    {% feature_reports_pdf_list as feature_reports_pdf_list_flag %}
+                                    {% if feature_reports_pdf_list_flag %}
+                                        <li><a href="{% url 'reports' %}"> All Reports </a></li>
+                                    {% endif %}
                                     <li><a href="{% url 'report_builder' %}"> Report Builder </a></li>
                                 </ul>
                                 <!-- /.nav-second-level -->

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
+{% load display_tags %}
 {% block content %}
     <link href="{% static "google-code-prettify/src/prettify.css" %}" rel="stylesheet"/>
     <div class="row">
@@ -8,7 +9,6 @@
                 <div class="panel-heading">
                     <div class="clearfix">
                         <h4 class="pull-left">Report Format</h4>
-                        <a class="btn btn-success disabled pull-right run_report" href="#">Save and Run</a>
                     </div>
                 </div>
                 <div class="panel-body in-use-widgets">
@@ -22,7 +22,12 @@
                 </div>
                 <div class="panel-footer">
                     <div class="clearfix">
-                        <a class="btn btn-success disabled pull-right run_report" href="#">Save and Run</a>
+                        {% feature_reports_pdf_list as feature_reports_pdf_list_flag %}
+                        {% if feature_reports_pdf_list_flag %}
+                            <a class="btn btn-success disabled pull-right run_report" href="#">Save and Run</a>
+                        {% else %}
+                            <a class="btn btn-success disabled pull-right run_report" href="#">Run</a>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -976,3 +976,8 @@ def import_history(finding, autoescape=True):
         list_of_status_changes += '<b>' + status_change.created.strftime('%b %d, %Y, %H:%M:%S') + '</b>: ' + status_change.get_action_display() + '<br/>'
 
     return mark_safe(html % (list_of_status_changes))
+
+
+@register.simple_tag
+def feature_reports_pdf_list():
+    return settings.FEATURE_REPORTS_PDF_LIST

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -40,7 +40,7 @@ class ReportBuilderTest(BaseTestCase):
         self.enter_values(driver)
         Select(driver.find_element_by_id("id_report_type")).select_by_visible_text("HTML")
         driver.find_element_by_id("id_report_name").send_keys('Test Report')
-        driver.find_elements_by_class_name("run_report")[1].click()
+        driver.find_element_by_class_name("run_report").click()
         self.assertTrue(driver.current_url == self.base_url + "reports/custom")
 
     def generate_AsciiDoc_report(self):
@@ -50,7 +50,7 @@ class ReportBuilderTest(BaseTestCase):
         self.enter_values(driver)
         Select(driver.find_element_by_id("id_report_type")).select_by_visible_text("AsciiDoc")
         driver.find_element_by_id("id_report_name").send_keys('Test Report')
-        driver.find_elements_by_class_name("run_report")[1].click()
+        driver.find_element_by_class_name("run_report").click()
         self.assertTrue(driver.current_url == self.base_url + "reports/custom")
 
     def test_product_type_report(self):


### PR DESCRIPTION
The reports list is only used to make pdf reports accessible. Now the PDF reports are not supported anymore for more than a year now. This PR hides the list behind a feature flag and renames the button in the report builder to just "Run". Goal is to avoid misunderstandings of users.

Additionally it removes the upper button to generate a report in the report builder because it is redundant and looks different than the one at the bottom.

Shall we additionally include a message, that PDF reports are deprecated and removed in the future, eg. 30.6.2021?