### PR TITLE
Authorization V2: API and queries for groups

### DIFF
--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -3,7 +3,7 @@ from dojo.models import Endpoint, Engagement, Finding, Product_Type, Product, Te
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions
 from dojo.authorization.authorization import user_has_permission
-from dojo.authorization.roles_permissions import Permissions
+from dojo.authorization.roles_permissions import Permissions, Roles
 
 
 def check_post_permission(request, post_model, post_pk, post_permission):
@@ -156,6 +156,14 @@ class UserHasProductMemberPermission(permissions.BasePermission):
         return check_object_permission(request, obj, Permissions.Product_View, Permissions.Product_Manage_Members, Permissions.Product_Member_Delete)
 
 
+class UserHasProductGroupPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return check_post_permission(request, Product, 'product', Permissions.Product_Group_Add)
+
+    def has_object_permission(self, request, view, obj):
+        return check_object_permission(request, obj, Permissions.Product_Group_View, Permissions.Product_Group_Edit, Permissions.Product_Group_Delete)
+
+
 class UserHasProductTypePermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method == 'POST':
@@ -173,6 +181,14 @@ class UserHasProductTypeMemberPermission(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return check_object_permission(request, obj, Permissions.Product_Type_View, Permissions.Product_Type_Manage_Members, Permissions.Product_Type_Member_Delete)
+
+
+class UserHasProductTypeGroupPermission(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return check_post_permission(request, Product_Type, 'product_type', Permissions.Product_Type_Group_Add)
+
+    def has_object_permission(self, request, view, obj):
+        return check_object_permission(request, obj, Permissions.Product_Type_Group_View, Permissions.Product_Type_Group_Edit, Permissions.Product_Group_Delete)
 
 
 class UserHasReimportPermission(permissions.BasePermission):

--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -188,7 +188,7 @@ class UserHasProductTypeGroupPermission(permissions.BasePermission):
         return check_post_permission(request, Product_Type, 'product_type', Permissions.Product_Type_Group_Add)
 
     def has_object_permission(self, request, view, obj):
-        return check_object_permission(request, obj, Permissions.Product_Type_Group_View, Permissions.Product_Type_Group_Edit, Permissions.Product_Group_Delete)
+        return check_object_permission(request, obj, Permissions.Product_Type_Group_View, Permissions.Product_Type_Group_Edit, Permissions.Product_Type_Group_Delete)
 
 
 class UserHasReimportPermission(permissions.BasePermission):

--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -3,7 +3,7 @@ from dojo.models import Endpoint, Engagement, Finding, Product_Type, Product, Te
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions
 from dojo.authorization.authorization import user_has_permission
-from dojo.authorization.roles_permissions import Permissions, Roles
+from dojo.authorization.roles_permissions import Permissions
 
 
 def check_post_permission(request, post_model, post_pk, post_permission):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -397,15 +397,27 @@ class ProductMemberSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
     def validate(self, data):
-        if self.context['request'].method == 'POST':
+        if self.instance is not None and \
+                data.get('product') != self.instance.product and \
+                not user_has_permission(self.context['request'].user, data.get('product'), Permissions.Product_Manage_Members):
+            raise PermissionDenied('You are not permitted to add a member to this product')
+
+        if self.instance is None or \
+                data.get('product') != self.instance.product or \
+                data.get('user') != self.instance.user:
             members = Product_Member.objects.filter(product=data.get('product'), user=data.get('user'))
             if members.count() > 0:
-                raise ValidationError('Product member already exists')
+                raise ValidationError('Product_Member already exists')
 
         if data.get('role') == Roles.Owner and not user_has_permission(self.context['request'].user, data.get('product'), Permissions.Product_Member_Add_Owner):
-            raise PermissionDenied('You are not permitted to add users as owners')
+            raise PermissionDenied('You are not permitted to add a member as Owner to this product')
 
         return data
+
+    def validate_role(self, value):
+        if not Roles.has_value(value):
+            raise ValidationError('Role {} does not exist'.format(value))
+        return value
 
 
 class ProductGroupSerializer(serializers.ModelSerializer):
@@ -419,15 +431,27 @@ class ProductGroupSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
     def validate(self, data):
-        if self.context['request'].method == 'POST':
-            members = Product_Group.objects.filter(product=data.get('product'), user=data.get('user'))
+        if self.instance is not None and \
+                data.get('product') != self.instance.product and \
+                not user_has_permission(self.context['request'].user, data.get('product'), Permissions.Product_Group_Add):
+            raise PermissionDenied('You are not permitted to add a group to this product')
+
+        if self.instance is None or \
+                data.get('product') != self.instance.product or \
+                data.get('group') != self.instance.group:
+            members = Product_Group.objects.filter(product=data.get('product'), group=data.get('group'))
             if members.count() > 0:
                 raise ValidationError('Product_Group already exists')
 
         if data.get('role') == Roles.Owner and not user_has_permission(self.context['request'].user, data.get('product'), Permissions.Product_Group_Add_Owner):
-            raise PermissionDenied('You are not permitted to add groups as owners')
+            raise PermissionDenied('You are not permitted to add a group as Owner to this product')
 
         return data
+
+    def validate_role(self, value):
+        if not Roles.has_value(value):
+            raise ValidationError('Role {} does not exist'.format(value))
+        return value
 
 
 class ProductSerializer(TaggitSerializer, serializers.ModelSerializer):
@@ -466,20 +490,27 @@ class ProductTypeMemberSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
     def validate(self, data):
-        if self.context['request'].method == 'POST':
+        if self.instance is not None and \
+                data.get('product_type') != self.instance.product_type and \
+                not user_has_permission(self.context['request'].user, data.get('product_type'), Permissions.Product_Type_Manage_Members):
+            raise PermissionDenied('You are not permitted to add a member to this product type')
+
+        if self.instance is None or \
+                data.get('product_type') != self.instance.product_type or \
+                data.get('user') != self.instance.user:
             members = Product_Type_Member.objects.filter(product_type=data.get('product_type'), user=data.get('user'))
             if members.count() > 0:
-                raise ValidationError('Product type member already exists')
-        else:
-            if data.get('role') != Roles.Owner:
-                owners = Product_Type_Member.objects.filter(product_type=data.get('product_type'), role=Roles.Owner).exclude(id=self.instance.id).count()
-                if owners < 1:
-                    raise ValidationError('There must be at least one owner')
+                raise ValidationError('Product_Type_Member already exists')
 
         if data.get('role') == Roles.Owner and not user_has_permission(self.context['request'].user, data.get('product_type'), Permissions.Product_Type_Member_Add_Owner):
-            raise PermissionDenied('You are not permitted to add users as owners')
+            raise PermissionDenied('You are not permitted to add a member as Owner to this product type')
 
         return data
+
+    def validate_role(self, value):
+        if not Roles.has_value(value):
+            raise ValidationError('Role {} does not exist'.format(value))
+        return value
 
 
 class ProductTypeGroupSerializer(serializers.ModelSerializer):
@@ -493,15 +524,27 @@ class ProductTypeGroupSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
     def validate(self, data):
-        if self.context['request'].method == 'POST':
-            members = Product_Type_Group.objects.filter(product_type=data.get('product_type'), user=data.get('user'))
+        if self.instance is not None and \
+                data.get('product_type') != self.instance.product_type and \
+                not user_has_permission(self.context['request'].user, data.get('product_type'), Permissions.Product_Type_Group_Add):
+            raise PermissionDenied('You are not permitted to add a group to this product type')
+
+        if self.instance is None or \
+                data.get('product_type') != self.instance.product_type or \
+                data.get('group') != self.instance.group:
+            members = Product_Type_Group.objects.filter(product_type=data.get('product_type'), group=data.get('group'))
             if members.count() > 0:
                 raise ValidationError('Product_Type_Group already exists')
 
         if data.get('role') == Roles.Owner and not user_has_permission(self.context['request'].user, data.get('product_type'), Permissions.Product_Type_Group_Add_Owner):
-            raise PermissionDenied('You are not permitted to add groups as owners')
+            raise PermissionDenied('You are not permitted to add a group as Owner to this product type')
 
         return data
+
+    def validate_role(self, value):
+        if not Roles.has_value(value):
+            raise ValidationError('Role {} does not exist'.format(value))
+        return value
 
 
 class ProductTypeSerializer(serializers.ModelSerializer):

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -502,6 +502,14 @@ class ProductTypeMemberSerializer(serializers.ModelSerializer):
             if members.count() > 0:
                 raise ValidationError('Product_Type_Member already exists')
 
+        if data.get('role') != Roles.Owner:
+            if self.instance is None:
+                owners = Product_Type_Member.objects.filter(product_type=data.get('product_type'), role=Roles.Owner).count()
+            else:
+                owners = Product_Type_Member.objects.filter(product_type=data.get('product_type'), role=Roles.Owner).exclude(id=self.instance.id).count()
+            if owners < 1:
+                raise ValidationError('There must be at least one owner')
+
         if data.get('role') == Roles.Owner and not user_has_permission(self.context['request'].user, data.get('product_type'), Permissions.Product_Type_Member_Add_Owner):
             raise PermissionDenied('You are not permitted to add a member as Owner to this product type')
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -976,6 +976,11 @@ class ProductMemberViewSet(prefetch.PrefetchListMixin,
     def get_queryset(self):
         return get_authorized_product_members(Permissions.Product_View).distinct()
 
+    def partial_update(self, request, pk=None):
+        # Object authorization won't work if not all data is provided
+        response = {'message': 'Patch function is not offered in this path.'}
+        return Response(response, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
 
 # Authorization: object-based
 class ProductGroupViewSet(prefetch.PrefetchListMixin,
@@ -997,6 +1002,11 @@ class ProductGroupViewSet(prefetch.PrefetchListMixin,
 
     def get_queryset(self):
         return get_authorized_product_groups(Permissions.Product_Group_View).distinct()
+
+    def partial_update(self, request, pk=None):
+        # Object authorization won't work if not all data is provided
+        response = {'message': 'Patch function is not offered in this path.'}
+        return Response(response, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 # Authorization: object-based
@@ -1087,6 +1097,11 @@ class ProductTypeMemberViewSet(prefetch.PrefetchListMixin,
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    def partial_update(self, request, pk=None):
+        # Object authorization won't work if not all data is provided
+        response = {'message': 'Patch function is not offered in this path.'}
+        return Response(response, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
 
 # Authorization: object-based
 class ProductTypeGroupViewSet(prefetch.PrefetchListMixin,
@@ -1108,6 +1123,11 @@ class ProductTypeGroupViewSet(prefetch.PrefetchListMixin,
 
     def get_queryset(self):
         return get_authorized_product_type_groups(Permissions.Product_Type_Group_View).distinct()
+
+    def partial_update(self, request, pk=None):
+        # Object authorization won't work if not all data is provided
+        response = {'message': 'Patch function is not offered in this path.'}
+        return Response(response, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
 # Authorization: object-based

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -960,6 +960,7 @@ class ProductTypeViewSet(prefetch.PrefetchListMixin,
         serializer.save()
         if settings.FEATURE_AUTHORIZATION_V2:
             product_type_data = serializer.data
+            product_type_data.pop('authorization_groups')
             product_type_data.pop('members')
             member = Product_Type_Member()
             member.user = self.request.user

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -19,7 +19,8 @@ from dojo.models import Product, Product_Type, Engagement, Test, Test_Import, Te
     Endpoint, JIRA_Project, JIRA_Instance, DojoMeta, Development_Environment, \
     Dojo_User, Note_Type, System_Settings, App_Analysis, Endpoint_Status, \
     Sonarqube_Issue, Sonarqube_Issue_Transition, Sonarqube_Product, Regulation, \
-    BurpRawRequestResponse, FileUpload, Product_Type_Member, Product_Member
+    BurpRawRequestResponse, FileUpload, Product_Type_Member, Product_Member, Dojo_Group, \
+    Product_Group, Product_Type_Group
 
 from dojo.endpoint.views import get_endpoint_ids
 from dojo.reports.views import report_url_resolver, prefetch_related_findings_for_report
@@ -37,8 +38,10 @@ from dojo.api_v2 import serializers, permissions, prefetch, schema
 import dojo.jira_link.helper as jira_helper
 import logging
 import tagulous
-from dojo.product_type.queries import get_authorized_product_types, get_authorized_product_type_members
-from dojo.product.queries import get_authorized_products, get_authorized_app_analysis, get_authorized_dojo_meta, get_authorized_product_members
+from dojo.product_type.queries import get_authorized_product_types, get_authorized_product_type_members, \
+    get_authorized_product_type_groups
+from dojo.product.queries import get_authorized_products, get_authorized_app_analysis, get_authorized_dojo_meta, \
+    get_authorized_product_members, get_authorized_product_groups
 from dojo.engagement.queries import get_authorized_engagements
 from dojo.test.queries import get_authorized_tests, get_authorized_test_imports
 from dojo.finding.queries import get_authorized_findings, get_authorized_stub_findings
@@ -46,6 +49,45 @@ from dojo.endpoint.queries import get_authorized_endpoints, get_authorized_endpo
 from dojo.authorization.roles_permissions import Permissions, Roles
 
 logger = logging.getLogger(__name__)
+
+
+# Authorization: superuser
+class DojoGroupViewSet(mixins.ListModelMixin,
+                                mixins.RetrieveModelMixin,
+                                mixins.DestroyModelMixin,
+                                mixins.UpdateModelMixin,
+                                mixins.CreateModelMixin,
+                                viewsets.GenericViewSet):
+    serializer_class = serializers.DojoGroupSerializer
+    queryset = Dojo_Group.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'name')
+    permission_classes = (permissions.IsSuperUser, DjangoModelPermissions)
+
+    @swagger_auto_schema(
+        method='post',
+        responses={status.HTTP_200_OK: "User added"},
+        request_body=no_body
+    )
+    @swagger_auto_schema(
+        method='delete',
+        responses={status.HTTP_200_OK: "User removed"},
+        request_body=no_body
+    )
+    @action(detail=True, methods=['post', 'delete'], url_path=r'users/(?P<user_id>\d+)')
+    def add_user(self, request, pk, user_id):
+        dojo_group = self.get_object()
+        user = get_object_or_404(Dojo_User, id=user_id)
+        if request.method == 'POST':
+            dojo_group.users.add(user)
+            dojo_group.save()
+            return Response(status=status.HTTP_200_OK)
+        if request.method == 'DELETE':
+            if user not in dojo_group.users.all():
+                return Response(status=status.HTTP_400_BAD_REQUEST)
+            dojo_group.users.remove(user)
+            dojo_group.save()
+            return Response(status=status.HTTP_200_OK)
 
 
 # Authorization: object-based
@@ -936,6 +978,28 @@ class ProductMemberViewSet(prefetch.PrefetchListMixin,
 
 
 # Authorization: object-based
+class ProductGroupViewSet(prefetch.PrefetchListMixin,
+                          prefetch.PrefetchRetrieveMixin,
+                          mixins.ListModelMixin,
+                          mixins.RetrieveModelMixin,
+                          mixins.CreateModelMixin,
+                          mixins.DestroyModelMixin,
+                          mixins.UpdateModelMixin,
+                          viewsets.GenericViewSet):
+    serializer_class = serializers.ProductGroupSerializer
+    queryset = Product_Group.objects.none()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'product_id', 'group_id')
+    swagger_schema = prefetch.get_prefetch_schema(["product_groups_list", "product_groups_read"],
+        serializers.ProductGroupSerializer).to_schema()
+    if settings.FEATURE_AUTHORIZATION_V2:
+        permission_classes = (IsAuthenticated, permissions.UserHasProductGroupPermission)
+
+    def get_queryset(self):
+        return get_authorized_product_groups(Permissions.Product_Group_View).distinct()
+
+
+# Authorization: object-based
 class ProductTypeViewSet(prefetch.PrefetchListMixin,
                          prefetch.PrefetchRetrieveMixin,
                          mixins.ListModelMixin,
@@ -1022,6 +1086,28 @@ class ProductTypeMemberViewSet(prefetch.PrefetchListMixin,
                 return Response('There must be at least one owner', status=status.HTTP_400_BAD_REQUEST)
         self.perform_destroy(instance)
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+# Authorization: object-based
+class ProductTypeGroupViewSet(prefetch.PrefetchListMixin,
+                              prefetch.PrefetchRetrieveMixin,
+                              mixins.ListModelMixin,
+                              mixins.RetrieveModelMixin,
+                              mixins.CreateModelMixin,
+                              mixins.DestroyModelMixin,
+                              mixins.UpdateModelMixin,
+                              viewsets.GenericViewSet):
+    serializer_class = serializers.ProductTypeGroupSerializer
+    queryset = Product_Type_Group.objects.none()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'product_type_id', 'group_id')
+    swagger_schema = prefetch.get_prefetch_schema(["product_type_groups_list", "product_type_groups_read"],
+        serializers.ProductTypeGroupSerializer).to_schema()
+    if settings.FEATURE_AUTHORIZATION_V2:
+        permission_classes = (IsAuthenticated, permissions.UserHasProductTypeGroupPermission)
+
+    def get_queryset(self):
+        return get_authorized_product_type_groups(Permissions.Product_Type_Group_View).distinct()
 
 
 # Authorization: object-based

--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -61,6 +61,10 @@ def user_has_permission(user, obj, permission):
             return obj.user == user or user_has_permission(user, obj.product, permission)
         else:
             return user_has_permission(user, obj.product, permission)
+    elif isinstance(obj, Product_Type_Group) and permission in Permissions.get_product_type_group_permissions():
+        return user_has_permission(user, obj.product_type, permission)
+    elif isinstance(obj, Product_Group) and permission in Permissions.get_product_group_permissions():
+        return user_has_permission(user, obj.product, permission)
     else:
         raise NoAuthorizationImplementedError('No authorization implemented for class {} and permission {}'.
             format(type(obj).__name__, permission))

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -83,6 +83,18 @@ class Permissions(IntEnum):
     Finding_Group_Edit = 1906
     Finding_Group_Delete = 1907
 
+    Product_Type_Group_View = 2002
+    Product_Type_Group_Add = 2003
+    Product_Type_Group_Add_Owner = 2005
+    Product_Type_Group_Edit = 2006
+    Product_Type_Group_Delete = 2007
+
+    Product_Group_View = 2102
+    Product_Group_Add = 2103
+    Product_Group_Add_Owner = 2105
+    Product_Group_Edit = 2106
+    Product_Group_Delete = 2107
+
     @classmethod
     def has_value(cls, value):
         try:
@@ -132,43 +144,42 @@ class Permissions(IntEnum):
         return {Permissions.Product_Type_View, Permissions.Product_Type_Manage_Members,
             Permissions.Product_Type_Member_Delete}
 
+    @classmethod
+    def get_product_group_permissions(cls):
+        return {Permissions.Product_Group_View, Permissions.Product_Group_Edit,
+            Permissions.Product_Group_Delete}
+
+    @classmethod
+    def get_product_type_group_permissions(cls):
+        return {Permissions.Product_Type_Group_View, Permissions.Product_Type_Group_Edit,
+            Permissions.Product_Type_Group_Delete}
+
 
 def get_roles_with_permissions():
     return {
         Roles.Reader: {
             Permissions.Product_Type_View,
-
             Permissions.Product_View,
-
             Permissions.Engagement_View,
-
             Permissions.Test_View,
-
             Permissions.Finding_View,
-
             Permissions.Finding_Group_View,
-
             Permissions.Endpoint_View,
-
-            Permissions.Component_View
+            Permissions.Component_View,
+            Permissions.Product_Group_View,
+            Permissions.Product_Type_Group_View
         },
         Roles.API_Importer: {
             Permissions.Product_Type_View,
-
             Permissions.Product_View,
-
             Permissions.Engagement_View,
-
             Permissions.Test_View,
-
             Permissions.Finding_View,
-
             Permissions.Finding_Group_View,
-
             Permissions.Endpoint_View,
-
             Permissions.Component_View,
-
+            Permissions.Product_Group_View,
+            Permissions.Product_Type_Group_View,
             Permissions.Import_Scan_Result
         },
         Roles.Writer: {
@@ -205,7 +216,10 @@ def get_roles_with_permissions():
 
             Permissions.Note_View_History,
             Permissions.Note_Edit,
-            Permissions.Note_Add
+            Permissions.Note_Add,
+
+            Permissions.Product_Group_View,
+            Permissions.Product_Type_Group_View
         },
         Roles.Maintainer: {
             Permissions.Product_Type_Add_Product,
@@ -255,7 +269,17 @@ def get_roles_with_permissions():
             Permissions.Note_View_History,
             Permissions.Note_Edit,
             Permissions.Note_Add,
-            Permissions.Note_Delete
+            Permissions.Note_Delete,
+
+            Permissions.Product_Group_View,
+            Permissions.Product_Group_Add,
+            Permissions.Product_Group_Edit,
+            Permissions.Product_Group_Delete,
+
+            Permissions.Product_Type_Group_View,
+            Permissions.Product_Group_Add,
+            Permissions.Product_Group_Edit,
+            Permissions.Product_Group_Delete
         },
         Roles.Owner: {
             Permissions.Product_Type_Add_Product,
@@ -309,6 +333,18 @@ def get_roles_with_permissions():
             Permissions.Note_View_History,
             Permissions.Note_Edit,
             Permissions.Note_Add,
-            Permissions.Note_Delete
+            Permissions.Note_Delete,
+
+            Permissions.Product_Group_View,
+            Permissions.Product_Group_Add,
+            Permissions.Product_Group_Add_Owner,
+            Permissions.Product_Group_Edit,
+            Permissions.Product_Group_Delete,
+
+            Permissions.Product_Type_Group_View,
+            Permissions.Product_Type_Group_Add,
+            Permissions.Product_Type_Group_Add_Owner,
+            Permissions.Product_Type_Group_Edit,
+            Permissions.Product_Type_Group_Delete
         }
     }

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -277,9 +277,9 @@ def get_roles_with_permissions():
             Permissions.Product_Group_Delete,
 
             Permissions.Product_Type_Group_View,
-            Permissions.Product_Group_Add,
-            Permissions.Product_Group_Edit,
-            Permissions.Product_Group_Delete
+            Permissions.Product_Type_Group_Add,
+            Permissions.Product_Type_Group_Edit,
+            Permissions.Product_Type_Group_Delete
         },
         Roles.Owner: {
             Permissions.Product_Type_Add_Product,

--- a/dojo/endpoint/queries.py
+++ b/dojo/endpoint/queries.py
@@ -1,7 +1,8 @@
 from crum import get_current_user
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
-from dojo.models import Endpoint, Endpoint_Status, Product_Member, Product_Type_Member
+from dojo.models import Endpoint, Endpoint_Status, Product_Member, Product_Type_Member, \
+    Product_Group, Product_Type_Group
 from dojo.authorization.authorization import get_roles_for_permission
 
 
@@ -34,12 +35,22 @@ def get_authorized_endpoints(permission, queryset=None, user=None):
             product=OuterRef('product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('product_id'),
+            group__users=user,
+            role__in=roles)
         endpoints = endpoints.annotate(
             product__prod_type__member=Exists(authorized_product_type_roles),
-            product__member=Exists(authorized_product_roles))
+            product__member=Exists(authorized_product_roles),
+            product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            product__authorized_group=Exists(authorized_product_groups))
         endpoints = endpoints.filter(
-            Q(product__prod_type__member=True) |
-            Q(product__member=True))
+            Q(product__prod_type__member=True) | Q(product__member=True) |
+            Q(product__prod_type__authorized_group=True) | Q(product__authorized_group=True))
     else:
         if not user.is_staff:
             endpoints = endpoints.filter(
@@ -77,12 +88,22 @@ def get_authorized_endpoint_status(permission, queryset=None, user=None):
             product=OuterRef('endpoint__product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('endpoint__product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('endpoint__product_id'),
+            group__users=user,
+            role__in=roles)
         endpoint_status = endpoint_status.annotate(
             endpoint__product__prod_type__member=Exists(authorized_product_type_roles),
-            endpoint__product__member=Exists(authorized_product_roles))
+            endpoint__product__member=Exists(authorized_product_roles),
+            endpoint__product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            endpoint__product__authorized_group=Exists(authorized_product_groups))
         endpoint_status = endpoint_status.filter(
-            Q(endpoint__product__prod_type__member=True) |
-            Q(endpoint__product__member=True))
+            Q(endpoint__product__prod_type__member=True) | Q(endpoint__product__member=True) |
+            Q(endpoint__product__prod_type__authorized_group=True) | Q(endpoint__product__authorized_group=True))
     else:
         if not user.is_staff:
             endpoint_status = endpoint_status.filter(

--- a/dojo/engagement/queries.py
+++ b/dojo/engagement/queries.py
@@ -1,7 +1,8 @@
 from crum import get_current_user
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
-from dojo.models import Engagement, Product_Member, Product_Type_Member
+from dojo.models import Engagement, Product_Member, Product_Type_Member, \
+    Product_Group, Product_Type_Group
 from dojo.authorization.authorization import get_roles_for_permission
 
 
@@ -27,12 +28,22 @@ def get_authorized_engagements(permission):
             product=OuterRef('product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('product_id'),
+            group__users=user,
+            role__in=roles)
         engagements = Engagement.objects.annotate(
             product__prod_type__member=Exists(authorized_product_type_roles),
-            product__member=Exists(authorized_product_roles))
+            product__member=Exists(authorized_product_roles),
+            product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            product__authorized_group=Exists(authorized_product_groups))
         engagements = engagements.filter(
-            Q(product__prod_type__member=True) |
-            Q(product__member=True))
+            Q(product__prod_type__member=True) | Q(product__member=True) |
+            Q(product__prod_type__authorized_group=True) | Q(product__authorized_group=True))
     else:
         if user.is_staff:
             engagements = Engagement.objects.all()

--- a/dojo/finding/queries.py
+++ b/dojo/finding/queries.py
@@ -1,7 +1,8 @@
 from crum import get_current_user
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
-from dojo.models import Finding, Product_Member, Product_Type_Member, Stub_Finding
+from dojo.models import Finding, Product_Member, Product_Type_Member, Stub_Finding, \
+    Product_Group, Product_Type_Group
 from dojo.authorization.authorization import get_roles_for_permission
 
 
@@ -34,12 +35,24 @@ def get_authorized_findings(permission, queryset=None, user=None):
             product=OuterRef('test__engagement__product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('test__engagement__product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('test__engagement__product_id'),
+            group__users=user,
+            role__in=roles)
         findings = findings.annotate(
             test__engagement__product__prod_type__member=Exists(authorized_product_type_roles),
-            test__engagement__product__member=Exists(authorized_product_roles))
+            test__engagement__product__member=Exists(authorized_product_roles),
+            test__engagement__product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            test__engagement__product__authorized_group=Exists(authorized_product_groups))
         findings = findings.filter(
             Q(test__engagement__product__prod_type__member=True) |
-            Q(test__engagement__product__member=True))
+            Q(test__engagement__product__member=True) |
+            Q(test__engagement__product__prod_type__authorized_group=True) |
+            Q(test__engagement__product__authorized_group=True))
     else:
         if not user.is_staff:
             findings = findings.filter(
@@ -70,12 +83,24 @@ def get_authorized_stub_findings(permission):
             product=OuterRef('test__engagement__product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('test__engagement__product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('test__engagement__product_id'),
+            group__users=user,
+            role__in=roles)
         findings = Stub_Finding.objects.annotate(
             test__engagement__product__prod_type__member=Exists(authorized_product_type_roles),
-            test__engagement__product__member=Exists(authorized_product_roles))
+            test__engagement__product__member=Exists(authorized_product_roles),
+            test__engagement__product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            test__engagement__product__authorized_group=Exists(authorized_product_groups))
         findings = findings.filter(
             Q(test__engagement__product__prod_type__member=True) |
-            Q(test__engagement__product__member=True))
+            Q(test__engagement__product__member=True) |
+            Q(test__engagement__product__prod_type__authorized_group=True) |
+            Q(test__engagement__product__authorized_group=True))
     else:
         if user.is_staff:
             findings = Stub_Finding.objects.all()

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -97,6 +97,22 @@ def get_authorized_product_members_for_user(user, permission):
     return Product_Member.objects.filter(user=user, product__in=products)
 
 
+def get_authorized_product_groups(permission):
+    user = get_current_user()
+
+    if user is None:
+        return Product_Group.objects.none()
+
+    if user.is_superuser:
+        return Product_Group.objects.all()
+
+    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
+        return Product_Group.objects.all()
+
+    products = get_authorized_products(permission)
+    return Product_Group.objects.filter(product__in=products)
+
+
 def get_authorized_app_analysis(permission):
     user = get_current_user()
 

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -119,12 +119,22 @@ def get_authorized_app_analysis(permission):
             product=OuterRef('product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('product_id'),
+            group__users=user,
+            role__in=roles)
         app_analysis = App_Analysis.objects.annotate(
             product__prod_type__member=Exists(authorized_product_type_roles),
-            product__member=Exists(authorized_product_roles)).order_by('name')
+            product__member=Exists(authorized_product_roles),
+            product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            product__authorized_group=Exists(authorized_product_groups)).order_by('name')
         app_analysis = app_analysis.filter(
-            Q(product__prod_type__member=True) |
-            Q(product__member=True))
+            Q(product__prod_type__member=True) | Q(product__member=True) |
+            Q(product__prod_type__authorized_group=True) | Q(product__authorized_group=True))
     else:
         if user.is_staff:
             app_analysis = App_Analysis.objects.all().order_by('name')
@@ -157,6 +167,14 @@ def get_authorized_dojo_meta(permission):
             product=OuterRef('product_id'),
             user=user,
             role__in=roles)
+        product_authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        product_authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('product_id'),
+            group__users=user,
+            role__in=roles)
         endpoint_authorized_product_type_roles = Product_Type_Member.objects.filter(
             product_type=OuterRef('endpoint__product__prod_type_id'),
             user=user,
@@ -164,6 +182,14 @@ def get_authorized_dojo_meta(permission):
         endpoint_authorized_product_roles = Product_Member.objects.filter(
             product=OuterRef('endpoint__product_id'),
             user=user,
+            role__in=roles)
+        endpoint_authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('endpoint__product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        endpoint_authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('endpoint__product_id'),
+            group__users=user,
             role__in=roles)
         finding_authorized_product_type_roles = Product_Type_Member.objects.filter(
             product_type=OuterRef('finding__test__engagement__product__prod_type_id'),
@@ -173,21 +199,41 @@ def get_authorized_dojo_meta(permission):
             product=OuterRef('finding__test__engagement__product_id'),
             user=user,
             role__in=roles)
+        finding_authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('finding__test__engagement__product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        finding_authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('finding__test__engagement__product_id'),
+            group__users=user,
+            role__in=roles)
         dojo_meta = DojoMeta.objects.annotate(
             product__prod_type__member=Exists(product_authorized_product_type_roles),
             product__member=Exists(product_authorized_product_roles),
-            endpoint_product__prod_type__member=Exists(endpoint_authorized_product_type_roles),
-            endpoint_product__member=Exists(endpoint_authorized_product_roles),
+            product__prod_type__authorized_group=Exists(product_authorized_product_type_groups),
+            product__authorized_group=Exists(product_authorized_product_groups),
+            endpoint__product__prod_type__member=Exists(endpoint_authorized_product_type_roles),
+            endpoint__product__member=Exists(endpoint_authorized_product_roles),
+            endpoint__product__prod_type__authorized_group=Exists(endpoint_authorized_product_type_groups),
+            endpoint__product__authorized_group=Exists(endpoint_authorized_product_groups),
             finding__test__engagement__product__prod_type__member=Exists(finding_authorized_product_type_roles),
-            finding__test__engagement__product__member=Exists(finding_authorized_product_roles)
+            finding__test__engagement__product__member=Exists(finding_authorized_product_roles),
+            finding__test__engagement__product__prod_type__authorized_group=Exists(finding_authorized_product_type_groups),
+            finding__test__engagement__product__authorized_group=Exists(finding_authorized_product_groups)
         ).order_by('name')
         dojo_meta = dojo_meta.filter(
             Q(product__prod_type__member=True) |
             Q(product__member=True) |
-            Q(endpoint_product__prod_type__member=True) |
-            Q(endpoint_product__member=True) |
+            Q(product__prod_type__authorized_group=True) |
+            Q(product__authorized_group=True) |
+            Q(endpoint__product__prod_type__member=True) |
+            Q(endpoint__product__member=True) |
+            Q(endpoint__product__prod_type__authorized_group=True) |
+            Q(endpoint__product__authorized_group=True) |
             Q(finding__test__engagement__product__prod_type__member=True) |
-            Q(finding__test__engagement__product__member=True))
+            Q(finding__test__engagement__product__member=True) |
+            Q(finding__test__engagement__product__prod_type__authorized_group=True) |
+            Q(finding__test__engagement__product__authorized_group=True))
     else:
         if user.is_staff:
             dojo_meta = DojoMeta.objects.all().order_by('name')

--- a/dojo/product_type/queries.py
+++ b/dojo/product_type/queries.py
@@ -77,3 +77,19 @@ def get_authorized_product_type_members_for_user(user, permission):
 
     product_types = get_authorized_product_types(permission)
     return Product_Type_Member.objects.filter(user=user, product_type__in=product_types)
+
+
+def get_authorized_product_type_groups(permission):
+    user = get_current_user()
+
+    if user is None:
+        return Product_Type_Group.objects.none()
+
+    if user.is_superuser:
+        return Product_Type_Group.objects.all()
+
+    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
+        return Product_Type_Group.objects.all()
+
+    product_types = get_authorized_product_types(permission)
+    return Product_Type_Group.objects.filter(product_type__in=product_types)

--- a/dojo/test/queries.py
+++ b/dojo/test/queries.py
@@ -1,7 +1,8 @@
 from crum import get_current_user
 from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
-from dojo.models import Test, Product_Member, Product_Type_Member, Test_Import
+from dojo.models import Test, Product_Member, Product_Type_Member, Test_Import, \
+    Product_Group, Product_Type_Group
 from dojo.authorization.authorization import get_roles_for_permission
 
 
@@ -27,12 +28,24 @@ def get_authorized_tests(permission):
             product=OuterRef('engagement__product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('engagement__product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('engagement__product_id'),
+            group__users=user,
+            role__in=roles)
         tests = Test.objects.annotate(
             engagement__product__prod_type__member=Exists(authorized_product_type_roles),
-            engagement__product__member=Exists(authorized_product_roles))
+            engagement__product__member=Exists(authorized_product_roles),
+            engagement__product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            engagement__product__authorized_group=Exists(authorized_product_groups))
         tests = tests.filter(
             Q(engagement__product__prod_type__member=True) |
-            Q(engagement__product__member=True))
+            Q(engagement__product__member=True) |
+            Q(engagement__product__prod_type__authorized_group=True) |
+            Q(engagement__product__authorized_group=True))
     else:
         if user.is_staff:
             tests = Test.objects.all()
@@ -65,12 +78,24 @@ def get_authorized_test_imports(permission):
             product=OuterRef('test__engagement__product_id'),
             user=user,
             role__in=roles)
+        authorized_product_type_groups = Product_Type_Group.objects.filter(
+            product_type=OuterRef('test__engagement__product__prod_type_id'),
+            group__users=user,
+            role__in=roles)
+        authorized_product_groups = Product_Group.objects.filter(
+            product=OuterRef('test__engagement__product_id'),
+            group__users=user,
+            role__in=roles)
         test_imports = Test_Import.objects.annotate(
             test__engagement__product__prod_type__member=Exists(authorized_product_type_roles),
-            test__engagement__product__member=Exists(authorized_product_roles))
+            test__engagement__product__member=Exists(authorized_product_roles),
+            test__engagement__product__prod_type__authorized_group=Exists(authorized_product_type_groups),
+            test__engagement__product__authorized_group=Exists(authorized_product_groups))
         test_imports = test_imports.filter(
             Q(test__engagement__product__prod_type__member=True) |
-            Q(test__engagement__product__member=True))
+            Q(test__engagement__product__member=True) |
+            Q(test__engagement__product__prod_type__authorized_group=True) |
+            Q(test__engagement__product__authorized_group=True))
     else:
         if user.is_staff:
             test_imports = Test_Import.objects.all()

--- a/dojo/unittests/test_metrics_queries.py
+++ b/dojo/unittests/test_metrics_queries.py
@@ -210,7 +210,9 @@ class EndpointQueriesTest(TestCase):
                             'endpoint_id': 2,
                             'finding_id': 2,
                             'endpoint__product__prod_type__member': False,
-                            'endpoint__product__member': True
+                            'endpoint__product__member': True,
+                            'endpoint__product__prod_type__authorized_group': False,
+                            'endpoint__product__authorized_group': False
                         }
                     ],
                 )

--- a/dojo/unittests/test_swagger_schema.py
+++ b/dojo/unittests/test_swagger_schema.py
@@ -19,14 +19,17 @@ from dojo.api_v2.views import \
     SonarqubeIssueViewSet, SonarqubeProductViewSet, \
     SonarqubeIssueTransitionViewSet, StubFindingsViewSet, SystemSettingsViewSet, \
     TestTypesViewSet, TestsViewSet, ToolConfigurationsViewSet, ToolProductSettingsViewSet, \
-    ToolTypesViewSet, UsersViewSet, JiraIssuesViewSet, JiraProjectViewSet, AppAnalysisViewSet
+    ToolTypesViewSet, UsersViewSet, JiraIssuesViewSet, JiraProjectViewSet, AppAnalysisViewSet, \
+    DojoGroupViewSet, ProductMemberViewSet, ProductTypeMemberViewSet, ProductGroupViewSet, \
+    ProductTypeGroupViewSet
 
 from dojo.models import \
     Development_Environment, Endpoint_Status, Endpoint, Engagement, Finding_Template, \
     Finding, JIRA_Instance, JIRA_Issue, DojoMeta, Note_Type, Notes, Product_Type, Product, Regulation, \
     Sonarqube_Issue, Sonarqube_Product, Sonarqube_Issue_Transition, \
     Stub_Finding, System_Settings, Test_Type, Test, Tool_Configuration, Tool_Product_Settings, \
-    Tool_Type, Dojo_User, JIRA_Project, App_Analysis
+    Tool_Type, Dojo_User, JIRA_Project, App_Analysis, Dojo_Group, Product_Member, Product_Type_Member, \
+    Product_Group, Product_Type_Group
 
 from dojo.api_v2.serializers import \
     DevelopmentEnvironmentSerializer, EndpointStatusSerializer, EndpointSerializer, \
@@ -36,7 +39,8 @@ from dojo.api_v2.serializers import \
     SonarqubeIssueSerializer, SonarqubeProductSerializer, SonarqubeIssueTransitionSerializer, \
     StubFindingSerializer, SystemSettingsSerializer, TestTypeSerializer, TestSerializer, ToolConfigurationSerializer, \
     ToolProductSettingsSerializer, ToolTypeSerializer, UserSerializer, NoteSerializer, ProductTypeSerializer, \
-    AppAnalysisSerializer
+    AppAnalysisSerializer, DojoGroupSerializer, ProductMemberSerializer, ProductTypeMemberSerializer, \
+    ProductGroupSerializer, ProductTypeGroupSerializer
 
 SWAGGER_SCHEMA_GENERATOR = OpenAPISchemaGenerator(Info("defectdojo", "v2"))
 BASE_API_URL = "/api/v2"
@@ -316,6 +320,15 @@ class DevelopmentEnvironmentTest(BaseClass.SchemaTest):
         self.serializer = DevelopmentEnvironmentSerializer
 
 
+class DojoUserTest(BaseClass.SchemaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewname = "dojo_groups"
+        self.viewset = DojoGroupViewSet
+        self.model = Dojo_Group
+        self.serializer = DojoGroupSerializer
+
+
 class EndpointStatusTest(BaseClass.SchemaTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -541,6 +554,24 @@ class ProductTypeTest(BaseClass.SchemaTest):
         }
 
 
+class ProductTypeMemberTest(BaseClass.SchemaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewname = "product_type_members"
+        self.viewset = ProductTypeMemberViewSet
+        self.model = Product_Type_Member
+        self.serializer = ProductTypeMemberSerializer
+
+
+class ProductTypeGroupTest(BaseClass.SchemaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewname = "product_type_groups"
+        self.viewset = ProductTypeGroupViewSet
+        self.model = Product_Type_Group
+        self.serializer = ProductTypeGroupSerializer
+
+
 class ProductTest(BaseClass.SchemaTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -571,6 +602,28 @@ class ProductTest(BaseClass.SchemaTest):
     @testIsBroken
     def test_post_endpoint(self):
         super().test_post_endpoint()
+
+
+class ProductMemberTest(BaseClass.SchemaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewname = "product_members"
+        self.viewset = ProductMemberViewSet
+        self.model = Product_Member
+        self.serializer = ProductMemberSerializer
+
+    @testIsBroken
+    def test_post_endpoint(self):
+        super().test_post_endpoint()
+
+
+class ProductGroupTest(BaseClass.SchemaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.viewname = "product_groups"
+        self.viewset = ProductGroupViewSet
+        self.model = Product_Group
+        self.serializer = ProductGroupSerializer
 
 
 class RegulationTest(BaseClass.SchemaTest):

--- a/dojo/unittests/test_swagger_schema.py
+++ b/dojo/unittests/test_swagger_schema.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.test import tag
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
@@ -320,13 +321,14 @@ class DevelopmentEnvironmentTest(BaseClass.SchemaTest):
         self.serializer = DevelopmentEnvironmentSerializer
 
 
-class DojoUserTest(BaseClass.SchemaTest):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.viewname = "dojo_groups"
-        self.viewset = DojoGroupViewSet
-        self.model = Dojo_Group
-        self.serializer = DojoGroupSerializer
+# Test will only work when FEATURE_AUTHENTICATION_V2 is the default
+# class DojoGroupTest(BaseClass.SchemaTest):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.viewname = "dojo_groups"
+#         self.viewset = DojoGroupViewSet
+#         self.model = Dojo_Group
+#         self.serializer = DojoGroupSerializer
 
 
 class EndpointStatusTest(BaseClass.SchemaTest):
@@ -554,22 +556,24 @@ class ProductTypeTest(BaseClass.SchemaTest):
         }
 
 
-class ProductTypeMemberTest(BaseClass.SchemaTest):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.viewname = "product_type_members"
-        self.viewset = ProductTypeMemberViewSet
-        self.model = Product_Type_Member
-        self.serializer = ProductTypeMemberSerializer
+# Test will only work when FEATURE_AUTHENTICATION_V2 is the default
+# class ProductTypeMemberTest(BaseClass.SchemaTest):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.viewname = "product_type_members"
+#         self.viewset = ProductTypeMemberViewSet
+#         self.model = Product_Type_Member
+#         self.serializer = ProductTypeMemberSerializer
 
 
-class ProductTypeGroupTest(BaseClass.SchemaTest):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.viewname = "product_type_groups"
-        self.viewset = ProductTypeGroupViewSet
-        self.model = Product_Type_Group
-        self.serializer = ProductTypeGroupSerializer
+# Test will only work when FEATURE_AUTHENTICATION_V2 is the default
+# class ProductTypeGroupTest(BaseClass.SchemaTest):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.viewname = "product_type_groups"
+#         self.viewset = ProductTypeGroupViewSet
+#         self.model = Product_Type_Group
+#         self.serializer = ProductTypeGroupSerializer
 
 
 class ProductTest(BaseClass.SchemaTest):
@@ -604,26 +608,32 @@ class ProductTest(BaseClass.SchemaTest):
         super().test_post_endpoint()
 
 
-class ProductMemberTest(BaseClass.SchemaTest):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.viewname = "product_members"
-        self.viewset = ProductMemberViewSet
-        self.model = Product_Member
-        self.serializer = ProductMemberSerializer
+# Test will only work when FEATURE_AUTHENTICATION_V2 is the default
+# class ProductMemberTest(BaseClass.SchemaTest):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.viewname = "product_members"
+#         self.viewset = ProductMemberViewSet
+#         self.model = Product_Member
+#         self.serializer = ProductMemberSerializer
 
-    @testIsBroken
-    def test_post_endpoint(self):
-        super().test_post_endpoint()
+#     @testIsBroken
+#     def test_post_endpoint(self):
+#         super().test_post_endpoint()
+
+#     @testIsBroken
+#     def test_patch_endpoint(self):
+#         super().test_post_endpoint()
 
 
-class ProductGroupTest(BaseClass.SchemaTest):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.viewname = "product_groups"
-        self.viewset = ProductGroupViewSet
-        self.model = Product_Group
-        self.serializer = ProductGroupSerializer
+# Test will only work when FEATURE_AUTHENTICATION_V2 is the default
+# class ProductGroupTest(BaseClass.SchemaTest):
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+#         self.viewname = "product_groups"
+#         self.viewset = ProductGroupViewSet
+#         self.model = Product_Group
+#         self.serializer = ProductGroupSerializer
 
 
 class RegulationTest(BaseClass.SchemaTest):

--- a/dojo/unittests/test_swagger_schema.py
+++ b/dojo/unittests/test_swagger_schema.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.test import tag
 from rest_framework.test import APIRequestFactory
 from rest_framework.views import APIView
@@ -20,17 +19,14 @@ from dojo.api_v2.views import \
     SonarqubeIssueViewSet, SonarqubeProductViewSet, \
     SonarqubeIssueTransitionViewSet, StubFindingsViewSet, SystemSettingsViewSet, \
     TestTypesViewSet, TestsViewSet, ToolConfigurationsViewSet, ToolProductSettingsViewSet, \
-    ToolTypesViewSet, UsersViewSet, JiraIssuesViewSet, JiraProjectViewSet, AppAnalysisViewSet, \
-    DojoGroupViewSet, ProductMemberViewSet, ProductTypeMemberViewSet, ProductGroupViewSet, \
-    ProductTypeGroupViewSet
+    ToolTypesViewSet, UsersViewSet, JiraIssuesViewSet, JiraProjectViewSet, AppAnalysisViewSet
 
 from dojo.models import \
     Development_Environment, Endpoint_Status, Endpoint, Engagement, Finding_Template, \
     Finding, JIRA_Instance, JIRA_Issue, DojoMeta, Note_Type, Notes, Product_Type, Product, Regulation, \
     Sonarqube_Issue, Sonarqube_Product, Sonarqube_Issue_Transition, \
     Stub_Finding, System_Settings, Test_Type, Test, Tool_Configuration, Tool_Product_Settings, \
-    Tool_Type, Dojo_User, JIRA_Project, App_Analysis, Dojo_Group, Product_Member, Product_Type_Member, \
-    Product_Group, Product_Type_Group
+    Tool_Type, Dojo_User, JIRA_Project, App_Analysis
 
 from dojo.api_v2.serializers import \
     DevelopmentEnvironmentSerializer, EndpointStatusSerializer, EndpointSerializer, \
@@ -40,8 +36,7 @@ from dojo.api_v2.serializers import \
     SonarqubeIssueSerializer, SonarqubeProductSerializer, SonarqubeIssueTransitionSerializer, \
     StubFindingSerializer, SystemSettingsSerializer, TestTypeSerializer, TestSerializer, ToolConfigurationSerializer, \
     ToolProductSettingsSerializer, ToolTypeSerializer, UserSerializer, NoteSerializer, ProductTypeSerializer, \
-    AppAnalysisSerializer, DojoGroupSerializer, ProductMemberSerializer, ProductTypeMemberSerializer, \
-    ProductGroupSerializer, ProductTypeGroupSerializer
+    AppAnalysisSerializer
 
 SWAGGER_SCHEMA_GENERATOR = OpenAPISchemaGenerator(Info("defectdojo", "v2"))
 BASE_API_URL = "/api/v2"

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -18,7 +18,8 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     UsersViewSet, ImportScanView, ReImportScanView, ProductTypeViewSet, DojoMetaViewSet, \
     DevelopmentEnvironmentViewSet, NotesViewSet, NoteTypeViewSet, SystemSettingsViewSet, \
     AppAnalysisViewSet, EndpointStatusViewSet, SonarqubeIssueViewSet, SonarqubeIssueTransitionViewSet, \
-    SonarqubeProductViewSet, RegulationsViewSet, ProductTypeMemberViewSet, ProductMemberViewSet
+    SonarqubeProductViewSet, RegulationsViewSet, ProductTypeMemberViewSet, ProductMemberViewSet, \
+    DojoGroupViewSet, ProductGroupViewSet, ProductTypeGroupViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -73,8 +74,11 @@ v2_api.register(r'jira_projects', JiraProjectViewSet)
 v2_api.register(r'products', ProductViewSet)
 v2_api.register(r'product_types', ProductTypeViewSet)
 if settings.FEATURE_AUTHORIZATION_V2:
+    v2_api.register(r'dojo_groups', DojoGroupViewSet)
     v2_api.register(r'product_type_members', ProductTypeMemberViewSet)
     v2_api.register(r'product_members', ProductMemberViewSet)
+    v2_api.register(r'product_type_groups', ProductTypeGroupViewSet)
+    v2_api.register(r'product_groups', ProductGroupViewSet)
 v2_api.register(r'sonarqube_issues', SonarqubeIssueViewSet)
 v2_api.register(r'sonarqube_transitions', SonarqubeIssueTransitionViewSet)
 v2_api.register(r'sonarqube_product_configurations', SonarqubeProductViewSet)

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -1,7 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.db.models import Q
-from dojo.models import Product_Member, Product_Type_Member
+from dojo.models import Dojo_Group, Product_Member, Product_Type_Member, \
+    Product_Group, Product_Type_Group
 from dojo.authorization.authorization import get_roles_for_permission
 
 
@@ -9,9 +10,14 @@ def get_authorized_users_for_product_type(users, product_type, permission):
     if settings.FEATURE_AUTHORIZATION_V2:
         roles = get_roles_for_permission(permission)
         product_type_members = Product_Type_Member.objects \
-            .filter(product_type=product_type, role__in=roles) \
-            .values_list('user_id', flat=True)
-        return users.filter(Q(id__in=product_type_members) | Q(is_superuser=True))
+            .filter(product_type=product_type, role__in=roles)
+        product_type_groups = Product_Type_Group.objects \
+            .filter(product_type=product_type, role__in=roles)
+        groups = Dojo_Group.objects \
+            .filter(id__in=[ptg.group.id for ptg in product_type_groups])
+        return users.filter(Q(id__in=[ptm.user.id for ptm in product_type_members]) |
+            Q(groups__id__in=[gu.id for gu in groups]) |
+            Q(is_superuser=True))
     else:
         return users.filter(Q(id__in=product_type.authorized_users.all()) |
             Q(is_superuser=True) |
@@ -26,13 +32,18 @@ def get_authorized_users_for_product_and_product_type(users, product, permission
     if settings.FEATURE_AUTHORIZATION_V2:
         roles = get_roles_for_permission(permission)
         product_members = Product_Member.objects \
-            .filter(product=product, role__in=roles) \
-            .values_list('user_id', flat=True)
+            .filter(product=product, role__in=roles)
         product_type_members = Product_Type_Member.objects \
-            .filter(product_type=product.prod_type, role__in=roles) \
-            .values_list('user_id', flat=True)
-        return users.filter(Q(id__in=product_members) |
-            Q(id__in=product_type_members) |
+            .filter(product_type=product.prod_type, role__in=roles)
+        product_groups = Product_Group.objects \
+            .filter(product=product, role__in=roles)
+        product_type_groups = Product_Type_Group.objects \
+            .filter(product_type=product.prod_type, role__in=roles)
+        groups = Dojo_Group.objects \
+            .filter(Q(id__in=[pg.group.id for pg in product_groups]) | Q(id__in=[ptg.group.id for ptg in product_type_groups]))
+        return users.filter(Q(id__in=[pm.user.id for pm in product_members]) |
+            Q(id__in=[ptm.user.id for ptm in product_type_members]) |
+            Q(groups__id__in=[gu.id for gu in groups]) |
             Q(is_superuser=True))
     else:
         return users.filter(Q(id__in=product.authorized_users.all()) |


### PR DESCRIPTION
As a follow-up to #4503, this PR adds:

- the API for `Dojo_Group`, `Product_Group` and `Product_Type_Group`
- the remaining queries to read data when a user is authorized by being a group member

The only thing missing to make groups fully functional is the user interface. This is currently being developed by Nick Cleary.