### PR TITLE
SARIF parser: implement 'level' (severity) attribute

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -152,7 +152,7 @@ def get_item(result, rules, artifacts, run_date):
         if len(description) < 150:
             title = description
     description = ''
-    severity = get_severity('warning')
+    severity = get_severity(result.get('level', 'warning'))
     if rule is not None:
         # get the severity from the rule
         if 'defaultConfiguration' in rule:
@@ -174,17 +174,20 @@ def get_item(result, rules, artifacts, run_date):
         if len(cwes_extracted) > 0:
             cwes = cwes_extracted
 
-    finding = Finding(title=textwrap.shorten(title, 150),
-                    severity=severity,
-                    description=description,
-                    mitigation=mitigation,
-                    references=references,
-                    cve=cve_try(result['ruleId']),  # for now we only support when the id of the rule is a CVE
-                    cwe=cwes[0],
-                    static_finding=True,  # by definition
-                    dynamic_finding=False,  # by definition
-                    file_path=file_path,
-                    line=line)
+    finding = Finding(
+        title=textwrap.shorten(title, 150),
+        severity=severity,
+        description=description,
+        mitigation=mitigation,
+        references=references,
+        cve=cve_try(result['ruleId']),  # for now we only support when the id of the rule is a CVE
+        cwe=cwes[0],
+        static_finding=True,  # by definition
+        dynamic_finding=False,  # by definition
+        file_path=file_path,
+        line=line,
+        vuln_id_from_tool=result['ruleId'],
+    )
 
     if run_date:
         finding.date = run_date

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -186,8 +186,10 @@ def get_item(result, rules, artifacts, run_date):
         dynamic_finding=False,  # by definition
         file_path=file_path,
         line=line,
-        vuln_id_from_tool=result['ruleId'],
     )
+
+    if 'ruleId' in result:
+        finding.vuln_id_from_tool = result['ruleId']
 
     if run_date:
         finding.date = run_date

--- a/dojo/unittests/scans/sarif/dockle_0_3_15.sarif
+++ b/dojo/unittests/scans/sarif/dockle_0_3_15.sarif
@@ -1,0 +1,82 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Dockle",
+          "informationUri": "https://github.com/goodwithtech/dockle",
+          "rules": [
+            {
+              "id": "CIS-DI-0010",
+              "shortDescription": {
+                "text": "Do not store credential in ENVIRONMENT vars/files"
+              },
+              "help": {
+                "text": "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0010"
+              }
+            },
+            {
+              "id": "CIS-DI-0005",
+              "shortDescription": {
+                "text": "Enable Content trust for Docker"
+              },
+              "help": {
+                "text": "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0005"
+              }
+            },
+            {
+              "id": "CIS-DI-0006",
+              "shortDescription": {
+                "text": "Add HEALTHCHECK instruction to the container image"
+              },
+              "help": {
+                "text": "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0006"
+              }
+            },
+            {
+              "id": "CIS-DI-0008",
+              "shortDescription": {
+                "text": "Confirm safety of setuid/setgid files"
+              },
+              "help": {
+                "text": "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0008"
+              }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "CIS-DI-0010",
+          "level": "error",
+          "message": {
+            "text": "Suspicious ENV key found : DD_ADMIN_PASSWORD, Suspicious ENV key found : DD_CELERY_BROKER_PASSWORD, Suspicious ENV key found : DD_DATABASE_PASSWORD"
+          }
+        },
+        {
+          "ruleId": "CIS-DI-0005",
+          "level": "note",
+          "message": {
+            "text": "export DOCKER_CONTENT_TRUST=1 before docker pull/build"
+          }
+        },
+        {
+          "ruleId": "CIS-DI-0006",
+          "level": "note",
+          "message": {
+            "text": "not found HEALTHCHECK statement"
+          }
+        },
+        {
+          "ruleId": "CIS-DI-0008",
+          "level": "note",
+          "message": {
+            "text": "setuid file: urwxr-xr-x usr/bin/chfn, setuid file: urwxr-xr-x usr/bin/chsh, setuid file: urwxr-xr-x usr/bin/passwd, setuid file: urwxr-xr-x bin/umount, setuid file: urwxr-xr-x bin/mount, setgid file: grwxr-xr-x usr/bin/wall, setgid file: grwxr-xr-x usr/bin/expiry, setuid file: urwxr-xr-x bin/su, setgid file: grwxr-xr-x sbin/unix_chkpwd, setuid file: urwxr-xr-x usr/bin/gpasswd, setgid file: grwxr-xr-x usr/bin/chage, setuid file: urwxr-xr-x usr/bin/newgrp"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -120,7 +120,7 @@ class TestSarifParser(TestCase):
         # finding 6
         item = findings[6]
         self.assertEqual("CVE-2019-11358", item.title)
-        self.assertEqual("Medium", item.severity)
+        self.assertEqual("Critical", item.severity)
         self.assertEqual("CVE-2019-11358", item.cve)
         for finding in findings:
             self.common_checks(finding)
@@ -204,3 +204,32 @@ class TestSarifParser(TestCase):
         self.assertEqual(datetime.datetime(2021, 3, 23, 0, 10, 48, tzinfo=datetime.timezone.utc), finding.date)
         for finding in findings:
             self.common_checks(finding)
+
+    def test_dockle(self):
+        """Generated with goodwithtech/dockle (https://github.com/goodwithtech/dockle)"""
+        testfile = open("dojo/unittests/scans/sarif/dockle_0_3_15.sarif")
+        parser = SarifParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(4, len(findings))
+        for finding in findings:
+            self.common_checks(finding)
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual("CIS-DI-0010", finding.vuln_id_from_tool)
+            self.assertEqual("Critical", finding.severity)
+            self.assertIn("Do not store credential in ENVIRONMENT vars/files", finding.description)
+        with self.subTest(i=1):
+            finding = findings[1]
+            self.assertEqual("CIS-DI-0005", finding.vuln_id_from_tool)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual("Enable Content trust for Docker", finding.description)
+        with self.subTest(i=2):
+            finding = findings[2]
+            self.assertEqual("CIS-DI-0006", finding.vuln_id_from_tool)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual("Add HEALTHCHECK instruction to the container image", finding.description)
+        with self.subTest(i=3):
+            finding = findings[3]
+            self.assertEqual("CIS-DI-0008", finding.vuln_id_from_tool)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual("Confirm safety of setuid/setgid files", finding.description)


### PR DESCRIPTION
# Work done

- [x] Add more test data from Dockle tool (https://github.com/goodwithtech/dockle)
- [x] implement `vuln_id_from_tool` from ruleId
- [x] fix bug when level is in `result` directly (it was ignored before)