### PR TITLE
edit engagement: unhide error messages, fix testing lead error

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -223,15 +223,15 @@ def edit_engagement(request, eid):
         else:
             logger.debug(form.errors)
 
-    form = EngForm(initial={'product': engagement.product}, instance=engagement, cicd=is_ci_cd, product=engagement.product, user=request.user)
+    else:
+        form = EngForm(initial={'product': engagement.product}, instance=engagement, cicd=is_ci_cd, product=engagement.product, user=request.user)
 
-    jira_project_form = None
-    jira_epic_form = None
-    if get_system_setting('enable_jira'):
-        jira_project = jira_helper.get_jira_project(engagement, use_inheritance=False)
-        jira_project_form = JIRAProjectForm(instance=jira_project, target='engagement', product=engagement.product)
-        logger.debug('showing jira-epic-form')
-        jira_epic_form = JIRAEngagementForm(instance=engagement)
+        jira_epic_form = None
+        if get_system_setting('enable_jira'):
+            jira_project = jira_helper.get_jira_project(engagement, use_inheritance=False)
+            jira_project_form = JIRAProjectForm(instance=jira_project, target='engagement', product=engagement.product)
+            logger.debug('showing jira-epic-form')
+            jira_epic_form = JIRAEngagementForm(instance=engagement)
 
     title = ' CI/CD' if is_ci_cd else ''
     product_tab = Product_Tab(engagement.product.id, title="Edit" + title + " Engagement", tab="engagements")

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -178,6 +178,7 @@ def prefetch_for_products_with_engagments(products_with_engagements):
 def edit_engagement(request, eid):
     engagement = Engagement.objects.get(pk=eid)
     is_ci_cd = engagement.engagement_type == "CI/CD"
+    jira_project_form = None
     jira_epic_form = None
     jira_project = None
     jira_error = False

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -184,7 +184,7 @@ def edit_engagement(request, eid):
     jira_error = False
 
     if request.method == 'POST':
-        form = EngForm(request.POST, instance=engagement, cicd=is_ci_cd, product=engagement.product.id, user=request.user)
+        form = EngForm(request.POST, instance=engagement, cicd=is_ci_cd, product=engagement.product, user=request.user)
         jira_project = jira_helper.get_jira_project(engagement, use_inheritance=False)
 
         if form.is_valid():

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2664,7 +2664,7 @@ class JIRA_Project(models.Model):
 
     def clean(self):
         if not self.jira_instance:
-            raise ValidationError('Cannot save JIRA_Project without JIRA_Instance')
+            raise ValidationError('Cannot save JIRA Project Configuration without JIRA Instance')
 
     def __str__(self):
         return ('%s: ' + self.project_key + '(%s)') % (str(self.id), str(self.jira_instance.url) if self.jira_instance else 'None')

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -773,15 +773,15 @@ def new_product(request, ptid=None):
             else:
                 # engagement was saved, but JIRA errors, so goto edit_product
                 return HttpResponseRedirect(reverse('edit_product', args=(product.id,)))
-
-    jira_project_form = None
-    if get_system_setting('enable_jira'):
-        jira_project_form = JIRAProjectForm()
-
-    if get_system_setting('enable_github'):
-        gform = GITHUB_Product_Form()
     else:
-        gform = None
+        jira_project_form = None
+        if get_system_setting('enable_jira'):
+            jira_project_form = JIRAProjectForm()
+
+        if get_system_setting('enable_github'):
+            gform = GITHUB_Product_Form()
+        else:
+            gform = None
 
     add_breadcrumb(title="New Product", top_level=False, request=request)
     return render(request, 'dojo/new_product.html',
@@ -853,25 +853,25 @@ def edit_product(request, pid):
 
             if not error:
                 return HttpResponseRedirect(reverse('view_product', args=(pid,)))
-
-    form = ProductForm(instance=product,
-                       initial={'auth_users': product.authorized_users.all()})
-
-    if jira_enabled:
-        jira_project = jira_helper.get_jira_project(product)
-        jform = JIRAProjectForm(instance=jira_project)
     else:
-        jform = None
+        form = ProductForm(instance=product,
+                        initial={'auth_users': product.authorized_users.all()})
 
-    if github_enabled and (github_inst is not None):
-        if github_inst is not None:
-            gform = GITHUB_Product_Form(instance=github_inst)
+        if jira_enabled:
+            jira_project = jira_helper.get_jira_project(product)
+            jform = JIRAProjectForm(instance=jira_project)
+        else:
+            jform = None
+
+        if github_enabled and (github_inst is not None):
+            if github_inst is not None:
+                gform = GITHUB_Product_Form(instance=github_inst)
+                gform = GITHUB_Product_Form()
             gform = GITHUB_Product_Form()
-        gform = GITHUB_Product_Form()
-    else:
-        gform = None
+        else:
+            gform = None
 
-    sonarqube_form = Sonarqube_ProductForm(instance=sonarqube_conf)
+        sonarqube_form = Sonarqube_ProductForm(instance=sonarqube_conf)
 
     product_tab = Product_Tab(pid, title="Edit Product", tab="settings")
     return render(request,

--- a/dojo/user/helper.py
+++ b/dojo/user/helper.py
@@ -89,30 +89,32 @@ def check_auth_users_list(user, obj):
             products = obj.prod_type.all()
             for product in products:
                 is_authorized = is_authorized or user in product.authorized_users.all()
-    if isinstance(obj, Finding):
+    elif isinstance(obj, Finding):
         is_authorized = user in obj.test.engagement.product.authorized_users.all()
         is_authorized = user in obj.test.engagement.product.prod_type.authorized_users.all() or is_authorized
-    if isinstance(obj, Test):
+    elif isinstance(obj, Test):
         is_authorized = user in obj.engagement.product.authorized_users.all()
         is_authorized = user in obj.engagement.product.prod_type.authorized_users.all() or is_authorized
-    if isinstance(obj, Engagement):
+    elif isinstance(obj, Engagement):
         is_authorized = user in obj.product.authorized_users.all()
         is_authorized = user in obj.product.prod_type.authorized_users.all() or is_authorized
-    if isinstance(obj, Product):
+    elif isinstance(obj, Product):
         is_authorized = user in obj.authorized_users.all()
         is_authorized = user in obj.prod_type.authorized_users.all() or is_authorized
-    if isinstance(obj, Endpoint):
+    elif isinstance(obj, Endpoint):
         is_authorized = user in obj.product.authorized_users.all()
         is_authorized = user in obj.product.prod_type.authorized_users.all() or is_authorized
-    if isinstance(obj, Risk_Acceptance):
+    elif isinstance(obj, Risk_Acceptance):
         return user.username == obj.owner.username or check_auth_users_list(user, obj.engagement_set.all()[0])
+    else:
+        raise ValueError('invalid obj %s to check for permissions' % obj)
 
     return is_authorized
 
 
 def user_is_authorized(user, perm_type, obj):
     # print('help.user_is_authorized')
-    # print('user: ', user)
+    # print('user: ', user.id)
     # print('perm_type', perm_type)
     # print('obj: ', obj)
 


### PR DESCRIPTION
When the engagement form contained an error while editing an engagement, the error was not shown. This was a generic issue, but we saw it in these cases:

- when adding/editing a product/engagement and changing some of the JIRA fields, but not specifying a JIRA instance or JIRA Project, there was only a generic error message on top of the page. (This was no bug, just a hidden error message)
- when selecting a testing lead, there was an error in the validation rejecting some testing lead values, especially those who are not staff users, but do in fact have staff permission on the product (This was a bug AND a hidden error message)

This PR ensures error messages are shown and fixes the bug around the testing lead field validation.

The cause of the testing lead problem was that on the form GET the list of testing leads was generated successfully using the authorization helper.
But on form POST the `id` of a `Product` instead of the `product` model instance itself got passed into the form. This cascaded into the authorization helper function where the check on the `id` always resulted in `False`. This lead to the form concluding the chosen lead was not allowed.

This is a corner case / programming error, but got swallowed by the way the authorization helper was built. This PR also makes the authorization helper more strict and throws an error if someone passes in an `id` instead of an `object`. (If we only get an id, the authorization helper doesn't which type it is and has no other choice but to raise an error.)