### PR TITLE
[docker-compose] Fix image version in use

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
           target: /app/docker/extra_settings
         - defectdojo_media:${DD_MEDIA_ROOT:-/app/media}
   celerybeat:
-    image: defectdojo/defectdojo-django:latest
+    image: defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}
     depends_on:
       - mysql
       - rabbitmq
@@ -67,7 +67,7 @@ services:
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
   celeryworker:
-    image: defectdojo/defectdojo-django:latest
+    image: defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}
     depends_on:
       - mysql
       - rabbitmq
@@ -83,7 +83,7 @@ services:
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
   initializer:
-    image: defectdojo/defectdojo-django:latest
+    image: defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}
     depends_on:
       - mysql
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '--', '/entrypoint-initializer.sh']


### PR DESCRIPTION
docker-compose.yml always took `latest` for celery and initializer instead of the possible version passed in.