### PR TITLE
Fix Burp Import Issues

### DIFF
--- a/dojo/tools/burp/parser.py
+++ b/dojo/tools/burp/parser.py
@@ -98,7 +98,7 @@ def get_clean_base64(value):
     if value is None:
         return ""
     try:
-        return base64.b64decode(value).decode()
+        return base64.b64decode(value).decode("utf-8","replace") # wouldn't this be cleaner than below?
     except UnicodeDecodeError as ue:
         # decoding of UTF-8 fail when you have a binary payload in the HTTP response
         # so we just cut it to have only the header and add fake body
@@ -134,7 +134,12 @@ def get_item(item_node, test):
     unsaved_req_resp = list()
     for request_response in item_node.findall('./requestresponse'):
         request = get_clean_base64(request_response.findall('request')[0].text)
-        response = get_clean_base64(request_response.findall('response')[0].text)
+        if request_response.findall('response'):
+            response = get_clean_base64(request_response.findall('response')[0].text)
+        else:
+            response = ""
+            # This case happens when a request_response pair doesn't have
+            # a response at all
         unsaved_req_resp.append({"req": request, "resp": response})
 
     collab_text = ""

--- a/dojo/tools/burp/parser.py
+++ b/dojo/tools/burp/parser.py
@@ -98,7 +98,7 @@ def get_clean_base64(value):
     if value is None:
         return ""
     try:
-        return base64.b64decode(value).decode("utf-8","replace") # wouldn't this be cleaner than below?
+        return base64.b64decode(value).decode("utf-8", "replace")  # wouldn't this be cleaner than below?
     except UnicodeDecodeError as ue:
         # decoding of UTF-8 fail when you have a binary payload in the HTTP response
         # so we just cut it to have only the header and add fake body


### PR DESCRIPTION
This aims at fixing import issues when:
 1. A response is missing from the request/response pair.
 2. Propose a simpler way of dealing with non-utf-8 compliant requests/responses. Sometimes it can be a single character that breaks this and not always in the body of the request/response.