### PR TITLE
Ability to invoke fix_loop_duplicates from celerybeat

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -749,6 +749,11 @@ CELERY_BEAT_SCHEDULE = {
     #     'schedule': timedelta(hours=12),
     #     'kwargs': {'mode': 'reconcile', 'dryrun': True, 'daysback': 10, 'product': None, 'engagement': None}
     # },
+    # 'fix_loop_duplicates': {
+    #     'task': 'dojo.tasks.fix_loop_duplicates_task',
+    #     'schedule': timedelta(hours=12)
+    # },
+
 
 }
 

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -309,3 +309,9 @@ def async_sla_compute_and_notify_task(*args, **kwargs):
 def jira_status_reconciliation_task(*args, **kwargs):
     from dojo.management.commands.jira_status_reconciliation import jira_status_reconciliation
     return jira_status_reconciliation(*args, **kwargs)
+
+
+@app.task
+def fix_loop_duplicates_task(*args, **kwargs):
+    from dojo.management.commands.fix_loop_duplicates import fix_loop_duplicates
+    return fix_loop_duplicates()


### PR DESCRIPTION
The fix_loop_duplicates allows to fix circular dups. It happens that sometimes due to the async dup mechanism, we have some of them forming again.
This gives the ability to schedule this management command if one wishes.