### PR TITLE
jira: remove validate parameter on config change

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1783,7 +1783,7 @@ class JIRAForm(forms.ModelForm):
         form_data = self.cleaned_data
 
         try:
-            jira = jira_helper.get_jira_connection_raw(form_data['url'], form_data['username'], form_data['password'], validate=True)
+            jira = jira_helper.get_jira_connection_raw(form_data['url'], form_data['username'], form_data['password'])
             logger.debug('valid JIRA config!')
         except Exception as e:
             # form only used by admins, so we can show full error message using str(e) which can help debug any problems
@@ -1810,7 +1810,7 @@ class ExpressJIRAForm(forms.ModelForm):
         form_data = self.cleaned_data
 
         try:
-            jira = jira_helper.get_jira_connection_raw(form_data['url'], form_data['username'], form_data['password'], validate=True)
+            jira = jira_helper.get_jira_connection_raw(form_data['url'], form_data['username'], form_data['password'],)
             logger.debug('valid JIRA config!')
         except Exception as e:
             # form only used by admins, so we can show full error message using str(e) which can help debug any problems

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -311,12 +311,12 @@ def has_jira_configured(obj):
     return get_jira_project(obj) is not None
 
 
-def get_jira_connection_raw(jira_server, jira_username, jira_password, validate=False):
+def get_jira_connection_raw(jira_server, jira_username, jira_password):
     try:
         jira = JIRA(server=jira_server,
                 basic_auth=(jira_username, jira_password),
                 options={"verify": settings.JIRA_SSL_VERIFY},
-                max_retries=0, validate=validate)
+                max_retries=0)
 
         logger.debug('logged in to JIRA ''%s'' successfully', jira_server)
 

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -217,7 +217,7 @@ def express_new_jira(request):
             jira_password = jform.cleaned_data.get('password')
 
             try:
-                jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password, validate=True)
+                jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password)
             except Exception as e:
                 logger.exception(e)  # already logged in jira_helper
                 messages.add_message(request,
@@ -301,7 +301,7 @@ def new_jira(request):
             jira_password = jform.cleaned_data.get('password')
 
             logger.debug('calling get_jira_connection_raw')
-            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password, validate=True)
+            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password)
 
             new_j = jform.save(commit=False)
             new_j.url = jira_server
@@ -342,7 +342,7 @@ def edit_jira(request, jid):
                 # on edit the password is optional
                 jira_password = jira_password_from_db
 
-            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password, validate=True)
+            jira = jira_helper.get_jira_connection_raw(jira_server, jira_username, jira_password)
 
             new_j = jform.save(commit=False)
             new_j.url = jira_server

--- a/dojo/unittests/test_jira_config_product.py
+++ b/dojo/unittests/test_jira_config_product.py
@@ -48,9 +48,9 @@ class JIRAConfigProductTest(DojoTestCase):
     def add_jira_instance(self, data, jira_mock):
         response = self.client.post(reverse('add_jira'), urlencode(data), content_type='application/x-www-form-urlencoded')
         # check that storing a new config triggers a login call to JIRA
-        call_1 = call(data['url'], data['username'], data['password'], validate=True)
-        call_2 = call(data['url'], data['username'], data['password'], validate=True)
-        # jira_mock.assert_called_once_with(data['url'], data['username'], data['password'], validate=True)
+        call_1 = call(data['url'], data['username'], data['password'])
+        call_2 = call(data['url'], data['username'], data['password'])
+        # jira_mock.assert_called_once_with(data['url'], data['username'], data['password'])
         jira_mock.assert_has_calls([call_1, call_2])
         # succesful, so should redirect to list of JIRA instances
         self.assertRedirects(response, '/jira')
@@ -85,7 +85,7 @@ class JIRAConfigProductTest(DojoTestCase):
 
         # test raw connection error
         with self.assertRaises(requests.exceptions.RequestException):
-            jira = jira_helper.get_jira_connection_raw(data['url'], data['username'], data['password'], validate=True)
+            jira = jira_helper.get_jira_connection_raw(data['url'], data['username'], data['password'])
 
     @patch('dojo.jira_link.views.jira_helper.get_jira_connection_raw')
     def test_add_jira_instance_invalid_credentials(self, jira_mock):


### PR DESCRIPTION
fixes #4225 where authorization to JIRA Cloud fails when adding/editing a JIRA instance.