### PR TITLE
fix missing one-to-one relationships from prefetch API specs

### DIFF
--- a/dojo/api_v2/prefetch/utils.py
+++ b/dojo/api_v2/prefetch/utils.py
@@ -37,10 +37,7 @@ def _get_prefetchable_fields(serializer):
         serializer (Serializer): [description]
     """
     def _is_field_prefetchable(field):
-        if _is_many_to_many_relation(field):
-            # print(serializer.__class__)
-            # print('ManytoMany: ', vars(field))
-            return _is_one_to_one_relation(field) or _is_many_to_many_relation(field)
+        return _is_one_to_one_relation(field) or _is_many_to_many_relation(field)
 
     meta = getattr(serializer, "Meta", None)
     if meta is None:


### PR DESCRIPTION
Due to a indentation bug the one-to-one relationships were missing from the API specs since #4541 