### PR TITLE
[Nikto parser] Fix severity and add more unit tests

### DIFF
--- a/dojo/tools/nikto/parser.py
+++ b/dojo/tools/nikto/parser.py
@@ -1,12 +1,11 @@
 
 import hashlib
+import json
 import logging
 import re
+
 import hyperlink
-import json
-
 from defusedxml import ElementTree as ET
-
 from dojo.models import Endpoint, Finding
 
 logger = logging.getLogger(__name__)
@@ -109,7 +108,7 @@ class NiktoParser(object):
         for item in scan.findall('item'):
             # Title
             titleText = None
-            description = item.find("description").text
+            description = item.findtext("description")
             # Cut the title down to the first sentence
             sentences = re.split(
                 r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s', description)
@@ -118,47 +117,50 @@ class NiktoParser(object):
             else:
                 titleText = description[:900]
 
-            # Url
-            ip = item.find("iplink").text
-            # Remove the port numbers for 80/443
-            ip = ip.replace(r":['80']{2}\/?$", "")
-            ip = ip.replace(r":['443']{3}\/?$", "")
-
-            # Severity
-            severity = "Info"  # Nikto doesn't assign severity, default to Info
-
             # Description
             description = "\n".join([
-                    f"**Host:** `{ip}`",
-                    f"**Description:** `{item.find('description').text}`",
-                    f"**HTTP Method:** `{item.attrib['method']}`",
+                    f"**Host:** `{item.findtext('iplink')}`",
+                    f"**Description:** `{item.findtext('description')}`",
+                    f"**HTTP Method:** `{item.attrib.get('method')}`",
             ])
 
-            url = hyperlink.parse(ip)
-            endpoint = Endpoint(
-                protocol=url.scheme,
-                host=url.host,
-                port=url.port,
-                path="/".join(url.path),
+            # Manage severity the same way with JSON
+            severity = "Info"  # Nikto doesn't assign severity, default to Info
+            if item.get('osvdbid') is not None and "0" != item.get('osvdbid'):
+                severity = "Medium"
+
+            finding = Finding(
+                title=titleText,
+                test=test,
+                description=description,
+                severity=severity,
+                dynamic_finding=True,
+                static_finding=False,
+                vuln_id_from_tool=item.attrib.get('id'),
+                nb_occurences=1,
             )
+
+            # endpoint
+            try:
+                ip = item.findtext("iplink")
+                url = hyperlink.parse(ip)
+                endpoint = Endpoint(
+                    protocol=url.scheme,
+                    host=url.host,
+                    port=url.port,
+                    path="/".join(url.path),
+                )
+                finding.unsaved_endpoints = [endpoint]
+            except ValueError as exce:
+                logger.warn("Invalid iplink in the report")
 
             dupe_key = hashlib.sha256(description.encode("utf-8")).hexdigest()
 
             if dupe_key in dupes:
-                finding = dupes[dupe_key]
-                if finding.description:
-                    finding.description = finding.description + "\nHost:" + ip + "\n" + description
-                finding.unsaved_endpoints.append(endpoint)
-                finding.nb_occurences += 1
+                find = dupes[dupe_key]
+                find.description += "\n-----\n" + finding.description
+                find.unsaved_endpoints.extend(finding.unsaved_endpoints)
+                find.nb_occurences += 1
 
             else:
-                finding = Finding(title=titleText,
-                                    test=test,
-                                    description=description,
-                                    severity=severity,
-                                    dynamic_finding=True,
-                                    nb_occurences=1,
-                                  )
-                finding.unsaved_endpoints = [endpoint]
-
                 dupes[dupe_key] = finding

--- a/dojo/unittests/scans/nikto/nikto-output.xml
+++ b/dojo/unittests/scans/nikto/nikto-output.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" ?>
+<!DOCTYPE niktoscan SYSTEM "/usr/share/doc/nikto/nikto.dtd">
+<niktoscan hoststest="0" options="-h 127.0.0.1 -p 8070 -output nikto-output.xml" version="2.1.5" scanstart="Mon Nov 16 03:45:06 2020" scanend="Wed Dec 31 19:00:00 1969" scanelapsed=" seconds" nxmlversion="1.2">
+
+<scandetails targetip="127.0.0.1" targethostname="localhost" targetport="8070" targetbanner="" starttime="2020-11-16 03:45:07" sitename="http://localhost:8070" siteip="http://127.0.0.1:8070" hostheader="localhost" errors="0" checks="6544">
+
+
+<item id="999976" osvdbid="0" osvdblink="http://osvdb.org/0" method="GET">
+<description><![CDATA[The anti-clickjacking X-Frame-Options header is not present.]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[http://localhost:8070/]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/]]></iplink>
+</item>
+
+<item id="999984" osvdbid="0" osvdblink="http://osvdb.org/0" method="GET">
+<description><![CDATA[Server leaks inodes via ETags, header found with file /favicon.ico, fields: 0xW/21630 0x1602011686000 ]]></description>
+<uri><![CDATA[/favicon.ico]]></uri>
+<namelink><![CDATA[http://localhost:8070/favicon.ico]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/favicon.ico]]></iplink>
+</item>
+
+<item id="500008" osvdbid="39272" osvdblink="http://osvdb.org/39272" method="GET">
+<description><![CDATA[favicon.ico file identifies this server as: Apache Tomcat]]></description>
+<uri><![CDATA[/favicon.ico]]></uri>
+<namelink><![CDATA[]]></namelink>
+<iplink><![CDATA[http://:/favicon.ico]]></iplink>
+</item>
+
+<item id="999990" osvdbid="0" osvdblink="http://osvdb.org/0" method="OPTIONS">
+<description><![CDATA[Allowed HTTP Methods: GET, HEAD, POST, PUT, DELETE, OPTIONS ]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[http://localhost:8070/]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/]]></iplink>
+</item>
+
+<item id="999978" osvdbid="397" osvdblink="http://osvdb.org/397" method="GET">
+<description><![CDATA[HTTP method ('Allow' Header): 'PUT' method could allow clients to save files on the web server.]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[http://localhost:8070/]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/]]></iplink>
+</item>
+
+<item id="999976" osvdbid="5646" osvdblink="http://osvdb.org/5646" method="GET">
+<description><![CDATA[HTTP method ('Allow' Header): 'DELETE' may allow clients to remove files on the web server.]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[http://localhost:8070/]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/]]></iplink>
+</item>
+
+<item id="000366" osvdbid="0" osvdblink="http://osvdb.org/0" method="GET">
+<description><![CDATA[/examples/servlets/index.html: Apache Tomcat default JSP pages present.]]></description>
+<uri><![CDATA[/examples/servlets/index.html]]></uri>
+<namelink><![CDATA[http://localhost:8070/examples/servlets/index.html]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/examples/servlets/index.html]]></iplink>
+</item>
+
+<item id="000834" osvdbid="3931" osvdblink="http://osvdb.org/3931" method="GET">
+<description><![CDATA[/myphpnuke/links.php?op=MostPopular&ratenum=[script]alert(document.cookie);[/script]&ratetype=percent: myphpnuke is vulnerable to Cross Site Scripting (XSS). CA-2000-02.]]></description>
+<uri><![CDATA[/myphpnuke/links.php?op=MostPopular&ratenum=[script]alert(document.cookie);[/script]&ratetype=percent]]></uri>
+<namelink><![CDATA[http://localhost:8070/myphpnuke/links.php?op=MostPopular&ratenum=[script]alert(document.cookie);[/script]&ratetype=percent]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/myphpnuke/links.php?op=MostPopular&ratenum=[script]alert(document.cookie);[/script]&ratetype=percent]]></iplink>
+</item>
+
+<item id="000863" osvdbid="4598" osvdblink="http://osvdb.org/4598" method="GET">
+<description><![CDATA[/members.asp?SF=%22;}alert(223344);function%20x(){v%20=%22: Web Wiz Forums ver. 7.01 and below is vulnerable to Cross Site Scripting (XSS). CA-2000-02.]]></description>
+<uri><![CDATA[/members.asp?SF=%22;}alert(223344);function%20x(){v%20=%22]]></uri>
+<namelink><![CDATA[http://localhost:8070/members.asp?SF=%22;}alert(223344);function%20x(){v%20=%22]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/members.asp?SF=%22;}alert(223344);function%20x(){v%20=%22]]></iplink>
+</item>
+
+<item id="000888" osvdbid="2946" osvdblink="http://osvdb.org/2946" method="GET">
+<description><![CDATA[/forum_members.asp?find=%22;}alert(9823);function%20x(){v%20=%22: Web Wiz Forums ver. 7.01 and below is vulnerable to Cross Site Scripting (XSS). CA-2000-02.]]></description>
+<uri><![CDATA[/forum_members.asp?find=%22;}alert(9823);function%20x(){v%20=%22]]></uri>
+<namelink><![CDATA[http://localhost:8070/forum_members.asp?find=%22;}alert(9823);function%20x(){v%20=%22]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/forum_members.asp?find=%22;}alert(9823);function%20x(){v%20=%22]]></iplink>
+</item>
+
+<item id="999960" osvdbid="0" osvdblink="http://osvdb.org/0" method="GET">
+<description><![CDATA[Cookie JSESSIONID created without the httponly flag]]></description>
+<uri><![CDATA[/examples/jsp/snp/snoop.jsp]]></uri>
+<namelink><![CDATA[http://localhost:8070/examples/jsp/snp/snoop.jsp]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/examples/jsp/snp/snoop.jsp]]></iplink>
+</item>
+
+<item id="001355" osvdbid="3720" osvdblink="http://osvdb.org/3720" method="GET">
+<description><![CDATA[/examples/jsp/snp/snoop.jsp: Displays information about page retrievals, including other users.]]></description>
+<uri><![CDATA[/examples/jsp/snp/snoop.jsp]]></uri>
+<namelink><![CDATA[http://localhost:8070/examples/jsp/snp/snoop.jsp]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/examples/jsp/snp/snoop.jsp]]></iplink>
+</item>
+
+<item id="006525" osvdbid="0" osvdblink="http://osvdb.org/0" method="GET">
+<description><![CDATA[/manager/html: Default Tomcat Manager interface found]]></description>
+<uri><![CDATA[/manager/html]]></uri>
+<namelink><![CDATA[http://localhost:8070/manager/html]]></namelink>
+<iplink><![CDATA[http://127.0.0.1:8070/manager/html]]></iplink>
+</item>
+
+<statistics elapsed="37" itemsfound="12" itemstested="6544" endtime="2020-11-16 03:45:44" />
+</scandetails>
+
+
+</niktoscan>

--- a/dojo/unittests/scans/nikto/tdh.json
+++ b/dojo/unittests/scans/nikto/tdh.json
@@ -1,0 +1,64 @@
+{
+    "host": "www.tdh.com",
+    "ip": "64.220.43.153",
+    "port": "443",
+    "banner": "nginx",
+    "vulnerabilities": [
+        {
+            "id": "999100",
+            "OSVDB": "0",
+            "method": "GET",
+            "url": "/",
+            "msg": "Uncommon header 'x-cacheable' found, with contents: YES"
+        },
+        {
+            "id": "999100",
+            "OSVDB": "0",
+            "method": "GET",
+            "url": "/",
+            "msg": "Uncommon header 'x-cache' found, with contents: HIT"
+        },
+        {
+            "id": "999100",
+            "OSVDB": "0",
+            "method": "GET",
+            "url": "/tldH5dDP.",
+            "msg": "Uncommon header 'x-redirect-by' found, with contents: WordPress"
+        },
+        {
+            "id": "999997",
+            "OSVDB": "0",
+            "method": "GET",
+            "url": "/wp-admin/",
+            "msg": "Entry '/wp-admin/' in robots.txt returned a non-forbidden or redirect HTTP code (302)"
+        },
+        {
+            "id": "999996",
+            "OSVDB": "0",
+            "method": "GET",
+            "url": "/robots.txt",
+            "msg": "\"robots.txt\" contains 2 entries which should be manually viewed."
+        },
+        {
+            "id": "999966",
+            "OSVDB": "0",
+            "method": "GET",
+            "url": "/",
+            "msg": "The Content-Encoding header is set to \"deflate\" this may mean that the server is vulnerable to the BREACH attack."
+        },
+        {
+            "id": "999967",
+            "OSVDB": "0",
+            "method": "SOWBGYUF",
+            "url": "/",
+            "msg": "Web Server returns a valid response with junk HTTP methods, this may cause false positives."
+        },
+        {
+            "id": "700007",
+            "OSVDB": "0",
+            "method": "GET",
+            "url": "/status",
+            "msg": "Default account found for 'Restricted' at /status (ID '', PW 'cisco'). Cisco device."
+        }
+    ]
+}

--- a/dojo/unittests/scans/nikto/tdh.xml
+++ b/dojo/unittests/scans/nikto/tdh.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" ?>
+<!DOCTYPE niktoscan SYSTEM "docs/nikto.dtd">
+<niktoscan>
+<niktoscan hoststest="0" options="-h https://www.tdh.com -o /tmp/tdh.xml" version="2.1.6" scanstart="Mon Apr 26 08:33:14 2021" scanend="Thu Jan  1 00:00:00 1970" scanelapsed=" seconds" nxmlversion="1.2">
+
+<scandetails targetip="64.220.43.153" targethostname="www.tdh.com" targetport="443" targetbanner="nginx" starttime="2021-04-26 08:33:16" sitename="https://www.tdh.com:443/" siteip="https://64.220.43.153:443/" hostheader="www.tdh.com" errors="0" checks="6955">
+<ssl ciphers="TLS_AES_128_GCM_SHA256" issuers="/C=GB/ST=Greater Manchester/L=Salford/O=Sectigo Limited/CN=Sectigo RSA Domain Validation Secure Server CA" info="/CN=tdh.com" altnames="tdh.com, www.tdh.com" />
+
+<item id="999100" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Uncommon header 'x-cache' found, with contents: HIT]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://www.tdh.com:443/]]></namelink>
+<iplink><![CDATA[https://64.220.43.153:443/]]></iplink>
+</item>
+
+<item id="999100" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Uncommon header 'x-cacheable' found, with contents: YES]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://www.tdh.com:443/]]></namelink>
+<iplink><![CDATA[https://64.220.43.153:443/]]></iplink>
+</item>
+
+<item id="999100" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Uncommon header 'x-redirect-by' found, with contents: WordPress]]></description>
+<uri><![CDATA[/iqeVqbOU.]]></uri>
+<namelink><![CDATA[https://www.tdh.com:443/iqeVqbOU.]]></namelink>
+<iplink><![CDATA[https://64.220.43.153:443/iqeVqbOU.]]></iplink>
+</item>
+
+<item id="999997" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[Entry '/wp-admin/' in robots.txt returned a non-forbidden or redirect HTTP code (302)]]></description>
+<uri><![CDATA[/wp-admin/]]></uri>
+<namelink><![CDATA[https://www.tdh.com:443/wp-admin/]]></namelink>
+<iplink><![CDATA[https://64.220.43.153:443/wp-admin/]]></iplink>
+</item>
+
+<item id="999996" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA["robots.txt" contains 2 entries which should be manually viewed.]]></description>
+<uri><![CDATA[/robots.txt]]></uri>
+<namelink><![CDATA[https://www.tdh.com:443/robots.txt]]></namelink>
+<iplink><![CDATA[https://64.220.43.153:443/robots.txt]]></iplink>
+</item>
+
+<item id="999966" osvdbid="0" osvdblink="" method="GET">
+<description><![CDATA[The Content-Encoding header is set to "deflate" this may mean that the server is vulnerable to the BREACH attack.]]></description>
+<uri><![CDATA[/]]></uri>
+<namelink><![CDATA[https://www.tdh.com:443/]]></namelink>
+<iplink><![CDATA[https://64.220.43.153:443/]]></iplink>
+</item>
+
+<statistics elapsed="1619427130" itemsfound="" itemstested="6955" endtime="2021-04-26 08:52:10" />
+</scandetails>
+
+</niktoscan>
+
+
+</niktoscan>

--- a/dojo/unittests/tools/test_nikto_parser.py
+++ b/dojo/unittests/tools/test_nikto_parser.py
@@ -121,20 +121,9 @@ class TestNiktoParser(TestCase):
         testfile = open("dojo/unittests/scans/nikto/tdh.xml")
         parser = NiktoParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertEqual(8, len(findings))
+        self.assertEqual(6, len(findings))
         with self.subTest(i=0):
             finding = findings[0]
-            self.assertEqual("Uncommon header 'x-cacheable' found, with contents: YES", finding.title)
-            self.assertEqual("999100", finding.vuln_id_from_tool)
-            self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual("Info", finding.severity)
-            self.assertEqual(1, len(finding.unsaved_endpoints))
-            endpoint = finding.unsaved_endpoints[0]
-            self.assertEqual(443, endpoint.port)
-            self.assertEqual("www.tdh.com", endpoint.host)
-            self.assertEqual("/", endpoint.path)
-        with self.subTest(i=1):
-            finding = findings[1]
             self.assertEqual("Uncommon header 'x-cache' found, with contents: HIT", finding.title)
             self.assertEqual("999100", finding.vuln_id_from_tool)
             self.assertEqual(1, finding.nb_occurences)
@@ -142,5 +131,27 @@ class TestNiktoParser(TestCase):
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
             self.assertEqual(443, endpoint.port)
-            self.assertEqual("www.tdh.com", endpoint.host)
-            self.assertEqual("/", endpoint.path)
+            self.assertEqual("64.220.43.153", endpoint.host)
+            self.assertEqual("", endpoint.path)
+        with self.subTest(i=1):
+            finding = findings[1]
+            self.assertEqual("Uncommon header 'x-cacheable' found, with contents: YES", finding.title)
+            self.assertEqual("999100", finding.vuln_id_from_tool)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual(1, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            self.assertEqual(443, endpoint.port)
+            self.assertEqual("64.220.43.153", endpoint.host)
+            self.assertEqual("", endpoint.path)
+        with self.subTest(i=5):
+            finding = findings[5]
+            self.assertEqual("The Content-Encoding header is set to \"deflate\" this may mean that the server is vulnerable to the BREACH attack.", finding.title)
+            self.assertEqual("999966", finding.vuln_id_from_tool)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual(1, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            self.assertEqual(443, endpoint.port)
+            self.assertEqual("64.220.43.153", endpoint.host)
+            self.assertEqual("", endpoint.path)

--- a/dojo/unittests/tools/test_nikto_parser.py
+++ b/dojo/unittests/tools/test_nikto_parser.py
@@ -62,3 +62,85 @@ class TestNiktoParser(TestCase):
             if ("Potentially Interesting Backup/Cert File Found. " == finding.title and
                     "Info" == finding.severity):
                 self.assertEqual(140, len(finding.unsaved_endpoints))
+
+    def test_parse_file_json_with_uri_errors(self):
+        testfile = open("dojo/unittests/scans/nikto/nikto-output.xml")
+        parser = NiktoParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(13, len(findings))
+        for finding in findings:
+            if "favicon.ico file identifies this server as: Apache Tomcat" == finding.title:
+                self.assertEqual("500008", finding.vuln_id_from_tool)
+                self.assertEqual(1, finding.nb_occurences)
+                self.assertEqual("Medium", finding.severity)
+                # this one as error in URL
+                # self.assertEqual(1, len(finding.unsaved_endpoints))
+                # endpoint = finding.unsaved_endpoints[0]
+                # self.assertEqual(443, endpoint.port)
+                # self.assertEqual("juice-shop.herokuapp.com", endpoint.host)
+                # self.assertEqual("/public/", endpoint.path)
+            elif "/examples/servlets/index.html: Apache Tomcat default JSP pages present." == finding.title:
+                self.assertEqual("000366", finding.vuln_id_from_tool)
+                self.assertEqual(1, finding.nb_occurences)
+                self.assertEqual("Info", finding.severity)
+                self.assertEqual(1, len(finding.unsaved_endpoints))
+                endpoint = finding.unsaved_endpoints[0]
+                self.assertEqual(8070, endpoint.port)
+                self.assertEqual("127.0.0.1", endpoint.host)
+                self.assertEqual("examples/servlets/index.html", endpoint.path)
+
+    def test_parse_file_json_another(self):
+        testfile = open("dojo/unittests/scans/nikto/tdh.json")
+        parser = NiktoParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(8, len(findings))
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual("Uncommon header 'x-cacheable' found, with contents: YES", finding.title)
+            self.assertEqual("999100", finding.vuln_id_from_tool)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual(1, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            self.assertEqual(443, endpoint.port)
+            self.assertEqual("www.tdh.com", endpoint.host)
+            self.assertEqual("/", endpoint.path)
+        with self.subTest(i=1):
+            finding = findings[1]
+            self.assertEqual("Uncommon header 'x-cache' found, with contents: HIT", finding.title)
+            self.assertEqual("999100", finding.vuln_id_from_tool)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual(1, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            self.assertEqual(443, endpoint.port)
+            self.assertEqual("www.tdh.com", endpoint.host)
+            self.assertEqual("/", endpoint.path)
+
+    def test_parse_file_xml_another(self):
+        testfile = open("dojo/unittests/scans/nikto/tdh.xml")
+        parser = NiktoParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(8, len(findings))
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual("Uncommon header 'x-cacheable' found, with contents: YES", finding.title)
+            self.assertEqual("999100", finding.vuln_id_from_tool)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual(1, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            self.assertEqual(443, endpoint.port)
+            self.assertEqual("www.tdh.com", endpoint.host)
+            self.assertEqual("/", endpoint.path)
+        with self.subTest(i=1):
+            finding = findings[1]
+            self.assertEqual("Uncommon header 'x-cache' found, with contents: HIT", finding.title)
+            self.assertEqual("999100", finding.vuln_id_from_tool)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual(1, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            self.assertEqual(443, endpoint.port)
+            self.assertEqual("www.tdh.com", endpoint.host)
+            self.assertEqual("/", endpoint.path)


### PR DESCRIPTION
## Work done
- [x] Sometimes Nikto generate report with not well formatted URLs, this pull request improve robustness of Nikto parser to ignore these broken URLs. See: https://github.com/DefectDojo/django-DefectDojo/issues/3268
- [x] The parser read reports in JSON and XML format but severity was not managed the same way. I modified the XML function to do the same thing as the JSON one.
- [x] add more unit tests and reports

Also fixes #3268 .