### PR TITLE
view_finding: show hash_code in title of ID field

### DIFF
--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -12,7 +12,10 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 
 def generate_hash_code(f):
+    old_hash_code = f.hash_code
     f.hash_code = f.compute_hash_code()
+    if f.hash_code != old_hash_code:
+        logger.debug('%d: hash_code changed from %d to %s', f.id, old_hash_code, f.hash_code)
     return f
 
 

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -249,14 +249,14 @@
                     <th>Found by</th>
                 </tr>
                 <tr>
-                    <td>{{ finding.id }}</td>
+                    <td title="hash_code: {{ finding.hash_code }}">{{ finding.id }}</td>
                     <td>
                         <span class="label severity severity-{{ finding.severity }}">
                             {% if finding.severity %}
                                 {% if finding.cvssv3 %}
                                     <i class="no-italics has-popover" font-style="normal" data-toggle="tooltip" data-placement="bottom" data-container="body" title="" href="#"
                                         data-content="{{ finding.cvssv3 }}">
-                                {% endif %}        
+                                {% endif %}
                                 {{ finding.severity_display }}
                                 {% if finding.cvssv3_score %}
                                     ({{ finding.cvssv3_score }})


### PR DESCRIPTION
sometimes it's useful to be able to see the hash_code values for findings when debugging some deduplication behaviour.
also add output to the `dedupe.py` command to show when a hash_code is actually changed.

![image](https://user-images.githubusercontent.com/4426050/115143067-60abee00-a045-11eb-9a32-6f4e876c05f7.png)
