### PR TITLE
Remove ct install step

### DIFF
--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -58,10 +58,10 @@ jobs:
         run: ct lint --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }}
         if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
-        if: steps.list-changed.outputs.changed == 'true'
+      # - name: Create kind cluster
+      #  uses: helm/kind-action@v1.1.0
+      #  if: steps.list-changed.outputs.changed == 'true'
 
-      - name: Run chart-testing (install)
-        run: ct install --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }}
-        if: steps.list-changed.outputs.changed == 'true'
+      # - name: Run chart-testing (install)
+      #   run: ct install --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }} --helm-extra-args '--set createSecret=true --set createRabbitMqSecret=true --set createPostgresqlSecret=true --set timeout=900'
+      #  if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
All the k8s installation tests already run in their own GHA's matrices.

The install step in the linting GHA actually never worked. The secrets were never created in the first place. I've put the (somewhat) working config in comments, but we don't need it (it still time out on some weird conditions and I am not going to investigate).