### PR TITLE
Show benchmark results in Product view only when benchmarks are enabled

### DIFF
--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -154,7 +154,9 @@
     </div>
   </div>
 </div>
-      <!-- Benchmark Tab -->
+
+<!-- Benchmark Tab -->
+{% if system_settings.enable_benchmark %}
 <div class="row">
   <div class="col-md-12">
     <div class="panel panel-default">
@@ -186,6 +188,8 @@
     </div>
   </div>
 </div>
+{% endif %}
+
 {% feature_authorization_v2 as feature_authorization_v2_flag %}
 {% if feature_authorization_v2_flag %}
     <div class="panel panel-default">


### PR DESCRIPTION
The panel for benchmark results is currently shown unconditionally in the product details view, even when benchmarks have been disabled in the system settings. With this PR the benchmarks results are only shown when benchmarks are enabled in the system settings.