### PR TITLE
Fix generic parser import endpoint without protocol

### DIFF
--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -116,7 +116,9 @@ class GenericParser(object):
 
             # manage endpoints
             if 'Url' in row:
-                finding.unsaved_endpoints = [Endpoint.from_uri(row['Url'])]
+                finding.unsaved_endpoints = [Endpoint.from_uri(row['Url'])
+                                             if '://' in row['Url'] else
+                                             Endpoint.from_uri("//" + row['Url'])]
 
             # manage internal de-duplication
             key = hashlib.sha256("|".join([

--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -48,9 +48,15 @@ class GenericParser(object):
                 finding.unsaved_endpoints = []
                 for item in unsaved_endpoints:
                     if type(item) is str:
-                        finding.unsaved_endpoints.append(Endpoint.from_uri(item))
+                        if '://' in item:  # is the host full uri?
+                            endpoint = Endpoint.from_uri(item)
+                            # can raise exception if the host is not valid URL
+                        else:
+                            endpoint = Endpoint.from_uri('//' + item)
+                            # can raise exception if there is no way to parse the host
                     else:
-                        finding.unsaved_endpoints.append(Endpoint(**item))
+                        endpoint = Endpoint(**item)
+                    finding.unsaved_endpoints.append(endpoint)
             findings.append(finding)
         return findings
 

--- a/dojo/unittests/scans/generic/generic_report4.csv
+++ b/dojo/unittests/scans/generic/generic_report4.csv
@@ -1,0 +1,5 @@
+Title,Description,Severity,Date,Url
+Title1,,,28/02/2021,www.example.com
+Title2,,,28/02/2021,localhost
+Title3,,,28/02/2021,127.0.0.1:80
+Title4,,,28/02/2021,foo.bar/path

--- a/dojo/unittests/scans/generic/generic_report4.json
+++ b/dojo/unittests/scans/generic/generic_report4.json
@@ -1,0 +1,12 @@
+{
+    "findings": [
+        {
+            "endpoints": [
+                "www.example.com",
+                "localhost",
+                "127.0.0.1:80",
+                "foo.bar/path"
+            ]
+        }
+    ]
+}

--- a/dojo/unittests/tools/test_generic_parser.py
+++ b/dojo/unittests/tools/test_generic_parser.py
@@ -516,3 +516,66 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             self.assertEqual("urlfiltering.paloaltonetworks.com", endpoint.host)
             self.assertEqual(2345, endpoint.port)
             self.assertEqual("test-pest", endpoint.path)
+
+    def test_parse_host_json(self):
+        file = open("dojo/unittests/scans/generic/generic_report4.json")
+        parser = GenericParser()
+        findings = parser.get_findings(file, Test())
+        self.assertEqual(1, len(findings))
+        finding = findings[0]
+        finding.clean()
+        self.assertEqual(4, len(finding.unsaved_endpoints))
+
+        endpoint = finding.unsaved_endpoints[0]
+        endpoint.clean()
+        self.assertEqual("www.example.com", endpoint.host)
+
+        endpoint = finding.unsaved_endpoints[1]
+        endpoint.clean()
+        self.assertEqual("localhost", endpoint.host)
+
+        endpoint = finding.unsaved_endpoints[2]
+        endpoint.clean()
+        self.assertEqual("127.0.0.1", endpoint.host)
+        self.assertEqual(80, endpoint.port)
+
+        endpoint = finding.unsaved_endpoints[3]
+        endpoint.clean()
+        self.assertEqual("foo.bar", endpoint.host)
+        self.assertEqual("path", endpoint.path)
+
+    def test_parse_host_csv(self):
+        file = open("dojo/unittests/scans/generic/generic_report4.csv")
+        parser = GenericParser()
+        findings = parser.get_findings(file, Test())
+        self.assertEqual(4, len(findings))
+
+        finding = findings[0]
+        finding.clean()
+        self.assertEqual(1, len(finding.unsaved_endpoints))
+        endpoint = finding.unsaved_endpoints[0]
+        endpoint.clean()
+        self.assertEqual("www.example.com", endpoint.host)
+
+        finding = findings[1]
+        finding.clean()
+        self.assertEqual(1, len(finding.unsaved_endpoints))
+        endpoint = finding.unsaved_endpoints[0]
+        endpoint.clean()
+        self.assertEqual("localhost", endpoint.host)
+
+        finding = findings[2]
+        finding.clean()
+        self.assertEqual(1, len(finding.unsaved_endpoints))
+        endpoint = finding.unsaved_endpoints[0]
+        endpoint.clean()
+        self.assertEqual("127.0.0.1", endpoint.host)
+        self.assertEqual(80, endpoint.port)
+
+        finding = findings[3]
+        finding.clean()
+        self.assertEqual(1, len(finding.unsaved_endpoints))
+        endpoint = finding.unsaved_endpoints[0]
+        endpoint.clean()
+        self.assertEqual("foo.bar", endpoint.host)
+        self.assertEqual("path", endpoint.path)


### PR DESCRIPTION
The generic importer uses Endpoint.from_uri() see https://github.com/DefectDojo/django-DefectDojo/blob/64701f1dac416b4baa08f9f1d4609ab0438481ef/dojo/tools/generic/parser.py#L49-L53, which relies on hyperlink.parse() introduced in #4473.

This library, however, does not support url's without protocol. Example: hyperlink.parse("www.google.com") creates an object with `host: None` and `path: "/www.google.com"`.

There exists a workaround for this in some places in the code like:

https://github.com/DefectDojo/django-DefectDojo/blob/64701f1dac416b4baa08f9f1d4609ab0438481ef/dojo/forms.py#L1365-L1370

This PR, brings the same capabilities to the generic importer.