### PR TITLE
Bump python to 3.8

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c as build
+FROM python:3.8.9-slim-buster@sha256:5d9e29ce2be0f6b0939691ac1331c4a42a2678d13c918a8eba00698449209ef1 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \
@@ -25,7 +25,7 @@ RUN \
 COPY requirements.txt ./
 RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c
+FROM python:3.8.9-slim-buster@sha256:5d9e29ce2be0f6b0939691ac1331c4a42a2678d13c918a8eba00698449209ef1
 WORKDIR /app
 ARG uid=1001
 ARG appuser=defectdojo

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -1,7 +1,7 @@
 
 # code: language=Dockerfile
 
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c as build
+FROM python:3.8.9-slim-buster@sha256:5d9e29ce2be0f6b0939691ac1331c4a42a2678d13c918a8eba00698449209ef1 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -3,7 +3,7 @@
 # The code for the build image should be identical with the code in
 # Dockerfile.django to use the caching mechanism of Docker.
 
-FROM python:3.6.12-slim-buster@sha256:e5259113df5a7c4dae16ad37c2ca53b1cf722e051cfd5f624e7b76aa72389e0c as build
+FROM python:3.8.9-slim-buster@sha256:5d9e29ce2be0f6b0939691ac1331c4a42a2678d13c918a8eba00698449209ef1 as build
 WORKDIR /app
 RUN \
   apt-get -y update && \


### PR DESCRIPTION
The kubernetes deployment in GHA keeps failing on Python 3.7, but works fine consitently on 3.8 so I propose we go with 3.8.
Fixes #4359

Python 3.8 also uses pip 21.1 which, by default, uses the new dependency resolver algorithm that caused a lot of issues in the past, but is now finally resolved as we can see in the tests in this PR and in #2978