### PR TITLE
allow non-staff users to perform bulk edit

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1797,15 +1797,16 @@ def merge_finding_product(request, pid):
 
 
 # bulk update and delete are combined, so we can't have the nice user_must_be_authorized decorator (yet)
-@user_passes_test(lambda u: u.is_staff)
-# @user_must_be_authorized(Product, 'staff', 'pid')
 def finding_bulk_update_all(request, pid=None):
     form = FindingBulkUpdateForm(request.POST)
     now = timezone.now()
     if request.method == "POST":
         finding_to_update = request.POST.getlist('finding_to_update')
+
         if request.POST.get('delete_bulk_findings') and finding_to_update:
             finds = Finding.objects.filter(id__in=finding_to_update)
+            total_find_count = finds.count()
+            skipped_find_count = 0
 
             # make sure users are not deleting stuff they are not authorized for
             if not request.user.is_staff and not request.user.is_superuser:
@@ -1815,26 +1816,39 @@ def finding_bulk_update_all(request, pid=None):
                 finds = finds.filter(
                     Q(test__engagement__product__authorized_users__in=[request.user]) |
                     Q(test__engagement__product__prod_type__authorized_users__in=[request.user])
-                )
+                ).distinct()
+
+                skipped_find_count = total_find_count - finds.count()
 
             product_calc = list(Product.objects.filter(engagement__test__finding__id__in=finding_to_update).distinct())
             finds.delete()
             for prod in product_calc:
                 calculate_grade(prod)
+
+            if skipped_find_count > 0:
+                add_error_message_to_response('skipped %i findings because you''re not authorized', skipped_find_count)
+
         else:
             if form.is_valid() and finding_to_update:
                 finding_to_update = request.POST.getlist('finding_to_update')
                 finds = Finding.objects.filter(id__in=finding_to_update).order_by("finding__test__engagement__product__id")
+                total_find_count = finds.count()
+                skipped_find_count = 0
 
                 # make sure users are not deleting stuff they are not authorized for
                 if not request.user.is_staff and not request.user.is_superuser:
-                    if not settings.AUTHORIZED_USERS_ALLOW_CHANGE:
+                    if not settings.AUTHORIZED_USERS_ALLOW_CHANGE and not settings.AUTHORIZED_USERS_ALLOW_STAFF:
                         raise PermissionDenied()
 
                     finds = finds.filter(
                         Q(test__engagement__product__authorized_users__in=[request.user]) |
                         Q(test__engagement__product__prod_type__authorized_users__in=[request.user])
-                    )
+                    ).distinct()
+
+                    skipped_find_count = total_find_count - finds.count()
+
+                if skipped_find_count > 0:
+                    add_error_message_to_response('skipped %i findings because you''re not authorized', skipped_find_count)
 
                 finds = prefetch_for_findings(finds)
                 if form.cleaned_data['severity'] or form.cleaned_data['status']:
@@ -1857,9 +1871,7 @@ def finding_bulk_update_all(request, pid=None):
 
                         # use super to avoid all custom logic in our overriden save method
                         # it will trigger the pre_save signal
-                        logger.debug('bulk update save')
                         find.save_no_options()
-                        logger.debug('bulk update save done')
 
                 skipped_risk_accept_count = 0
                 if form.cleaned_data['risk_acceptance']:

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -123,7 +123,6 @@ def finding_can_be_pushed_to_jira(finding, form=None):
 
 # use_inheritance=True means get jira_project config from product if engagement itself has none
 def get_jira_project(obj, use_inheritance=True):
-    print('get jira project for: ' + str(obj.id) + ':' + str(obj))
     if not is_jira_enabled():
         return None
 

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -30,9 +30,9 @@
                     {% include "dojo/paging_snippet.html" with page=findings page_size=True %}
                 </div>
             {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}
-            <div class="hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
+            <div class="dropdown hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
                 {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}
-                    <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
+                    <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
                             data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                         Bulk Edit
                         <span class="caret"></span>

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -29,93 +29,16 @@
                 <div class="clearfix">
                     {% include "dojo/paging_snippet.html" with page=findings page_size=True %}
                 </div>
-            {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled%}
+            {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}
             <div class="hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
-                <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-                  <div class="btn-group mr-2" role="group" aria-label="Second group">
-                    <button class="btn btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
+                {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}
+                    <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                             data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                         Bulk Edit
                         <span class="caret"></span>
                     </button>
-                    <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
-                        <li class="dropdown-header">Choose wisely...</li>
-                        <li style="padding-left: 8px;">
-                          {% if product_tab %}
-                            <form action="{% url 'finding_bulk_update_all_product' product_tab.product.id %}" method="post" id="bulk_change_form">
-                          {% else %}
-                            <form action="{% url 'finding_bulk_update_all' %}" method="post" id="bulk_change_form">
-                          {% endif %}
-                                {% csrf_token %}
-                                <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
-                                <label style="display: block" for="severity">Severity</label>
-                                <select name="severity" id="severity" style="font-size: 80%">
-                                    <option value="">Choose...</option>
-                                    <option value="Info">Info</option>
-                                    <option value="Low">Low</option>
-                                    <option value="Medium">Medium</option>
-                                    <option value="High">High</option>
-                                    <option value="Critical">Critical</option>
-                                </select><br/><br/>
-
-                                <label><b>Status</b><input id="id_bulk_status" name="status" type="checkbox" alt="Select to enable"/></label><br/>
-
-                                <label style="font-size: 80%; font-weight: normal; display: block">
-                                    <input id="id_bulk_active" name="active" type="checkbox" disabled/> <span>Active</span>
-                                </label>
-                                <label style="font-size: 80%; font-weight: normal; display: block">
-                                    <input id="id_bulk_verified" name="verified" type="checkbox" disabled/> <span>Verified</span>
-                                </label>
-                                <label style="font-size: 80%; font-weight: normal; display: block">
-                                    <input id="id_bulk_false_p" name="false_p" type="checkbox" disabled/> <span>False Positive</span>
-                                </label>
-                                <label style="font-size: 80%; font-weight: normal; display: block">
-                                    <input id="id_bulk_out_of_scope" name="out_of_scope" type="checkbox" disabled/>
-                                    <span>Out of scope</span>
-                                </label>
-                                <label style="font-size: 80%; font-weight: normal; display: block">
-                                    <input id="id_bulk_is_Mitigated" name="is_Mitigated" type="checkbox" disabled/>
-                                    <span>Mitigated</span>
-                                </label>
-                                <br/>
-
-                                <label><b>Risk Acceptance</b><input id="id_bulk_risk_acceptance" name="risk_acceptance" type="checkbox" alt="Select to enable"/></label><br/>
-                                <label style="font-size: 80%; font-weight: normal; display: block">
-                                    <input id="id_bulk_risk_accept" name="risk_accept" type="checkbox" disabled/> <span>Accept</span>
-                                </label>
-                                <label style="font-size: 80%; font-weight: normal; display: block">
-                                    <input id="id_bulk_risk_unaccept" name="risk_unaccept" type="checkbox" disabled/> <span>Unaccept</span>
-                                </label>
-
-                                <br>
-                                {% if system_settings.enable_jira %}
-                                <label style="font-size: 80%; font-weight: bold; display: block">Push to Jira
-                                  <input id="id_push_tojira" name="push_to_jira" type="checkbox" alt="Select to push to JIRA"/>
-                                </label>
-                                {% comment %} <label style="font-size: 80%; font-weight: bold; display: block">Unlink JIRA issues
-                                  <input id="unlink_from_jira" name="unlink_from_jira" type="checkbox" alt="Select to unlink JIRA issues from Defect Dojo findings"/>
-                                </label> {% endcomment %}
-                                {% endif %}
-                                {% if system_settings.enable_github %}
-                                <label style="font-size: 80%; font-weight: bold; display: block">Push to GitHub
-                                  <input id="id_push_togithub" name="push_to_github" type="checkbox" alt="Select to push to GitHub"/>
-                                </label>
-                                <br/>
-                                {% endif %}
-                                <label style="display: block">Tags</label>
-                                {% comment %}
-                                    Quick hack to make bulk edit work without refactoring the whole bulk edit form
-                                    {{ bulk_edit_form.media.css }}
-                                    {{ bulk_edit_form.media.js }}
-                                {% endcomment %}
-                                {{ bulk_edit_form.tags }}
-                                <input type="submit" class="btn btn-sm btn-primary" value="Submit"/>
-                            </form>
-                        </li>
-                    </ul>
-                  </div>
-                  {% endif %}
-                  <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
+                {% endif %}
+                <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
                     {% if product_tab and not 'DISABLE_FINDING_MERGE'|setting_enabled %}
                     <button type="button" class="btn btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
                       <a class="white-color merge" href="#" alt="Merge Findings">
@@ -130,9 +53,85 @@
                       </a>
                     </button>
                     {% endif %}
-                  </div>
                 </div>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
+                    <li class="dropdown-header">Choose wisely...</li>
+                    <li style="padding-left: 8px;">
+                        {% if product_tab %}
+                        <form action="{% url 'finding_bulk_update_all_product' product_tab.product.id %}" method="post" id="bulk_change_form">
+                        {% else %}
+                        <form action="{% url 'finding_bulk_update_all' %}" method="post" id="bulk_change_form">
+                        {% endif %}
+                            {% csrf_token %}
+                            <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
+                            <label style="display: block" for="severity">Severity</label>
+                            <select name="severity" id="severity" style="font-size: 80%">
+                                <option value="">Choose...</option>
+                                <option value="Info">Info</option>
+                                <option value="Low">Low</option>
+                                <option value="Medium">Medium</option>
+                                <option value="High">High</option>
+                                <option value="Critical">Critical</option>
+                            </select><br/><br/>
+
+                            <label><b>Status</b><input id="id_bulk_status" name="status" type="checkbox" alt="Select to enable"/></label><br/>
+
+                            <label style="font-size: 80%; font-weight: normal; display: block">
+                                <input id="id_bulk_active" name="active" type="checkbox" disabled/> <span>Active</span>
+                            </label>
+                            <label style="font-size: 80%; font-weight: normal; display: block">
+                                <input id="id_bulk_verified" name="verified" type="checkbox" disabled/> <span>Verified</span>
+                            </label>
+                            <label style="font-size: 80%; font-weight: normal; display: block">
+                                <input id="id_bulk_false_p" name="false_p" type="checkbox" disabled/> <span>False Positive</span>
+                            </label>
+                            <label style="font-size: 80%; font-weight: normal; display: block">
+                                <input id="id_bulk_out_of_scope" name="out_of_scope" type="checkbox" disabled/>
+                                <span>Out of scope</span>
+                            </label>
+                            <label style="font-size: 80%; font-weight: normal; display: block">
+                                <input id="id_bulk_is_Mitigated" name="is_Mitigated" type="checkbox" disabled/>
+                                <span>Mitigated</span>
+                            </label>
+                            <br/>
+
+                            <label><b>Risk Acceptance</b><input id="id_bulk_risk_acceptance" name="risk_acceptance" type="checkbox" alt="Select to enable"/></label><br/>
+                            <label style="font-size: 80%; font-weight: normal; display: block">
+                                <input id="id_bulk_risk_accept" name="risk_accept" type="checkbox" disabled/> <span>Accept</span>
+                            </label>
+                            <label style="font-size: 80%; font-weight: normal; display: block">
+                                <input id="id_bulk_risk_unaccept" name="risk_unaccept" type="checkbox" disabled/> <span>Unaccept</span>
+                            </label>
+
+                            <br>
+                            {% if system_settings.enable_jira %}
+                            <label style="font-size: 80%; font-weight: bold; display: block">Push to Jira
+                                <input id="id_push_tojira" name="push_to_jira" type="checkbox" alt="Select to push to JIRA"/>
+                            </label>
+                            {% comment %} <label style="font-size: 80%; font-weight: bold; display: block">Unlink JIRA issues
+                                <input id="unlink_from_jira" name="unlink_from_jira" type="checkbox" alt="Select to unlink JIRA issues from Defect Dojo findings"/>
+                            </label> {% endcomment %}
+                            {% endif %}
+                            {% if system_settings.enable_github %}
+                            <label style="font-size: 80%; font-weight: bold; display: block">Push to GitHub
+                                <input id="id_push_togithub" name="push_to_github" type="checkbox" alt="Select to push to GitHub"/>
+                            </label>
+                            <br/>
+                            {% endif %}
+                            <label style="display: block">Tags</label>
+                            {% comment %}
+                                Quick hack to make bulk edit work without refactoring the whole bulk edit form
+                                {{ bulk_edit_form.media.css }}
+                                {{ bulk_edit_form.media.js }}
+                            {% endcomment %}
+                            {{ bulk_edit_form.tags }}
+                            <input type="submit" class="btn btn-sm btn-primary" value="Submit"/>
+                        </form>
+                    </li>
+                </ul>
             </div>
+            {% endif %}
+
                 <div class="panel panel-default table-responsive">
                     <table id="open_findings"
                            class="tablesorter-bootstrap table table-condensed table-striped table-hover">
@@ -192,7 +191,7 @@
                         <tbody>
                         {% for finding in findings %}
                             <tr class="{% if finding.active %}active_finding{% else %}inactive_finding{% endif %}">
-                                {% if user|is_authorized_for_staff:finding %}
+                                {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}
                                   <td class="hidden-sm centered">
                                     <form action="#">
                                         <input type="checkbox" name="select_{{ finding.id }}" id="{{ finding.id }}"
@@ -614,7 +613,7 @@
                 $('#bulk_edit_menu #id_bulk_false_p').prop('disabled', checked);
                 $('#bulk_edit_menu #id_bulk_false_p').prop('checked', false);
             })
-            
+
             $('#bulk_edit_menu #id_bulk_risk_acceptance').on('click', function (e) {
                 var checked = this.checked;
                 $('#bulk_edit_menu #id_bulk_risk_accept').prop('disabled', !checked);

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -302,6 +302,7 @@
             {% include "dojo/paging_snippet.html" with page=findings prefix='findings' page_size=True %}
         </div>
 
+        {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}
         <div class="dropdown hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
             {% if test|has_object_permission:"Test_Edit" or user|is_authorized_for_change:test %}
                 <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
@@ -310,16 +311,16 @@
                     <span class="caret"></span>
                 </button>
             {% endif %}
-                <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
+            <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
                 {% if product_tab and not 'DISABLE_FINDING_MERGE'|setting_enabled %}
-                    <button type="button" class="btn btn-info btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
+                    <button type="button" class="btn btn-info btn-sm btn-primary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
                         <a class="white-color merge" href="#" alt="Merge Findings">
                             <i class="fa fa-compress"></i>
                         </a>
                     </button>
                 {% endif %}
                 {% if test|has_object_permission:"Test_Delete" or user|is_authorized_for_delete:test %}
-                    <button type="button" class="btn btn-info btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Delete Findings">
+                    <button type="button" class="btn btn-info btn-sm btn-primary" data-toggle="tooltip" data-placement="bottom" title="Delete Findings">
                         <a class="white-color delete-bulk" href="#" alt="Delete Findings">
                             <i class="fa fa-trash"></i>
                         </a>
@@ -384,6 +385,7 @@
                 </li>
             </ul>
         </div>
+        {% endif %}
     {% endif %}
      <div class="panel panel-default table-responsive">
         {% if findings %}
@@ -1041,7 +1043,7 @@
 
         $(function () {
             check_checked_finding();
-            
+
             $('#id_bulk_status').on('click', function (e) {
                 var checked = this.checked;
                 $('#bulk_edit_menu #id_bulk_active').prop('disabled', !checked);
@@ -1089,7 +1091,7 @@
                 $('#bulk_edit_menu #id_bulk_false_p').prop('disabled', checked);
                 $('#bulk_edit_menu #id_bulk_false_p').prop('checked', false);
             })
-            
+
             $('#bulk_edit_menu #id_bulk_risk_acceptance').on('click', function (e) {
                 var checked = this.checked;
                 $('#bulk_edit_menu #id_bulk_risk_accept').prop('disabled', !checked);


### PR DESCRIPTION
fixes #4136 

Most code was already in place, but there was a decorator on the bulk edit method that allowed only staff users to perform bulk edits. Removed decorator, updated permission checks and tested all scenarios around True/False for:

```
AUTHORIZED_USERS_ALLOW_CHANGE
AUTHORIZED_USERS_ALLOW_DELETE
AUTHORIZED_USERS_ALLOW_STAFF
```

Moved some code around to make `view_test` align more with `findings_list_snippet.html`
