### PR TITLE
Optimize (pdf) report in main menu and small fix for product type list

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -276,18 +276,23 @@
                                 </li>
                             {% endif %}
                             <li>
+                                {% if 'FEATURE_REPORTS_PDF_LIST'|setting_enabled %}
                                 <a href="{% url 'reports' %}" aria-expanded="false" aria-label="Reports">
 				                    <i class="fa fa-file-text-o fa-fw"></i>
                                     <span>Reports</span>
                                     <span class="glyphicon arrow"></span>
                                 </a>
                                 <ul class="nav nav-second-level">
-                                    {% feature_reports_pdf_list as feature_reports_pdf_list_flag %}
-                                    {% if feature_reports_pdf_list_flag %}
-                                        <li><a href="{% url 'reports' %}"> All Reports </a></li>
-                                    {% endif %}
+                                    <li><a href="{% url 'reports' %}"> All Reports </a></li>
                                     <li><a href="{% url 'report_builder' %}"> Report Builder </a></li>
                                 </ul>
+                                {% else %}
+                                <a href="{% url 'report_builder' %}" aria-expanded="false" aria-label="Reports">
+				                    <i class="fa fa-file-text-o fa-fw"></i>
+                                    <span>Reports</span>
+                                    <span class="glyphicon arrow"></span>
+                                </a>
+                                {% endif %}
                                 <!-- /.nav-second-level -->
                             </li>
                             <li>

--- a/dojo/templates/dojo/product_type.html
+++ b/dojo/templates/dojo/product_type.html
@@ -46,9 +46,7 @@
                            class="tablesorter-bootstrap table table-condensed table-striped">
                         <thead>
                         <tr>
-                            {% if request.user|feature_authorization_v2_or_user_is_staff %}
                             <th></th>
-                            {% endif %}
                             <th>{% dojo_sort request 'Product Type' 'name' 'asc' %}</th>
                             <th>Product count</th>
                             <th>Active (Verified) findings</th>

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -22,8 +22,7 @@
                 </div>
                 <div class="panel-footer">
                     <div class="clearfix">
-                        {% feature_reports_pdf_list as feature_reports_pdf_list_flag %}
-                        {% if feature_reports_pdf_list_flag %}
+                        {% if 'FEATURE_REPORTS_PDF_LIST'|setting_enabled %}
                             <a class="btn btn-success disabled pull-right run_report" href="#">Save and Run</a>
                         {% else %}
                             <a class="btn btn-success disabled pull-right run_report" href="#">Run</a>

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -976,8 +976,3 @@ def import_history(finding, autoescape=True):
         list_of_status_changes += '<b>' + status_change.created.strftime('%b %d, %Y, %H:%M:%S') + '</b>: ' + status_change.get_action_display() + '<br/>'
 
     return mark_safe(html % (list_of_status_changes))
-
-
-@register.simple_tag
-def feature_reports_pdf_list():
-    return settings.FEATURE_REPORTS_PDF_LIST


### PR DESCRIPTION
This is an update to #4065. The Reports entry in the main menu still led to the report list. Now there is no submenu anymore but the report builder is immediately shown when clicking on Reports. Plus a small fix for the product type list for non-staff users and a small refactoring.