### PR TITLE
Added skip_duplicates flag when importing scans via APIv2

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -160,37 +160,42 @@ def deduplicate_legacy(new_finding, return_original_without_save=False):
     """
     # ---------------------------------------------------------
     # 1) Collects all the findings that have the same:
-    #      (title  and static_finding and dynamic_finding)
-    #      or (CWE and static_finding and dynamic_finding)
+    #       hash_code and (
+    #           (title  and static_finding and dynamic_finding)
+    #           or (CWE and static_finding and dynamic_finding)
+    #       )
     #    as the new one
     #    (this is "cond1")
     # ---------------------------------------------------------
     if new_finding.test.engagement.deduplication_on_engagement:
         eng_findings_cwe = Finding.objects.filter(
             test__engagement=new_finding.test.engagement,
+            hash_code=new_finding.hash_code,
             cwe=new_finding.cwe).exclude(id=new_finding.id).exclude(cwe=0).exclude(duplicate=True).values('id')
         eng_findings_title = Finding.objects.filter(
             test__engagement=new_finding.test.engagement,
+            hash_code=new_finding.hash_code,
             title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True).values('id')
     else:
         eng_findings_cwe = Finding.objects.filter(
             test__engagement__product=new_finding.test.engagement.product,
+            hash_code=new_finding.hash_code,
             cwe=new_finding.cwe).exclude(id=new_finding.id).exclude(cwe=0).exclude(duplicate=True).values('id')
         eng_findings_title = Finding.objects.filter(
             test__engagement__product=new_finding.test.engagement.product,
+            hash_code=new_finding.hash_code,
             title=new_finding.title).exclude(id=new_finding.id).exclude(duplicate=True).values('id')
 
     total_findings = Finding.objects.filter(Q(id__in=eng_findings_cwe) | Q(id__in=eng_findings_title)).prefetch_related('endpoints', 'test', 'test__engagement', 'found_by', 'original_finding', 'test__test_type')
     deduplicationLogger.debug("Found " +
-        str(len(eng_findings_cwe)) + " findings with same cwe, " +
-        str(len(eng_findings_title)) + " findings with same title: " +
-        str(len(total_findings)) + " findings with either same title or same cwe")
+        str(len(eng_findings_cwe)) + " findings with same cwe and hash, " +
+        str(len(eng_findings_title)) + " findings with same title and hash: " +
+        str(len(total_findings)) + " findings with either one")
 
     # total_findings = total_findings.order_by('date')
     for find in total_findings.order_by('id'):
         flag_endpoints = False
         flag_line_path = False
-        flag_hash = False
         if is_deduplication_on_engagement_mismatch(new_finding, find):
             deduplicationLogger.debug(
                 'deduplication_on_engagement_mismatch, skipping dedupe.')
@@ -223,19 +228,15 @@ def deduplicate_legacy(new_finding, return_original_without_save=False):
 
             deduplicationLogger.debug("no endpoints on one of the findings and the new finding is either dynamic or doesn't have a file_path; Deduplication will not occur")
 
-        if find.hash_code == new_finding.hash_code:
-            flag_hash = True
-
         deduplicationLogger.debug(
             'deduplication flags for new finding (' + ('dynamic' if new_finding.dynamic_finding else 'static') + ') ' + str(new_finding.id) + ' and existing finding ' + str(find.id) +
-            ' flag_endpoints: ' + str(flag_endpoints) + ' flag_line_path:' + str(flag_line_path) + ' flag_hash:' + str(flag_hash))
+            ' flag_endpoints: ' + str(flag_endpoints) + ' flag_line_path:' + str(flag_line_path))
 
         # ---------------------------------------------------------
-        # 3) Findings are duplicate if (cond1 is true) and they have the same:
-        #    hash
-        #    and (endpoints or (line and file_path)
+        # 3) Findings are duplicate if:
+        #       (cond1 is true) and they have the same (endpoints or (line and file_path)
         # ---------------------------------------------------------
-        if ((flag_endpoints or flag_line_path) and flag_hash):
+        if flag_endpoints or flag_line_path:
             if return_original_without_save:
                 return find
             try:


### PR DESCRIPTION
**Added:**

- `skip_duplicates` flag to `api/v2/import-scan/`
- Option to return the original finding when calling the deduplication method instead of saving the duplicate, this allows us to reuse the deduplication logic in other places, reducing the amount of duplicated code and making it easier to add features that require/use deduplication.
- A few docstrings <3
  
**Changed:**

- Now the legacy deduplication method also filters findings by hash_code instead of filtering only by title/cwe and looping through each one comparing hash_codes. This greatly improves performance when working with a lot of findings with similar title/cwe but different hash_codes.

**TODO:**

- [ ] Add unittests
- [ ] Refactor `return_original_without_save`