### PR TITLE
Authorization V2: Performance optimization

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2308,7 +2308,7 @@ class ProductTypeFilter(DojoFilter):
         if settings.FEATURE_AUTHORIZATION_V2:
             exclude = ['authorized_users']
         else:
-            exclude = ['members']
+            exclude = ['members', 'authorization_groups']
         include = ('name',)
 
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -386,6 +386,9 @@ class Dojo_Group(models.Model):
     description = models.CharField(max_length=4000, null=True)
     users = models.ManyToManyField(Dojo_User, blank=True)
 
+    def __str__(self):
+        return self.name
+
 
 class Contact(models.Model):
     name = models.CharField(max_length=100)

--- a/dojo/unittests/authorization/test_authorization.py
+++ b/dojo/unittests/authorization/test_authorization.py
@@ -109,14 +109,14 @@ class TestAuthorization(TestCase):
         with self.assertRaises(PermissionDenied):
             user_has_permission_or_403(self.user, self.product_type, Permissions.Product_Type_Delete)
 
-    @patch('dojo.models.Product_Type_Member.objects.get')
-    def test_user_has_permission_or_403_success(self, mock_get):
-        mock_get.return_value = self.product_type_member_owner
+    @patch('dojo.models.Product_Type_Member.objects')
+    def test_user_has_permission_or_403_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_type_member_owner]
 
         user_has_permission_or_403(self.user, self.product_type, Permissions.Product_Type_Delete)
 
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
+        mock_foo.filter.assert_called_with(user=self.user)
 
     def test_user_has_permission_exception(self):
         with self.assertRaisesMessage(dojo.authorization.authorization.NoAuthorizationImplementedError,
@@ -127,15 +127,15 @@ class TestAuthorization(TestCase):
         result = user_has_permission(self.user, self.product_type, Permissions.Product_Type_View)
         self.assertFalse(result)
 
-    @patch('dojo.models.Product_Type_Member.objects.get')
-    def test_user_has_permission_product_type_no_permissions(self, mock_get):
-        mock_get.return_value = self.product_type_member_reader
+    @patch('dojo.models.Product_Type_Member.objects')
+    def test_user_has_permission_product_type_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_type_member_reader]
 
         result = user_has_permission(self.user, self.product_type, Permissions.Product_Type_Delete)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
+        mock_foo.filter.assert_called_with(user=self.user)
 
     def test_user_has_permission_superuser(self):
         self.user.is_superuser = True
@@ -156,136 +156,136 @@ class TestAuthorization(TestCase):
 
         self.user.is_staff = False
 
-    @patch('dojo.models.Product_Type_Member.objects.get')
-    def test_user_has_permission_product_type_success(self, mock_get):
-        mock_get.return_value = self.product_type_member_owner
+    @patch('dojo.models.Product_Type_Member.objects')
+    def test_user_has_permission_product_type_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_type_member_owner]
 
         result = user_has_permission(self.user, self.product_type, Permissions.Product_Type_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
+        mock_foo.filter.assert_called_with(user=self.user)
 
     def test_user_has_permission_product_no_member(self):
         result = user_has_permission(self.user, self.product, Permissions.Product_View)
         self.assertFalse(result)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_product_no_permissions(self, mock_get):
-        mock_get.return_value = self.product_member_reader
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_product_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_reader]
 
         result = user_has_permission(self.user, self.product, Permissions.Product_Delete)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Type_Member.objects.get')
-    def test_user_has_permission_product_product_type_success(self, mock_get):
-        mock_get.return_value = self.product_type_member_owner
-
-        result = user_has_permission(self.user, self.product, Permissions.Product_Delete)
-
-        self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
-
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_product_success(self, mock_get):
-        mock_get.return_value = self.product_member_owner
+    @patch('dojo.models.Product_Type_Member.objects')
+    def test_user_has_permission_product_product_type_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_type_member_owner]
 
         result = user_has_permission(self.user, self.product, Permissions.Product_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_engagement_no_permissions(self, mock_get):
-        mock_get.return_value = self.product_member_reader
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_product_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_owner]
+
+        result = user_has_permission(self.user, self.product, Permissions.Product_Delete)
+
+        self.assertTrue(result)
+        mock_foo.filter.assert_called_with(user=self.user)
+
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_engagement_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_reader]
 
         result = user_has_permission(self.user, self.engagement, Permissions.Engagement_Edit)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_engagement_success(self, mock_get):
-        mock_get.return_value = self.product_member_owner
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_engagement_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_owner]
 
         result = user_has_permission(self.user, self.engagement, Permissions.Engagement_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_test_no_permissions(self, mock_get):
-        mock_get.return_value = self.product_member_reader
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_test_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_reader]
 
         result = user_has_permission(self.user, self.test, Permissions.Test_Edit)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_test_success(self, mock_get):
-        mock_get.return_value = self.product_member_owner
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_test_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_owner]
 
         result = user_has_permission(self.user, self.test, Permissions.Test_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_finding_no_permissions(self, mock_get):
-        mock_get.return_value = self.product_member_reader
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_finding_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_reader]
 
         result = user_has_permission(self.user, self.finding, Permissions.Finding_Edit)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_finding_success(self, mock_get):
-        mock_get.return_value = self.product_member_owner
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_finding_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_owner]
 
         result = user_has_permission(self.user, self.finding, Permissions.Finding_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_endpoint_no_permissions(self, mock_get):
-        mock_get.return_value = self.product_member_reader
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_endpoint_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_reader]
 
         result = user_has_permission(self.user, self.endpoint, Permissions.Endpoint_Edit)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_endpoint_success(self, mock_get):
-        mock_get.return_value = self.product_member_owner
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_endpoint_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_member_owner]
 
         result = user_has_permission(self.user, self.endpoint, Permissions.Endpoint_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=self.user)
 
     def test_user_has_permission_product_type_member_success_same_user(self):
         result = user_has_permission(self.user, self.product_type_member_owner, Permissions.Product_Type_Member_Delete)
         self.assertTrue(result)
 
-    @patch('dojo.models.Product_Type_Member.objects.get')
-    def test_user_has_permission_product_type_member_no_permission(self, mock_get):
+    @patch('dojo.models.Product_Type_Member.objects')
+    def test_user_has_permission_product_type_member_no_permission(self, mock_foo):
         other_user = User()
         other_user.id = 2
         product_type_member_other_user = Product_Type_Member()
@@ -293,16 +293,16 @@ class TestAuthorization(TestCase):
         product_type_member_other_user.user = other_user
         product_type_member_other_user.product_type = self.product_type
         product_type_member_other_user.role = Roles.Reader
-        mock_get.return_value = product_type_member_other_user
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [product_type_member_other_user]
 
         result = user_has_permission(other_user, self.product_type_member_owner, Permissions.Product_Type_Member_Delete)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], other_user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
+        mock_foo.filter.assert_called_with(user=other_user)
 
-    @patch('dojo.models.Product_Type_Member.objects.get')
-    def test_user_has_permission_product_type_member_success(self, mock_get):
+    @patch('dojo.models.Product_Type_Member.objects')
+    def test_user_has_permission_product_type_member_success(self, mock_foo):
         other_user = User()
         other_user.id = 2
         product_type_member_other_user = Product_Type_Member()
@@ -310,20 +310,20 @@ class TestAuthorization(TestCase):
         product_type_member_other_user.user = other_user
         product_type_member_other_user.product_type = self.product_type
         product_type_member_other_user.role = Roles.Owner
-        mock_get.return_value = product_type_member_other_user
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [product_type_member_other_user]
 
         result = user_has_permission(other_user, self.product_type_member_reader, Permissions.Product_Type_Member_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], other_user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
+        mock_foo.filter.assert_called_with(user=other_user)
 
     def test_user_has_permission_product_member_success_same_user(self):
         result = user_has_permission(self.user, self.product_member_owner, Permissions.Product_Member_Delete)
         self.assertTrue(result)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_product_member_no_permission(self, mock_get):
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_product_member_no_permission(self, mock_foo):
         other_user = User()
         other_user.id = 2
         product_member_other_user = Product_Member()
@@ -331,67 +331,67 @@ class TestAuthorization(TestCase):
         product_member_other_user.user = other_user
         product_member_other_user.product = self.product
         product_member_other_user.role = Roles.Reader
-        mock_get.return_value = product_member_other_user
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [product_member_other_user]
 
         result = user_has_permission(other_user, self.product_member_owner, Permissions.Product_Member_Delete)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['user'], other_user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=other_user)
 
-    @patch('dojo.models.Product_Member.objects.get')
-    def test_user_has_permission_product_member_success(self, mock_get):
+    @patch('dojo.models.Product_Member.objects')
+    def test_user_has_permission_product_member_success(self, mock_foo):
         other_user = User()
         other_user.id = 2
         product_member_other_user = Product_Member()
         product_member_other_user.id = 2
         product_member_other_user.user = other_user
-        product_member_other_user.product_type = self.product
+        product_member_other_user.product = self.product
         product_member_other_user.role = Roles.Owner
-        mock_get.return_value = product_member_other_user
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [product_member_other_user]
 
         result = user_has_permission(other_user, self.product_member_reader, Permissions.Product_Member_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['user'], other_user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(user=other_user)
 
-    @patch('dojo.models.Product_Group.objects.filter')
-    def test_user_has_group_product_no_permissions(self, mock_get):
-        mock_get.return_value = {self.product_group_reader}
+    @patch('dojo.models.Product_Group.objects')
+    def test_user_has_group_product_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_group_reader]
 
         result = user_has_permission(self.user, self.product, Permissions.Product_Delete)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['group__users'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(group__users=self.user)
 
-    @patch('dojo.models.Product_Group.objects.filter')
-    def test_user_has_group_product_success(self, mock_get):
-        mock_get.return_value = {self.product_group_owner}
+    @patch('dojo.models.Product_Group.objects')
+    def test_user_has_group_product_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_group_owner]
 
         result = user_has_permission(self.user, self.product, Permissions.Product_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['group__users'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product'], self.product)
+        mock_foo.filter.assert_called_with(group__users=self.user)
 
-    @patch('dojo.models.Product_Type_Group.objects.filter')
-    def test_user_has_group_product_type_no_permissions(self, mock_get):
-        mock_get.return_value = {self.product_type_group_reader}
+    @patch('dojo.models.Product_Type_Group.objects')
+    def test_user_has_group_product_type_no_permissions(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_type_group_reader]
 
         result = user_has_permission(self.user, self.product_type, Permissions.Product_Type_Delete)
 
         self.assertFalse(result)
-        self.assertEqual(mock_get.call_args[1]['group__users'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
+        mock_foo.filter.assert_called_with(group__users=self.user)
 
-    @patch('dojo.models.Product_Type_Group.objects.filter')
-    def test_user_has_group_product_type_success(self, mock_get):
-        mock_get.return_value = {self.product_type_group_owner}
+    @patch('dojo.models.Product_Type_Group.objects')
+    def test_user_has_group_product_type_success(self, mock_foo):
+        mock_foo.select_related.return_value = mock_foo
+        mock_foo.filter.return_value = [self.product_type_group_owner]
 
         result = user_has_permission(self.user, self.product_type, Permissions.Product_Type_Delete)
 
         self.assertTrue(result)
-        self.assertEqual(mock_get.call_args[1]['group__users'], self.user)
-        self.assertEqual(mock_get.call_args[1]['product_type'], self.product_type)
+        mock_foo.filter.assert_called_with(group__users=self.user)


### PR DESCRIPTION
The caching of member and groups wasn't efficient when there are many products or product types in one list. This PR decreases the number of SQL request substantially.