### PR TITLE
Fix datetime/date mismatch between CICD engagement and test

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -609,7 +609,7 @@ def import_scan_results(request, eid=None, pid=None):
                 add_success_message_to_response(message)
 
             except Exception as e:
-                # exceptions are already logged by the importer
+                logger.exception(e)
                 add_error_message_to_response('An exception error occurred during the report import:%s' % str(e))
                 error = True
 

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -389,7 +389,7 @@
     "pk": 3,
     "model": "dojo.engagement_type",
     "fields": {
-      "name": "Type 3",
+      "name": "CI/CD",
       "id": 3
     }
   },
@@ -428,7 +428,7 @@
       "description": "test Engagement",
       "reason": null,
       "requester": null,
-      "eng_type": null,
+      "eng_type": 3,
       "active": true,
       "done_testing": false,
       "target_end": "2018-04-12",

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -32,7 +32,7 @@ def parse_findings(scan, test, active, verified, scan_type):
 def update_timestamps(test, scan_date, version, branch_tag, build_id, commit_hash, now, scan_date_time):
     test.engagement.updated = now
     if test.engagement.engagement_type == 'CI/CD':
-        test.engagement.target_end = max_safe([scan_date, test.engagement.target_end])
+        test.engagement.target_end = max_safe([scan_date_time.date(), test.engagement.target_end])
 
     test.updated = now
     test.target_end = max_safe([scan_date_time, test.target_end])

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -714,7 +714,7 @@ def re_import_scan_results(request, tid):
                                                 commit_hash=commit_hash, push_to_jira=push_to_jira,
                                                 close_old_findings=close_old_findings)
             except Exception as e:
-                # exceptions are already logged by the importer
+                logger.exception(e)
                 add_error_message_to_response('An exception error occurred during the report import:%s' % str(e))
                 error = True
 


### PR DESCRIPTION
for ci/cd engagements the updating of timestamps failed. made sure there's at least 1 ci/cd enagement in the testdata fixture.