### PR TITLE
Bugfixes for Questionnaires

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -87,9 +87,6 @@ User.objects.create_superuser(
 )
 EOD
 
-  echo "Preparing survey fixture"
-  # surveys fixture needs to be modified as it contains an instance dependant polymorphic content id
-  python3 manage.py import_surveys
   # load surveys all at once as that's much faster
    echo "Importing fixtures all at once"
    python3 manage.py loaddata system_settings initial_banner_conf product_type test_type \
@@ -107,4 +104,8 @@ EOD
 
   echo "Installing watson search index"
   python3 manage.py installwatson
+
+  # surveys fixture needs to be modified as it contains an instance dependant polymorphic content id
+  echo "Migration of textquestions for surveys"
+  python3 manage.py migrate_textquestions
 fi

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -3030,7 +3030,7 @@ class AssignUserForm(forms.ModelForm):
             assignee = kwargs.pop('asignees')
         super(AssignUserForm, self).__init__(*args, **kwargs)
         if assignee is None:
-            self.fields['assignee'] = forms.ModelChoiceField(queryset=User.objects.all(), empty_label='Not Assigned', required=False)
+            self.fields['assignee'] = forms.ModelChoiceField(queryset=Dojo_User.objects.all(), empty_label='Not Assigned', required=False)
         else:
             self.fields['assignee'].initial = assignee
 

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -9,7 +9,7 @@ from django.http import HttpResponseRedirect, HttpResponse, HttpRequest
 from django.shortcuts import render
 from django.utils import timezone
 
-from django.db.models import Count
+from django.db.models import Count, Q
 from dojo.utils import add_breadcrumb, get_punchcard_data
 from dojo.models import Answered_Survey
 from dojo.authorization.roles_permissions import Permissions
@@ -46,7 +46,11 @@ def dashboard(request: HttpRequest) -> HttpResponse:
     severity_count_by_month = get_severities_by_month(findings, today)
     punchcard, ticks = get_punchcard_data(findings, today - relativedelta(weeks=26), 26)
 
-    unassigned_surveys = Answered_Survey.objects.filter(assignee_id__isnull=True, completed__gt=0)
+    if request.user.is_staff:
+        unassigned_surveys = Answered_Survey.objects.filter(assignee_id__isnull=True, completed__gt=0, ) \
+            .filter(Q(engagement__isnull=True) | Q(engagement__in=engagements))
+    else:
+        unassigned_surveys = None
 
     add_breadcrumb(request=request, clear=True)
     return render(request, 'dojo/dashboard.html', {

--- a/dojo/management/commands/migrate_textquestions.py
+++ b/dojo/management/commands/migrate_textquestions.py
@@ -1,0 +1,32 @@
+import logging
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Textquestions for surveys need to be modified after loading the fixture 
+    as they contain an instance dependant polymorphic content id
+    """
+    help = 'Usage: manage.py migration_textquestions'
+
+    def handle(self, *args, **options):
+        logger.info('Started migrating textquestions ...')
+
+        update_textquestions = """UPDATE dojo_question
+SET polymorphic_ctype_id = (
+    SELECT id
+    FROM django_content_type
+    WHERE app_label = 'dojo'
+      AND model = 'textquestion')
+WHERE
+    id IN (SELECT question_ptr_id
+           FROM dojo_textquestion)"""
+
+        with connection.cursor() as cursor:
+            cursor.execute(update_textquestions)
+
+        logger.info('Finished migrating textquestions')

--- a/dojo/management/commands/migrate_textquestions.py
+++ b/dojo/management/commands/migrate_textquestions.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     """
-    Textquestions for surveys need to be modified after loading the fixture 
+    Textquestions for surveys need to be modified after loading the fixture
     as they contain an instance dependant polymorphic content id
     """
     help = 'Usage: manage.py migration_textquestions'

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -1,8 +1,3 @@
-'''
-Created on Feb 18, 2015
-
-@author: jay7958
-'''
 import pickle
 from datetime import date
 
@@ -14,9 +9,9 @@ from django.urls import reverse
 from django.http.response import HttpResponseRedirect, HttpResponse, Http404
 from django.shortcuts import render, get_object_or_404
 from django.utils.html import escape
-from pytz import timezone
 from datetime import timedelta
 from django.utils import timezone as tz
+from django.conf import settings
 
 from dojo.filters import QuestionnaireFilter, QuestionFilter
 from dojo.models import Engagement, System_Settings
@@ -27,11 +22,12 @@ from dojo.forms import Add_Questionnaire_Form, Delete_Questionnaire_Form, Create
     AddEngagementForm, AddGeneralQuestionnaireForm, DeleteGeneralQuestionnaireForm
 from dojo.models import Answered_Survey, Engagement_Survey, Answer, TextQuestion, ChoiceQuestion, Choice, General_Survey, Question
 from dojo.user.helper import check_auth_users_list
+from dojo.authorization.authorization import user_has_permission_or_403, user_has_permission
+from dojo.authorization.roles_permissions import Permissions
+from dojo.authorization.authorization_decorators import user_is_authorized
 
-localtz = timezone('America/Chicago')
 
-
-@user_passes_test(lambda u: u.is_staff)
+@user_is_authorized(Engagement, Permissions.Engagement_Edit, 'eid', 'staff')
 def delete_engagement_survey(request, eid, sid):
     engagement = get_object_or_404(Engagement, id=eid)
     survey = get_object_or_404(Answered_Survey, id=sid)
@@ -73,16 +69,18 @@ def answer_questionnaire(request, eid, sid):
     survey = get_object_or_404(Answered_Survey, id=sid)
     engagement = get_object_or_404(Engagement, id=eid)
     prod = engagement.product
-    settings = System_Settings.objects.all()[0]
+    system_settings = System_Settings.objects.all()[0]
 
-    if not settings.allow_anonymous_survey_repsonse:
-        auth = request.user.is_staff or check_auth_users_list(request.user, prod)
+    if not system_settings.allow_anonymous_survey_repsonse:
+        if not settings.FEATURE_AUTHORIZATION_V2:
+            auth = check_auth_users_list(request.user, prod)
+        else:
+            auth = user_has_permission(request.user, engagement, Permissions.Engagement_Edit)
         if not auth:
             messages.add_message(request,
                                  messages.ERROR,
-                                 'You must be logged in to answer questionnaire. Otherwise, enable anonymous response in system settings.',
+                                 'You must be authorized to answer questionnaire. Otherwise, enable anonymous response in system settings.',
                                  extra_tags='alert-danger')
-            # will render 403
             raise PermissionDenied
 
     questions = get_answered_questions(survey=survey, read_only=False)
@@ -130,15 +128,10 @@ def answer_questionnaire(request, eid, sid):
                    })
 
 
-@user_passes_test(lambda u: u.is_staff)
+@user_is_authorized(Engagement, Permissions.Engagement_Edit, 'eid', 'staff')
 def assign_questionnaire(request, eid, sid):
     survey = get_object_or_404(Answered_Survey, id=sid)
     engagement = get_object_or_404(Engagement, id=eid)
-    prod = engagement.product
-    auth = request.user.is_staff or check_auth_users_list(request.user, prod)
-    if not auth:
-        # will render 403
-        raise PermissionDenied
 
     form = AssignUserForm(instance=survey)
     if request.method == 'POST':
@@ -156,7 +149,7 @@ def assign_questionnaire(request, eid, sid):
                    })
 
 
-@user_passes_test(lambda u: u.is_staff)
+@user_is_authorized(Engagement, Permissions.Engagement_View, 'eid', 'staff')
 def view_questionnaire(request, eid, sid):
     survey = get_object_or_404(Answered_Survey, id=sid)
     engagement = get_object_or_404(Engagement, id=eid)
@@ -397,12 +390,12 @@ def questionnaire(request):
                                  'For docker-compose, run `docker ps -a` to find the uwsgi container name then `docker exec -it <conainter_name> ./manage.py migrate_sruveys`',
                                  extra_tags='alert-info')
 
-    add_breadcrumb(title="All Questionnaires", top_level=True, request=request)
+    add_breadcrumb(title="Questionnaires", top_level=True, request=request)
     return render(request, 'defectDojo-engagement-survey/list_surveys.html',
                   {"surveys": paged_surveys,
                    "filtered": surveys,
                    "general": general_surveys,
-                   "name": "All Surveys",
+                   "name": "Questionnaires",
                    })
 
 
@@ -509,17 +502,17 @@ def edit_question(request, qid):
 
     type = str(ContentType.objects.get_for_model(question))
 
-    if type == 'text question':
+    if type == 'dojo | text question':
         form = EditTextQuestionForm(instance=question)
-    elif type == 'choice question':
+    elif type == 'dojo | choice question':
         form = EditChoiceQuestionForm(instance=question)
     else:
         raise Http404()
 
     if request.method == 'POST':
-        if type == 'text question':
+        if type == 'dojo | text question':
             form = EditTextQuestionForm(request.POST, instance=question)
-        elif type == 'choice question':
+        elif type == 'dojo | choice question':
             form = EditChoiceQuestionForm(request.POST, instance=question)
         else:
             raise Http404()
@@ -776,23 +769,13 @@ def answer_empty_survey(request, esid):
 def engagement_empty_survey(request, esid):
     survey = get_object_or_404(Answered_Survey, id=esid)
     engagement = None
-    settings = System_Settings.objects.all()[0]
     form = AddEngagementForm()
-
-    if not settings.allow_anonymous_survey_repsonse:
-        auth = request.user.is_staff
-        if not auth:
-            messages.add_message(request,
-                                 messages.ERROR,
-                                 'You must be logged in to answer questionnaire. Otherwise, enable anonymous response in system settings.',
-                                 extra_tags='alert-danger')
-            # will render 403
-            raise PermissionDenied
 
     if request.method == 'POST':
         form = AddEngagementForm(request.POST)
         if form.is_valid():
             product = form.cleaned_data.get('product')
+            user_has_permission_or_403(request.user, product, Permissions.Engagement_Add)
             engagement = Engagement(product_id=product.id,
                                     target_start=tz.now().date(),
                                     target_end=tz.now().date() + timedelta(days=7))
@@ -809,6 +792,6 @@ def engagement_empty_survey(request, esid):
                                  messages.ERROR,
                                  'Questionnaire could not be added.',
                                  extra_tags='alert-danger')
-    add_breadcrumb(title="Add Empty Questionnaire", top_level=False, request=request)
+    add_breadcrumb(title="Link Questionnaire to new Engagement", top_level=False, request=request)
     return render(request, 'defectDojo-engagement-survey/add_engagement.html',
                   {'form': form})

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -401,15 +401,14 @@ def questionnaire(request):
 
 @user_passes_test(lambda u: u.is_staff)
 def questions(request):
-    user = request.user
     questions = Question.objects.all()
     questions = QuestionFilter(request.GET, queryset=questions)
     paged_questions = get_page_items(request, questions.qs, 25)
-    add_breadcrumb(title="All Questions", top_level=False, request=request)
+    add_breadcrumb(title="Questions", top_level=False, request=request)
     return render(request, 'defectDojo-engagement-survey/list_questions.html',
                   {"questions": paged_questions,
                    "filtered": questions,
-                   "name": "All Questions",
+                   "name": "Questions",
                    })
 
 

--- a/dojo/templates/defectDojo-engagement-survey/assign_survey.html
+++ b/dojo/templates/defectDojo-engagement-survey/assign_survey.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
     {{ block.super }}
-	<h3>Assign User to {{ survey }}</h3>
+	<h3>Assign User to Questionnaire {{ survey }}</h3>
 	<form class="form-horizontal" method="post">{% csrf_token %}
 		{% include "dojo/form_fields.html" with form=form %}
 		<div class="form-group">

--- a/dojo/templates/defectDojo-engagement-survey/list_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_questions.html
@@ -4,9 +4,17 @@
     {{ block.super }}
     <div class="row">
         <div class="col-md-10">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    {{ name }}
+                </div>
+            </div>
             {% if questions %}
+                <div class="clearfix">
+                    {% include "dojo/paging_snippet.html" with page=questions page_size=True %}
+                </div>
                 <div class="panel panel-default table-responsive">
-                    <table class="tablesorter-bootstrap table table-bordered table-condensed table-striped table-hover">
+                    <table id="groups" class="tablesorter-bootstrap table table-condensed table-striped">
                         <thead>
                         <tr>
                             <th>Text</th>
@@ -27,7 +35,9 @@
                         </tbody>
                     </table>
                 </div>
-                {% include "dojo/paging_snippet.html" with page=questions %}
+                <div class="clearfix">
+                    {% include "dojo/paging_snippet.html" with page=questions page_size=True %}
+                </div>
             {% else %}
                 No Questionnaires found.
             {% endif %}

--- a/dojo/templates/defectDojo-engagement-survey/list_surveys.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_surveys.html
@@ -3,10 +3,15 @@
     {{ block.super }}
     <div class="row">
         <div class="col-md-10">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    {{ name }}
+                </div>
+            </div>
             {% if surveys %}
-                <div class="panel panel-default table-responsive">
-                    <table class="tablesorter-bootstrap table table-bordered table-condensed table-striped table-hover">
-                        <thead>
+            <div class="panel panel-default table-responsive">
+                <table id="groups" class="tablesorter-bootstrap table table-condensed table-striped">
+                    <thead>
                         <tr>
                             <th>Name</th>
                             <th>Question Count</th>
@@ -26,7 +31,9 @@
                         </tbody>
                     </table>
                 </div>
-                {% include "dojo/paging_snippet.html" with page=surveys %}
+                <div class="clearfix">
+                    {% include "dojo/paging_snippet.html" with page=surveys page_size=True %}
+                </div>
             {% else %}
                 No questionnaires found.
             {% endif %}

--- a/dojo/templates/defectDojo-engagement-survey/surveys.html
+++ b/dojo/templates/defectDojo-engagement-survey/surveys.html
@@ -1,3 +1,5 @@
+{% load display_tags %}
+{% load authorization_tags %}
 {% if surveys %}
     <table id="surveys" class="tablesorter-bootstrap table table-condensed table-striped">
         <thead>
@@ -32,21 +34,25 @@
                                     <i class="fa fa-edit"></i> Edit Responses</a>
                                 </li>
                                 {% endif %}
+                                {% if survey.engagement|has_object_permission:"Engagement_Edit" or user|is_authorized_for_change:survey.engagement %}
                                 <li role="presentation"
                                     ><a class="" href="/engagement/{{ survey.engagement.id }}/questionnaire/{{ survey.id }}/assign">
                                         <i class="fa fa-plus"></i> Assign User</a>
                                 </li>
+                                {% endif %}
                                 <li>
                                     <a class="" data-toggle="modal"
                                     data-target="#shareQuestionnaireModal"
                                     data-whatever="/engagement/{{ survey.engagement.id }}/questionnaire/{{ survey.id }}/answer">
                                     <i class="fa fa-share-alt"></i> Share Questionnaire</a>
                                 </li>
+                                {% if survey.engagement|has_object_permission:"Engagement_Edit" or user|is_authorized_for_change:survey.engagement %}
                                 <li class="divider"></li>
                                 <li role="presentation">
                                     <a class="text-danger" href="/engagement/{{ survey.engagement.id }}/questionnaire/{{ survey.id }}/delete">
                                     <i class="fa fa-trash-o"></i> Delete Questionnaire</a>
                                 </li>
+                                {% endif %}
                             </ul>
                         </li>
                     </ul>

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -129,7 +129,7 @@
         </div>
         <!-- /.col-lg-6 -->
     </div>
-    {% if system_settings.enable_questionnaires %}
+    {% if system_settings.enable_questionnaires and request.user.is_staff %}
     <div class="row">
         <div class="col-lg-12">
             <div class="panel panel-default">


### PR DESCRIPTION
This PR solves several problems with questionnaires:

- Operations on questionnaires that are linked to engagements are now completely authorized with AuthV2
- The script to change the `polymorphic_ctype_id` of the fixture for text questions didn't work with docker, because all files in the docker container are write protected. It has been replaced by a new script, which does a SQL update after the fixture has been loaded
- Questions couldn't been edited because of failing check of the type of the question
- The design of the questionnaires list and questions list had some layout problems and are now more in line with other dialogues