### PR TITLE
Snyk parser: fix CVSS parsing

### DIFF
--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -134,7 +134,7 @@ def get_item(vulnerability, test):
         "CVSS score of: **" + str(vulnerability['cvssScore']) + "**",
         cwe=cwe,
         cve=cve,
-        cvssv3=vulnerability['CVSSv3'][9:],
+        cvssv3=vulnerability['CVSSv3'],
         description="## Component Details\n - **Vulnerable Package**: " +
         vulnerability['packageName'] + "\n- **Current Version**: " + str(
             vulnerability['version']) + "\n- **Vulnerable Version(s)**: " +

--- a/dojo/unittests/tools/test_snyk_parser.py
+++ b/dojo/unittests/tools/test_snyk_parser.py
@@ -67,7 +67,7 @@ class TestSnykParser(TestCase):
         )
         self.assertEqual("CVE-2019-12400", finding.cve)
         self.assertEqual(611, finding.cwe)
-        self.assertEqual("AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L", finding.cvssv3)
+        self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:L", finding.cvssv3)
         self.assertEqual(
             "## Remediation\nUpgrade `org.apache.santuario:xmlsec` to version 2.1.4 or higher.\n",
             finding.mitigation,


### PR DESCRIPTION
This PR addresses one bug:

- **CVSS3** string field for Snyk Findings was being added without the "CVSS:3.x/" prefix, causing failure in the cvssScore computation: https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/models.py#L2124

In the current implementation, the removal of the "CVSS:3.x/" prefix when parsing the CVSS string was based on the Finding "cvss3" field validation: https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/models.py#L1420 . I am not sure if this validation is correct taking into account the cvssScore computation logic.

Regards