### PR TITLE
remove obsolete django-rest-swagger dependency

### DIFF
--- a/docs/content/en/integrations/api-v2-docs.md
+++ b/docs/content/en/integrations/api-v2-docs.md
@@ -15,8 +15,8 @@ Docs link on the user drop down menu in the header.
 ![image](../../images/api_v2_1.png)
 
 The documentation is generated using [Django Rest Framework
-Swagger](https://marcgibbons.com/django-rest-swagger/), and is
-interactive.
+Yet Another Swagger Generator](https://github.com/axnsan12/drf-yasg/), and is
+interactive. On the top of API v2 docs is a link that generates an OpenAPI v2 spec.
 
 To interact with the documentation, a valid Authorization header value
 is needed. Visit the `/api/v2/key/` view to generate your

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -641,7 +641,6 @@ INSTALLED_APPS = (
     'multiselectfield',
     'rest_framework',
     'rest_framework.authtoken',
-    'rest_framework_swagger',
     'dbbackup',
     'django_celery_results',
     'social_django',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@ django-multiselectfield==0.1.12
 django-polymorphic==3.0.0
 django-crispy-forms==1.11.2
 django_extensions==3.1.3
-django-rest-swagger==2.2.0
 django-slack==5.16.2
 django-tagging==0.5.0
 django-watson==1.5.5


### PR DESCRIPTION
`drf-yasg` is used for Swagger/OpenAPI spec generation.

https://github.com/axnsan12/drf-yasg/
