### PR TITLE
[Bandit parser] Fix internal de-duplication

### DIFF
--- a/dojo/tools/bandit/parser.py
+++ b/dojo/tools/bandit/parser.py
@@ -47,7 +47,6 @@ class BanditParser(object):
                 file_path=item["filename"],
                 line=item["line_number"],
                 date=find_date,
-                references=item["more_info"],
                 static_finding=True,
                 dynamic_finding=False,
                 vuln_id_from_tool=":".join([item["test_name"], item["test_id"]]),
@@ -58,6 +57,8 @@ class BanditParser(object):
                 finding.scanner_confidence = self.convert_confidence(
                     item.get("issue_confidence")
                 )
+            if "more_info" in item:
+                finding.references = item.get["more_info"]
 
             dupe_key = finding.vuln_id_from_tool
 

--- a/dojo/tools/bandit/parser.py
+++ b/dojo/tools/bandit/parser.py
@@ -58,7 +58,7 @@ class BanditParser(object):
                     item.get("issue_confidence")
                 )
             if "more_info" in item:
-                finding.references = item.get["more_info"]
+                finding.references = item["more_info"]
 
             dupe_key = finding.vuln_id_from_tool
 

--- a/dojo/tools/bandit/parser.py
+++ b/dojo/tools/bandit/parser.py
@@ -1,4 +1,3 @@
-
 import json
 import dateutil.parser
 
@@ -6,7 +5,6 @@ from dojo.models import Finding
 
 
 class BanditParser(object):
-
     def get_scan_types(self):
         return ["Bandit Scan"]
 
@@ -20,48 +18,57 @@ class BanditParser(object):
         data = json.load(filename)
 
         dupes = dict()
+
+        find_date = None
         if "generated_at" in data:
             find_date = dateutil.parser.parse(data["generated_at"])
 
         for item in data["results"]:
 
-            findingdetail = "\n".join([
-                "**Test Name:** `" + item["test_name"] + "`",
-                "**Test ID:** `" + item["test_id"] + "`",
-                "**Filename:** `" + item["filename"] + "`",
-                "**Line number:** `" + str(item["line_number"]) + "`",
-                "**Issue Confidence:** `" + item["issue_confidence"] + "`",
-                "**Code:**",
-                "```\n" + str(item.get("code")).replace('```', '\\`\\`\\`') + "\n```",
-            ])
+            findingdetail = "\n".join(
+                [
+                    "**Test Name:** `" + item["test_name"] + "`",
+                    "**Test ID:** `" + item["test_id"] + "`",
+                    "**Filename:** `" + item["filename"] + "`",
+                    "**Line number:** `" + str(item["line_number"]) + "`",
+                    "**Issue Confidence:** `" + item["issue_confidence"] + "`",
+                    "**Code:**",
+                    "```\n" +
+                    str(item.get("code")).replace("```", "\\`\\`\\`") +
+                    "\n```",
+                ]
+            )
 
-            sev = item["issue_severity"].title()
-
-            find = Finding(
+            finding = Finding(
                 title=item["issue_text"],
                 test=test,
                 description=findingdetail,
-                severity=sev,
+                severity=item["issue_severity"].title(),
                 file_path=item["filename"],
                 line=item["line_number"],
                 date=find_date,
+                references=item["more_info"],
                 static_finding=True,
                 dynamic_finding=False,
                 vuln_id_from_tool=":".join([item["test_name"], item["test_id"]]),
                 nb_occurences=1,
             )
             # manage confidence
-            confidence = self.convert_confidence(item.get('issue_confidence'))
-            if confidence:
-                find.scanner_confidence = confidence
+            if "issue_confidence" in item:
+                finding.scanner_confidence = self.convert_confidence(
+                    item.get("issue_confidence")
+                )
 
-            dupe_key = item["issue_text"] + item["filename"] + str(item["line_number"])
+            dupe_key = finding.vuln_id_from_tool
 
             if dupe_key in dupes:
                 find = dupes[dupe_key]
-                find.nb_occurences += find.nb_occurences
+                find.file_path = None  # as there is more than one file we remove this data
+                find.line = 0
+                find.description += "\n-----\n\n" + finding.description
+                find.nb_occurences += 1
             else:
-                dupes[dupe_key] = find
+                dupes[dupe_key] = finding
 
         return list(dupes.values())
 

--- a/dojo/unittests/tools/test_bandit_parser.py
+++ b/dojo/unittests/tools/test_bandit_parser.py
@@ -19,31 +19,61 @@ class TestBanditParser(TestCase):
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(1, len(findings))
+        with self.subTest(i=0):
+            item = findings[0]
+            self.assertEqual("Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.", item.title)
+            self.assertEqual(datetime.datetime(2020, 12, 30, 10, 3, 39, tzinfo=tzlocal()), item.date)
+            self.assertEqual("Low", item.severity)
+            self.assertEqual("one/one.py", item.file_path)
+            self.assertEqual('assert_used:B101', item.vuln_id_from_tool)
+            self.assertEqual("Certain", item.get_scanner_confidence_text())
+            self.assertEqual(1, item.nb_occurences)
+            self.assertIn("B101", item.references.upper())
 
     def test_bandit_parser_has_many_findings(self):
         testfile = open("dojo/unittests/scans/bandit/many_vulns.json")
         parser = BanditParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertEqual(213, len(findings))
-        item = findings[0]
-        self.assertEqual("Try, Except, Pass detected.", item.title)
-        self.assertEqual(datetime.datetime(2020, 12, 30, 9, 35, 48, tzinfo=tzlocal()), item.date)
-        self.assertEqual("Low", item.severity)
-        self.assertEqual("dojo/benchmark\\views.py", item.file_path)
-        self.assertEqual('try_except_pass:B110', item.vuln_id_from_tool)
-        self.assertEqual("Certain", item.get_scanner_confidence_text())
+        self.assertEqual(16, len(findings))
+        with self.subTest(i=0):
+            item = findings[0]
+            self.assertEqual("Try, Except, Pass detected.", item.title)
+            self.assertEqual(datetime.datetime(2020, 12, 30, 9, 35, 48, tzinfo=tzlocal()), item.date)
+            self.assertEqual("Low", item.severity)
+            self.assertEqual('try_except_pass:B110', item.vuln_id_from_tool)
+            self.assertEqual("Certain", item.get_scanner_confidence_text())
+            self.assertEqual(20, item.nb_occurences)
+            self.assertIn("B110", item.references.upper())
 
     def test_bandit_parser_has_many_findings_recent(self):
         testfile = open("dojo/unittests/scans/bandit/dd.json")
         parser = BanditParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertEqual(47, len(findings))
-        item = findings[0]
-        self.assertEqual("Use of insecure MD2, MD4, MD5, or SHA1 hash function.", item.title)
-        self.assertEqual(datetime.datetime(2021, 3, 30, 18, 23, 12, tzinfo=tzlocal()), item.date)
-        self.assertEqual("Medium", item.severity)
-        self.assertEqual("dojo/tools/acunetix/parser.py", item.file_path)
-        self.assertEqual('blacklist:B303', item.vuln_id_from_tool)
-        self.assertEqual("Certain", item.get_scanner_confidence_text())
+        self.assertEqual(8, len(findings))
+        with self.subTest(i=0):
+            item = findings[0]
+            self.assertEqual("Use of insecure MD2, MD4, MD5, or SHA1 hash function.", item.title)
+            self.assertEqual(datetime.datetime(2021, 3, 30, 18, 23, 12, tzinfo=tzlocal()), item.date)
+            self.assertEqual("Medium", item.severity)
+            self.assertEqual('blacklist:B303', item.vuln_id_from_tool)
+            self.assertEqual("Certain", item.get_scanner_confidence_text())
+            self.assertEqual(30, item.nb_occurences)
+            self.assertIn("B303", item.references.upper())
+
+    def test_bandit_parser_has_many_findings_big(self):
+        testfile = open("dojo/unittests/scans/bandit/kolibri_0_14_7.json")
+        parser = BanditParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(43, len(findings))
+        with self.subTest(i=0):
+            item = findings[0]
+            self.assertEqual("Try, Except, Pass detected.", item.title)
+            self.assertEqual(datetime.datetime(2021, 6, 18, 21, 46, 58, tzinfo=tzlocal()), item.date)
+            self.assertEqual("Low", item.severity)
+            self.assertEqual('try_except_pass:B110', item.vuln_id_from_tool)
+            self.assertEqual("Certain", item.get_scanner_confidence_text())
+            self.assertEqual(78, item.nb_occurences)
+            self.assertIn("B110", item.references.upper())

--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -153,7 +153,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_path_1.json")
         driver.find_elements_by_css_selector("button.btn.btn-primary")[1].click()
 
-        self.assertTrue(self.is_success_message_present(text='a total of 3 findings'))
+        self.assertTrue(self.is_success_message_present(text='a total of 1 findings'))
 
         # Second test
         self.goto_active_engagements_overview(driver)
@@ -166,7 +166,7 @@ class DedupeTest(BaseTestCase):
         driver.find_element_by_id('id_file').send_keys(self.relative_path + "/dedupe_scans/dedupe_path_2.json")
         driver.find_elements_by_css_selector("button.btn.btn-primary")[1].click()
 
-        self.assertTrue(self.is_success_message_present(text='a total of 3 findings'))
+        self.assertTrue(self.is_success_message_present(text='a total of 1 findings'))
 
     @on_exception_html_source_logger
     def test_check_path_status(self):


### PR DESCRIPTION
# Work done

Tested demo instance and loaded big Bandit reports (more than 3000 findings by report) and found few pbs.

## What was implemented

- [x] Fix internal de-duplication to highly reduce the number of findings (group by `vuln_id_from_tool`)
- [x] improve description when grouping finding
- [x] implement `references`
- [x] add more test data and unit tests (a big report)

![bandit_dup](https://user-images.githubusercontent.com/1694940/122673607-78345e00-d1d1-11eb-91f7-78f600d6aefd.png)

