### PR TITLE
login banner: allow clickable urls

### DIFF
--- a/dojo/db_migrations/0026_login_banner.py
+++ b/dojo/db_migrations/0026_login_banner.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('banner_enable', models.BooleanField(blank=True, default=False, null=True)),
-                ('banner_message', models.CharField(default='', help_text='This message will be displayed on the login page', max_length=500)),
+                ('banner_message', models.CharField(default='', help_text="This message will be displayed on the login page. It can contain basic html tags, for example <a href='https://www.fred.com' style='color: #337ab7;' target='_blank'>https://example.com</a>", max_length=500)),
             ],
         ),
     ]

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2634,7 +2634,7 @@ class FindingImageAccessToken(models.Model):
 
 class BannerConf(models.Model):
     banner_enable = models.BooleanField(default=False, null=True, blank=True)
-    banner_message = models.CharField(max_length=500, help_text="This message will be displayed on the login page", default='')
+    banner_message = models.CharField(max_length=500, help_text="This message will be displayed on the login page. It can contain basic html tags, for example <a href='https://www.fred.com' style='color: #337ab7;' target='_blank'>https://example.com</a>", default='')
 
 
 class GITHUB_Conf(models.Model):

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -4,9 +4,9 @@
     <h3>Login</h3>
     <form class="form-horizontal" method="POST" autocomplete="off"> {% csrf_token %}
         <fieldset class="col-md-offset-3 col-md-6">
-            {% if "banner_enable"|get_banner %}
+            {% if "banner_enable"|get_banner_conf %}
                 <div class="well">
-                {{ "banner_message"|get_banner }}
+                    {{ "banner_message"|get_banner_conf }}
                 </div>
             {% endif %}
 

--- a/dojo/templatetags/get_banner.py
+++ b/dojo/templatetags/get_banner.py
@@ -1,4 +1,5 @@
-
+from django.utils.safestring import mark_safe
+import bleach
 from django import template
 from dojo.models import BannerConf
 
@@ -6,11 +7,20 @@ register = template.Library()
 
 
 @register.filter
-def get_banner(banner_conf):
+def get_banner_conf(attribute):
     try:
         banner_config = BannerConf.objects.get()
-        if getattr(banner_config, banner_conf, None):
-            return getattr(banner_config, banner_conf, None)
+
+        value = getattr(banner_config, attribute, None)
+        if value:
+
+            if attribute == 'banner_message':
+                # only staff/admin can edit login banner, so we allow html, but still bleach it
+                allowed_attributes = bleach.ALLOWED_ATTRIBUTES
+                allowed_attributes['a'] = allowed_attributes['a'] + ['style', 'target']
+                return mark_safe(bleach.clean(value, attributes=allowed_attributes, styles=['color', 'font-weight']))
+            else:
+                return value
         else:
             return False
     except Exception:


### PR DESCRIPTION
The login banner currently doesn't allow any html or clickable urls. That could be helpful to add a link to login/sso instructions or terms of use or just a link to fred.com:

![image](https://user-images.githubusercontent.com/4426050/114169369-c1467700-9931-11eb-9bb0-96e67c611ff1.png)

This PR allows the basic html tags allowed by the bleach library and a couple of styling tags, i.e. to give a nice blue color to the url and to let it open in a new tab.

Also tried to simplify the setup and do something straightforward like {% if get_banner.banner_enable %} but apparently the django templates require this weird construct with passing in strings into filters/tags.