### PR TITLE
always log the admin password

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -64,8 +64,8 @@ if [ -z "${DD_ADMIN_PASSWORD}" ]
 then
   export DD_ADMIN_PASSWORD="$(cat /dev/urandom | LC_ALL=C tr -dc a-zA-Z0-9 | \
     head -c 22)"
-  echo "Admin password: ${DD_ADMIN_PASSWORD}"
 fi
+echo "Admin password: ${DD_ADMIN_PASSWORD}"
 
 if [ -z "${DD_JIRA_WEBHOOK_SECRET}" ]
 then


### PR DESCRIPTION
Even when a hardcoded default is set, show the admin password in the logs.