### PR TITLE
fix counts returned to non-staff users in apiv2

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -386,7 +386,7 @@ class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
         }
 
     def get_findings_count(self, obj):
-        return obj.findings_count
+        return obj.findings_count()
 
     def get_findings_list(self, obj):
         return obj.open_findings_list()

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -386,10 +386,10 @@ class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
         }
 
     def get_findings_count(self, obj):
-        return obj.findings_count()
+        return obj.findings_count
 
     def get_findings_list(self, obj):
-        return obj.open_findings_list()
+        return obj.open_findings_list
 
 
 class ProductTypeMemberSerializer(serializers.ModelSerializer):

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -62,7 +62,7 @@ class EndPointViewSet(mixins.ListModelMixin,
             return Endpoint.objects.filter(
                 Q(product__authorized_users__in=[self.request.user]) |
                 Q(product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return Endpoint.objects.all()
 
@@ -109,7 +109,7 @@ class EndpointStatusViewSet(mixins.ListModelMixin,
             return Endpoint_Status.objects.filter(
                 Q(endpoint__product__authorized_users__in=[self.request.user]) |
                 Q(endpoint__product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return Endpoint_Status.objects.all()
 
@@ -139,7 +139,7 @@ class EngagementViewSet(mixins.ListModelMixin,
             return self.queryset.filter(
                 Q(product__authorized_users__in=[self.request.user]) |
                 Q(product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return self.queryset
 
@@ -290,7 +290,7 @@ class AppAnalysisViewSet(mixins.ListModelMixin,
             return self.queryset.filter(
                 Q(product__authorized_users__in=[self.request.user]) |
                 Q(product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return self.queryset
 
@@ -370,7 +370,7 @@ class FindingViewSet(prefetch.PrefetchListMixin,
             return self.queryset.filter(
                 Q(test__engagement__product__authorized_users__in=[self.request.user]) |
                 Q(test__engagement__product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return self.queryset
 
@@ -883,7 +883,7 @@ class DojoMetaViewSet(mixins.ListModelMixin,
                 Q(endpoint__product__prod_type__authorized_users__in=[self.request.user]) |
                 Q(finding__test__engagement__product__authorized_users__in=[self.request.user]) |
                 Q(finding__test__engagement__product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return self.queryset
 
@@ -906,7 +906,7 @@ class ProductViewSet(prefetch.PrefetchListMixin,
         to_schema()
 
     def get_queryset(self):
-        return get_authorized_products(Permissions.Product_View)
+        return get_authorized_products(Permissions.Product_View).distinct()
 
     @swagger_auto_schema(
         request_body=serializers.ReportGenerateOptionSerializer,
@@ -947,7 +947,7 @@ class ProductTypeViewSet(mixins.ListModelMixin,
         permission_classes = (IsAuthenticated, permissions.UserHasProductTypePermission)
 
     def get_queryset(self):
-        return get_authorized_product_types(Permissions.Product_Type_View)
+        return get_authorized_product_types(Permissions.Product_Type_View).distinct()
 
     # Overwrite perfom_create of CreateModelMixin to add current user as owner
     def perform_create(self, serializer):
@@ -1002,7 +1002,7 @@ class StubFindingsViewSet(mixins.ListModelMixin,
             return Finding.objects.filter(
                 Q(test__engagement__product__authorized_users__in=[self.request.user]) |
                 Q(test__engagement__product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return Finding.objects.all()
 
@@ -1050,7 +1050,7 @@ class TestsViewSet(mixins.ListModelMixin,
             return self.queryset.filter(
                 Q(engagement__product__authorized_users__in=[self.request.user]) |
                 Q(engagement__product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             return self.queryset
 
@@ -1205,7 +1205,7 @@ class TestImportViewSet(prefetch.PrefetchListMixin,
             test_imports = Test_Import.objects.filter(
                 Q(test__engagement__product__authorized_users__in=[self.request.user]) |
                 Q(test__engagement__product__prod_type__authorized_users__in=[self.request.user])
-            )
+            ).distinct()
         else:
             test_imports = Test_Import.objects.all()
         return test_imports.prefetch_related(

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -780,13 +780,11 @@ class Product(models.Model):
     def get_product_type(self):
         return self.prod_type if self.prod_type is not None else 'unknown'
 
+    # only used in APIv2 serializers.py, query should be aligned with findings_count
+    @cached_property
     def open_findings_list(self):
         findings = Finding.objects.filter(test__engagement__product=self,
-                                          mitigated__isnull=True,
-                                          verified=True,
-                                          false_p=False,
-                                          duplicate=False,
-                                          out_of_scope=False
+                                          active=True,
                                           )
         findings_list = []
         for i in findings:


### PR DESCRIPTION
fix #4069 

For non-staff users, we have queries where we filter objects based on the `authorized_users` property of the product or product type:

```
    def get_queryset(self):
        if not self.request.user.is_staff:
            return self.queryset.filter(
                Q(test__engagement__product__authorized_users__in=[self.request.user]) |
                Q(test__engagement__product__prod_type__authorized_users__in=[self.request.user])
            )
        else:
            return self.queryset
```  

This works OK, but will join a couple of tables and could lead to objects being in the result multiple times. This PR adds `.distinct()` to resolve this.

There's also one place where we had 2 different queries for the list of findings and the count of that list.