### PR TITLE
JIRA: Always check credentials when creating/saving a JIRA instance

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -317,7 +317,7 @@ def get_jira_connection_raw(jira_server, jira_username, jira_password):
         jira = JIRA(server=jira_server,
                 basic_auth=(jira_username, jira_password),
                 options={"verify": settings.JIRA_SSL_VERIFY},
-                max_retries=0)
+                max_retries=0, validate=True)
 
         logger.debug('logged in to JIRA ''%s'' successfully', jira_server)
 

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -312,12 +312,12 @@ def has_jira_configured(obj):
     return get_jira_project(obj) is not None
 
 
-def get_jira_connection_raw(jira_server, jira_username, jira_password):
+def get_jira_connection_raw(jira_server, jira_username, jira_password, validate=False):
     try:
         jira = JIRA(server=jira_server,
                 basic_auth=(jira_username, jira_password),
                 options={"verify": settings.JIRA_SSL_VERIFY},
-                max_retries=0, validate=True)
+                max_retries=0, validate=validate)
 
         logger.debug('logged in to JIRA ''%s'' successfully', jira_server)
 

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -217,7 +217,7 @@ def express_new_jira(request):
             jira_password = jform.cleaned_data.get('password')
 
             try:
-                jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password)
+                jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password, validate=True)
             except Exception as e:
                 logger.exception(e)  # already logged in jira_helper
                 messages.add_message(request,
@@ -301,7 +301,7 @@ def new_jira(request):
             jira_password = jform.cleaned_data.get('password')
 
             logger.debug('calling get_jira_connection_raw')
-            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password)
+            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password, validate=True)
 
             new_j = jform.save(commit=False)
             new_j.url = jira_server
@@ -342,7 +342,7 @@ def edit_jira(request, jid):
                 # on edit the password is optional
                 jira_password = jira_password_from_db
 
-            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password)
+            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password, validate=True)
 
             new_j = jform.save(commit=False)
             new_j.url = jira_server

--- a/dojo/unittests/test_jira_config_product.py
+++ b/dojo/unittests/test_jira_config_product.py
@@ -46,7 +46,7 @@ class JIRAConfigProductTest(DojoTestCase):
     def add_jira_instance(self, data, jira_mock):
         response = self.client.post(reverse('add_jira'), urlencode(data), content_type='application/x-www-form-urlencoded')
         # check that storing a new config triggers a login call to JIRA
-        jira_mock.assert_called_once_with(data['url'], data['username'], data['password'])
+        jira_mock.assert_called_once_with(data['url'], data['username'], data['password'], validate=True)
         # succesful, so should redirect to list of JIRA instances
         self.assertRedirects(response, '/jira')
 


### PR DESCRIPTION
fixes #4131 