### PR TITLE
Leverage template inheritance more effectively

### DIFF
--- a/dojo/settings/settings.py
+++ b/dojo/settings/settings.py
@@ -22,5 +22,4 @@ from split_settings.tools import optional, include
 include(
     'settings.dist.py',
     optional('local_settings.py'),
-    optional('dark_mode_settings.py')
 )

--- a/dojo/settings/settings.py
+++ b/dojo/settings/settings.py
@@ -21,5 +21,6 @@ from split_settings.tools import optional, include
 
 include(
     'settings.dist.py',
-    optional('local_settings.py')
+    optional('local_settings.py'),
+    optional('dark_mode_settings.py')
 )

--- a/dojo/settings/settings.py
+++ b/dojo/settings/settings.py
@@ -21,5 +21,5 @@ from split_settings.tools import optional, include
 
 include(
     'settings.dist.py',
-    optional('local_settings.py'),
+    optional('local_settings.py')
 )

--- a/dojo/templates/403.html
+++ b/dojo/templates/403.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h1>403</h1>
     <hr/>
     <h2>

--- a/dojo/templates/404.html
+++ b/dojo/templates/404.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h1>404</h1>
     <hr/>
     <h1>

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -78,7 +78,9 @@
     <link rel="shortcut icon" href="{% static "dojo/img/favicon.ico" %}"/>
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
     <link rel="stylesheet" href="{% static "fullcalendar/dist/fullcalendar.min.css" %}">
-    <link rel="stylesheet" href="{% static "dojo/css/dojo.css" %}">
+    {% block dojo_css %}
+        <link rel="stylesheet" href="{% static "dojo/css/dojo.css" %}">
+    {% endblock %}
     <link rel="stylesheet" href="{% static "datatables.net-dt/css/jquery.dataTables.min.css" %}">
     {% comment %} <link rel="stylesheet" href="{% static "datatables.net-buttons-dt/css/buttons.dataTables.min.css" %}"> {% endcomment %}
     <link rel="stylesheet" href="{% static "datatables.net-bs/css/dataTables.bootstrap.min.css" %}">

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -161,7 +161,6 @@
                             <li><a href="https://defectdojo.github.io/django-DefectDojo" target="_blank">
                                 <i class="fa fa-question-circle fa-fw"></i> Documentation</a>
                             </li>
-                            {{ block.super }}
                             {% if user.is_staff and system_settings.enable_questionnaires %}
                                 <li><a href="{% url 'questionnaire' %}"> <i class="fa fa-hospital-o fa-fw"> </i> Questionnaires </a></li>
                             {% endif %}

--- a/dojo/templates/defectDojo-engagement-survey/add_choices.html
+++ b/dojo/templates/defectDojo-engagement-survey/add_choices.html
@@ -13,5 +13,6 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{{ STATIC_URL }}admin/js/admin/RelatedObjectLookups.js"></script>
 {% endblock %}

--- a/dojo/templates/defectDojo-engagement-survey/add_choices.html
+++ b/dojo/templates/defectDojo-engagement-survey/add_choices.html
@@ -1,5 +1,6 @@
 {% extends "dojo/add_related.html" %}
 {% block content %}
+    {{ block.super }}
     <h3>Add Choice</h3>
 
     <form class="form-horizontal" method="post">{% csrf_token %}

--- a/dojo/templates/defectDojo-engagement-survey/add_engagement.html
+++ b/dojo/templates/defectDojo-engagement-survey/add_engagement.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
 	<h3>Link Questionnaire to New Engagement</h3>
 	<form class="form-horizontal" method="post">
 		{% csrf_token %}

--- a/dojo/templates/defectDojo-engagement-survey/add_survey.html
+++ b/dojo/templates/defectDojo-engagement-survey/add_survey.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
 {% if engagement %}
 	<h3>Add Questionnaire to {{engagement}}</h3>
 {% else %}

--- a/dojo/templates/defectDojo-engagement-survey/answer_survey.html
+++ b/dojo/templates/defectDojo-engagement-survey/answer_survey.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
 <div class="well">
 {% if engagement %}
     <h4>Answer {{survey}} Questionnaire for {{engagement}}</h4>

--- a/dojo/templates/defectDojo-engagement-survey/assign_survey.html
+++ b/dojo/templates/defectDojo-engagement-survey/assign_survey.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
 	<h3>Assign User to {{ survey }}</h3>
 	<form class="form-horizontal" method="post">{% csrf_token %}
 		{% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/defectDojo-engagement-survey/create_questionnaire.html
+++ b/dojo/templates/defectDojo-engagement-survey/create_questionnaire.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3>Create New Questionnaire</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/defectDojo-engagement-survey/create_related_question.html
+++ b/dojo/templates/defectDojo-engagement-survey/create_related_question.html
@@ -37,6 +37,7 @@
 <!-- Page Content -->
 
 {% block content %}
+    {{ block.super }}
     <div class="container">
         <div class="row">
             <div class="col-lg-12">

--- a/dojo/templates/defectDojo-engagement-survey/delete_questionnaire.html
+++ b/dojo/templates/defectDojo-engagement-survey/delete_questionnaire.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete {{ survey }} Questionnaire</h3>
     <p>
         Deleting this Questionnaire will remove any answers associated with it. These relationships are listed below:
@@ -36,6 +37,7 @@
     <br/>
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .form-read-only {text-align: left !important }
     .form-read-only .control-label{width: 100%; float: none; text-align: left;}
     .form-read-only textarea {width: 90% !important;}

--- a/dojo/templates/defectDojo-engagement-survey/edit_question.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_question.html
@@ -18,6 +18,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript">
         $(function () {
             $("#id_choices").bind("DOMSubtreeModified", function () {

--- a/dojo/templates/defectDojo-engagement-survey/edit_question.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_question.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{{ STATIC_URL }}chosen-bootstrap/chosen.bootstrap.min.css">
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3>Edit Question: {{ question.name }}</h3>
 
     <form class="form-horizontal" method="post">{% csrf_token %}

--- a/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
@@ -18,6 +18,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript">
         $(function () {
             $("#id_questions").bind("DOMSubtreeModified", function() {

--- a/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/edit_survey_questions.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{{ STATIC_URL }}chosen-bootstrap/chosen.bootstrap.min.css">
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3>Edit Questionnaire Questions ({{ survey.name }})</h3>
 
     <form class="form-horizontal" method="post">{% csrf_token %}

--- a/dojo/templates/defectDojo-engagement-survey/list_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_questions.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-10">
             {% if questions %}

--- a/dojo/templates/defectDojo-engagement-survey/list_surveys.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_surveys.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-10">
             {% if surveys %}

--- a/dojo/templates/defectDojo-engagement-survey/list_surveys.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_surveys.html
@@ -127,6 +127,7 @@
 {% endblock %}
 
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript">
         $('#shareQuestionnaireModal').on('show.bs.modal', function (event) {
             var button = $(event.relatedTarget) // Button that triggered the modal

--- a/dojo/templates/defectDojo-engagement-survey/view_survey.html
+++ b/dojo/templates/defectDojo-engagement-survey/view_survey.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
 <div class="well">
 <h4>{{name}}</h4>
 <p>{{ survey.survey.description }} </p>
@@ -15,6 +16,7 @@
 {% endif %}
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .form-horizontal .control-label{width: 100%; float: none; text-align: left;}
     .form-horizontal textarea {width: 90% !important;}
     .form-horizontal .controls {margin-left: 10px;}

--- a/dojo/templates/disabled.html
+++ b/dojo/templates/disabled.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h1>Feature Disabled</h1>
     <hr/>
     <h2>

--- a/dojo/templates/dojo/action_history.html
+++ b/dojo/templates/dojo/action_history.html
@@ -48,5 +48,6 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/action_history.html
+++ b/dojo/templates/dojo/action_history.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -3,14 +3,17 @@
 {% load display_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .select2 .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div>
         <h3> Add Findings to a Test </h3>
     </div>

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -55,6 +55,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>

--- a/dojo/templates/dojo/add_endpoint.html
+++ b/dojo/templates/dojo/add_endpoint.html
@@ -21,6 +21,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js"%}"></script>
     <script type="application/javascript" src="{% static "admin/js/admin/RelatedObjectLookups.js" %}"></script>
 

--- a/dojo/templates/dojo/add_endpoint.html
+++ b/dojo/templates/dojo/add_endpoint.html
@@ -2,12 +2,14 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
 {% endblock %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Add Endpoint</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/add_endpoint_meta_data.html
+++ b/dojo/templates/dojo/add_endpoint_meta_data.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Add Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -3,10 +3,12 @@
 {% load display_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
@@ -15,6 +17,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div>
         <h3> Add Findings to a Test</h3>
     </div>

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -87,6 +87,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>

--- a/dojo/templates/dojo/add_note_type.html
+++ b/dojo/templates/dojo/add_note_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Add a new Note Type </h3>
     <form class="form-horizontal" action="{% url 'add_note_type' %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/add_product_meta_data.html
+++ b/dojo/templates/dojo/add_product_meta_data.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Add {{ product.name }} Custom Fields</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/add_risk_acceptance.html
+++ b/dojo/templates/dojo/add_risk_acceptance.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
@@ -10,9 +11,11 @@
     }
 {% endblock %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static 'easymde/dist/easymde.min.css' %}">
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Risk acceptance</h3>
     <div id="risk_acceptance">
         <p>

--- a/dojo/templates/dojo/add_risk_acceptance.html
+++ b/dojo/templates/dojo/add_risk_acceptance.html
@@ -39,6 +39,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 <script type="application/javascript" src="{% static 'easymde/dist/easymde.min.js' %}"></script>
 <script type="text/javascript">
     $("#add_risk_acceptance textarea").each(function (index, elem) {

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -45,6 +45,7 @@
     {% endif %}
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
@@ -13,6 +15,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> {{ name }} {{ template }}</h3>
 
     <form id="add_template" class="form-horizontal" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/add_tests.html
+++ b/dojo/templates/dojo/add_tests.html
@@ -25,4 +25,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/add_tests.html
+++ b/dojo/templates/dojo/add_tests.html
@@ -2,12 +2,14 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
 }
 {% endblock %}
 
 {% block content %}
+    {{ block.super }}
 
     <h3> Add Tests</h3>
     <form class="form-horizontal" action="{% url 'add_tests' eid%}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/add_user.html
+++ b/dojo/templates/dojo/add_user.html
@@ -3,6 +3,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> {{ name }} {% if to_edit %}- {{ to_edit.username }}{% endif %}</h3>
     <div class="alert alert-info" role="alert">
         By default all users are created with an unusable password. If a password is needed it can be set using the

--- a/dojo/templates/dojo/add_user.html
+++ b/dojo/templates/dojo/add_user.html
@@ -38,6 +38,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% if to_add or to_edit and not to_edit.is_staff %}
         <script type="application/javascript">
             $(function () {

--- a/dojo/templates/dojo/alerts.html
+++ b/dojo/templates/dojo/alerts.html
@@ -52,6 +52,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
 <script type="text/javascript">
     $(function () {

--- a/dojo/templates/dojo/alerts.html
+++ b/dojo/templates/dojo/alerts.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load static %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             {% if alerts %}

--- a/dojo/templates/dojo/api_v2_key.html
+++ b/dojo/templates/dojo/api_v2_key.html
@@ -2,6 +2,7 @@
 {% load event_tags %}
 
 {% block content %}
+    {{ block.super }}
     <h2> {{ name }}</h2>
     <hr/>
     <p>Your current API key is <code>{{ key.key }}</code></p>

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -2,10 +2,12 @@
 {% load event_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
@@ -14,6 +16,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Apply template to a Finding</h3>
     <form id="add_finding" class="form-horizontal" name="apply_template"
           action="{% url 'apply_template_to_finding' finding.id template.id %}" method="post">

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -33,6 +33,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
    <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>

--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -2,11 +2,9 @@
 {% load event_tags %}
 {% load get_attribute %}
 {% block css %}
-    {{ block.super }}
     {{ form.media.css }}
 {% endblock %}
 {% block js %}
-    {{ block.super }}
     {{ form.media.js }}
 {% endblock %}
 {% if form.non_field_errors %}

--- a/dojo/templates/dojo/apply_finding_template_form_fields.html
+++ b/dojo/templates/dojo/apply_finding_template_form_fields.html
@@ -2,9 +2,11 @@
 {% load event_tags %}
 {% load get_attribute %}
 {% block css %}
+    {{ block.super }}
     {{ form.media.css }}
 {% endblock %}
 {% block js %}
+    {{ block.super }}
     {{ form.media.js }}
 {% endblock %}
 {% if form.non_field_errors %}

--- a/dojo/templates/dojo/asciidoc_report.html
+++ b/dojo/templates/dojo/asciidoc_report.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     {% load event_tags %}
     {% load display_tags %}
     {% load humanize %}

--- a/dojo/templates/dojo/asciidoc_report.html
+++ b/dojo/templates/dojo/asciidoc_report.html
@@ -529,6 +529,7 @@
 	{% endif %}
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript">
 
         window.onload = function () {

--- a/dojo/templates/dojo/banner.html
+++ b/dojo/templates/dojo/banner.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <form class="form-horizontal" action="{%  url 'configure_banner' %}" method="post" enctype="multipart/form-data">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">

--- a/dojo/templates/dojo/benchmark.html
+++ b/dojo/templates/dojo/benchmark.html
@@ -4,6 +4,7 @@
 {% load display_tags %}
 
 {% block content %}
+    {{ block.super }}
       <div class="panel panel-default">
           <div class="panel-heading">
               <div class="clearfix">

--- a/dojo/templates/dojo/benchmark.html
+++ b/dojo/templates/dojo/benchmark.html
@@ -96,6 +96,7 @@
 </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         function highlight_level(desired_level) {
             $( ".level2_select" ).removeClass("level2");

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <form method="GET" id="calfilter" action="/calendar">
         <div class="container-fluid chosen-container side-by-side">
             <div class="row">

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -32,6 +32,7 @@
     <br/><br/>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
           $(function () {
             $('#caltype').change(function() { $('#calfilter').attr('action', '/calendar/' + $(this).val()); });

--- a/dojo/templates/dojo/change_pwd.html
+++ b/dojo/templates/dojo/change_pwd.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <form method="post" class="form-horizontal" autocomplete="off">
         {% csrf_token %}
         <fieldset>

--- a/dojo/templates/dojo/checklist.html
+++ b/dojo/templates/dojo/checklist.html
@@ -3,6 +3,7 @@
 <head>
 </head>
 {% block content %}
+    {{ block.super }}
     <h3>Checklist</h3>
     <form class="form-horizontal" action="{% url 'complete_checklist' eid %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/clear_finding_review.html
+++ b/dojo/templates/dojo/clear_finding_review.html
@@ -3,11 +3,13 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
 }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Clear Finding Review</h3>
     <h4>{{ finding.title }}</h4>
     <p>Set the appropriate status for this finding.  Please add notes to help document.</p>

--- a/dojo/templates/dojo/clear_finding_review.html
+++ b/dojo/templates/dojo/clear_finding_review.html
@@ -24,6 +24,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript">
         $(function () {
             $('#id_reviewers').chosen({'placeholder_text_multiple': 'Select some reviewers...'});

--- a/dojo/templates/dojo/close_finding.html
+++ b/dojo/templates/dojo/close_finding.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <h3> Close a Finding</h3>
     <h4>{{ finding.title }}</h4>
     {% if note_types|length == 0 %}

--- a/dojo/templates/dojo/components.html
+++ b/dojo/templates/dojo/components.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 {% load static %}
 {% block content %}
+    {{ block.super }}
 <div class="row">
     <div class="col-md-12">
         <div class="panel panel-default">

--- a/dojo/templates/dojo/components.html
+++ b/dojo/templates/dojo/components.html
@@ -84,6 +84,7 @@
 </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 <script>
         $(function () {
             //Ensures dropdown has proper zindex

--- a/dojo/templates/dojo/custom_asciidoc_report.html
+++ b/dojo/templates/dojo/custom_asciidoc_report.html
@@ -5,6 +5,7 @@
 {% load humanize %}
 
 {% block content %}
+    {{ block.super }}
     <button onclick="asciidocDownload()" class="btn btn-primary" type="button">
         Download Report
     </button>

--- a/dojo/templates/dojo/custom_html_report.html
+++ b/dojo/templates/dojo/custom_html_report.html
@@ -166,6 +166,7 @@
         }
     </style>
 {% block content %}
+    {{ block.super }}
     <div class="container" id="html_report">
         {% for widget in widgets %}
             {{ widget.get_html }}

--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -2,6 +2,7 @@
 {% load event_tags %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     body{
         padding-top: 0px !important;
     }
@@ -22,6 +23,7 @@
     rotate(-45deg);-ms-transform:rotate(-45deg);display: inline-block;}
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="row navbar-fixed-top">
         <div class="col-md-12">
             <h2>{{ name }} For {{ start_date.date }} - {{ end_date.date }}

--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -181,6 +181,7 @@
     <br/>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <!-- Flot Charts JavaScript -->
     <script src="{% static "flot/excanvas.min.js" %}"></script>
     <script src="{% static "flot/jquery.flot.js" %}"></script>

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -228,6 +228,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <!-- Flot Charts JavaScript -->
     <script src="{% static "flot/excanvas.min.js" %}"></script>
     <script src="{% static "flot/jquery.flot.js" %}"></script>

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -2,12 +2,14 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
     .chart {height: 300px}
     .status .panel {min-height: 140px;background-color: #f5f5f5;}
     #punchcard {height: 350px}
 {% endblock %}
 
 {% block content %}
+    {{ block.super }}
     <div class="row status">
         <div class="col-lg-3 col-md-6">
             <div class="panel secondary-color">

--- a/dojo/templates/dojo/defect_finding_review.html
+++ b/dojo/templates/dojo/defect_finding_review.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <h3> Review Finding from Jira</h3>
     <h4>{{ finding.title }}</h4>
     <p>Please provide a description on why the finding should be closed or marked as not fixed.</p>

--- a/dojo/templates/dojo/delete_alerts.html
+++ b/dojo/templates/dojo/delete_alerts.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete All alerts {{ product }}</h3>
     <p>
         Delete all alerts will remove all alerts from this instance

--- a/dojo/templates/dojo/delete_benchmark.html
+++ b/dojo/templates/dojo/delete_benchmark.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Benchmarks for {{ product }}</h3>
     <p>
         Deleting these benchmarks will remove the benchmarks from the product and any related notes on the benchmarks.

--- a/dojo/templates/dojo/delete_cred_all.html
+++ b/dojo/templates/dojo/delete_cred_all.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Credential Mapping</h3>
 
     <div class="danger-zone panel panel-danger">

--- a/dojo/templates/dojo/delete_endpoint.html
+++ b/dojo/templates/dojo/delete_endpoint.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Endpoint {{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</h3>
     <p>
         Deleting this Endpoint will disassociate it with any findings and products and other relationships associated

--- a/dojo/templates/dojo/delete_engagement.html
+++ b/dojo/templates/dojo/delete_engagement.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete {{ engagement }}</h3>
     <p>
         Deleting this Engagement will remove any related objects associated

--- a/dojo/templates/dojo/delete_finding_group.html
+++ b/dojo/templates/dojo/delete_finding_group.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Finding Group {{ finding_group }}</h3>
     <p>
         Deleting this Finding Group will NOT remove any findings inside this group.

--- a/dojo/templates/dojo/delete_github.html
+++ b/dojo/templates/dojo/delete_github.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Test {{ test }}</h3>
     <p>
         Deleting this configuration will remove any GITHUB product configurations, settings, and other relationships associate

--- a/dojo/templates/dojo/delete_jira.html
+++ b/dojo/templates/dojo/delete_jira.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Test {{ test }}</h3>
     <p>
         Deleting this configuration will remove any JIRA product configurations, settings, and other relationships associate

--- a/dojo/templates/dojo/delete_object.html
+++ b/dojo/templates/dojo/delete_object.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3>Delete Tracked File, Folder or Artifact</h3>
 
     <div class="danger-zone panel panel-danger">

--- a/dojo/templates/dojo/delete_presets.html
+++ b/dojo/templates/dojo/delete_presets.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Engagement Preset {{ test }}</h3>
     <p>
         Deleting this Engagement Preset will remove the engagement relationships associated

--- a/dojo/templates/dojo/delete_product.html
+++ b/dojo/templates/dojo/delete_product.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Product {{ product }}</h3>
     <p>
         Deleting this Product will remove any related objects associated

--- a/dojo/templates/dojo/delete_product_member.html
+++ b/dojo/templates/dojo/delete_product_member.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete a Product Member </h3>
     <form class="form-horizontal" action="{%  url 'delete_product_member' memberid %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/delete_product_type.html
+++ b/dojo/templates/dojo/delete_product_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Product Type {{ product_type }}</h3>
     <p>
         Deleting this Product Type will remove any related objects associated

--- a/dojo/templates/dojo/delete_product_type_member.html
+++ b/dojo/templates/dojo/delete_product_type_member.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete a Product Type Member </h3>
     <form class="form-horizontal" action="{%  url 'delete_product_type_member' memberid %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/delete_rule.html
+++ b/dojo/templates/dojo/delete_rule.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Rule {{ rule }}</h3>
     <p>
         Deleting this rule will remove any related objects associated

--- a/dojo/templates/dojo/delete_test.html
+++ b/dojo/templates/dojo/delete_test.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Test {{ test }}</h3>
     <p>
         Deleting this Test will remove any findings, risk acceptances, check lists, and other relationships associated

--- a/dojo/templates/dojo/delete_tool_product.html
+++ b/dojo/templates/dojo/delete_tool_product.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete Product Tool Configuration</h3>
 
     <div class="danger-zone panel panel-danger">

--- a/dojo/templates/dojo/delete_user.html
+++ b/dojo/templates/dojo/delete_user.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Delete User {{ to_delete }}</h3>
     <p>
         Deleting this User will remove any related objects associated

--- a/dojo/templates/dojo/dev_env.html
+++ b/dojo/templates/dojo/dev_env.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/dev_env.html
+++ b/dojo/templates/dojo/dev_env.html
@@ -67,6 +67,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             var availableTags = [

--- a/dojo/templates/dojo/disable_note_type.html
+++ b/dojo/templates/dojo/disable_note_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Disable Note Type {{ nt.name }}</h3>
     <form class="form-horizontal" action="{% url 'disable_note_type' nt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=nt_form %}

--- a/dojo/templates/dojo/edit_cred.html
+++ b/dojo/templates/dojo/edit_cred.html
@@ -14,4 +14,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_cred.html
+++ b/dojo/templates/dojo/edit_cred.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit Credential Configuration</h3>
     <form class="form-horizontal" enctype="multipart/form-data" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}

--- a/dojo/templates/dojo/edit_cred_all.html
+++ b/dojo/templates/dojo/edit_cred_all.html
@@ -14,4 +14,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_cred_all.html
+++ b/dojo/templates/dojo/edit_cred_all.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit {{cred_type}} Credential</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}

--- a/dojo/templates/dojo/edit_dev_env.html
+++ b/dojo/templates/dojo/edit_dev_env.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit Environment {{ pt.name }}</h3>
     <form class="form-horizontal" action="{% url 'edit_dev_env' de.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form1 %}

--- a/dojo/templates/dojo/edit_endpoint.html
+++ b/dojo/templates/dojo/edit_endpoint.html
@@ -2,11 +2,13 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
 }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit Endpoint </h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_endpoint.html
+++ b/dojo/templates/dojo/edit_endpoint.html
@@ -20,4 +20,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_endpoint_meta_data.html
+++ b/dojo/templates/dojo/edit_endpoint_meta_data.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
     <p>
         Use the form below to edit the values in each of the metadata fields.  To remove a field, leave the value blank.

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -3,9 +3,11 @@
 {% load display_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
@@ -14,6 +16,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit a Finding </h3>
     {% if temp %}
         <form id="add_finding" class="form-horizontal" action="{% url 'edit_finding' finding.id %}" method="post">

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -122,6 +122,7 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>

--- a/dojo/templates/dojo/edit_jira.html
+++ b/dojo/templates/dojo/edit_jira.html
@@ -14,4 +14,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_jira.html
+++ b/dojo/templates/dojo/edit_jira.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit JIRA Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=jform %}

--- a/dojo/templates/dojo/edit_note.html
+++ b/dojo/templates/dojo/edit_note.html
@@ -2,6 +2,7 @@
 {% load humanize %}
 {% load static %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit Note</h3><br></br>
     <form class="form-horizontal" action="{% url 'edit_note' note.id page objid %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_note_type.html
+++ b/dojo/templates/dojo/edit_note_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit Note Type {{ nt.name }}</h3>
     <form class="form-horizontal" action="{% url 'edit_note_type' nt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=nt_form %}

--- a/dojo/templates/dojo/edit_object.html
+++ b/dojo/templates/dojo/edit_object.html
@@ -14,4 +14,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_object.html
+++ b/dojo/templates/dojo/edit_object.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3>Edit Tracked Files</h3>
     <form class="form-horizontal" enctype="multipart/form-data" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
@@ -13,6 +15,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <form class="form-horizontal" enctype="multipart/form-data" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}
         <div class="form-group">

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -26,6 +26,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
     }
@@ -16,6 +18,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit {{ product.name }}</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -45,6 +45,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/edit_product_member.html
+++ b/dojo/templates/dojo/edit_product_member.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit a Product Member </h3>
     <form class="form-horizontal" action="{%  url 'edit_product_member' memberid %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_product_meta_data.html
+++ b/dojo/templates/dojo/edit_product_meta_data.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit {{ product.name }} Metadata</h3>
     <p>
         Use the form below to edit the values in each of the metadata fields.  To remove a field, leave the value blank.

--- a/dojo/templates/dojo/edit_product_type.html
+++ b/dojo/templates/dojo/edit_product_type.html
@@ -27,6 +27,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/edit_product_type.html
+++ b/dojo/templates/dojo/edit_product_type.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
@@ -12,6 +14,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit Product Type {{ pt.name }}</h3>
     <form class="form-horizontal" action="{% url 'edit_product_type' pt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=pt_form %}

--- a/dojo/templates/dojo/edit_product_type_member.html
+++ b/dojo/templates/dojo/edit_product_type_member.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit a Product Type Member </h3>
     <form class="form-horizontal" action="{%  url 'edit_product_type_member' memberid %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_regulation.html
+++ b/dojo/templates/dojo/edit_regulation.html
@@ -15,4 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_regulation.html
+++ b/dojo/templates/dojo/edit_regulation.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit Regulation Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}

--- a/dojo/templates/dojo/edit_rule.html
+++ b/dojo/templates/dojo/edit_rule.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit Rule {{ pt.name }}</h3>
     <form class="form-horizontal" action="{% url 'Edit Rule' pt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_rule.html
+++ b/dojo/templates/dojo/edit_rule.html
@@ -13,6 +13,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 <script type="application/javascript">
     $(document).ready(function() {
         $('#id_applied_field).empty();

--- a/dojo/templates/dojo/edit_test.html
+++ b/dojo/templates/dojo/edit_test.html
@@ -21,4 +21,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_test.html
+++ b/dojo/templates/dojo/edit_test.html
@@ -2,12 +2,14 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
 }
 {% endblock %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit Test Details </h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_test_type.html
+++ b/dojo/templates/dojo/edit_test_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Edit Test Type {{ pt.name }}</h3>
     <form class="form-horizontal" action="{% url 'edit_test_type' pt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/edit_tool_config.html
+++ b/dojo/templates/dojo/edit_tool_config.html
@@ -14,4 +14,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_config.html
+++ b/dojo/templates/dojo/edit_tool_config.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit Tool Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}

--- a/dojo/templates/dojo/edit_tool_product.html
+++ b/dojo/templates/dojo/edit_tool_product.html
@@ -14,4 +14,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_product.html
+++ b/dojo/templates/dojo/edit_tool_product.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit Product Tool Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}

--- a/dojo/templates/dojo/edit_tool_type.html
+++ b/dojo/templates/dojo/edit_tool_type.html
@@ -14,4 +14,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/edit_tool_type.html
+++ b/dojo/templates/dojo/edit_tool_type.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Edit Tool Type Configuration</h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=tform %}

--- a/dojo/templates/dojo/enable_note_type.html
+++ b/dojo/templates/dojo/enable_note_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Disable Note Type {{ nt.name }}</h3>
     <form class="form-horizontal" action="{% url 'enable_note_type' nt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=nt_form %}

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -7,6 +7,7 @@
 {% load get_notetype_availability %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
         {% if include_table_of_contents%}
 			<div class="row">

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -255,6 +255,7 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
+    {{ block.super }}
     <script src="{{ host }}{% static "jquery/dist/jquery.min.js" %}"></script>
     <!-- Flot Charts JavaScript -->
     <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 {% load authorization_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -166,6 +166,7 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 <script>
         var checkbox_count = 0;
         function check_checked_endpoint()

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -106,6 +106,7 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             var prodWords = [

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -4,6 +4,7 @@
 {% load dict_key %}
 
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -7,6 +7,7 @@
 {% load get_notetype_availability %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
       <div class="row">
           <div class="col-lg-12">

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -389,6 +389,7 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
+    {{ block.super }}
     <script src="{{ host }}{% static "jquery/dist/jquery.min.js" %}"></script>
     <!-- Flot Charts JavaScript -->
     <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -2,6 +2,7 @@
 {% load navigation_tags %}
 {% load display_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row" xmlns="http://www.w3.org/1999/html">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -114,6 +114,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 
     <script>
         $(function () {

--- a/dojo/templates/dojo/engineer_metrics.html
+++ b/dojo/templates/dojo/engineer_metrics.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="clearfix">
         <h3 class="pull-left">Engineers</h3>{% include "dojo/paging_snippet.html" with page=users page_size=True%}
     </div>

--- a/dojo/templates/dojo/express_new_jira.html
+++ b/dojo/templates/dojo/express_new_jira.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a JIRA Configuration Express </h3>
     <form class="form-horizontal" action="{% url 'express_jira' %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -2,6 +2,7 @@
 {% load event_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}
 {% block css %}

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -2,13 +2,12 @@
 {% load event_tags %}
 {% load static %}
 {% block add_css %}
-    {{ block.super }}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}
 {% block css %}
     {{ form.media.css }}
 {% endblock %}
-{% block js %}
+{% block js %}    
     {{ form.media.js }}
 {% endblock %}
 <div class="filter-set">

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -7,6 +7,7 @@
 {% load get_notetype_availability %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
         {% if include_table_of_contents%}
 			<div class="row">

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -229,6 +229,7 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
+    {{ block.super }}
     <script src="{{ host }}{% static "jquery/dist/jquery.min.js" %}"></script>
     <!-- Flot Charts JavaScript -->
     <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -3,7 +3,6 @@
 {% load display_tags %}
 {% load static %}
 {% block content %}
-    {{ block.super }}
     {% comment %} include inherits the current context so findings, filtered and other variables {% endcomment %}
     {% include "dojo/findings_list_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/findings_list.html
+++ b/dojo/templates/dojo/findings_list.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 {% load static %}
 {% block content %}
+    {{ block.super }}
     {% comment %} include inherits the current context so findings, filtered and other variables {% endcomment %}
     {% include "dojo/findings_list_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -469,7 +469,6 @@
 
 {% endblock %}
 {% block postscript %}
-    {{ block.super }}
     <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         // DataTables Setup

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -469,6 +469,7 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "chosen-js/chosen.jquery.min.js" %}"></script>
     <script type="application/javascript">
         // DataTables Setup

--- a/dojo/templates/dojo/github.html
+++ b/dojo/templates/dojo/github.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/github.html
+++ b/dojo/templates/dojo/github.html
@@ -68,5 +68,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/google_sheet_configuration.html
+++ b/dojo/templates/dojo/google_sheet_configuration.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <form class="form-horizontal" action="{%  url 'configure_google_sheets' %}" method="post" enctype="multipart/form-data">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -59,6 +59,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 	<script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
 	<script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
 	<script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -2,11 +2,13 @@
 {% load static %}
 {% load display_tags %}
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
 }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Add Tests</h3>
     <form class="form-horizontal" action="" enctype="multipart/form-data" method="post">
 	{% csrf_token %}

--- a/dojo/templates/dojo/jira.html
+++ b/dojo/templates/dojo/jira.html
@@ -88,5 +88,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/jira.html
+++ b/dojo/templates/dojo/jira.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load get_banner %}
 {% block content %}
+    {{ block.super }}
     <h3>Login</h3>
     <form class="form-horizontal" method="POST" autocomplete="off"> {% csrf_token %}
         <fieldset class="col-md-offset-3 col-md-6">

--- a/dojo/templates/dojo/manage_files.html
+++ b/dojo/templates/dojo/manage_files.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Add files to {{ obj }}</h3>
     <div class="alert alert-info" role="alert">
         You may add as many files to this {{ obj_type }} as needed (three new files at a time). To delete an file, check the

--- a/dojo/templates/dojo/manage_images.html
+++ b/dojo/templates/dojo/manage_images.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
     <h3> Add images to {{ finding }}</h3>
     <div class="alert alert-info" role="alert">
         You may add as many images to this finding as needed (three new images at a time). To delete an image, check the

--- a/dojo/templates/dojo/merge_findings.html
+++ b/dojo/templates/dojo/merge_findings.html
@@ -36,6 +36,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         var prior_select_val, prior_select_text;
 

--- a/dojo/templates/dojo/merge_findings.html
+++ b/dojo/templates/dojo/merge_findings.html
@@ -3,10 +3,12 @@
 {% load display_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
@@ -15,6 +17,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Merge Findings</h3>
     <div id="merge">
         <p>

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     .tabs-below > .nav-tabs,
     .tabs-right > .nav-tabs,
     .tabs-left > .nav-tabs {
@@ -111,6 +112,7 @@
     #chart_div, #chart_div5, #chart_div2, #chart_div3, #chart_div4 {height: 300px}
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="col-md-12">
         <div class="panel panel-default">
             <div class="panel-heading tight">

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -635,6 +635,7 @@
     <br/>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <!-- Flot Charts JavaScript -->
     <script src="{% static "flot/excanvas.min.js" %}"></script>
     <script src="{% static "flot/jquery.flot.js" %}"></script>

--- a/dojo/templates/dojo/migrate_endpoints.html
+++ b/dojo/templates/dojo/migrate_endpoints.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 {% load authorization_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/new_cred.html
+++ b/dojo/templates/dojo/new_cred.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a Credential</h3>
     <form class="form-horizontal" action="{% url 'add_cred' %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_cred_mapping.html
+++ b/dojo/templates/dojo/new_cred_mapping.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a Credential</h3>
     <form class="form-horizontal" action="{{formlink}}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_cred_product.html
+++ b/dojo/templates/dojo/new_cred_product.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a Credential</h3>
     <form class="form-horizontal" action="{% url 'new_cred_product' pid %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_dev_env.html
+++ b/dojo/templates/dojo/new_dev_env.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Register a new Environment </h3>
     <form class="form-horizontal" action="{% url 'add_dev_env' %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -2,10 +2,12 @@
 {% load display_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
@@ -14,6 +16,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> {{ title }} </h3>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -60,6 +60,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/new_github.html
+++ b/dojo/templates/dojo/new_github.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a Github Configuration </h3>
     <form class="form-horizontal" action="{% url 'add_github' %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_jira.html
+++ b/dojo/templates/dojo/new_jira.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a JIRA Configuration </h3>
     <form class="form-horizontal" action="{% url 'add_jira' %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_object.html
+++ b/dojo/templates/dojo/new_object.html
@@ -15,4 +15,5 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 {% endblock %}

--- a/dojo/templates/dojo/new_object.html
+++ b/dojo/templates/dojo/new_object.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add Tracked Files to a Product</h3>
     <form class="form-horizontal" action="{% url 'new_object' pid %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
@@ -13,6 +15,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <form class="form-horizontal" action="{% url 'add_engagement_presets' pid %}" method="post">{% csrf_token %}
      {% include "dojo/form_fields.html" with form=tform %}
         <div class="form-group">

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -26,6 +26,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -1,10 +1,12 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
 
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
@@ -14,6 +16,7 @@
 {% endblock %}
 
 {% block content %}
+    {{ block.super }}
     <form class="form-horizontal" action="{% url 'new_product' %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
         {%  if jform %}

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -42,6 +42,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/new_product_member.html
+++ b/dojo/templates/dojo/new_product_member.html
@@ -5,6 +5,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Register new Product Members </h3>
     <form class="form-horizontal" action="{%  url 'add_product_member' product.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_product_member_user.html
+++ b/dojo/templates/dojo/new_product_member_user.html
@@ -5,6 +5,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Register new Product Members </h3>
     <form class="form-horizontal" action="{%  url 'add_product_member_user' user.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_product_type.html
+++ b/dojo/templates/dojo/new_product_type.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
@@ -12,6 +14,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Register a new Product Type </h3>
     <form class="form-horizontal" action="{%  url 'add_product_type' %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_product_type.html
+++ b/dojo/templates/dojo/new_product_type.html
@@ -26,6 +26,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {

--- a/dojo/templates/dojo/new_product_type_member.html
+++ b/dojo/templates/dojo/new_product_type_member.html
@@ -5,6 +5,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Register new Product Type Members </h3>
     <form class="form-horizontal" action="{%  url 'add_product_type_member' pt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_product_type_member_user.html
+++ b/dojo/templates/dojo/new_product_type_member_user.html
@@ -5,6 +5,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Register new Product Type Members </h3>
     <form class="form-horizontal" action="{%  url 'add_product_type_member_user' user.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_regulation.html
+++ b/dojo/templates/dojo/new_regulation.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Add new regulation </h3>
     <form class="form-horizontal" action="{% url 'new_regulation' %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_rule.html
+++ b/dojo/templates/dojo/new_rule.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load get_attribute %}
 {% block content %}
+    {{ block.super }}
     <h3> Add Child Rules </h3>
     <form class="form-horizontal" action="{%  url 'Add Child' pid %}" method="post">{% csrf_token %}
         {% for f in form %}

--- a/dojo/templates/dojo/new_rule.html
+++ b/dojo/templates/dojo/new_rule.html
@@ -28,6 +28,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 <script type="application/javascript">
     $(document).ready(function() {
         $('#id_applied_field).empty();

--- a/dojo/templates/dojo/new_rule2.html
+++ b/dojo/templates/dojo/new_rule2.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Add New Rule </h3>
     <form class="form-horizontal" action="{%  url 'Add Rule' %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_tech.html
+++ b/dojo/templates/dojo/new_tech.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
  {% block content %}
+    {{ block.super }}
      <h3> Register a new Technology </h3>
      <form class="form-horizontal" action="{%  url 'new_tech_for_prod' pid %}" method="post">{% csrf_token %}
          {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_test_type.html
+++ b/dojo/templates/dojo/new_test_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h3> Register a new Test Type </h3>
     <form class="form-horizontal" action="{% url 'add_test_type' %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/new_tool_config.html
+++ b/dojo/templates/dojo/new_tool_config.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a Tool Configuration </h3>
     <form class="form-horizontal" action="{% url 'add_tool_config' %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_tool_product.html
+++ b/dojo/templates/dojo/new_tool_product.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add Product Tool Type Configuration </h3>
     <form class="form-horizontal" action="{% url 'new_tool_product' pid %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/new_tool_type.html
+++ b/dojo/templates/dojo/new_tool_type.html
@@ -1,5 +1,6 @@
 {% extends "base.html"%}
 {% block content %}
+    {{ block.super }}
  {{ block.super }}
     <h3> Add a Tool Type Configuration </h3>
     <form class="form-horizontal" action="{% url 'add_tool_type' %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/note_type.html
+++ b/dojo/templates/dojo/note_type.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/note_type.html
+++ b/dojo/templates/dojo/note_type.html
@@ -116,6 +116,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             var availableTags = [

--- a/dojo/templates/dojo/notifications.html
+++ b/dojo/templates/dojo/notifications.html
@@ -76,6 +76,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             $(".chosen-select").chosen({disable_search_threshold: 10});

--- a/dojo/templates/dojo/notifications.html
+++ b/dojo/templates/dojo/notifications.html
@@ -4,6 +4,7 @@
 
 
 {% block content %}
+    {{ block.super }}
     <h3> {% if scope == 'system' %}System{% else %}Personal{% endif %} Notification Settings </h3>
     <form class="form-inline col-sm-10" method="post" id="notform">{% csrf_token %}
         <div class="container" style="width:50%">

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 {% load authorization_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -275,6 +275,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             //Ensures dropdown has proper zindex

--- a/dojo/templates/dojo/product_components.html
+++ b/dojo/templates/dojo/product_components.html
@@ -82,6 +82,7 @@
 </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
 <script>
         $(function () {
             //Ensures dropdown has proper zindex

--- a/dojo/templates/dojo/product_components.html
+++ b/dojo/templates/dojo/product_components.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
 
 
 <div class="row">

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -7,6 +7,7 @@
 {% load get_notetype_availability %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
         {% if include_table_of_contents%}
             <div class="row">

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -304,6 +304,7 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
+    {{ block.super }}
     <!-- jQuery -->
     <script src="{{ host }}{% static "jquery/dist/jquery.js" %}"></script>
     <!-- Flot Charts JavaScript -->

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -462,6 +462,7 @@
 </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <!-- Flot Charts JavaScript -->
     <script src="{% static "flot/excanvas.min.js" %}"></script>

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -3,9 +3,11 @@
 {% load display_tags %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     .graph {min-height: 158px;}
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="panel panel-default">
         <div class="panel-heading tight">
             <div class="clearfix">

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -7,6 +7,7 @@
 {% load get_note_status %}
 {% load get_notetype_availability %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
       <div class="row">
         <div class="col-lg-12">

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -369,6 +369,7 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
+    {{ block.super }}
     <!-- jQuery -->
     <script src="{{ host }}{% static "jquery/dist/jquery.js" %}"></script>
     <!-- Flot Charts JavaScript -->

--- a/dojo/templates/dojo/product_type.html
+++ b/dojo/templates/dojo/product_type.html
@@ -4,6 +4,7 @@
 {% load display_tags %}
 
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/product_type.html
+++ b/dojo/templates/dojo/product_type.html
@@ -134,6 +134,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             var availableTags = [

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -7,6 +7,7 @@
 {% load get_notetype_availability %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
         {% if include_table_of_contents%}
 			<div class="row">

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -306,6 +306,7 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
+    {{ block.super }}
     <script src="{{ host }}{% static "jquery/dist/jquery.min.js" %}"></script>
     <!-- Flot Charts JavaScript -->
     <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>

--- a/dojo/templates/dojo/profile.html
+++ b/dojo/templates/dojo/profile.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% block content %}
+    {{ block.super }}
     <h3> User Profile - {{ user.get_full_name }}</h3>
     <div class="row">
         <div class="col-md-7">

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -2,14 +2,17 @@
 {% load event_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
+    {{ block.super }}
     .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div>
         <h3>Promote Potential Finding</h3>
     </div>

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -37,6 +37,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="text/javascript" src="{% static "admin/js/jquery.init.js" %}"></script>

--- a/dojo/templates/dojo/pt_counts.html
+++ b/dojo/templates/dojo/pt_counts.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load display_tags %}
 {% block add_styles %}
+    {{ block.super }}
     form.biweekly-metrics p { display: inline-block;}
     form.biweekly-metrics input {border: 1px solid #ccc;border-radius: 4px;padding: 3px 6px;}
     form.biweekly-metrics select {border-radius: 4px;background-color: #fff;background-image: none;border: 1px solid
@@ -8,6 +9,7 @@
     .errorlist {color: #a94442; display: inline-block;}
 {% endblock %}
 {% block content %}
+    {{ block.super }}
 
     <form class="biweekly-metrics" action="{% url 'product_type_counts' %}" method="get">
         {{ form.as_p }}

--- a/dojo/templates/dojo/regulations.html
+++ b/dojo/templates/dojo/regulations.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/regulations.html
+++ b/dojo/templates/dojo/regulations.html
@@ -82,5 +82,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/regulations_config.html
+++ b/dojo/templates/dojo/regulations_config.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/regulations_config.html
+++ b/dojo/templates/dojo/regulations_config.html
@@ -65,5 +65,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -53,6 +53,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script src="{% static "google-code-prettify/src/prettify.js" %}"></script>
     <script src="{% static "bootstrap-wysiwyg/src/bootstrap-wysiwyg.js" %}"></script>

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load display_tags %}
 {% block content %}
+    {{ block.super }}
     <link href="{% static "google-code-prettify/src/prettify.css" %}" rel="stylesheet"/>
     <div class="row">
         <div class="col-md-8">

--- a/dojo/templates/dojo/report_cover_page.html
+++ b/dojo/templates/dojo/report_cover_page.html
@@ -1,6 +1,7 @@
 {% extends "report_base.html" %}
 {% load static %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
         <div class="page-cover-spacer">&nbsp;</div>
         <div class="text-center page-cover">

--- a/dojo/templates/dojo/report_filter_snippet.html
+++ b/dojo/templates/dojo/report_filter_snippet.html
@@ -1,7 +1,6 @@
 {% load navigation_tags %}
 {% load static %}
 {% block add_css %}
-    {{ block.super }}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}
 <div class="filter-set report-filter-set">

--- a/dojo/templates/dojo/report_filter_snippet.html
+++ b/dojo/templates/dojo/report_filter_snippet.html
@@ -1,6 +1,7 @@
 {% load navigation_tags %}
 {% load static %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}">
 {% endblock %}
 <div class="filter-set report-filter-set">

--- a/dojo/templates/dojo/request_endpoint_report.html
+++ b/dojo/templates/dojo/request_endpoint_report.html
@@ -78,5 +78,6 @@
 {% endblock %}
 
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/request_endpoint_report.html
+++ b/dojo/templates/dojo/request_endpoint_report.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/request_report.html
+++ b/dojo/templates/dojo/request_report.html
@@ -109,5 +109,6 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/request_report.html
+++ b/dojo/templates/dojo/request_report.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load humanize %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/research_metrics.html
+++ b/dojo/templates/dojo/research_metrics.html
@@ -2,6 +2,7 @@
 {% load event_tags %}
 {% load display_tags %}
 {% block content %}
+    {{ block.super }}
     <table id="content" class="table-full">
         <tr id="open">
             <td class="top">

--- a/dojo/templates/dojo/review_finding.html
+++ b/dojo/templates/dojo/review_finding.html
@@ -3,11 +3,13 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
 }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h3> Mark Finding for Review</h3>
     <h4>{{ finding.title }}</h4>
     <p>Please provide a reason why this finding needs to be reviewed.</p>

--- a/dojo/templates/dojo/review_finding.html
+++ b/dojo/templates/dojo/review_finding.html
@@ -24,6 +24,7 @@
     </form>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript">
         $(function () {
             $('#id_reviewers').chosen({'placeholder_text_multiple': 'Select some reviewers...'});

--- a/dojo/templates/dojo/rules.html
+++ b/dojo/templates/dojo/rules.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="alert alert-danger">

--- a/dojo/templates/dojo/simple_metrics.html
+++ b/dojo/templates/dojo/simple_metrics.html
@@ -2,6 +2,7 @@
 {% load event_tags %}
 {% load display_tags %}
 {% block content %}
+    {{ block.super }}
 
     <h2> {{ name }}</h2>
     <form class="simple_metrics" action="{% url 'simple_metrics' %}" method="post">{% csrf_token %}

--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -549,6 +549,7 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript">
         {% comment %} django filters do no support a "full_text" query field which is not a field of the model
         so we have to inject it clientside to qavoid duplicating the whole form with hardcoded fields etc. {% endcomment %}

--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 
 {% block content %}
+    {{ block.super }}
     <h2> {{ name }} <i class="fa fa-question-circle has-popover" data-trigger="hover"
                        data-content="This simple search function will return results whose findings or finding templates
                                      title, URL, description, endpoints, tags, references, languages or technologies contain the search query and products whose

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -277,6 +277,7 @@
     </div>
 </div>
 {% block postscript %}
+    {{ block.super }}
 <script>
         // DataTables setup
         $(document).ready(function() {

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -277,7 +277,6 @@
     </div>
 </div>
 {% block postscript %}
-    {{ block.super }}
 <script>
         // DataTables setup
         $(document).ready(function() {

--- a/dojo/templates/dojo/syncing_errors.html
+++ b/dojo/templates/dojo/syncing_errors.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     {% load display_tags %}
     <p>
         Synced with "{{ sheet_title }}" sheet of Spreadsheet "{{ spreadsheet_name }}"

--- a/dojo/templates/dojo/system_settings.html
+++ b/dojo/templates/dojo/system_settings.html
@@ -2,12 +2,14 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
 .chosen-container {
     width: 70% !important;
 }
 {% endblock %}
 
 {% block content %}
+    {{ block.super }}
 <div class="row">
     <h3> System Status </h3>
     <br>

--- a/dojo/templates/dojo/system_settings.html
+++ b/dojo/templates/dojo/system_settings.html
@@ -45,6 +45,7 @@
 Django forms are very rigid so without crispy-forms we're forced to use javascript to add some flavour...
 {endcomment}
 {% block postscript %}
+    {{ block.super }}
     <script>
         function updatenotificationsgroup(group) {
            if ($('#id_enable_' + group + "_notifications").is(':checked')) {

--- a/dojo/templates/dojo/templates.html
+++ b/dojo/templates/dojo/templates.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/templates.html
+++ b/dojo/templates/dojo/templates.html
@@ -157,6 +157,7 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             $('button.template-delete').on('click', function (e) {

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -403,6 +403,7 @@
     </div> <!-- /container -->
 {% endblock %}
 {% block js %}
+    {{ block.super }}
 
     <script src="{{ host }}{% static "jquery/dist/jquery.min.js" %}"></script>
     <!-- Flot Charts JavaScript -->

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -7,6 +7,7 @@
 {% load get_notetype_availability %}
 {% load event_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="container">
         <div class="row">
           <div class="col-lg-12">

--- a/dojo/templates/dojo/test_type.html
+++ b/dojo/templates/dojo/test_type.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/test_type.html
+++ b/dojo/templates/dojo/test_type.html
@@ -66,6 +66,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script>
         $(function () {
             var availableTags = [

--- a/dojo/templates/dojo/tool_config.html
+++ b/dojo/templates/dojo/tool_config.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/tool_config.html
+++ b/dojo/templates/dojo/tool_config.html
@@ -69,5 +69,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/tool_type.html
+++ b/dojo/templates/dojo/tool_type.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/tool_type.html
+++ b/dojo/templates/dojo/tool_type.html
@@ -65,5 +65,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/up_threat.html
+++ b/dojo/templates/dojo/up_threat.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <form class="form-horizontal" action="{% url 'upload_threatmodel' eng.id %}" enctype="multipart/form-data"
           method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/users.html
+++ b/dojo/templates/dojo/users.html
@@ -2,6 +2,7 @@
 {% load navigation_tags %}
 {% load authorization_tags %}
 {% block content %}
+    {{ block.super }}
     {% load display_tags %}
     <div class="row">
         <div class="col-md-12">

--- a/dojo/templates/dojo/users.html
+++ b/dojo/templates/dojo/users.html
@@ -131,5 +131,6 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/view_cred.html
+++ b/dojo/templates/dojo/view_cred.html
@@ -2,6 +2,7 @@
 {% load navigation_tags %}
 {% load get_config_setting %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
         <div class="col-md-12">
             <div class="panel panel-default">

--- a/dojo/templates/dojo/view_cred.html
+++ b/dojo/templates/dojo/view_cred.html
@@ -86,5 +86,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/view_cred_all_details.html
+++ b/dojo/templates/dojo/view_cred_all_details.html
@@ -3,11 +3,13 @@
 {% load get_config_setting %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="panel panel-default">
         <div class="panel-heading">
             <div class="clearfix">

--- a/dojo/templates/dojo/view_cred_all_details.html
+++ b/dojo/templates/dojo/view_cred_all_details.html
@@ -176,6 +176,7 @@
 {% endblock %}
 
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/view_cred_details.html
+++ b/dojo/templates/dojo/view_cred_details.html
@@ -223,6 +223,7 @@
 {% endblock %}
 
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/view_cred_details.html
+++ b/dojo/templates/dojo/view_cred_details.html
@@ -3,11 +3,13 @@
 {% load get_config_setting %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="panel panel-default">
         <div class="panel-heading">
             <div class="clearfix">

--- a/dojo/templates/dojo/view_cred_prod.html
+++ b/dojo/templates/dojo/view_cred_prod.html
@@ -2,6 +2,7 @@
 {% load navigation_tags %}
 {% load get_config_setting %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
       <div class="col-md-12">
           <div class="panel panel-default table-responsive">

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -291,6 +291,7 @@
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <!-- Flot Charts JavaScript -->
     <script src="{% static "flot/excanvas.min.js" %}"></script>
     <script src="{% static "flot/jquery.flot.js" %}"></script>

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -4,6 +4,7 @@
 {% load authorization_tags %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     .graph {min-height: 158px;}
     h3 { margin-top: 5px; margin-bottom: 5px; font-size: 20px; line-height: 22px;}
     .tooltip-inner {
@@ -11,6 +12,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="panel panel-default">
         <div class="panel-heading">
             <div class="clearfix">

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -5,11 +5,13 @@
 {% load authorization_tags %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     .tooltip-inner {
       max-width: 350px;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
 
 <div class="row">
   <div class="col-md-8">

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -5,1078 +5,1063 @@
 {% load authorization_tags %}
 {% load static %}
 {% block add_styles %}
-    {{ block.super }}
     .tooltip-inner {
-      max-width: 350px;
+        max-width: 350px;
     }
 {% endblock %}
 {% block content %}
-    {{ block.super }}
-
-<div class="row">
-  <div class="col-md-8">
-      <div class="panel panel-default">
-          <div class="panel-heading">
-              <div class="clearfix">
-                  <h4 class="pull-left">
-                      Description
-                  </h4>
-
-                  <div class="dropdown pull-right">
-                      <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
-                              data-toggle="dropdown" aria-expanded="true">
-                          <span class="fa fa-bars"></span>
-                          <span class="caret"></span>
-                      </button>
-                      <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
-                          {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_change:eng %}
-                              <li role="presentation">
-                                  <a class="" href="{% url 'edit_engagement' eng.id %}">
-                                      <i class="fa fa-pencil-square-o"></i> Edit Engagement
-                                  </a>
-                              </li>
-                          {% endif %}
-                          {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
-                            <li role="presentation">
-                                {% if eng.active %}
-                                    <a class="" href="{% url 'close_engagement' eng.id %}">
-                                        <i class="fa fa-close"></i> Close Engagement
-                                    </a>
-                                {% else %}
-                                    <a class="" href="{% url 'reopen_engagement' eng.id %}">
-                                        <i class="fa fa-undo"></i> Reopen Engagement
-                                    </a>
+    <div class="row">
+        <div class="col-md-8">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <div class="clearfix">
+                        <h4 class="pull-left">
+                            Description
+                        </h4>
+                        <div class="dropdown pull-right">
+                            <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
+                                data-toggle="dropdown" aria-expanded="true">
+                            <span class="fa fa-bars"></span>
+                            <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
+                                {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_change:eng %}
+                                    <li role="presentation">
+                                        <a class="" href="{% url 'edit_engagement' eng.id %}">
+                                        <i class="fa fa-pencil-square-o"></i> Edit Engagement
+                                        </a>
+                                    </li>
                                 {% endif %}
-                            </li>
-                          {% endif %}
-                          <li role="presentation">
-                              <a href="{% url 'engagement_report' eng.id %}?title=&active=1&verified=1&false_p=2&duplicate=2">
-                                  <i class="fa fa-file-text-o"></i> Report
-                              </a>
-                          </li>
-                          <li role="presentation">
-                              <a href="{% url 'engagement_ics' eng.id %}">
-                                  <i class="fa fa-calendar-plus-o"></i> Add To Calendar
-                              </a>
-                          </li>
-                          <li role="presentation">
-                              <a href="{% url 'view_object_eng' eng.id %}">
-                                  <i class="fa fa-file-text-o"></i> View Files for this Build
-                              </a>
-                          </li>
-                          <li role="presentation">
-                              <a href="{% url 'action_history' eng|content_type eng.id %}">
-                                  <i class="fa fa-history"></i> View History
-                              </a>
-                          </li>
-                          {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
-                              <li role="separator" class="divider"></li>
-                              <li role="presentation">
-                                  {% if eng.test_strategy %}
-                                      <a target="_blank" href="{{ eng.test_strategy }}"><i class="fa fa-file-text-o"></i> View Test
-                                          Strategy </a>
-                                  {% else %}
-                                      <a href="{% url 'edit_engagement' eng.id %}"><i class="fa fa-file-text-o"></i> Add a Test Strategy</a>
-                                  {% endif %}
-                              </li>
-                              {% if threat != 'none' %}
-                                  <li role="presentation">
-                                          <a href="{% url 'view_threatmodel' eng.id %}"><i class="fa fa-file-text-o"></i> Download Threat Model</a>
-                                  </li>
-                                  <li role="presentation">
-                                          <a href="{% url 'upload_threatmodel' eng.id %}"><i class="fa fa-file-text-o"></i> Upload Threat Model</a>
-                                  </li>
-                              {% else %}
-                                  <li role="presentation">
-                                      <a href="{% url 'upload_threatmodel' eng.id %}"><i class="fa fa-file-text-o"></i> Upload Threat Model</a>
-                                  </li>
-                              {% endif %}
-                          {% endif %}
-                          {% if eng|has_object_permission:"Engagement_Delete" or user|is_authorized_for_delete:eng %}
-                              <li role="separator" class="divider"></li>
-                              <li role="presentation">
-                                  <a class="text-danger" href="{% url 'delete_engagement' eng.id %}">
-                                      <i class="fa fa-trash-o"></i> Delete Engagement
-                                  </a>
-                              </li>
-                          {% endif %}
-                      </ul>
-                  </div>
-              </div>
-          </div>
-            <div class="panel-body">
-              {% if eng.description %}
-                {{ eng.description|markdown_render }}
-              {% else %}
-                <small class="text-muted"><em>There is no description.</em></small>
-              {% endif %}
-            </div>
-        </div>
-        {% if eng.preset %}
-        <div class="row">
-            <div id="tests" class="col-md-12">
-                <div class="panel panel-default">
-                    <div class="panel-heading">
-                        <div class="clearfix">
-                            <h4 class="pull-left">
-                            Engagement Presets <small>{{ eng.preset.title|truncatechars_html:60 }}</small>
-                            </h4>
-                            {% if eng.product|has_object_permission:"Product_Edit" or user|is_authorized_for_staff:eng %}
-                            <div class="dropdown pull-right">
-                                <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
-                                        data-toggle="dropdown" aria-expanded="true">
-                                    <span class="fa fa-bars"></span>
-                                    <span class="caret"></span>
-                                </button>
-                                <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
+                                {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
                                     <li role="presentation">
-                                        <a class="" href="{% url 'add_engagement_presets' eng.product.id %}">
-                                            <i class="fa fa-plus"></i> Add Engagement Preset
+                                        {% if eng.active %}
+                                            <a class="" href="{% url 'close_engagement' eng.id %}">
+                                            <i class="fa fa-close"></i> Close Engagement
+                                            </a>
+                                        {% else %}
+                                            <a class="" href="{% url 'reopen_engagement' eng.id %}">
+                                            <i class="fa fa-undo"></i> Reopen Engagement
+                                            </a>
+                                        {% endif %}
+                                    </li>
+                                {% endif %}
+                                <li role="presentation">
+                                    <a href="{% url 'engagement_report' eng.id %}?title=&active=1&verified=1&false_p=2&duplicate=2">
+                                    <i class="fa fa-file-text-o"></i> Report
+                                    </a>
+                                </li>
+                                <li role="presentation">
+                                    <a href="{% url 'engagement_ics' eng.id %}">
+                                    <i class="fa fa-calendar-plus-o"></i> Add To Calendar
+                                    </a>
+                                </li>
+                                <li role="presentation">
+                                    <a href="{% url 'view_object_eng' eng.id %}">
+                                    <i class="fa fa-file-text-o"></i> View Files for this Build
+                                    </a>
+                                </li>
+                                <li role="presentation">
+                                    <a href="{% url 'action_history' eng|content_type eng.id %}">
+                                    <i class="fa fa-history"></i> View History
+                                    </a>
+                                </li>
+                                {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
+                                    <li role="separator" class="divider"></li>
+                                    <li role="presentation">
+                                        {% if eng.test_strategy %}
+                                            <a target="_blank" href="{{ eng.test_strategy }}"><i class="fa fa-file-text-o"></i> View Test
+                                            Strategy </a>
+                                        {% else %}
+                                            <a href="{% url 'edit_engagement' eng.id %}"><i class="fa fa-file-text-o"></i> Add a Test Strategy</a>
+                                        {% endif %}
+                                    </li>
+                                    {% if threat != 'none' %}
+                                        <li role="presentation">
+                                            <a href="{% url 'view_threatmodel' eng.id %}"><i class="fa fa-file-text-o"></i> Download Threat Model</a>
+                                        </li>
+                                        <li role="presentation">
+                                            <a href="{% url 'upload_threatmodel' eng.id %}"><i class="fa fa-file-text-o"></i> Upload Threat Model</a>
+                                        </li>
+                                    {% else %}
+                                        <li role="presentation">
+                                            <a href="{% url 'upload_threatmodel' eng.id %}"><i class="fa fa-file-text-o"></i> Upload Threat Model</a>
+                                        </li>
+                                    {% endif %}
+                                {% endif %}
+                                {% if eng|has_object_permission:"Engagement_Delete" or user|is_authorized_for_delete:eng %}
+                                    <li role="separator" class="divider"></li>
+                                    <li role="presentation">
+                                        <a class="text-danger" href="{% url 'delete_engagement' eng.id %}">
+                                        <i class="fa fa-trash-o"></i> Delete Engagement
                                         </a>
                                     </li>
-                                    <li role="presentation">
-                                        <a class="" href="{% url 'edit_engagement_presets' eng.product.id eng.preset.id %}">
-                                            <i class="fa fa-edit"></i> Edit Engagement Preset
-                                        </a>
-                                    </li>
-                                </ul>
-                            </div>
-                            {% endif %}
+                                {% endif %}
+                            </ul>
                         </div>
                     </div>
+                </div>
+                <div class="panel-body">
+                    {% if eng.description %}
+                        {{ eng.description|markdown_render }}
+                    {% else %}
+                        <small class="text-muted"><em>There is no description.</em></small>
+                    {% endif %}
+                </div>
+            </div>
+            {% if eng.preset %}
+                <div class="row">
+                    <div id="tests" class="col-md-12">
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <div class="clearfix">
+                                    <h4 class="pull-left">
+                                        Engagement Presets <small>{{ eng.preset.title|truncatechars_html:60 }}</small>
+                                    </h4>
+                                    {% if eng.product|has_object_permission:"Product_Edit" or user|is_authorized_for_staff:eng %}
+                                        <div class="dropdown pull-right">
+                                            <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
+                                                data-toggle="dropdown" aria-expanded="true">
+                                            <span class="fa fa-bars"></span>
+                                            <span class="caret"></span>
+                                            </button>
+                                            <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
+                                                <li role="presentation">
+                                                    <a class="" href="{% url 'add_engagement_presets' eng.product.id %}">
+                                                    <i class="fa fa-plus"></i> Add Engagement Preset
+                                                    </a>
+                                                </li>
+                                                <li role="presentation">
+                                                    <a class="" href="{% url 'edit_engagement_presets' eng.product.id eng.preset.id %}">
+                                                    <i class="fa fa-edit"></i> Edit Engagement Preset
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            <div class="table-responsive">
+                                <table class="tablesorter-bootstrap table table-condensed table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>Test Type</th>
+                                            <th>Network</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>
+                                                {% if preset_test_type.count > 1 %}
+                                                    {% for test in preset_test_type %}
+                                                        {{test.name}}{%if not forloop.last%},{%endif%}
+                                                    {% endfor %}
+                                                {% else %}
+                                                    {{ preset_test_type.0.name }}
+                                                {% endif %}
+                                            </td>
+                                            <td>
+                                                {% if network.count > 1 %}
+                                                    {% for net in network %}
+                                                        {{ net.location }}{%if not forloop.last%},{%endif%}
+                                                    {% endfor %}
+                                                {% else %}
+                                                    {{ network.0.location }}
+                                                {% endif %}
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            <div class="panel-body">
+                                {% if eng.preset.notes %}
+                                    <strong>Notes: </strong>{{ eng.preset.notes|markdown_render }}
+                                {% else %}
+                                    <small class="text-muted"><em>No test notes found.</em></small>
+                                {% endif %}
+                                {% if eng.preset.scope %}
+                                    <strong>Scope: </strong>{{ eng.preset.scope|markdown_render }}
+                                {% else %}
+                                    <small class="text-muted"><em>Testing scope not specified.</em></small>
+                                {% endif %}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+            <div class="row">
+                <div id="tests" class="col-md-12">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <div class="clearfix">
+                                <h4>
+                                    Tests ({{tests.paginator.count}}) <small>{{ eng.id|get_severity_count:"engagement" }}</small>
+                                    <div class="dropdown pull-right">
+                                        <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
+                                        <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
+                                            data-toggle="dropdown" aria-expanded="true">
+                                        <span class="fa fa-bars"></span>
+                                        <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
+                                            {% if eng|has_object_permission:"Test_Add" or user|is_authorized_for_change:eng %}
+                                                <li role="presentation">
+                                                    <a class="" href="{% url 'add_tests' eng.id %}">
+                                                    <i class="fa fa-plus"></i> Add Tests
+                                                    </a>
+                                                </li>
+                                            {% endif %}
+                                            {% if eng|has_object_permission:"Import_Scan_Result" or user|is_authorized_for_change:eng %}
+                                                <li role="presentation">
+                                                    <a class="" href="{% url 'import_scan_results' eng.id %}">
+                                                    <i class="fa fa-upload"></i> Import Scan Results
+                                                    </a>
+                                                </li>
+                                                <li class="divider"></li>
+                                            {% endif %}
+                                            <li role="presentation">
+                                                <a href="{% url 'engagment_open_findings' eng.id %}?active=true">
+                                                <i class="fa fa-file-text-o"></i> View Open Findings
+                                                </a>
+                                            </li>
+                                            <li role="presentation">
+                                                <a href="{% url 'engagment_all_findings' eng.id %}">
+                                                <i class="fa fa-file-text-o"></i> View All Findings
+                                                </a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </h4>
+                            </div>
+                        </div>
+                        <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
+                            {% include "dojo/filter_snippet.html" with form=filter.form %}
+                        </div>
+                    </div>
+                    {% if tests %}
+                        <div class="clearfix">
+                            {% include "dojo/paging_snippet.html" with page=tests page_size=True %}
+                        </div>
                         <div class="table-responsive">
                             <table class="tablesorter-bootstrap table table-condensed table-striped">
                                 <thead>
-                                <tr>
-                                    <th>Test Type</th>
-                                    <th>Network</th>
-                                </tr>
+                                    <tr>
+                                        <th></th>
+                                        <th>Title / Type</th>
+                                        <th>Date</th>
+                                        <th>Lead</th>
+                                        <th>Total Findings</th>
+                                        <th>Active (Verified)</th>
+                                        <th>Mitigated</th>
+                                        <th>Duplicates</th>
+                                        <th>Notes</th>
+                                        {% if 'TRACK_IMPORT_HISTORY'|setting_enabled %}
+                                            <th>Reimports</th>
+                                        {% endif %}
+                                    </tr>
                                 </thead>
                                 <tbody>
-                                    <tr>
-                                        <td>
-                                          {% if preset_test_type.count > 1 %}
-                                            {% for test in preset_test_type %}
-                                               {{test.name}}{%if not forloop.last%},{%endif%}
-                                            {% endfor %}
-                                          {% else %}
-                                            {{ preset_test_type.0.name }}
-                                          {% endif %}
-                                        </td>
-                                        <td>
-                                          {% if network.count > 1 %}
-                                            {% for net in network %}
-                                               {{ net.location }}{%if not forloop.last%},{%endif%}
-                                            {% endfor %}
-                                          {% else %}
-                                            {{ network.0.location }}
-                                          {% endif %}
-                                        </td>
-                                    </tr>
-
+                                    {% for test in tests %}
+                                        <tr>
+                                            <td>
+                                                <ul>
+                                                    <li class="dropdown" style="list-style:none;position:absolute">
+                                                        <a href="#" id='test-menu' class="dropdown-toggle" data-toggle="dropdown" aria-expanded="true">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
+                                                        <ul class="dropdown-menu">
+                                                            <li>
+                                                                <a class="" href="{% url 'view_test' test.id %}">
+                                                                <i class="fa fa-list-alt"></i> View</a>
+                                                            </li>
+                                                            {% if test|has_object_permission:"Test_Edit" or user|is_authorized_for_change:test %}
+                                                                <li>
+                                                                    <a class="" href="{% url 'edit_test' test.id %}">
+                                                                    <i class="fa fa-pencil-square-o"></i> Edit</a>
+                                                                </li>
+                                                            {% endif %}
+                                                            {% if test|has_object_permission:"Finding_Add" or user|is_authorized_for_change:test %}
+                                                                <li class="divider"></li>
+                                                                <li>
+                                                                    <a class="" href="{% url 'add_findings' test.id %}">
+                                                                    <i class="fa fa-plus"></i> Add Finding to Test
+                                                                    </a>
+                                                                </li>
+                                                            {% endif %}
+                                                            {% if test|has_object_permission:"Import_Scan_Result" or user|is_authorized_for_change:test %}
+                                                                <li class="divider"></li>
+                                                                <li><a class="" href="{% url 're_import_scan_results' test.id %}">
+                                                                    <i class="fa fa-upload"></i> Re-Upload Scan Results
+                                                                    </a>
+                                                                </li>
+                                                            {% endif %}
+                                                            <li class="divider"></li>
+                                                            <li role="presentation">
+                                                                <a href="{% url 'test_report' test.id %}?title=&active=1&verified=1&false_p=2&duplicate=2">
+                                                                <i class="fa fa-file-text-o"></i> Test Report
+                                                                </a>
+                                                            </li>
+                                                            {% if test|has_object_permission:"Test_Delete" or user|is_authorized_for_delete:test %}
+                                                                <li class="divider"></li>
+                                                                <li>
+                                                                    <a class="text-danger" href="{% url 'delete_test' test.id %}">
+                                                                    <i class="fa fa-trash-o"></i> Delete</a>
+                                                                </li>
+                                                            {% endif %}
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </td>
+                                            <td><a title="{{ test.description }}" href="{% url 'view_test' test.id %}">{{ test }}</a>
+                                                {% if test.version %}
+                                                    <sup>
+                                                    <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ test.version }}">
+                                                    {{ test.version }}</a>
+                                                    </sup>
+                                                {% endif %}
+                                                {% if test.tags %}
+                                                    <sup>
+                                                    {% for tag in test.tags.all %}
+                                                        <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query=test-tag:{{ tag }}">{{ tag }}</a>
+                                                    {% endfor %}
+                                                    </sup>
+                                                {% endif %}
+                                            </td>
+                                            <td>{{ test.target_start|date }} - {{ test.target_end|date }}</td>
+                                            <td>
+                                                {% if test.lead.get_full_name and test.lead.get_full_name.strip %}
+                                                    {{ test.lead.get_full_name }}
+                                                {% elif test.lead %}
+                                                    {{ test.lead }}
+                                                {% endif %}
+                                            </td>
+                                            <td><a href="{% url 'view_test' test.id %}">{{ test.count_findings_test_all }}</a></td>
+                                            <td>
+                                                <a href="{% url 'view_test' test.id %}?active=true">{{ test.count_findings_test_active }}</a>&nbsp;
+                                                (<a href="{% url 'view_test' test.id %}?active=true&verified=true">{{ test.count_findings_test_active_verified }}</a>)
+                                            </td>
+                                            <td><a href="{% url 'view_test' test.id %}?is_mitigated=true">{{ test.count_findings_test_mitigated }}</a></td>
+                                            <td><a href="{% url 'view_test' test.id %}?duplicate=true">{{ test.count_findings_test_dups }}</a></td>
+                                            <td class="nowrap">
+                                                {% if test.notes.count %}
+                                                    <a href="{% url 'view_test' test.id %}#vuln_notes" alt="{{ test.notes.count }} comment{{ test.notes.count|pluralize }}">
+                                                    <span class="glyphicon glyphicon-comment"></span> {{ test.notes.count }}
+                                                    </a>
+                                                {% endif %}
+                                            </td>
+                                            {% if 'TRACK_IMPORT_HISTORY'|setting_enabled %}
+                                                <td>
+                                                    {{ test.total_reimport_count }}
+                                                </td>
+                                            {% endif %}
+                                        </tr>
+                                    {% endfor %}
                                 </tbody>
                             </table>
                         </div>
-                        <div class="panel-body">
-                          {% if eng.preset.notes %}
-                            <strong>Notes: </strong>{{ eng.preset.notes|markdown_render }}
-                          {% else %}
-                            <small class="text-muted"><em>No test notes found.</em></small>
-                          {% endif %}
-                          {% if eng.preset.scope %}
-                            <strong>Scope: </strong>{{ eng.preset.scope|markdown_render }}
-                          {% else %}
-                            <small class="text-muted"><em>Testing scope not specified.</em></small>
-                          {% endif %}
+                        <div class="clearfix">
+                            {% include "dojo/paging_snippet.html" with page=tests page_size=True %}
                         </div>
+                    {% else %}
+                        <div class="panel-body">
+                            <small class="text-muted"><em>No tests found.</em></small>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
-</div>
-{% endif %}
-<div class="row">
-    <div id="tests" class="col-md-12">
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <div class="clearfix">
-                    <h4>
-                        Tests ({{tests.paginator.count}}) <small>{{ eng.id|get_severity_count:"engagement" }}</small>
-                        <div class="dropdown pull-right">
-                            <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
-                            <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
-                                data-toggle="dropdown" aria-expanded="true">
-                                <span class="fa fa-bars"></span>
-                                <span class="caret"></span>
-                            </button>
-                            <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
-                                {% if eng|has_object_permission:"Test_Add" or user|is_authorized_for_change:eng %}
-                                <li role="presentation">
-                                    <a class="" href="{% url 'add_tests' eng.id %}">
-                                        <i class="fa fa-plus"></i> Add Tests
-                                    </a>
-                                </li>
+            <div class="row">
+                <div id="risk" class="col-md-12">
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h4> Risk Acceptance
+                                {% if eng.product.enable_full_risk_acceptance %}
+                                    {% if eng|has_object_permission:"Risk_Acceptance" or user|is_authorized_for_staff:eng %}
+                                        <a title="Add Risk Acceptance..." class="pull-right btn btn-sm btn-primary"
+                                            href="{% url 'add_risk_acceptance' eng.id %}?return_url={{ request.get_full_path|urlencode }}"><span class="fa fa-plus"></span></a>
+                                        </a>
+                                    {% endif %}
                                 {% endif %}
-                                {% if eng|has_object_permission:"Import_Scan_Result" or user|is_authorized_for_change:eng %}
-                                <li role="presentation">
-                                    <a class="" href="{% url 'import_scan_results' eng.id %}">
-                                        <i class="fa fa-upload"></i> Import Scan Results
-                                    </a>
-                                </li>
-                                <li class="divider"></li>
-                                {% endif %}
-                                <li role="presentation">
-                                    <a href="{% url 'engagment_open_findings' eng.id %}?active=true">
-                                        <i class="fa fa-file-text-o"></i> View Open Findings
-                                    </a>
-                                </li>
-                                <li role="presentation">
-                                    <a href="{% url 'engagment_all_findings' eng.id %}">
-                                        <i class="fa fa-file-text-o"></i> View All Findings
-                                    </a>
-                                </li>
-                            </ul>
+                            </h4>
                         </div>
+                        {% if risks_accepted %}
+                            <div class="table-responsive">
+                                <table id="risk_acceptances"
+                                    class="tablesorter-bootstrap table table-condensed table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th></th>
+                                            <th>Date</th>
+                                            <th>Accepted By</th>
+                                            <th>Name</th>
+                                            <th>Decision</th>
+                                            <!-- <th>Decision Details</th> -->
+                                            <th>Expiration</th>
+                                            <th>Findings</th>
+                                            <th>Proof</th>
+                                            <th>Owner</th>
+                                    </thead>
+                                    <tbody>
+                                        {% for risk_acceptance in risks_accepted %}
+                                            <tr>
+                                                <td class="centered">
+                                                    <ul>
+                                                        <li class="dropdown" style="list-style:none;position:absolute">
+                                                            <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="true">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
+                                                            <ul class="dropdown-menu">
+                                                                {% with engagement=eng %}
+                                                                    {% include 'dojo/snippets/risk_acceptance_actions_snippet.html' with include_view=True %}
+                                                                {% endwith %}
+                                                            </ul>
+                                                        </li>
+                                                    </ul>
+                                                </td>
+                                                <td><a href="{% url 'view_risk_acceptance' eng.id risk_acceptance.id %}">{{ risk_acceptance.created|date }}</a></td>
+                                                <td>{{ risk_acceptance.accepted_by.get_full_name }}</td>
+                                                <td><a href="{% url 'view_risk_acceptance' eng.id risk_acceptance.id %}">{{ risk_acceptance.name }}</a></td>
+                                                <td>
+                                                    {{ risk_acceptance.get_decision_display|default_if_none:"" }}
+                                                    {% if risk_acceptance.decision_details %}
+                                                        &nbsp;<i style="position:absolute;" class="fa has-popover fa-info-circle" title="Decision Details" data-trigger="hover" data-placement="bottom" data-container="body" data-html="true"
+                                                            data-content="{{ risk_acceptance.decision_details }}"></i>
+                                                    {% endif %}
+                                                </td>
+                                                <!-- <td>{{ risk_acceptance.decision_details|default_if_none:""| truncatechars_html:100 }}</td> -->
+                                                <td class="{% if risk_acceptance.is_expired %}red{% endif%}">
+                                                    {% if risk_acceptance.expiration_date %}
+                                                        {{ risk_acceptance.expiration_date|date }}
+                                                    {% else %}
+                                                        Never
+                                                    {% endif %}
+                                                </td>
+                                                <td>{{ risk_acceptance.accepted_findings_count }}</td>
+                                                {% if risk_acceptance.filename %}
+                                                    <td><a href="{% url 'download_risk_acceptance' eng.id risk_acceptance.id %}">Yes</a>
+                                                        &nbsp;<i style="position:absolute;" class="fa has-popover fa-info-circle" title="Uploaded proof" data-trigger="hover" data-placement="bottom" data-container="body" data-html="true"
+                                                            data-content="{{ risk_acceptance.filename }}"></i>
+                                                    </td>
+                                                {% else %}
+                                                    <td>No</a></td>
+                                                {% endif %}
+                                                <td>{{ risk_acceptance.owner.get_full_name }}</td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <div class="panel-body">
+                                <small class="text-muted"><em>No Risk Acceptances found.</em></small>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h4>Additional Features<span class="pull-right"><a name="collapsible" data-toggle="collapse" href="#add_feat">
+                        <i class="glyphicon glyphicon-chevron-down"></i></a></span>
                     </h4>
                 </div>
+                <div id="add_feat" class="panel-body collapse">
+                    {% if eng.engagement_type == "Interactive" and system_settings.enable_checklists %}
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <h4> Checklist<span class="pull-right"><a name="collapsible" data-toggle="collapse" href="#add_feat_check_list">
+                                    <i class="glyphicon glyphicon-chevron-down"></i></a></span>
+                                    {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_delete:eng %}
+                                        {% if check %}
+                                            <a title="Edit Checklist" class="btn btn-primary pull-right"
+                                                href="{% url 'complete_checklist' eng.id %}">
+                                            <span class="fa fa-edit"></span></a>
+                                        {% else %}
+                                            <a title="Complete Checklist" class="btn btn-sm btn-primary pull-right"
+                                                href="{% url 'complete_checklist' eng.id %}">
+                                            <span class="fa fa-edit"></span></a></a>
+                                        {% endif %}
+                                    {% endif %}
+                                </h4>
+                            </div>
+                            <div id="add_feat_check_list" class="panel-body collapse">
+                                {% if check %}
+                                    <div class="panel panel-default">
+                                        <div class="table-responsive">
+                                            <table class="tablesorter-bootstrap table table-condensed table-striped">
+                                                <thead>
+                                                    <tr>
+                                                        <th>Session</th>
+                                                        <th>Encryption</th>
+                                                        <th>Configuration</th>
+                                                        <th>Authentication</th>
+                                                        <th>Authorization</th>
+                                                        <th>Data Input</th>
+                                                        <th>Sensitive Data</th>
+                                                        <th>Other</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    <tr>
+                                                        <td><span
+                                                            class="label label-{{ check.session_management|checklist_status }}">{{ check.session_management }}</span></td>
+                                                        <td><span
+                                                            class="label label-{{ check.encryption_crypto|checklist_status }}">{{ check.encryption_crypto }}</span></td>
+                                                        <td><span
+                                                            class="label label-{{ check.configuration_management|checklist_status }}">{{ check.configuration_management }}</span></td>
+                                                        <td><span
+                                                            class="label label-{{ check.authentication|checklist_status }}">{{ check.authentication }}</span></td>
+                                                        <td><span
+                                                            class="label label-{{ check.authorization_and_access_control|checklist_status }}">{{ check.authorization_and_access_control }}</span></td>
+                                                        <td><span
+                                                            class="label label-{{ check.data_input_sanitization_validation|checklist_status }}">{{ check.data_input_sanitization_validation }}</span></td>
+                                                        <td><span
+                                                            class="label label-{{ check.sensitive_data|checklist_status }}">{{ check.sensitive_data }}</span></td>
+                                                        <td><span
+                                                            class="label label-{{ check.other|checklist_status }}">{{ check.other }}</span></td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                {% else %}
+                                    <div class="panel panel-default">
+                                        <div class="panel-body">
+                                            <small class="text-muted"><em>Checklist has not been completed.</em></small>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% endif %}
+                    {% if system_settings.enable_questionnaires %}
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <h4>Questionnaires<span class="pull-right">
+                                    <a name="collapsible" data-toggle="collapse" href="#add_feat_survey">
+                                    <i class="glyphicon glyphicon-chevron-down"></i></a></span>
+                                    {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
+                                    {% add_surveys eng %}
+                                    {% endif %}
+                                </h4>
+                            </div>
+                            <div id="add_feat_survey" class="panel-body collapse">
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <div class="panel panel-default">
+                                            {% show_surveys eng users %}
+                                        </div>
+                                    </div>
+                                    <div class="modal fade" id="shareQuestionnaireModal" tabindex="-1" role="dialog" aria-labelledby="shareSurveyModalLabel">
+                                        <div class="modal-dialog" role="document">
+                                            <div class="modal-content">
+                                                <div class="modal-header">
+                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                                        aria-hidden="true">&times;</span></button>
+                                                    <h4 class="modal-title" id="shareSurveyModalLabel">Share Questionnaire Link</h4>
+                                                </div>
+                                                <div class="modal-body">
+                                                    <p id="questionnaireURL"></p>
+                                                    <div class="alert alert-info" role="alert">
+                                                        <b>Note:</b> Only users that are authorized for {{ eng.product}} will be allowed to answer
+                                                        this questionnaire.
+                                                    </div>
+                                                </div>
+                                                <div class="modal-footer">
+                                                    <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endif %}
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h4>Notes<span class="pull-right">
+                                <a name="collapsible" data-toggle="collapse" href="#add_feat_notes">
+                                <i class="glyphicon glyphicon-chevron-down"></i></a></span>
+                            </h4>
+                        </div>
+                        <div id="add_feat_notes" class="panel-body collapse">
+                            {% if eng|has_object_permission:"Note_Add" or user|is_authorized_for_staff:eng %}
+                                <form class="form-horizontal" action="" method="post">
+                                    {% csrf_token %}
+                                    {% include "dojo/form_fields.html" with form=form %}
+                                    <div class="form-group">
+                                        <div class="col-sm-offset-2 col-sm-10">
+                                            <input class="btn btn-primary" type="submit" id="add_note" label="Add Notes" value="Add Note"/>
+                                        </div>
+                                    </div>
+                                </form>
+                            {% endif %}
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <h4>Note Log<span class="pull-right">
+                                        <a data-toggle="collapse" href="#add_feat_note_log">
+                                        <i class="glyphicon glyphicon-chevron-{% if notes %}up{%else%}down{%endif%}"></i></a></span>
+                                    </h4>
+                                </div>
+                                <div id="add_feat_note_log" class="panel-body collapse {% if notes %}in{%endif%}">
+                                    {% for note in notes %}
+                                        <div>
+                                            <div class="panel panel-default">
+                                                <div class="panel-comments">
+                                                    {% if user.username == note.author.username or eng|has_object_permission:"Note_Delete" or user.is_superuser %}
+                                                        <div class="pull-right">
+                                                            <form method="post" action="{% url 'delete_note' note.id 'engagement' eng.id %}">
+                                                                {% csrf_token %}
+                                                                <input type="hidden" aria-label="id" name="id" value="{{note.id}}" id="id_id" />
+                                                                <button type="submit" aria-label="Delete Note" class="btn-delete">
+                                                                <i class="fa fa-trash"></i>
+                                                                </button>
+                                                            </form>
+                                                        </div>
+                                                    {% endif %}
+                                                    {% if user.username == note.author.username or eng|has_object_permission:"Note_Edit" or user|is_authorized_for_staff:eng %}
+                                                        <div class="pull-right">
+                                                            <form method="get" action="{% url 'edit_note' note.id 'engagement' eng.id %}">
+                                                                {% csrf_token %}
+                                                                <input type="hidden" aria-label="id" name="id" value="{{note.id}}" id="id_id" />
+                                                                <button type="submit" aria-label="Edit Note" class="btn-edit">
+                                                                <i class="fa fa-edit"></i>
+                                                                </button>
+                                                            </form>
+                                                        </div>
+                                                    {% endif %}
+                                                    {% if user.username == note.author.username or eng|has_object_permission:"Note_View_History" or user|is_authorized_for_staff:eng %}
+                                                        <div class="pull-right">
+                                                            <form method="get" action="{% url 'note_history' note.id 'engagement' eng.id %}">
+                                                                {% csrf_token %}
+                                                                <input type="hidden" aria-label="id" name="id" value="{{note.id}}" id="id_id" />
+                                                                <button type="submit" aria-label="history" class="btn-history">
+                                                                <i class="fa fa-history"></i>
+                                                                </button>
+                                                            </form>
+                                                        </div>
+                                                    {% endif %}
+                                                    <div class="row-sm-2">
+                                                        <strong>{{ note.author.username }}</strong>
+                                                        <span class="text-muted">commented {{ note.date }}</span>
+                                                    </div>
+                                                    {% if note.edited %}
+                                                        <div class="row-sm-2">
+                                                            <strong>{{ note.editor.username }}</strong>
+                                                            <span class="text-muted">edited {{ note.edit_time }}</span>
+                                                        </div>
+                                                    {% endif %}
+                                                    {% if note.private %}
+                                                        <div class="row-sm-2">
+                                                            <span class="text-muted">(will not appear in report)</span>
+                                                        </div>
+                                                    {% endif %}
+                                                </div>
+                                                <div class="panel-body">
+                                                    {% if note.note_type != None %}
+                                                        <strong>Note type : {{ note.note_type }}</strong>
+                                                        <br><br>
+                                                    {% endif %}
+                                                    {{ note|linebreaks }}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-default">
+                        <div class="panel-heading">
+                            <h4>Files<span class="pull-right">
+                                <a data-toggle="collapse" href="#add_feat_files">
+                                <i class="glyphicon glyphicon-chevron-down"></i></a></span>
+                                {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
+                                    <a title="Manage Files" name="Manage Files" class="btn btn-sm btn-primary pull-right"
+                                        href="{% url 'manage_files' oid=eng.id obj_type='Engagement' %}">
+                                    <span class="fa fa-edit"></span></a>
+                                {% endif %}
+                            </h4>
+                        </div>
+                        <div id="add_feat_files" class="panel-body collapse {% if files %}in{% endif %}">
+                            {% for file in files %}
+                                <div class="col-md-2" style="text-align: center">
+                                    <div class="row">
+                                        <a href="{{ request.scheme }}://{{ request.get_host }}{{ file.file.url }}" target="_blank">
+                                        {% if file.file.url|get_thumbnail %}
+                                            <img src="{{ file.file.url }}" alt="thumbnail" style="width:150px">
+                                        {% else %}
+                                            <span style="font-size: 50px;" class="glyphicon glyphicon-file"></span>
+                                        {% endif %}
+                                        </a>
+                                    </div>
+                                    <div class="row">
+                                        <caption style="text-align:center">{{ file.title }}</caption>
+                                    </div>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
             </div>
-            <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
-                {% include "dojo/filter_snippet.html" with form=filter.form %}
-            </div>
+            <!-- Sidebar -->
         </div>
-        {% if tests %}
-                <div class="clearfix">
-                    {% include "dojo/paging_snippet.html" with page=tests page_size=True %}
+        <div class="col-md-4">
+            <div class="panel panel-default-secondary">
+                <div class="panel-heading">
+                    <h3 class="panel-title"><span class="fa fa-info-circle fa-fw" aria-hidden="true"></span> 
+                        {% if eng.name %}
+                            {{ eng.name }}
+                        {% else %}
+                            Engagement for <a href="{% url 'view_product' eng.product.id %}">{{ eng.product }}</a>
+                        {% endif %}
+                        {% if eng.version %}
+                            <sup>
+                            <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ eng.version }}">
+                            {{ eng.version }}</a>
+                            </sup>
+                        {% endif %}
+                        {% if eng.tags %}
+                            <sup>
+                            {% for tag in eng.tags.all %}
+                                <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query=engagement-tag:{{ tag }}">{{ tag }}</a>
+                            {% endfor %}
+                            </sup>
+                        {% endif %}
+                    </h3>
                 </div>
                 <div class="table-responsive">
-                    <table class="tablesorter-bootstrap table table-condensed table-striped">
-                        <thead>
-                        <tr>
-                            <th></th>
-                            <th>Title / Type</th>
-                            <th>Date</th>
-                            <th>Lead</th>
-                            <th>Total Findings</th>
-                            <th>Active (Verified)</th>
-                            <th>Mitigated</th>
-                            <th>Duplicates</th>
-                            <th>Notes</th>
-                            {% if 'TRACK_IMPORT_HISTORY'|setting_enabled %}
-                                <th>Reimports</th>
-                            {% endif %}
-                        </tr>
-                        </thead>
+                    <table class="table table-striped">
                         <tbody>
-                        {% for test in tests %}
                             <tr>
+                                <td style="width: 150px;"><strong>Status</strong></td>
                                 <td>
-                                    <ul>
-                                     <li class="dropdown" style="list-style:none;position:absolute">
-                                           <a href="#" id='test-menu' class="dropdown-toggle" data-toggle="dropdown" aria-expanded="true">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
-                                           <ul class="dropdown-menu">
-                                              <li>
-                                               <a class="" href="{% url 'view_test' test.id %}">
-                                                 <i class="fa fa-list-alt"></i> View</a>
-                                            </li>
-                                            {% if test|has_object_permission:"Test_Edit" or user|is_authorized_for_change:test %}
-                                            <li>
-                                               <a class="" href="{% url 'edit_test' test.id %}">
-                                                <i class="fa fa-pencil-square-o"></i> Edit</a>
-                                            </li>
-                                            {% endif %}
-                                            {% if test|has_object_permission:"Finding_Add" or user|is_authorized_for_change:test %}
-                                            <li class="divider"></li>
-                                            <li>
-                                              <a class="" href="{% url 'add_findings' test.id %}">
-                                                <i class="fa fa-plus"></i> Add Finding to Test
-                                              </a>
-                                            </li>
-                                            {% endif %}
-                                            {% if test|has_object_permission:"Import_Scan_Result" or user|is_authorized_for_change:test %}
-                                             <li class="divider"></li>
-                                             <li><a class="" href="{% url 're_import_scan_results' test.id %}">
-                                                 <i class="fa fa-upload"></i> Re-Upload Scan Results
-                                             </a></li>
-                                             {% endif %}
-                                             <li class="divider"></li>
-                                             <li role="presentation">
-                                                 <a href="{% url 'test_report' test.id %}?title=&active=1&verified=1&false_p=2&duplicate=2">
-                                                     <i class="fa fa-file-text-o"></i> Test Report
-                                                 </a>
-                                             </li>
-                                             {% if test|has_object_permission:"Test_Delete" or user|is_authorized_for_delete:test %}
-                                             <li class="divider"></li>
-                                             <li>
-                                               <a class="text-danger" href="{% url 'delete_test' test.id %}">
-                                                <i class="fa fa-trash-o"></i> Delete</a>
-                                            </li>
-                                            {% endif %}
-                                           </ul>
-                                         </li>
-                                     </ul>
-                                  </td>
-                                <td><a title="{{ test.description }}" href="{% url 'view_test' test.id %}">{{ test }}</a>
-                                    {% if test.version %}
+                                    {% if eng.status == "Blocked" %}
+                                        <em class="text-danger">
+                                    {% elif eng.status == "On Hold" %}
+                                        <em class="text-warning">
+                                    {% else %}
+                                        <em>
+                                    {% endif %}
+                                    {{ eng.status }}
+                                    </em>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><strong>Dates</strong></td>
+                                <td><a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ eng.target_start|date:"l, jS F Y" }} - {{ eng.target_end|date:"l, jS F Y" }}">
+                                    {{ eng.target_start|date:"jS F" }} - {{ eng.target_end|date:"jS F" }}
+                                    </a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><strong>Length</strong></td>
+                                <td>
+                                    {{ eng.target_start|datediff_time:eng.target_end }}
+                                    {% if eng.is_overdue and eng.status != 'Completed'%}
                                         <sup>
-                                            <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ test.version }}">
-                                            {{ test.version }}</a>
+                                            <div class="tag-label warning-color">
+                                                {{ eng.target_end|overdue }} overdue
+                                            </div>
                                         </sup>
                                     {% endif %}
-                                    {% if test.tags %}
-                                      <sup>
-                                          {% for tag in test.tags.all %}
-                                          <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query=test-tag:{{ tag }}">{{ tag }}</a>
-                                          {% endfor %}
-                                      </sup>
-                                  {% endif %}
                                 </td>
-                                <td>{{ test.target_start|date }} - {{ test.target_end|date }}</td>
-                                <td>
-                                  {% if test.lead.get_full_name and test.lead.get_full_name.strip %}
-                                      {{ test.lead.get_full_name }}
-                                  {% elif test.lead %}
-                                      {{ test.lead }}
-                                  {% endif %}
-                                </td>
-                                <td><a href="{% url 'view_test' test.id %}">{{ test.count_findings_test_all }}</a></td>
-                                <td>
-                                  <a href="{% url 'view_test' test.id %}?active=true">{{ test.count_findings_test_active }}</a>&nbsp;
-                                  (<a href="{% url 'view_test' test.id %}?active=true&verified=true">{{ test.count_findings_test_active_verified }}</a>)
-                                </td>
-                                <td><a href="{% url 'view_test' test.id %}?is_mitigated=true">{{ test.count_findings_test_mitigated }}</a></td>
-                                <td><a href="{% url 'view_test' test.id %}?duplicate=true">{{ test.count_findings_test_dups }}</a></td>
-                                <td class="nowrap">
-                                  {% if test.notes.count %}
-                                    <a href="{% url 'view_test' test.id %}#vuln_notes" alt="{{ test.notes.count }} comment{{ test.notes.count|pluralize }}">
-                                      <span class="glyphicon glyphicon-comment"></span> {{ test.notes.count }}
-                                    </a>
-                                  {% endif %}
-                                </td>
-                                {% if 'TRACK_IMPORT_HISTORY'|setting_enabled %}
-                                    <td>
-                                        {{ test.total_reimport_count }}
-                                    </td>
-                                {% endif %}
                             </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-                <div class="clearfix">
-                    {% include "dojo/paging_snippet.html" with page=tests page_size=True %}
-                </div>
-        {% else %}
-                <div class="panel-body">
-                    <small class="text-muted"><em>No tests found.</em></small>
-                </div>
-        {% endif %}
-    </div>
-
-</div>
-
-<div class="row">
-    <div id="risk" class="col-md-12">
-        <div class="panel panel-default">
-            <div class="panel-heading">
-                <h4> Risk Acceptance
-                    {% if eng.product.enable_full_risk_acceptance %}
-                    {% if eng|has_object_permission:"Risk_Acceptance" or user|is_authorized_for_staff:eng %}
-                        <a title="Add Risk Acceptance..." class="pull-right btn btn-sm btn-primary"
-                           href="{% url 'add_risk_acceptance' eng.id %}?return_url={{ request.get_full_path|urlencode }}"><span class="fa fa-plus"></span></a>
-                        </a>
-                    {% endif %}
-                    {% endif %}
-                </h4>
-            </div>
-            {% if risks_accepted %}
-                <div class="table-responsive">
-                    <table id="risk_acceptances"
-                           class="tablesorter-bootstrap table table-condensed table-striped">
-                        <thead>
-                        <tr>
-                            <th></th>
-                            <th>Date</th>
-                            <th>Accepted By</th>
-                            <th>Name</th>
-                            <th>Decision</th>
-                            <!-- <th>Decision Details</th> -->
-                            <th>Expiration</th>
-                            <th>Findings</th>
-                            <th>Proof</th>
-                            <th>Owner</th>
-                        </thead>
-                        <tbody>
-                        {% for risk_acceptance in risks_accepted %}
                             <tr>
-                                <td class="centered">
-                                    <ul>
-                                        <li class="dropdown" style="list-style:none;position:absolute">
-                                              <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="true">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
-                                              <ul class="dropdown-menu">
-                                                {% with engagement=eng %}
-                                                    {% include 'dojo/snippets/risk_acceptance_actions_snippet.html' with include_view=True %}
-                                                {% endwith %}
-                                            </ul>
-                                        </li>
-                                    </ul>
-                                </td>
-                                <td><a href="{% url 'view_risk_acceptance' eng.id risk_acceptance.id %}">{{ risk_acceptance.created|date }}</a></td>
-                                <td>{{ risk_acceptance.accepted_by.get_full_name }}</td>
-                                <td><a href="{% url 'view_risk_acceptance' eng.id risk_acceptance.id %}">{{ risk_acceptance.name }}</a></td>
                                 <td>
-                                    {{ risk_acceptance.get_decision_display|default_if_none:"" }}
-
-                                    {% if risk_acceptance.decision_details %}
-                                    &nbsp;<i style="position:absolute;" class="fa has-popover fa-info-circle" title="Decision Details" data-trigger="hover" data-placement="bottom" data-container="body" data-html="true"
-                                    data-content="{{ risk_acceptance.decision_details }}"></i>
-                                    {% endif %}
-
+                                    <strong>
+                                        {% if eng.engagement_type == "Interactive" %}
+                                            Lead
+                                        {% else %}
+                                            Service Account
+                                        {% endif %}
+                                    </strong>
                                 </td>
-                                <!-- <td>{{ risk_acceptance.decision_details|default_if_none:""| truncatechars_html:100 }}</td> -->
-                                <td class="{% if risk_acceptance.is_expired %}red{% endif%}">
-                                    {% if risk_acceptance.expiration_date %}
-                                        {{ risk_acceptance.expiration_date|date }}
+                                <td>
+                                    {% if eng.lead.get_full_name and eng.lead.get_full_name.strip %}
+                                        {{ eng.lead.get_full_name }}
+                                    {% elif eng.lead %}
+                                        {{ eng.lead }}
                                     {% else %}
-                                        Never
+                                        None Assigned
                                     {% endif %}
                                 </td>
-                                <td>{{ risk_acceptance.accepted_findings_count }}</td>
-                                {% if risk_acceptance.filename %}
-                                <td><a href="{% url 'download_risk_acceptance' eng.id risk_acceptance.id %}">Yes</a>
-                                    &nbsp;<i style="position:absolute;" class="fa has-popover fa-info-circle" title="Uploaded proof" data-trigger="hover" data-placement="bottom" data-container="body" data-html="true"
-                                    data-content="{{ risk_acceptance.filename }}"></i>
-                                </td>
-                                {% else %}
-                                    <td>No</a></td>
-                                {% endif %}
-                                <td>{{ risk_acceptance.owner.get_full_name }}</td>
                             </tr>
-                        {% endfor %}
+                            <tr>
+                                <td><strong>Tracker</strong></td>
+                                <td>
+                                    {% if eng.tracker %}
+                                        <a target="_blank" data-toggle="tooltip" data-placement="top" title="{{ eng.tracker }}" href="{{ eng.tracker }}" alt="Development epic or ticket for development requirements.">
+                                        <i class="fa fa-external-link"></i> {{ eng.tracker|last_value }}</a>
+                                    {% else %}
+                                        {{ eng.tracker|notspecified}}
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><strong>Repo</strong></td>
+                                <td>
+                                    {% if eng.source_code_management_uri %}
+                                        <a target="_blank" data-toggle="tooltip" data-placement="top" title="{{ eng.source_code_management_uri }}" href="{{ eng.source_code_management_uri }}">
+                                        <i class="fa fa-external-link"></i> {{ eng.source_code_management_uri|last_value }}
+                                        </a>
+                                    {% else %}
+                                        {{ eng.source_code_management_uri|notspecified}}
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><strong>Test Strategy</strong></td>
+                                <td>
+                                    {% if eng.test_strategy %}
+                                        <a target="_blank" data-toggle="tooltip" data-placement="top" title="{{ eng.test_strategy }}" href="{{ eng.test_strategy }}">
+                                        <i class="fa fa-external-link"></i> {{ eng.test_strategy|last_value }}
+                                        </a>
+                                    {% else %}
+                                        {{ eng.test_strategy|notspecified}}
+                                    {% endif %}
+                                </td>
+                            </tr>
+                            {% if jissue and jira_project %}
+                                <tr>
+                                    <td><strong>Jira</strong></td>
+                                    <td><a href="{{ eng | jira_issue_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
+                                        <small>(epic)</small>
+                                        </a>
+                                    </td>
+                                </tr>
+                            {% elif jira_project %}
+                                <tr>
+                                    <td><strong>JIRA</strong></td>
+                                    <td>
+                                        <a href="{{ eng | jira_project_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
+                                            {% if jira_project.engagement is not eng %}
+                                                <small>(inherited)</small>
+                                            {% else %}
+                                                <small>(project)</small>
+                                            {% endif %}
+                                        </a>
+                                    </td>
+                                </tr>
+                            {% endif %}
+                            <tr>
+                                <td><strong>Updated</strong></td>
+                                <td><a target="_blank" data-toggle="tooltip" data-placement="bottom" title="{{ eng.updated|default_if_none:"" }}">
+                                    {{ eng.updated|naturaltime|default_if_none:"" }}</a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><strong>Created</strong></td>
+                                <td><a target="_blank" data-toggle="tooltip" data-placement="bottom" title="{{ eng.created|default_if_none:"" }}">
+                                    {{ eng.created|naturaltime|default_if_none:"" }}</a>
+                                </td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>
-            {% else %}
-                <div class="panel-body">
-                    <small class="text-muted"><em>No Risk Acceptances found.</em></small>
-                </div>
-            {% endif %}
-
-        </div>
-
-    </div>
-
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h4>Additional Features<span class="pull-right"><a name="collapsible" data-toggle="collapse" href="#add_feat">
-      <i class="glyphicon glyphicon-chevron-down"></i></a></span></h4>
-  </div>
-
-  <div id="add_feat" class="panel-body collapse">
-
-    {% if eng.engagement_type == "Interactive" and system_settings.enable_checklists %}
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h4> Checklist<span class="pull-right"><a name="collapsible" data-toggle="collapse" href="#add_feat_check_list">
-            <i class="glyphicon glyphicon-chevron-down"></i></a></span>
-            {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_delete:eng %}
-              {% if check %}
-                  <a title="Edit Checklist" class="btn btn-primary pull-right"
-                    href="{% url 'complete_checklist' eng.id %}">
-                      <span class="fa fa-edit"></span></a>
-              {% else %}
-                  <a title="Complete Checklist" class="btn btn-sm btn-primary pull-right"
-                    href="{% url 'complete_checklist' eng.id %}">
-                      <span class="fa fa-edit"></span></a></a>
-              {% endif %}
-            {% endif %}
-
-          </h4>
-        </div>
-        <div id="add_feat_check_list" class="panel-body collapse">
-          {% if check %}
-            <div class="panel panel-default">
-              <div class="table-responsive">
-                <table class="tablesorter-bootstrap table table-condensed table-striped">
-                  <thead>
-                    <tr>
-                      <th>Session</th>
-                      <th>Encryption</th>
-                      <th>Configuration</th>
-                      <th>Authentication</th>
-                      <th>Authorization</th>
-                      <th>Data Input</th>
-                      <th>Sensitive Data</th>
-                      <th>Other</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><span
-                        class="label label-{{ check.session_management|checklist_status }}">{{ check.session_management }}</span>
-                      </td>
-                      <td><span
-                        class="label label-{{ check.encryption_crypto|checklist_status }}">{{ check.encryption_crypto }}</span>
-                      </td>
-                      <td><span
-                        class="label label-{{ check.configuration_management|checklist_status }}">{{ check.configuration_management }}</span>
-                      </td>
-                      <td><span
-                        class="label label-{{ check.authentication|checklist_status }}">{{ check.authentication }}</span>
-                      </td>
-                      <td><span
-                        class="label label-{{ check.authorization_and_access_control|checklist_status }}">{{ check.authorization_and_access_control }}</span>
-                      </td>
-                      <td><span
-                        class="label label-{{ check.data_input_sanitization_validation|checklist_status }}">{{ check.data_input_sanitization_validation }}</span>
-                      </td>
-                      <td><span
-                        class="label label-{{ check.sensitive_data|checklist_status }}">{{ check.sensitive_data }}</span>
-                      </td>
-                      <td><span
-                        class="label label-{{ check.other|checklist_status }}">{{ check.other }}</span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
             </div>
-          {% else %}
-            <div class="panel panel-default">
-              <div class="panel-body">
-                <small class="text-muted"><em>Checklist has not been completed.</em></small>
-              </div>
-            </div>
-          {% endif %}
-        </div>
-      </div>
-    {% endif %}
-
-    {% if system_settings.enable_questionnaires %}
-    <div class="panel panel-default">
-
-      <div class="panel-heading">
-        <h4>Questionnaires<span class="pull-right">
-          <a name="collapsible" data-toggle="collapse" href="#add_feat_survey">
-            <i class="glyphicon glyphicon-chevron-down"></i></a></span>
-            {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
-            {% add_surveys eng %}
-            {% endif %}
-        </h4>
-      </div>
-
-      <div id="add_feat_survey" class="panel-body collapse">
-        <div class="row">
-          <div class="col-md-12">
-            <div class="panel panel-default">
-              {% show_surveys eng users %}
-            </div>
-          </div>
-          <div class="modal fade" id="shareQuestionnaireModal" tabindex="-1" role="dialog" aria-labelledby="shareSurveyModalLabel">
-            <div class="modal-dialog" role="document">
-              <div class="modal-content">
-                <div class="modal-header">
-                  <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
-                          aria-hidden="true">&times;</span></button>
-                  <h4 class="modal-title" id="shareSurveyModalLabel">Share Questionnaire Link</h4>
-                </div>
-                <div class="modal-body">
-                  <p id="questionnaireURL"></p>
-                  <div class="alert alert-info" role="alert">
-                      <b>Note:</b> Only users that are authorized for {{ eng.product}} will be allowed to answer
-                      this questionnaire.
-                  </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-    </div>
-    {% endif %}
-
-    <div class="panel panel-default">
-
-      <div class="panel-heading">
-        <h4>Notes<span class="pull-right">
-          <a name="collapsible" data-toggle="collapse" href="#add_feat_notes">
-            <i class="glyphicon glyphicon-chevron-down"></i></a></span>
-        </h4>
-      </div>
-
-      <div id="add_feat_notes" class="panel-body collapse">
-        {% if eng|has_object_permission:"Note_Add" or user|is_authorized_for_staff:eng %}
-        <form class="form-horizontal" action="" method="post">{% csrf_token %}
-          {% include "dojo/form_fields.html" with form=form %}
-          <div class="form-group">
-              <div class="col-sm-offset-2 col-sm-10">
-                  <input class="btn btn-primary" type="submit" id="add_note" label="Add Notes" value="Add Note"/>
-              </div>
-          </div>
-        </form>
-        {% endif %}
-
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h4>Note Log<span class="pull-right">
-              <a data-toggle="collapse" href="#add_feat_note_log">
-                <i class="glyphicon glyphicon-chevron-{% if notes %}up{%else%}down{%endif%}"></i></a></span>
-            </h4>
-          </div>
-          <div id="add_feat_note_log" class="panel-body collapse {% if notes %}in{%endif%}">
-            {% for note in notes %}
-              <div>
-                <div class="panel panel-default">
-                  <div class="panel-comments">
-                      {% if user.username == note.author.username or eng|has_object_permission:"Note_Delete" or user.is_superuser %}
-                      <div class="pull-right">
-                        <form method="post" action="{% url 'delete_note' note.id 'engagement' eng.id %}">
-                            {% csrf_token %}
-                            <input type="hidden" aria-label="id" name="id" value="{{note.id}}" id="id_id" />
-                            <button type="submit" aria-label="Delete Note" class="btn-delete">
-                              <i class="fa fa-trash"></i>
-                            </button>
-                        </form>
-                      </div>
-                      {% endif %}
-                      {% if user.username == note.author.username or eng|has_object_permission:"Note_Edit" or user|is_authorized_for_staff:eng %}
-                        <div class="pull-right">
-                          <form method="get" action="{% url 'edit_note' note.id 'engagement' eng.id %}">
-                              {% csrf_token %}
-                              <input type="hidden" aria-label="id" name="id" value="{{note.id}}" id="id_id" />
-                              <button type="submit" aria-label="Edit Note" class="btn-edit">
-                                <i class="fa fa-edit"></i>
-                              </button>
-                          </form>
+            {% if eng.engagement_type == "CI/CD" %}
+                <div>
+                    <div class="panel panel-default-secondary">
+                        <div class="panel-heading">
+                            <h3 class="panel-title"><span class="fa fa-server" aria-hidden="true"></span>
+                                CI/CD Engagement Details
+                            </h3>
                         </div>
-                      {% endif %}
-                      {% if user.username == note.author.username or eng|has_object_permission:"Note_View_History" or user|is_authorized_for_staff:eng %}
-                        <div class="pull-right">
-                          <form method="get" action="{% url 'note_history' note.id 'engagement' eng.id %}">
-                              {% csrf_token %}
-                              <input type="hidden" aria-label="id" name="id" value="{{note.id}}" id="id_id" />
-                              <button type="submit" aria-label="history" class="btn-history">
-                                <i class="fa fa-history"></i>
-                              </button>
-                          </form>
+                        <div class="table-responsive">
+                            <table class="table table-striped">
+                                <tbody>
+                                    <tr>
+                                        <td style="width: 150px;"><strong>Build ID</strong></td>
+                                        <td>{{ eng.build_id|notspecified }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>Commit Hash</strong></td>
+                                        <td>{{ eng.commit_hash|notspecified|truncatechars_html:13 }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>Branch/Tag</strong></td>
+                                        <td>{{ eng.branch_tag|notspecified }}</td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>Orchestration</strong></td>
+                                        <td>
+                                            {% if eng.orchestration_engine.id %}
+                                                <a href="{% url 'edit_tool_config' eng.orchestration_engine.id %}">{{ eng.orchestration_engine.name }}</a>
+                                            {% else %}
+                                                {{ eng.orchestration_engine.name|notspecified }}
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>SCM Server</strong></td>
+                                        <td>
+                                            {% if eng.source_code_management_server.id %}
+                                                <a href="{% url 'edit_tool_config' eng.source_code_management_server.id %}">{{ eng.source_code_management_server.name }}</a>
+                                            {% else %}
+                                                {{ eng.source_code_management_server.name|notspecified }}
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td><strong>Build Server</strong></td>
+                                        <td>
+                                            {% if eng.build_server.id %}
+                                                <a href="{% url 'edit_tool_config' eng.build_server.id %}">{{ eng.build_server.name }}</a>
+                                            {% else %}
+                                                {{ eng.build_server.name|notspecified }}
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </div>
-                      {% endif %}
-
-                      <div class="row-sm-2">
-                        <strong>{{ note.author.username }}</strong>
-                        <span class="text-muted">commented {{ note.date }}</span>
-                      </div>
-                      {% if note.edited %}
-                        <div class="row-sm-2">
-                          <strong>{{ note.editor.username }}</strong>
-                          <span class="text-muted">edited {{ note.edit_time }}</span>
-                        </div>
-                      {% endif %}
-                      {% if note.private %}
-                        <div class="row-sm-2">
-                          <span class="text-muted">(will not appear in report)</span>
-                        </div>
-                      {% endif %}
-                  </div>
-                  <div class="panel-body">
-                    {% if note.note_type != None %}
-                      <strong>Note type : {{ note.note_type }}</strong>
-                      <br><br>
-                    {% endif %}
-                    {{ note|linebreaks }}
-                  </div>
-                </div>
-              </div>
-            {% endfor %}
-          </div>
-        </div>
-
-      </div>
-
-    </div>
-
-    <div class="panel panel-default">
-
-      <div class="panel-heading">
-        <h4>Files<span class="pull-right">
-          <a data-toggle="collapse" href="#add_feat_files">
-            <i class="glyphicon glyphicon-chevron-down"></i></a></span>
-            {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
-            <a title="Manage Files" name="Manage Files" class="btn btn-sm btn-primary pull-right"
-            href="{% url 'manage_files' oid=eng.id obj_type='Engagement' %}">
-              <span class="fa fa-edit"></span></a>
-            {% endif %}
-        </h4>
-      </div>
-
-      <div id="add_feat_files" class="panel-body collapse {% if files %}in{% endif %}">
-                {% for file in files %}
-                <div class="col-md-2" style="text-align: center">
-                    <div class="row">
-                        <a href="{{ request.scheme }}://{{ request.get_host }}{{ file.file.url }}" target="_blank">
-                            {% if file.file.url|get_thumbnail %}
-                                <img src="{{ file.file.url }}" alt="thumbnail" style="width:150px">
-                            {% else %}
-                                <span style="font-size: 50px;" class="glyphicon glyphicon-file"></span>
-                            {% endif %}
-                        </a>
-                    </div>
-                    <div class="row">
-                        <caption style="text-align:center">{{ file.title }}</caption>
                     </div>
                 </div>
-                {% endfor %}
-            </div>
-
-      </div>
-
-  </div>
-</div>
-
-<!-- Sidebar -->
-</div>
-<div class="col-md-4">
-  <div class="panel panel-default-secondary">
-    <div class="panel-heading">
-      <h3 class="panel-title"><span class="fa fa-info-circle fa-fw" aria-hidden="true"></span> {% if eng.name %}
-          {{ eng.name }}
-      {% else %}
-          Engagement for <a href="{% url 'view_product' eng.product.id %}">{{ eng.product }}</a>
-      {% endif %}
-      {% if eng.version %}
-          <sup>
-                <a target="_blank" class="tag-label tag-version" data-toggle="tooltip" data-placement="bottom" title="Product Version: {{ eng.version }}">
-                {{ eng.version }}</a>
-          </sup>
-      {% endif %}
-      {% if eng.tags %}
-          <sup>
-              {% for tag in eng.tags.all %}
-              <a title="Search {{ tag }}" class="tag-label tag-color" href="{% url 'simple_search' %}?query=engagement-tag:{{ tag }}">{{ tag }}</a>
-              {% endfor %}
-          </sup>
-      {% endif %}
-      </h3>
-    </div>
-    <div class="table-responsive">
-      <table class="table table-striped">
-        <tbody>
-          <tr>
-            <td style="width: 150px;"><strong>Status</strong></td>
-            <td>
-              {% if eng.status == "Blocked" %}
-              <em class="text-danger">
-              {% elif eng.status == "On Hold" %}
-              <em class="text-warning">
-              {% else %}
-              <em>
-              {% endif %}
-              {{ eng.status }}
-            </em>
-            </td>
-          </tr>
-          <tr>
-            <td><strong>Dates</strong></td>
-            <td><a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ eng.target_start|date:"l, jS F Y" }} - {{ eng.target_end|date:"l, jS F Y" }}">
-            {{ eng.target_start|date:"jS F" }} - {{ eng.target_end|date:"jS F" }}
-          </a></td>
-          </tr>
-          <tr>
-            <td><strong>Length</strong></td>
-            <td>{{ eng.target_start|datediff_time:eng.target_end }}
-              {% if eng.is_overdue and eng.status != 'Completed'%}
-              <sup>
-                <div class="tag-label warning-color">
-                  {{ eng.target_end|overdue }} overdue
+            {% endif %}
+            {% if system_settings.enable_credentials %}
+                <div>
+                    <div class="panel panel-default-secondary">
+                        <div class="panel-heading">
+                            <h4><span class="fa fa-key" aria-hidden="true"></span>
+                                Credentials
+                                {% if creds %}
+                                    <a title="Add New Credential" class="pull-right btn btn-sm btn-primary"
+                                        href="{% url 'new_cred_product_engagement' eng.id %}"><span class="fa fa-plus"></span></a>
+                                {% endif %}
+                            </h4>
+                        </div>
+                        <div class="table-responsive">
+                            <table class="table table-striped">
+                                <thead>
+                                    <tr>
+                                        <th>Name</th>
+                                        <th></th>
+                                        <th>Username</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {% if creds %}
+                                    <tr>
+                                        <td colspan="3">
+                                            <small class="text-muted"><em>
+                                                {% if cred_eng %}
+                                                    Credentials Configured for this <strong>Engagement</strong>
+                                                {% else %}
+                                                    No Credentials Configured for this <strong>Engagement</strong>
+                                                {% endif %}
+                                            </em></small>
+                                        </td>
+                                    </tr>
+                                    {% endif %}
+                                    {% for cred in cred_eng %}
+                                        <tr>
+                                            <td>
+                                                <a href="{% url 'view_cred_product_engagement' cred.engagement.id cred.id  %}">{{ cred.cred_id.name }}</a>
+                                            </td>
+                                            <td>
+                                                <ul>
+                                                    <li class="dropdown" style="list-style:none;">
+                                                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
+                                                        <ul class="dropdown-menu">
+                                                            <li>
+                                                                <a class="" href="{% url 'view_cred_product_engagement' cred.engagement.id cred.id %}">
+                                                                View</a>
+                                                            </li>
+                                                            <li>
+                                                                <a class="" href="{% url 'delete_cred_engagement' cred.engagement.id cred.id %}">
+                                                                Delete</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </td>
+                                            <td>{{ cred.cred_id.username }}</td>
+                                        </tr>
+                                    {% endfor %}
+                                    <tr>
+                                        <td colspan="3">
+                                            <small class="text-muted"><em>
+                                                {% if creds %}
+                                                    Credentials Configured for this <strong>Product</strong>
+                                                {% else %}
+                                                    No Credentials Configured for this <strong>Product</strong>
+                                                {% endif %}
+                                            </em></small>
+                                        </td>
+                                    </tr>
+                                    {% for cred in creds %}
+                                        <tr>
+                                            <td>
+                                                <a href="{% url 'view_cred_product' cred.product.id cred.id  %}">{{ cred.cred_id.name }}</a>
+                                            </td>
+                                            <td>
+                                                <ul>
+                                                    <li class="dropdown" style="list-style:none;">
+                                                        <a href="#" class="dropdown-toggle" data-toggle="dropdown">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
+                                                        <ul class="dropdown-menu">
+                                                            <li>
+                                                                <a class="" href="{% url 'view_cred_product' cred.product.id cred.id %}">
+                                                                View</a>
+                                                            </li>
+                                                        </ul>
+                                                    </li>
+                                                </ul>
+                                            </td>
+                                            <td>{{ cred.cred_id.username }}</td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
                 </div>
-              </sup>
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <td><strong>
-              {% if eng.engagement_type == "Interactive" %}Lead{% else %}Service Account {% endif %}</strong></td>
-            <td>{% if eng.lead.get_full_name and eng.lead.get_full_name.strip %}
-                {{ eng.lead.get_full_name }}
-            {% elif eng.lead %}
-                {{ eng.lead }}
-            {% else %}
-                None Assigned
-            {% endif %}</td>
-          </tr>
-          <tr>
-            <td><strong>Tracker</strong></td>
-            <td>
-              {% if eng.tracker %}
-                <a target="_blank" data-toggle="tooltip" data-placement="top" title="{{ eng.tracker }}" href="{{ eng.tracker }}" alt="Development epic or ticket for development requirements.">
-                <i class="fa fa-external-link"></i> {{ eng.tracker|last_value }}</a>
-              {% else %}
-                {{ eng.tracker|notspecified}}
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <td><strong>Repo</strong></td>
-            <td>
-              {% if eng.source_code_management_uri %}
-                <a target="_blank" data-toggle="tooltip" data-placement="top" title="{{ eng.source_code_management_uri }}" href="{{ eng.source_code_management_uri }}">
-                  <i class="fa fa-external-link"></i> {{ eng.source_code_management_uri|last_value }}
-                </a>
-              {% else %}
-                {{ eng.source_code_management_uri|notspecified}}
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <td><strong>Test Strategy</strong></td>
-            <td>
-              {% if eng.test_strategy %}
-                <a target="_blank" data-toggle="tooltip" data-placement="top" title="{{ eng.test_strategy }}" href="{{ eng.test_strategy }}">
-                  <i class="fa fa-external-link"></i> {{ eng.test_strategy|last_value }}
-                </a>
-              {% else %}
-                {{ eng.test_strategy|notspecified}}
-              {% endif %}
-            </td>
-          </tr>
-        {% if jissue and jira_project %}
-        <tr>
-            <td><strong>Jira</strong></td>
-            <td><a href="{{ eng | jira_issue_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
-            <small>(epic)</small>
-            </a></td>
-        </tr>
-        {% elif jira_project %}
-        <tr>
-            <td><strong>JIRA</strong></td>
-            <td><a href="{{ eng | jira_project_url }}" target="_blank"><i class="fa fa-external-link"></i> {{ eng | jira_key }}
-            {% if jira_project.engagement is not eng %}
-            <small>(inherited)</small>
-            {% else %}
-            <small>(project)</small>
             {% endif %}
-            </a></td>
-        </tr>
-        {% endif %}
-          <tr>
-            <td><strong>Updated</strong></td>
-            <td><a target="_blank" data-toggle="tooltip" data-placement="bottom" title="{{ eng.updated|default_if_none:"" }}">
-            {{ eng.updated|naturaltime|default_if_none:"" }}</a></td>
-          </tr>
-          <tr>
-            <td><strong>Created</strong></td>
-            <td><a target="_blank" data-toggle="tooltip" data-placement="bottom" title="{{ eng.created|default_if_none:"" }}">
-            {{ eng.created|naturaltime|default_if_none:"" }}</a></td>
-          </tr>
-
-        </tbody>
-      </table>
+        </div>
     </div>
-  </div>
-  {% if eng.engagement_type == "CI/CD" %}
-  <div>
-    <div class="panel panel-default-secondary">
-      <div class="panel-heading">
-        <h3 class="panel-title"><span class="fa fa-server" aria-hidden="true"></span>
-          CI/CD Engagement Details
-      </h3>
-      </div>
-      <div class="table-responsive">
-        <table class="table table-striped">
-          <tbody>
-            <tr>
-              <td style="width: 150px;"><strong>Build ID</strong></td>
-              <td>{{ eng.build_id|notspecified }}</td>
-            </tr>
-            <tr>
-              <td><strong>Commit Hash</strong></td>
-              <td>{{ eng.commit_hash|notspecified|truncatechars_html:13 }}</td>
-            </tr>
-            <tr>
-              <td><strong>Branch/Tag</strong></td>
-              <td>{{ eng.branch_tag|notspecified }}</td>
-            </tr>
-            <tr>
-              <td><strong>Orchestration</strong></td>
-              <td>{% if eng.orchestration_engine.id %}
-                  <a href="{% url 'edit_tool_config' eng.orchestration_engine.id %}">{{ eng.orchestration_engine.name }}</a>
-                  {% else %}
-                    {{ eng.orchestration_engine.name|notspecified }}
-                  {% endif %}
-              </td>
-            </tr>
-            <tr>
-              <td><strong>SCM Server</strong></td>
-              <td>{% if eng.source_code_management_server.id %}
-                <a href="{% url 'edit_tool_config' eng.source_code_management_server.id %}">{{ eng.source_code_management_server.name }}</a>
-                {% else %}
-                  {{ eng.source_code_management_server.name|notspecified }}
-                {% endif %}
-              </td>
-            </tr>
-            <tr>
-              <td><strong>Build Server</strong></td>
-              <td>{% if eng.build_server.id %}
-                <a href="{% url 'edit_tool_config' eng.build_server.id %}">{{ eng.build_server.name }}</a>
-                {% else %}
-                  {{ eng.build_server.name|notspecified }}
-                {% endif %}
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+    <div class="protip">
+        <i class="fa fa-lightbulb-o"></i> <strong>ProTip!</strong> Type <kbd>e</kbd> to edit this engagement. Type <kbd>i</kbd> to import scan results or <kbd>a</kbd> to add tests.
     </div>
-</div>
-{% endif %}
-{% if system_settings.enable_credentials %}
-  <div>
-    <div class="panel panel-default-secondary">
-      <div class="panel-heading">
-        <h4><span class="fa fa-key" aria-hidden="true"></span>
-          Credentials
-        {% if creds %}
-          <a title="Add New Credential" class="pull-right btn btn-sm btn-primary"
-             href="{% url 'new_cred_product_engagement' eng.id %}"><span class="fa fa-plus"></span></a>
-        {% endif %}
-      </h4>
-      </div>
-      <div class="table-responsive">
-        <table class="table table-striped">
-          <thead>
-          <tr>
-            <th>Name</th>
-            <th></th>
-            <th>Username</th>
-          </tr>
-          </thead>
-          <tbody>
-            {% if creds %}
-            <tr><td colspan="3">
-              <small class="text-muted"><em>
-                {% if cred_eng %}
-                Credentials Configured for this <strong>Engagement</strong>
-                {% else %}
-                No Credentials Configured for this <strong>Engagement</strong>
-                {% endif %}
-              </em></small></td>
-            </tr>
-            {% endif %}
-            {% for cred in cred_eng %}
-                <tr>
-                  <td>
-                      <a href="{% url 'view_cred_product_engagement' cred.engagement.id cred.id  %}">{{ cred.cred_id.name }}</a>
-                  </td>
-                  <td>
-                    <ul>
-                     <li class="dropdown" style="list-style:none;">
-                           <a href="#" class="dropdown-toggle" data-toggle="dropdown">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
-                           <ul class="dropdown-menu">
-                             <li>
-                               <a class="" href="{% url 'view_cred_product_engagement' cred.engagement.id cred.id %}">
-                                 View</a>
-                            </li>
-                            <li>
-                               <a class="" href="{% url 'delete_cred_engagement' cred.engagement.id cred.id %}">
-                                 Delete</a>
-                            </li>
-                           </ul>
-                         </li>
-                     </ul>
-                  </td>
-                  <td>{{ cred.cred_id.username }}</td>
-                </tr>
-            {% endfor %}
-            <tr><td colspan="3">
-              <small class="text-muted"><em>
-                {% if creds %}
-                Credentials Configured for this <strong>Product</strong>
-                {% else %}
-                No Credentials Configured for this <strong>Product</strong>
-                {% endif %}
-              </em></small></td>
-            </tr>
-            {% for cred in creds %}
-                <tr>
-                  <td>
-                      <a href="{% url 'view_cred_product' cred.product.id cred.id  %}">{{ cred.cred_id.name }}</a>
-                  </td>
-                  <td>
-                    <ul>
-                     <li class="dropdown" style="list-style:none;">
-                           <a href="#" class="dropdown-toggle" data-toggle="dropdown">&nbsp;<b class="fa fa-ellipsis-v"></b>&nbsp;</a>
-                           <ul class="dropdown-menu">
-                             <li>
-                               <a class="" href="{% url 'view_cred_product' cred.product.id cred.id %}">
-                                 View</a>
-                            </li>
-                           </ul>
-                         </li>
-                     </ul>
-                  </td>
-                  <td>{{ cred.cred_id.username }}</td>
-                </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </div>
-    </div>
-</div>
-{% endif %}
-
-</div>
-</div>
-
-<div class="protip">
-    <i class="fa fa-lightbulb-o"></i> <strong>ProTip!</strong> Type <kbd>e</kbd> to edit this engagement. Type <kbd>i</kbd> to import scan results or <kbd>a</kbd> to add tests.
- </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
-        <script type="text/javascript">
+    <script type="text/javascript">
         $(function () {
             $(document).on('keypress', null, 'e', function () {
-              window.location.assign('{% url 'edit_engagement' eng.id %}');
+                window.location.assign('{% url 'edit_engagement' eng.id %}');
             });
-
+        
             $(document).on('keypress', null, 'a', function () {
                 window.location.assign('{% url 'add_tests' eng.id %}');
             });
-
+        
             $(document).on('keypress', null, 'i', function () {
                 window.location.assign('{% url 'import_scan_results' eng.id %}');
             });
-
+        
             $("a[data-toggle='collapse']").on('click', function () {
                 var i = $($(this).find('i').get(0));
                 i.toggleClass('glyphicon-chevron-up').toggleClass('glyphicon-chevron-down');
             });
-
+        
             //Ensures dropdown has proper zindex
             $('.table-responsive').on('show.bs.dropdown', function () {
-              $('.table-responsive').css( "overflow", "inherit" );
+            $('.table-responsive').css( "overflow", "inherit" );
             });
-
+        
             $('.table-responsive').on('hide.bs.dropdown', function () {
-              $('.table-responsive').css( "overflow", "auto" );
+                $('.table-responsive').css( "overflow", "auto" );
             })
+
             if (document.referrer.indexOf('simple_search') > 0) {
                 var terms = '';
                 if ($.cookie('highlight')) {
                     terms = $.cookie('highlight').split(' ');
-
+                    
                     for (var i = 0; i < terms.length; i++) {
                         $('body').highlight(terms[i]);
                     }
                 }
-
+                
                 $('input#simple_search').val(terms);
             }
-
+        
             $('#shareQuestionnaireModal').on('show.bs.modal', function (event) {
             var button = $(event.relatedTarget) // Button that triggered the modal
             var path = button.data('whatever') // Extract info from data-* attributes
@@ -1089,8 +1074,8 @@
             modal.find('p#questionnaireURL').text('Questionnaire URL: ' + host + path)
             })
         });
-
+        
         {% include 'dojo/snippets/risk_acceptance_actions_snippet_js.html' %}
-
+        
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/view_engagements.html
+++ b/dojo/templates/dojo/view_engagements.html
@@ -20,6 +20,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/view_engagements.html
+++ b/dojo/templates/dojo/view_engagements.html
@@ -3,11 +3,13 @@
 {% load display_tags %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     .tooltip-inner {
       max-width: 350px;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
           {% include "dojo/snippets/engagement_list.html" with engs=engs filter=engs_filter count=engs_count prefix="engs" status="open" type=engagement_type recent_test_day_count=recent_test_day_count %}
           {% include "dojo/snippets/engagement_list.html" with engs=queued_engs filter=queued_engs_filter count=queued_engs_count prefix="queued_engs_count" status="paused" type=engagement_type recent_test_day_count=recent_test_day_count %}

--- a/dojo/templates/dojo/view_engineer.html
+++ b/dojo/templates/dojo/view_engineer.html
@@ -3,6 +3,7 @@
 {% load display_tags %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     #chart_div3 .flot-x-axis .tickLabel, #chart_div4 .flot-x-axis .tickLabel
     {   top: 290px !important;
     font-size: 10px;
@@ -15,6 +16,7 @@
     #chart_div, #chart_div2, #chart_div3, #chart_div4 {height: 300px}
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <h2> {{ name }}</h2>
     <div class="row metric-data">
         <div class="col-md-12">

--- a/dojo/templates/dojo/view_engineer.html
+++ b/dojo/templates/dojo/view_engineer.html
@@ -572,6 +572,7 @@
     <br/>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <!-- Flot Charts JavaScript -->
     <script src="{% static "flot/excanvas.min.js" %}"></script>
     <script src="{% static "flot/jquery.flot.js" %}"></script>

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -5,15 +5,18 @@
 {% load static %}
 {% load get_endpoint_status %}
 {% block add_styles %}
+    {{ block.super }}
   .tooltip-inner {
     max-width: 650px;
   }
 {% endblock %}
 {% block add_css_before %}
+    {{ block.super }}
 <!-- Source Code Highlight CSS -->
 <link rel="stylesheet" href="{% static "dojo/css/highlight.css" %}">
 {% endblock %}
 {% block content %}
+    {{ block.super }}
 <div id="test">
     <div class="panel panel-default">
         <div class="panel-heading">

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -1020,6 +1020,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script src="{% static "clipboard/dist/clipboard.min.js" %}"></script>
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>

--- a/dojo/templates/dojo/view_note_history.html
+++ b/dojo/templates/dojo/view_note_history.html
@@ -2,6 +2,7 @@
 {% load humanize %}
 {% load static %}
 {% block content %}
+    {{ block.super }}
     <h3>Note History</h3><br></br>
     <form class="form-horizontal" action="{% url 'note_history' note.id page objid %}" method="post">{% csrf_token %}
         {% for entry in history %}

--- a/dojo/templates/dojo/view_objects.html
+++ b/dojo/templates/dojo/view_objects.html
@@ -71,6 +71,7 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/view_objects.html
+++ b/dojo/templates/dojo/view_objects.html
@@ -3,11 +3,13 @@
 {% load get_config_setting %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="panel panel-default">
         <div class="panel-heading">
             <div class="clearfix">

--- a/dojo/templates/dojo/view_objects_eng.html
+++ b/dojo/templates/dojo/view_objects_eng.html
@@ -61,6 +61,7 @@ No files for this build were found.
 
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/view_objects_eng.html
+++ b/dojo/templates/dojo/view_objects_eng.html
@@ -3,11 +3,13 @@
 {% load get_config_setting %}
 {% load static %}
 {% block add_styles %}
+    {{ block.super }}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
 {% if object_queryset %}
     <div class="panel panel-default">
         <div class="panel-heading">

--- a/dojo/templates/dojo/view_presets.html
+++ b/dojo/templates/dojo/view_presets.html
@@ -2,6 +2,7 @@
 {% load navigation_tags %}
 {% load get_config_setting %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
       <div class="col-md-12">
           <div class="panel panel-default table-responsive">

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -4,9 +4,11 @@
 {% load display_tags %}
 {% load authorization_tags %}
 {% block add_styles %}
+    {{ block.super }}
   .chart {height: 160px}
 {% endblock %}
 {% block content %}
+    {{ block.super }}
 <div class="row">
   <div class="col-md-8">
     <div class="panel panel-default">

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -481,6 +481,7 @@
 </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
   <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
   <!-- Flot Charts JavaScript -->
   <script src="{% static "flot/excanvas.min.js" %}"></script>

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -3,6 +3,7 @@
 {% load authorization_tags %}
 
 {% block content %}
+    {{ block.super }}
     <h3 id="id_heading"> Product Type {{ pt.name }}</h3>
     <div class="row">
         <div id="tests" class="col-md-8">

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -331,6 +331,7 @@
 {% endblock %}
 
 {% block postscript %}
+    {{ block.super }}
 {% if not edit_mode %}
     <script type="text/javascript">
         // keyboard shortcuts

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -5,6 +5,7 @@
 {% load static %}
 
 {% block add_styles %}
+    {{ block.super }}
     .chosen-container {
     width: 70% !important;
     }
@@ -13,9 +14,11 @@
     }
 {% endblock %}
 {% block add_css %}
+    {{ block.super }}
     <link rel="stylesheet" href="{% static 'easymde/dist/easymde.min.css' %}">
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     {% if risk_acceptance.is_expired %}
         <div class="danger-zone panel panel-danger">
             <div class="panel-heading">

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1131,6 +1131,7 @@
 </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     <script type="application/javascript" src="{% static "jquery.hotkeys/jquery.hotkeys.js" %}"></script>
     <script type="text/javascript" src="{% static "jquery-highlight/jquery.highlight.js" %}"></script>
     <script type="text/javascript">

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -5,6 +5,7 @@
 {% load static %}
 {% load humanize %}
 {% block add_styles %}
+    {{ block.super }}
     ul#select_by_severity a:hover, ul#bulk_edit a:hover {
     cursor: pointer;
     }
@@ -19,6 +20,7 @@
     }
 {% endblock %}
 {% block content %}
+    {{ block.super }}
     <div class="panel panel-default">
         <div class="panel-heading">
             <div class="clearfix">

--- a/dojo/templates/dojo/view_tool_product_all.html
+++ b/dojo/templates/dojo/view_tool_product_all.html
@@ -2,6 +2,7 @@
 {% load navigation_tags %}
 {% load get_config_setting %}
 {% block content %}
+    {{ block.super }}
     <div class="row">
           <div class="col-md-12">
               <div class="panel panel-default table-responsive">

--- a/dojo/templates/dojo/view_tool_product_all.html
+++ b/dojo/templates/dojo/view_tool_product_all.html
@@ -56,5 +56,6 @@
     </div>
 {% endblock %}
 {% block postscript %}
+    {{ block.super }}
     {% include "dojo/filter_js_snippet.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -3,6 +3,7 @@
 {% load authorization_tags %}
 
 {% block content %}
+    {{ block.super }}
 <h3 id="id_heading"> User {{ user.first_name }} {{ user.last_name }}</h3>
 <div class="row">
     <div id="tests" class="col-md-8">

--- a/dojo/templates/google_sheet_error.html
+++ b/dojo/templates/google_sheet_error.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
+    {{ block.super }}
     <h1>Error</h1>
     <hr/>
     <h2>

--- a/dojo/templates/report_base.html
+++ b/dojo/templates/report_base.html
@@ -173,6 +173,7 @@
 </head>
 <body>
 {% block content %}
+    {{ block.super }}
 {% endblock %}
 {% block js %}
 {% endblock %}


### PR DESCRIPTION
 Currently, almost none of the templates here use template inheritance effectively as initially setup in `base.html`. 

**What is the goal of this PR:**
When extending a template block (in most cases here it's the content block in `base.html`) the html from the child templates content block will **overwrite** everything in the parent templates content block. The additions made to each of the template blocks int this PR is the `block.super` tag. This tag allows for the child templates content block to be **appended** to the parent templates content block.

**Why is this important:**
When developing features for internal use, extending pages is essential to maintaining an untouched dojo instance, while also accomplishing the goal of external features. 

**Who does this change affect:**
This change will go virtually unnoticed as none of the templates in defectdojo extends more than `base.html`


References: [Template Inheritance](https://docs.djangoproject.com/en/3.2/ref/templates/language/#template-inheritance)