### PR TITLE
Revert "Bump urllib3 from 1.26.4 to 1.26.5"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ redis==3.5.3
 requests==2.25.1
 sqlalchemy==1.4.11  # Required by Celery broker transport
 supervisor==4.2.2
-urllib3==1.26.5
+urllib3==1.26.4
 uWSGI==2.0.19.1
 vobject==0.9.6.1
 whitenoise==5.2.0


### PR DESCRIPTION
Reverts DefectDojo/django-DefectDojo#4590