### PR TITLE
Bugfix: Handle Exception in Endpoint metrics when no Endpoints visible

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -67,7 +67,7 @@ def get_earliest_finding(queryset=None):
 
     try:
         EARLIEST_FINDING = queryset.earliest('date')
-    except Finding.DoesNotExist:
+    except (Finding.DoesNotExist, Endpoint_Status.DoesNotExist):
         EARLIEST_FINDING = None
     return EARLIEST_FINDING
 

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -54,6 +54,24 @@
     }
   },
   {
+    "pk": 4,
+    "model": "auth.user",
+    "fields": {
+      "username": "user3",
+      "first_name": "",
+      "last_name": "",
+      "is_active": true,
+      "is_superuser": false,
+      "is_staff": false,
+      "last_login": null,
+      "groups": [],
+      "user_permissions": [],
+      "password": "pbkdf2_sha256$36000$pe8Ff8HrBPac$Lb3ee6/R9z/aL9nM+D2AXWTpIt9Pa9kcLueXxYNy1ZY=",
+      "email": "",
+      "date_joined": "2018-04-13T07:59:51.527Z"
+    }
+  },
+  {
     "pk": "2dqr18yqu9mzb87abk0okid75w2clakl",
     "model": "sessions.session",
     "fields": {

--- a/dojo/unittests/test_metrics_queries.py
+++ b/dojo/unittests/test_metrics_queries.py
@@ -26,6 +26,21 @@ class FindingQueriesTest(TestCase):
         self.request.user = user
         self.request._messages = MockMessages()
 
+    def test_finding_queries_no_data(self):
+        user3 = User.objects.get(username='user3')
+        self.request.user = user3
+
+        product_types = []
+        finding_queries = views.finding_querys(
+            product_types,
+            self.request
+        )
+
+        self.assertSequenceEqual(
+            finding_queries['all'].values(),
+            [],
+        )
+
     @patch('django.utils.timezone.now')
     def test_finding_queries(self, mock_timezone):
         mock_datetime = datetime(2020, 12, 9, tzinfo=timezone.utc)
@@ -133,6 +148,21 @@ class EndpointQueriesTest(TestCase):
         self.request = RequestFactory().get(reverse('metrics'))
         self.request.user = user
         self.request._messages = MockMessages()
+
+    def test_endpoint_queries_no_data(self):
+        user3 = User.objects.get(username='user3')
+        self.request.user = user3
+
+        product_types = []
+        endpoint_queries = views.endpoint_querys(
+            product_types,
+            self.request
+        )
+
+        self.assertSequenceEqual(
+            endpoint_queries['all'].values(),
+            [],
+        )
 
     def test_endpoint_queries(self):
         # Queries over Finding and Endpoint_Status


### PR DESCRIPTION
Stumbled over a bug while testing: When a user cannot see any Endpoints, the metrics for Endpoints will show a HTTP 500 error, because an Exception is not handled in `dojo.filters.get_earliest_finding()