### PR TITLE
fix __str__ for GitHub_Issue model

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2656,7 +2656,7 @@ class GITHUB_Issue(models.Model):
     finding = models.OneToOneField(Finding, null=True, blank=True, on_delete=models.CASCADE)
 
     def __str__(self):
-        return str(self.github_issue_id) + '| GitHub Issue URL: ' + str(self.github_issue_url)
+        return str(self.issue_id) + '| GitHub Issue URL: ' + str(self.issue_url)
 
 
 class GITHUB_Clone(models.Model):


### PR DESCRIPTION
the __str__ was referencing invalid field names, causing an exception when trying to delete a product with github integration enabled.