### PR TITLE
[Coverity API parser] add verified data and de-duplication algorythm (unique ID)

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -865,6 +865,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Checkmarx Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Checkmarx Scan': DEDUPE_ALGO_HASH_CODE,
     'Checkmarx OSA': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
+    'Coverity API': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Dependency Track Finding Packaging Format (FPF) Export': DEDUPE_ALGO_HASH_CODE,
     'SonarQube Scan detailed': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'SonarQube Scan': DEDUPE_ALGO_HASH_CODE,

--- a/dojo/tools/coverity_api/parser.py
+++ b/dojo/tools/coverity_api/parser.py
@@ -31,9 +31,10 @@ class CoverityApiParser(object):
 
             description_formated = "\n".join(
                 [
-                    f"**CID:** `{issue['cid']}`",
-                    f"**displayType:** `{issue['displayType']}`",
-                    f"**Status:** `{issue['status']}`",
+                    f"**CID:** `{issue.get('cid')}`",
+                    f"**Type:** `{issue.get('displayType')}`",
+                    f"**Status:** `{issue.get('status')}`",
+                    f"**Classification:** `{issue.get('classification')}`",
                 ]
             )
 
@@ -62,10 +63,13 @@ class CoverityApiParser(object):
 
             if "New" == issue.get("status"):
                 finding.active = True
+                finding.verified = False
             elif "Triaged" == issue.get("status"):
                 finding.active = True
+                finding.verified = True
             elif "Fixed" == issue.get("status"):
                 finding.active = False
+                finding.verified = True
             else:
                 if "False Positive" == issue.get("classification"):
                     finding.false_p = True
@@ -74,6 +78,7 @@ class CoverityApiParser(object):
                     finding.mitigated = datetime.strptime(ds, "%Y-%M-%d")
                 finding.is_mitigated = True
                 finding.active = False
+                finding.verified = True
 
             items.append(finding)
 

--- a/dojo/unittests/tools/test_coverity_api_parser.py
+++ b/dojo/unittests/tools/test_coverity_api_parser.py
@@ -34,6 +34,7 @@ class TestZapParser(TestCase):
         with self.subTest(i=0):
             finding = findings[0]
             self.assertTrue(finding.active)
+            self.assertFalse(finding.verified)  # this one is marked as new ("status": "New")
             self.assertEqual("Risky cryptographic hashing function", finding.title)
             self.assertEqual("Medium", finding.severity)
             self.assertEqual(328, finding.cwe)
@@ -50,6 +51,7 @@ class TestZapParser(TestCase):
         with self.subTest(i=0):
             finding = findings[0]
             self.assertTrue(finding.active)
+            self.assertTrue(finding.verified)
             self.assertEqual("HTTP header injection", finding.title)
             self.assertEqual("Medium", finding.severity)
             self.assertEqual(610, finding.cwe)
@@ -64,8 +66,10 @@ class TestZapParser(TestCase):
         self.assertIsInstance(findings, list)
         self.assertEqual(20, len(findings))
         with self.subTest(i=0):
-            finding = findings[0]
+            finding = findings[0]  # this one is dismissed as a false positive
             self.assertFalse(finding.active)
+            self.assertTrue(finding.verified)
+            self.assertTrue(finding.false_p)
             self.assertEqual("Cross-site scripting", finding.title)
             self.assertEqual("High", finding.severity)
             self.assertEqual(79, finding.cwe)
@@ -75,6 +79,7 @@ class TestZapParser(TestCase):
         with self.subTest(i=10):
             finding = findings[10]
             self.assertFalse(finding.active)
+            self.assertTrue(finding.verified)
             self.assertEqual("Use of hard-coded password", finding.title)
             self.assertEqual("Medium", finding.severity)
             self.assertEqual(259, finding.cwe)
@@ -84,6 +89,7 @@ class TestZapParser(TestCase):
         with self.subTest(i=19):
             finding = findings[19]
             self.assertFalse(finding.active)
+            self.assertTrue(finding.verified)
             self.assertEqual("Cross-site scripting", finding.title)
             self.assertEqual("High", finding.severity)
             self.assertEqual(79, finding.cwe)


### PR DESCRIPTION
Add `verified` flag and manage it with classification and status data.

This pull request follows #4393 