### PR TITLE
SpotBugs: Use hash_code for deduplication and minor enhancements

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -843,7 +843,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'DSOP Scan': True,
     'Acunetix Scan': True,
     'Trivy Scan': True,
-    'SpotBugs Scan ': False,
+    'SpotBugs Scan': False,
 }
 
 # List of fields that are known to be usable in hash_code computation)
@@ -901,6 +901,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Safety Scan': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'GitLab SAST Report': DEDUPE_ALGO_HASH_CODE,
     'Checkov Scan': DEDUPE_ALGO_HASH_CODE,
+    'SpotBugs Scan': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -821,7 +821,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Trivy Scan': ['title', 'severity', 'cve', 'cwe'],
     'Snyk Scan': ['vuln_id_from_tool', 'file_path', 'component_name', 'component_version'],
     'GitLab Dependency Scanning Report': ['title', 'cve', 'file_path', 'component_name', 'component_version'],
-    'SpotBugs Scan': ['cwe', 'severity', 'file_path'],
+    'SpotBugs Scan': ['cwe', 'severity', 'file_path', 'line'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)

--- a/dojo/tools/spotbugs/parser.py
+++ b/dojo/tools/spotbugs/parser.py
@@ -41,7 +41,7 @@ class SpotbugsParser(object):
         for bug in root.findall('BugInstance'):
             desc = ''
             for message in bug.itertext():
-                desc += message
+                desc += message + '\n'
 
             dupe_key = bug.get('instanceHash')
 
@@ -50,8 +50,6 @@ class SpotbugsParser(object):
             severity = SEVERITY[bug.get('priority')]
             description = desc
             mitigation = bug_patterns[bug.get('type')]
-            impact = 'N/A'
-            references = 'N/A'
 
             # find the source line and file on the buginstance
             source_line = None
@@ -71,8 +69,6 @@ class SpotbugsParser(object):
                     severity=severity,
                     description=description,
                     mitigation=mitigation,
-                    impact=impact,
-                    references=references,
                     test=test,
                     static_finding=True,
                     line=source_line,


### PR DESCRIPTION
With the legacy deduplication algorithm, the reimport of a SpotBugs report closes a majority of the findings. When using the hash_code it produces the expected results.

[EDIT] hash_code uses now the line number as well. There can be multiple instances for one CWE in a file, eg. when you have a controller providing some REST-Endpoints.

Furthermore there are 2 minor enhancements of the parser:

- Newlines for the description, otherwise it is just a long unreadable string
- Removal of 'N/A' for impact and references because they can be NULL now