### PR TITLE
ORT security tool parser: add license path in finding description

### DIFF
--- a/dojo/tools/ort/parser.py
+++ b/dojo/tools/ort/parser.py
@@ -116,11 +116,11 @@ def get_rule_violation_model(rule_violation_unresolved, packages, licenses, depe
     for id in project_ids:
         project_names.append(get_name_id_for_package(packages, id))
     package = find_package_by_id(packages, rule_violation_unresolved['pkg'])
-    if 'license' in rule_violation_unresolved: 
+    if 'license' in rule_violation_unresolved:
         license_tmp = rule_violation_unresolved['license']
     else:
         license_tmp = 'unset'
-    if 'license_source' not in rule_violation_unresolved: 
+    if 'license_source' not in rule_violation_unresolved:
         rule_violation_unresolved['license_source'] = 'unset'
     license_id = find_license_id(licenses, license_tmp)
 
@@ -155,7 +155,7 @@ def find_finding_path(findings, license_num):
 def get_item(model, test):
 
     if 'findings' in model.pkg:
-        finding_path = find_finding_path(model.pkg['findings'], model.license_id_number) 
+        finding_path = find_finding_path(model.pkg['findings'], model.license_id_number)
         desc = f"""root projects: {', '.join(model.projects)}
         source  : {model.rule_violation['license_source']}
         license : {model.license_id}

--- a/dojo/tools/ort/parser.py
+++ b/dojo/tools/ort/parser.py
@@ -116,15 +116,15 @@ def get_rule_violation_model(rule_violation_unresolved, packages, licenses, depe
     for id in project_ids:
         project_names.append(get_name_id_for_package(packages, id))
     package = find_package_by_id(packages, rule_violation_unresolved['pkg'])
-    if 'license' in rule_violation_unresolved:
+    if 'license' in rule_violation_unresolved: 
         license_tmp = rule_violation_unresolved['license']
     else:
         license_tmp = 'unset'
-    if 'license_source' not in rule_violation_unresolved:
+    if 'license_source' not in rule_violation_unresolved: 
         rule_violation_unresolved['license_source'] = 'unset'
     license_id = find_license_id(licenses, license_tmp)
 
-    return RuleViolationModel(package, license_id, project_names, rule_violation_unresolved)
+    return RuleViolationModel(package, license_id, license_tmp, project_names, rule_violation_unresolved)
 
 
 def find_package_by_id(packages, pkg_id):
@@ -145,13 +145,31 @@ def find_license_id(licenses, license_id):
     return id
 
 
+def find_finding_path(findings, license_num):
+    for f in findings:
+        if f['type'] == 'LICENSE':
+            if license_num == f['license']:
+                return f['path']
+
+
 def get_item(model, test):
-    desc = f"""root projects: {', '.join(model.projects)}
-source  : {model.rule_violation['license_source']}
-license : {model.license_id}
-package : {model.pkg['id']}
-message : {model.rule_violation['message']}
-how to fix : {model.rule_violation['how_to_fix']}"""
+
+    if 'findings' in model.pkg:
+        finding_path = find_finding_path(model.pkg['findings'], model.license_id_number) 
+        desc = f"""root projects: {', '.join(model.projects)}
+        source  : {model.rule_violation['license_source']}
+        license : {model.license_id}
+        package : {model.pkg['id']}
+        message : {model.rule_violation['message']}
+        path	: {finding_path}
+        how to fix : {model.rule_violation['how_to_fix']}"""
+    else:
+        desc = f"""root projects: {', '.join(model.projects)}
+        source  : {model.rule_violation['license_source']}
+        license : {model.license_id}
+        package : {model.pkg['id']}
+        message : {model.rule_violation['message']}
+        how to fix : {model.rule_violation['how_to_fix']}"""
 
     severity = get_severity(model.rule_violation)
 
@@ -179,6 +197,7 @@ how to fix : {model.rule_violation['how_to_fix']}"""
 RuleViolationModel = namedtuple('RuleViolationModel', [
     'pkg',
     'license_id',
+    'license_id_number',
     'projects',
     'rule_violation'
 ])


### PR DESCRIPTION
This will add feature #4222

 - [x] A new value is added to the model in order to allow the finding path to be found: license id number.
 - [x] A new function is added in order to find the path of a license id number in a given findings list.
 - [x] A condition was added in order to capture the cases where findings are present and the path value is applicable (i.e. can be found in the file).

