### PR TITLE
Bump python to 3.7

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c as build
+FROM python:3.7.10-slim-buster@sha256:013b24591a793efde7b6987372c66a24ab8f777c86df0919a91e6813f43a6724 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \
@@ -25,7 +25,7 @@ RUN \
 COPY requirements.txt ./
 RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c
+FROM python:3.7.10-slim-buster@sha256:013b24591a793efde7b6987372c66a24ab8f777c86df0919a91e6813f43a6724
 WORKDIR /app
 ARG uid=1001
 ARG appuser=defectdojo

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -1,7 +1,7 @@
 
 # code: language=Dockerfile
 
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c as build
+FROM python:3.7.10-slim-buster@sha256:013b24591a793efde7b6987372c66a24ab8f777c86df0919a91e6813f43a6724 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -3,7 +3,7 @@
 # The code for the build image should be identical with the code in
 # Dockerfile.django to use the caching mechanism of Docker.
 
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c as build
+FROM python:3.7.10-slim-buster@sha256:013b24591a793efde7b6987372c66a24ab8f777c86df0919a91e6813f43a6724 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \


### PR DESCRIPTION
It's time to update Python to at least 3.7, see more discussions in #4359.