### PR TITLE
finding.save and dedupe streamlining

### DIFF
--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1584,8 +1584,6 @@ class ReImportScanResource(MultipartResource, Resource):
                 if Finding.SEVERITIES[sev] > Finding.SEVERITIES[min_sev]:
                     continue
 
-                from titlecase import titlecase
-                item.title = titlecase(item.title)
                 if scan_type == 'Veracode Scan':
                     find = Finding.objects.filter(title=item.title,
                                                   test__id=test.id,

--- a/dojo/api.py
+++ b/dojo/api.py
@@ -1584,6 +1584,8 @@ class ReImportScanResource(MultipartResource, Resource):
                 if Finding.SEVERITIES[sev] > Finding.SEVERITIES[min_sev]:
                     continue
 
+                from titlecase import titlecase
+                item.title = titlecase(item.title)
                 if scan_type == 'Veracode Scan':
                     find = Finding.objects.filter(title=item.title,
                                                   test__id=test.id,

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1366,9 +1366,6 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 component_name = item.component_name if hasattr(item, 'component_name') else None
                 component_version = item.component_version if hasattr(item, 'component_version') else None
 
-                from titlecase import titlecase
-                item.title = titlecase(item.title)
-
                 item.hash_code = item.compute_hash_code()
                 deduplicationLogger.debug("new finding's hash_code: %s", item.hash_code)
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1376,8 +1376,6 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
 
                 deduplicationLogger.debug('found %i findings matching with current new finding', len(findings))
 
-                # raise ValueError('bla')
-
                 if findings:
                     # existing finding found
                     finding = findings[0]

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1374,6 +1374,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
 
                 findings = match_new_finding_to_existing_finding(item, test, deduplication_algorithm, scan_type)
 
+                deduplicationLogger.debug('found %i findings matching with current new finding', len(findings))
+
+                # raise ValueError('bla')
+
                 if findings:
                     # existing finding found
                     finding = findings[0]

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -1,11 +1,14 @@
+from dojo.celery import app
+from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
 import logging
 from django.utils import timezone
 from django.conf import settings
 from fieldsignals import pre_save_changed
-from dojo.models import Finding
 from dojo.utils import get_current_user
+from dojo.models import Finding, System_Settings
 
 logger = logging.getLogger(__name__)
+deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 
 # this signal is triggered just before a finding is getting saved
@@ -15,9 +18,9 @@ logger = logging.getLogger(__name__)
 # - update any audit log / status history
 def pre_save_finding_status_change(sender, instance, changed_fields=None, **kwargs):
     # some code is cloning findings by setting id/pk to None, ignore those, will be handled on next save
-    if not instance.id:
-        logger.info('ignoring save of finding without id')
-        return
+    # if not instance.id:
+    #     logger.info('ignoring save of finding without id')
+    #     return
 
     logger.info('%i: changed status fields pre_save: %s', instance.id or 0, changed_fields)
 
@@ -105,3 +108,49 @@ def update_finding_status(new_state_finding, user, changed_fields=None):
 
 def can_edit_mitigated_data(user):
     return settings.EDITABLE_MITIGATED_DATA and user.is_superuser
+
+
+@dojo_model_to_id
+@dojo_async_task
+@app.task
+@dojo_model_from_id
+def post_process_finding_save(finding, dedupe_option=True, false_history=False, rules_option=True, product_grading_option=True,
+             issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):
+
+    system_settings = System_Settings.objects.get()
+
+    # STEP 1 run all status changing tasks sequentially to avoid race conditions
+    if dedupe_option:
+        if finding.hash_code is not None:
+            if system_settings.enable_deduplication:
+                from dojo.utils import do_dedupe_finding
+                do_dedupe_finding(finding, *args, **kwargs)
+            else:
+                deduplicationLogger.debug("skipping dedupe because it's disabled in system settings")
+        else:
+            deduplicationLogger.warning("skipping dedupe because hash_code is None")
+
+    if false_history:
+        if system_settings.false_positive_history:
+            from dojo.utils import do_false_positive_history
+            do_false_positive_history(finding, *args, **kwargs)
+        else:
+            deduplicationLogger.debug("skipping false positive history because it's disabled in system settings")
+
+    # STEP 2 run all non-status changing tasks as celery tasks in the background
+    if issue_updater_option:
+        from dojo.tools import tool_issue_updater
+        tool_issue_updater.async_tool_issue_update(finding)
+
+    if product_grading_option:
+        if system_settings.enable_product_grade:
+            from dojo.utils import calculate_grade
+            calculate_grade(finding.test.engagement.product)
+        else:
+            deduplicationLogger.debug("skipping product grading because it's disabled in system settings")
+
+    # Adding a snippet here for push to JIRA so that it's in one place
+    if push_to_jira:
+        logger.debug('pushing finding %s to jira from finding.save()', finding.pk)
+        import dojo.jira_link.helper as jira_helper
+        jira_helper.push_to_jira(finding)

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1804,27 +1804,26 @@ def finding_bulk_update_all(request, pid=None):
     now = timezone.now()
     if request.method == "POST":
         finding_to_update = request.POST.getlist('finding_to_update')
-        if request.POST.get('delete_bulk_findings') and finding_to_update:
-            finds = Finding.objects.filter(id__in=finding_to_update)
+        finds = Finding.objects.filter(id__in=finding_to_update).order_by("id")
+        prods = set([find.test.engagement.product for find in finds])
+        if request.POST.get('delete_bulk_findings'):
+            if form.is_valid() and finding_to_update:
+                # make sure users are not deleting stuff they are not authorized for
+                if not request.user.is_staff and not request.user.is_superuser:
+                    if not settings.AUTHORIZED_USERS_ALLOW_DELETE:
+                        raise PermissionDenied()
 
-            # make sure users are not deleting stuff they are not authorized for
-            if not request.user.is_staff and not request.user.is_superuser:
-                if not settings.AUTHORIZED_USERS_ALLOW_DELETE:
-                    raise PermissionDenied()
+                    finds = finds.filter(
+                        Q(test__engagement__product__authorized_users__in=[request.user]) |
+                        Q(test__engagement__product__prod_type__authorized_users__in=[request.user])
+                    )
 
-                finds = finds.filter(
-                    Q(test__engagement__product__authorized_users__in=[request.user]) |
-                    Q(test__engagement__product__prod_type__authorized_users__in=[request.user])
-                )
-
-            product_calc = list(Product.objects.filter(engagement__test__finding__id__in=finding_to_update).distinct())
-            finds.delete()
-            for prod in product_calc:
-                calculate_grade(prod)
+                finds.delete()
+                for prod in prods:
+                    calculate_grade(prod)
         else:
             if form.is_valid() and finding_to_update:
                 finding_to_update = request.POST.getlist('finding_to_update')
-                finds = Finding.objects.filter(id__in=finding_to_update).order_by("finding__test__engagement__product__id")
 
                 # make sure users are not deleting stuff they are not authorized for
                 if not request.user.is_staff and not request.user.is_superuser:
@@ -1861,6 +1860,9 @@ def finding_bulk_update_all(request, pid=None):
                         find.save_no_options()
                         logger.debug('bulk update save done')
 
+                    for prod in prods:
+                        calculate_grade(prod)
+
                 skipped_risk_accept_count = 0
                 if form.cleaned_data['risk_acceptance']:
                     for finding in finds:
@@ -1871,6 +1873,9 @@ def finding_bulk_update_all(request, pid=None):
                                 ra_helper.simple_risk_accept(finding)
                         elif form.cleaned_data['risk_unaccept']:
                             ra_helper.risk_unaccept(finding)
+
+                    for prod in prods:
+                        calculate_grade(prod)
 
                 if skipped_risk_accept_count > 0:
                     messages.add_message(request,
@@ -1897,15 +1902,6 @@ def finding_bulk_update_all(request, pid=None):
                         # currently bulk edit overwrites existing tags
                         finding.tags = tags
                         finding.save()
-
-                if form.cleaned_data['severity'] or form.cleaned_data['status']:
-                    prev_prod = None
-                    for finding in finds:
-                        # findings are ordered by product_id
-                        if prev_prod != finding.test.engagement.product.id:
-                            # TODO this can be inefficient as most findings usually have the same product
-                            calculate_grade(finding.test.engagement.product)
-                            prev_prod = finding.test.engagement.product.id
 
                 for finding in finds:
                     from dojo.tools import tool_issue_updater

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -847,7 +847,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf",
+      "hash_code": "5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -898,7 +898,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf",
+      "hash_code": "5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -949,7 +949,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf",
+      "hash_code": "5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1000,7 +1000,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf",
+      "hash_code": "5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1051,7 +1051,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf",
+      "hash_code": "5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1156,7 +1156,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba",
+      "hash_code": "9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1207,7 +1207,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba",
+      "hash_code": "9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1258,7 +1258,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba",
+      "hash_code": "9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1310,7 +1310,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba",
+      "hash_code": "9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1362,7 +1362,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba",
+      "hash_code": "9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1414,7 +1414,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "3c5e9d1ec77aea19dd2bbf3aa51f585fc0da876174be8cac885966db1271f147",
+      "hash_code": "6f8d0bf970c14175e597843f4679769a4775742549d90f902ff803de9244c7e1",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1466,7 +1466,7 @@
       "url": null,
       "notes": [],
       "dynamic_finding": false,
-      "hash_code": "3c5e9d1ec77aea19dd2bbf3aa51f585fc0da876174be8cac885966db1271f147",
+      "hash_code": "6f8d0bf970c14175e597843f4679769a4775742549d90f902ff803de9244c7e1",
       "is_template": false,
       "endpoints": [],
       "last_reviewed": null
@@ -1924,7 +1924,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "2",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 2
     }
@@ -1939,7 +1939,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "3",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 3
     }
@@ -1954,7 +1954,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "4",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 4
     }
@@ -1969,7 +1969,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "5",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 5
     }
@@ -1984,7 +1984,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "6",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 6
     }
@@ -2089,7 +2089,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "2",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 2
     }
@@ -2104,7 +2104,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "3",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 3
     }
@@ -2119,7 +2119,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "4",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 4
     }
@@ -2134,7 +2134,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "5",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 5
     }
@@ -2149,7 +2149,7 @@
       "title": "High Impact Test Finding",
       "url": "",
       "object_id": "6",
-      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf ",
+      "content": "High Impact Test Finding None High test finding test mitigation High  S0 None None None None None 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7 ",
       "content_type": 33,
       "object_id_int": 6
     }

--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -59,8 +59,8 @@ class Command(BaseCommand):
         if not hash_code_only:
             if get_system_setting('enable_deduplication'):
                 for finding in findings:
-                    from dojo.utils import do_dedupe_finding_sync
-                    do_dedupe_finding_sync(finding)
+                    from dojo.utils import do_dedupe_finding
+                    do_dedupe_finding(finding)
                 logger.info("######## Done deduplicating########")
             else:
                 logger.debug("skipping dedupe because it's disabled in system settings")

--- a/dojo/management/commands/rename_whitesource_findings.py
+++ b/dojo/management/commands/rename_whitesource_findings.py
@@ -36,7 +36,5 @@ def rename_whitesource_finding():
             logger.debug('Set cwe for finding %d to 1035 if not an cwe Number is set' % finding.id)
             finding.cwe = 1035
         finding.title = finding.title.rstrip()  # delete \n at the end of the title
-        from titlecase import titlecase
-        finding.title = titlecase(finding.title)
         finding.hash_code = finding.compute_hash_code()
         finding.save()

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2134,7 +2134,6 @@ class Finding(models.Model):
         self.found_by.add(self.test.test_type)
 
         # postprocessing is done in a celery task
-        print('kwargs: ', kwargs)
         finding_helper.post_process_finding_save(self, dedupe_option=dedupe_option, false_history=false_history, rules_option=rules_option, product_grading_option=product_grading_option,
              issue_updater_option=issue_updater_option, push_to_jira=push_to_jira, user=user, *args, **kwargs)
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2064,54 +2064,19 @@ class Finding(models.Model):
 
     def save(self, dedupe_option=True, false_history=False, rules_option=True, product_grading_option=True,
              issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):
-        # Make changes to the finding before it's saved to add a CWE template
-        new_finding = False
+
+        from dojo.finding import helper as finding_helper
+
+        system_settings = System_Settings.objects.get()
 
         if not user:
             from dojo.utils import get_current_user
             user = get_current_user()
             logger.debug('finding.save() getting current user: %s', user)
 
-        if self.pk is None:
-            # We enter here during the first call from serializers.py
-            logger.debug("Saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is None)")
-            false_history = True
-            from dojo.utils import apply_cwe_to_template
-            self = apply_cwe_to_template(self)
-            # calling django.db.models superclass save method
-            super(Finding, self).save(*args, **kwargs)
-        else:
-            # We enter here during the second call from serializers.py
-            logger.debug("Saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is not None)")
-            # calling django.db.models superclass save method
-            super(Finding, self).save(*args, **kwargs)
-
-            # Run async the tool issue update to update original issue with Defect Dojo updates
-            if issue_updater_option:
-                from dojo.tools import tool_issue_updater
-                tool_issue_updater.async_tool_issue_update(self)
-        if (self.file_path is not None) and (self.endpoints.count() == 0):
-            self.static_finding = True
-            self.dynamic_finding = False
-        elif (self.file_path is not None):
-            self.static_finding = True
-
-        # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
-        # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
-        if(dedupe_option):
-            if (self.hash_code is not None):
-                deduplicationLogger.debug("Hash_code already computed for finding")
-            else:
-                self.hash_code = self.compute_hash_code()
-        self.found_by.add(self.test.test_type)
-
-        if rules_option:
-            from dojo.utils import do_apply_rules
-            do_apply_rules(self, *args, **kwargs)
-
-        if product_grading_option:
-            from dojo.utils import calculate_grade
-            calculate_grade(self.test.engagement.product)
+        # Title Casing
+        from titlecase import titlecase
+        self.title = titlecase(self.title)
 
         # Assign the numerical severity for correct sorting order
         self.numerical_severity = Finding.get_numerical_severity(self.severity)
@@ -2124,34 +2089,54 @@ class Finding(models.Model):
                 self.cvssv3_score = cvss_object.scores()[2]
             except Exception as ex:
                 logger.error("Can't compute cvssv3 score for finding id %i. Invalid cvssv3 vector found: '%s'. Exception: %s", self.id, self.cvssv3, ex)
-        super(Finding, self).save()
-        system_settings = System_Settings.objects.get()
 
-        if dedupe_option and self.hash_code is not None:
-            if system_settings.enable_deduplication:
-                from dojo.utils import do_dedupe_finding
-                do_dedupe_finding(self, *args, **kwargs)
+        if rules_option:
+            from dojo.utils import do_apply_rules
+            do_apply_rules(self, *args, **kwargs)
+
+        # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
+        # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
+        if dedupe_option:
+            if (self.hash_code is not None):
+                deduplicationLogger.debug("Hash_code already computed for finding")
             else:
-                deduplicationLogger.debug("skipping dedupe because it's disabled in system settings")
+                self.hash_code = self.compute_hash_code()
+                deduplicationLogger.debug("Hash_code computed for finding: %s", self.hash_code)
 
-        if system_settings.false_positive_history and false_history:
-            from dojo.utils import do_false_positive_history
-            do_false_positive_history(self, *args, **kwargs)
+        if self.pk is None:
+            # We enter here during the first call from serializers.py
+            false_history = True
+            from dojo.utils import apply_cwe_to_template
+            self = apply_cwe_to_template(self)
+
+            if (self.file_path is not None) and (len(self.unsaved_endpoints) == 0):
+                self.static_finding = True
+                self.dynamic_finding = False
+            elif (self.file_path is not None):
+                self.static_finding = True
+
+            # because we have reduced the number of (super()).save() calls, the helper is no longer called for new findings
+            # so we call it manually
+            finding_helper.update_finding_status(self, user, changed_fields={'id': (None, None)})
+
         else:
-            deduplicationLogger.debug("skipping false positive history because it's disabled in system settings or false_history param is False")
+            logger.debug('setting static / dynamic in save')
+            # need to have an id/pk before we can access endpoints
+            if (self.file_path is not None) and (self.endpoints.count() == 0):
+                self.static_finding = True
+                self.dynamic_finding = False
+            elif (self.file_path is not None):
+                self.static_finding = True
 
-        # Title Casing
-        from titlecase import titlecase
-        self.title = titlecase(self.title)
+        logger.debug("Saving finding of id " + str(self.id) + " dedupe_option:" + str(dedupe_option) + " (self.pk is %s)", "None" if self.pk is None else "not None")
+        super(Finding, self).save(*args, **kwargs)
 
-        from dojo.utils import calculate_grade
-        calculate_grade(self.test.engagement.product)
+        self.found_by.add(self.test.test_type)
 
-        # Adding a snippet here for push to JIRA so that it's in one place
-        if push_to_jira:
-            logger.debug('pushing finding %s to jira from finding.save()', self.pk)
-            import dojo.jira_link.helper as jira_helper
-            jira_helper.push_to_jira(self)
+        # postprocessing is done in a celery task
+        print('kwargs: ', kwargs)
+        finding_helper.post_process_finding_save(self, dedupe_option=dedupe_option, false_history=false_history, rules_option=rules_option, product_grading_option=product_grading_option,
+             issue_updater_option=issue_updater_option, push_to_jira=push_to_jira, user=user, *args, **kwargs)
 
     def delete(self, *args, **kwargs):
         for find in self.original_finding.all():

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1866,15 +1866,9 @@ class Finding(models.Model):
 
     # Compute the hash_code from the fields to hash
     def hash_fields(self, fields_to_hash):
-        # get bytes to hash
-        if(isinstance(fields_to_hash, str)):
-            hash_string = fields_to_hash.encode('utf-8').strip()
-        elif(isinstance(fields_to_hash, bytes)):
-            hash_string = fields_to_hash.strip()
-        else:
-            deduplicationLogger.debug("trying to convert hash_string of type " + str(type(fields_to_hash)) + " to str and then bytes")
-            hash_string = str(fields_to_hash).encode('utf-8').strip()
-        return hashlib.sha256(hash_string).hexdigest()
+        logger.debug('fields_to_hash      : %s', fields_to_hash)
+        logger.debug('fields_to_hash lower: %s', fields_to_hash.lower())
+        return hashlib.sha256(fields_to_hash.casefold().encode('utf-8').strip()).hexdigest()
 
     def duplicate_finding_set(self):
         if self.duplicate:

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 from dojo.utils import get_system_setting, get_full_url
 from dateutil.relativedelta import relativedelta

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -996,7 +996,7 @@ LOGGING = {
             'propagate': False,
         },
         'titlecase': {
-            # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
+            # The titlecase library is too verbose in it's logging, reducing the verbosity in our logs.
             'handlers': [r'%s' % LOGGING_HANDLER],
             'level': 'WARNING',
             'propagate': False,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -741,6 +741,7 @@ def re_import_scan_results(request, tid):
 
                     from titlecase import titlecase
                     item.title = titlecase(item.title)
+
                     item.hash_code = item.compute_hash_code()
                     deduplicationLogger.debug("new finding's hash_code: %s", item.hash_code)
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -739,9 +739,6 @@ def re_import_scan_results(request, tid):
                     if Finding.SEVERITIES[sev] > Finding.SEVERITIES[min_sev]:
                         continue
 
-                    from titlecase import titlecase
-                    item.title = titlecase(item.title)
-
                     item.hash_code = item.compute_hash_code()
                     deduplicationLogger.debug("new finding's hash_code: %s", item.hash_code)
 

--- a/dojo/unittests/test_deduplication_logic.py
+++ b/dojo/unittests/test_deduplication_logic.py
@@ -43,11 +43,11 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 #       engagement 1: 1st Quarter Engagement (dedupe_inside: True)
 #               test 3: ZAP Scan (algo=hash_code, dynamic=True)
 #               findings:
-#                       2   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf: eps: 0: notes: []: uid: None
-#                       3   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf: eps: 0: notes: []: uid: None
-#                       4   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf: eps: 0: notes: []: uid: None
-#                       5   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf: eps: 0: notes: []: uid: None
-#                       6   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 8cba854f0b70f8a25064952402fbe30c728c0017b83c245d786366956044e0bf: eps: 0: notes: []: uid: None
+#                       2   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7: eps: 0: notes: []: uid: None
+#                       3   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7: eps: 0: notes: []: uid: None
+#                       4   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7: eps: 0: notes: []: uid: None
+#                       5   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7: eps: 0: notes: []: uid: None
+#                       6   : "High Impact Test Fin": High : act: True : ver: True : mit: False: dup: True : dup_id: 2   : hash_code: 5d368a051fdec959e08315a32ef633ba5711bed6e8e75319ddee2cab4d4608c7: eps: 0: notes: []: uid: None
 #                       7   : "DUMMY FINDING       ": High : act: False: ver: False: mit: False: dup: False: dup_id: None: hash_code: c89d25e445b088ba339908f68e15e3177b78d22f3039d1bfea51c4be251bf4e0: eps: 0: notes: [1]: uid: None
 #               endpoints
 #                       2: ftp://localhost/
@@ -75,8 +75,8 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 #       engagement 5: April monthly engagement (dedupe_inside: True)
 #               test 55: Checkmarx Scan detailed (algo=unique_id_from_tool, dynamic=False)
 #               findings:
-#                       124 : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba: eps: 0: notes: []: uid: 12345
-#                       125 : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: None: hash_code: 5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba: eps: 0: notes: []: uid: 12345
+#                       124 : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa: eps: 0: notes: []: uid: 12345
+#                       125 : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: None: hash_code: 9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa: eps: 0: notes: []: uid: 12345
 #               endpoints
 #                       2: ftp://localhost/
 #                       1: http://127.0.0.1/endpoint/420/edit/
@@ -93,8 +93,8 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 #                       1: dojo.Endpoint.None dojo.Finding.None 1 2020-07-01 00:00:00+00:00 2020-07-01 17:45:39.791907+00:00 False None None False False False ftp://localhost/ High Impact Test Finding
 #               test 77: Veracode Scan (algo=unique_id_from_tool_or_hash_code, dynamic=False)
 #               findings:
-#                       224 : "UID Impact Test Find": Low  : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 3c5e9d1ec77aea19dd2bbf3aa51f585fc0da876174be8cac885966db1271f147: eps: 0: notes: []: uid: 6789
-#                       225 : "UID Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: 224 : hash_code: 3c5e9d1ec77aea19dd2bbf3aa51f585fc0da876174be8cac885966db1271f147: eps: 0: notes: []: uid: 6789
+#                       224 : "UID Impact Test Find": Low  : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 6f8d0bf970c14175e597843f4679769a4775742549d90f902ff803de9244c7e1: eps: 0: notes: []: uid: 6789
+#                       225 : "UID Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: 224 : hash_code: 6f8d0bf970c14175e597843f4679769a4775742549d90f902ff803de9244c7e1: eps: 0: notes: []: uid: 6789
 #               endpoints
 #                       2: ftp://localhost/
 #                       1: http://127.0.0.1/endpoint/420/edit/
@@ -113,9 +113,9 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 #       engagement 3: weekly engagement (dedupe_inside: True)
 #               test 33: Generic Findings Import (algo=legacy, dynamic=False)
 #               findings:
-#                       22  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba: eps: 0: notes: []: uid: None
-#                       23  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: 22  : hash_code: 5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba: eps: 0: notes: []: uid: None
-#                       24  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: 22  : hash_code: 5f272ec29b29d56ca08eba26435bdb225ae4956812c10fce872a6143b73474ba: eps: 0: notes: []: uid: None
+#                       22  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa: eps: 0: notes: []: uid: None
+#                       23  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: 22  : hash_code: 9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa: eps: 0: notes: []: uid: None
+#                       24  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: 22  : hash_code: 9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa: eps: 0: notes: []: uid: None
 #               endpoints
 #                       2: ftp://localhost/
 #                       1: http://127.0.0.1/endpoint/420/edit/
@@ -1346,6 +1346,9 @@ class TestDuplicationLogic(TestCase):
         return new, Engagement.objects.get(id=id)
 
     def assert_finding(self, finding, not_pk=None, duplicate=False, duplicate_finding_id=None, hash_code=None, not_hash_code=None):
+        if hash_code:
+            self.assertEqual(finding.hash_code, hash_code)
+
         if not_pk:
             self.assertNotEqual(finding.pk, not_pk)
 
@@ -1357,9 +1360,6 @@ class TestDuplicationLogic(TestCase):
             logger.debug('asserting that finding %i is a duplicate of %i', finding.id if finding.id is not None else 'None', duplicate_finding_id if duplicate_finding_id is not None else 'None')
             self.assertTrue(finding.duplicate_finding)  # True -> not None
             self.assertEqual(finding.duplicate_finding.id, duplicate_finding_id)
-
-        if hash_code:
-            self.assertEqual(finding.hash_code, hash_code)
 
         if not_hash_code:
             self.assertNotEqual(finding.hash_code, not_hash_code)

--- a/dojo/unittests/test_deduplication_logic.py
+++ b/dojo/unittests/test_deduplication_logic.py
@@ -1203,10 +1203,10 @@ class TestDuplicationLogic(TestCase):
 
     def test_case_sensitiveness_hash_code_computation(self):
         # hash_code calculation is case sensitive. feature or BUG?
-        finding_new, finding_24 = self.copy_and_reset_finding(id=24)
-        finding_new.title = finding_24.title.upper()
+        finding_new, finding_22 = self.copy_and_reset_finding(id=22)
+        finding_new.title = finding_22.title.upper()
         finding_new.save(dedupe_option=True)
-        self.assert_finding(finding_new, not_pk=24, duplicate=False, not_hash_code=finding_24.hash_code)
+        self.assert_finding(finding_new, not_pk=22, duplicate=True, duplicate_finding_id=finding_22.id, hash_code=finding_22.hash_code)
 
     def test_title_case(self):
         # currentlt the finding.save method applies title casing to the title

--- a/dojo/unittests/test_finding_helper.py
+++ b/dojo/unittests/test_finding_helper.py
@@ -21,6 +21,7 @@ class TestUpdateFindingStatusSignal(TestCase):
         self.user_2 = User.objects.get(id='2')
 
     def get_status_fields(self, finding):
+        logger.debug('%s, %s, %s, %s, %s, %s, %s, %s', finding.active, finding.verified, finding.false_p, finding.out_of_scope, finding.is_Mitigated, finding.mitigated, finding.mitigated_by, finding.last_status_update)
         return finding.active, finding.verified, finding.false_p, finding.out_of_scope, finding.is_Mitigated, finding.mitigated, finding.mitigated_by, finding.last_status_update
 
     @mock.patch('dojo.finding.helper.timezone.now')
@@ -36,7 +37,9 @@ class TestUpdateFindingStatusSignal(TestCase):
                 (True, True, False, False, False, None, None, frozen_datetime)
             )
 
-    def test_no_status_change(self):
+    @mock.patch('dojo.finding.helper.timezone.now')
+    def test_no_status_change(self, mock_tz):
+        mock_tz.return_value = frozen_datetime
         with impersonate(self.user_1):
             test = Test.objects.last()
             finding = Finding(test=test)
@@ -59,7 +62,6 @@ class TestUpdateFindingStatusSignal(TestCase):
             test = Test.objects.last()
             finding = Finding(test=test, is_Mitigated=True, active=False)
             finding.save()
-
             self.assertEqual(
                 self.get_status_fields(finding),
                 (False, True, False, False, True, frozen_datetime, self.user_1, frozen_datetime)

--- a/dojo/unittests/test_utils.py
+++ b/dojo/unittests/test_utils.py
@@ -42,8 +42,8 @@ class assertNumOfModelsCreated():
         created_count = self.final_model_count - self.initial_model_count
         self.test_case.assertEqual(
             created_count, self.num,
-            "%i objects created, %i expected. query: %s, first 100 objects: %s" % (
-                created_count, self.num, self.queryset.query, self.queryset.all().order_by('-id')[:100]
+            "%i %s objects created, %i expected. query: %s, first 100 objects: %s" % (
+                created_count, self.queryset.model, self.num, self.queryset.query, self.queryset.all().order_by('-id')[:100]
             )
         )
 


### PR DESCRIPTION
As we have seen in #3944 and #4048 the current `finding.save()` logic triggers multiple processes in parallel, leading to possible race conditions:

- deduplication
- false positive history
- pushing to sonarqube
- push to jira
- applying rules
- product grade calculation

My opinion is that at least we should make sure the logic that possibly changes a findings status should be predictable, i.e. ordered. Same for the hash code calculation which currently is case-sensitive.

This PR wraps all post processing in a single celery task. So we still get a performance benefit by executing these tasks in the background. But inside this celery task there are some sequential steps that possibly change the findings status:

- deduplication
- false positive history

After that some async celery tasks are kicked off for readonly tasks:

- tool updater (sonar)
- product grading
- push to JIRA

Fixes along the way:
- Titlecase was not always applied correctly, leading to deduplication mismatches
- Rules are now applied before deduplication. Some rules might be created to correct data on findings with the goal to improve the dedupe process, so we want to apply them before deduplication.

The product grading happens for each finding, which is really inefficient. If you import 1000 finding, the grade of the product gets recalculated a 1000 times. There currently is no reliable way to fix this as there still are background processes that can change a findings status, i.e. deduplication and false positive history.
Also the ordering of deduplication is still unpredictable as depending on the timing finding 100 can be marked as a duplicate of 101 or the other way around.

As I have said before, I think these should be run in the foreground to avoid all these complicated situations, or find a better solution. I will discuss on Slack for a next PR.

fixes #3944 
fixes #4135
fixes #4144 