### PR TITLE
Import History: fix Endpoint JSON Serialization issue

### DIFF
--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -129,29 +129,30 @@ class DojoDefaultImporter(object):
                 item.endpoint_status.add(eps)
                 item.endpoints.add(ep)
 
-                if endpoints_to_add:
-                    for endpoint in endpoints_to_add:
-                        # TODO Not sure what happens here, we get an endpoint model and try to create it again?
-                        try:
-                            ep, created = Endpoint.objects.get_or_create(
-                                protocol=endpoint.protocol,
-                                host=endpoint.host,
-                                path=endpoint.path,
-                                query=endpoint.query,
-                                fragment=endpoint.fragment,
-                                product=test.engagement.product)
-                        except (MultipleObjectsReturned):
-                            pass
-                        try:
-                            eps, created = Endpoint_Status.objects.get_or_create(
-                                finding=item,
-                                endpoint=ep)
-                        except (MultipleObjectsReturned):
-                            pass
+            if endpoints_to_add:
+                for endpoint in endpoints_to_add:
+                    logger.debug('adding endpoint %s', endpoint)
+                    # TODO Not sure what happens here, we get an endpoint model and try to create it again?
+                    try:
+                        ep, created = Endpoint.objects.get_or_create(
+                            protocol=endpoint.protocol,
+                            host=endpoint.host,
+                            path=endpoint.path,
+                            query=endpoint.query,
+                            fragment=endpoint.fragment,
+                            product=test.engagement.product)
+                    except (MultipleObjectsReturned):
+                        pass
+                    try:
+                        eps, created = Endpoint_Status.objects.get_or_create(
+                            finding=item,
+                            endpoint=ep)
+                    except (MultipleObjectsReturned):
+                        pass
 
-                        ep.endpoint_status.add(eps)
-                        item.endpoints.add(ep)
-                        item.endpoint_status.add(eps)
+                    ep.endpoint_status.add(eps)
+                    item.endpoints.add(ep)
+                    item.endpoint_status.add(eps)
 
             if item.unsaved_tags:
                 item.tags = item.unsaved_tags

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -69,10 +69,15 @@ def update_import_history(type, active, verified, tags, minimum_severity, endpoi
 
     # tags=tags TODO no tags field in api for reimport it seems
     if endpoints_to_add:
-        import_settings['endpoints'] = str(endpoints_to_add)
+        import_settings['endpoints'] = [str(endpoint) for endpoint in endpoints_to_add]
+
+    print('import_settings')
+    print(import_settings)
 
     test_import = Test_Import(test=test, import_settings=import_settings, version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, type=type)
     test_import.save()
+
+    print('saved!')
 
     test_import_finding_action_list = []
     for finding in closed_findings:

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -71,13 +71,8 @@ def update_import_history(type, active, verified, tags, minimum_severity, endpoi
     if endpoints_to_add:
         import_settings['endpoints'] = [str(endpoint) for endpoint in endpoints_to_add]
 
-    print('import_settings')
-    print(import_settings)
-
     test_import = Test_Import(test=test, import_settings=import_settings, version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, type=type)
     test_import.save()
-
-    print('saved!')
 
     test_import_finding_action_list = []
     for finding in closed_findings:

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -69,7 +69,7 @@ def update_import_history(type, active, verified, tags, minimum_severity, endpoi
 
     # tags=tags TODO no tags field in api for reimport it seems
     if endpoints_to_add:
-        import_settings['endpoints'] = endpoints_to_add
+        import_settings['endpoints'] = str(endpoints_to_add)
 
     test_import = Test_Import(test=test, import_settings=import_settings, version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, type=type)
     test_import.save()

--- a/dojo/unittests/dojo_test_case.py
+++ b/dojo/unittests/dojo_test_case.py
@@ -350,7 +350,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
         # print('test.content: ', response.content)
         return json.loads(response.content)
 
-    def import_scan_with_params(self, filename, scan_type='ZAP Scan', engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None, close_old_findings=False):
+    def import_scan_with_params(self, filename, scan_type='ZAP Scan', engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, endpoint_to_add=None, tags=None, close_old_findings=False):
         payload = {
                 "scan_date": '2020-06-04',
                 "minimum_severity": minimum_severity,
@@ -365,6 +365,9 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
         if push_to_jira is not None:
             payload['push_to_jira'] = push_to_jira
+
+        if endpoint_to_add is not None:
+            payload['endpoint_to_add'] = endpoint_to_add
 
         if tags is not None:
             payload['tags'] = tags

--- a/dojo/unittests/scans/clair/few_vuln.json
+++ b/dojo/unittests/scans/clair/few_vuln.json
@@ -1,0 +1,82 @@
+{
+    "image": "default-docker-3rdparty.bahnhub.tech.rz.db.de:443/ubuntu:bionic-20190912.1",
+    "unapproved": [
+        "CVE-2019-13050",
+        "CVE-2019-5094",
+        "CVE-2018-1000654",
+        "CVE-2016-2781",
+        "CVE-2019-18224",
+        "CVE-2019-12290",
+        "CVE-2018-20482",
+        "CVE-2019-17543",
+        "CVE-2017-8283",
+        "CVE-2019-17594",
+        "CVE-2019-17595",
+        "CVE-2018-7738",
+        "CVE-2016-10228",
+        "CVE-2018-11237",
+        "CVE-2016-10739",
+        "CVE-2019-7309",
+        "CVE-2018-19591",
+        "CVE-2018-20796",
+        "CVE-2019-9192",
+        "CVE-2018-11236",
+        "CVE-2015-8985",
+        "CVE-2019-9169",
+        "CVE-2009-5155",
+        "CVE-2019-13627",
+        "CVE-2019-12904",
+        "CVE-2017-7246",
+        "CVE-2017-7245",
+        "CVE-2017-11164",
+        "CVE-2018-16868",
+        "CVE-2018-16869",
+        "CVE-2018-20839",
+        "CVE-2019-3844",
+        "CVE-2019-3843",
+        "CVE-2013-4235",
+        "CVE-2018-7169"
+    ],
+    "vulnerabilities": [
+        {
+            "featurename": "systemd",
+            "featureversion": "237-3ubuntu10.29",
+            "vulnerability": "CVE-2018-20839",
+            "namespace": "ubuntu:18.04",
+            "description": "systemd 242 changes the VT1 mode upon a logout, which allows attackers to read cleartext passwords in certain circumstances, such as watching a shutdown, or using Ctrl-Alt-F1 and Ctrl-Alt-F2. This occurs because the KDGKBMODE (aka current keyboard mode) check is mishandled.",
+            "link": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839",
+            "severity": "Medium",
+            "fixedby": ""
+        },
+        {
+            "featurename": "e2fsprogs",
+            "featureversion": "1.44.1-1ubuntu1.1",
+            "vulnerability": "CVE-2019-5094",
+            "namespace": "ubuntu:18.04",
+            "description": "An exploitable code execution vulnerability exists in the quota file functionality of E2fsprogs 1.45.3. A specially crafted ext4 partition can cause an out-of-bounds write on the heap, resulting in code execution. An attacker can corrupt a partition to trigger this vulnerability.",
+            "link": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5094",
+            "severity": "Medium",
+            "fixedby": "1.44.1-1ubuntu1.2"
+        },
+        {
+            "featurename": "glibc",
+            "featureversion": "2.27-3ubuntu1",
+            "vulnerability": "CVE-2018-11236",
+            "namespace": "ubuntu:18.04",
+            "description": "stdlib/canonicalize.c in the GNU C Library (aka glibc or libc6) 2.27 and earlier, when processing very long pathname arguments to the realpath function, could encounter an integer overflow on 32-bit architectures, leading to a stack-based buffer overflow and, potentially, arbitrary code execution.",
+            "link": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-11236",
+            "severity": "Medium",
+            "fixedby": ""
+        },
+        {
+            "featurename": "gnupg2",
+            "featureversion": "2.2.4-1ubuntu1.2",
+            "vulnerability": "CVE-2019-13050",
+            "namespace": "ubuntu:18.04",
+            "description": "Interaction between the sks-keyserver code through 1.2.0 of the SKS keyserver network, and GnuPG through 2.2.16, makes it risky to have a GnuPG keyserver configuration line referring to a host on the SKS keyserver network. Retrieving data from this network may cause a persistent denial of service, because of a Certificate Spamming Attack.",
+            "link": "http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-13050",
+            "severity": "Medium",
+            "fixedby": ""
+        }
+    ]
+}

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -1008,7 +1008,7 @@ class ImportReimportMixin(object):
         # imported findings should be active in the engagement
         engagement_findings = Finding.objects.filter(test__engagement_id=1, test__test_type=test.test_type, active=True, is_Mitigated=False)
         self.assertEqual(engagement_findings.count(), 24)
-        
+
         # findings should have only one endpoint, added with endpoint_to_add
         for finding in engagement_findings:
             self.assertEqual(finding.endpoints.count(), 1)

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -1084,7 +1084,7 @@ class ImportReimportTestUI(DojoAPITestCase, ImportReimportMixin):
         test = Test.objects.get(id=response.url.split('/')[-1])
         return {'test': test.id}
 
-    def import_scan_with_params_ui(self, filename, scan_type='ZAP Scan', engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, tags=None, close_old_findings=False):
+    def import_scan_with_params_ui(self, filename, scan_type='ZAP Scan', engagement=1, minimum_severity='Low', active=True, verified=True, push_to_jira=None, endpoint_to_add=None, tags=None, close_old_findings=False):
         payload = {
                 "scan_date": '2020-06-04',
                 "minimum_severity": minimum_severity,
@@ -1099,6 +1099,9 @@ class ImportReimportTestUI(DojoAPITestCase, ImportReimportMixin):
 
         if push_to_jira is not None:
             payload['push_to_jira'] = push_to_jira
+
+        if endpoint_to_add is not None:
+            payload['endpoint_to_add'] = endpoint_to_add
 
         if tags is not None:
             payload['tags'] = tags

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -66,7 +66,7 @@ class ImportReimportMixin(object):
         self.veracode_different_hash_code_different_unique_id = self.scans_path + 'veracode/many_findings_different_hash_code_different_unique_id.xml'
         self.scan_type_veracode = 'Veracode Scan'
 
-        self.clair_many_findings = self.scans_path + 'clair/many_vul.json'
+        self.clair_few_findings = self.scans_path + 'clair/few_vuln.json'
         self.clair_empty = self.scans_path + 'clair/empty.json'
         self.scan_type_clair = 'Clair Scan'
 
@@ -995,19 +995,19 @@ class ImportReimportMixin(object):
     # close_old_findings functionality: secony (empty) import should close all findings from the first import
     def test_import_param_close_old_findings_with_additional_endpoint(self):
         logger.debug('importing clair report with additional endpoint')
-        with assertTestImportModelsCreated(self, imports=1, affected_findings=24, created=24):
-            import0 = self.import_scan_with_params(self.clair_many_findings, scan_type=self.scan_type_clair, close_old_findings=True, endpoint_to_add=1)
+        with assertTestImportModelsCreated(self, imports=1, affected_findings=4, created=4):
+            import0 = self.import_scan_with_params(self.clair_few_findings, scan_type=self.scan_type_clair, close_old_findings=True, endpoint_to_add=1)
 
         test_id = import0['test']
         test = self.get_test(test_id)
         findings = self.get_test_findings_api(test_id)
         self.log_finding_summary_json_api(findings)
         # imported count must match count in the report
-        self.assert_finding_count_json(24, findings)
+        self.assert_finding_count_json(4, findings)
 
         # imported findings should be active in the engagement
         engagement_findings = Finding.objects.filter(test__engagement_id=1, test__test_type=test.test_type, active=True, is_Mitigated=False)
-        self.assertEqual(engagement_findings.count(), 24)
+        self.assertEqual(engagement_findings.count(), 4)
 
         # findings should have only one endpoint, added with endpoint_to_add
         for finding in engagement_findings:
@@ -1015,7 +1015,7 @@ class ImportReimportMixin(object):
             self.assertEqual(finding.endpoints.first().id, 1)
 
         # reimport exact same report
-        with assertTestImportModelsCreated(self, imports=1, affected_findings=24, closed=24):
+        with assertTestImportModelsCreated(self, imports=1, affected_findings=4, closed=4):
             self.import_scan_with_params(self.clair_empty, scan_type=self.scan_type_clair, close_old_findings=True, endpoint_to_add=1)
 
         # all findings from import0 should be closed now

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -1067,6 +1067,10 @@ class ImportReimportTestUI(DojoAPITestCase, ImportReimportMixin):
 
     def import_scan_ui(self, engagement, payload):
         logger.debug('import_scan payload %s', payload)
+        # if 'endpoint_to_add' in payload:
+        #     payload['endpoints'] = payload['endpoint_to_add']
+        #     del payload['endpoint_to_add']
+
         # response = self.client_ui.post(reverse('import_scan_results', args=(engagement, )), urlencode(payload), content_type='application/x-www-form-urlencoded')
         response = self.client_ui.post(reverse('import_scan_results', args=(engagement, )), payload)
         # print(vars(response))
@@ -1094,14 +1098,14 @@ class ImportReimportTestUI(DojoAPITestCase, ImportReimportMixin):
                 "file": open(filename),
                 "environment": 1,
                 "version": "1.0.1",
-                # "close_old_findings": close_old_findings,
+                "close_old_findings": close_old_findings,
         }
 
         if push_to_jira is not None:
             payload['push_to_jira'] = push_to_jira
 
         if endpoint_to_add is not None:
-            payload['endpoint_to_add'] = endpoint_to_add
+            payload['endpoints'] = [endpoint_to_add]
 
         if tags is not None:
             payload['tags'] = tags

--- a/dojo/unittests/test_import_reimport.py
+++ b/dojo/unittests/test_import_reimport.py
@@ -1,5 +1,5 @@
 from django.urls import reverse
-from dojo.models import User, Test
+from dojo.models import User, Test, Finding
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 from django.test.client import Client
@@ -65,6 +65,10 @@ class ImportReimportMixin(object):
         self.veracode_same_unique_id_different_hash_code = self.scans_path + 'veracode/many_findings_same_unique_id_different_hash_code.xml'
         self.veracode_different_hash_code_different_unique_id = self.scans_path + 'veracode/many_findings_different_hash_code_different_unique_id.xml'
         self.scan_type_veracode = 'Veracode Scan'
+
+        self.clair_many_findings = self.scans_path + 'clair/many_vul.json'
+        self.clair_empty = self.scans_path + 'clair/empty.json'
+        self.scan_type_clair = 'Clair Scan'
 
     # import zap scan, testing:
     # - import
@@ -985,6 +989,31 @@ class ImportReimportMixin(object):
                 count = count + 1
 
         self.assertEqual(5, count)
+
+    # currenty break when using the parameter endpoint_to_add
+    def test_import_param_close_old_findings_with_additional_endpoint(self):
+        logger.debug('importing clair report with additional endpoint')
+        with assertTestImportModelsCreated(self, imports=1, affected_findings=24, created=24):
+            import0 = self.import_scan_with_params(self.clair_many_findings, scan_type=self.scan_type_clair, close_old_findings=True, endpoint_to_add=1)
+
+        test_id = import0['test']
+        test = self.get_test(test_id)
+        findings = self.get_test_findings_api(test_id)
+        self.log_finding_summary_json_api(findings)
+        # imported count must match count in the report
+        self.assert_finding_count_json(24, findings)
+
+        # imported findings should be active in the engagement
+        engagement_findings_count = Finding.objects.filter(test__engagement_id=1, test__test_type=test.test_type, active=True, is_Mitigated=False).count()
+        self.assertEqual(engagement_findings_count, 24)
+
+        # reimport exact same report
+        with assertTestImportModelsCreated(self, imports=1, affected_findings=24, closed=24):
+            self.import_scan_with_params(self.clair_empty, scan_type=self.scan_type_clair, close_old_findings=True, endpoint_to_add=1)
+
+        # all findings from import0 should be closed now
+        engagement_findings_count = Finding.objects.filter(test__engagement_id=1, test__test_type=test.test_type, active=True, is_Mitigated=False).count()
+        self.assertEqual(engagement_findings_count, 0)
 
 
 @override_settings(TRACK_IMPORT_HISTORY=True)


### PR DESCRIPTION
A server error occurs when importing a scan in the apiv2 with the parameter endpoint_to_add and TRACK_IMPORT_HISTORY=True. 

This PR adds a test which (currently) breaks.

---
On behalf of DB Systel GmbH