### PR TITLE
Make hashcode recomputation visible in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,10 +6,11 @@ categories:
   - title: '💣 Breaking changes'
     labels:
       - 'Breaking Changes'
-  - title: '🚩 Requires settings change or database migration'
+  - title: '🚩 Requires settings changes, database migration, hash code recomputation'
     labels:
       - 'settings_changes'
       - 'New Migration'
+      - 'hashcode-update-needed'
   - title: '🚩 Security'
     labels:
       - 'security'


### PR DESCRIPTION
Just to make that more visible in the release notes.