### PR TITLE
Authorization V2: Improved error code and message

### DIFF
--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -1,4 +1,6 @@
 import re
+
+from rest_framework.exceptions import ParseError
 from dojo.models import Endpoint, Engagement, Finding, Product_Type, Product, Test
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions
@@ -8,6 +10,8 @@ from dojo.authorization.roles_permissions import Permissions
 
 def check_post_permission(request, post_model, post_pk, post_permission):
     if request.method == 'POST':
+        if request.data.get(post_pk) is None:
+            raise ParseError('Attribute \'{}\' is required'.format(post_pk))
         object = get_object_or_404(post_model, pk=request.data.get(post_pk))
         return user_has_permission(request.user, object, post_permission)
     else:

--- a/dojo/unittests/test_apiv2_endpoint.py
+++ b/dojo/unittests/test_apiv2_endpoint.py
@@ -1,6 +1,7 @@
 from rest_framework.test import APITestCase, APIClient
 from django.urls import reverse
 from rest_framework.authtoken.models import Token
+from django.conf import settings
 
 
 class EndpointTest(APITestCase):
@@ -19,7 +20,10 @@ class EndpointTest(APITestCase):
             "host": "FOO.BAR"
         }, format='json')
         self.assertEqual(r.status_code, 400, r.content[:1000])
-        self.assertIn("Attribute \'product\' is required", r.content.decode("utf-8"))
+        if settings.FEATURE_AUTHORIZATION_V2:
+            self.assertIn("Attribute \'product\' is required", r.content.decode("utf-8"))
+        else:
+            self.assertIn("Product is required", r.content.decode("utf-8"))
 
         r = self.client.post(reverse('endpoint-list'), {
             "product": 1

--- a/dojo/unittests/test_apiv2_endpoint.py
+++ b/dojo/unittests/test_apiv2_endpoint.py
@@ -19,7 +19,7 @@ class EndpointTest(APITestCase):
             "host": "FOO.BAR"
         }, format='json')
         self.assertEqual(r.status_code, 400, r.content[:1000])
-        self.assertIn("Product is required", r.content.decode("utf-8"))
+        self.assertIn("Attribute \'product\' is required", r.content.decode("utf-8"))
 
         r = self.client.post(reverse('endpoint-list'), {
             "product": 1


### PR DESCRIPTION
Improved error code and message when the primary key of necessary relationship in a POST of the API is missing, This fixes a new unit test that was broken for Authentication V2.