### PR TITLE
don't show fields on delete forms

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -186,7 +186,7 @@ class Delete_Product_TypeForm(forms.ModelForm):
 
     class Meta:
         model = Product_Type
-        exclude = ['name', 'description', 'critical_product', 'key_product', 'authorized_users', 'members']
+        fields = []
 
 
 class Edit_Product_Type_MemberForm(forms.ModelForm):
@@ -235,7 +235,7 @@ class Development_EnvironmentForm(forms.ModelForm):
 class Delete_Dev_EnvironmentForm(forms.ModelForm):
     class Meta:
         model = Development_Environment
-        exclude = ['name']
+        fields = []
 
 
 class ProductForm(forms.ModelForm):
@@ -286,12 +286,7 @@ class DeleteProductForm(forms.ModelForm):
 
     class Meta:
         model = Product
-        exclude = ['name', 'description', 'prod_manager', 'tech_contact', 'manager', 'created',
-                   'prod_type', 'updated', 'tid', 'authorized_users', 'product_manager',
-                   'technical_contact', 'team_manager', 'prod_numeric_grade', 'business_criticality',
-                   'platform', 'lifecycle', 'origin', 'user_records', 'revenue', 'external_audience',
-                   'internet_accessible', 'regulations', 'product_meta', 'members', 'tags',
-                   'enable_simple_risk_acceptance', 'enable_full_risk_acceptance']
+        fields = []
 
 
 class DeleteFindingGroupForm(forms.ModelForm):
@@ -300,7 +295,7 @@ class DeleteFindingGroupForm(forms.ModelForm):
 
     class Meta:
         model = Finding_Group
-        fields = ['id']
+        fields = []
 
 
 class Edit_Product_MemberForm(forms.ModelForm):
@@ -725,13 +720,7 @@ class DeleteEngagementForm(forms.ModelForm):
 
     class Meta:
         model = Engagement
-        exclude = ['name', 'version', 'eng_type', 'first_contacted', 'target_start',
-                   'target_end', 'lead', 'requester', 'reason', 'report_type',
-                   'product', 'test_strategy', 'threat_model', 'api_test', 'pen_test',
-                   'check_list', 'status', 'description', 'engagement_type', 'build_id',
-                   'commit_hash', 'branch_tag', 'build_server', 'source_code_management_server',
-                   'source_code_management_uri', 'orchestration_engine', 'preset', 'tracker',
-                   'deduplication_on_engagement', 'tags']
+        fields = []
 
 
 class TestForm(forms.ModelForm):
@@ -1175,7 +1164,7 @@ class DeleteFindingTemplateForm(forms.ModelForm):
 
     class Meta:
         model = Finding_Template
-        fields = ('id',)
+        fields = []
 
 
 class FindingBulkUpdateForm(forms.ModelForm):
@@ -1400,14 +1389,7 @@ class DeleteEndpointForm(forms.ModelForm):
 
     class Meta:
         model = Endpoint
-        exclude = ('protocol',
-                   'fqdn',
-                   'port',
-                   'host',
-                   'path',
-                   'query',
-                   'fragment',
-                   'product')
+        fields = []
 
 
 class NoteForm(forms.ModelForm):
@@ -1437,7 +1419,7 @@ class DeleteNoteForm(forms.ModelForm):
 
     class Meta:
         model = Notes
-        fields = ('id',)
+        fields = []
 
 
 class CloseFindingForm(forms.ModelForm):
@@ -1611,9 +1593,7 @@ class DeleteUserForm(forms.ModelForm):
 
     class Meta:
         model = User
-        exclude = ['username', 'first_name', 'last_name', 'email', 'is_active',
-                   'is_staff', 'is_superuser', 'password', 'last_login', 'groups',
-                   'date_joined', 'user_permissions']
+        fields = []
 
 
 class UserContactInfoForm(forms.ModelForm):
@@ -1680,7 +1660,7 @@ class DeleteReportForm(forms.ModelForm):
 
     class Meta:
         model = Report
-        fields = ('id',)
+        fields = []
 
 
 class DeleteFindingForm(forms.ModelForm):
@@ -1689,7 +1669,7 @@ class DeleteFindingForm(forms.ModelForm):
 
     class Meta:
         model = Finding
-        fields = ('id',)
+        fields = []
 
 
 class FindingFormID(forms.ModelForm):
@@ -1707,7 +1687,7 @@ class DeleteStubFindingForm(forms.ModelForm):
 
     class Meta:
         model = Stub_Finding
-        fields = ('id',)
+        fields = []
 
 
 class AddFindingImageForm(forms.ModelForm):
@@ -1740,7 +1720,7 @@ class DeleteGITHUBConfForm(forms.ModelForm):
 
     class Meta:
         model = GITHUB_Conf
-        fields = ('id',)
+        fields = []
 
 
 class ExpressGITHUBForm(forms.ModelForm):
@@ -1855,7 +1835,7 @@ class DeleteBenchmarkForm(forms.ModelForm):
 
     class Meta:
         model = Benchmark_Product_Summary
-        exclude = ['product', 'benchmark_type', 'desired_level', 'current_level', 'asvs_level_1_benchmark', 'asvs_level_1_score', 'asvs_level_2_benchmark', 'asvs_level_2_score', 'asvs_level_3_benchmark', 'asvs_level_3_score', 'publish']
+        fields = []
 
 
 # class JIRA_ProjectForm(forms.ModelForm):
@@ -1888,7 +1868,7 @@ class DeleteJIRAInstanceForm(forms.ModelForm):
 
     class Meta:
         model = JIRA_Instance
-        fields = ('id',)
+        fields = []
 
 
 class ToolTypeForm(forms.ModelForm):
@@ -1950,7 +1930,7 @@ class DeleteObjectsSettingsForm(forms.ModelForm):
 
     class Meta:
         model = Objects_Product
-        exclude = ['tool_type']
+        fields = []
 
 
 class DeleteToolProductSettingsForm(forms.ModelForm):
@@ -1959,7 +1939,7 @@ class DeleteToolProductSettingsForm(forms.ModelForm):
 
     class Meta:
         model = Tool_Product_Settings
-        exclude = ['tool_type']
+        fields = []
 
 
 class ToolProductSettingsForm(forms.ModelForm):
@@ -2043,7 +2023,7 @@ class DeleteEngagementPresetsForm(forms.ModelForm):
 
     class Meta:
         model = Engagement_Presets
-        fields = ['id']
+        fields = []
 
 
 class SystemSettingsForm(forms.ModelForm):
@@ -2119,7 +2099,7 @@ class DeleteRuleForm(forms.ModelForm):
 
     class Meta:
         model = Rule
-        fields = ('id',)
+        fields = []
 
 
 class CredUserForm(forms.ModelForm):
@@ -2674,12 +2654,7 @@ class Delete_Questionnaire_Form(forms.ModelForm):
 
     class Meta:
         model = Answered_Survey
-        exclude = ('responder',
-                   'completed',
-                   'engagement',
-                   'answered_on',
-                   'survey',
-                   'assignee')
+        fields = []
 
 
 class DeleteGeneralQuestionnaireForm(forms.ModelForm):
@@ -2688,10 +2663,7 @@ class DeleteGeneralQuestionnaireForm(forms.ModelForm):
 
     class Meta:
         model = General_Survey
-        exclude = ('num_responses',
-                   'generated',
-                   'expiration',
-                   'survey')
+        fields = []
 
 
 class Delete_Eng_Survey_Form(forms.ModelForm):
@@ -2700,10 +2672,7 @@ class Delete_Eng_Survey_Form(forms.ModelForm):
 
     class Meta:
         model = Engagement_Survey
-        exclude = ('name',
-                   'questions',
-                   'description',
-                   'active')
+        fields = []
 
 
 class CreateQuestionnaireForm(forms.ModelForm):


### PR DESCRIPTION
Sometimes somebody adds a field on de model, but forgets to exclude it on the form used to delete that model. And the delete page then looks something like this:

![image](https://user-images.githubusercontent.com/4426050/113927403-b97dba00-97ed-11eb-9942-786bd55ad945.png)

This PR changes from `exclude=[field1,field2, ...]` to `fields=[]`. This makes user no model fields are shown. The delete still works as the `id` field is explicitly defined.

To be honest I think we probably shouldn't use a separate from for each model just to be able to delete them, but for now I created this easy PR making it at least more clean. 