### PR TITLE
Auto-redirect when only one Social Auth is defined

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -77,6 +77,7 @@ env = environ.Env(
     DD_CREDENTIAL_AES_256_KEY=(str, '.'),
     DD_DATA_UPLOAD_MAX_MEMORY_SIZE=(int, 8388608),  # Max post size set to 8mb
     DD_SOCIAL_AUTH_SHOW_LOGIN_FORM=(bool, True),  # do we show user/pass input
+    DD_SOCIAL_LOGIN_AUTO_REDIRECT=(bool, False),  # auto-redirect if there is only one social login method
     DD_SOCIAL_AUTH_TRAILING_SLASH=(bool, True),
     DD_SOCIAL_AUTH_AUTH0_OAUTH2_ENABLED=(bool, False),
     DD_SOCIAL_AUTH_AUTH0_KEY=(str, ''),
@@ -392,6 +393,7 @@ SOCIAL_AUTH_PIPELINE = (
 CLASSIC_AUTH_ENABLED = True
 # Showing login form (form is not needed for external auth: OKTA, Google Auth, etc.)
 SHOW_LOGIN_FORM = env('DD_SOCIAL_AUTH_SHOW_LOGIN_FORM')
+SOCIAL_LOGIN_AUTO_REDIRECT = env('DD_SOCIAL_LOGIN_AUTO_REDIRECT')
 
 SOCIAL_AUTH_STRATEGY = 'social_django.strategy.DjangoStrategy'
 SOCIAL_AUTH_STORAGE = 'social_django.models.DjangoStorage'

--- a/dojo/user/urls.py
+++ b/dojo/user/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     # social-auth-django required url package
     url('', include('social_django.urls', namespace='social')),
     #  user specific
-    url(r'^login$', LoginView.as_view(template_name='dojo/login.html', authentication_form=AuthenticationForm), name='login'),
+    url(r'^login$', views.login_view, name='login'),
     url(r'^logout$', views.logout_view, name='logout'),
     url(r'^alerts$', views.alerts, name='alerts'),
     url(r'^alerts/json$', views.alerts_json, name='alerts_json'),

--- a/dojo/user/urls.py
+++ b/dojo/user/urls.py
@@ -1,6 +1,4 @@
 from django.conf.urls import url, include
-from django.contrib.auth.views import LoginView
-from django.contrib.auth.forms import AuthenticationForm
 
 from dojo.user import views
 

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -132,6 +132,7 @@ def login_view(request):
     else:
         return LoginView.as_view(template_name='dojo/login.html', authentication_form=AuthenticationForm)(request)
 
+
 def logout_view(request):
     logout(request)
     messages.add_message(request,

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -113,22 +113,19 @@ def login_view(request):
         settings.SAML2_ENABLED
     ]) == 1:
         if settings.GOOGLE_OAUTH_ENABLED:
-            return HttpResponseRedirect('{}?{}'.format(reverse('social:begin', args=['google-oauth2']),
-                                                       urlencode({'next': request.GET.get('next')})))
+            social_auth = 'google-oauth2'
         elif settings.OKTA_OAUTH_ENABLED:
-            return HttpResponseRedirect('{}?{}'.format(reverse('social:begin', 'okta-oauth2'),
-                                                       urlencode({'next': request.GET.get('next')})))
+            social_auth = 'okta-oauth2'
         elif settings.AZUREAD_TENANT_OAUTH2_ENABLED:
-            return HttpResponseRedirect('{}?{}'.format(reverse('social:begin', 'azuread-tenant-oauth2'),
-                                                       urlencode({'next': request.GET.get('next')})))
+            social_auth = 'azuread-tenant-oauth2'
         elif settings.GITLAB_OAUTH2_ENABLED:
-            return HttpResponseRedirect('{}?{}'.format(reverse('social:begin', 'gitlab'),
-                                                       urlencode({'next': request.GET.get('next')})))
+            social_auth = 'gitlab'
         elif settings.AUTH0_OAUTH2_ENABLED:
-            return HttpResponseRedirect('{}?{}'.format(reverse('social:begin', 'auth0'),
-                                                       urlencode({'next': request.GET.get('next')})))
+            social_auth = 'auth0'
         else:
             return HttpResponseRedirect('/saml2/login')
+        return HttpResponseRedirect('{}?{}'.format(reverse('social:begin', args=[social_auth]),
+                                                   urlencode({'next': request.GET.get('next')})))
     else:
         return LoginView.as_view(template_name='dojo/login.html', authentication_form=AuthenticationForm)(request)
 

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -104,7 +104,7 @@ def api_v2_key(request):
 
 
 def login_view(request):
-    if not settings.SHOW_LOGIN_FORM and sum([
+    if not settings.SHOW_LOGIN_FORM and settings.SOCIAL_LOGIN_AUTO_REDIRECT and sum([
         settings.GOOGLE_OAUTH_ENABLED,
         settings.OKTA_OAUTH_ENABLED,
         settings.AZUREAD_TENANT_OAUTH2_ENABLED,


### PR DESCRIPTION
If `DD_SOCIAL_AUTH_SHOW_LOGIN_FORM` is set to `False` (local login is not allowed) and there is exactly one Social Auth definition, the `/login` page automatically redirect to the Social login form.
There is no reason to show only one Social button.