### PR TITLE
Re-import fix "Finding has not test" exception

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -58,6 +58,9 @@ class DojoDefaultReImporter(object):
             component_name = item.component_name if hasattr(item, 'component_name') else None
             component_version = item.component_version if hasattr(item, 'component_version') else None
 
+            if not hasattr(item, 'test'):
+                item.test = test
+
             item.hash_code = item.compute_hash_code()
             deduplicationLogger.debug("item's hash_code: %s", item.hash_code)
 
@@ -113,7 +116,6 @@ class DojoDefaultReImporter(object):
                     update_endpoint_status(finding, item, user)
             else:
                 # no existing finding found
-                item.test = test
                 item.reporter = user
                 item.last_reviewed = timezone.now()
                 item.last_reviewed_by = user


### PR DESCRIPTION
When re-importing, the hashcode of a finding is computed before it is compared with other findings. The test type is used in this hashcode. Some parsers, such as Qualys WebApp, do not supply the test to each finding object it creates. This results in the following exception:

`dojo.models.Finding.test.RelatedObjectDoesNotExist: Finding has no test.`

to combat this, check for a test object before computing the hash code, and if it does not exist, add the test to the finding. This step was initially done if a new finding was actually created if another finding did not match the new one, but moving that step a bit further up does not change anything.