### PR TITLE
Documentation: Put django-DefectDojo back in the URL

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,7 +1,7 @@
 **Description**
 
 Describe the feature / bug fix implemented by this PR.
-If this is a new parser, [the parser guide](https://defectdojo.github.io/contributing/how-to-write-a-parser/) may be worth (re)reading.
+If this is a new parser, [the parser guide](https://defectdojo.github.io/django-DefectDojo/contributing/how-to-write-a-parser/) may be worth (re)reading.
 
 **Test results**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Here are a few things to keep in mind when making changes to DefectDojo.
 
 ## Writing a new parser
 
-Please see [the parser guide](https://defectdojo.github.io/contributing/how-to-write-a-parser/) for guidance on how to write a parser.
+Please see [the parser guide](https://defectdojo.github.io/django-DefectDojo/contributing/how-to-write-a-parser/) for guidance on how to write a parser.
 
 ## Modifying DefectDojo and Testing
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Log in with `admin / defectdojo@demo#appsec` and please note that the demo serve
 ## Documentation
 
 For detailed documentation you can visit
-[Github Pages](https://defectdojo.github.io/).
+[Github Pages](https://defectdojo.github.io/django-DefectDojo/).
 
 ## Supported Installation Options
 
@@ -51,10 +51,10 @@ For detailed documentation you can visit
 We recommend checking out the
 [about](https://defectdojo.github.io/basics/about/) document to
 learn the terminology of DefectDojo and the
-[getting started guide](https://defectdojo.github.io/running/getting-started/)
+[getting started guide](https://defectdojo.github.io/django-DefectDojo/running/getting-started/)
 for setting up a new installation.
 We've also created some example
-[workflows](https://defectdojo.github.io/basics/workflows/) that
+[workflows](https://defectdojo.github.io/django-DefectDojo/basics/workflows/) that
 should give you an idea of how to use DefectDojo for your own team.
 
 ## REST APIs
@@ -62,7 +62,7 @@ should give you an idea of how to use DefectDojo for your own team.
 > ** Deprecation notice ** apiv1 is deprecated and EOS is on 12-31-2020. EOL is planned for 06-30-2021.
 > Please move on to apiv2 and raise issues for any unsupported operations.
 
-Defectdojo can be accessed through a Swagger REST API. Please see [the API documentation](https://defectdojo.github.io/integrations/api-v2-docs/) or the in-app Swagger documentation.
+Defectdojo can be accessed through a Swagger REST API. Please see [the API documentation](https://defectdojo.github.io/django-DefectDojo/integrations/api-v2-docs/) or the in-app Swagger documentation.
 
 ## Client APIs and wrappers
 This section presents different ways to programmatically interact with DefectDojo APIs.

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://defectdojo.github.io/"
+baseURL = "https://defectdojo.github.io/django-DefectDojo/"
 title = "DefectDojo"
 
 enableRobotsTXT = true

--- a/docs/content/en/integrations/jira.md
+++ b/docs/content/en/integrations/jira.md
@@ -66,7 +66,7 @@ To obtain \'epic name id\': If you have admin access to JIRA:
 4.  **Note**: dojojira uses the same celery functionality as
     reports. Make sure the celery runner is setup correctly as
     described:
-    <https://defectdojo.github.io/basics/features/#reports>
+    <https://defectdojo.github.io/django-DefectDojo/basics/features/#reports>
 
 Or
 

--- a/dojo/__init__.py
+++ b/dojo/__init__.py
@@ -8,4 +8,4 @@ default_app_config = 'dojo.apps.DojoAppConfig'
 
 __version__ = '2.0.0-dev'
 __url__ = 'https://github.com/DefectDojo/django-DefectDojo'
-__docs__ = 'https://defectdojo.github.io'
+__docs__ = 'https://defectdojo.github.io/django-DefectDojo'

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -210,7 +210,7 @@
                         </li>
                     </ul>
                     &nbsp;
-                    <a href="https://defectdojo.github.io/basics/permissions/" target="_blank">
+                    <a href="https://defectdojo.github.io/django-DefectDojo/basics/permissions/" target="_blank">
                         <i class="fa fa-question-circle text-low"></i></a>
                 </div>
                 {% endif %}

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -142,7 +142,7 @@
                                     </li>
                                 </ul>
                                 &nbsp;
-                                <a href="https://defectdojo.github.io/basics/permissions/" target="_blank">
+                                <a href="https://defectdojo.github.io/django-DefectDojo/basics/permissions/" target="_blank">
                                     <i class="fa fa-question-circle text-low"></i></a>
                             </div>
                             {% endif %}

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -119,7 +119,7 @@
                             </li>
                         </ul>
                         &nbsp;
-                        <a href="https://defectdojo.github.io/basics/permissions/" target="_blank">
+                        <a href="https://defectdojo.github.io/django-DefectDojo/basics/permissions/" target="_blank">
                             <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}
@@ -192,7 +192,7 @@
                             </li>
                         </ul>
                         &nbsp;
-                        <a href="https://defectdojo.github.io/basics/permissions/" target="_blank">
+                        <a href="https://defectdojo.github.io/django-DefectDojo/basics/permissions/" target="_blank">
                             <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}

--- a/dojo/tools/risk_recon/api.py
+++ b/dojo/tools/risk_recon/api.py
@@ -13,13 +13,13 @@ class RiskReconAPI:
             raise Exception(
                 'Please supply a Risk Recon API key. \n'
                 'This can be generated in the system admin panel. \n'
-                'See https://defectdojo.github.io/integrations/import/#risk-recon-api-importer \n'
+                'See https://defectdojo.github.io/django-DefectDojo/integrations/import/#risk-recon-api-importer \n'
             )
         if not self.url:
             raise Exception(
                 'Please supply a Risk Recon API url. \n'
                 'A general url is https://api.riskrecon.com/v1/ \n'
-                'See https://defectdojo.github.io/integrations/import/#risk-recon-api-importer \n'
+                'See https://defectdojo.github.io/django-DefectDojo/integrations/import/#risk-recon-api-importer \n'
             )
         if self.url.endswith('/'):
             self.url = endpoint[:-1]

--- a/tests/Import_scanner_test.py
+++ b/tests/Import_scanner_test.py
@@ -51,7 +51,7 @@ class ScannerTest(BaseTestCase):
 
     def test_check_for_doc(self):
         driver = self.driver
-        driver.get('https://defectdojo.github.io/integrations/import/')
+        driver.get('https://defectdojo.github.io/django-DefectDojo/integrations/import/')
 
         integration_index = integration_text.index('Integrations') + len('Integrations') + 1
         usage_index = integration_text.index('Usage Examples') - len('Models') - 2


### PR DESCRIPTION
Now the new documentation got deployed, great. Unfortunately it wasn't a good idea to make the URL shorter and get rid of the project name. This doesn't work, so this PR puts the project name back in the URL. Sorry about all the PR's.