### PR TITLE
Docker volume for /var/lib/rabbitmq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,9 @@ services:
        - defectdojo_data:/var/lib/mysql
   rabbitmq:
     image: rabbitmq:3.8.17@sha256:02a9baba56dc6065a64c76330f75d5b5722258c67e94371853bf29728713f686
+    volumes:
+       - defectdojo_rabbitmq:/var/lib/rabbitmq
 volumes:
   defectdojo_data: {}
   defectdojo_media: {}
+  defectdojo_rabbitmq: {}


### PR DESCRIPTION
A new volume with a generic name gets created everytime you start the dev or other environment with docker. This volume contains files for RabbitMQ. https://hub.docker.com/_/rabbitmq states:

> This image makes all of /var/lib/rabbitmq a volume by default

`var/lib/rabbitmq` contains RabbitMQ's internal database among other things.

This PR inserts a volume statement for docker-compose so that the same volume is used every time the container is started. Otherwise messages, that have not yet been consumed, could get lost with a restart.