### PR TITLE
Authorization V2: Management command to migrate users and set Auth V2 as the default

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -104,6 +104,8 @@ The new authorization system for Products and Product Types based on roles is th
   - If `AUTHORIZED_USERS_ALLOW_STAFF` is `True`, the user will get the *Owner* role for the respective Product or Product Type.
   - If `AUTHORIZED_USERS_ALLOW_CHANGE` or `AUTHORIZED_USERS_ALLOW_DELETE` is `True`, the user will get the *Writer* role for the respective Product or Product Type.
 
+The new authorization is active for both UI and API. Permissions set via authorized users or via the Django Admin interface are no longer taken into account.
+
 Please review the roles for your users after the upgrade to avoid an unintended permissions creep.
 
 

--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -62,15 +62,6 @@ Replace the first step above with this one: `docker-compose build`
 
 Follow the usual steps to upgrade as described above.
 
-AFTER UPGRADING
-- Usual migration process (`python manage.py migrate`) try to migrate all endpoints to new format and merge duplicates.
-- All broken endpoints (which weren't possible to migrate) have red flag 🚩 in standard list of endpoints.
-- Check if all your endpoints was migrated successfully, go to: https://<defect-dojo-url>/endpoint/migrate.
-- Alternatively, this can be run as management command:  `docker-compose exec uwsgi ./manage.py endpoint_migration --dry-run`
-- When all endpoint will be fixed (there is not broken endpoint), press "Run migration" in https://<defect-dojo-url>/endpoint/migrate
-- Or, you can run management command: `docker-compose exec uwsgi ./manage.py endpoint_migration`
-- Details about endpoint migration / improvements in https://github.com/DefectDojo/django-DefectDojo/pull/4473
-
 We decided to name this version 2.0.0 because we did some big cleanups in this release:
 
 - Remove API v1 ([#4413](https://github.com/DefectDojo/django-DefectDojo/pull/4413))
@@ -81,18 +72,39 @@ We decided to name this version 2.0.0 because we did some big cleanups in this r
 - Refactor EndPoint handling/formatting ([#4473](https://github.com/DefectDojo/django-DefectDojo/pull/4473))
 - Upgrade to Django 3.x ([#3632](https://github.com/DefectDojo/django-DefectDojo/pull/3632))
 - PDF Reports removed ([#4418](https://github.com/DefectDojo/django-DefectDojo/pull/4418))
+- Hashcode calculation logic has changed. To update existing findings run: 
+  
+  `./manage.py dedupe --hash_code_only`.
+
+If you're using docker: 
+
+`docker-compose exec uwsgi ./manage.py dedupe --hash_code_only`.
+
+This can take a while depending on your instance size.
 
 - See release notes: https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.0.0
 
-- Hashcode calculation logic has changed. To update existing findings run:
+### Endpoints
 
-    `./manage.py dedupe --hash_code_only`
+- The usual migration process (`python manage.py migrate`) tries to migrate all endpoints to new format and merge duplicates.
+- All broken endpoints (which weren't possible to migrate) have a red flag 🚩 in the standard list of endpoints.
+- Check if all your endpoints were migrated successfully, go to: https://<defect-dojo-url>/endpoint/migrate.
+- Alternatively, this can be run as management command:  `docker-compose exec uwsgi ./manage.py endpoint_migration --dry-run`
+- When all endpoint are fixed (there is not broken endpoint), press "Run migration" in https://<defect-dojo-url>/endpoint/migrate
+- Or, you can run management command: `docker-compose exec uwsgi ./manage.py endpoint_migration`
+- Details about endpoint migration / improvements in https://github.com/DefectDojo/django-DefectDojo/pull/4473
 
-If you're using docker:
+### Authorization
 
-    `docker-compose exec uwsgi ./manage.py dedupe --hash_code_only`
+The new authorization system for Products and Product Types based on roles is the default now. The fields for authorized users are not available anymore, but you can assign roles as described in [Permissions](../../usage/permissions). Users are migrated automatically, so that their permissions are as close as possible to the previous authorization:
+- Superusers will still have all permissions on Products and Product Types, so they must not be changed.
+- Staff users have had all permissions for all product types and products, so they will be get a global role as *Owner*.
+- Product_Members and Product Type_Members will be added for authorized users according to the settings for the previous authorization:
+  - The *Reader* role is set as the default.
+  - If `AUTHORIZED_USERS_ALLOW_STAFF` is `True`, the user will get the *Owner* role for the respective Product or Product Type.
+  - If `AUTHORIZED_USERS_ALLOW_CHANGE` or `AUTHORIZED_USERS_ALLOW_DELETE` is `True`, the user will get the *Writer* role for the respective Product or Product Type.
 
-This can take a while depending on your instance size.
+Please review the roles for your users after the upgrade to avoid an unintended permissions creep.
 
 
 ## Upgrading to DefectDojo Version 1.15.x

--- a/docs/content/en/usage/permissions.md
+++ b/docs/content/en/usage/permissions.md
@@ -5,10 +5,6 @@ weight: 3
 draft: false
 ---
 
-{{% alert title="Warning" color="warning" %}}
-The permissions described on this page only become active if you set the ``FEATURE_AUTHORIZATION_V2`` feature flag to ``True``. This feature is currently in beta, you should not use it in production environments.
-{{% /alert %}}
-
 ## System-wide permissions
 
 * Administrators (aka super users) have no limitations in the system. They can change all settings, manage users  and have read and write access to all data.
@@ -17,7 +13,7 @@ The permissions described on this page only become active if you set the ``FEATU
 
 ## Product and Product Type permissions
 
-Users can be assigned as members to Products and Product Types, giving them one out of five predefined roles. The roles define what kind of access a user has to functions for interacting with data of that Product or Product Type:
+Users can be assigned as members to Products and Product Types, giving them one out of five predefined roles. The role defines what kind of access a user has to functions for interacting with data of that Product or Product Type:
 
 **Product / Product Type roles:**
 

--- a/dojo/db_migrations/0108_auth_v2_migrate_user_roles.py
+++ b/dojo/db_migrations/0108_auth_v2_migrate_user_roles.py
@@ -1,0 +1,18 @@
+
+from django.core.management import call_command
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dojo', '0107_global_role'),
+    ]
+
+    def migrate_users(apps, schema_editor):
+        call_command('migrate_authorization_v2')
+
+    operations = [
+        # Migrate roles for staff users and authorized users to authorization v2
+        migrations.RunPython(migrate_users),
+    ]

--- a/dojo/db_migrations/0109_auth_v2_migrate_user_roles.py
+++ b/dojo/db_migrations/0109_auth_v2_migrate_user_roles.py
@@ -6,7 +6,7 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dojo', '0107_global_role'),
+        ('dojo', '0108_blank_fields'),
     ]
 
     def migrate_users(apps, schema_editor):

--- a/dojo/management/commands/migrate_authorization_v2.py
+++ b/dojo/management/commands/migrate_authorization_v2.py
@@ -1,7 +1,7 @@
 import logging
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from dojo.models import Dojo_User, Product, Product_Member, Product_Type, Product_Type_Member
+from dojo.models import Dojo_User, Global_Role, Role, Product, Product_Member, Product_Type, Product_Type_Member
 from dojo.authorization.roles_permissions import Roles
 
 
@@ -16,32 +16,36 @@ class Command(BaseCommand):
     """
     help = 'Usage: manage.py migration_authorization_v2'
 
-    def handle(self, *args, **options):
+    def __init__(self, **kwargs):
+        self.reader_role = Role.objects.get(id=Roles.Reader)
+        self.writer_role = Role.objects.get(id=Roles.Writer)
+        self.owner_role = Role.objects.get(id=Roles.Owner)
 
+    def handle(self, *args, **options):
         logger.info('Started migrating users for authorization v2 ...')
 
         authorized_user_exists = False
 
-        product_types = Product_Type.objects.all().prefetch_related('authorized_users')
+        # Staff users have had all permissions for all product types and products,
+        # so they will be get a global role as Owner.
+        # Superusers will have all permissions anyway, so they must not be set as members.
         staff_users = Dojo_User.objects.filter(is_staff=True, is_superuser=False)
-        for product_type in product_types:
-            # Staff users have had all permissions for all product types and products,
-            # so they will be set as owners for all product types.
-            # Superusers will have all permissions anyway, so they must not be set as members.
-            for staff_user in staff_users:
-                # If the product type member already exists, it won't be changed
-                if Product_Type_Member.objects.filter(product_type=product_type, user=staff_user).count() == 0:
-                    product_type_member = Product_Type_Member()
-                    product_type_member.product_type = product_type
-                    product_type_member.user = staff_user
-                    product_type_member.role = 4  # Owner
-                    product_type_member.save()
-                    logger.info('Product_Type_Member added: {} / {} / {}'.format(product_type.name, staff_user.username, Roles(product_type_member.role).name))
-                else:
-                    logger.info('Product_Type_Member already exists: {} / {}'.format(product_type.name, staff_user.username))
+        for staff_user in staff_users:
+            global_role = staff_user.global_role if hasattr(staff_user, 'global_role') else None
+            if global_role is None:
+                global_role = Global_Role()
+                global_role.user = staff_user
+            if global_role.role is None:
+                global_role.role = self.owner_role
+                global_role.save()
+                logger.info('Global_Role Owner added for staff user {}'.format(staff_user))
+            else:
+                logger.info('Staff user {} already has Global_Role {}'.format(staff_user, global_role.role))
 
-            # Authorized users for product types will be converted to product type members
-            # with a role according to the settings
+        # Authorized users for product types will be converted to product type members
+        # with a role according to the settings
+        product_types = Product_Type.objects.all().prefetch_related('authorized_users')
+        for product_type in product_types:
             for authorized_user in product_type.authorized_users.all():
                 # If the product type member already exists, it won't be changed
                 if Product_Type_Member.objects.filter(product_type=product_type, user=authorized_user).count() == 0:
@@ -49,16 +53,16 @@ class Command(BaseCommand):
                     product_type_member = Product_Type_Member()
                     product_type_member.product_type = product_type
                     product_type_member.user = authorized_user
-                    product_type_member.role = get_role()
+                    product_type_member.role = self.get_role()
                     product_type_member.save()
-                    logger.info('Product_Type_Member added: {} / {} / {}'.format(product_type.name, authorized_user.username, Roles(product_type_member.role).name))
+                    logger.info('Product_Type_Member added: {} / {} / {}'.format(product_type, authorized_user, product_type_member.role))
                 else:
-                    logger.info('Product_Type_Member already exists: {} / {}'.format(product_type.name, authorized_user.username))
+                    logger.info('Product_Type_Member already exists: {} / {}'.format(product_type, authorized_user))
 
+        # Authorized users for products will be converted to product members
+        # with a role according to the settings
         products = Product.objects.all().prefetch_related('authorized_users')
         for product in products:
-            # Authorized users for products will be converted to product members
-            # with a role according to the settings
             for authorized_user in product.authorized_users.all():
                 # If the product member already exists, it won't be changed
                 if Product_Member.objects.filter(product=product, user=authorized_user).count() == 0:
@@ -66,11 +70,11 @@ class Command(BaseCommand):
                     product_member = Product_Member()
                     product_member.product = product
                     product_member.user = authorized_user
-                    product_member.role = get_role()
+                    product_member.role = self.get_role()
                     product_member.save()
-                    logger.info('Product_Member added: {} / {} / {}'.format(product.name, authorized_user.username, Roles(product_member.role).name))
+                    logger.info('Product_Member added: {} / {} / {}'.format(product, authorized_user, product_member.role))
                 else:
-                    logger.info('Product_Member already exists: {} / {}'.format(product.name, authorized_user.username))
+                    logger.info('Product_Member already exists: {} / {}'.format(product, authorized_user))
 
         if authorized_user_exists and not settings.AUTHORIZED_USERS_ALLOW_STAFF and \
                 (settings.AUTHORIZED_USERS_ALLOW_CHANGE or settings.AUTHORIZED_USERS_ALLOW_DELETE):
@@ -78,11 +82,10 @@ class Command(BaseCommand):
 
         logger.info('Finished migrating users for authorization v2')
 
-
-def get_role():
-    if settings.AUTHORIZED_USERS_ALLOW_STAFF:
-        return 4  # Owner
-    elif settings.AUTHORIZED_USERS_ALLOW_CHANGE or settings.AUTHORIZED_USERS_ALLOW_DELETE:
-        return 2  # Writer
-    else:
-        return 0  # Reader
+    def get_role(self):
+        if settings.AUTHORIZED_USERS_ALLOW_STAFF:
+            return self.owner_role
+        elif settings.AUTHORIZED_USERS_ALLOW_CHANGE or settings.AUTHORIZED_USERS_ALLOW_DELETE:
+            return self.writer_role
+        else:
+            return self.reader_role

--- a/dojo/management/commands/migrate_authorization_v2.py
+++ b/dojo/management/commands/migrate_authorization_v2.py
@@ -74,7 +74,7 @@ class Command(BaseCommand):
 
         if authorized_user_exists and not settings.AUTHORIZED_USERS_ALLOW_STAFF and \
                 (settings.AUTHORIZED_USERS_ALLOW_CHANGE or settings.AUTHORIZED_USERS_ALLOW_DELETE):
-            logger.warn('Authorized users have less permissions than before, because there is no equivalent for AUTHORIZED_USERS_ALLOW_CHANGE and AUTHORIZED_USERS_ALLOW_DELETE')
+            logger.warn('Authorized users have more permissions than before, because there is no equivalent for AUTHORIZED_USERS_ALLOW_CHANGE and AUTHORIZED_USERS_ALLOW_DELETE')
 
         logger.info('Finished migrating users for authorization v2')
 
@@ -82,5 +82,7 @@ class Command(BaseCommand):
 def get_role():
     if settings.AUTHORIZED_USERS_ALLOW_STAFF:
         return 4  # Owner
+    elif settings.AUTHORIZED_USERS_ALLOW_CHANGE or settings.AUTHORIZED_USERS_ALLOW_DELETE:
+        return 2  # Writer
     else:
         return 0  # Reader

--- a/dojo/management/commands/migrate_authorization_v2.py
+++ b/dojo/management/commands/migrate_authorization_v2.py
@@ -1,0 +1,80 @@
+import logging
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from dojo.models import Dojo_User, Product, Product_Member, Product_Type, Product_Type_Member
+from dojo.authorization.roles_permissions import Roles
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    When changing to authorization v2, this command adds staff users and
+    authorized users as product type members / product members according
+    to their permissions they have had before and the settings.
+    """
+    help = 'Usage: manage.py migration_authorization_v2'
+
+    def handle(self, *args, **options):
+
+        logger.info('Started migrating users for authorization v2 ...')
+
+        authorized_user_exists = False
+
+        product_types = Product_Type.objects.all().prefetch_related('authorized_users')
+        staff_users = Dojo_User.objects.filter(is_staff=True, is_superuser=False)
+        for product_type in product_types:
+            # Staff users have had all permissions for all product types and products,
+            # so they will be set as owners for all product types.
+            # Superusers will have all permissions anyway, so they must not be set as members.
+            for staff_user in staff_users:
+                # If the product type member already exists, it won't be changed
+                if Product_Type_Member.objects.filter(product_type=product_type, user=staff_user).count() == 0:
+                    product_type_member = Product_Type_Member()
+                    product_type_member.product_type = product_type
+                    product_type_member.user = staff_user
+                    product_type_member.role = 4  # Owner
+                    product_type_member.save()
+                    logger.info('ProductTypeMember added: {} / {} / {}'.format(product_type.name, staff_user.username, Roles(product_type_member.role).name))
+
+            # Authorized users for product types will be converted to product type members
+            # with a role according to the settings
+            for authorized_user in product_type.authorized_users.all():
+                # If the product type member already exists, it won't be changed
+                if Product_Type_Member.objects.filter(product_type=product_type, user=authorized_user).count() == 0:
+                    authorized_user_exists = True
+                    product_type_member = Product_Type_Member()
+                    product_type_member.product_type = product_type
+                    product_type_member.user = authorized_user
+                    product_type_member.role = get_role()
+                    product_type_member.save()
+                    logger.info('ProductTypeMember added: {} / {} / {}'.format(product_type.name, authorized_user.username, Roles(product_type_member.role).name))
+
+        products = Product.objects.all().prefetch_related('authorized_users')
+        for product in products:
+            # Authorized users for products will be converted to product members
+            # with a role according to the settings
+            for authorized_user in product.authorized_users.all():
+                # If the product member already exists, it won't be changed
+                if Product_Member.objects.filter(product=product, user=authorized_user).count() == 0:
+                    authorized_user_exists = True
+                    product_member = Product_Member()
+                    product_member.product = product
+                    product_member.user = authorized_user
+                    product_member.role = get_role()
+                    product_member.save()
+                    logger.info('ProductMember added: {} / {} / {}'.format(product.name, authorized_user.username, Roles(product_member.role).name))
+
+        if authorized_user_exists and not settings.AUTHORIZED_USERS_ALLOW_STAFF and \
+                (settings.AUTHORIZED_USERS_ALLOW_CHANGE or settings.AUTHORIZED_USERS_ALLOW_DELETE):
+            logger.warn('Authorized users have less permissions than before, because there is no equivalent for AUTHORIZED_USERS_ALLOW_CHANGE and AUTHORIZED_USERS_ALLOW_DELETE')
+
+        logger.info('Finished migrating users for authorization v2')
+
+
+def get_role():
+    if settings.AUTHORIZED_USERS_ALLOW_STAFF:
+        return 4  # Owner
+    else:
+        return 0  # Reader

--- a/dojo/management/commands/migrate_authorization_v2.py
+++ b/dojo/management/commands/migrate_authorization_v2.py
@@ -36,7 +36,9 @@ class Command(BaseCommand):
                     product_type_member.user = staff_user
                     product_type_member.role = 4  # Owner
                     product_type_member.save()
-                    logger.info('ProductTypeMember added: {} / {} / {}'.format(product_type.name, staff_user.username, Roles(product_type_member.role).name))
+                    logger.info('Product_Type_Member added: {} / {} / {}'.format(product_type.name, staff_user.username, Roles(product_type_member.role).name))
+                else:
+                    logger.info('Product_Type_Member already exists: {} / {}'.format(product_type.name, staff_user.username))
 
             # Authorized users for product types will be converted to product type members
             # with a role according to the settings
@@ -49,7 +51,9 @@ class Command(BaseCommand):
                     product_type_member.user = authorized_user
                     product_type_member.role = get_role()
                     product_type_member.save()
-                    logger.info('ProductTypeMember added: {} / {} / {}'.format(product_type.name, authorized_user.username, Roles(product_type_member.role).name))
+                    logger.info('Product_Type_Member added: {} / {} / {}'.format(product_type.name, authorized_user.username, Roles(product_type_member.role).name))
+                else:
+                    logger.info('Product_Type_Member already exists: {} / {}'.format(product_type.name, authorized_user.username))
 
         products = Product.objects.all().prefetch_related('authorized_users')
         for product in products:
@@ -64,7 +68,9 @@ class Command(BaseCommand):
                     product_member.user = authorized_user
                     product_member.role = get_role()
                     product_member.save()
-                    logger.info('ProductMember added: {} / {} / {}'.format(product.name, authorized_user.username, Roles(product_member.role).name))
+                    logger.info('Product_Member added: {} / {} / {}'.format(product.name, authorized_user.username, Roles(product_member.role).name))
+                else:
+                    logger.info('Product_Member already exists: {} / {}'.format(product.name, authorized_user.username))
 
         if authorized_user_exists and not settings.AUTHORIZED_USERS_ALLOW_STAFF and \
                 (settings.AUTHORIZED_USERS_ALLOW_CHANGE or settings.AUTHORIZED_USERS_ALLOW_DELETE):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -175,7 +175,7 @@ env = environ.Env(
 
     # Feature toggle for new authorization, which is incomplete at the moment.
     # Don't set it to True for productive environments!
-    DD_FEATURE_AUTHORIZATION_V2=(bool, False),
+    DD_FEATURE_AUTHORIZATION_V2=(bool, True),
     # When enabled, staff users have full access to all product types and products
     DD_AUTHORIZATION_STAFF_OVERRIDE=(bool, False),
 


### PR DESCRIPTION
The management command `migration_authorization_v2` creates Product_Members and Product_Type_Members:

- Staff users currently have all permissions for all product types and products --> Every staff users gets the Owner role for all product types.
- Authorized users for product types or products types currently are non-staff users. They get a role for the respective product type or product based on the settings parameter `AUTHORIZED_USERS_ALLOW_STAFF`:
    - If that parameter is `False`, authorized users can only read the product type / product and they will get the role Reader.
    - If that parameter is `True`, they have all permissions and will get the role Owner.

The settings parameters `AUTHORIZED_USERS_ALLOW_CHANGE` and `AUTHORIZED_USERS_ALLOW_DELETE` give authorized users currently permissions that are quite different from the defined roles. So these parameters are not used to define roles.