### PR TITLE
Add cvss score to sonatype parser

### DIFF
--- a/dojo/tools/sonatype/parser.py
+++ b/dojo/tools/sonatype/parser.py
@@ -109,7 +109,7 @@ def get_item(vulnerability, test):
         finding = Finding(
             title=finding_title,
             cve=cve,
-            cvssv3_score = score,
+            cvssv3_score=score,
             test=test,
             severity=severity,
             description=finding_description,

--- a/dojo/tools/sonatype/parser.py
+++ b/dojo/tools/sonatype/parser.py
@@ -109,6 +109,7 @@ def get_item(vulnerability, test):
         finding = Finding(
             title=finding_title,
             cve=cve,
+            cvssv3_score = score,
             test=test,
             severity=severity,
             description=finding_description,

--- a/dojo/tools/sonatype/parser.py
+++ b/dojo/tools/sonatype/parser.py
@@ -99,7 +99,7 @@ def get_item(vulnerability, test):
         finding_description += "\n\nPlease check the CVE details of this finding for a detailed description. The details of issues beginning with \"SONATYPE-\" can be found by contacting Sonatype, Inc. or through mechanisms they have provided in their product."
         threat_category = main_finding.get("threatCategory", "CVSS vector not provided. ").title()
         status = main_finding['status']
-        score = main_finding.get('severity', "No CVSS score yet.")
+        score = main_finding.get('severity', 0.0)
         if 'pathnames' in vulnerability:
             file_path = ' '.join(vulnerability['pathnames'])[:1000]
         else:


### PR DESCRIPTION
Sonatype is not providing detailed cvss v3 report, this cause cvssv3_score to be null, at the same time a pre calculate score is present in the vulnerability report. To remediate cvssv3_score have to be added in the finding object.