### PR TITLE
 Nexpose parser: Process all hosts + add Endpoint(and protocol) + add new reference links + test

### DIFF
--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -99,13 +99,12 @@ class NexposeParser(object):
         """
         vulns = list()
 
-        for tests in node.iter('tests'):
-            for test in tests.iter('test'):
-                vuln = dict()
+        for tests in node.findall('tests'):
+            for test in tests.findall('test'):
                 if test.get('id') in vulnsDefinitions and (
                         test.get('status') in ['vulnerable-exploited', 'vulnerable-version', 'vulnerable-potential']):
                     vuln = vulnsDefinitions[test.get('id').lower()]
-                    for desc in list(test):
+                    for desc in test.getchildren():
                         if 'pluginOutput' in vuln:
                             vuln['pluginOutput'] += "\n\n" + \
                                 self.parse_html_type(desc)
@@ -121,8 +120,8 @@ class NexposeParser(object):
         """
         vulns = dict()
         url_index = 0
-        for vulnsDef in tree.iter('VulnerabilityDefinitions'):
-            for vulnDef in vulnsDef.iter('vulnerability'):
+        for vulnsDef in tree.findall('VulnerabilityDefinitions'):
+            for vulnDef in vulnsDef.findall('vulnerability'):
                 vid = vulnDef.get('id').lower()
                 severity_chk = int(vulnDef.get('severity'))
                 if severity_chk >= 9:
@@ -131,7 +130,7 @@ class NexposeParser(object):
                     sev = 'High'
                 elif severity_chk >= 4:
                     sev = 'Medium'
-                elif severity_chk < 4 and severity_chk > 0:
+                elif 0 < severity_chk < 4:
                     sev = 'Low'
                 else:
                     sev = 'Info'
@@ -144,29 +143,31 @@ class NexposeParser(object):
                     'severity': sev,
                     'tags': list()
                 }
-                for item in list(vulnDef):
+                for item in vulnDef.getchildren():
                     if item.tag == 'description':
-                        for htmlType in list(item):
+                        for htmlType in item.getchildren():
                             vuln['desc'] += self.parse_html_type(htmlType)
 
-                    if item.tag == 'exploits':
-                        for exploit in list(item):
+                    elif item.tag == 'exploits':
+                        for exploit in item.getchildren():
                             vuln['refs'][exploit.get('title')] = str(exploit.get('title')).strip() + ' ' + \
                                                                  str(exploit.get('link')).strip()
-                    if item.tag == 'references':
-                        for ref in list(item):
+
+                    elif item.tag == 'references':
+                        for ref in item.getchildren():
                             if 'URL' in ref.get('source'):
                                 vuln['refs'][ref.get('source') + str(url_index)] = str(ref.text).strip()
                                 url_index += 1
                             else:
                                 vuln['refs'][ref.get('source')] = str(ref.text).strip()
-                    if item.tag == 'solution':
-                        for htmlType in list(item):
+
+                    elif item.tag == 'solution':
+                        for htmlType in item.getchildren():
                             vuln['resolution'] += self.parse_html_type(htmlType)
 
                     # there is currently no method to register tags in vulns
-                    if item.tag == 'tags':
-                        for tag in list(item):
+                    elif item.tag == 'tags':
+                        for tag in item.getchildren():
                             vuln['tags'].append(tag.text.lower())
 
                 vulns[vid] = vuln
@@ -174,8 +175,8 @@ class NexposeParser(object):
 
     def get_items(self, tree, vulns, test):
         hosts = list()
-        for nodes in tree.iter('nodes'):
-            for node in nodes.iter('node'):
+        for nodes in tree.findall('nodes'):
+            for node in nodes.findall('node'):
                 host = dict()
                 host['name'] = node.get('address')
                 host['hostnames'] = set()
@@ -183,24 +184,24 @@ class NexposeParser(object):
                 host['services'] = list()
                 host['vulns'] = self.parse_tests_type(node, vulns)
 
-                for names in node.iter('names'):
-                    for name in list(names):
+                for names in node.findall('names'):
+                    for name in names.findall('name'):
                         host['hostnames'].add(name.text)
 
-                for endpoints in node.iter('endpoints'):
-                    for endpoint in list(endpoints):
+                for endpoints in node.findall('endpoints'):
+                    for endpoint in endpoints.findall('endpoint'):
                         svc = {
                             'protocol': endpoint.get('protocol'),
-                            'port': endpoint.get('port'),
+                            'port': int(endpoint.get('port')),
                             'status': endpoint.get('status'),
                         }
-                        for services in endpoint.iter('services'):
-                            for service in list(services):
+                        for services in endpoint.findall('services'):
+                            for service in services.findall('service'):
                                 svc['name'] = service.get('name')
                                 svc['vulns'] = self.parse_tests_type(service, vulns)
 
-                                for configs in service.iter('configurations'):
-                                    for config in list(configs):
+                                for configs in service.findall('configurations'):
+                                    for config in configs.findall('config'):
                                         if "banner" in config.get('name'):
                                             svc['version'] = config.get('name')
 
@@ -228,11 +229,7 @@ class NexposeParser(object):
 
                     find = self.findings(dupe_key, dupes, test, vuln)
 
-                    endpoint = Endpoint(host=host['name'])
-                    if 'port' in service:
-                        endpoint.port = int(service['port'])
-                    if 'name' in service:
-                        endpoint.protocol = service['name'].lower()
+                    endpoint = Endpoint(host=host['name'], port=service['port'], protocol=service['name'].lower())
                     find.unsaved_endpoints.append(endpoint)
                     find.unsaved_tags = vuln['tags']
 

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -231,6 +231,8 @@ class NexposeParser(object):
                     endpoint = Endpoint(host=host['name'])
                     if 'port' in service:
                         endpoint.port = int(service['port'])
+                    if 'name' in service:
+                        endpoint.protocol = service['name'].lower()
                     find.unsaved_endpoints.append(endpoint)
                     find.unsaved_tags = vuln['tags']
 

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -173,7 +173,7 @@ class NexposeParser(object):
         return vulns
 
     def get_items(self, tree, vulns, test):
-        x = list()
+        hosts = list()
         for nodes in tree.iter('nodes'):
             for node in nodes.iter('node'):
                 host = dict()
@@ -206,29 +206,29 @@ class NexposeParser(object):
 
                         host['services'].append(svc)
 
-                x.append(host)
+                hosts.append(host)
 
         dupes = {}
 
-        for item in x:
+        for host in hosts:
             # manage findings by node only
-            for vuln in item['vulns']:
+            for vuln in host['vulns']:
                 dupe_key = vuln['severity'] + vuln['name']
 
                 find = self.findings(dupe_key, dupes, test, vuln)
 
-                endpoint = Endpoint(host=item['name'])
+                endpoint = Endpoint(host=host['name'])
                 find.unsaved_endpoints.append(endpoint)
                 find.unsaved_tags = vuln['tags']
 
             # manage findings by service
-            for service in item['services']:
+            for service in host['services']:
                 for vuln in service['vulns']:
                     dupe_key = vuln['severity'] + vuln['name']
 
                     find = self.findings(dupe_key, dupes, test, vuln)
 
-                    endpoint = Endpoint(host=item['name'])
+                    endpoint = Endpoint(host=host['name'])
                     if 'port' in service:
                         endpoint.port = int(service['port'])
                     find.unsaved_endpoints.append(endpoint)

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -266,12 +266,20 @@ class NexposeParser(object):
             # build references
             refs = ''
             for ref in vuln['refs']:
-                if ref.startswith('CA'):
+                if ref.startswith('BID'):
+                    refs += f" * [{vuln['refs'][ref]}](https://www.securityfocus.com/bid/{vuln['refs'][ref]})"
+                elif ref.startswith('CA'):
                     refs += f" * [{vuln['refs'][ref]}](https://www.cert.org/advisories/{vuln['refs'][ref]}.html)"
+                elif ref.startswith('CERT-VN'):
+                    refs += f" * [{vuln['refs'][ref]}](https://www.kb.cert.org/vuls/id/{vuln['refs'][ref]}.html)"
                 elif ref.startswith('CVE'):
                     refs += f" * [{vuln['refs'][ref]}](https://cve.mitre.org/cgi-bin/cvename.cgi?name={vuln['refs'][ref]})"
+                if ref.startswith('DEBIAN'):
+                    refs += f" * [{vuln['refs'][ref]}](https://security-tracker.debian.org/tracker/{vuln['refs'][ref]})"
                 elif ref.startswith('URL'):
                     refs += f" * URL: {vuln['refs'][ref]}"
+                if ref.startswith('XF'):
+                    refs += f" * [{vuln['refs'][ref]}](https://exchange.xforce.ibmcloud.com/vulnerabilities/{vuln['refs'][ref]})"
                 else:
                     refs += f" * {ref}: {vuln['refs'][ref]}"
                 refs += "\n"

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -211,6 +211,17 @@ class NexposeParser(object):
         dupes = {}
 
         for item in x:
+            # manage findings by node only
+            for vuln in item['vulns']:
+                dupe_key = vuln['severity'] + vuln['name']
+
+                find = self.findings(dupe_key, dupes, test, vuln)
+
+                endpoint = Endpoint(host=item['name'])
+                find.unsaved_endpoints.append(endpoint)
+                find.unsaved_tags = vuln['tags']
+
+            # manage findings by service
             for service in item['services']:
                 for vuln in service['vulns']:
                     dupe_key = vuln['severity'] + vuln['name']
@@ -221,17 +232,7 @@ class NexposeParser(object):
                     if 'port' in service:
                         endpoint.port = int(service['port'])
                     find.unsaved_endpoints.append(endpoint)
-                    find.unsaved_tags = list()
                     find.unsaved_tags = vuln['tags']
-
-        # manage findings by node only
-        for vuln in host['vulns']:
-            dupe_key = vuln['severity'] + vuln['name']
-
-            find = self.findings(dupe_key, dupes, test, vuln)
-
-            find.unsaved_tags = list()
-            find.unsaved_tags = vuln['tags']
 
         return list(dupes.values())
 

--- a/dojo/unittests/scans/nexpose/report_auth.xml
+++ b/dojo/unittests/scans/nexpose/report_auth.xml
@@ -1,425 +1,652 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <NexposeReport version="2.0">
-<scans>
-<scan id="27992" name="Site1-serv1" startTime="20210211T162340221" endTime="20210211T164705486" status="finished"/>
-</scans><nodes>
-<node address="192.168.0.12" status="alive" device-id="26083" site-name="Site1" site-importance="Normal" scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
-<names>
-<name>host0</name>
-</names>
-<fingerprints>
-<os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
-</fingerprints>
-<tests>
-<test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163822649" pci-compliance-status="fail">
-
-<Paragraph>
-	<UnorderedList>
-		<ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected 0.</ListItem></UnorderedList></Paragraph>
-</test>
-
-<test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163822649" pci-compliance-status="fail">
-
-<Paragraph>
-	<Paragraph>Grub config with no password found.
-		<UnorderedList>
-			<ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem></UnorderedList></Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822649" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822649" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user netdata was found to be 775 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822649" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user lxd was found to be 711 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822649" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-</tests>
-</node>
-
-<node address="192.168.0.10" status="alive" device-id="26084" site-name="Site1" site-importance="Normal" scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
-<names>
-<name>host1</name>
-</names>
-<fingerprints>
-<os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
-</fingerprints>
-<tests>
-<test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163833380" pci-compliance-status="fail">
-
-<Paragraph>
-	<UnorderedList>
-		<ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected 0.</ListItem></UnorderedList></Paragraph>
-</test>
-
-<test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163833380" pci-compliance-status="fail">
-
-<Paragraph>
-	<Paragraph>Grub config with no password found.
-		<UnorderedList>
-			<ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem></UnorderedList></Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163833380" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user lxd was found to be 711 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163833380" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163833380" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163833380" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user netdata was found to be 775 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-</tests>
-</node>
-
-<node address="192.168.0.11" status="alive" device-id="26086" site-name="Site1" site-importance="Normal" scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
-<names>
-<name>host3</name>
-</names>
-<fingerprints>
-<os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
-</fingerprints>
-<tests>
-<test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163823297" pci-compliance-status="fail">
-
-<Paragraph>
-	<UnorderedList>
-		<ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected 0.</ListItem></UnorderedList></Paragraph>
-</test>
-
-<test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163823297" pci-compliance-status="fail">
-
-<Paragraph>
-	<Paragraph>Grub config with no password found.
-		<UnorderedList>
-			<ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem></UnorderedList></Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163823297" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163823297" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user lxd was found to be 711 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163823297" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163823297" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user netdata was found to be 775 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="generic-tcp-timestamp" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163823297" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>Able to determine system boot time.</Paragraph></Paragraph>
-</test>
-
-</tests>
-</node>
-
-<node address="192.168.0.42" status="alive" device-id="26088" site-name="Site1" site-importance="Normal" scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
-<names>
-<name>host4</name>
-</names>
-<fingerprints>
-<os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
-</fingerprints>
-<tests>
-<test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163822163" pci-compliance-status="fail">
-
-<Paragraph>
-	<UnorderedList>
-		<ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.</ListItem>
-		<ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected 0.</ListItem></UnorderedList></Paragraph>
-</test>
-
-<test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163822163" pci-compliance-status="fail">
-
-<Paragraph>
-	<Paragraph>Grub config with no password found.
-		<UnorderedList>
-			<ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem></UnorderedList></Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822163" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user netdata was found to be 775 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822163" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822163" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992" vulnerable-since="20210211T163822163" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>The permissions for home directory of user lxd was found to be 711 which is more permissive than 750.</Paragraph></Paragraph>
-</test>
-
-<test id="generic-tcp-timestamp" key="" status="vulnerable-exploited" scan-id="27992" vulnerable-since="20210211T163822163" pci-compliance-status="pass">
-
-<Paragraph>
-	<Paragraph>Able to determine system boot time.</Paragraph></Paragraph>
-</test>
-
-</tests>
-</node>
-</nodes><VulnerabilityDefinitions>
-<vulnerability id="generic-tcp-timestamp" title="TCP timestamp response" severity="1" pciSeverity="1" cvssScore="0.0" cvssVector="(AV:N/AC:L/Au:N/C:N/I:N/A:N)" published="19970801T000000000" added="20110401T000000000" modified="20180321T000000000" riskScore="0.0">
-<malware/><exploits/><description>
-
-<ContainerBlockElement>
-
-	<Paragraph>
-      The remote host responded with a TCP timestamp.  The TCP timestamp response
-      can be used to approximate the remote host's uptime, potentially aiding in
-      further attacks.  Additionally, some operating systems can be fingerprinted
-      based on the behavior of their TCP timestamps.
-    </Paragraph>
-  </ContainerBlockElement></description>
-<references>
-<reference source="URL">http://uptime.netcraft.com</reference>
-<reference source="URL">http://www.forensicswiki.org/wiki/TCP_timestamps</reference>
-<reference source="URL">http://www.ietf.org/rfc/rfc1323.txt</reference>
-</references><tags>
-<tag>Network</tag>
-</tags>
-<solution>
-
-<ContainerBlockElement>
-	<UnorderedList>
-		<ListItem>
-			<Paragraph>Cisco</Paragraph>
-			<Paragraph>
-				<Paragraph>
-      Run the following command to disable TCP timestamps:
-    </Paragraph>
-				<Paragraph preformat="true">
-      no ip tcp timestamp
-    </Paragraph></Paragraph></ListItem>
-		<ListItem>
-			<Paragraph>FreeBSD</Paragraph>
-			<Paragraph>
-				<Paragraph>
-      Set the value of net.inet.tcp.rfc1323 to 0 by running the
-      following command:
-    </Paragraph>
-				<Paragraph preformat="true">
-      sysctl -w net.inet.tcp.rfc1323=0
-    </Paragraph>
-				<Paragraph>
-      Additionally, put the following value in the default sysctl
-      configuration file, generally sysctl.conf:
-    </Paragraph>
-				<Paragraph preformat="true">
-      net.inet.tcp.rfc1323=0
-    </Paragraph></Paragraph></ListItem>
-		<ListItem>
-			<Paragraph>Linux</Paragraph>
-			<Paragraph>
-				<Paragraph>
-      Set the value of net.ipv4.tcp_timestamps to 0 by running the
-      following command:
-    </Paragraph>
-				<Paragraph preformat="true">
-      sysctl -w net.ipv4.tcp_timestamps=0
-    </Paragraph>
-				<Paragraph>
-      Additionally, put the following value in the default sysctl
-      configuration file, generally sysctl.conf:
-    </Paragraph>
-				<Paragraph preformat="true">
-      net.ipv4.tcp_timestamps=0
-    </Paragraph></Paragraph></ListItem>
-		<ListItem>
-			<Paragraph>OpenBSD</Paragraph>
-			<Paragraph>
-				<Paragraph>
-      Set the value of net.inet.tcp.rfc1323 to 0 by running the
-      following command:
-    </Paragraph>
-				<Paragraph preformat="true">
-      sysctl -w net.inet.tcp.rfc1323=0
-    </Paragraph>
-				<Paragraph>
-      Additionally, put the following value in the default sysctl
-      configuration file, generally sysctl.conf:
-    </Paragraph>
-				<Paragraph preformat="true">
-      net.inet.tcp.rfc1323=0
-    </Paragraph></Paragraph></ListItem>
-		<ListItem>
-			<Paragraph>Microsoft Windows NT, Microsoft Windows NT Workstation, Microsoft Windows NT Server, Microsoft Windows NT Advanced Server, Microsoft Windows NT Server, Enterprise Edition, Microsoft Windows NT Server, Terminal Server Edition, Microsoft Windows 95, Microsoft Windows 98, Microsoft Windows 98SE, Microsoft Windows ME, Microsoft Windows 2000, Microsoft Windows 2000 Professional, Microsoft Windows 2000 Server, Microsoft Windows 2000 Advanced Server, Microsoft Windows 2000 Datacenter Server, Microsoft Windows XP, Microsoft Windows XP Home, Microsoft Windows XP Professional, Microsoft Windows XP Tablet PC Edition, Microsoft Windows CE, Microsoft Windows Server 2003, Microsoft Windows Server 2003, Standard Edition, Microsoft Windows Server 2003, Enterprise Edition, Microsoft Windows Server 2003, Datacenter Edition, Microsoft Windows Server 2003, Web Edition, Microsoft Windows Small Business Server 2003, Microsoft Windows Server 2003 R2, Microsoft Windows Server 2003 R2, Standard Edition, Microsoft Windows Server 2003 R2, Enterprise Edition, Microsoft Windows Server 2003 R2, Datacenter Edition, Microsoft Windows Server 2003 R2, Web Edition, Microsoft Windows Small Business Server 2003 R2, Microsoft Windows Server 2003 R2, Express Edition, Microsoft Windows Server 2003 R2, Workgroup Edition</Paragraph>
-			<Paragraph>
-				<Paragraph>
-      Set the Tcp1323Opts value in the following key to 1:
-    </Paragraph>
-				<Paragraph preformat="true">
-      HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters
-    </Paragraph></Paragraph></ListItem>
-		<ListItem>
-			<Paragraph>Microsoft Windows Server 2008, Microsoft Windows Server 2008 Standard Edition, Microsoft Windows Server 2008 Enterprise Edition, Microsoft Windows Server 2008 Datacenter Edition, Microsoft Windows Server 2008 HPC Edition, Microsoft Windows Server 2008 Web Edition, Microsoft Windows Server 2008 Storage Edition, Microsoft Windows Small Business Server 2008, Microsoft Windows Essential Business Server 2008, Microsoft Windows Server 2008 R2, Microsoft Windows Server 2008 R2, Standard Edition, Microsoft Windows Server 2008 R2, Enterprise Edition, Microsoft Windows Server 2008 R2, Datacenter Edition, Microsoft Windows Server 2008 R2, Web Edition, Microsoft Windows Server 2012, Microsoft Windows Server 2012 Standard Edition, Microsoft Windows Server 2012 Foundation Edition, Microsoft Windows Server 2012 Essentials Edition, Microsoft Windows Server 2012 Datacenter Edition, Microsoft Windows Storage Server 2012, Microsoft Windows Vista, Microsoft Windows Vista Home, Basic Edition, Microsoft Windows Vista Home, Basic N Edition, Microsoft Windows Vista Home, Premium Edition, Microsoft Windows Vista Ultimate Edition, Microsoft Windows Vista Enterprise Edition, Microsoft Windows Vista Business Edition, Microsoft Windows Vista Business N Edition, Microsoft Windows Vista Starter Edition, Microsoft Windows 7, Microsoft Windows 7 Home, Basic Edition, Microsoft Windows 7 Home, Basic N Edition, Microsoft Windows 7 Home, Premium Edition, Microsoft Windows 7 Home, Premium N Edition, Microsoft Windows 7 Ultimate Edition, Microsoft Windows 7 Ultimate N Edition, Microsoft Windows 7 Enterprise Edition, Microsoft Windows 7 Enterprise N Edition, Microsoft Windows 7 Professional Edition, Microsoft Windows 7 Starter Edition, Microsoft Windows 7 Starter N Edition, Microsoft Windows 8, Microsoft Windows 8 Enterprise Edition, Microsoft Windows 8 Professional Edition, Microsoft Windows 8 RT, Microsoft Windows Longhorn Server Beta</Paragraph>
-			<Paragraph>
-				<Paragraph>
-      TCP timestamps cannot be reliably disabled on this OS.  If TCP timestamps present enough of a risk, put a firewall capable of blocking TCP timestamp packets in front of the affected assets.
-    </Paragraph></Paragraph></ListItem></UnorderedList></ContainerBlockElement></solution>
-</vulnerability>
-
-<vulnerability id="linux-grub-missing-passwd" title="No password for Grub" severity="5" pciSeverity="3" cvssScore="4.6" cvssVector="(AV:L/AC:L/Au:N/C:P/I:P/A:P)" published="19990101T000000000" added="20041130T000000000" modified="20190711T000000000" riskScore="751.7289">
-<malware/><exploits/><description>
-
-<ContainerBlockElement>
-
-	<Paragraph>GRUB bootloader is not password protected. An attacker can use the
-      GRUB editor interface to change its configuration or to gather information
-      using the cat command. It can also be exploited to boot into single user
-      mode as root or boot into an insecure operating system.  </Paragraph>
-  </ContainerBlockElement></description>
-<references>
-</references><tags>
-<tag>UNIX</tag>
-</tags>
-<solution>
-
-<ContainerBlockElement>
-	<Paragraph>
-		<Paragraph>Set a password in the GRUB configuration file.  This
-          is often located in one of several locations, but can really be
-          anywhere:</Paragraph>
-		<Paragraph preformat="true">
-          /etc/grub.conf
-          /boot/grub/grub.conf
-          /boot/grub/grub.cfg
-          /boot/grub/menu.lst
-        </Paragraph>
-		<Paragraph>For all files mentioned above ensure that a password is set or that the files do not exist.</Paragraph>
-		<Paragraph>To set a plain-text password, edit your GRUB configuration file
-          and add the following line before the first uncommented line:</Paragraph>
-		<Paragraph preformat="true">   password &lt;password&gt;</Paragraph>
-		<Paragraph>To set an encrypted password, run grub-md5-crypt and use its
-          output when adding the following line before the first
-          uncommented line:</Paragraph>
-		<Paragraph preformat="true">   password --md5 &lt;encryptedpassword&gt;</Paragraph>
-		<Paragraph>For either approach, choose an appropriately strong password.</Paragraph></Paragraph></ContainerBlockElement></solution>
-</vulnerability>
-
-<vulnerability id="linux-icmp-redirect" title="ICMP redirection enabled" severity="7" pciSeverity="4" cvssScore="6.8" cvssVector="(AV:N/AC:M/Au:N/C:P/I:P/A:P)" published="20031231T000000000" added="20041130T000000000" modified="20120719T000000000" riskScore="740.62415">
-<malware/><exploits/><description>
-
-<ContainerBlockElement>
-
-	<Paragraph>By default, many linux systems enable a feature called ICMP redirection,
-   where the machine will alter its route table in response to an ICMP
-   redirect message from any network device.</Paragraph>
-
-
-
-	<Paragraph>There is a risk that this feature could be used to subvert a host's
-   routing table in order to compromise its security (e.g., tricking it
-   into sending packets via a specific route where they may be sniffed
-   or altered).</Paragraph>
-  </ContainerBlockElement></description>
-<references>
-<reference source="BID">6823</reference>
-<reference source="MSKB">293626</reference>
-<reference source="XF">cisco-ios-icmp-redirect(11306)</reference>
-</references><tags>
-<tag>UNIX</tag>
-</tags>
-<solution>
-
-<ContainerBlockElement>
-	<Paragraph>Linux</Paragraph>
-	<Paragraph>
-		<Paragraph>Issue the following commands as root:</Paragraph>
-		<Paragraph preformat="true">   sysctl -w net.ipv4.conf.all.accept_redirects=0</Paragraph>
-		<Paragraph preformat="true">   sysctl -w net.ipv4.conf.default.accept_redirects=0</Paragraph>
-		<Paragraph preformat="true">   sysctl -w net.ipv4.conf.all.secure_redirects=0</Paragraph>
-		<Paragraph preformat="true">   sysctl -w net.ipv4.conf.default.secure_redirects=0</Paragraph>
-		<Paragraph>These settings can be added to /etc/sysctl.conf to make them permanent.</Paragraph></Paragraph></ContainerBlockElement></solution>
-</vulnerability>
-
-<vulnerability id="unix-user-home-dir-mode" title="User home directory mode unsafe" severity="2" pciSeverity="2" cvssScore="2.1" cvssVector="(AV:L/AC:L/Au:N/C:P/I:N/A:N)" published="20050115T000000000" added="20050115T000000000" modified="20200211T000000000" riskScore="579.081">
-<malware/><exploits/><description>
-
-<ContainerBlockElement>
-
-	<Paragraph>A user's home directory was found to have a permission mode which is more permissive than 750 (Owner=READ/WRITE/EXECUTE, Group=READ/EXECUTE, Other=NONE).
-    "Group" or "Other" WRITE permissions means that a malicious user may gain complete access to user data by escalating privileges.
-    In addition "read" and "execute" access for "Other" should always be disabled (sensitive data access).</Paragraph>
-  </ContainerBlockElement></description>
-<references>
-</references><tags>
-<tag>UNIX</tag>
-</tags>
-<solution>
-
-<ContainerBlockElement>
-	<Paragraph>
-		<Paragraph>Restrict the user home directory mode to at most 750 using the command: </Paragraph>
-		<Paragraph preformat="true">chmod 750 userDir </Paragraph></Paragraph></ContainerBlockElement></solution>
-</vulnerability>
-</VulnerabilityDefinitions>
+    <scans>
+        <scan id="27992" name="Site1-serv1" startTime="20210211T162340221" endTime="20210211T164705486"
+              status="finished"/>
+    </scans>
+    <nodes>
+        <node address="192.168.0.12" status="alive" device-id="26083" site-name="Site1" site-importance="Normal"
+              scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
+            <names>
+                <name>host0</name>
+            </names>
+            <fingerprints>
+                <os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
+            </fingerprints>
+            <tests>
+                <test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163822649" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <UnorderedList>
+                            <ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                        </UnorderedList>
+                    </Paragraph>
+                </test>
+
+                <test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163822649" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <Paragraph>Grub config with no password found.
+                            <UnorderedList>
+                                <ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem>
+                            </UnorderedList>
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822649" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which
+                            is more permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822649" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user netdata was found to be 775 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822649" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user lxd was found to be 711 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822649" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+            </tests>
+        </node>
+
+        <node address="192.168.0.10" status="alive" device-id="26084" site-name="Site1" site-importance="Normal"
+              scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
+            <names>
+                <name>host1</name>
+            </names>
+            <fingerprints>
+                <os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
+            </fingerprints>
+            <tests>
+                <test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163833380" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <UnorderedList>
+                            <ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                        </UnorderedList>
+                    </Paragraph>
+                </test>
+
+                <test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163833380" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <Paragraph>Grub config with no password found.
+                            <UnorderedList>
+                                <ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem>
+                            </UnorderedList>
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163833380" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user lxd was found to be 711 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163833380" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163833380" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which
+                            is more permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163833380" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user netdata was found to be 775 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+            </tests>
+        </node>
+
+        <node address="192.168.0.11" status="alive" device-id="26086" site-name="Site1" site-importance="Normal"
+              scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
+            <names>
+                <name>host3</name>
+            </names>
+            <fingerprints>
+                <os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
+            </fingerprints>
+            <tests>
+                <test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163823297" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <UnorderedList>
+                            <ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                        </UnorderedList>
+                    </Paragraph>
+                </test>
+
+                <test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163823297" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <Paragraph>Grub config with no password found.
+                            <UnorderedList>
+                                <ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem>
+                            </UnorderedList>
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163823297" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which
+                            is more permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163823297" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user lxd was found to be 711 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163823297" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163823297" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user netdata was found to be 775 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="generic-tcp-timestamp" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163823297" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>Able to determine system boot time.</Paragraph>
+                    </Paragraph>
+                </test>
+
+            </tests>
+        </node>
+
+        <node address="192.168.0.42" status="alive" device-id="26088" site-name="Site1" site-importance="Normal"
+              scan-template="Discovery Scan,Full audit" risk-score="2649.9238">
+            <names>
+                <name>host4</name>
+            </names>
+            <fingerprints>
+                <os certainty="1.00" vendor="Ubuntu" family="Linux" product="Linux" version="20.04"/>
+            </fingerprints>
+            <tests>
+                <test id="linux-icmp-redirect" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163822163" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <UnorderedList>
+                            <ListItem>The net.ipv4.conf.all.accept_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.accept_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.all.secure_redirects sysctl variable is set to 1, expected 0.
+                            </ListItem>
+                            <ListItem>The net.ipv4.conf.default.secure_redirects sysctl variable is set to 1, expected
+                                0.
+                            </ListItem>
+                        </UnorderedList>
+                    </Paragraph>
+                </test>
+
+                <test id="linux-grub-missing-passwd" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163822163" pci-compliance-status="fail">
+
+                    <Paragraph>
+                        <Paragraph>Grub config with no password found.
+                            <UnorderedList>
+                                <ListItem>Vulnerable file: /boot/grub/grub.cfg</ListItem>
+                            </UnorderedList>
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822163" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user netdata was found to be 775 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822163" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user anycastcontrol was found to be 755 which
+                            is more permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822163" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user ubuntu was found to be 755 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="unix-user-home-dir-mode" key="" status="vulnerable-version" scan-id="27992"
+                      vulnerable-since="20210211T163822163" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>The permissions for home directory of user lxd was found to be 711 which is more
+                            permissive than 750.
+                        </Paragraph>
+                    </Paragraph>
+                </test>
+
+                <test id="generic-tcp-timestamp" key="" status="vulnerable-exploited" scan-id="27992"
+                      vulnerable-since="20210211T163822163" pci-compliance-status="pass">
+
+                    <Paragraph>
+                        <Paragraph>Able to determine system boot time.</Paragraph>
+                    </Paragraph>
+                </test>
+
+            </tests>
+        </node>
+    </nodes>
+    <VulnerabilityDefinitions>
+        <vulnerability id="generic-tcp-timestamp" title="TCP timestamp response" severity="1" pciSeverity="1"
+                       cvssScore="0.0" cvssVector="(AV:N/AC:L/Au:N/C:N/I:N/A:N)" published="19970801T000000000"
+                       added="20110401T000000000" modified="20180321T000000000" riskScore="0.0">
+            <malware/>
+            <exploits/>
+            <description>
+
+                <ContainerBlockElement>
+
+                    <Paragraph>
+                        The remote host responded with a TCP timestamp. The TCP timestamp response
+                        can be used to approximate the remote host's uptime, potentially aiding in
+                        further attacks. Additionally, some operating systems can be fingerprinted
+                        based on the behavior of their TCP timestamps.
+                    </Paragraph>
+                </ContainerBlockElement>
+            </description>
+            <references>
+                <reference source="URL">http://uptime.netcraft.com</reference>
+                <reference source="URL">http://www.forensicswiki.org/wiki/TCP_timestamps</reference>
+                <reference source="URL">http://www.ietf.org/rfc/rfc1323.txt</reference>
+            </references>
+            <tags>
+                <tag>Network</tag>
+            </tags>
+            <solution>
+
+                <ContainerBlockElement>
+                    <UnorderedList>
+                        <ListItem>
+                            <Paragraph>Cisco</Paragraph>
+                            <Paragraph>
+                                <Paragraph>
+                                    Run the following command to disable TCP timestamps:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    no ip tcp timestamp
+                                </Paragraph>
+                            </Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>FreeBSD</Paragraph>
+                            <Paragraph>
+                                <Paragraph>
+                                    Set the value of net.inet.tcp.rfc1323 to 0 by running the
+                                    following command:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    sysctl -w net.inet.tcp.rfc1323=0
+                                </Paragraph>
+                                <Paragraph>
+                                    Additionally, put the following value in the default sysctl
+                                    configuration file, generally sysctl.conf:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    net.inet.tcp.rfc1323=0
+                                </Paragraph>
+                            </Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>Linux</Paragraph>
+                            <Paragraph>
+                                <Paragraph>
+                                    Set the value of net.ipv4.tcp_timestamps to 0 by running the
+                                    following command:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    sysctl -w net.ipv4.tcp_timestamps=0
+                                </Paragraph>
+                                <Paragraph>
+                                    Additionally, put the following value in the default sysctl
+                                    configuration file, generally sysctl.conf:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    net.ipv4.tcp_timestamps=0
+                                </Paragraph>
+                            </Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>OpenBSD</Paragraph>
+                            <Paragraph>
+                                <Paragraph>
+                                    Set the value of net.inet.tcp.rfc1323 to 0 by running the
+                                    following command:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    sysctl -w net.inet.tcp.rfc1323=0
+                                </Paragraph>
+                                <Paragraph>
+                                    Additionally, put the following value in the default sysctl
+                                    configuration file, generally sysctl.conf:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    net.inet.tcp.rfc1323=0
+                                </Paragraph>
+                            </Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>Microsoft Windows NT, Microsoft Windows NT Workstation, Microsoft Windows NT
+                                Server, Microsoft Windows NT Advanced Server, Microsoft Windows NT Server, Enterprise
+                                Edition, Microsoft Windows NT Server, Terminal Server Edition, Microsoft Windows 95,
+                                Microsoft Windows 98, Microsoft Windows 98SE, Microsoft Windows ME, Microsoft Windows
+                                2000, Microsoft Windows 2000 Professional, Microsoft Windows 2000 Server, Microsoft
+                                Windows 2000 Advanced Server, Microsoft Windows 2000 Datacenter Server, Microsoft
+                                Windows XP, Microsoft Windows XP Home, Microsoft Windows XP Professional, Microsoft
+                                Windows XP Tablet PC Edition, Microsoft Windows CE, Microsoft Windows Server 2003,
+                                Microsoft Windows Server 2003, Standard Edition, Microsoft Windows Server 2003,
+                                Enterprise Edition, Microsoft Windows Server 2003, Datacenter Edition, Microsoft Windows
+                                Server 2003, Web Edition, Microsoft Windows Small Business Server 2003, Microsoft
+                                Windows Server 2003 R2, Microsoft Windows Server 2003 R2, Standard Edition, Microsoft
+                                Windows Server 2003 R2, Enterprise Edition, Microsoft Windows Server 2003 R2, Datacenter
+                                Edition, Microsoft Windows Server 2003 R2, Web Edition, Microsoft Windows Small Business
+                                Server 2003 R2, Microsoft Windows Server 2003 R2, Express Edition, Microsoft Windows
+                                Server 2003 R2, Workgroup Edition
+                            </Paragraph>
+                            <Paragraph>
+                                <Paragraph>
+                                    Set the Tcp1323Opts value in the following key to 1:
+                                </Paragraph>
+                                <Paragraph preformat="true">
+                                    HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\Tcpip\Parameters
+                                </Paragraph>
+                            </Paragraph>
+                        </ListItem>
+                        <ListItem>
+                            <Paragraph>Microsoft Windows Server 2008, Microsoft Windows Server 2008 Standard Edition,
+                                Microsoft Windows Server 2008 Enterprise Edition, Microsoft Windows Server 2008
+                                Datacenter Edition, Microsoft Windows Server 2008 HPC Edition, Microsoft Windows Server
+                                2008 Web Edition, Microsoft Windows Server 2008 Storage Edition, Microsoft Windows Small
+                                Business Server 2008, Microsoft Windows Essential Business Server 2008, Microsoft
+                                Windows Server 2008 R2, Microsoft Windows Server 2008 R2, Standard Edition, Microsoft
+                                Windows Server 2008 R2, Enterprise Edition, Microsoft Windows Server 2008 R2, Datacenter
+                                Edition, Microsoft Windows Server 2008 R2, Web Edition, Microsoft Windows Server 2012,
+                                Microsoft Windows Server 2012 Standard Edition, Microsoft Windows Server 2012 Foundation
+                                Edition, Microsoft Windows Server 2012 Essentials Edition, Microsoft Windows Server 2012
+                                Datacenter Edition, Microsoft Windows Storage Server 2012, Microsoft Windows Vista,
+                                Microsoft Windows Vista Home, Basic Edition, Microsoft Windows Vista Home, Basic N
+                                Edition, Microsoft Windows Vista Home, Premium Edition, Microsoft Windows Vista Ultimate
+                                Edition, Microsoft Windows Vista Enterprise Edition, Microsoft Windows Vista Business
+                                Edition, Microsoft Windows Vista Business N Edition, Microsoft Windows Vista Starter
+                                Edition, Microsoft Windows 7, Microsoft Windows 7 Home, Basic Edition, Microsoft Windows
+                                7 Home, Basic N Edition, Microsoft Windows 7 Home, Premium Edition, Microsoft Windows 7
+                                Home, Premium N Edition, Microsoft Windows 7 Ultimate Edition, Microsoft Windows 7
+                                Ultimate N Edition, Microsoft Windows 7 Enterprise Edition, Microsoft Windows 7
+                                Enterprise N Edition, Microsoft Windows 7 Professional Edition, Microsoft Windows 7
+                                Starter Edition, Microsoft Windows 7 Starter N Edition, Microsoft Windows 8, Microsoft
+                                Windows 8 Enterprise Edition, Microsoft Windows 8 Professional Edition, Microsoft
+                                Windows 8 RT, Microsoft Windows Longhorn Server Beta
+                            </Paragraph>
+                            <Paragraph>
+                                <Paragraph>
+                                    TCP timestamps cannot be reliably disabled on this OS. If TCP timestamps present
+                                    enough of a risk, put a firewall capable of blocking TCP timestamp packets in front
+                                    of the affected assets.
+                                </Paragraph>
+                            </Paragraph>
+                        </ListItem>
+                    </UnorderedList>
+                </ContainerBlockElement>
+            </solution>
+        </vulnerability>
+
+        <vulnerability id="linux-grub-missing-passwd" title="No password for Grub" severity="5" pciSeverity="3"
+                       cvssScore="4.6" cvssVector="(AV:L/AC:L/Au:N/C:P/I:P/A:P)" published="19990101T000000000"
+                       added="20041130T000000000" modified="20190711T000000000" riskScore="751.7289">
+            <malware/>
+            <exploits/>
+            <description>
+
+                <ContainerBlockElement>
+
+                    <Paragraph>GRUB bootloader is not password protected. An attacker can use the
+                        GRUB editor interface to change its configuration or to gather information
+                        using the cat command. It can also be exploited to boot into single user
+                        mode as root or boot into an insecure operating system.
+                    </Paragraph>
+                </ContainerBlockElement>
+            </description>
+            <references>
+            </references>
+            <tags>
+                <tag>UNIX</tag>
+            </tags>
+            <solution>
+
+                <ContainerBlockElement>
+                    <Paragraph>
+                        <Paragraph>Set a password in the GRUB configuration file. This
+                            is often located in one of several locations, but can really be
+                            anywhere:
+                        </Paragraph>
+                        <Paragraph preformat="true">
+                            /etc/grub.conf
+                            /boot/grub/grub.conf
+                            /boot/grub/grub.cfg
+                            /boot/grub/menu.lst
+                        </Paragraph>
+                        <Paragraph>For all files mentioned above ensure that a password is set or that the files do not
+                            exist.
+                        </Paragraph>
+                        <Paragraph>To set a plain-text password, edit your GRUB configuration file
+                            and add the following line before the first uncommented line:
+                        </Paragraph>
+                        <Paragraph preformat="true">password &lt;password&gt;</Paragraph>
+                        <Paragraph>To set an encrypted password, run grub-md5-crypt and use its
+                            output when adding the following line before the first
+                            uncommented line:
+                        </Paragraph>
+                        <Paragraph preformat="true">password --md5 &lt;encryptedpassword&gt;</Paragraph>
+                        <Paragraph>For either approach, choose an appropriately strong password.</Paragraph>
+                    </Paragraph>
+                </ContainerBlockElement>
+            </solution>
+        </vulnerability>
+
+        <vulnerability id="linux-icmp-redirect" title="ICMP redirection enabled" severity="7" pciSeverity="4"
+                       cvssScore="6.8" cvssVector="(AV:N/AC:M/Au:N/C:P/I:P/A:P)" published="20031231T000000000"
+                       added="20041130T000000000" modified="20120719T000000000" riskScore="740.62415">
+            <malware/>
+            <exploits/>
+            <description>
+
+                <ContainerBlockElement>
+
+                    <Paragraph>By default, many linux systems enable a feature called ICMP redirection,
+                        where the machine will alter its route table in response to an ICMP
+                        redirect message from any network device.
+                    </Paragraph>
+
+
+                    <Paragraph>There is a risk that this feature could be used to subvert a host's
+                        routing table in order to compromise its security (e.g., tricking it
+                        into sending packets via a specific route where they may be sniffed
+                        or altered).
+                    </Paragraph>
+                </ContainerBlockElement>
+            </description>
+            <references>
+                <reference source="BID">6823</reference>
+                <reference source="MSKB">293626</reference>
+                <reference source="XF">cisco-ios-icmp-redirect(11306)</reference>
+            </references>
+            <tags>
+                <tag>UNIX</tag>
+            </tags>
+            <solution>
+
+                <ContainerBlockElement>
+                    <Paragraph>Linux</Paragraph>
+                    <Paragraph>
+                        <Paragraph>Issue the following commands as root:</Paragraph>
+                        <Paragraph preformat="true">sysctl -w net.ipv4.conf.all.accept_redirects=0</Paragraph>
+                        <Paragraph preformat="true">sysctl -w net.ipv4.conf.default.accept_redirects=0</Paragraph>
+                        <Paragraph preformat="true">sysctl -w net.ipv4.conf.all.secure_redirects=0</Paragraph>
+                        <Paragraph preformat="true">sysctl -w net.ipv4.conf.default.secure_redirects=0</Paragraph>
+                        <Paragraph>These settings can be added to /etc/sysctl.conf to make them permanent.</Paragraph>
+                    </Paragraph>
+                </ContainerBlockElement>
+            </solution>
+        </vulnerability>
+
+        <vulnerability id="unix-user-home-dir-mode" title="User home directory mode unsafe" severity="2" pciSeverity="2"
+                       cvssScore="2.1" cvssVector="(AV:L/AC:L/Au:N/C:P/I:N/A:N)" published="20050115T000000000"
+                       added="20050115T000000000" modified="20200211T000000000" riskScore="579.081">
+            <malware/>
+            <exploits/>
+            <description>
+
+                <ContainerBlockElement>
+
+                    <Paragraph>A user's home directory was found to have a permission mode which is more permissive than
+                        750 (Owner=READ/WRITE/EXECUTE, Group=READ/EXECUTE, Other=NONE).
+                        "Group" or "Other" WRITE permissions means that a malicious user may gain complete access to
+                        user data by escalating privileges.
+                        In addition "read" and "execute" access for "Other" should always be disabled (sensitive data
+                        access).
+                    </Paragraph>
+                </ContainerBlockElement>
+            </description>
+            <references>
+            </references>
+            <tags>
+                <tag>UNIX</tag>
+            </tags>
+            <solution>
+
+                <ContainerBlockElement>
+                    <Paragraph>
+                        <Paragraph>Restrict the user home directory mode to at most 750 using the command:</Paragraph>
+                        <Paragraph preformat="true">chmod 750 userDir</Paragraph>
+                    </Paragraph>
+                </ContainerBlockElement>
+            </solution>
+        </vulnerability>
+    </VulnerabilityDefinitions>
 </NexposeReport>

--- a/dojo/unittests/tools/test_nexpose_parser.py
+++ b/dojo/unittests/tools/test_nexpose_parser.py
@@ -26,9 +26,9 @@ class TestNexposeParser(TestCase):
         self.assertEqual("TCP Sequence Number Approximation Vulnerability", finding.title)
         self.assertEqual("CVE-2004-0230", finding.cve)
         self.assertEqual(3, len(finding.unsaved_endpoints))
-        self.assertIn("https://www.securityfocus.com/bid/10183", finding.references) # BID: 10183
-        self.assertIn("https://www.kb.cert.org/vuls/id/415294.html", finding.references) # CERT-VN: 415294
-        self.assertIn("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2004-0230", finding.references) # CVE: CVE-2004-0230
+        self.assertIn("https://www.securityfocus.com/bid/10183", finding.references)  # BID: 10183
+        self.assertIn("https://www.kb.cert.org/vuls/id/415294.html", finding.references)  # CERT-VN: 415294
+        self.assertIn("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2004-0230", finding.references)  # CVE: CVE-2004-0230
         # vuln 2
         finding = findings[2]
         self.assertEqual("Low", finding.severity)

--- a/dojo/unittests/tools/test_nexpose_parser.py
+++ b/dojo/unittests/tools/test_nexpose_parser.py
@@ -19,19 +19,19 @@ class TestNexposeParser(TestCase):
         parser = NexposeParser()
         findings = parser.get_findings(testfile, test)
         testfile.close()
-        self.assertEqual(13, len(findings))
+        self.assertEqual(16, len(findings))
         # vuln 1
         finding = findings[0]
-        self.assertEqual("Critical", finding.severity)
-        self.assertEqual("Default SSH password: root password \"root\"", finding.title)
-        self.assertIsNone(finding.cve)
-        self.assertEqual(1, len(finding.unsaved_endpoints))
+        self.assertEqual("Medium", finding.severity)
+        self.assertEqual("TCP Sequence Number Approximation Vulnerability", finding.title)
+        self.assertEqual("CVE-2004-0230", finding.cve)
+        self.assertEqual(3, len(finding.unsaved_endpoints))
         # vuln 2
         finding = findings[2]
-        self.assertEqual("Medium", finding.severity)
-        self.assertEqual("Missing HttpOnly Flag From Cookie", finding.title)
+        self.assertEqual("Low", finding.severity)
+        self.assertEqual("TCP timestamp response", finding.title)
         self.assertIsNone(finding.cve)
-        self.assertEqual(1, len(finding.unsaved_endpoints))
+        self.assertEqual(5, len(finding.unsaved_endpoints))
 
     def test_nexpose_parser_tests_outside_endpoint(self):
         testfile = open("dojo/unittests/scans/nexpose/report_auth.xml")

--- a/dojo/unittests/tools/test_nexpose_parser.py
+++ b/dojo/unittests/tools/test_nexpose_parser.py
@@ -35,16 +35,16 @@ class TestNexposeParser(TestCase):
         self.assertEqual("TCP timestamp response", finding.title)
         self.assertIsNone(finding.cve)
         self.assertEqual(5, len(finding.unsaved_endpoints))
-        # vuln 3
-        finding = findings[3]
-        self.assertEqual("Default SSH password: root password \"root\"", finding.title)
-        self.assertEqual(2, len(finding.unsaved_endpoints))
-        # vuln 3 - endpoint 1
+        # vuln 2 - endpoint
         endpoint = finding.unsaved_endpoints[0]
         self.assertIsNone(endpoint.port)
         self.assertIsNone(endpoint.protocol)
-        # vuln 3 - endpoint 2
-        endpoint = finding.unsaved_endpoints[1]
+        # vuln 3
+        finding = findings[3]
+        self.assertEqual("Default SSH password: root password \"root\"", finding.title)
+        self.assertEqual(1, len(finding.unsaved_endpoints))
+        # vuln 3 - endpoint
+        endpoint = finding.unsaved_endpoints[0]
         self.assertEqual(22, endpoint.port)
         self.assertEqual("ssh", endpoint.protocol)
 

--- a/dojo/unittests/tools/test_nexpose_parser.py
+++ b/dojo/unittests/tools/test_nexpose_parser.py
@@ -26,12 +26,25 @@ class TestNexposeParser(TestCase):
         self.assertEqual("TCP Sequence Number Approximation Vulnerability", finding.title)
         self.assertEqual("CVE-2004-0230", finding.cve)
         self.assertEqual(3, len(finding.unsaved_endpoints))
+        self.assertIn("https://www.securityfocus.com/bid/10183", finding.references) # BID: 10183
+        self.assertIn("https://www.kb.cert.org/vuls/id/415294.html", finding.references) # CERT-VN: 415294
+        self.assertIn("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2004-0230", finding.references) # CVE: CVE-2004-0230
         # vuln 2
         finding = findings[2]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("TCP timestamp response", finding.title)
         self.assertIsNone(finding.cve)
         self.assertEqual(5, len(finding.unsaved_endpoints))
+        # vuln 3
+        finding = findings[3]
+        self.assertEqual("Default SSH password: root password \"root\"", finding.title)
+        self.assertEqual(2, len(finding.unsaved_endpoints))
+        # vuln 3 - endpoint 1
+        endpoint = finding.unsaved_endpoints[0]
+        self.assertIsNone(endpoint.port)
+        # vuln 3 - endpoint 2
+        endpoint = finding.unsaved_endpoints[1]
+        self.assertEqual(22, endpoint.port)
 
     def test_nexpose_parser_tests_outside_endpoint(self):
         testfile = open("dojo/unittests/scans/nexpose/report_auth.xml")
@@ -43,13 +56,16 @@ class TestNexposeParser(TestCase):
         self.assertEqual("High", finding.severity)
         self.assertEqual("ICMP redirection enabled", finding.title)
         self.assertIsNone(finding.cve)
+        self.assertEqual(4, len(finding.unsaved_endpoints))
         # vuln 1
         finding = findings[1]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("No password for Grub", finding.title)
         self.assertIsNone(finding.cve)
+        self.assertEqual(4, len(finding.unsaved_endpoints))
         # vuln 2
         finding = findings[2]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("User home directory mode unsafe", finding.title)
         self.assertIsNone(finding.cve)
+        self.assertEqual(16, len(finding.unsaved_endpoints))

--- a/dojo/unittests/tools/test_nexpose_parser.py
+++ b/dojo/unittests/tools/test_nexpose_parser.py
@@ -42,9 +42,11 @@ class TestNexposeParser(TestCase):
         # vuln 3 - endpoint 1
         endpoint = finding.unsaved_endpoints[0]
         self.assertIsNone(endpoint.port)
+        self.assertIsNone(endpoint.protocol)
         # vuln 3 - endpoint 2
         endpoint = finding.unsaved_endpoints[1]
         self.assertEqual(22, endpoint.port)
+        self.assertEqual("ssh", endpoint.protocol)
 
     def test_nexpose_parser_tests_outside_endpoint(self):
         testfile = open("dojo/unittests/scans/nexpose/report_auth.xml")


### PR DESCRIPTION
Used [for-loop](https://github.com/DefectDojo/django-DefectDojo/blob/6a2b0e5939155554a284f90f58e6287632436ce8/dojo/tools/nexpose/parser.py#L228) processed only last "discovered" host in the XML file. I move it to the upper loop.

There was missing also adding Endpoint - so it wasn't possible to identify where vulnerability is.

For finding on specific service, I added also a protocol name to the Endpoint

I also added a couple of new references used in Nexpose reports.

Test XML changed to easier readable.

\+ Using better names of variables

\+ Tests