### PR TITLE
jira: fix crash on invalid credentials

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1786,8 +1786,8 @@ class JIRAForm(forms.ModelForm):
             jira = jira_helper.get_jira_connection_raw(form_data['url'], form_data['username'], form_data['password'], validate=True)
             logger.debug('valid JIRA config!')
         except Exception as e:
-            error_message = e.text if hasattr(e, 'text') else e.message if hasattr(e, 'message') else e.args[0]
-            message = 'Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + str(error_message)
+            # form only used by admins, so we can show full error message using str(e) which can help debug any problems
+            message = 'Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + str(e)
             self.add_error('username', message)
             self.add_error('password', message)
 
@@ -1804,6 +1804,21 @@ class ExpressJIRAForm(forms.ModelForm):
                     'close_status_key', 'info_mapping_severity',
                     'low_mapping_severity', 'medium_mapping_severity',
                     'high_mapping_severity', 'critical_mapping_severity', 'finding_text']
+
+    def clean(self):
+        import dojo.jira_link.helper as jira_helper
+        form_data = self.cleaned_data
+
+        try:
+            jira = jira_helper.get_jira_connection_raw(form_data['url'], form_data['username'], form_data['password'], validate=True)
+            logger.debug('valid JIRA config!')
+        except Exception as e:
+            # form only used by admins, so we can show full error message using str(e) which can help debug any problems
+            message = 'Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + str(e)
+            self.add_error('username', message)
+            self.add_error('password', message)
+
+        return form_data
 
 
 class Benchmark_Product_SummaryForm(forms.ModelForm):

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -324,19 +324,22 @@ def get_jira_connection_raw(jira_server, jira_username, jira_password, validate=
     except JIRAError as e:
         logger.exception(e)
 
-        if e.status_code in [401, 403]:
-            log_jira_generic_alert('JIRA Authentication Error', e)
-        else:
-            log_jira_generic_alert('Unknown JIRA Connection Error', e)
+        error_message = e.text if hasattr(e, 'text') else e.message if hasattr(e, 'message') else e.args[0]
 
-        add_error_message_to_response('Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + str(e))
+        if e.status_code in [401, 403]:
+            log_jira_generic_alert('JIRA Authentication Error', error_message)
+        else:
+            log_jira_generic_alert('Unknown JIRA Connection Error', error_message)
+
+        add_error_message_to_response('Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + str(error_message))
         raise e
 
     except requests.exceptions.RequestException as re:
         logger.exception(re)
+        error_message = re.text if hasattr(re, 'text') else re.message if hasattr(re, 'message') else re.args[0]
         log_jira_generic_alert('Unknown JIRA Connection Error', re)
 
-        add_error_message_to_response('Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + str(re))
+        add_error_message_to_response('Unable to authenticate to JIRA. Please check the URL, username, password, captcha challenge, Network connection. Details in alert on top right. ' + str(error_message))
 
         raise re
 

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -165,7 +165,7 @@ class DojoTestUtilsMixin(object):
     def add_product_jira(self, data, expect_redirect_to=None, expect_200=False):
         response = self.client.get(reverse('new_product'))
 
-        logger.debug('before: JIRA_Project last')
+        # logger.debug('before: JIRA_Project last')
         self.log_model_instance(JIRA_Project.objects.last())
 
         if not expect_redirect_to and not expect_200:
@@ -173,7 +173,7 @@ class DojoTestUtilsMixin(object):
 
         response = self.client.post(reverse('new_product'), urlencode(data), content_type='application/x-www-form-urlencoded')
 
-        logger.debug('after: JIRA_Project last')
+        # logger.debug('after: JIRA_Project last')
         self.log_model_instance(JIRA_Project.objects.last())
 
         product = None

--- a/dojo/unittests/test_jira_config_product.py
+++ b/dojo/unittests/test_jira_config_product.py
@@ -2,8 +2,10 @@ from django.urls import reverse
 from .dojo_test_case import DojoTestCase
 from dojo.models import JIRA_Instance, Product
 from django.utils.http import urlencode
-from unittest.mock import patch
+from unittest.mock import patch, call
+from jira.exceptions import JIRAError
 import requests
+import dojo.jira_link.helper as jira_helper
 # from unittest import skip
 import logging
 
@@ -46,7 +48,10 @@ class JIRAConfigProductTest(DojoTestCase):
     def add_jira_instance(self, data, jira_mock):
         response = self.client.post(reverse('add_jira'), urlencode(data), content_type='application/x-www-form-urlencoded')
         # check that storing a new config triggers a login call to JIRA
-        jira_mock.assert_called_once_with(data['url'], data['username'], data['password'], validate=True)
+        call_1 = call(data['url'], data['username'], data['password'], validate=True)
+        call_2 = call(data['url'], data['username'], data['password'], validate=True)
+        # jira_mock.assert_called_once_with(data['url'], data['username'], data['password'], validate=True)
+        jira_mock.assert_has_calls([call_1, call_2])
         # succesful, so should redirect to list of JIRA instances
         self.assertRedirects(response, '/jira')
 
@@ -67,10 +72,37 @@ class JIRAConfigProductTest(DojoTestCase):
         data = self.data_jira_instance
         data['url'] = 'https://jira.hj23412341hj234123421341234ljl.nl'
 
+        # test UI validation error
+
         # self.client.force_login('admin', backend='django.contrib.auth.backends.ModelBackend')
         # Client.raise_request_exception = False  # needs Django 3.0
+        # can't use helper method which has patched connection raw method
+        response = self.client.post(reverse('add_jira'), urlencode(data), content_type='application/x-www-form-urlencoded')
+
+        self.assertEqual(200, response.status_code)
+        content = response.content.decode('utf-8')
+        self.assertTrue('Name or service not known' in content)
+
+        # test raw connection error
         with self.assertRaises(requests.exceptions.RequestException):
-            response = self.client.post(reverse('add_jira'), urlencode(data), content_type='application/x-www-form-urlencoded')
+            jira = jira_helper.get_jira_connection_raw(data['url'], data['username'], data['password'], validate=True)
+
+    @patch('dojo.jira_link.views.jira_helper.get_jira_connection_raw')
+    def test_add_jira_instance_invalid_credentials(self, jira_mock):
+        jira_mock.side_effect = JIRAError(status_code=401, text='Login failed')
+        data = self.data_jira_instance
+
+        # test UI validation error
+
+        # self.client.force_login('admin', backend='django.contrib.auth.backends.ModelBackend')
+        # Client.raise_request_exception = False  # needs Django 3.0
+        # can't use helper method which has patched connection raw method
+        response = self.client.post(reverse('add_jira'), urlencode(data), content_type='application/x-www-form-urlencoded')
+
+        self.assertEqual(200, response.status_code)
+        content = response.content.decode('utf-8')
+        self.assertTrue('Login failed' in content)
+        self.assertTrue('Unable to authenticate to JIRA' in content)
 
     @patch('dojo.jira_link.views.jira_helper.is_jira_project_valid')
     def test_add_jira_project_to_product_without_jira_project(self, jira_mock):


### PR DESCRIPTION
fixes #4130

Since #4132, when a user entered the wrong credentials when adding/editing a JIRA instance, a 500 errors was generated.