### PR TITLE
Fix docs example to run unittests

### DIFF
--- a/docs/content/en/contributing/how-to-write-a-parser.md
+++ b/docs/content/en/contributing/how-to-write-a-parser.md
@@ -76,13 +76,13 @@ MYSQL> flush privileges;
 This local command will launch the unit test for your new parser
 
 {{< highlight bash >}}
-$ docker-compose exec uwsgi bash -c 'python manage.py test dojo.unittests.<your_unittest_py_file>.<main_class_name> -v2'
+$ docker-compose exec uwsgi bash -c 'python manage.py test dojo.unittests.tools.<your_unittest_py_file>.<main_class_name> -v2'
 {{< /highlight >}}
 
 Example for the blackduck hub parser:
 
 {{< highlight bash >}}
-$ docker-compose exec uwsgi bash -c 'python manage.py test dojo.unittests.test_blackduck_csv_parser.TestBlackduckHubParser -v2'
+$ docker-compose exec uwsgi bash -c 'python manage.py test dojo.unittests.tools.test_blackduck_csv_parser.TestBlackduckHubParser -v2'
 {{< /highlight >}}
 
 {{% alert title="Information" color="info" %}}


### PR DESCRIPTION
During development, I tried to run unit tests according to [documentation](https://defectdojo.github.io/django-DefectDojo/contributing/how-to-write-a-parser/#run-your-tests), but I get this error:
```
defectdojo@dccdeec6caf6:/app$ python manage.py test dojo.unittests.test_gitleaks_parser.TestGitleaksParser
[12/May/2021 15:47:00] INFO [dojo.models:3363] enabling audit logging
System check identified no issues (0 silenced).
E
======================================================================
ERROR: test_gitleaks_parser (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_gitleaks_parser
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
ModuleNotFoundError: No module named 'dojo.unittests.test_gitleaks_parser'


----------------------------------------------------------------------
Ran 1 test in 0.001s

FAILED (errors=1)
```

With this call, I was able to run the tests successfully:
```
python manage.py test dojo.unittests.tools.test_gitleaks_parser.TestGitleaksParser
```

Correcting this inaccuracy. 