### PR TITLE
Anchore parser, use vuln_id_from_tool instead of unique_id_from_tool

### DIFF
--- a/dojo/db_migrations/0098_anchore_vuln_id.py
+++ b/dojo/db_migrations/0098_anchore_vuln_id.py
@@ -7,7 +7,8 @@ class Migration(migrations.Migration):
         finding_model = apps.get_model('dojo', 'Finding')
         test_type_model = apps.get_model('dojo', 'Test_Type')
         anchore_scan, _ = test_type_model.objects.get_or_create(name='Anchore Engine Scan')
-        findings = finding_model.objects.filter(test__test_type=anchore_scan)
+        # extra protection, only migrate for the findings that have a non-null unique_id_from_tool
+        findings = finding_model.objects.filter(test__test_type=anchore_scan, unique_id_from_tool__isnull=False)
 
         # assign value from unique_id_from tool to vuln_id_from_tool
         findings.update(vuln_id_from_tool=F('unique_id_from_tool'))
@@ -19,7 +20,7 @@ class Migration(migrations.Migration):
         finding_model = apps.get_model('dojo', 'Finding')
         test_type_model = apps.get_model('dojo', 'Test_Type')
         anchore_scan, _ = test_type_model.objects.get_or_create(name='Anchore Engine Scan')
-        findings = finding_model.objects.filter(test__test_type=anchore_scan)
+        findings = finding_model.objects.filter(test__test_type=anchore_scan, vuln_id_from_tool__isnull=False)
 
         # assign value from vuln_id_from tool to unique_id_from_tool
         findings.update(unique_id_from_tool=F('vuln_id_from_tool'))

--- a/dojo/db_migrations/0098_anchore_vuln_id.py
+++ b/dojo/db_migrations/0098_anchore_vuln_id.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+from django.db.models import F
+
+
+class Migration(migrations.Migration):
+    def move_to_vuln_id(apps, schema_editor):
+        finding_model = apps.get_model('dojo', 'Finding')
+        test_type_model = apps.get_model('dojo', 'Test_Type')
+        anchore_scan, _ = test_type_model.objects.get_or_create(name='Anchore Engine Scan')
+        findings = finding_model.objects.filter(test__test_type=anchore_scan)
+
+        # assign value from unique_id_from tool to vuln_id_from_tool
+        findings.update(vuln_id_from_tool=F('unique_id_from_tool'))
+
+        # reset unique_id_from_tool
+        findings.update(unique_id_from_tool=None)
+
+    def reverse_move_to_vuln_id(apps, schema_editor):
+        finding_model = apps.get_model('dojo', 'Finding')
+        test_type_model = apps.get_model('dojo', 'Test_Type')
+        anchore_scan, _ = test_type_model.objects.get_or_create(name='Anchore Engine Scan')
+        findings = finding_model.objects.filter(test__test_type=anchore_scan)
+
+        # assign value from vuln_id_from tool to unique_id_from_tool
+        findings.update(unique_id_from_tool=F('vuln_id_from_tool'))
+
+        # reset vuln_id_from_tool
+        findings.update(vuln_id_from_tool=None)
+
+    dependencies = [
+        ('dojo', '0097_engagement_type'),
+    ]
+
+    operations = [migrations.RunPython(move_to_vuln_id, reverse_move_to_vuln_id)]

--- a/dojo/fixtures/initial_surveys.json
+++ b/dojo/fixtures/initial_surveys.json
@@ -6,7 +6,7 @@
       "modified": "2015-03-30T19:31:16Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 3
@@ -18,7 +18,7 @@
       "modified": "2015-03-30T19:31:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 4
@@ -30,7 +30,7 @@
       "modified": "2015-03-30T19:31:45Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 5
@@ -42,7 +42,7 @@
       "modified": "2015-03-30T19:52:57Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 6
@@ -54,7 +54,7 @@
       "modified": "2015-03-30T19:53:37Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 7
@@ -66,7 +66,7 @@
       "modified": "2015-03-30T19:54:20Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 8
@@ -78,7 +78,7 @@
       "modified": "2015-03-30T19:54:34Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 9
@@ -90,7 +90,7 @@
       "modified": "2015-03-30T19:54:48Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 10
@@ -102,7 +102,7 @@
       "modified": "2015-03-30T19:55:00Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 11
@@ -114,7 +114,7 @@
       "modified": "2015-03-30T19:55:20Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 12
@@ -126,7 +126,7 @@
       "modified": "2015-03-30T19:56:24Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 13
@@ -138,7 +138,7 @@
       "modified": "2015-03-30T19:57:22Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 14
@@ -150,7 +150,7 @@
       "modified": "2015-03-30T19:57:34Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 15
@@ -162,7 +162,7 @@
       "modified": "2015-03-30T19:57:55Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 16
@@ -174,7 +174,7 @@
       "modified": "2015-03-30T19:58:36Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 17
@@ -186,7 +186,7 @@
       "modified": "2015-03-30T20:00:35Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 18
@@ -198,7 +198,7 @@
       "modified": "2015-03-30T20:00:46Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 19
@@ -210,7 +210,7 @@
       "modified": "2015-03-30T20:00:58Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 20
@@ -222,7 +222,7 @@
       "modified": "2015-03-30T20:02:18Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 21
@@ -234,7 +234,7 @@
       "modified": "2015-03-30T20:02:32Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 22
@@ -246,7 +246,7 @@
       "modified": "2015-03-30T20:02:46Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 23
@@ -258,7 +258,7 @@
       "modified": "2015-03-30T20:02:57Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 24
@@ -270,7 +270,7 @@
       "modified": "2015-03-30T20:04:46Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 25
@@ -282,7 +282,7 @@
       "modified": "2015-03-30T20:05:10Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 26
@@ -294,7 +294,7 @@
       "modified": "2015-03-30T20:05:22Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 27
@@ -306,7 +306,7 @@
       "modified": "2015-03-30T20:05:32Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 28
@@ -318,7 +318,7 @@
       "modified": "2015-03-30T20:05:43Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 29
@@ -330,7 +330,7 @@
       "modified": "2015-03-30T20:05:57Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 30
@@ -342,7 +342,7 @@
       "modified": "2015-03-30T20:06:15Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 31
@@ -354,7 +354,7 @@
       "modified": "2015-03-30T20:08:08Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 32
@@ -366,7 +366,7 @@
       "modified": "2015-03-30T20:08:19Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 33
@@ -378,7 +378,7 @@
       "modified": "2015-03-30T20:08:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 34
@@ -390,7 +390,7 @@
       "modified": "2015-03-30T20:08:43Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 35
@@ -402,7 +402,7 @@
       "modified": "2015-03-30T20:08:54Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 36
@@ -414,7 +414,7 @@
       "modified": "2015-03-30T20:10:15Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 37
@@ -426,7 +426,7 @@
       "modified": "2015-03-30T20:10:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 38
@@ -438,7 +438,7 @@
       "modified": "2015-03-30T20:10:42Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 39
@@ -450,7 +450,7 @@
       "modified": "2015-03-30T20:10:52Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 40
@@ -462,7 +462,7 @@
       "modified": "2015-03-30T20:11:04Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 41
@@ -474,7 +474,7 @@
       "modified": "2015-03-30T20:11:17Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 42
@@ -486,7 +486,7 @@
       "modified": "2015-03-30T20:11:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 18
+      "polymorphic_ctype": 74
     },
     "model": "dojo.question",
     "pk": 43

--- a/dojo/fixtures/initial_surveys.json
+++ b/dojo/fixtures/initial_surveys.json
@@ -6,7 +6,7 @@
       "modified": "2015-03-30T19:31:16Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 3
@@ -18,7 +18,7 @@
       "modified": "2015-03-30T19:31:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 4
@@ -30,7 +30,7 @@
       "modified": "2015-03-30T19:31:45Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 5
@@ -42,7 +42,7 @@
       "modified": "2015-03-30T19:52:57Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 6
@@ -54,7 +54,7 @@
       "modified": "2015-03-30T19:53:37Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 7
@@ -66,7 +66,7 @@
       "modified": "2015-03-30T19:54:20Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 8
@@ -78,7 +78,7 @@
       "modified": "2015-03-30T19:54:34Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 9
@@ -90,7 +90,7 @@
       "modified": "2015-03-30T19:54:48Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 10
@@ -102,7 +102,7 @@
       "modified": "2015-03-30T19:55:00Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 11
@@ -114,7 +114,7 @@
       "modified": "2015-03-30T19:55:20Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 12
@@ -126,7 +126,7 @@
       "modified": "2015-03-30T19:56:24Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 13
@@ -138,7 +138,7 @@
       "modified": "2015-03-30T19:57:22Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 14
@@ -150,7 +150,7 @@
       "modified": "2015-03-30T19:57:34Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 15
@@ -162,7 +162,7 @@
       "modified": "2015-03-30T19:57:55Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 16
@@ -174,7 +174,7 @@
       "modified": "2015-03-30T19:58:36Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 17
@@ -186,7 +186,7 @@
       "modified": "2015-03-30T20:00:35Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 18
@@ -198,7 +198,7 @@
       "modified": "2015-03-30T20:00:46Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 19
@@ -210,7 +210,7 @@
       "modified": "2015-03-30T20:00:58Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 20
@@ -222,7 +222,7 @@
       "modified": "2015-03-30T20:02:18Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 21
@@ -234,7 +234,7 @@
       "modified": "2015-03-30T20:02:32Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 22
@@ -246,7 +246,7 @@
       "modified": "2015-03-30T20:02:46Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 23
@@ -258,7 +258,7 @@
       "modified": "2015-03-30T20:02:57Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 24
@@ -270,7 +270,7 @@
       "modified": "2015-03-30T20:04:46Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 25
@@ -282,7 +282,7 @@
       "modified": "2015-03-30T20:05:10Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 26
@@ -294,7 +294,7 @@
       "modified": "2015-03-30T20:05:22Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 27
@@ -306,7 +306,7 @@
       "modified": "2015-03-30T20:05:32Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 28
@@ -318,7 +318,7 @@
       "modified": "2015-03-30T20:05:43Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 29
@@ -330,7 +330,7 @@
       "modified": "2015-03-30T20:05:57Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 30
@@ -342,7 +342,7 @@
       "modified": "2015-03-30T20:06:15Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 31
@@ -354,7 +354,7 @@
       "modified": "2015-03-30T20:08:08Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 32
@@ -366,7 +366,7 @@
       "modified": "2015-03-30T20:08:19Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 33
@@ -378,7 +378,7 @@
       "modified": "2015-03-30T20:08:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 34
@@ -390,7 +390,7 @@
       "modified": "2015-03-30T20:08:43Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 35
@@ -402,7 +402,7 @@
       "modified": "2015-03-30T20:08:54Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 36
@@ -414,7 +414,7 @@
       "modified": "2015-03-30T20:10:15Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 37
@@ -426,7 +426,7 @@
       "modified": "2015-03-30T20:10:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 38
@@ -438,7 +438,7 @@
       "modified": "2015-03-30T20:10:42Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 39
@@ -450,7 +450,7 @@
       "modified": "2015-03-30T20:10:52Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 40
@@ -462,7 +462,7 @@
       "modified": "2015-03-30T20:11:04Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 41
@@ -474,7 +474,7 @@
       "modified": "2015-03-30T20:11:17Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 42
@@ -486,7 +486,7 @@
       "modified": "2015-03-30T20:11:30Z",
       "optional": false,
       "order": 1,
-      "polymorphic_ctype": 74
+      "polymorphic_ctype": 18
     },
     "model": "dojo.question",
     "pk": 43

--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -85,7 +85,7 @@ class AnchoreEngineParser(object):
                     url=item.get('url'),
                     static_finding=True,
                     dynamic_finding=False,
-                    unique_id_from_tool=item.get('vuln'),
+                    vuln_id_from_tool=item.get('vuln'),
                 )
 
                 dupes[dupe_key] = find

--- a/dojo/unittests/tools/test_anchore_engine_parser.py
+++ b/dojo/unittests/tools/test_anchore_engine_parser.py
@@ -31,7 +31,7 @@ class TestAnchoreEngineParser(TestCase):
         testfile.close()
         self.assertEqual(51, len(findings))
         finding = findings[50]
-        self.assertEqual("CVE-2020-13776", finding.unique_id_from_tool)
+        self.assertEqual("CVE-2020-13776", finding.vuln_id_from_tool)
         self.assertEqual('systemd-pam', finding.component_name)
         self.assertEqual('239-41.el8_3.1', finding.component_version)
         self.assertEqual(6.7, finding.cvssv3_score)


### PR DESCRIPTION
As discussed in https://owasp.slack.com/archives/C014H3ZV9U6/p1619635577100800

No real impact out of the box, unless for people that may have used a different dedupe algo than the default for this parser.