### PR TITLE
fix Nonetype when adding from template

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -45,7 +45,9 @@ pre_save_changed.connect(pre_save_finding_status_change, sender=Finding, fields=
 def update_finding_status(new_state_finding, user, changed_fields=None):
     now = timezone.now()
 
-    is_new_finding = changed_fields and len(changed_fields) == 1 and 'id' in changed_fields
+    logger.debug('changed fields: %s', changed_fields)
+
+    is_new_finding = not changed_fields or (changed_fields and len(changed_fields) == 1 and 'id' in changed_fields)
 
     # activated
     # reactivated
@@ -55,7 +57,7 @@ def update_finding_status(new_state_finding, user, changed_fields=None):
     # marked as duplicate
     # marked as original
 
-    if 'is_Mitigated' in changed_fields or is_new_finding:
+    if is_new_finding or 'is_Mitigated' in changed_fields:
         # finding is being mitigated
         if new_state_finding.is_Mitigated:
             # when mitigating a finding, the meta fields can only be editted if allowed
@@ -78,7 +80,7 @@ def update_finding_status(new_state_finding, user, changed_fields=None):
         new_state_finding.mitigated = new_state_finding.mitigated or now
         new_state_finding.mitigated_by = new_state_finding.mitigated_by or user
 
-    if 'active' in changed_fields or is_new_finding:
+    if is_new_finding or 'active' in changed_fields:
         # finding is being (re)activated
         if new_state_finding.active:
             new_state_finding.false_p = False
@@ -90,10 +92,10 @@ def update_finding_status(new_state_finding, user, changed_fields=None):
             # finding is being deactivated
             pass
 
-    if 'verified' in changed_fields or is_new_finding:
+    if is_new_finding or 'verified' in changed_fields:
         pass
 
-    if 'false_p' in changed_fields or 'out_of_scope' in changed_fields or is_new_finding:
+    if is_new_finding or 'false_p' in changed_fields or 'out_of_scope' in changed_fields:
         # existing behaviour is that false_p or out_of_scope implies mitigated
         if new_state_finding.false_p or new_state_finding.out_of_scope:
             new_state_finding.mitigated = new_state_finding.mitigated or now

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2280,7 +2280,7 @@ class JIRAFindingForm(forms.Form):
 
         self.fields['jira_issue'].widget = forms.TextInput(attrs={'placeholder': 'Leave empty and check push to jira to create a new JIRA issue'})
 
-        if self.instance.has_jira_group_issue:
+        if self.instance and self.instance.has_jira_group_issue:
             self.fields['push_to_jira'].widget.attrs['checked'] = 'checked'
             self.fields['jira_issue'].help_text = 'Changing the linked JIRA issue for finding groups is not (yet) supported.'
             self.initial['jira_issue'] = self.instance.finding_group.jira_issue.jira_key


### PR DESCRIPTION
fixes 2 exceptions in 1.14.1 when adding a finding from a template:

```
  File "/home/valentijn/dd/dojo/forms.py", line 2283, in __init__
    if self.instance.has_jira_group_issue:
AttributeError: 'NoneType' object has no attribute 'has_jira_group_issue'
```

and

```
  File "/home/valentijn/dd/dojo/finding/helper.py", line 58, in update_finding_status
    if 'is_Mitigated' in changed_fields or is_new_finding:
TypeError: argument of type 'NoneType' is not iterable
```