### PR TITLE
upgrade django 3.1.8 -> 3.1.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-slack==5.16.2
 django-tagging==0.5.0
 django-watson==1.5.5
 django-prometheus==2.1.0
-Django==3.1.8
+Django==3.1.11
 djangorestframework==3.12.4
 gunicorn==20.1.0
 html2text==2020.1.16


### PR DESCRIPTION
I tested the DefectDojo source code with Snyk and 2 problems were found:
- https://snyk.io/vuln/SNYK-PYTHON-DJANGO-1279042
- https://snyk.io/vuln/SNYK-PYTHON-DJANGO-1290072

Looking at Django releases:
- https://docs.djangoproject.com/en/3.2/releases/3.1.9/
- https://docs.djangoproject.com/en/3.2/releases/3.1.10/
- https://docs.djangoproject.com/en/3.2/releases/3.1.11/

Noticed that there are only CVE fixes and bugfixes.  Checked the work locally and it still works.
