### PR TITLE
Add hook to initializer

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "defectdojo.chart" . }}
+  annotations:
+    "helm.sh/hook": pre-install
 spec:
   ttlSecondsAfterFinished: {{ .Values.initializerKeepSeconds }}
   template:


### PR DESCRIPTION
Add a hook to the Helm template to ensure that the initializer does not get ran every time as it breaks the database schema/data.