### PR TITLE
Improve factory to support Python >= 3.8

### DIFF
--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -53,21 +53,23 @@ def requires_file(scan_type):
 
 import os
 from inspect import isclass
-from pkgutil import iter_modules
+from pkgutil import iter_modules, find_loader
 from pathlib import Path
 from importlib import import_module
 
 # iterate through the modules in the current package
-package_dir = str(Path(__file__).resolve().parent)
-for (path, module_name, _) in iter_modules([package_dir]):
-    # check if it's submodule
+package_dir = Path(__file__).resolve().parent
+for module_name in os.listdir(package_dir):
+    # check if it's dir
     if os.path.isdir(os.path.join(package_dir, module_name)):
         try:
-            # import the module and iterate through its attributes
-            module = import_module(f"dojo.tools.{module_name}.parser")
-            for attribute_name in dir(module):
-                attribute = getattr(module, attribute_name)
-                if isclass(attribute) and attribute_name.lower() == module_name.replace("_", "") + 'parser':
-                    register(attribute)
+            # check if it's a Python module
+            if find_loader(os.path.join(package_dir, module_name)):
+                # import the module and iterate through its attributes
+                module = import_module(f"dojo.tools.{module_name}.parser")
+                for attribute_name in dir(module):
+                    attribute = getattr(module, attribute_name)
+                    if isclass(attribute) and attribute_name.lower() == module_name.replace("_", "") + 'parser':
+                        register(attribute)
         except:
             logging.exception(f"failed to load {module_name}")

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -53,7 +53,7 @@ def requires_file(scan_type):
 
 import os
 from inspect import isclass
-from pkgutil import iter_modules, find_loader
+from pkgutil import find_loader
 from pathlib import Path
 from importlib import import_module
 

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -53,18 +53,18 @@ def requires_file(scan_type):
 
 import os
 from inspect import isclass
-from pkgutil import find_loader
 from pathlib import Path
 from importlib import import_module
+from importlib.util import find_spec
 
 # iterate through the modules in the current package
-package_dir = Path(__file__).resolve().parent
+package_dir = str(Path(__file__).resolve().parent)
 for module_name in os.listdir(package_dir):
     # check if it's dir
     if os.path.isdir(os.path.join(package_dir, module_name)):
         try:
             # check if it's a Python module
-            if find_loader(os.path.join(package_dir, module_name)):
+            if find_spec(f"dojo.tools.{module_name}.parser"):
                 # import the module and iterate through its attributes
                 module = import_module(f"dojo.tools.{module_name}.parser")
                 for attribute_name in dir(module):


### PR DESCRIPTION
Made some tests with Python > 3.6 (the current version of our containers) and the loading fail.
This patch will make us ok with version 3.8 and 3.9.