### PR TITLE
Dockle parser findings marked static and dynamic

### DIFF
--- a/dojo/tools/dockle/parser.py
+++ b/dojo/tools/dockle/parser.py
@@ -52,6 +52,7 @@ class DockleParser(object):
                     severity=severity,
                     description=description,
                     static_finding=True,
+                    dynamic_finding=False,
                     nb_occurences=1,
                     vuln_id_from_tool=code,
                 )

--- a/dojo/tools/dockle/parser.py
+++ b/dojo/tools/dockle/parser.py
@@ -47,7 +47,7 @@ class DockleParser(object):
                 finding.nb_occurences += 1
             else:
                 finding = Finding(
-                    title=f"Found {code}: {title}",
+                    title=f"{code}: {title}",
                     test=test,
                     severity=severity,
                     description=description,

--- a/dojo/unittests/tools/test_dockle_parser.py
+++ b/dojo/unittests/tools/test_dockle_parser.py
@@ -19,27 +19,30 @@ class TestDockleParser(TestCase):
 
         with self.subTest(i=0):
             finding = findings[0]
-            self.assertEqual("Found CIS-DI-0001: Create a user for the container", finding.title)
+            self.assertEqual("CIS-DI-0001: Create a user for the container", finding.title)
             self.assertEqual("Medium", finding.severity)
             self.assertIsNotNone(finding.description)
             self.assertTrue(finding.static_finding)
+            self.assertFalse(finding.dynamic_finding)
             self.assertEqual(1, finding.nb_occurences)
             self.assertEqual("CIS-DI-0001", finding.vuln_id_from_tool)
 
         with self.subTest(i=1):
             finding = findings[1]
-            self.assertEqual("Found CIS-DI-0005: Enable Content trust for Docker", finding.title)
+            self.assertEqual("CIS-DI-0005: Enable Content trust for Docker", finding.title)
             self.assertEqual("Low", finding.severity)
             self.assertIsNotNone(finding.description)
             self.assertTrue(finding.static_finding)
+            self.assertFalse(finding.dynamic_finding)
             self.assertEqual(1, finding.nb_occurences)
             self.assertEqual("CIS-DI-0005", finding.vuln_id_from_tool)
 
         with self.subTest(i=2):
             finding = findings[2]
-            self.assertEqual("Found CIS-DI-0008: Confirm safety of setuid/setgid files", finding.title)
+            self.assertEqual("CIS-DI-0008: Confirm safety of setuid/setgid files", finding.title)
             self.assertEqual("Low", finding.severity)
             self.assertIsNotNone(finding.description)
             self.assertTrue(finding.static_finding)
+            self.assertFalse(finding.dynamic_finding)
             self.assertEqual(1, finding.nb_occurences)
             self.assertEqual("CIS-DI-0008", finding.vuln_id_from_tool)


### PR DESCRIPTION
Findings from the Dockle parser are marked as static and dynamic findings, which causes problems with reimports. This PR marks the findings as static only.

Additionally I removed the prefix "Found " from the title, as it doesn't add any information but makes the titles more crowded and distracts from the useful information.