### PR TITLE
[Nexpose parser] Fix error with Python 3.9

### DIFF
--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -104,7 +104,7 @@ class NexposeParser(object):
                 if test.get('id') in vulnsDefinitions and (
                         test.get('status') in ['vulnerable-exploited', 'vulnerable-version', 'vulnerable-potential']):
                     vuln = vulnsDefinitions[test.get('id').lower()]
-                    for desc in test:
+                    for desc in list(test):
                         if 'pluginOutput' in vuln:
                             vuln['pluginOutput'] += "\n\n" + \
                                 self.parse_html_type(desc)
@@ -143,18 +143,18 @@ class NexposeParser(object):
                     'severity': sev,
                     'tags': list()
                 }
-                for item in vulnDef:
+                for item in list(vulnDef):
                     if item.tag == 'description':
-                        for htmlType in item:
+                        for htmlType in list(item):
                             vuln['desc'] += self.parse_html_type(htmlType)
 
                     elif item.tag == 'exploits':
-                        for exploit in item:
+                        for exploit in list(item):
                             vuln['refs'][exploit.get('title')] = str(exploit.get('title')).strip() + ' ' + \
                                                                  str(exploit.get('link')).strip()
 
                     elif item.tag == 'references':
-                        for ref in item:
+                        for ref in list(item):
                             if 'URL' in ref.get('source'):
                                 vuln['refs'][ref.get('source') + str(url_index)] = str(ref.text).strip()
                                 url_index += 1
@@ -162,12 +162,12 @@ class NexposeParser(object):
                                 vuln['refs'][ref.get('source')] = str(ref.text).strip()
 
                     elif item.tag == 'solution':
-                        for htmlType in item:
+                        for htmlType in list(item):
                             vuln['resolution'] += self.parse_html_type(htmlType)
 
                     # there is currently no method to register tags in vulns
                     elif item.tag == 'tags':
-                        for tag in item:
+                        for tag in list(item):
                             vuln['tags'].append(tag.text.lower())
 
                 vulns[vid] = vuln

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -104,7 +104,7 @@ class NexposeParser(object):
                 if test.get('id') in vulnsDefinitions and (
                         test.get('status') in ['vulnerable-exploited', 'vulnerable-version', 'vulnerable-potential']):
                     vuln = vulnsDefinitions[test.get('id').lower()]
-                    for desc in test.getchildren():
+                    for desc in test:
                         if 'pluginOutput' in vuln:
                             vuln['pluginOutput'] += "\n\n" + \
                                 self.parse_html_type(desc)
@@ -143,18 +143,18 @@ class NexposeParser(object):
                     'severity': sev,
                     'tags': list()
                 }
-                for item in vulnDef.getchildren():
+                for item in vulnDef:
                     if item.tag == 'description':
-                        for htmlType in item.getchildren():
+                        for htmlType in item:
                             vuln['desc'] += self.parse_html_type(htmlType)
 
                     elif item.tag == 'exploits':
-                        for exploit in item.getchildren():
+                        for exploit in item:
                             vuln['refs'][exploit.get('title')] = str(exploit.get('title')).strip() + ' ' + \
                                                                  str(exploit.get('link')).strip()
 
                     elif item.tag == 'references':
-                        for ref in item.getchildren():
+                        for ref in item:
                             if 'URL' in ref.get('source'):
                                 vuln['refs'][ref.get('source') + str(url_index)] = str(ref.text).strip()
                                 url_index += 1
@@ -162,12 +162,12 @@ class NexposeParser(object):
                                 vuln['refs'][ref.get('source')] = str(ref.text).strip()
 
                     elif item.tag == 'solution':
-                        for htmlType in item.getchildren():
+                        for htmlType in item:
                             vuln['resolution'] += self.parse_html_type(htmlType)
 
                     # there is currently no method to register tags in vulns
                     elif item.tag == 'tags':
-                        for tag in item.getchildren():
+                        for tag in item:
                             vuln['tags'].append(tag.text.lower())
 
                 vulns[vid] = vuln


### PR DESCRIPTION
Python 3.9 removed support for `getchildren` according to https://docs.python.org/3/whatsnew/3.9.html#removed

> * Methods getchildren() and getiterator() of classes ElementTree and Element in the ElementTree module have been removed. They were deprecated in Python 3.2. Use iter(x) or list(x) instead of x.getchildren() and x.iter() or list(x.iter()) instead of x.getiterator(). (Contributed by Serhiy Storchaka in bpo-36543.)

https://bugs.python.org/issue36543

This could lead to error: 
```
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
```