### PR TITLE
Nexpose parser: Process all hosts + add Endpoint (+ add new reference links)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       # phased startup so we can use the exit code from unit test container
       - name: Start MySQL
-        run: docker-compose up --no-deps -d mysql
+        run: docker-compose up -d
 
       # no celery or initializer needed for unit tests
       - name: Unit tests

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ A magical, illusionary, non-existent, YMMV, wannabe, no guarantees list of thing
 - New permission model
 - Push groups of findings to a single JIRA ticket
 - Reimport matching improvements
-- New UI (SPA on top of API)
-- More parsers (CycloneDX, OVAL)
 
 
 ## Support, Bug Reports and Getting Involved

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ See [Wrappers](WRAPPERS.md)
 See [Release and branch model](BRANCHING-MODEL.md)
 
 
+## Roadmap
+A magical, illusionary, non-existent, YMMV, wannabe, no guarantees list of thing we may or may not be working on:
+- New permission model
+- Push groups of findings to a single JIRA ticket
+- Reimport matching improvements
+- New UI (SPA on top of API)
+- More parsers (CycloneDX, OVAL)
+
+
 ## Support, Bug Reports and Getting Involved
 Please come to our Slack channel first, where we can try to help you or point you in the right direction:
 

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -266,12 +266,20 @@ class NexposeParser(object):
             # build references
             refs = ''
             for ref in vuln['refs']:
-                if ref.startswith('CA'):
+                if ref.startswith('BID'):
+                    refs += f" * [{vuln['refs'][ref]}](https://www.securityfocus.com/bid/{vuln['refs'][ref]})"
+                elif ref.startswith('CA'):
                     refs += f" * [{vuln['refs'][ref]}](https://www.cert.org/advisories/{vuln['refs'][ref]}.html)"
+                elif ref.startswith('CERT-VN'):
+                    refs += f" * [{vuln['refs'][ref]}](https://www.kb.cert.org/vuls/id/{vuln['refs'][ref]}.html)"
                 elif ref.startswith('CVE'):
                     refs += f" * [{vuln['refs'][ref]}](https://cve.mitre.org/cgi-bin/cvename.cgi?name={vuln['refs'][ref]})"
+                if ref.startswith('DEBIAN'):
+                    refs += f" * [{vuln['refs'][ref]}](https://security-tracker.debian.org/tracker/{vuln['refs'][ref]})"
                 elif ref.startswith('URL'):
                     refs += f" * URL: {vuln['refs'][ref]}"
+                if ref.startswith('XF'):
+                    refs += f" * [{vuln['refs'][ref]}](https://exchange.xforce.ibmcloud.com/vulnerabilities/{vuln['refs'][ref]})"
                 else:
                     refs += f" * {ref}: {vuln['refs'][ref]}"
                 refs += "\n"

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -211,6 +211,17 @@ class NexposeParser(object):
         dupes = {}
 
         for item in x:
+            # manage findings by node only
+            for vuln in item['vulns']:
+                dupe_key = vuln['severity'] + vuln['name']
+
+                find = self.findings(dupe_key, dupes, test, vuln)
+
+                endpoint = Endpoint(host=item['name'])
+                find.unsaved_endpoints.append(endpoint)
+                find.unsaved_tags = vuln['tags']
+
+            # manage findings by service
             for service in item['services']:
                 for vuln in service['vulns']:
                     dupe_key = vuln['severity'] + vuln['name']
@@ -221,17 +232,7 @@ class NexposeParser(object):
                     if 'port' in service:
                         endpoint.port = int(service['port'])
                     find.unsaved_endpoints.append(endpoint)
-                    find.unsaved_tags = list()
                     find.unsaved_tags = vuln['tags']
-
-        # manage findings by node only
-        for vuln in host['vulns']:
-            dupe_key = vuln['severity'] + vuln['name']
-
-            find = self.findings(dupe_key, dupes, test, vuln)
-
-            find.unsaved_tags = list()
-            find.unsaved_tags = vuln['tags']
 
         return list(dupes.values())
 


### PR DESCRIPTION
Used [for-loop](https://github.com/DefectDojo/django-DefectDojo/blob/6a2b0e5939155554a284f90f58e6287632436ce8/dojo/tools/nexpose/parser.py#L228) processed only last "discovered" host in XML file. I move it to the upper loop.

There was missing also adding Endpoint - so it wasn't possible to identify where vulnerability is.

I also added a couple of new references used in Nexpose reports.