### PR TITLE
Bugfix for global roles

### DIFF
--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -14,11 +14,11 @@ def user_has_permission(user, obj, permission):
     if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return True
 
-    if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+    if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
         return True
 
     for group in get_groups(user):
-        if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+        if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
             return True
 
     if isinstance(obj, Product_Type):

--- a/dojo/endpoint/queries.py
+++ b/dojo/endpoint/queries.py
@@ -27,11 +27,11 @@ def get_authorized_endpoints(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return endpoints
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return endpoints
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return endpoints
 
         roles = get_roles_for_permission(permission)
@@ -87,11 +87,11 @@ def get_authorized_endpoint_status(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return endpoint_status
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return endpoint_status
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return endpoint_status
 
         roles = get_roles_for_permission(permission)

--- a/dojo/engagement/queries.py
+++ b/dojo/engagement/queries.py
@@ -20,11 +20,11 @@ def get_authorized_engagements(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Engagement.objects.all()
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return Engagement.objects.all()
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return Engagement.objects.all()
 
         roles = get_roles_for_permission(permission)

--- a/dojo/finding/queries.py
+++ b/dojo/finding/queries.py
@@ -27,11 +27,11 @@ def get_authorized_findings(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return findings
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return findings
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return findings
 
         roles = get_roles_for_permission(permission)
@@ -82,11 +82,11 @@ def get_authorized_stub_findings(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Stub_Finding.objects.all()
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return Stub_Finding.objects.all()
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return Stub_Finding.objects.all()
 
         roles = get_roles_for_permission(permission)

--- a/dojo/finding_group/queries.py
+++ b/dojo/finding_group/queries.py
@@ -27,11 +27,11 @@ def get_authorized_finding_groups(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return finding_groups
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return finding_groups
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return finding_groups
 
         roles = get_roles_for_permission(permission)

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -22,11 +22,11 @@ def get_authorized_products(permission, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Product.objects.all().order_by('name')
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return Product.objects.all().order_by('name')
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return Product.objects.all().order_by('name')
 
         roles = get_roles_for_permission(permission)
@@ -85,7 +85,7 @@ def get_authorized_product_members(permission):
     if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Member.objects.all()
 
-    if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+    if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
         return Product_Member.objects.all()
 
     products = get_authorized_products(permission)
@@ -104,7 +104,7 @@ def get_authorized_product_members_for_user(user, permission):
     if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Member.objects.all(user=user)
 
-    if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+    if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
         return Product_Member.objects.all(user=user)
 
     products = get_authorized_products(permission)
@@ -140,11 +140,11 @@ def get_authorized_app_analysis(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return App_Analysis.objects.all().order_by('name')
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return App_Analysis.objects.all().order_by('name')
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return App_Analysis.objects.all().order_by('name')
 
         roles = get_roles_for_permission(permission)
@@ -195,11 +195,11 @@ def get_authorized_dojo_meta(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return DojoMeta.objects.all().order_by('name')
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return DojoMeta.objects.all().order_by('name')
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return DojoMeta.objects.all().order_by('name')
 
         roles = get_roles_for_permission(permission)

--- a/dojo/product_type/queries.py
+++ b/dojo/product_type/queries.py
@@ -19,11 +19,11 @@ def get_authorized_product_types(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Product_Type.objects.all().order_by('name')
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return Product_Type.objects.all().order_by('name')
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return Product_Type.objects.all().order_by('name')
 
         roles = get_roles_for_permission(permission)
@@ -67,7 +67,7 @@ def get_authorized_product_type_members(permission):
     if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Type_Member.objects.all()
 
-    if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+    if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
         return Product_Type_Member.objects.all()
 
     product_types = get_authorized_product_types(permission)
@@ -86,7 +86,7 @@ def get_authorized_product_type_members_for_user(user, permission):
     if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Type_Member.objects.all(user=user)
 
-    if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+    if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
         return Product_Type_Member.objects.all(user=user)
 
     product_types = get_authorized_product_types(permission)

--- a/dojo/test/queries.py
+++ b/dojo/test/queries.py
@@ -24,11 +24,11 @@ def get_authorized_tests(permission, product=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Test.objects.all()
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return Test.objects.all()
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return Test.objects.all()
 
         roles = get_roles_for_permission(permission)
@@ -82,11 +82,11 @@ def get_authorized_test_imports(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Test_Import.objects.all()
 
-        if hasattr(user, 'global_role') and role_has_permission(user.global_role.role.id, permission):
+        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
             return Test_Import.objects.all()
 
         for group in get_groups(user):
-            if hasattr(group, 'global_role') and role_has_permission(group.global_role.role.id, permission):
+            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
                 return Test_Import.objects.all()
 
         roles = get_roles_for_permission(permission)

--- a/dojo/unittests/authorization/test_authorization.py
+++ b/dojo/unittests/authorization/test_authorization.py
@@ -104,6 +104,10 @@ class TestAuthorization(TestCase):
 
         cls.user3 = Dojo_User()
         cls.user3.id = 2
+        cls.global_role_user = Global_Role()
+        cls.global_role_user.id = 3
+        cls.global_role_user.user = cls.user3
+        cls.global_role_user.role = None
 
     def test_role_has_permission_exception(self):
         with self.assertRaisesMessage(RoleDoesNotExistError,


### PR DESCRIPTION
There are three possibilities for users and global roles:

- User has no Global_Role object: that case worked
- User has a Global_Role object pointing to a Role: that case worked as well
- User has a Global_Role object where the Role is None: that case produced an exception --> That is now fixed with this PR 