### PR TITLE
Authorization V2: Feature-complete, ready for testing

### DIFF
--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -104,6 +104,11 @@ class UserHasFindingPermission(permissions.BasePermission):
         return check_object_permission(request, obj, Permissions.Finding_View, Permissions.Finding_Edit, Permissions.Finding_Delete)
 
 
+class UserHasImportPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return check_post_permission(request, Engagement, 'engagement', Permissions.Import_Scan_Result)
+
+
 class UserHasProductPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         return check_post_permission(request, Product_Type, 'prod_type', Permissions.Product_Type_Add_Product)
@@ -121,6 +126,11 @@ class UserHasProductTypePermission(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return check_object_permission(request, obj, Permissions.Product_Type_View, Permissions.Product_Type_Edit, Permissions.Product_Type_Delete)
+
+
+class UserHasReimportPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return check_post_permission(request, Test, 'test', Permissions.Import_Scan_Result)
 
 
 class UserHasTestPermission(permissions.BasePermission):

--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -117,6 +117,14 @@ class UserHasProductPermission(permissions.BasePermission):
         return check_object_permission(request, obj, Permissions.Product_View, Permissions.Product_Edit, Permissions.Product_Delete)
 
 
+class UserHasProductMemberPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return check_post_permission(request, Product, 'product', Permissions.Product_Manage_Members)
+
+    def has_object_permission(self, request, view, obj):
+        return check_object_permission(request, obj, Permissions.Product_View, Permissions.Product_Manage_Members, Permissions.Product_Member_Delete)
+
+
 class UserHasProductTypePermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method == 'POST':
@@ -126,6 +134,14 @@ class UserHasProductTypePermission(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return check_object_permission(request, obj, Permissions.Product_Type_View, Permissions.Product_Type_Edit, Permissions.Product_Type_Delete)
+
+
+class UserHasProductTypeMemberPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return check_post_permission(request, Product_Type, 'product_type', Permissions.Product_Type_Manage_Members)
+
+    def has_object_permission(self, request, view, obj):
+        return check_object_permission(request, obj, Permissions.Product_Type_View, Permissions.Product_Type_Manage_Members, Permissions.Product_Type_Member_Delete)
 
 
 class UserHasReimportPermission(permissions.BasePermission):

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -19,7 +19,7 @@ from dojo.models import Product, Product_Type, Engagement, Test, Test_Import, Te
     Endpoint, JIRA_Project, JIRA_Instance, DojoMeta, Development_Environment, \
     Dojo_User, Note_Type, System_Settings, App_Analysis, Endpoint_Status, \
     Sonarqube_Issue, Sonarqube_Issue_Transition, Sonarqube_Product, Regulation, \
-    BurpRawRequestResponse, FileUpload, Product_Type_Member
+    BurpRawRequestResponse, FileUpload, Product_Type_Member, Product_Member
 
 from dojo.endpoint.views import get_endpoint_ids
 from dojo.reports.views import report_url_resolver, prefetch_related_findings_for_report
@@ -37,8 +37,8 @@ from dojo.api_v2 import serializers, permissions, prefetch, schema
 import dojo.jira_link.helper as jira_helper
 import logging
 import tagulous
-from dojo.product_type.queries import get_authorized_product_types
-from dojo.product.queries import get_authorized_products, get_authorized_app_analysis, get_authorized_dojo_meta
+from dojo.product_type.queries import get_authorized_product_types, get_authorized_product_type_members
+from dojo.product.queries import get_authorized_products, get_authorized_app_analysis, get_authorized_dojo_meta, get_authorized_product_members
 from dojo.engagement.queries import get_authorized_engagements
 from dojo.test.queries import get_authorized_tests, get_authorized_test_imports
 from dojo.finding.queries import get_authorized_findings, get_authorized_stub_findings
@@ -912,7 +912,31 @@ class ProductViewSet(prefetch.PrefetchListMixin,
 
 
 # Authorization: object-based
-class ProductTypeViewSet(mixins.ListModelMixin,
+class ProductMemberViewSet(prefetch.PrefetchListMixin,
+                           prefetch.PrefetchRetrieveMixin,
+                           mixins.ListModelMixin,
+                           mixins.RetrieveModelMixin,
+                           mixins.CreateModelMixin,
+                           mixins.DestroyModelMixin,
+                           mixins.UpdateModelMixin,
+                           viewsets.GenericViewSet):
+    serializer_class = serializers.ProductMemberSerializer
+    queryset = Product_Member.objects.none()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'product_id', 'user_id')
+    swagger_schema = prefetch.get_prefetch_schema(["product_members_list", "product_members_read"],
+        serializers.ProductMemberSerializer).to_schema()
+    if settings.FEATURE_AUTHORIZATION_V2:
+        permission_classes = (IsAuthenticated, permissions.UserHasProductMemberPermission)
+
+    def get_queryset(self):
+        return get_authorized_product_members(Permissions.Product_View).distinct()
+
+
+# Authorization: object-based
+class ProductTypeViewSet(prefetch.PrefetchListMixin,
+                         prefetch.PrefetchRetrieveMixin,
+                         mixins.ListModelMixin,
                          mixins.RetrieveModelMixin,
                          mixins.CreateModelMixin,
                          mixins.UpdateModelMixin,
@@ -921,6 +945,8 @@ class ProductTypeViewSet(mixins.ListModelMixin,
     queryset = Product_Type.objects.none()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'name', 'critical_product', 'key_product', 'created', 'updated')
+    swagger_schema = prefetch.get_prefetch_schema(["product_types_list", "product_types_read"],
+        serializers.ProductTypeSerializer).to_schema()
     if settings.FEATURE_AUTHORIZATION_V2:
         permission_classes = (IsAuthenticated, permissions.UserHasProductTypePermission)
 
@@ -962,6 +988,37 @@ class ProductTypeViewSet(mixins.ListModelMixin,
         data = report_generate(request, product_type, options)
         report = serializers.ReportGenerateSerializer(data)
         return Response(report.data)
+
+
+# Authorization: object-based
+class ProductTypeMemberViewSet(prefetch.PrefetchListMixin,
+                               prefetch.PrefetchRetrieveMixin,
+                               mixins.ListModelMixin,
+                               mixins.RetrieveModelMixin,
+                               mixins.CreateModelMixin,
+                               mixins.DestroyModelMixin,
+                               mixins.UpdateModelMixin,
+                               viewsets.GenericViewSet):
+    serializer_class = serializers.ProductTypeMemberSerializer
+    queryset = Product_Type_Member.objects.none()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'product_type_id', 'user_id')
+    swagger_schema = prefetch.get_prefetch_schema(["product_type_members_list", "product_type_members_read"],
+        serializers.ProductTypeMemberSerializer).to_schema()
+    if settings.FEATURE_AUTHORIZATION_V2:
+        permission_classes = (IsAuthenticated, permissions.UserHasProductTypeMemberPermission)
+
+    def get_queryset(self):
+        return get_authorized_product_type_members(Permissions.Product_Type_View).distinct()
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if instance.role == Roles.Owner:
+            owners = Product_Type_Member.objects.filter(product_type=instance.product_type, role=Roles.Owner).count()
+            if owners <= 1:
+                return Response('There must be at least one owner', status=status.HTTP_400_BAD_REQUEST)
+        self.perform_destroy(instance)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 # Authorization: object-based

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1281,7 +1281,10 @@ class ImportScanView(mixins.CreateModelMixin,
     serializer_class = serializers.ImportScanSerializer
     parser_classes = [MultiPartParser]
     queryset = Test.objects.none()
-    permission_classes = (IsAuthenticated, DjangoModelPermissions)
+    if settings.FEATURE_AUTHORIZATION_V2:
+        permission_classes = (IsAuthenticated, permissions.UserHasImportPermission)
+    else:
+        permission_classes = (IsAuthenticated, DjangoModelPermissions)
 
     def perform_create(self, serializer):
         engagement = serializer.validated_data['engagement']
@@ -1304,7 +1307,10 @@ class ReImportScanView(mixins.CreateModelMixin,
     serializer_class = serializers.ReImportScanSerializer
     parser_classes = [MultiPartParser]
     queryset = Test.objects.none()
-    permission_classes = (IsAuthenticated, DjangoModelPermissions)
+    if settings.FEATURE_AUTHORIZATION_V2:
+        permission_classes = (IsAuthenticated, permissions.UserHasReimportPermission)
+    else:
+        permission_classes = (IsAuthenticated, DjangoModelPermissions)
 
     def get_queryset(self):
         return get_authorized_tests(Permissions.Import_Scan_Result)

--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -36,7 +36,7 @@ def user_has_permission(user, obj, permission):
         return user_has_permission(user, obj.engagement.product, permission)
     elif isinstance(obj, Finding) and permission in Permissions.get_finding_permissions():
         return user_has_permission(user, obj.test.engagement.product, permission)
-    elif isinstance(obj, Finding_Group) and permission in Permissions.get_finding_permissions():
+    elif isinstance(obj, Finding_Group) and permission in Permissions.get_finding_group_permissions():
         return user_has_permission(user, obj.test.engagement.product, permission)
     elif isinstance(obj, Endpoint) and permission in Permissions.get_endpoint_permissions():
         return user_has_permission(user, obj.product, permission)

--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from dojo.request_cache import cache_for_request
 from dojo.authorization.roles_permissions import Permissions, Roles, get_roles_with_permissions
 from dojo.models import Product_Type, Product_Type_Member, Product, Product_Member, Engagement, \
-    Test, Finding, Endpoint
+    Test, Finding, Endpoint, Finding_Group
 
 
 def user_has_permission(user, obj, permission):
@@ -35,6 +35,8 @@ def user_has_permission(user, obj, permission):
     elif isinstance(obj, Test) and permission in Permissions.get_test_permissions():
         return user_has_permission(user, obj.engagement.product, permission)
     elif isinstance(obj, Finding) and permission in Permissions.get_finding_permissions():
+        return user_has_permission(user, obj.test.engagement.product, permission)
+    elif isinstance(obj, Finding_Group) and permission in Permissions.get_finding_permissions():
         return user_has_permission(user, obj.test.engagement.product, permission)
     elif isinstance(obj, Endpoint) and permission in Permissions.get_endpoint_permissions():
         return user_has_permission(user, obj.product, permission)

--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -41,9 +41,17 @@ def user_has_permission(user, obj, permission):
     elif isinstance(obj, Endpoint) and permission in Permissions.get_endpoint_permissions():
         return user_has_permission(user, obj.product, permission)
     elif isinstance(obj, Product_Type_Member) and permission in Permissions.get_product_type_member_permissions():
-        return obj.user == user or user_has_permission(user, obj.product_type, Permissions.Product_Type_Manage_Members)
+        if permission == Permissions.Product_Type_Member_Delete:
+            # Every member is allowed to remove himself
+            return obj.user == user or user_has_permission(user, obj.product_type, permission)
+        else:
+            return user_has_permission(user, obj.product_type, permission)
     elif isinstance(obj, Product_Member) and permission in Permissions.get_product_member_permissions():
-        return obj.user == user or user_has_permission(user, obj.product, Permissions.Product_Manage_Members)
+        if permission == Permissions.Product_Member_Delete:
+            # Every member is allowed to remove himself
+            return obj.user == user or user_has_permission(user, obj.product, permission)
+        else:
+            return user_has_permission(user, obj.product, permission)
     else:
         raise NoAuthorizationImplementedError('No authorization implemented for class {} and permission {}'.
             format(type(obj).__name__, permission))

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -32,14 +32,14 @@ def django_enum(cls):
 class Permissions(IntEnum):
     Product_Type_Add_Product = 1001
     Product_Type_View = 1002
-    Product_Type_Remove_Member = 1003
+    Product_Type_Member_Delete = 1003
     Product_Type_Manage_Members = 1004
     Product_Type_Member_Add_Owner = 1005
     Product_Type_Edit = 1006
     Product_Type_Delete = 1007
 
     Product_View = 1102
-    Product_Remove_Member = 1103
+    Product_Member_Delete = 1103
     Product_Manage_Members = 1104
     Product_Member_Add_Owner = 1105
     Product_Configure_Notifications = 1106
@@ -113,21 +113,21 @@ class Permissions(IntEnum):
 
     @classmethod
     def get_product_member_permissions(cls):
-        return {Permissions.Product_Manage_Members, Permissions.Product_Remove_Member}
+        return {Permissions.Product_View, Permissions.Product_Manage_Members,
+            Permissions.Product_Member_Delete}
 
     @classmethod
     def get_product_type_member_permissions(cls):
-        return {Permissions.Product_Type_Manage_Members, Permissions.Product_Type_Remove_Member}
+        return {Permissions.Product_Type_View, Permissions.Product_Type_Manage_Members,
+            Permissions.Product_Type_Member_Delete}
 
 
 def get_roles_with_permissions():
     return {
         Roles.Reader: {
             Permissions.Product_Type_View,
-            Permissions.Product_Type_Remove_Member,
 
             Permissions.Product_View,
-            Permissions.Product_Remove_Member,
 
             Permissions.Engagement_View,
 
@@ -144,10 +144,8 @@ def get_roles_with_permissions():
         },
         Roles.Writer: {
             Permissions.Product_Type_View,
-            Permissions.Product_Type_Remove_Member,
 
             Permissions.Product_View,
-            Permissions.Product_Remove_Member,
 
             Permissions.Engagement_View,
             Permissions.Engagement_Add,
@@ -178,12 +176,12 @@ def get_roles_with_permissions():
         Roles.Maintainer: {
             Permissions.Product_Type_Add_Product,
             Permissions.Product_Type_View,
-            Permissions.Product_Type_Remove_Member,
+            Permissions.Product_Type_Member_Delete,
             Permissions.Product_Type_Manage_Members,
             Permissions.Product_Type_Edit,
 
             Permissions.Product_View,
-            Permissions.Product_Remove_Member,
+            Permissions.Product_Member_Delete,
             Permissions.Product_Manage_Members,
             Permissions.Product_Configure_Notifications,
             Permissions.Product_Edit,
@@ -223,14 +221,14 @@ def get_roles_with_permissions():
         Roles.Owner: {
             Permissions.Product_Type_Add_Product,
             Permissions.Product_Type_View,
-            Permissions.Product_Type_Remove_Member,
+            Permissions.Product_Type_Member_Delete,
             Permissions.Product_Type_Manage_Members,
             Permissions.Product_Type_Member_Add_Owner,
             Permissions.Product_Type_Edit,
             Permissions.Product_Type_Delete,
 
             Permissions.Product_View,
-            Permissions.Product_Remove_Member,
+            Permissions.Product_Member_Delete,
             Permissions.Product_Manage_Members,
             Permissions.Product_Member_Add_Owner,
             Permissions.Product_Configure_Notifications,

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -111,7 +111,7 @@ class Permissions(IntEnum):
         return {Permissions.Finding_View, Permissions.Finding_Edit, Permissions.Import_Scan_Result,
             Permissions.Finding_Delete, Permissions.Risk_Acceptance, Permissions.Note_Add,
             Permissions.Note_Delete, Permissions.Note_Edit, Permissions.Note_View_History} \
-            .union(cls.get_finding_group_permissions)
+            .union(cls.get_finding_group_permissions())
 
     @classmethod
     def get_finding_group_permissions(cls):

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -3,7 +3,7 @@ from enum import IntEnum
 
 class Roles(IntEnum):
     Reader = 0
-    Technical_User = 1
+    Scan_User = 1
     Writer = 2
     Maintainer = 3
     Owner = 4
@@ -91,13 +91,15 @@ class Permissions(IntEnum):
         return {Permissions.Engagement_View, Permissions.Engagement_Edit,
             Permissions.Engagement_Delete, Permissions.Risk_Acceptance,
             Permissions.Test_Add, Permissions.Import_Scan_Result, Permissions.Note_Add,
-            Permissions.Note_Delete, Permissions.Note_Edit, Permissions.Note_View_History}
+            Permissions.Note_Delete, Permissions.Note_Edit, Permissions.Note_View_History} \
+            .union(cls.get_test_permissions())
 
     @classmethod
     def get_test_permissions(cls):
         return {Permissions.Test_View, Permissions.Test_Edit, Permissions.Test_Delete,
             Permissions.Finding_Add, Permissions.Import_Scan_Result, Permissions.Note_Add,
-            Permissions.Note_Delete, Permissions.Note_Edit, Permissions.Note_View_History}
+            Permissions.Note_Delete, Permissions.Note_Edit, Permissions.Note_View_History} \
+            .union(cls.get_finding_permissions())
 
     @classmethod
     def get_finding_permissions(cls):
@@ -137,7 +139,7 @@ def get_roles_with_permissions():
 
             Permissions.Component_View
         },
-        Roles.Technical_User: {
+        Roles.Scan_User: {
             Permissions.Import_Scan_Result
         },
         Roles.Writer: {

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -78,6 +78,11 @@ class Permissions(IntEnum):
     Note_Edit = 1806
     Note_Delete = 1807
 
+    Finding_Group_View = 1902
+    Finding_Group_Add = 1903
+    Finding_Group_Edit = 1906
+    Finding_Group_Delete = 1907
+
     @classmethod
     def has_value(cls, value):
         try:
@@ -105,7 +110,13 @@ class Permissions(IntEnum):
     def get_finding_permissions(cls):
         return {Permissions.Finding_View, Permissions.Finding_Edit, Permissions.Import_Scan_Result,
             Permissions.Finding_Delete, Permissions.Risk_Acceptance, Permissions.Note_Add,
-            Permissions.Note_Delete, Permissions.Note_Edit, Permissions.Note_View_History}
+            Permissions.Note_Delete, Permissions.Note_Edit, Permissions.Note_View_History} \
+            .union(cls.get_finding_group_permissions)
+
+    @classmethod
+    def get_finding_group_permissions(cls):
+        return {Permissions.Finding_Group_View, Permissions.Finding_Group_Edit,
+            Permissions.Finding_Group_Delete}
 
     @classmethod
     def get_endpoint_permissions(cls):
@@ -135,6 +146,8 @@ def get_roles_with_permissions():
 
             Permissions.Finding_View,
 
+            Permissions.Finding_Group_View,
+
             Permissions.Endpoint_View,
 
             Permissions.Component_View
@@ -160,6 +173,11 @@ def get_roles_with_permissions():
             Permissions.Finding_Add,
             Permissions.Import_Scan_Result,
             Permissions.Finding_Edit,
+
+            Permissions.Finding_Group_View,
+            Permissions.Finding_Group_Add,
+            Permissions.Finding_Group_Edit,
+            Permissions.Finding_Group_Delete,
 
             Permissions.Endpoint_View,
             Permissions.Endpoint_Add,
@@ -202,6 +220,11 @@ def get_roles_with_permissions():
             Permissions.Import_Scan_Result,
             Permissions.Finding_Edit,
             Permissions.Finding_Delete,
+
+            Permissions.Finding_Group_View,
+            Permissions.Finding_Group_Add,
+            Permissions.Finding_Group_Edit,
+            Permissions.Finding_Group_Delete,
 
             Permissions.Endpoint_View,
             Permissions.Endpoint_Add,
@@ -251,6 +274,11 @@ def get_roles_with_permissions():
             Permissions.Import_Scan_Result,
             Permissions.Finding_Edit,
             Permissions.Finding_Delete,
+
+            Permissions.Finding_Group_View,
+            Permissions.Finding_Group_Add,
+            Permissions.Finding_Group_Edit,
+            Permissions.Finding_Group_Delete,
 
             Permissions.Endpoint_View,
             Permissions.Endpoint_Add,

--- a/dojo/endpoint/urls.py
+++ b/dojo/endpoint/urls.py
@@ -24,6 +24,8 @@ urlpatterns = [
         name='edit_endpoint_meta_data'),
     url(r'^endpoint/bulk$', views.endpoint_bulk_update_all,
         name='endpoints_bulk_all'),
+    url(r'^product/(?P<pid>\d+)/endpoint/bulk_product$', views.endpoint_bulk_update_all,
+        name='endpoints_bulk_update_all_product'),
     url(r'^endpoint/(?P<fid>\d+)/bulk_status$', views.endpoint_status_bulk_update,
         name='endpoints_status_bulk'),
 ]

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -209,6 +209,7 @@ def delete_endpoint(request, eid):
         if 'id' in request.POST and str(endpoint.id) == request.POST['id']:
             form = DeleteEndpointForm(request.POST, instance=endpoint)
             if form.is_valid():
+                product = endpoint.product
                 endpoint.delete()
                 messages.add_message(request,
                                      messages.SUCCESS,
@@ -216,6 +217,7 @@ def delete_endpoint(request, eid):
                                      extra_tags='alert-success')
                 create_notification(event='other',
                                     title='Deletion of %s' % endpoint,
+                                    product=product,
                                     description='The endpoint "%s" was deleted by %s' % (endpoint, request.user),
                                     url=request.build_absolute_uri(reverse('endpoints')),
                                     icon="exclamation-triangle")
@@ -375,7 +377,7 @@ def endpoint_bulk_update_all(request, pid=None):
         if request.POST.get('delete_bulk_endpoints') and endpoints_to_update:
 
             if not settings.FEATURE_AUTHORIZATION_V2:
-                if not request.user.is_staff or settings.AUTHORIZED_USERS_ALLOW_DELETE or settings.AUTHORIZED_USERS_ALLOW_STAFF:
+                if not (request.user.is_staff or settings.AUTHORIZED_USERS_ALLOW_DELETE or settings.AUTHORIZED_USERS_ALLOW_STAFF):
                     raise PermissionDenied
             else:
                 if pid is None:

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -98,7 +98,8 @@ def all_endpoints(request):
             "endpoints": paged_endpoints,
             "filtered": endpoints,
             "name": view_name,
-            "show_uri": show_uri
+            "show_uri": show_uri,
+            "product_tab": product_tab
         })
 
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -271,6 +271,7 @@ def delete_engagement(request, eid):
         if 'id' in request.POST and str(engagement.id) == request.POST['id']:
             form = DeleteEngagementForm(request.POST, instance=engagement)
             if form.is_valid():
+                product = engagement.product
                 engagement.delete()
                 messages.add_message(
                     request,
@@ -279,6 +280,7 @@ def delete_engagement(request, eid):
                     extra_tags='alert-success')
                 create_notification(event='other',
                                     title='Deletion of %s' % engagement.name,
+                                    product=product,
                                     description='The engagement "%s" was deleted by %s' % (engagement.name, request.user),
                                     url=request.build_absolute_uri(reverse('view_engagements', args=(product.id, ))),
                                     recipients=[engagement.lead],
@@ -686,6 +688,7 @@ def reopen_eng(request, eid):
         extra_tags='alert-success')
     create_notification(event='other',
                         title='Reopening of %s' % eng.name,
+                        engagement=eng,
                         description='The engagement "%s" was reopened' % (eng.name),
                         url=reverse('view_engagement', args=(eng.id, ))),
     return HttpResponseRedirect(reverse("view_engagements", args=(eng.product.id, )))

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -969,7 +969,7 @@ class OpenFindingFilter(DojoFilter):
         if self.form.fields.get('test__engagement__product'):
             self.form.fields['test__engagement__product'].queryset = get_authorized_products(Permissions.Product_View)
         if self.form.fields.get('finding_group', None):
-            self.form.fields['finding_group'].queryset = get_authorized_finding_groups(Permissions.Finding_View)
+            self.form.fields['finding_group'].queryset = get_authorized_finding_groups(Permissions.Finding_Group_View)
         self.form.fields['endpoints'].queryset = get_authorized_endpoints(Permissions.Endpoint_View).distinct()
 
         # Don't show the product filter on the product finding view

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -31,6 +31,7 @@ from dojo.engagement.queries import get_authorized_engagements
 from dojo.test.queries import get_authorized_tests
 from dojo.finding.queries import get_authorized_findings
 from dojo.endpoint.queries import get_authorized_endpoints
+from dojo.finding_group.queries import get_authorized_finding_groups
 from django.forms import HiddenInput
 
 logger = logging.getLogger(__name__)
@@ -967,18 +968,8 @@ class OpenFindingFilter(DojoFilter):
         self.form.fields['cwe'].choices = list(cwe.items())
         if self.form.fields.get('test__engagement__product'):
             self.form.fields['test__engagement__product'].queryset = get_authorized_products(Permissions.Product_View)
-        if self.user is not None and not self.user.is_staff:
-
-            if self.form.fields.get('finding_group', None):
-                logger.debug('setting queryset for finding_group field')
-                self.form.fields['test__engagement__product'].queryset = \
-                    Finding_Group.objects.filter(
-                        Q(test__engagement__product__authorized_users__in=[self.user]) | Q(test__engagement__product__prod_type__authorized_users__in=[self.user])
-                                                )
-        else:
-            if self.form.fields.get('finding_group', None):
-                self.form.fields['finding_group'].queryset = Finding_Group.objects.all()
-
+        if self.form.fields.get('finding_group', None):
+            self.form.fields['finding_group'].queryset = get_authorized_finding_groups(Permissions.Finding_View)
         self.form.fields['endpoints'].queryset = get_authorized_endpoints(Permissions.Endpoint_View).distinct()
 
         # Don't show the product filter on the product finding view

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -454,6 +454,7 @@ def close_finding(request, fid):
                     extra_tags='alert-success')
                 create_notification(event='other',
                                     title='Closing of %s' % finding.title,
+                                    finding=finding,
                                     description='The finding "%s" was closed by %s' % (finding.title, request.user),
                                     url=request.build_absolute_uri(reverse('view_test', args=(finding.test.id, ))),
                                     )
@@ -590,6 +591,7 @@ def reopen_finding(request, fid):
         extra_tags='alert-success')
     create_notification(event='other',
                         title='Reopening of %s' % finding.title,
+                        finding=finding,
                         description='The finding "%s" was reopened by %s' % (finding.title, request.user),
                         url=request.build_absolute_uri(reverse('view_test', args=(finding.test.id, ))),
                         )
@@ -642,6 +644,7 @@ def delete_finding(request, fid):
             create_notification(event='other',
                                 title='Deletion of %s' % finding.title,
                                 description='The finding "%s" was deleted by %s' % (finding.title, request.user),
+                                product=product,
                                 url=request.build_absolute_uri(reverse('all_findings')),
                                 recipients=[finding.test.engagement.lead],
                                 icon="exclamation-triangle")
@@ -942,6 +945,7 @@ def request_finding_review(request, fid):
 
             create_notification(event='review_requested',
                                 title='Finding review requested',
+                                finding=finding,
                                 description='User %s has requested that users %s review the finding "%s" for accuracy:\n\n%s' % (user, reviewers, finding.title, new_note),
                                 icon='check',
                                 url=reverse("view_finding", args=(finding.id,)))
@@ -1856,6 +1860,9 @@ def finding_bulk_update_all(request, pid=None):
                     if not request.user.is_staff and not settings.AUTHORIZED_USERS_ALLOW_CHANGE and not settings.AUTHORIZED_USERS_ALLOW_STAFF:
                         raise PermissionDenied
                 else:
+                    print('---------------------------------------------')
+                    print('PID: ', pid)
+                    print('---------------------------------------------')
                     if pid is None:
                         if not request.user.is_staff:
                             raise PermissionDenied

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1860,9 +1860,6 @@ def finding_bulk_update_all(request, pid=None):
                     if not request.user.is_staff and not settings.AUTHORIZED_USERS_ALLOW_CHANGE and not settings.AUTHORIZED_USERS_ALLOW_STAFF:
                         raise PermissionDenied
                 else:
-                    print('---------------------------------------------')
-                    print('PID: ', pid)
-                    print('---------------------------------------------')
                     if pid is None:
                         if not request.user.is_staff:
                             raise PermissionDenied

--- a/dojo/finding_group/queries.py
+++ b/dojo/finding_group/queries.py
@@ -46,4 +46,3 @@ def get_authorized_finding_groups(permission, queryset=None, user=None):
                 Q(test__engagement__product__authorized_users__in=[user]) |
                 Q(test__engagement__product__prod_type__authorized_users__in=[user]))
     return finding_groups
-

--- a/dojo/finding_group/queries.py
+++ b/dojo/finding_group/queries.py
@@ -1,0 +1,49 @@
+from crum import get_current_user
+from django.conf import settings
+from django.db.models import Exists, OuterRef, Q
+from dojo.models import Finding_Group, Product_Member, Product_Type_Member
+from dojo.authorization.authorization import get_roles_for_permission
+
+
+def get_authorized_finding_groups(permission, queryset=None, user=None):
+
+    if user is None:
+        user = get_current_user()
+
+    if user is None:
+        return Finding_Group.objects.none()
+
+    if queryset is None:
+        finding_groups = Finding_Group.objects.all()
+    else:
+        finding_groups = queryset
+
+    if user.is_superuser:
+        return finding_groups
+
+    if settings.FEATURE_AUTHORIZATION_V2:
+        if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
+            return finding_groups
+
+        roles = get_roles_for_permission(permission)
+        authorized_product_type_roles = Product_Type_Member.objects.filter(
+            product_type=OuterRef('test__engagement__product__prod_type_id'),
+            user=user,
+            role__in=roles)
+        authorized_product_roles = Product_Member.objects.filter(
+            product=OuterRef('test__engagement__product_id'),
+            user=user,
+            role__in=roles)
+        finding_groups = finding_groups.annotate(
+            test__engagement__product__prod_type__member=Exists(authorized_product_type_roles),
+            test__engagement__product__member=Exists(authorized_product_roles))
+        finding_groups = finding_groups.filter(
+            Q(test__engagement__product__prod_type__member=True) |
+            Q(test__engagement__product__member=True))
+    else:
+        if not user.is_staff:
+            finding_groups = finding_groups.filter(
+                Q(test__engagement__product__authorized_users__in=[user]) |
+                Q(test__engagement__product__prod_type__authorized_users__in=[user]))
+    return finding_groups
+

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -11,25 +11,26 @@ from django.urls.base import reverse
 from django.views.decorators.http import require_POST
 from dojo.models import Finding_Group
 import logging
-from dojo.user.helper import user_must_be_authorized
 import dojo.jira_link.helper as jira_helper
+from dojo.authorization.authorization_decorators import user_is_authorized
+from dojo.authorization.roles_permissions import Permissions
 
 logger = logging.getLogger(__name__)
 
 
-@user_must_be_authorized(Finding_Group, 'view', 'fgid')
+@user_is_authorized(Finding_Group, Permissions.Finding_View, 'fgid', 'view')
 def view_finding_group(request, fgid):
     logger.debug('view finding group: %s', fgid)
     return HttpResponse('Not implemented yet')
 
 
-@user_must_be_authorized(Finding_Group, 'change', 'fgid')
+@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'change')
 def edit_finding_group(request, fgid):
     logger.debug('edit finding group: %s', fgid)
     return HttpResponse('Not implemented yet')
 
 
-@user_must_be_authorized(Finding_Group, 'delete', 'fgid')
+@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'delete')
 @require_POST
 def delete_finding_group(request, fgid):
     logger.debug('delete finding group: %s', fgid)
@@ -66,7 +67,7 @@ def delete_finding_group(request, fgid):
                    })
 
 
-@user_must_be_authorized(Finding_Group, 'change', 'fgid')
+@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'change')
 @require_POST
 def unlink_jira(request, fgid):
     logger.debug('/finding_group/%s/jira/unlink', fgid)
@@ -101,7 +102,7 @@ def unlink_jira(request, fgid):
         return HttpResponse(status=400)
 
 
-@user_must_be_authorized(Finding_Group, 'change', 'fgid')
+@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'change')
 @require_POST
 def push_to_jira(request, fgid):
     logger.debug('/finding_group/%s/jira/push', fgid)

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -41,6 +41,7 @@ def delete_finding_group(request, fgid):
         if 'id' in request.POST and str(finding_group.id) == request.POST['id']:
             form = DeleteFindingGroupForm(request.POST, instance=finding_group)
             if form.is_valid():
+                product = finding_group.test.engagement.product
                 finding_group.delete()
                 messages.add_message(request,
                                      messages.SUCCESS,
@@ -49,6 +50,7 @@ def delete_finding_group(request, fgid):
 
                 create_notification(event='other',
                                     title='Deletion of %s' % finding_group.name,
+                                    product=product,
                                     description='The finding group "%s" was deleted by %s' % (finding_group.name, request.user),
                                     url=request.build_absolute_uri(reverse('view_test', args=(finding_group.test.id,))),
                                     icon="exclamation-triangle")

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -18,19 +18,19 @@ from dojo.authorization.roles_permissions import Permissions
 logger = logging.getLogger(__name__)
 
 
-@user_is_authorized(Finding_Group, Permissions.Finding_View, 'fgid', 'view')
+@user_is_authorized(Finding_Group, Permissions.Finding_Group_View, 'fgid', 'view')
 def view_finding_group(request, fgid):
     logger.debug('view finding group: %s', fgid)
     return HttpResponse('Not implemented yet')
 
 
-@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'change')
+@user_is_authorized(Finding_Group, Permissions.Finding_Group_Edit, 'fgid', 'change')
 def edit_finding_group(request, fgid):
     logger.debug('edit finding group: %s', fgid)
     return HttpResponse('Not implemented yet')
 
 
-@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'delete')
+@user_is_authorized(Finding_Group, Permissions.Finding_Group_Delete, 'fgid', 'delete')
 @require_POST
 def delete_finding_group(request, fgid):
     logger.debug('delete finding group: %s', fgid)
@@ -69,7 +69,7 @@ def delete_finding_group(request, fgid):
                    })
 
 
-@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'change')
+@user_is_authorized(Finding_Group, Permissions.Finding_Group_Edit, 'fgid', 'change')
 @require_POST
 def unlink_jira(request, fgid):
     logger.debug('/finding_group/%s/jira/unlink', fgid)
@@ -104,7 +104,7 @@ def unlink_jira(request, fgid):
         return HttpResponse(status=400)
 
 
-@user_is_authorized(Finding_Group, Permissions.Finding_Edit, 'fgid', 'change')
+@user_is_authorized(Finding_Group, Permissions.Finding_Group_Edit, 'fgid', 'change')
 @require_POST
 def push_to_jira(request, fgid):
     logger.debug('/finding_group/%s/jira/push', fgid)

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -711,10 +711,10 @@ class EngForm(forms.ModelForm):
         if product:
             self.fields['preset'] = forms.ModelChoiceField(help_text="Settings and notes for performing this engagement.", required=False, queryset=Engagement_Presets.objects.filter(product=product))
             if not settings.FEATURE_AUTHORIZATION_V2:
-                authorized_users = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', product)]
+                authorized_for_lead = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', product)]
+                self.fields['lead'].queryset = User.objects.filter(id__in=authorized_for_lead)
             else:
-                authorized_users = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
-            self.fields['lead'].queryset = User.objects.filter(id__in=authorized_users)
+                self.fields['lead'].queryset = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
         else:
             self.fields['lead'].queryset = User.objects.exclude(is_staff=False)
 
@@ -791,10 +791,10 @@ class TestForm(forms.ModelForm):
         if obj:
             product = get_product(obj)
             if not settings.FEATURE_AUTHORIZATION_V2:
-                authorized_users = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', product)]
+                authorized_for_lead = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', product)]
+                self.fields['lead'].queryset = User.objects.filter(id__in=authorized_for_lead)
             else:
-                authorized_users = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
-            self.fields['lead'].queryset = User.objects.filter(id__in=authorized_users)
+                self.fields['lead'].queryset = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
         else:
             self.fields['lead'].queryset = User.objects.exclude(is_staff=False)
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -38,12 +38,13 @@ from django.urls import reverse
 from tagulous.forms import TagField
 import logging
 from crum import get_current_user
-from dojo.utils import get_system_setting
+from dojo.utils import get_system_setting, get_product
 from django.conf import settings
 from dojo.authorization.roles_permissions import Permissions, Roles
 from dojo.product_type.queries import get_authorized_product_types
 from dojo.product.queries import get_authorized_products
 from dojo.finding.queries import get_authorized_findings
+from dojo.user.queries import get_authorized_users_for_product_and_product_type
 
 logger = logging.getLogger(__name__)
 
@@ -709,8 +710,11 @@ class EngForm(forms.ModelForm):
 
         if product:
             self.fields['preset'] = forms.ModelChoiceField(help_text="Settings and notes for performing this engagement.", required=False, queryset=Engagement_Presets.objects.filter(product=product))
-            staff_users = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', product)]
-            self.fields['lead'].queryset = User.objects.filter(id__in=staff_users)
+            if not settings.FEATURE_AUTHORIZATION_V2:
+                authorized_users = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', product)]
+            else:
+                authorized_users = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
+            self.fields['lead'].queryset = User.objects.filter(id__in=authorized_users)
         else:
             self.fields['lead'].queryset = User.objects.exclude(is_staff=False)
 
@@ -785,10 +789,14 @@ class TestForm(forms.ModelForm):
         super(TestForm, self).__init__(*args, **kwargs)
 
         if obj:
-            staff_users = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', obj)]
+            product = get_product(obj)
+            if not settings.FEATURE_AUTHORIZATION_V2:
+                authorized_users = [user.id for user in User.objects.all() if user_is_authorized(user, 'staff', product)]
+            else:
+                authorized_users = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
+            self.fields['lead'].queryset = User.objects.filter(id__in=authorized_users)
         else:
-            staff_users = [user.id for user in User.objects.exclude(is_staff=False)]
-        self.fields['lead'].queryset = User.objects.filter(id__in=staff_users)
+            self.fields['lead'].queryset = User.objects.exclude(is_staff=False)
 
     class Meta:
         model = Test

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -173,10 +173,10 @@ def webhook(request, secret=None):
                 findings = None
                 if jissue.finding:
                     findings = [jissue.finding]
-                    create_notification(event='other', title='JIRA incoming comment - %s' % (jissue.finding), url=reverse("view_finding", args=(jissue.finding.id, )), icon='check')
+                    create_notification(event='other', title='JIRA incoming comment - %s' % (jissue.finding), finding=jissue.finding, url=reverse("view_finding", args=(jissue.finding.id, )), icon='check')
                 elif jissue.finding_group:
                     findings = [jissue.finding_group.findings.all()]
-                    create_notification(event='other', title='JIRA incoming comment - %s' % (jissue.finding), url=reverse("view_finding_group", args=(jissue.finding_group.id, )), icon='check')
+                    create_notification(event='other', title='JIRA incoming comment - %s' % (jissue.finding), finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id, )), icon='check')
                 elif jissue.engagement:
                     return HttpResponse('Comment for engagement ignored')
                 else:

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from django.db.models import Q, Count, Prefetch
 from django.urls import reverse
 from dojo.celery import app
-from dojo.user.queries import get_authorized_users_for_product_and_product_type
+from dojo.user.queries import get_authorized_users_for_product_and_product_type, get_authorized_users_for_product_type
 from dojo.authorization.roles_permissions import Permissions
 # from dojo.decorators import dojo_async_task, we_want_async, convert_kwargs_if_async
 
@@ -29,20 +29,20 @@ def create_notification(event=None, **kwargs):
         # send system notifications to all admin users
 
         # parse kwargs before converting them to dicts
+        product_type = None
+        if 'product_type' in kwargs:
+            product_type = kwargs.get('product_type')
+
         product = None
         if 'product' in kwargs:
             product = kwargs.get('product')
-
-        if not product and 'engagement' in kwargs:
+        elif 'engagement' in kwargs:
             product = kwargs['engagement'].product
-
-        if not product and 'test' in kwargs:
+        elif 'test' in kwargs:
             product = kwargs['test'].engagement.product
-
-        if not product and 'finding' in kwargs:
+        elif 'finding' in kwargs:
             product = kwargs['finding'].test.engagement.product
-
-        if not product and 'obj' in kwargs:
+        elif 'obj' in kwargs:
             from dojo.utils import get_product
             product = get_product(kwargs['obj'])
 
@@ -64,30 +64,33 @@ def create_notification(event=None, **kwargs):
         # only retrieve users which have at least one notification type enabled for this event type.
         logger.debug('creating personal notifications for event: %s', event)
 
-        # get users with either global notifications, or a product specific noditiciation
-        # and all admin/superuser, they will always be notified
-        users = Dojo_User.objects.filter(is_active=True).prefetch_related(Prefetch(
-            "notifications_set",
-            queryset=Notifications.objects.filter(Q(product_id=product) | Q(product__isnull=True)),
-            to_attr="applicable_notifications"
-        )).annotate(applicable_notifications_count=Count('notifications__id', filter=Q(notifications__product_id=product) | Q(notifications__product__isnull=True)))\
-            .filter((Q(applicable_notifications_count__gt=0) | Q(is_superuser=True) | Q(is_staff=True)))
+        if not ('no_users' in kwargs and kwargs['no_users'] is True):
+            # get users with either global notifications, or a product specific noditiciation
+            # and all admin/superuser, they will always be notified
+            users = Dojo_User.objects.filter(is_active=True).prefetch_related(Prefetch(
+                "notifications_set",
+                queryset=Notifications.objects.filter(Q(product_id=product) | Q(product__isnull=True)),
+                to_attr="applicable_notifications"
+            )).annotate(applicable_notifications_count=Count('notifications__id', filter=Q(notifications__product_id=product) | Q(notifications__product__isnull=True)))\
+                .filter((Q(applicable_notifications_count__gt=0) | Q(is_superuser=True) | Q(is_staff=True)))
 
-        # only send to authorized users or admin/superusers
-        if product:
-            users = get_authorized_users_for_product_and_product_type(users, product, Permissions.Product_View)
+            # only send to authorized users or admin/superusers
+            if product:
+                users = get_authorized_users_for_product_and_product_type(users, product, Permissions.Product_View)
+            elif product_type:
+                users = get_authorized_users_for_product_type(users, product_type, Permissions.Product_Type_View)
 
-        for user in users:
-            # send notifications to user after merging possible multiple notifications records (i.e. personal global + personal product)
-            # kwargs.update({'user': user})
-            applicable_notifications = user.applicable_notifications
-            if user.is_staff or user.is_superuser:
-                # admin users get all system notifications
-                applicable_notifications.append(system_notifications)
+            for user in users:
+                # send notifications to user after merging possible multiple notifications records (i.e. personal global + personal product)
+                # kwargs.update({'user': user})
+                applicable_notifications = user.applicable_notifications
+                if user.is_staff or user.is_superuser:
+                    # admin users get all system notifications
+                    applicable_notifications.append(system_notifications)
 
-            notifications_set = Notifications.merge_notifications_list(applicable_notifications)
-            notifications_set.user = user
-            process_notifications(event, notifications_set, **kwargs)
+                notifications_set = Notifications.merge_notifications_list(applicable_notifications)
+                notifications_set.user = user
+                process_notifications(event, notifications_set, **kwargs)
 
 
 def create_description(event, *args, **kwargs):

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -64,6 +64,8 @@ def create_notification(event=None, **kwargs):
         # only retrieve users which have at least one notification type enabled for this event type.
         logger.debug('creating personal notifications for event: %s', event)
 
+        # There are notification like deleting a product type that shall not be sent to users. 
+        # These notifications will have the parameter no_users=True
         if not ('no_users' in kwargs and kwargs['no_users'] is True):
             # get users with either global notifications, or a product specific noditiciation
             # and all admin/superuser, they will always be notified

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -7,6 +7,8 @@ from django.template.loader import render_to_string
 from django.db.models import Q, Count, Prefetch
 from django.urls import reverse
 from dojo.celery import app
+from dojo.user.queries import get_authorized_users_for_product_and_product_type
+from dojo.authorization.roles_permissions import Permissions
 # from dojo.decorators import dojo_async_task, we_want_async, convert_kwargs_if_async
 
 logger = logging.getLogger(__name__)
@@ -73,7 +75,7 @@ def create_notification(event=None, **kwargs):
 
         # only send to authorized users or admin/superusers
         if product:
-            users = users.filter(Q(id__in=product.authorized_users.all()) | Q(id__in=product.prod_type.authorized_users.all()) | Q(is_superuser=True) | Q(is_staff=True))
+            users = get_authorized_users_for_product_and_product_type(users, product, Permissions.Product_View)
 
         for user in users:
             # send notifications to user after merging possible multiple notifications records (i.e. personal global + personal product)

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -64,7 +64,7 @@ def create_notification(event=None, **kwargs):
         # only retrieve users which have at least one notification type enabled for this event type.
         logger.debug('creating personal notifications for event: %s', event)
 
-        # There are notification like deleting a product type that shall not be sent to users. 
+        # There are notification like deleting a product type that shall not be sent to users.
         # These notifications will have the parameter no_users=True
         if not ('no_users' in kwargs and kwargs['no_users'] is True):
             # get users with either global notifications, or a product specific noditiciation

--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -3,10 +3,11 @@ import gitlab
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q
-from dojo.models import Engagement, Product, Product_Type, Test
+from dojo.models import Engagement, Product, Product_Member, Product_Type, Test
 from social_core.backends.azuread_tenant import AzureADTenantOAuth2
 from social_core.backends.google import GoogleOAuth2
+from dojo.authorization.roles_permissions import Permissions
+from dojo.product.queries import get_authorized_products
 
 
 def social_uid(backend, details, response, *args, **kwargs):
@@ -59,7 +60,7 @@ def social_uid(backend, details, response, *args, **kwargs):
 def modify_permissions(backend, uid, user=None, social=None, *args, **kwargs):
     if kwargs.get('is_new'):
         user.is_staff = False
-        if settings.GITLAB_PROJECT_AUTO_IMPORT is True:
+        if settings.GITLAB_PROJECT_AUTO_IMPORT is True and not settings.FEATURE_AUTHORIZATION_V2:
             # Add engagement creation permission if auto_import  is set
             user.user_permissions.set([Permission.objects.get(codename='add_engagement', content_type=ContentType.objects.get_for_model(Engagement)), Permission.objects.get(codename='add_test', content_type=ContentType.objects.get_for_model(Test)), Permission.objects.get(codename='change_test', content_type=ContentType.objects.get_for_model(Test))])
 
@@ -67,10 +68,7 @@ def modify_permissions(backend, uid, user=None, social=None, *args, **kwargs):
 def update_product_access(backend, uid, user=None, social=None, *args, **kwargs):
     if settings.GITLAB_PROJECT_AUTO_IMPORT is True:
         # Get user's product names
-        user_product_names = [prod.name for prod in Product.objects.filter(
-            Q(authorized_users__in=[user]) |
-            Q(prod_type__authorized_users__in=[user])
-        )]
+        user_product_names = [prod.name for prod in get_authorized_products(Permissions.Product_View, user)]
         # Get Gitlab access token
         soc = user.social_auth.get()
         token = soc.extra_data['access_token']
@@ -86,11 +84,22 @@ def update_product_access(backend, uid, user=None, social=None, *args, **kwargs)
             if project_name not in user_product_names:
                 # Create new product
                 product, created = Product.objects.get_or_create(name=project_name, prod_type=product_type)
-                product.authorized_users.add(user)
-                product.save()
+                if not settings.FEATURE_AUTHORIZATION_V2:
+                    product.authorized_users.add(user)
+                    product.save()
+                else:
+                    product_member, created = Product_Member.objects.get_or_create(product=product, user=user)
+                    if created:
+                        # Make product member an Owner of the product
+                        product_member.role = 4
+                        product_member.save()
+
         # For each product: if user is not project member any more, remove him from product's authorized users
         for product_name in user_product_names:
             if product_name not in project_names:
                 product = Product.objects.get(name=product_name)
-                product.authorized_users.remove(user)
-                product.save()
+                if not settings.FEATURE_AUTHORIZATION_V2:
+                    product.authorized_users.remove(user)
+                    product.save()
+                else:
+                    Product_Member.objects.filter(product=product, user=user).delete()

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -43,7 +43,7 @@ def get_authorized_products(permission):
     return products
 
 
-def get_authorized_product_members_product(product, permission):
+def get_authorized_product_members_for_product(product, permission):
     user = get_current_user()
 
     if user.is_superuser or user_has_permission(user, product, permission):
@@ -52,20 +52,20 @@ def get_authorized_product_members_product(product, permission):
         return None
 
 
-def get_authorized_product_members_user(user, permission):
-    request_user = get_current_user()
+def get_authorized_product_members(permission):
+    user = get_current_user()
 
-    if request_user is None:
+    if user is None:
         return Product_Member.objects.none()
 
-    if request_user.is_superuser:
-        return Product_Member.objects.filter(user=user)
+    if user.is_superuser:
+        return Product_Member.objects.all()
 
-    if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Product_Member.objects.all(user=user)
+    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
+        return Product_Member.objects.all()
 
     products = get_authorized_products(permission)
-    return Product_Member.objects.filter(user=user, product__in=products)
+    return Product_Member.objects.filter(product__in=products)
 
 
 def get_authorized_app_analysis(permission):

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -70,6 +70,22 @@ def get_authorized_product_members(permission):
     return Product_Member.objects.filter(product__in=products)
 
 
+def get_authorized_product_members_for_user(user, permission):
+    request_user = get_current_user()
+
+    if request_user is None:
+        return Product_Member.objects.none()
+
+    if request_user.is_superuser:
+        return Product_Member.objects.filter(user=user)
+
+    if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
+        return Product_Member.objects.all(user=user)
+
+    products = get_authorized_products(permission)
+    return Product_Member.objects.filter(user=user, product__in=products)
+
+
 def get_authorized_app_analysis(permission):
     user = get_current_user()
 

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -5,8 +5,10 @@ from dojo.models import Product, Product_Member, Product_Type_Member, App_Analys
 from dojo.authorization.authorization import get_roles_for_permission, user_has_permission
 
 
-def get_authorized_products(permission):
-    user = get_current_user()
+def get_authorized_products(permission, user=None):
+
+    if user is None:
+        user = get_current_user()
 
     if user is None:
         return Product.objects.none()
@@ -43,7 +45,7 @@ def get_authorized_products(permission):
     return products
 
 
-def get_authorized_product_members_for_product(product, permission):
+def get_authorized_members_for_product(product, permission):
     user = get_current_user()
 
     if user.is_superuser or user_has_permission(user, product, permission):

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -775,6 +775,7 @@ def new_product(request, ptid=None):
                 sonarqube_product.save()
 
             create_notification(event='product_added', title=product.name,
+                                product=product,
                                 url=reverse('view_product', args=(product.id,)))
 
             if not error:
@@ -902,6 +903,7 @@ def delete_product(request, pid):
         if 'id' in request.POST and str(product.id) == request.POST['id']:
             form = DeleteProductForm(request.POST, instance=product)
             if form.is_valid():
+                product_type = product.prod_type
                 product.delete()
                 messages.add_message(request,
                                      messages.SUCCESS,
@@ -909,6 +911,7 @@ def delete_product(request, pid):
                                      extra_tags='alert-success')
                 create_notification(event='other',
                                     title='Deletion of %s' % product.name,
+                                    product_type=product_type,
                                     description='The product "%s" was deleted by %s' % (product.name, request.user),
                                     url=request.build_absolute_uri(reverse('product')),
                                     icon="exclamation-triangle")

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -38,8 +38,8 @@ from dojo.authorization.authorization import user_has_permission, user_has_permi
 from django.conf import settings
 from dojo.authorization.roles_permissions import Permissions, Roles
 from dojo.authorization.authorization_decorators import user_is_authorized
-from dojo.product.queries import get_authorized_products, get_authorized_product_members_for_product
-from dojo.product_type.queries import get_authorized_product_type_members_for_product_type
+from dojo.product.queries import get_authorized_products, get_authorized_members_for_product
+from dojo.product_type.queries import get_authorized_members_for_product_type
 
 logger = logging.getLogger(__name__)
 
@@ -134,8 +134,8 @@ def view_product(request, pid):
                                       .prefetch_related('members') \
                                       .prefetch_related('prod_type__members')
     prod = get_object_or_404(prod_query, id=pid)
-    product_members = get_authorized_product_members_for_product(prod, Permissions.Product_View)
-    product_type_members = get_authorized_product_type_members_for_product_type(prod.prod_type, Permissions.Product_Type_View)
+    product_members = get_authorized_members_for_product(prod, Permissions.Product_View)
+    product_type_members = get_authorized_members_for_product_type(prod.prod_type, Permissions.Product_Type_View)
     personal_notifications_form = ProductNotificationsForm(
         instance=Notifications.objects.filter(user=request.user).filter(product=prod).first())
     langSummary = Languages.objects.filter(product=prod).aggregate(Sum('files'), Sum('code'), Count('files'))

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -38,8 +38,8 @@ from dojo.authorization.authorization import user_has_permission, user_has_permi
 from django.conf import settings
 from dojo.authorization.roles_permissions import Permissions, Roles
 from dojo.authorization.authorization_decorators import user_is_authorized
-from dojo.product.queries import get_authorized_products, get_authorized_product_members_product
-from dojo.product_type.queries import get_authorized_members_product_type
+from dojo.product.queries import get_authorized_products, get_authorized_product_members_for_product
+from dojo.product_type.queries import get_authorized_product_type_members_for_product_type
 
 logger = logging.getLogger(__name__)
 
@@ -134,8 +134,8 @@ def view_product(request, pid):
                                       .prefetch_related('members') \
                                       .prefetch_related('prod_type__members')
     prod = get_object_or_404(prod_query, id=pid)
-    product_members = get_authorized_product_members_product(prod, Permissions.Product_View)
-    product_type_members = get_authorized_members_product_type(prod.prod_type, Permissions.Product_Type_View)
+    product_members = get_authorized_product_members_for_product(prod, Permissions.Product_View)
+    product_type_members = get_authorized_product_type_members_for_product_type(prod.prod_type, Permissions.Product_Type_View)
     personal_notifications_form = ProductNotificationsForm(
         instance=Notifications.objects.filter(user=request.user).filter(product=prod).first())
     langSummary = Languages.objects.filter(product=prod).aggregate(Sum('files'), Sum('code'), Count('files'))
@@ -1507,7 +1507,7 @@ def edit_product_member(request, memberid):
     })
 
 
-@user_is_authorized(Product_Member, Permissions.Product_Remove_Member, 'memberid')
+@user_is_authorized(Product_Member, Permissions.Product_Member_Delete, 'memberid')
 def delete_product_member(request, memberid):
     member = get_object_or_404(Product_Member, pk=memberid)
     memberform = Delete_Product_MemberForm(instance=member)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -220,7 +220,7 @@ def view_product_components(request, pid):
 
     # Append finding counts
     component_query = component_query.annotate(total=Count('id')).order_by('component_name', 'component_version')
-    component_query = component_query.annotate(actives=Count('id', filter=Q(active=True)))
+    component_query = component_query.annotate(active=Count('id', filter=Q(active=True)))
     component_query = component_query.annotate(duplicate=(Count('id', filter=Q(duplicate=True))))
 
     # Default sort by total descending

--- a/dojo/product_type/queries.py
+++ b/dojo/product_type/queries.py
@@ -32,7 +32,7 @@ def get_authorized_product_types(permission):
     return product_types
 
 
-def get_authorized_members_product_type(product_type, permission):
+def get_authorized_product_type_members_for_product_type(product_type, permission):
     user = get_current_user()
 
     if user.is_superuser or user_has_permission(user, product_type, permission):
@@ -41,17 +41,17 @@ def get_authorized_members_product_type(product_type, permission):
         return None
 
 
-def get_authorized_members_user(user, permission):
-    request_user = get_current_user()
+def get_authorized_product_type_members(permission):
+    user = get_current_user()
 
-    if request_user is None:
+    if user is None:
         return Product_Type_Member.objects.none()
 
-    if request_user.is_superuser:
-        return Product_Type_Member.objects.filter(user=user)
+    if user.is_superuser:
+        return Product_Type_Member.objects.all()
 
-    if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Product_Type_Member.objects.all(user=user)
+    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
+        return Product_Type_Member.objects.all()
 
     product_types = get_authorized_product_types(permission)
-    return Product_Type_Member.objects.filter(user=user, product_type__in=product_types)
+    return Product_Type_Member.objects.filter(product_type__in=product_types)

--- a/dojo/product_type/queries.py
+++ b/dojo/product_type/queries.py
@@ -55,3 +55,19 @@ def get_authorized_product_type_members(permission):
 
     product_types = get_authorized_product_types(permission)
     return Product_Type_Member.objects.filter(product_type__in=product_types)
+
+
+def get_authorized_product_type_members_for_user(user, permission):
+    request_user = get_current_user()
+
+    if request_user is None:
+        return Product_Type_Member.objects.none()
+
+    if request_user.is_superuser:
+        return Product_Type_Member.objects.filter(user=user)
+
+    if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
+        return Product_Type_Member.objects.all(user=user)
+
+    product_types = get_authorized_product_types(permission)
+    return Product_Type_Member.objects.filter(user=user, product_type__in=product_types)

--- a/dojo/product_type/queries.py
+++ b/dojo/product_type/queries.py
@@ -32,7 +32,7 @@ def get_authorized_product_types(permission):
     return product_types
 
 
-def get_authorized_product_type_members_for_product_type(product_type, permission):
+def get_authorized_members_for_product_type(product_type, permission):
     user = get_current_user()
 
     if user.is_superuser or user_has_permission(user, product_type, permission):

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -19,7 +19,7 @@ from django.conf import settings
 from dojo.authorization.authorization import user_has_permission
 from dojo.authorization.roles_permissions import Permissions, Roles
 from dojo.authorization.authorization_decorators import user_is_authorized
-from dojo.product_type.queries import get_authorized_product_types, get_authorized_product_type_members_for_product_type
+from dojo.product_type.queries import get_authorized_product_types, get_authorized_members_for_product_type
 from dojo.product.queries import get_authorized_products
 
 logger = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ def add_product_type(request):
 @user_is_authorized(Product_Type, Permissions.Product_Type_View, 'ptid', 'view')
 def view_product_type(request, ptid):
     pt = get_object_or_404(Product_Type, pk=ptid)
-    members = get_authorized_product_type_members_for_product_type(pt, Permissions.Product_Type_View)
+    members = get_authorized_members_for_product_type(pt, Permissions.Product_Type_View)
     products = get_authorized_products(Permissions.Product_View).filter(prod_type=pt)
     add_breadcrumb(title="View Product Type", top_level=False, request=request)
     return render(request, 'dojo/view_product_type.html', {
@@ -147,7 +147,7 @@ def delete_product_type(request, ptid):
 def edit_product_type(request, ptid):
     pt = get_object_or_404(Product_Type, pk=ptid)
     authed_users = pt.authorized_users.all()
-    members = get_authorized_product_type_members_for_product_type(pt, Permissions.Product_Type_Manage_Members)
+    members = get_authorized_members_for_product_type(pt, Permissions.Product_Type_Manage_Members)
     pt_form = Product_TypeForm(instance=pt, initial={'authorized_users': authed_users})
     if request.method == "POST" and request.POST.get('edit_product_type'):
         pt_form = Product_TypeForm(request.POST, instance=pt)

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -86,6 +86,7 @@ def add_product_type(request):
                                  'Product type added successfully.',
                                  extra_tags='alert-success')
             create_notification(event='product_type_added', title=product_type.name,
+                                product_type=product_type,
                                 url=reverse('view_product_type', args=(product_type.id,)))
             return HttpResponseRedirect(reverse('product_type'))
     add_breadcrumb(title="Add Product Type", top_level=False, request=request)
@@ -124,6 +125,7 @@ def delete_product_type(request, ptid):
                                      extra_tags='alert-success')
                 create_notification(event='other',
                                 title='Deletion of %s' % product_type.name,
+                                no_users=True,
                                 description='The product type "%s" was deleted by %s' % (product_type.name, request.user),
                                 url=request.build_absolute_uri(reverse('product_type')),
                                 icon="exclamation-triangle")

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -19,7 +19,7 @@ from django.conf import settings
 from dojo.authorization.authorization import user_has_permission
 from dojo.authorization.roles_permissions import Permissions, Roles
 from dojo.authorization.authorization_decorators import user_is_authorized
-from dojo.product_type.queries import get_authorized_product_types, get_authorized_members_product_type
+from dojo.product_type.queries import get_authorized_product_types, get_authorized_product_type_members_for_product_type
 from dojo.product.queries import get_authorized_products
 
 logger = logging.getLogger(__name__)
@@ -98,7 +98,7 @@ def add_product_type(request):
 @user_is_authorized(Product_Type, Permissions.Product_Type_View, 'ptid', 'view')
 def view_product_type(request, ptid):
     pt = get_object_or_404(Product_Type, pk=ptid)
-    members = get_authorized_members_product_type(pt, Permissions.Product_Type_View)
+    members = get_authorized_product_type_members_for_product_type(pt, Permissions.Product_Type_View)
     products = get_authorized_products(Permissions.Product_View).filter(prod_type=pt)
     add_breadcrumb(title="View Product Type", top_level=False, request=request)
     return render(request, 'dojo/view_product_type.html', {
@@ -145,7 +145,7 @@ def delete_product_type(request, ptid):
 def edit_product_type(request, ptid):
     pt = get_object_or_404(Product_Type, pk=ptid)
     authed_users = pt.authorized_users.all()
-    members = get_authorized_members_product_type(pt, Permissions.Product_Type_Manage_Members)
+    members = get_authorized_product_type_members_for_product_type(pt, Permissions.Product_Type_Manage_Members)
     pt_form = Product_TypeForm(instance=pt, initial={'authorized_users': authed_users})
     if request.method == "POST" and request.POST.get('edit_product_type'):
         pt_form = Product_TypeForm(request.POST, instance=pt)
@@ -240,7 +240,7 @@ def edit_product_type_member(request, memberid):
     })
 
 
-@user_is_authorized(Product_Type_Member, Permissions.Product_Type_Remove_Member, 'memberid')
+@user_is_authorized(Product_Type_Member, Permissions.Product_Type_Member_Delete, 'memberid')
 def delete_product_type_member(request, memberid):
     member = get_object_or_404(Product_Type_Member, pk=memberid)
     memberform = Delete_Product_Type_MemberForm(instance=member)

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -248,8 +248,6 @@
                                     </ul>
                                     <!-- /.nav-second-level -->
                                 </li>
-                            {% endif %}
-                            {% if request.user.is_staff %}
                                 <li>
 				                    <a href="{% url 'components' %}" id="product_component_view" aria-expanded="false"  aria-label="Components">
                                         <i class="fa fa-th-large fa-fw"></i>
@@ -261,8 +259,6 @@
                                         </li>
                                     </ul>
                                 </li>
-                            {% endif %}
-                            {% if request.user|feature_authorization_v2_or_user_is_staff %}
                                 <li>
                                     <a href="{% url 'endpoints' %}" aria-expanded="false" aria-label="Endpoints">
 					                    <i class="fa fa-sitemap fa-fw"></i>

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -210,7 +210,7 @@
                                 </a>
                                 <ul class="nav nav-second-level">
                                     <li><a href="{% url 'engagement' %}">Active Engagements</a></li>
-                                    {% if request.user|feature_authorization_v2_or_user_is_staff %}
+                                    {% if request.user.is_staff or 'FEATURE_AUTHORIZATION_V2'|setting_enabled %}
                                         <li><a href="{% url 'engagements_all' %}">All Engagements</a></li>
                                     {% endif %}
                                     {% if request.user.is_staff %}
@@ -220,7 +220,7 @@
                                 </ul>
                                 <!-- /.nav-second-level -->
                             </li>
-                            {% if request.user|feature_authorization_v2_or_user_is_staff %}
+                            {% if request.user.is_staff or 'FEATURE_AUTHORIZATION_V2'|setting_enabled %}
                                 <li>
                                     <a href="{% url 'open_findings' %}" aria-expanded="false" aria-label="Findings">
                                         <i class="fa fa-bug fa-fw"></i>
@@ -324,7 +324,7 @@
                                     </a>
                                 </li>
                             {% endif %}
-                            {% if request.user|feature_authorization_v2_or_user_is_staff %}
+                            {% if request.user.is_staff or 'FEATURE_AUTHORIZATION_V2'|setting_enabled %}
                                 <li>
 				                    <a href="{% url 'engagement_calendar' %}" aria-disabled="true" aria-expanded="false" aria-label="Calendar">
                                         <i class="fa fa-calendar fa-fw"></i>

--- a/dojo/templates/dojo/components.html
+++ b/dojo/templates/dojo/components.html
@@ -27,9 +27,9 @@
                     <tr>
                         <th>Name</th>
                         <th>Version</th>
-                        <th>Active</th>
-                        <th>Duplicate</th>
-                        <th>Total</th>
+                        <th class="text-center">Active</th>
+                        <th class="text-center">Duplicate</th>
+                        <th class="text-center">Total</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -44,7 +44,7 @@
                         </td>
 
                         <td>{{result.component_version}} </td>
-                        <td>
+                        <td class="text-center">
                             {% if result.active and result.component_name == none %}
                             <a href="{% url 'open_findings' %}?has_component=false"><b>{{ result.active }}</b></a>
                             {% elif result.active%}
@@ -53,7 +53,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td>
+                        <td class="text-center">
                             {% if result.duplicate and result.component_name == none %}
                             <a href="{% url 'findings' %}?has_component=false&duplicate=1"><b>{{ result.duplicate }}</b></a>
                             {% elif result.duplicate %}
@@ -62,7 +62,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td>
+                        <td class="text-center">
                             {% if result.total and result.component_name == none %}
                             <a href="{% url 'findings' %}?has_component=false"><b>{{ result.total }}</b></a>
                             {% elif result.total %}

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -39,8 +39,12 @@
             </div>
             {% if endpoints %}
 				<div class="hidden" style="padding-bottom: 5px;" id="bulk_remedy">
-					<form action="{% url 'endpoints_bulk_all' %}" method="post" id="bulk_change_form">
-						{% csrf_token %}
+                    {% if product_tab %}
+                        <form action="{% url 'endpoints_bulk_update_all_product' product_tab.product.id %}" method="post" id="bulk_change_form">
+                    {% else %}
+                        <form action="{% url 'endpoints_bulk_all' %}" method="post" id="bulk_change_form">
+                    {% endif %}
+                        {% csrf_token %}
                         {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
 						<button class="btn btn-sm btn-primary" type="submit" id="remedy_endpoint" title="Mitigate Endpoints">
                 Bulk Mitigate

--- a/dojo/templates/dojo/product_components.html
+++ b/dojo/templates/dojo/product_components.html
@@ -26,9 +26,9 @@
                     <tr>
                         <th>Name</th>
                         <th>Version</th>
-                        <th>Active</th>
-                        <th>Duplicate</th>
-                        <th>Total</th>
+                        <th class="text-center">Active</th>
+                        <th class="text-center">Duplicate</th>
+                        <th class="text-center">Total</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -42,7 +42,7 @@
                             {% endif %}
                         </td>
                         <td>{{result.component_version}} </td>
-                        <td>
+                        <td class="text-center">
                             {% if result.active and result.component_name == none %}
                             <a href="{% url 'open_findings' %}?has_component=false&test__engagement__product={{prod.id}}"><b>{{ result.active }}</b></a>
                             {% elif result.active %}
@@ -51,7 +51,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td>
+                        <td class="text-center">
                             {% if result.duplicate and result.component_name == none %}
                             <a href="{% url 'findings' %}?has_component=false&test__engagement__product={{prod.id}}&duplicate=1"><b>{{ result.duplicate }}</b></a>
                             {% elif result.duplicate %}
@@ -60,7 +60,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td>
+                        <td class="text-center">
                             {% if result.total and result.component_name == none %}
                             <a href="{% url 'findings' %}?has_component=false&test__engagement__product={{prod.id}}"><b>{{ result.total }}</b></a>
                             {% elif result.total %}

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -238,7 +238,7 @@
                                             <i class="fa fa-pencil-square-o"></i> Edit</a>
                                         </li>
                                         {% endif %}
-                                        {% if member|has_object_permission:"Product_Remove_Member" %}
+                                        {% if member|has_object_permission:"Product_Member_Delete" %}
                                         <li>
                                             <a class="" href="{% url 'delete_product_member' member.id %}">
                                             <i class="fa fa-trash"></i> Delete</a>

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -169,7 +169,7 @@
                                                         <i class="fa fa-pencil-square-o"></i> Edit</a>
                                                     </li>
                                                     {% endif %}
-                                                    {% if member|has_object_permission:"Product_Type_Remove_Member" %}
+                                                    {% if member|has_object_permission:"Product_Type_Member_Delete" %}
                                                     <li>
                                                         <a class="" href="{% url 'delete_product_type_member' member.id %}">
                                                         <i class="fa fa-trash"></i> Delete</a>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -501,7 +501,7 @@
             <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
                 <li class="dropdown-header">Choose wisely...</li>
                 <li style="padding-left: 8px;padding-right: 8px;">
-                    <form action="{% url 'finding_bulk_update_all' %}" method="post" id="bulk_change_form">
+                    <form action="{% url 'finding_bulk_update_all_product' product_tab.product.id %}" method="post" id="bulk_change_form">
                         {% csrf_token %}
                         <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
                         <label style="display: block" for="severity">Severity</label>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -328,14 +328,14 @@
                                         <i class="fa fa-arrow-circle-right"></i> View
                                         </a>
                                     </li>
-                                    {% if user|is_authorized_for_change:group %}
+                                    {% if user|is_authorized_for_change:group or group|has_object_permission:"Finding_Edit" %}
                                         <li>
                                             <a class="" href="{% url 'edit_finding_group' group.id %}?return_url={{ request.get_full_path|urlencode }}">
                                             <i class="fa fa-pencil-square-o"></i> Edit
                                             </a>
                                         </li>
                                     {% endif %}
-                                    {% if user|is_authorized_for_delete:group %}
+                                    {% if user|is_authorized_for_delete:group or group|has_object_permission:"Finding_Edit" %}
                                         <li>
                                             <form method="post" action="{% url 'delete_finding_group' group.id %}"
                                                 style="display: inline" class="form-inline form" id="delete-finding-group-menu-{{ group.id }}-form">
@@ -473,9 +473,9 @@
             {% include "dojo/paging_snippet.html" with page=findings prefix='findings' page_size=True %}
         </div>
 
-        {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled %}
+        {% if user.is_staff or 'AUTHORIZED_USERS_ALLOW_CHANGE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_DELETE'|setting_enabled or 'AUTHORIZED_USERS_ALLOW_STAFF'|setting_enabled or test|has_object_permission:"Finding_Edit" %}
         <div class="dropdown hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
-            {% if test|has_object_permission:"Test_Edit" or user|is_authorized_for_change:test %}
+            {% if test|has_object_permission:"Finding_Edit" or user|is_authorized_for_change:test %}
                 <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     Bulk Edit
@@ -490,7 +490,7 @@
                         </a>
                     </button>
                 {% endif %}
-                {% if test|has_object_permission:"Test_Delete" or user|is_authorized_for_delete:test %}
+                {% if test|has_object_permission:"Finding_Delete" or user|is_authorized_for_delete:test %}
                     <button type="button" class="btn btn-info btn-sm btn-primary" data-toggle="tooltip" data-placement="bottom" title="Delete Findings">
                         <a class="white-color delete-bulk" href="#" alt="Delete Findings">
                             <i class="fa fa-trash"></i>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -328,14 +328,14 @@
                                         <i class="fa fa-arrow-circle-right"></i> View
                                         </a>
                                     </li>
-                                    {% if user|is_authorized_for_change:group or group|has_object_permission:"Finding_Edit" %}
+                                    {% if user|is_authorized_for_change:group or group|has_object_permission:"Finding_Group_Edit" %}
                                         <li>
                                             <a class="" href="{% url 'edit_finding_group' group.id %}?return_url={{ request.get_full_path|urlencode }}">
                                             <i class="fa fa-pencil-square-o"></i> Edit
                                             </a>
                                         </li>
                                     {% endif %}
-                                    {% if user|is_authorized_for_delete:group or group|has_object_permission:"Finding_Edit" %}
+                                    {% if user|is_authorized_for_delete:group or group|has_object_permission:"Finding_Group_Delete" %}
                                         <li>
                                             <form method="post" action="{% url 'delete_finding_group' group.id %}"
                                                 style="display: inline" class="form-inline form" id="delete-finding-group-menu-{{ group.id }}-form">

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -147,7 +147,7 @@
                                                     <i class="fa fa-pencil-square-o"></i> Edit</a>
                                             </li>
                                             {% endif %}
-                                            {% if member|has_object_permission:"Product_Type_Remove_Member" %}
+                                            {% if member|has_object_permission:"Product_Type_Member_Delete" %}
                                             <li>
                                                 <a class="" href="{% url 'delete_product_type_member' member.id %}">
                                                     <i class="fa fa-trash"></i> Delete</a>
@@ -217,7 +217,7 @@
                                                     <i class="fa fa-pencil-square-o"></i> Edit</a>
                                             </li>
                                             {% endif %}
-                                            {% if member|has_object_permission:"Product_Remove_Member" %}
+                                            {% if member|has_object_permission:"Product_Member_Delete" %}
                                             <li>
                                                 <a class="" href="{% url 'delete_product_member' member.id %}">
                                                     <i class="fa fa-trash"></i> Delete</a>

--- a/dojo/templatetags/authorization_tags.py
+++ b/dojo/templatetags/authorization_tags.py
@@ -13,11 +13,6 @@ def role_as_string(id):
 
 
 @register.filter
-def feature_authorization_v2_or_user_is_staff(user):
-    return settings.FEATURE_AUTHORIZATION_V2 or user.is_staff
-
-
-@register.filter
 def has_object_permission(obj, permission):
 
     if settings.FEATURE_AUTHORIZATION_V2:

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -271,6 +271,7 @@ def delete_test(request, tid):
         if 'id' in request.POST and str(test.id) == request.POST['id']:
             form = DeleteTestForm(request.POST, instance=test)
             if form.is_valid():
+                product = test.engagement.product
                 test.delete()
                 messages.add_message(request,
                                      messages.SUCCESS,
@@ -278,6 +279,7 @@ def delete_test(request, tid):
                                      extra_tags='alert-success')
                 create_notification(event='other',
                                     title='Deletion of %s' % test.title,
+                                    product=product,
                                     description='The test "%s" was deleted by %s' % (test.title, request.user),
                                     url=request.build_absolute_uri(reverse('view_engagement', args=(eng.id, ))),
                                     recipients=[test.engagement.lead],
@@ -432,6 +434,7 @@ def add_findings(request, tid):
             new_finding.save(false_history=True, push_to_jira=push_to_jira)
             create_notification(event='other',
                                 title='Addition of %s' % new_finding.title,
+                                finding=new_finding,
                                 description='Finding "%s" was added by %s' % (new_finding.title, request.user),
                                 url=request.build_absolute_uri(reverse('view_finding', args=(new_finding.id,))),
                                 icon="exclamation-triangle")

--- a/dojo/unittests/authorization/test_authorization.py
+++ b/dojo/unittests/authorization/test_authorization.py
@@ -254,7 +254,7 @@ class TestAuthorization(TestCase):
         self.assertEqual(mock_get.call_args[1]['product'], self.product)
 
     def test_user_has_permission_product_type_member_success_same_user(self):
-        result = user_has_permission(self.user, self.product_type_member_owner, Permissions.Product_Type_Remove_Member)
+        result = user_has_permission(self.user, self.product_type_member_owner, Permissions.Product_Type_Member_Delete)
         self.assertTrue(result)
 
     @patch('dojo.models.Product_Type_Member.objects.get')
@@ -268,7 +268,7 @@ class TestAuthorization(TestCase):
         product_type_member_other_user.role = Roles.Reader
         mock_get.return_value = product_type_member_other_user
 
-        result = user_has_permission(other_user, self.product_type_member_owner, Permissions.Product_Type_Remove_Member)
+        result = user_has_permission(other_user, self.product_type_member_owner, Permissions.Product_Type_Member_Delete)
 
         self.assertFalse(result)
         self.assertEqual(mock_get.call_args[1]['user'], other_user)
@@ -285,14 +285,14 @@ class TestAuthorization(TestCase):
         product_type_member_other_user.role = Roles.Owner
         mock_get.return_value = product_type_member_other_user
 
-        result = user_has_permission(other_user, self.product_type_member_reader, Permissions.Product_Type_Remove_Member)
+        result = user_has_permission(other_user, self.product_type_member_reader, Permissions.Product_Type_Member_Delete)
 
         self.assertTrue(result)
         self.assertEqual(mock_get.call_args[1]['user'], other_user)
         self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
 
     def test_user_has_permission_product_member_success_same_user(self):
-        result = user_has_permission(self.user, self.product_member_owner, Permissions.Product_Remove_Member)
+        result = user_has_permission(self.user, self.product_member_owner, Permissions.Product_Member_Delete)
         self.assertTrue(result)
 
     @patch('dojo.models.Product_Member.objects.get')
@@ -306,7 +306,7 @@ class TestAuthorization(TestCase):
         product_member_other_user.role = Roles.Reader
         mock_get.return_value = product_member_other_user
 
-        result = user_has_permission(other_user, self.product_member_owner, Permissions.Product_Remove_Member)
+        result = user_has_permission(other_user, self.product_member_owner, Permissions.Product_Member_Delete)
 
         self.assertFalse(result)
         self.assertEqual(mock_get.call_args[1]['user'], other_user)
@@ -323,7 +323,7 @@ class TestAuthorization(TestCase):
         product_member_other_user.role = Roles.Owner
         mock_get.return_value = product_member_other_user
 
-        result = user_has_permission(other_user, self.product_member_reader, Permissions.Product_Remove_Member)
+        result = user_has_permission(other_user, self.product_member_reader, Permissions.Product_Member_Delete)
 
         self.assertTrue(result)
         self.assertEqual(mock_get.call_args[1]['user'], other_user)

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -30,7 +30,7 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
     DevelopmentEnvironmentViewSet, NotesViewSet, NoteTypeViewSet, SystemSettingsViewSet, \
     AppAnalysisViewSet, EndpointStatusViewSet, SonarqubeIssueViewSet, SonarqubeIssueTransitionViewSet, \
-    SonarqubeProductViewSet, RegulationsViewSet
+    SonarqubeProductViewSet, RegulationsViewSet, ProductTypeMemberViewSet, ProductMemberViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -113,6 +113,9 @@ v2_api.register(r'jira_product_configurations', JiraProjectViewSet)  # backwards
 v2_api.register(r'jira_projects', JiraProjectViewSet)
 v2_api.register(r'products', ProductViewSet)
 v2_api.register(r'product_types', ProductTypeViewSet)
+if settings.FEATURE_AUTHORIZATION_V2:
+    v2_api.register(r'product_type_members', ProductTypeMemberViewSet)
+    v2_api.register(r'product_members', ProductMemberViewSet)
 v2_api.register(r'sonarqube_issues', SonarqubeIssueViewSet)
 v2_api.register(r'sonarqube_transitions', SonarqubeIssueTransitionViewSet)
 v2_api.register(r'sonarqube_product_configurations', SonarqubeProductViewSet)

--- a/dojo/user/helper.py
+++ b/dojo/user/helper.py
@@ -1,81 +1,9 @@
 from django.conf import settings
 import logging
-from django.core.exceptions import PermissionDenied
-import functools
-from django.shortcuts import get_object_or_404
 from dojo.models import Finding, Finding_Group, Test, Engagement, Product, Endpoint, Product_Type, \
     Risk_Acceptance
 
 logger = logging.getLogger(__name__)
-
-
-def user_must_be_authorized(model, perm_type, arg, lookup="pk", view_func=None):
-    # print('model: ', model)
-    # print('arg: ', arg)
-    # print('lookup: ', lookup)
-    # print('view_func: ', view_func)
-
-    """Decorator for view functions that ensures the user has permission on an object.
-    It looks up the requested object in the user-restricted base queryset, checks
-    for the object-level permission with given type and, if all went well, passes the
-    retrieved object through to the view function. The object retrieved is passed
-    as positional argument, directly after ``request``, the original lookup value
-    (such as a primary key from URL) is removed from the arguments.
-    This unifies (and simplifies) the typical ``get_object_or_404()`` + permission
-    checking workflow, so that the view function doesn't have to deal with permissions
-    and object retrival at all.
-    :param model: The model to fetch objects of and do permission checking for
-    :type  model: Model
-    :param arg:
-        Index of the function argument containing the value to look up in database
-        (i.e. the object's primary key), not counting the first argument (``request``).
-        If this is a keyword-argument rather than a positional one, specify its name
-        as a string.
-        ``None`` will disable object fetching entirely and only do model-level
-        permission checking (usable for permission types like "add" that aren't
-        related to a specific object).
-    :type  arg: int, str
-    :param lookup: Db lookup for selecting the requested object
-    :type  lookup: str, optional
-    :param view_func: The view function to wrap, not required for use as a decorator
-    :type  view_func: callable, optional
-    :raises Http404:
-        if requested object isn't found
-    :raises PermissionDenied: If object-/model-level permission check fails
-    """
-
-    if view_func is None:
-        return functools.partial(user_must_be_authorized, model, perm_type, arg, lookup)
-
-    @functools.wraps(view_func)
-    def _wrapped(request, *args, **kwargs):
-        # Fetch object from database
-        if isinstance(arg, int):
-            # Lookup value came as a positional argument
-            args = list(args)
-            lookup_value = args.pop(arg)
-        else:
-            # Lookup value was passed as keyword argument
-            lookup_value = kwargs.pop(arg)
-
-        # object must exist
-        obj = get_object_or_404(
-            # model.objects.for_user(request), **{lookup: lookup_value}
-            model.objects.filter(**{lookup: lookup_value})
-        )
-
-        is_authorized = user_is_authorized(request.user, perm_type, obj)
-        if not is_authorized:
-            logger.warn('User %s is not authorized to %s for %s', request.user, perm_type, obj)
-            raise PermissionDenied()
-
-        # print('user is authorized for: ', obj)
-        # Django doesn't seem to easily support just passing on the original positional parameters
-        # so we resort to explicitly putting lookup_value here (which is for example the 'fid' parameter)
-        print('view_func params', lookup_value, *args, **kwargs)
-        return view_func(request, lookup_value, *args, **kwargs)
-
-    return _wrapped
 
 
 def check_auth_users_list(user, obj):

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.db.models import Q
+from dojo.models import Product_Member, Product_Type_Member
+from dojo.authorization.authorization import get_roles_for_permission
+
+
+def get_authorized_users_for_product_and_product_type(users, product, permission):
+    if settings.FEATURE_AUTHORIZATION_V2:
+        roles = get_roles_for_permission(permission)
+        product_members = Product_Member.objects \
+            .filter(product=product, role__in=roles) \
+            .values_list('user_id', flat=True)
+        product_type_members = Product_Type_Member.objects \
+            .filter(product_type=product.prod_type, role__in=roles) \
+            .values_list('user_id', flat=True)
+        return users.filter(Q(id__in=product_members) |
+            Q(id__in=product_type_members) |
+            Q(is_superuser=True))
+    else:
+        return users.filter(Q(id__in=product.authorized_users.all()) |
+            Q(id__in=product.prod_type.authorized_users.all()) |
+            Q(is_superuser=True) |
+            Q(is_staff=True))

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -4,6 +4,19 @@ from dojo.models import Product_Member, Product_Type_Member
 from dojo.authorization.authorization import get_roles_for_permission
 
 
+def get_authorized_users_for_product_type(users, product_type, permission):
+    if settings.FEATURE_AUTHORIZATION_V2:
+        roles = get_roles_for_permission(permission)
+        product_type_members = Product_Type_Member.objects \
+            .filter(product_type=product_type, role__in=roles) \
+            .values_list('user_id', flat=True)
+        return users.filter(Q(id__in=product_type_members) | Q(is_superuser=True))
+    else:
+        return users.filter(Q(id__in=product_type.authorized_users.all()) |
+            Q(is_superuser=True) |
+            Q(is_staff=True))
+
+
 def get_authorized_users_for_product_and_product_type(users, product, permission):
     if settings.FEATURE_AUTHORIZATION_V2:
         roles = get_roles_for_permission(permission)

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.db.models import Q
 from dojo.models import Product_Member, Product_Type_Member
@@ -18,6 +19,10 @@ def get_authorized_users_for_product_type(users, product_type, permission):
 
 
 def get_authorized_users_for_product_and_product_type(users, product, permission):
+    if users is None:
+        User = get_user_model()
+        users = User.objects.all()
+
     if settings.FEATURE_AUTHORIZATION_V2:
         roles = get_roles_for_permission(permission)
         product_members = Product_Member.objects \

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -19,8 +19,8 @@ from dojo.forms import DojoUserForm, AddDojoUserForm, DeleteUserForm, APIKeyForm
     Add_Product_Type_Member_UserForm, Add_Product_Member_UserForm
 from dojo.models import Product, Product_Type, Dojo_User, Alerts, Product_Member, Product_Type_Member
 from dojo.utils import get_page_items, add_breadcrumb
-from dojo.product.queries import get_authorized_product_members_user
-from dojo.product_type.queries import get_authorized_members_user
+from dojo.product.queries import get_authorized_product_members_for_user
+from dojo.product_type.queries import get_authorized_product_type_members_for_user
 from dojo.authorization.roles_permissions import Permissions
 
 logger = logging.getLogger(__name__)
@@ -293,8 +293,8 @@ def view_user(request, uid):
     user = get_object_or_404(Dojo_User, id=uid)
     authorized_products = Product.objects.filter(authorized_users__in=[user])
     authorized_product_types = Product_Type.objects.filter(authorized_users__in=[user])
-    product_members = get_authorized_product_members_user(user, Permissions.Product_View)
-    product_type_members = get_authorized_members_user(user, Permissions.Product_Type_View)
+    product_members = get_authorized_product_members_for_user(user, Permissions.Product_View)
+    product_type_members = get_authorized_product_type_members_for_user(user, Permissions.Product_Type_View)
 
     add_breadcrumb(title="View User", top_level=False, request=request)
     return render(request, 'dojo/view_user.html', {

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -261,14 +261,15 @@ def add_user(request):
             contact = contact_form.save(commit=False)
             contact.user = user
             contact.save()
-            if 'authorized_products' in form.cleaned_data and len(form.cleaned_data['authorized_products']) > 0:
-                for p in form.cleaned_data['authorized_products']:
-                    p.authorized_users.add(user)
-                    p.save()
-            if 'authorized_product_types' in form.cleaned_data and len(form.cleaned_data['authorized_product_types']) > 0:
-                for pt in form.cleaned_data['authorized_product_types']:
-                    pt.authorized_users.add(user)
-                    pt.save()
+            if not settings.FEATURE_AUTHORIZATION_V2:
+                if 'authorized_products' in form.cleaned_data and len(form.cleaned_data['authorized_products']) > 0:
+                    for p in form.cleaned_data['authorized_products']:
+                        p.authorized_users.add(user)
+                        p.save()
+                if 'authorized_product_types' in form.cleaned_data and len(form.cleaned_data['authorized_product_types']) > 0:
+                    for pt in form.cleaned_data['authorized_product_types']:
+                        pt.authorized_users.add(user)
+                        pt.save()
             messages.add_message(request,
                                  messages.SUCCESS,
                                  'User added successfully, you may edit if necessary.',
@@ -334,20 +335,21 @@ def edit_user(request, uid):
 
         if form.is_valid() and contact_form.is_valid():
             form.save()
-            for init_auth_prods in authed_products:
-                init_auth_prods.authorized_users.remove(user)
-                init_auth_prods.save()
-            for init_auth_prod_types in authed_product_types:
-                init_auth_prod_types.authorized_users.remove(user)
-                init_auth_prod_types.save()
-            if 'authorized_products' in form.cleaned_data and len(form.cleaned_data['authorized_products']) > 0:
-                for p in form.cleaned_data['authorized_products']:
-                    p.authorized_users.add(user)
-                    p.save()
-            if 'authorized_product_types' in form.cleaned_data and len(form.cleaned_data['authorized_product_types']) > 0:
-                for pt in form.cleaned_data['authorized_product_types']:
-                    pt.authorized_users.add(user)
-                    pt.save()
+            if settings.FEATURE_AUTHORIZATION_V2:
+                for init_auth_prods in authed_products:
+                    init_auth_prods.authorized_users.remove(user)
+                    init_auth_prods.save()
+                for init_auth_prod_types in authed_product_types:
+                    init_auth_prod_types.authorized_users.remove(user)
+                    init_auth_prod_types.save()
+                if 'authorized_products' in form.cleaned_data and len(form.cleaned_data['authorized_products']) > 0:
+                    for p in form.cleaned_data['authorized_products']:
+                        p.authorized_users.add(user)
+                        p.save()
+                if 'authorized_product_types' in form.cleaned_data and len(form.cleaned_data['authorized_product_types']) > 0:
+                    for pt in form.cleaned_data['authorized_product_types']:
+                        pt.authorized_users.add(user)
+                        pt.save()
             contact = contact_form.save(commit=False)
             contact.user = user
             contact.save()

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -335,7 +335,7 @@ def edit_user(request, uid):
 
         if form.is_valid() and contact_form.is_valid():
             form.save()
-            if settings.FEATURE_AUTHORIZATION_V2:
+            if not settings.FEATURE_AUTHORIZATION_V2:
                 for init_auth_prods in authed_products:
                     init_auth_prods.authorized_users.remove(user)
                     init_auth_prods.save()


### PR DESCRIPTION
This PR, together with PR #4247 makes the implementation of the new authorization feature-complete, so that it can be end-2-end tested. I worked on the permissions based on being a Product_Member or Product_Type_Member for:

- API for Import and Reimport
- API for Product_Members and Product_Type_Members
- Components
- Finding_Groups
- Selection of engagement lead and test lead
- Notifications
- GitLab
- Bulk edit and delete

About notifications: I had to fix a lot of create_notification() calls, where the product, engagement, test or finding weren't set. Because of that, notifications where send to all users, not only authorized users. This has been fixed for the current authorization as well.

About GitLab: I couldn't test this implementation, because I can't create an OAuth2 connection to a GitLab instance.

Question: What to do with Tags? Currently all tags are visible for every user. I wouldn't change that, tags shouldn't contain sensible information.

There are still some things missing before declaring general availability, which will come with following PRs:

- Integration tests
- Documentation
- Migration procedure from authorized users to Product_Members/Product_Type_Members