### PR TITLE
Spotbugs: fix error on missing start line value

### DIFF
--- a/dojo/tools/spotbugs/parser.py
+++ b/dojo/tools/spotbugs/parser.py
@@ -60,7 +60,8 @@ class SpotbugsParser(object):
             source_extract = bug.find('SourceLine')
             if source_extract is not None:
                 source_file = source_extract.get("sourcepath")
-                source_line = int(source_extract.get("start") if source_extract.get("start") is not None else "0")
+                if 'start' in source_extract and source_extract["start"].isdigit():
+                    source_line = int(source_extract["start"])
 
             if dupe_key in dupes:
                 finding = dupes[dupe_key]

--- a/dojo/tools/spotbugs/parser.py
+++ b/dojo/tools/spotbugs/parser.py
@@ -60,7 +60,7 @@ class SpotbugsParser(object):
             source_extract = bug.find('SourceLine')
             if source_extract is not None:
                 source_file = source_extract.get("sourcepath")
-                source_line = int(source_extract.get("start"))
+                source_line = int(source_extract.get("start") if source_extract.get("start") is not None else "0")
 
             if dupe_key in dupes:
                 finding = dupes[dupe_key]


### PR DESCRIPTION
Some time, start is not defined and cause an 500 error.
This patch cover the error