### PR TITLE
Add endpoints to generic parser for JSON format

### DIFF
--- a/docs/content/en/integrations/import.md
+++ b/docs/content/en/integrations/import.md
@@ -228,7 +228,78 @@ Import Findings from XML file format.
 
 ### Generic Findings Import
 
-Import Generic findings in CSV format.
+Import Generic findings in CSV or JSON format.
+
+Attributes supported for CSV:
+ - Title
+ - Description
+ - Date
+ - Severity
+ - Duplicate ('TRUE', 'FALSE')
+ - Active ('TRUE', 'FALSE')
+ - Mitigation
+ - Impact
+ - References
+ - Verified ('TRUE', 'FALSE')
+ - FalsePositive
+ - CVE
+ - CweId
+ - CVSSV3
+ - Url
+
+Exemple of JSON format:
+
+```JSON
+{
+    "findings": [
+        {
+            "title": "test title with endpoints as dict",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau",
+            "severity": "Medium",
+            "mitigation": "Some mitigation",
+            "date": "2021-01-06",
+            "cve": "CVE-2020-36234",
+            "cwe": 261,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/first.cpp",
+            "line": 13,
+            "endpoints": [
+                {
+                    "host": "exemple.com"
+                }
+            ]
+        },
+        {
+            "title": "test title with endpoints as strings",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
+            "severity": "Critical",
+            "mitigation": "Some mitigation",
+            "date": "2021-01-06",
+            "cve": "CVE-2020-36235",
+            "cwe": 287,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/two.cpp",
+            "line": 135,
+            "endpoints": [
+                "http://urlfiltering.paloaltonetworks.com/test-command-and-control",
+                "https://urlfiltering.paloaltonetworks.com:2345/test-pest"
+            ]
+        },
+        {
+            "title": "test title",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
+            "severity": "Critical",
+            "mitigation": "Some mitigation",
+            "date": "2021-01-06",
+            "cve": "CVE-2020-36236",
+            "cwe": 287,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/threeeeeeeeee.cpp",
+            "line": 1353
+        }
+    ]
+}
+```
 
 ### Hadolint
 

--- a/docs/content/en/integrations/import.md
+++ b/docs/content/en/integrations/import.md
@@ -247,7 +247,7 @@ Attributes supported for CSV:
  - CVSSV3
  - Url
 
-Exemple of JSON format:
+Example of JSON format:
 
 ```JSON
 {

--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -30,12 +30,27 @@ class GenericParser(object):
         data = json.load(filename)
         findings = list()
         for item in data['findings']:
+            # remove endpoints of the dictionnary
+            unsaved_endpoints = None
+            if "endpoints" in item:
+                unsaved_endpoints = item["endpoints"]
+                del item["endpoints"]
+
             finding = Finding(**item)
             # manage active/verified overrride
             if active is not None:
                 finding.active = active
             if verified is not None:
                 finding.verified = verified
+
+            # manage endpoints
+            if unsaved_endpoints:
+                finding.unsaved_endpoints = []
+                for item in unsaved_endpoints:
+                    if type(item) is str:
+                        finding.unsaved_endpoints.append(Endpoint.from_uri(item))
+                    else:
+                        finding.unsaved_endpoints.append(Endpoint(**item))
             findings.append(finding)
         return findings
 

--- a/dojo/unittests/scans/generic/generic_report3.json
+++ b/dojo/unittests/scans/generic/generic_report3.json
@@ -1,0 +1,49 @@
+{
+    "findings": [
+        {
+            "title": "test title with endpoints as dict",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau",
+            "severity": "Medium",
+            "mitigation": "Some mitigation",
+            "date": "2021-01-06",
+            "cve": "CVE-2020-36234",
+            "cwe": 261,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/first.cpp",
+            "line": 13,
+            "endpoints": [
+                {
+                    "host": "exemple.com"
+                }
+            ]
+        },
+        {
+            "title": "test title with endpoints as strings",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
+            "severity": "Critical",
+            "mitigation": "Some mitigation",
+            "date": "2021-01-06",
+            "cve": "CVE-2020-36235",
+            "cwe": 287,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/two.cpp",
+            "line": 135,
+            "endpoints": [
+                "http://urlfiltering.paloaltonetworks.com/test-command-and-control",
+                "https://urlfiltering.paloaltonetworks.com:2345/test-pest"
+            ]
+        },
+        {
+            "title": "test title",
+            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
+            "severity": "Critical",
+            "mitigation": "Some mitigation",
+            "date": "2021-01-06",
+            "cve": "CVE-2020-36236",
+            "cwe": 287,
+            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
+            "file_path": "src/threeeeeeeeee.cpp",
+            "line": 1353
+        }
+    ]
+}

--- a/dojo/unittests/tools/test_generic_parser.py
+++ b/dojo/unittests/tools/test_generic_parser.py
@@ -422,3 +422,40 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             self.assertEqual("test title4", finding.title)
             self.assertIn(finding.severity, Finding.SEVERITIES)
             self.assertEqual("Some mitigation", finding.mitigation)
+
+    def test_parse_json3(self):
+        file = open("dojo/unittests/scans/generic/generic_report3.json")
+        parser = GenericParser()
+        findings = parser.get_findings(file, Test())
+        self.assertEqual(3, len(findings))
+        with self.subTest(i=0):
+            finding = findings[0]
+            finding.clean()
+            self.assertEqual("test title with endpoints as dict", finding.title)
+            self.assertIn(finding.severity, Finding.SEVERITIES)
+            self.assertEqual("CVE-2020-36234", finding.cve)
+            self.assertEqual(261, finding.cwe)
+            self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N", finding.cvssv3)
+            self.assertEqual("Some mitigation", finding.mitigation)
+            self.assertEqual(1, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            endpoint.clean()
+            self.assertEqual("exemple.com", endpoint.host)
+        with self.subTest(i=1):
+            finding = findings[1]
+            self.assertEqual("test title with endpoints as strings", finding.title)
+            self.assertIn(finding.severity, Finding.SEVERITIES)
+            self.assertEqual("Some mitigation", finding.mitigation)
+            self.assertEqual(2, len(finding.unsaved_endpoints))
+            endpoint = finding.unsaved_endpoints[0]
+            endpoint.clean()
+            self.assertEqual("http", endpoint.protocol)
+            self.assertEqual("urlfiltering.paloaltonetworks.com", endpoint.host)
+            self.assertEqual(80, endpoint.port)
+            self.assertEqual("test-command-and-control", endpoint.path)
+            endpoint = finding.unsaved_endpoints[1]
+            endpoint.clean()
+            self.assertEqual("https", endpoint.protocol)
+            self.assertEqual("urlfiltering.paloaltonetworks.com", endpoint.host)
+            self.assertEqual(2345, endpoint.port)
+            self.assertEqual("test-pest", endpoint.path)


### PR DESCRIPTION
Add support for endpoints for Generic parser (JSON)

```JSON
{
    "findings": [
        {
            "title": "test title with endpoints as dict",
            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau",
            "severity": "Medium",
            "mitigation": "Some mitigation",
            "date": "2021-01-06",
            "cve": "CVE-2020-36234",
            "cwe": 261,
            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
            "file_path": "src/first.cpp",
            "line": 13,
            "endpoints": [
                {
                    "host": "exemple.com"
                }
            ]
        },
        {
            "title": "test title with endpoints as strings",
            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
            "severity": "Critical",
            "mitigation": "Some mitigation",
            "date": "2021-01-06",
            "cve": "CVE-2020-36235",
            "cwe": 287,
            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
            "file_path": "src/two.cpp",
            "line": 135,
            "endpoints": [
                "http://urlfiltering.paloaltonetworks.com/test-command-and-control",
                "https://urlfiltering.paloaltonetworks.com:2345/test-pest"
            ]
        },
        {
            "title": "test title",
            "description": "Some very long description with\n\n some UTF-8 chars à qu'il est beau2",
            "severity": "Critical",
            "mitigation": "Some mitigation",
            "date": "2021-01-06",
            "cve": "CVE-2020-36236",
            "cwe": 287,
            "cvssv3": "CVSS:3.1/AV:N/AC:L/PR:H/UI:R/S:C/C:L/I:L/A:N",
            "file_path": "src/threeeeeeeeee.cpp",
            "line": 1353
        }
    ]
}
```