### PR TITLE
don't delete all duplicates when deleting an original, fix product grade on deletion.

### DIFF
--- a/dojo/db_migrations/0058_document_finding_model.py
+++ b/dojo/db_migrations/0058_document_finding_model.py
@@ -72,7 +72,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='finding',
             name='duplicate_finding',
-            field=models.ForeignKey(blank=True, editable=False, help_text='Link to the original finding if this finding is a duplicate.', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='original_finding', to='dojo.Finding', verbose_name='Duplicate Finding'),
+            field=models.ForeignKey(blank=True, editable=False, help_text='Link to the original finding if this finding is a duplicate.', null=True, on_delete=django.db.models.deletion.DO_NOTHING, related_name='original_finding', to='dojo.Finding', verbose_name='Duplicate Finding'),
         ),
         migrations.AlterField(
             model_name='finding',

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -134,7 +134,14 @@
       "delete_duplicates": false,
       "slack_channel": "",
       "mail_notifications_to": "",
-      "enable_jira": false
+      "enable_jira": false,
+      "enable_product_grade": true,
+      "product_grade": "def grade_product(crit, high, med, low):\r\n    health=100\r\n    if crit > 0:\r\n        health = 40\r\n        health = health - ((crit - 1) * 5)\r\n    if high > 0:\r\n        if health == 100:\r\n            health = 60\r\n        health = health - ((high - 1) * 3)\r\n    if med > 0:\r\n        if health == 100:\r\n            health = 80\r\n        health = health - ((med - 1) * 2)\r\n    if low > 0:\r\n        if health == 100:\r\n            health = 95\r\n        health = health - low\r\n\r\n    if health < 5:\r\n        health = 5\r\n\r\n    return health",
+      "product_grade_a": 90,
+      "product_grade_b": 80,
+      "product_grade_c": 70,
+      "product_grade_d": 60,
+      "product_grade_f": 59
     }
   },
   {

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1501,7 +1501,7 @@ class Finding(models.Model):
                                           editable=False,
                                           null=True,
                                           related_name='original_finding',
-                                          blank=True, on_delete=models.CASCADE,
+                                          blank=True, on_delete=models.DO_NOTHING,
                                           verbose_name="Duplicate Finding",
                                           help_text="Link to the original finding if this finding is a duplicate.")
     out_of_scope = models.BooleanField(default=False,
@@ -2159,14 +2159,6 @@ class Finding(models.Model):
         # postprocessing is done in a celery task
         finding_helper.post_process_finding_save(self, dedupe_option=dedupe_option, false_history=false_history, rules_option=rules_option, product_grading_option=product_grading_option,
              issue_updater_option=issue_updater_option, push_to_jira=push_to_jira, user=user, *args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        for find in self.original_finding.all():
-            # Explicitely delete the duplicates
-            super(Finding, find).delete()
-        super(Finding, self).delete(*args, **kwargs)
-        from dojo.utils import calculate_grade
-        calculate_grade(self.test.engagement.product)
 
     # Check if a mandatory field is empty. If it's the case, fill it with "no <fieldName> given"
     def clean(self):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -181,7 +181,12 @@ env = environ.Env(
 
     DD_FEATURE_FINDING_GROUPS=(bool, False),
     DD_JIRA_TEMPLATE_ROOT=(str, 'dojo/templates/issue-trackers'),
-    DD_TEMPLATE_DIR_PREFIX=(str, 'dojo/templates/')
+    DD_TEMPLATE_DIR_PREFIX=(str, 'dojo/templates/'),
+
+    # Initial behaviour in Defect Dojo was to delete all duplicates when an original was deleted
+    # New behaviour is to leave the duplicates in place, but set the oldest of duplicates as new original
+    # Set to True to revert to the old behaviour where all duplicates are deleted
+    DD_DUPLICATE_CLUSTER_CASCADE_DELETE=(str, False)
 )
 
 
@@ -1057,3 +1062,5 @@ USE_L10N = True
 FEATURE_FINDING_GROUPS = env('DD_FEATURE_FINDING_GROUPS')
 JIRA_TEMPLATE_ROOT = env('DD_JIRA_TEMPLATE_ROOT')
 TEMPLATE_DIR_PREFIX = env('DD_TEMPLATE_DIR_PREFIX')
+
+DUPLICATE_CLUSTER_CASCADE_DELETE = env('DD_DUPLICATE_CLUSTER_CASCADE_DELETE')

--- a/dojo/unittests/test_duplication_loops.py
+++ b/dojo/unittests/test_duplication_loops.py
@@ -1,29 +1,49 @@
-from django.test import TestCase
+from crum import impersonate
+from django.test import TestCase, override_settings
 from dojo.utils import set_duplicate
 from dojo.management.commands.fix_loop_duplicates import fix_loop_duplicates
-from dojo.models import Finding
+from dojo.models import Finding, User
 import logging
-deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 
-class TestDuplication(TestCase):
+logger = logging.getLogger(__name__)
+
+
+class TestDuplicationLoops(TestCase):
     fixtures = ['dojo_testdata.json']
+
+    def run(self, result=None):
+        testuser = User.objects.get(username='admin')
+        testuser.usercontactinfo.block_execution = True
+        testuser.save()
+
+        # unit tests are running without any user, which will result in actions like dedupe happening in the celery process
+        # this doesn't work in unittests as unittests are using an in memory sqlite database and celery can't see the data
+        # so we're running the test under the admin user context and set block_execution to True
+        with impersonate(testuser):
+            super().run(result)
 
     def setUp(self):
         self.finding_a = Finding.objects.get(id=2)
         self.finding_a.pk = None
+        self.finding_a.title = 'A: ' + self.finding_a.title
         self.finding_a.duplicate = False
         self.finding_a.duplicate_finding = None
+        self.finding_a.hash_code = None
         self.finding_a.save()
         self.finding_b = Finding.objects.get(id=3)
         self.finding_b.pk = None
+        self.finding_b.title = 'B: ' + self.finding_b.title
         self.finding_b.duplicate = False
         self.finding_b.duplicate_finding = None
+        self.finding_b.hash_code = None
         self.finding_b.save()
         self.finding_c = Finding.objects.get(id=4)
+        self.finding_c.pk = None
+        self.finding_c.title = 'C: ' + self.finding_c.title
         self.finding_c.duplicate = False
         self.finding_c.duplicate_finding = None
-        self.finding_c.pk = None
+        self.finding_c.hash_code = None
         self.finding_c.save()
 
     def tearDown(self):
@@ -86,21 +106,66 @@ class TestDuplication(TestCase):
         self.assertEqual(self.finding_a.duplicate_finding.id, self.finding_c.id)
 
     # if a duplicate is deleted the original should still be present
-    def test_set_duplicate_exception_delete_1(self):
+    def test_set_duplicate_exception_delete_a_duplicate(self):
         set_duplicate(self.finding_a, self.finding_b)
         self.assertEqual(self.finding_b.original_finding.first().id, self.finding_a.id)
         self.finding_a.delete()
         self.assertEqual(self.finding_a.id, None)
         self.assertEqual(self.finding_b.original_finding.first(), None)
 
-    # if the original is deleted all duplicates should be deleted
-    def test_set_duplicate_exception_delete_2(self):
+    # # if the original is deleted all duplicates should be deleted
+    @override_settings(DUPLICATE_CLUSTER_CASCADE_DELETE=True)
+    def test_set_duplicate_exception_delete_original_cascade(self):
         set_duplicate(self.finding_a, self.finding_b)
         self.assertEqual(self.finding_b.original_finding.first().id, self.finding_a.id)
+        logger.debug('going to delete finding B')
         self.finding_b.delete()
+        logger.debug('deleted finding B')
         with self.assertRaises(Finding.DoesNotExist):
             self.finding_a = Finding.objects.get(id=self.finding_a.id)
         self.assertEqual(self.finding_b.id, None)
+
+    # if the original is deleted all duplicates should adjusted to a new original
+    @override_settings(DUPLICATE_CLUSTER_CASCADE_DELETE=False)
+    def test_set_duplicate_exception_delete_original_duplicates_adapt(self):
+        set_duplicate(self.finding_a, self.finding_b)
+        set_duplicate(self.finding_c, self.finding_b)
+        self.assertEqual(self.finding_b.original_finding.first().id, self.finding_a.id)
+        logger.debug('going to delete finding B')
+        b_id = self.finding_b.id
+        self.finding_b.delete()
+        logger.debug('deleted finding B')
+        self.finding_a.refresh_from_db()
+        self.finding_c.refresh_from_db()
+        self.assertEqual(self.finding_a.original_finding.first(), self.finding_c)
+        self.assertEqual(self.finding_a.duplicate_finding, None)
+        self.assertEqual(self.finding_a.duplicate, False)
+        self.assertEqual(self.finding_a.active, True)
+
+        self.assertEqual(self.finding_c.original_finding.first(), None)
+        self.assertEqual(self.finding_c.duplicate_finding, self.finding_a)
+        self.assertEqual(self.finding_c.duplicate, True)
+        self.assertEqual(self.finding_c.active, False)
+        with self.assertRaises(Finding.DoesNotExist):
+            self.finding_b = Finding.objects.get(id=b_id)
+
+    # if the original is deleted all duplicates should adjusted to a new original
+    # in this test there's only 1 duplicate, so that should be marked as no longer duplicate
+    @override_settings(DUPLICATE_CLUSTER_CASCADE_DELETE=False)
+    def test_set_duplicate_exception_delete_original_1_duplicate_adapt(self):
+        set_duplicate(self.finding_a, self.finding_b)
+        self.assertEqual(self.finding_b.original_finding.first().id, self.finding_a.id)
+        logger.debug('going to delete finding B')
+        b_id = self.finding_b.id
+        self.finding_b.delete()
+        logger.debug('deleted finding B')
+        self.finding_a.refresh_from_db()
+        self.assertEqual(self.finding_a.original_finding.first(), None)
+        self.assertEqual(self.finding_a.duplicate_finding, None)
+        self.assertEqual(self.finding_a.duplicate, False)
+        self.assertEqual(self.finding_a.active, True)
+        with self.assertRaises(Finding.DoesNotExist):
+            self.finding_b = Finding.objects.get(id=b_id)
 
     def test_loop_relations_for_one(self):
         # B -> B

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -327,6 +327,7 @@ def deduplicate_uid_or_hash_code(new_finding):
 
 def set_duplicate(new_finding, existing_finding):
     if existing_finding.duplicate:
+        logger.debug('existing finding: %s:%s:duplicate=%s;duplicate_finding=%s', existing_finding.id, existing_finding.title, existing_finding.duplicate, existing_finding.duplicate_finding.id if existing_finding.duplicate_finding else 'None')
         raise Exception("Existing finding is a duplicate")
     if existing_finding.id == new_finding.id:
         raise Exception("Can not add duplicate to itself")
@@ -1434,7 +1435,11 @@ def get_system_setting(setting, default=None):
 @dojo_model_from_id(model=Product)
 def calculate_grade(product):
     system_settings = System_Settings.objects.get()
+    if not product:
+        logger.warning('ignoring calculate product for product None!')
+
     if system_settings.enable_product_grade:
+        logger.debug('calculating product grade for %s:%s', product.id, product.name)
         severity_values = Finding.objects.filter(
             ~Q(severity='Info'),
             active=True,


### PR DESCRIPTION
fixes #3057 

Current behavior:
Assume you have a finding A with two duplicates, so finding B is a duplicate of A and C is a duplicate of A:

B->A and C->A

When deleting finding A, also B and C get deleted. This is confusing as described in #3057 

New behavior:

When A gets deleted, the duplicates B and C remain and they get a new original finding assigned. The oldest of B and C becomes the new original, so C->B and B is the new original and no longer marked as duplicate.

There is a flag `DD_DUPLICATE_CLUSTER_CASCADE_DELETE` / `DUPLICATE_CLUSTER_CASCADE_DELETE` that can be set to `True` to revert to the old behavior. The default is `False`.

To achieve this, we had to change the `on_delete` parameter of the `duplicate_finding` field. This can be done without a new migration as it doesn't affect the SQL schema.

There is some discussion on Slack where some are arguing for more complicated scenario's where the data of the deleted original should be migrated to the next/new original. Sounds way to complicated for me. If the original contains valuable information, don't delete it! https://owasp.slack.com/archives/C2P5BA8MN/p1616780956093700


bug fixes along the way:
- fixes #4140 