### PR TITLE
k8s: increase initializer memory

### DIFF
--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -181,13 +181,15 @@ jobs:
       - name: Check Application
         run: |-
              to_complete () {
-               kubectl wait  --for=$1 $2 --timeout=500s --selector=$3
-               if [[ ${?} != 0 ]]; then
+               kubectl wait --for=$1 $2 --timeout=500s --selector=$3 2>/tmp/test || true
+               if [[ -s /tmp/test ]]; then
                  echo "ERROR: $2"
+                 cat /tmp/test
                  echo "INFO: status:"
                  kubectl get pods
                  echo "INFO: logs:"
-                 kubectl logs  --selector=$3
+                 kubectl logs  --selector=$3 --all-containers=true
+                 exit 1
                fi
                return ${?}
              }

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.0.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.1
+version: 1.6.2
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -166,10 +166,10 @@ initializer:
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
     limits:
       cpu: 2000m
-      memory: 256Mi
+      memory: 512Mi
 
 mysql:
   enabled: false


### PR DESCRIPTION
Thanks to @dsever we finally found out why the GHA k8s workflow was failing randomly. This PR enables logging and that showed that the initilializer sometimes went out of memory. So we increase the limits a little bit and now it seems to run more consistently successful.