### PR TITLE
Anchore parser: add optional custom vulnerability description

### DIFF
--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -30,7 +30,9 @@ class AnchoreEngineParser(object):
             findingdetail += '**Feed**: ' + item['feed'] + '/' + item['feed_group'] + '\n\n'
             findingdetail += '**CVE**: ' + cve + '\n\n'
             findingdetail += '**CPE**: ' + item['package_cpe'] + '\n\n'
-            findingdetail += '**Description**: ' + item.get('description', '') + '\n\n'
+            vulndescription = item.get('description', '')
+            if vulndescription != '':
+                findingdetail += '**Description**: ' + vulndescription + '\n\n'
 
             sev = item['severity']
             if sev == "Negligible" or sev == "Unknown":

--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -30,6 +30,7 @@ class AnchoreEngineParser(object):
             findingdetail += '**Feed**: ' + item['feed'] + '/' + item['feed_group'] + '\n\n'
             findingdetail += '**CVE**: ' + cve + '\n\n'
             findingdetail += '**CPE**: ' + item['package_cpe'] + '\n\n'
+            findingdetail += '**Description**: ' + item.get('description', '') + '\n\n'
 
             sev = item['severity']
             if sev == "Negligible" or sev == "Unknown":

--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -30,9 +30,7 @@ class AnchoreEngineParser(object):
             findingdetail += '**Feed**: ' + item['feed'] + '/' + item['feed_group'] + '\n\n'
             findingdetail += '**CVE**: ' + cve + '\n\n'
             findingdetail += '**CPE**: ' + item['package_cpe'] + '\n\n'
-            vulndescription = item.get('description', '')
-            if vulndescription != '':
-                findingdetail += '**Description**: ' + vulndescription + '\n\n'
+            findingdetail += '**Description**: ' + item.get('description', '<None>') + '\n\n'
 
             sev = item['severity']
             if sev == "Negligible" or sev == "Unknown":


### PR DESCRIPTION
Add an optional field to add a custom vulnerability description in the Anchore parser. This will allow to enrich the finding description with further details which describes the vulnerability. 

For example, one could augment the details by grabbing informations from Anchore at https://anchore-api.mydomain.com/v1/query/vulnerabilities?id=CVE-ID URL and populate DefectDojo with more useful data.