### PR TITLE
dependabot: update django from 2.2.17 to 2.2.18

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
       # phased startup so we can use the exit code from unit test container
       - name: Start MySQL
-        run: docker-compose up --no-deps -d mysql
+        run: docker-compose up -d
 
       # no celery or initializer needed for unit tests
       - name: Unit tests

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ A magical, illusionary, non-existent, YMMV, wannabe, no guarantees list of thing
 - New permission model
 - Push groups of findings to a single JIRA ticket
 - Reimport matching improvements
-- New UI (SPA on top of API)
-- More parsers (CycloneDX, OVAL)
 
 
 ## Support, Bug Reports and Getting Involved

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ See [Wrappers](WRAPPERS.md)
 See [Release and branch model](BRANCHING-MODEL.md)
 
 
+## Roadmap
+A magical, illusionary, non-existent, YMMV, wannabe, no guarantees list of thing we may or may not be working on:
+- New permission model
+- Push groups of findings to a single JIRA ticket
+- Reimport matching improvements
+- New UI (SPA on top of API)
+- More parsers (CycloneDX, OVAL)
+
+
 ## Support, Bug Reports and Getting Involved
 Please come to our Slack channel first, where we can try to help you or point you in the right direction:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ git+https://github.com/DefectDojo/django-tastypie-swagger.git@c7c5629480dc20cadd
 django-tastypie==0.14.2
 django-watson==1.5.5
 django-prometheus==2.1.0
-Django==2.2.17
+Django==2.2.18
 djangorestframework==3.12.2
 gunicorn==20.0.4
 html2text==2020.1.16

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="Tool for managing vulnerability engagements",
     install_requires=[
         'defusedxml',
-        'Django==2.2.17',
+        'Django==2.2.18',
         'django-auditlog==0.4.7',
         'django-custom-field',
         'django-filter==2.4.0',


### PR DESCRIPTION
Dependabot generated a PR against `master` instead of `dev` and I didn't notice (https://github.com/DefectDojo/django-DefectDojo/pull/4086).
Easest is to just merge master into dev, which is this PR.