### PR TITLE
Make mitigation, impact, url fields optional

### DIFF
--- a/docs/content/running/upgrading.md
+++ b/docs/content/running/upgrading.md
@@ -111,6 +111,18 @@ Upgrade Celery to the latest version:
 
 > `pip install --upgrade celery`
 
+Upgrading to DefectDojo Version 1.14.x
+--------------------------------------
+- See release notes: https://github.com/DefectDojo/django-DefectDojo/releases/tag/1.14.0
+
+Note that the below fields are now optional without default value. They will not be filled anymore with values such as "No references given" when found empty while saving the findings
+- mitigation
+- references
+- impact
+- url
+
+
+
 Upgrading to DefectDojo Version 1.13.x
 --------------------------------------
 - See release notes: https://github.com/DefectDojo/django-DefectDojo/releases/tag/1.13.0


### PR DESCRIPTION
Documentation part regarding the fields that have become optional in https://github.com/DefectDojo/django-DefectDojo/pull/4016

This PR also serves as making this change more visible in the release note
