### PR TITLE
Integrate interactive and ci/cd engagements in one list

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -245,11 +245,16 @@ def edit_engagement(request, eid):
             logger.debug('showing jira-epic-form')
             jira_epic_form = JIRAEngagementForm(instance=engagement)
 
-    title = ' CI/CD' if is_ci_cd else ''
-    product_tab = Product_Tab(engagement.product.id, title="Edit" + title + " Engagement", tab="engagements")
+    if is_ci_cd:
+        title = 'Edit CI/CD Engagement'
+    else:
+        title = 'Edit Interactive Engagement'
+
+    product_tab = Product_Tab(engagement.product.id, title=title, tab="engagements")
     product_tab.setEngagement(engagement)
     return render(request, 'dojo/new_eng.html', {
         'product_tab': product_tab,
+        'title': title,
         'form': form,
         'edit': True,
         'jira_epic_form': jira_epic_form,
@@ -281,10 +286,7 @@ def delete_engagement(request, eid):
                                     recipients=[engagement.lead],
                                     icon="exclamation-triangle")
 
-                if engagement.engagement_type == 'CI/CD':
-                    return HttpResponseRedirect(reverse("view_engagements_cicd", args=(product.id, )))
-                else:
-                    return HttpResponseRedirect(reverse("view_engagements", args=(product.id, )))
+                return HttpResponseRedirect(reverse("view_engagements", args=(product.id, )))
 
     collector = NestedObjects(using=DEFAULT_DB_ALIAS)
     collector.collect([engagement])
@@ -826,10 +828,7 @@ def close_eng(request, eid):
                         title='Closure of %s' % eng.name,
                         description='The engagement "%s" was closed' % (eng.name),
                         engagement=eng, url=reverse('engagment_all_findings', args=(eng.id, ))),
-    if eng.engagement_type == 'CI/CD':
-        return HttpResponseRedirect(reverse("view_engagements_cicd", args=(eng.product.id, )))
-    else:
-        return HttpResponseRedirect(reverse("view_engagements", args=(eng.product.id, )))
+    return HttpResponseRedirect(reverse("view_engagements", args=(eng.product.id, )))
 
 
 @user_is_authorized(Engagement, Permissions.Engagement_Edit, 'eid', 'staff')
@@ -845,10 +844,7 @@ def reopen_eng(request, eid):
                         title='Reopening of %s' % eng.name,
                         description='The engagement "%s" was reopened' % (eng.name),
                         url=reverse('view_engagement', args=(eng.id, ))),
-    if eng.engagement_type == 'CI/CD':
-        return HttpResponseRedirect(reverse("view_engagements_cicd", args=(eng.product.id, )))
-    else:
-        return HttpResponseRedirect(reverse("view_engagements", args=(eng.product.id, )))
+    return HttpResponseRedirect(reverse("view_engagements", args=(eng.product.id, )))
 
 
 """

--- a/dojo/product/urls.py
+++ b/dojo/product/urls.py
@@ -11,8 +11,6 @@ urlpatterns = [
         name='view_product_components'),
     url(r'^product/(?P<pid>\d+)/engagements$', views.view_engagements,
         name='view_engagements'),
-    url(r'^product/(?P<pid>\d+)/engagements/cicd$', views.view_engagements_cicd,
-        name='view_engagements_cicd'),
     url(r'^product/(?P<pid>\d+)/import_scan_results$',
         views.import_scan_results_prod, name='import_scan_results_prod'),
     url(r'^product/(?P<pid>\d+)/metrics$', views.view_product_metrics,

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -430,11 +430,8 @@
                     <ul class="dropdown-menu">
                       <li><a href="{% url 'view_engagements' product_tab.product.id %}"><i class="fa fa-calendar"></i> View Engagements</a></li>
                       {% if product_tab.product|has_object_permission:"Engagement_Add" or user|is_authorized_for_staff:product_tab.product %}
-                      <li><a href="{% url 'new_eng_for_prod' product_tab.product.id %}"><i class="fa fa-plus"></i> Add New Engagement</a></li>
-                      {% endif %}
                       <li role="separator" class="divider"></li>
-                      <li><a href="{% url 'view_engagements_cicd' product_tab.product.id %}"><i class="fa fa-calendar"></i> View CI/CD Engagements</a></li>
-                      {% if product_tab.product|has_object_permission:"Engagement_Add" or user|is_authorized_for_staff:product_tab.product%}
+                      <li><a href="{% url 'new_eng_for_prod' product_tab.product.id %}"><i class="fa fa-plus"></i> Add New Interactive Engagement</a></li>
                       <li><a href="{% url 'new_eng_for_prod_cicd' product_tab.product.id %}"><i class="fa fa-plus"></i> Add New CI/CD Engagement</a></li>
                       {% endif %}
                     </ul>

--- a/dojo/templates/dojo/breadcrumbs/engagement_breadcrumb.html
+++ b/dojo/templates/dojo/breadcrumbs/engagement_breadcrumb.html
@@ -1,11 +1,7 @@
 {% if product_tab.tab == "engagements" and not custom_breadcrumb %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
-  {% if product_tab.engagement.engagement_type == "CI/CD" or "cicd" in request.path %}
-    <li><a data-toggle="tooltip" data-placement="top" title="CI/CD Engagements" href="{% url 'view_engagements_cicd' product_tab.product.id %}">CI/CD Engagements</a></li>
-  {% else %}
     <li><a data-toggle="tooltip" data-placement="top" title="Engagements" href="{% url 'view_engagements' product_tab.product.id %}">Engagements</a></li>
-  {% endif %}
   {% if product_tab.engagement.id %}
     <li><a data-toggle="tooltip" data-placement="top" title="Engagement" href="{% url 'view_engagement' product_tab.engagement.id %}">{{product_tab.engagement.name}}</a></li>
   {% endif %}

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -14,11 +14,7 @@
     }
 {% endblock %}
 {% block content %}
-    {% if edit %}
-        <h3> Edit Engagement </h3>
-    {% else %}
-        <h3> New Engagement </h3>
-    {% endif %}
+    <h3> {{ title }} </h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
 

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -4,18 +4,25 @@
 <div class="col-md-12">
     <div class="panel panel-default table-responsive">
         <div class="panel-heading">
-            <h4> {% if status == "open" %}Active{% elif status == "paused" %}Paused {% else %}Closed{% endif %} {% if type == "CI/CD" %}CI/CD{% endif %} Engagements ({{ count }})
+            <h4> {% if status == "open" %}Active{% elif status == "paused" %}Paused {% else %}Closed{% endif %} Engagements ({{ count }})
                 <div class="dropdown pull-right">
-                    <button id="show-filters" data-toggle="collapse" data-target="#the-filters-{{status}}" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
-                    {% if prod|has_object_permission:"Engagement_Add" or user|is_authorized_for_staff:prod %}
-                        {% if type == "CI/CD" %}
-                        <a title="Add New Engagement" class="btn btn-sm btn-primary" href="{% url 'new_eng_for_prod_cicd' prod.id %}"><span
-                            class="fa fa-plus"></span> </a>
-                        {% else %}
-                        <a title="Add New Engagement" class="btn btn-sm btn-primary" href="{% url 'new_eng_for_prod' prod.id %}"><span
-                            class="fa fa-plus"></span> </a>
-                        {% endif %}
-                    {% endif %}
+                    <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
+                    data-toggle="dropdown" aria-expanded="true">
+                <span class="fa fa-bars"></span>
+                <span class="caret"></span>
+            </button>
+          <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
+                            <li role="presentation">
+                                <a class="" href="{% url 'new_eng_for_prod' prod.id %}">
+                                    <i class="fa fa-plus"></i> Add New Interactive Engagement
+                                </a>
+                            </li>
+                            <li role="presentation">
+                                <a class="" href="{% url 'new_eng_for_prod_cicd' prod.id %}">
+                                    <i class="fa fa-plus"></i> Add New CI/CD Engagement
+                                </a>
+                            </li>
+                    </ul>
                 </div>
               </h4>
         </div>
@@ -33,6 +40,7 @@
                 <tr>
                     <th></th>
                     <th>Name</th>
+                    <th>Type</th>
                     <th>Lead</th>
                     <th class="text-left">Date</th>
                     <th class="text-left">Length</th>
@@ -45,7 +53,6 @@
                     <th class="text-center">Accepted</th>
                     <th class="text-center">All</th>
                     <th class="text-center">Duplicates</th>
-                    <th class="text-left">Updated</th>
                     {% if status == "paused" or status == "closed" %}
                       <th class="text-left">Status</th>
                     {% endif %}
@@ -141,7 +148,7 @@
                          </li>
                      </ul>
                     </td>
-                    <td class="text-center" style="width: 250px;">
+                    <td style="width: 250px;">
                     <a href="{% url 'view_engagement' eng.id %}" data-toggle="tooltip" data-placement="bottom" title="{{ eng.name|default:"N/A" }}">
                     {{ eng.name|truncatechars_html:35|default:"N/A" }}</a>
                     {% if eng.version %}
@@ -158,6 +165,7 @@
                         </sup>
                     {% endif %}
                     </td>
+                    <td>{{ eng.engagement_type }}</td>
                     <td style="width: 150px;">
                       {% if eng.lead.get_full_name and eng.lead.get_full_name.strip %}
                           {{ eng.lead.get_full_name }}
@@ -242,9 +250,6 @@
                     <td class="text-center">{{ eng.count_findings_accepted }}</td>
                     <td class="text-center">{{ eng.count_findings_all }}</td>
                     <td class="text-center">{{ eng.count_findings_duplicate }}</td>
-                    <td class="text-left"><a target="_blank" data-toggle="tooltip" data-placement="bottom" title="{{ eng.updated|default_if_none:"" }}">
-                    {{ eng.updated|naturaltime|default_if_none:"" }}</a>
-                    </td>
                     {% if status == "paused" or status == "closed" %}
                     <td class="text-left">
                       {% if eng.status == "Blocked" %}
@@ -295,6 +300,7 @@
                 "columns": [
                     { "data": "action" },
                     { "data": "eng_name" },
+                    { "data": "engagement_type" },
                     { "data": "lead" },
                     { "data": "date" },
                     { "data": "length" },
@@ -307,9 +313,8 @@
                     { "data": "accepted" },
                     { "data": "all" },
                     { "data": "dups" },
-                    { "data": "updated" },
                     {% if status == "paused" or status == "closed" %}
-                      { "data": "updated" },
+                      { "data": "status" },
                     {% endif %}
                 ],
                 columnDefs: [

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -6,7 +6,7 @@
         <div class="panel-heading">
             <h4> {% if status == "open" %}Active{% elif status == "paused" %}Paused {% else %}Closed{% endif %} Engagements ({{ count }})
                 <div class="dropdown pull-right">
-                    <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
+                    <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1" aria-label="Add Engagement"
                     data-toggle="dropdown" aria-expanded="true">
                 <span class="fa fa-bars"></span>
                 <span class="caret"></span>

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -119,7 +119,7 @@ class ProductTest(BaseTestCase):
         # Click on the 'Engagement dropdown button'
         driver.find_element_by_partial_link_text("Engagement").click()
         # 'click' the Add New Engagement option
-        driver.find_element_by_link_text("Add New Engagement").click()
+        driver.find_element_by_link_text("Add New Interactive Engagement").click()
         # Keep a good practice of clearing field before entering value
         # fill up at least all required input field options.
         # fields: 'Name', 'Description', 'Target Start', 'Target End', 'Testing Lead' and 'Status'

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -59,7 +59,7 @@ class TestUnitTest(BaseTestCase):
         # Click on the 'Engagement' Dropdown button
         driver.find_element_by_partial_link_text("Engagement").click()
         # 'click' the Add New Engagement option
-        driver.find_element_by_link_text("Add New Engagement").click()
+        driver.find_element_by_link_text("Add New Interactive Engagement").click()
         # Keep a good practice of clearing field before entering value
         # fill up at least all required input field options.
         # fields: 'Name', 'Description', 'Target Start', 'Target End', 'Testing Lead' and 'Status'


### PR DESCRIPTION
Interactive engagements and CI/CD engagements are currently separated in the Product tab. This might be confusing for users, when they have to look in 2 different lists to search for an engagement. A poll in Slack (https://owasp.slack.com/archives/C2P5BA8MN/p1617816100165000) gave a clear picture other users are thinking the same. This PR integrates both types of engagements in one list under the Product tab:

![2021-04-09 14_50_36-Product _ DefectDojo](https://user-images.githubusercontent.com/2698502/114183450-feb40000-9943-11eb-9f61-7e28f7970423.png)

![2021-04-09 15_02_15-All Engagements _ DefectDojo](https://user-images.githubusercontent.com/2698502/114184074-adf0d700-9944-11eb-86ee-01b252d3f89b.png)

The list contains a new column to show the type of the engagement. To make room for the new column, the "Updated" column at the end of the list has been removed.