### PR TITLE
[Gitlab SAST parser] Fixes missing severity error

### DIFF
--- a/dojo/tools/gitlab_sast/parser.py
+++ b/dojo/tools/gitlab_sast/parser.py
@@ -90,8 +90,8 @@ def get_item(vuln, test):
     elif 'method' in location:
         sast_object = location['method']
 
-    severity = vuln['severity']
-    if severity == 'Undefined' or severity == 'Unknown':
+    severity = vuln.get('severity')
+    if severity is None or severity == 'Undefined' or severity == 'Unknown':
         # Severity can be "Undefined" or "Unknown" in SAST report
         # In that case we set it as Info and specify the initial severity in the title
         title = '[{} severity] {}'.format(severity, title)

--- a/dojo/unittests/scans/gitlab_sast/gl-sast-report_issue4344.json
+++ b/dojo/unittests/scans/gitlab_sast/gl-sast-report_issue4344.json
@@ -1,0 +1,44 @@
+{
+  "version": "14.0.0",
+  "vulnerabilities": [
+    {
+      "id": "38646099571534a07b62ae42b37fb3640d620c48d561456fb3ecdf929b9e5933",
+      "category": "sast",
+      "name": "Potential XSS vulnerability",
+      "message": "Potential XSS vulnerability",
+      "cve": "XXXX.aspx.cs:98:SCS0029",
+      "scanner": {
+        "id": "security_code_scan",
+        "name": "Security Code Scan"
+      },
+      "location": {
+        "file": "XXXXX.aspx.cs",
+        "start_line": 98
+      },
+      "identifiers": [
+        {
+          "type": "security_code_scan_rule_id",
+          "name": "SCS0029",
+          "value": "SCS0029",
+          "url": "https://security-code-scan.github.io/#SCS0029"
+        }
+      ]
+    }
+  ],
+  "remediations": [],
+  "scan": {
+    "scanner": {
+      "id": "security_code_scan",
+      "name": "Security Code Scan",
+      "url": "https://security-code-scan.github.io",
+      "vendor": {
+        "name": "GitLab"
+      },
+      "version": "3.5.3"
+    },
+    "type": "sast",
+    "start_time": "2021-04-22T09:32:27",
+    "end_time": "2021-04-22T09:33:29",
+    "status": "success"
+  }
+}

--- a/dojo/unittests/tools/test_gitlab_sast_parser.py
+++ b/dojo/unittests/tools/test_gitlab_sast_parser.py
@@ -16,6 +16,9 @@ class TestGitlabSastParser(TestCase):
         parser = GitlabSastParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
+        finding = findings[0]
+        self.assertEqual("Password in URL", finding.title)
+        self.assertEqual("Critical", finding.severity)
 
     def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
         testfile = open(
@@ -23,7 +26,16 @@ class TestGitlabSastParser(TestCase):
         )
         parser = GitlabSastParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) > 2)
+        self.assertTrue(3, len(findings))
+        finding = findings[0]
+        self.assertEqual("Password in URL", finding.title)
+        self.assertEqual("Critical", finding.severity)
+        finding = findings[1]
+        self.assertEqual("Password in URL", finding.title)
+        self.assertEqual("Critical", finding.severity)
+        finding = findings[2]
+        self.assertEqual("PKCS8 key", finding.title)
+        self.assertEqual("Critical", finding.severity)
 
     def test_parse_file_with_various_confidences(self):
         testfile = open(
@@ -32,13 +44,18 @@ class TestGitlabSastParser(TestCase):
         parser = GitlabSastParser()
         findings = parser.get_findings(testfile, Test())
         self.assertTrue(len(findings) == 8)
-        i = 0
         for item in findings:
             self.assertTrue(item.cwe is None or isinstance(item.cwe, int))
-            self.assertEqual(
-                item.get_scanner_confidence_text(), get_confidence_defectdojo(i)
-            )
-            i = i + 1
+        finding = findings[3]
+        self.assertEqual("Tentative", finding.get_scanner_confidence_text())
+        finding = findings[4]
+        self.assertEqual("Tentative", finding.get_scanner_confidence_text())
+        finding = findings[5]
+        self.assertEqual("Firm", finding.get_scanner_confidence_text())
+        finding = findings[6]
+        self.assertEqual("Firm", finding.get_scanner_confidence_text())
+        finding = findings[7]
+        self.assertEqual("Certain", finding.get_scanner_confidence_text())
 
     def test_parse_file_with_various_cwes(self):
         testfile = open("dojo/unittests/scans/gitlab_sast/gl-sast-report-cwe.json")
@@ -49,16 +66,10 @@ class TestGitlabSastParser(TestCase):
         self.assertEqual(89, findings[1].cwe)
         self.assertEqual(None, findings[2].cwe)
 
-
-def get_confidence_defectdojo(argument):
-    switcher = {
-        0: "",
-        1: "",
-        2: "",
-        3: "Tentative",
-        4: "Tentative",
-        5: "Firm",
-        6: "Firm",
-        7: "Certain",
-    }
-    return switcher.get(argument, None)
+    def test_parse_file_issue4336(self):
+        testfile = open("dojo/unittests/scans/gitlab_sast/gl-sast-report_issue4344.json")
+        parser = GitlabSastParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+        finding = findings[0]
+        self.assertEqual("[None severity] Potential XSS vulnerability", finding.title)


### PR DESCRIPTION
One attribute is missing 'severity'
Fixes #4344 