### PR TITLE
Fix erroneous comparison causing dev env to also be single process

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -1,19 +1,13 @@
 #!/bin/sh
 
 
-# Copy settings.py (settings.py copied to allow for legacy installs and customizations)
 cd /app
-# TARGET_SETTINGS_FILE=dojo/settings/settings.py
-# if [ ! -f ${TARGET_SETTINGS_FILE} ]; then
-#   echo "Creating settings.py"
-#   cp dojo/settings/settings.dist.py dojo/settings/settings.py
-# fi
 
 # Full list of uwsgi options: https://uwsgi-docs.readthedocs.io/en/latest/Options.html
 # --lazy-apps required for debugging --> https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html?highlight=lazy-apps#preforking-vs-lazy-apps-vs-lazy
 
 
-if [ ! -z ${DD_DEBUG} ];then
+if [ ${DD_DEBUG} == "True" ]; then
   echo "Debug mode enabled, reducing # of processes and threads to 1"
   DD_UWSGI_NUM_OF_PROCESSES=1
   DD_UWSGI_NUM_OF_THREADS=1
@@ -31,4 +25,3 @@ exec uwsgi \
   --py-autoreload 1 \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
   --lazy-apps
-

--- a/dojo/wsgi.py
+++ b/dojo/wsgi.py
@@ -15,6 +15,10 @@ framework.
 """
 import os
 import socket
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 # We defer to a DJANGO_SETTINGS_MODULE already in the environment. This breaks
 # if running multiple sites in the same mod_wsgi process. To fix this, use
@@ -33,7 +37,7 @@ debugpy_port = os.environ.get("DD_DEBUG_PORT") if os.environ.get("DD_DEBUG_PORT"
 
 # Checking for RUN_MAIN for those that want to run the app locally with the python interpreter instead of uwsgi
 if os.environ.get("DD_DEBUG") == "True" and not os.getenv("RUN_MAIN") and is_debugger_listening(debugpy_port) != 0:
-    print("DD_DEBUG is set to True, setting remote debugging on port {}".format(debugpy_port))
+    logger.info("DD_DEBUG is set to True, setting remote debugging on port {}".format(debugpy_port))
     import traceback
     try:
         import debugpy
@@ -44,13 +48,12 @@ if os.environ.get("DD_DEBUG") == "True" and not os.getenv("RUN_MAIN") and is_deb
                             "subProcess": True
                         })
         debugpy.listen(("0.0.0.0", debugpy_port))
-        print("DebugPy listening on port {}".format(debugpy_port))
         if os.environ.get("DD_DEBUG_WAIT_FOR_CLIENT") == "True":
-            print("Waiting for the debugging client to connect on port {}".format(debugpy_port))
+            logger.info("Waiting for the debugging client to connect on port {}".format(debugpy_port))
             debugpy.wait_for_client()
             print("Debugging client connected, resuming execution")
     except Exception as e:
-        print("Exception caught while enabling debug mode, passing. \nPrinting error {}".format(traceback.format_exc()))
+        logger.exception(e)
         pass
 
 # This application object is used by any WSGI server configured to use this

--- a/dojo/wsgi.py
+++ b/dojo/wsgi.py
@@ -38,7 +38,6 @@ debugpy_port = os.environ.get("DD_DEBUG_PORT") if os.environ.get("DD_DEBUG_PORT"
 # Checking for RUN_MAIN for those that want to run the app locally with the python interpreter instead of uwsgi
 if os.environ.get("DD_DEBUG") == "True" and not os.getenv("RUN_MAIN") and is_debugger_listening(debugpy_port) != 0:
     logger.info("DD_DEBUG is set to True, setting remote debugging on port {}".format(debugpy_port))
-    import traceback
     try:
         import debugpy
 


### PR DESCRIPTION
If `DD_DEBUG` is somehow set to `False`, then the `dev` env would also enter single process mode like `debug`.

This basically ensures that `DD_DEBUG` must be set to `True` in the entrypoint.