### PR TITLE
Fix Github Issue Creation

### DIFF
--- a/dojo/github.py
+++ b/dojo/github.py
@@ -145,7 +145,7 @@ def add_external_issue_github(find, prod, eng):
 
 
 def github_body(find):
-    template = 'issue-trackers/github-body.tpl'
+    template = 'issue-trackers/jira_full/jira-description.tpl'
     kwargs = {}
     kwargs['finding'] = find
     return render_to_string(template, kwargs)


### PR DESCRIPTION
There is no `GitHub-body.tpl' file (and never was from what it looks like) so use the Jira one instead since it already does a good job at listing all pertinent info.