### PR TITLE
Recognize .nessus file names

### DIFF
--- a/dojo/tools/nessus/parser.py
+++ b/dojo/tools/nessus/parser.py
@@ -246,9 +246,9 @@ class NessusParser(object):
 
     def get_findings(self, filename, test):
 
-        if filename.name.lower().endswith('.xml'):
+        if filename.name.lower().endswith('.xml') or filename.name.lower().endswith('.nessus'):
             return NessusXMLParser().get_findings(filename, test)
         elif filename.name.lower().endswith('.csv'):
             return NessusCSVParser().get_findings(filename, test)
         else:
-            raise ValueError('Unknown File Format')
+            raise ValueError('Filename extension not recognized. Use .xml, .nessus or .csv')


### PR DESCRIPTION
As a new DefectDojo user, I thought I had a corrupt .nessus file, until I renamed it with .xml.

This change recognizes XML exports with the `.nessus` extension, matching the documentation at line #245.

Also clarifies the error when trying to import a Nessus file.