### PR TITLE
Set rabbitMQ memory high watermark

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.15.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.0
+version: 1.6.1
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -261,11 +261,12 @@ rabbitmq:
     erlangCookie: ""
     existingPasswordSecret: defectdojo-rabbitmq-specific
     existingErlangSecret: defectdojo-rabbitmq-specific
-  memoryHighWatermark.enabled: true  
-  memoryHighWatermark.type: relative
-  memoryHighWatermark.value: 0.5
-    affinity: {}
-    nodeSelector: {}
+  memoryHighWatermark:
+    enabled: true
+    type: relative
+    value: 0.5
+  affinity: {}
+  nodeSelector: {}
   resources:
     requests:
       cpu: 100m

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -261,6 +261,9 @@ rabbitmq:
     erlangCookie: ""
     existingPasswordSecret: defectdojo-rabbitmq-specific
     existingErlangSecret: defectdojo-rabbitmq-specific
+  memoryHighWatermark.enabled: true  
+  memoryHighWatermark.type: relative
+  memoryHighWatermark.value: 0.5
     affinity: {}
     nodeSelector: {}
   resources:


### PR DESCRIPTION
Fixes #4276

In the rabbitMQ helm chart, the default for `memoryHighWatermark.enabled` is false, astonishingly, causing it to not push back whenever it starts drowning.

https://github.com/bitnami/charts/tree/master/bitnami/rabbitmq/#installing-the-chart

This PR enables memory high watermark and will prevent rabbitMQ from crashing when processing a lot of messages.