### PR TITLE
reimporter: make close_old_findings True by default everywhere

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -238,7 +238,7 @@ class DojoDefaultReImporter(object):
 
     def reimport_scan(self, scan, scan_type, test, active=True, verified=True, tags=None, minimum_severity=None,
                     user=None, endpoints_to_add=None, scan_date=None, version=None, branch_tag=None, build_id=None,
-                    commit_hash=None, push_to_jira=None, close_old_findings=False):
+                    commit_hash=None, push_to_jira=None, close_old_findings=True):
 
         user = user or get_current_user()
 


### PR DESCRIPTION
Both the API and UI set close_old_findings to True for reimport, so all works well.
But in the reimporter.py kwarg the default is False, which is confusing and could lead to future bugs.