### PR TITLE
prod overview: fix perf regression

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -194,7 +194,6 @@ django_filter=open_findings_filter, prefetch_type='all'):
 def prefetch_for_findings(findings, prefetch_type='all'):
     prefetched_findings = findings
     if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
-        # prefetched_findings = prefetched_findings.select_related('reporter')
         prefetched_findings = prefetched_findings.prefetch_related('reporter')
         prefetched_findings = prefetched_findings.prefetch_related('jira_issue__jira_project__jira_instance')
         prefetched_findings = prefetched_findings.prefetch_related('test__test_type')

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -138,7 +138,7 @@ django_filter=open_findings_filter, prefetch_type='all'):
 
     elif eid:
         engagement = get_object_or_404(Engagement, id=eid)
-        findings = Finding.objects.filter(test__engagement=eid).order_by('numerical_severity')
+        findings = findings.filter(test__engagement=eid)
 
         show_product_column = False
         product_tab = Product_Tab(engagement.product_id, title=engagement.name, tab="engagements")
@@ -194,7 +194,8 @@ django_filter=open_findings_filter, prefetch_type='all'):
 def prefetch_for_findings(findings, prefetch_type='all'):
     prefetched_findings = findings
     if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
-        prefetched_findings = prefetched_findings.select_related('reporter')
+        # prefetched_findings = prefetched_findings.select_related('reporter')
+        prefetched_findings = prefetched_findings.prefetch_related('reporter')
         prefetched_findings = prefetched_findings.prefetch_related('jira_issue__jira_project__jira_instance')
         prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__jira_project__jira_instance')

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -228,7 +228,7 @@ def prefetch_for_findings(findings, prefetch_type='all'):
 def prefetch_for_similar_findings(findings):
     prefetched_findings = findings
     if isinstance(findings, QuerySet):  # old code can arrive here with prods being a list because the query was already executed
-        prefetched_findings = prefetched_findings.select_related('reporter')
+        prefetched_findings = prefetched_findings.prefetch_related('reporter')
         prefetched_findings = prefetched_findings.prefetch_related('jira_issue__jira_project__jira_instance')
         prefetched_findings = prefetched_findings.prefetch_related('test__test_type')
         prefetched_findings = prefetched_findings.prefetch_related('test__engagement__jira_project__jira_instance')

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -81,8 +81,11 @@ def prefetch_for_product(prods):
     prefetched_prods = prods
     if isinstance(prods,
                   QuerySet):  # old code can arrive here with prods being a list because the query was already executed
-        prefetched_prods = prefetched_prods.select_related('technical_contact').select_related(
-            'product_manager').select_related('prod_type').select_related('team_manager')
+
+        prefetched_prods = prefetched_prods.prefetch_related('team_manager')
+        prefetched_prods = prefetched_prods.prefetch_related('product_manager')
+        prefetched_prods = prefetched_prods.prefetch_related('technical_contact')
+
         prefetched_prods = prefetched_prods.annotate(
             active_engagement_count=Count('engagement__id', filter=Q(engagement__active=True)))
         prefetched_prods = prefetched_prods.annotate(
@@ -96,6 +99,8 @@ def prefetch_for_product(prods):
                                                                                     engagement__test__finding__active=True,
                                                                                     engagement__test__finding__verified=True)))
         prefetched_prods = prefetched_prods.prefetch_related('jira_project_set__jira_instance')
+        prefetched_prods = prefetched_prods.prefetch_related('authorized_users')
+        prefetched_prods = prefetched_prods.prefetch_related('prod_type__authorized_users')
         active_endpoint_query = Endpoint.objects.filter(
             finding__active=True,
             finding__mitigated__isnull=True)


### PR DESCRIPTION
I think something changed recently around authorizations on the product overview as it is doing lots of queries to retrieve authorized users.
This PR ensures authorized users are prefetched.

Also it changes some `selected_related` clauses to `prefetch_related` as it turns it that is a lot faster (thanks @danielnaab)

Also fixes a bug when viewing findings for an engagement where it was not filtering correctly on status.