### PR TITLE
Add Rate Limiting to Login Page

### DIFF
--- a/docs/content/en/integrations/rate_limiting.md
+++ b/docs/content/en/integrations/rate_limiting.md
@@ -46,7 +46,7 @@ In the event of a brute force attack, a users credentials could potentially be c
 
 In an attempt to circumvent that event, setting `DD_RATE_LIMITER_ACCOUNT_LOCKOUT` will force a user to reset their password upon the next attempted login. 
 
-#### Multi-Process Behvaior
+#### Multi-Process Behavior
 
 When using configurations with multiple uwsgi processes, the rate limiting package uses the default cache that is memory based and local to a process.
 

--- a/docs/content/en/integrations/rate_limiting.md
+++ b/docs/content/en/integrations/rate_limiting.md
@@ -46,6 +46,10 @@ In the event of a brute force attack, a users credentials could potentially be c
 
 In an attempt to circumvent that event, setting `DD_RATE_LIMITER_ACCOUNT_LOCKOUT` will force a user to reset their password upon the next attempted login. 
 
+#### Multi-Process Behvaior
+
+When using configurations with multiple uwsgi processes, the rate limiting package uses the default cache that is memory based and local to a process.
+
 #### Extra Configuation 
 
 For further information, please visit the package documentation [Django Ratelimit](https://django-ratelimit.readthedocs.io/en/stable/index.html)

--- a/docs/content/en/integrations/rate_limiting.md
+++ b/docs/content/en/integrations/rate_limiting.md
@@ -1,0 +1,51 @@
+---
+title: "Rate Limiting"
+description: "Configurable rate limiting on the login page to mitigate brute force attacks"
+draft: false
+weight: 9
+---
+
+
+DefectDojo has protection against brute force attacks through rate limiting
+
+## Configuration
+
+For further information, please visit the package documentation [Django Ratelimit](https://django-ratelimit.readthedocs.io/en/stable/index.html)
+
+#### Enable Rate Limiting
+
+To enable and configure rate limiting, edit the `dojo/settings/settings.dist.py` file and edit/replace the following information:
+
+    {{< highlight python >}}
+    DD_RATE_LIMITER_ENABLED=(bool, True),
+    DD_RATE_LIMITER_RATE=(str, '5/m'),
+    DD_RATE_LIMITER_BLOCK=(bool, True),
+    DD_RATE_LIMITER_ACCOUNT_LOCKOUT=(bool, True),
+    {{< /highlight >}}
+
+#### Rate Limit
+
+The frequency at which the request will be limited can be set to 
+
+* seconds - `1s`
+* minutes - `5m`
+* hours - `100h`
+* days - `2400d`
+
+Extended configuration can be found [here](https://django-ratelimit.readthedocs.io/en/stable/rates.html)
+
+#### Block Requests
+
+By default, rate limiting is set to record offenses, but does not actually block requests and enforce the limit.
+
+Setting `DD_RATE_LIMITER_BLOCK` will block all incoming requests at the configured frequncy once that frequency has been exceeded. 
+
+#### Account Lockout 
+
+In the event of a brute force attack, a users credentials could potentially be comprimised. 
+
+In an attempt to circumvent that event, setting `DD_RATE_LIMITER_ACCOUNT_LOCKOUT` will force a user to reset their password upon the next attempted login. 
+
+#### Extra Configuation 
+
+For further information, please visit the package documentation [Django Ratelimit](https://django-ratelimit.readthedocs.io/en/stable/index.html)

--- a/docs/content/en/integrations/rate_limiting.md
+++ b/docs/content/en/integrations/rate_limiting.md
@@ -46,10 +46,6 @@ In the event of a brute force attack, a users credentials could potentially be c
 
 In an attempt to circumvent that event, setting `DD_RATE_LIMITER_ACCOUNT_LOCKOUT` will force a user to reset their password upon the next attempted login. 
 
-#### Multi-Process Behvaior
-
-When using configurations with multiple uwsgi processes, the rate limiting package uses the default cache that is memory based and local to a process.
-
 #### Extra Configuation 
 
 For further information, please visit the package documentation [Django Ratelimit](https://django-ratelimit.readthedocs.io/en/stable/index.html)

--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -1,9 +1,15 @@
 from functools import wraps
-from dojo.models import Finding
+from dojo.models import Finding, Dojo_User
 from django.db import models
 from django.conf import settings
 from django.forms.models import model_to_dict
 from django.db.models.query import QuerySet
+from django.conf import settings
+
+from ratelimit.exceptions import Ratelimited
+from ratelimit.core import is_ratelimited
+from ratelimit import ALL
+
 import logging
 
 
@@ -197,3 +203,28 @@ def on_exception_log_kwarg(func):
             raise(e)
 
     return wrapper
+
+
+def dojo_ratelimit(key='ip', rate=None, method=ALL, block=False):
+    def decorator(fn):
+        @wraps(fn)
+        def _wrapped(request, *args, **kw):
+            _block = getattr(settings, 'RATE_LIMITER_BLOCK', block)
+            _rate = getattr(settings, 'RATE_LIMITER_RATE', rate)
+            _lockout = getattr(settings, 'RATE_LIMITER_ACCOUNT_LOCKOUT', False)
+            old_limited = getattr(request, 'limited', False)
+            ratelimited = is_ratelimited(request=request, fn=fn,
+                                         key=key, rate=_rate, method=method,
+                                         increment=True)
+            request.limited = ratelimited or old_limited
+            if ratelimited and _block:
+                if _lockout:
+                    username = request.POST.get('username', None)
+                    if username:
+                        dojo_user = Dojo_User.objects.filter(username=username).first()
+                        if dojo_user:
+                            Dojo_User.enable_force_password_rest(dojo_user)
+                raise Ratelimited()
+            return fn(request, *args, **kw)
+        return _wrapped
+    return decorator

--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -4,7 +4,6 @@ from django.db import models
 from django.conf import settings
 from django.forms.models import model_to_dict
 from django.db.models.query import QuerySet
-from django.conf import settings
 
 from ratelimit.exceptions import Ratelimited
 from ratelimit.core import is_ratelimited

--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.conf import settings
 from django.forms.models import model_to_dict
 from django.db.models.query import QuerySet
+from django.conf import settings
 
 from ratelimit.exceptions import Ratelimited
 from ratelimit.core import is_ratelimited

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -180,7 +180,15 @@ env = environ.Env(
     # Initial behaviour in Defect Dojo was to delete all duplicates when an original was deleted
     # New behaviour is to leave the duplicates in place, but set the oldest of duplicates as new original
     # Set to True to revert to the old behaviour where all duplicates are deleted
-    DD_DUPLICATE_CLUSTER_CASCADE_DELETE=(str, False)
+    DD_DUPLICATE_CLUSTER_CASCADE_DELETE=(str, False),
+    # Enable Rate Limiting for the login page
+    DD_RATE_LIMITER_ENABLED=(bool, False),
+    # Examples include 5/m 100/h and more https://django-ratelimit.readthedocs.io/en/stable/rates.html#simple-rates
+    DD_RATE_LIMITER_RATE=(str, '5/m'),
+    # Block the requests after rate limit is exceeded
+    DD_RATE_LIMITER_BLOCK=(bool, False),
+    # Forces the user to change password on next login.
+    DD_RATE_LIMITER_ACCOUNT_LOCKOUT=(bool, False),
 )
 
 
@@ -488,6 +496,12 @@ AUTH_PASSWORD_VALIDATORS = [
         'NAME': 'dojo.user.validators.SymbolValidator'
     }
 ]
+
+# https://django-ratelimit.readthedocs.io/en/stable/index.html
+RATE_LIMITER_ENABLED = env('DD_RATE_LIMITER_ENABLED')
+RATE_LIMITER_RATE = env('DD_RATE_LIMITER_RATE')  # Examples include 5/m 100/h and more https://django-ratelimit.readthedocs.io/en/stable/rates.html#simple-rates
+RATE_LIMITER_BLOCK = env('DD_RATE_LIMITER_BLOCK')  # Block the requests after rate limit is exceeded
+RATE_LIMITER_ACCOUNT_LOCKOUT = env('DD_RATE_LIMITER_ACCOUNT_LOCKOUT')  # Forces the user to change password on next login. 
 
 # ------------------------------------------------------------------------------
 # SECURITY DIRECTIVES

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -501,7 +501,7 @@ AUTH_PASSWORD_VALIDATORS = [
 RATE_LIMITER_ENABLED = env('DD_RATE_LIMITER_ENABLED')
 RATE_LIMITER_RATE = env('DD_RATE_LIMITER_RATE')  # Examples include 5/m 100/h and more https://django-ratelimit.readthedocs.io/en/stable/rates.html#simple-rates
 RATE_LIMITER_BLOCK = env('DD_RATE_LIMITER_BLOCK')  # Block the requests after rate limit is exceeded
-RATE_LIMITER_ACCOUNT_LOCKOUT = env('DD_RATE_LIMITER_ACCOUNT_LOCKOUT')  # Forces the user to change password on next login.
+RATE_LIMITER_ACCOUNT_LOCKOUT = env('DD_RATE_LIMITER_ACCOUNT_LOCKOUT')  # Forces the user to change password on next login. 
 
 # ------------------------------------------------------------------------------
 # SECURITY DIRECTIVES

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -501,7 +501,7 @@ AUTH_PASSWORD_VALIDATORS = [
 RATE_LIMITER_ENABLED = env('DD_RATE_LIMITER_ENABLED')
 RATE_LIMITER_RATE = env('DD_RATE_LIMITER_RATE')  # Examples include 5/m 100/h and more https://django-ratelimit.readthedocs.io/en/stable/rates.html#simple-rates
 RATE_LIMITER_BLOCK = env('DD_RATE_LIMITER_BLOCK')  # Block the requests after rate limit is exceeded
-RATE_LIMITER_ACCOUNT_LOCKOUT = env('DD_RATE_LIMITER_ACCOUNT_LOCKOUT')  # Forces the user to change password on next login. 
+RATE_LIMITER_ACCOUNT_LOCKOUT = env('DD_RATE_LIMITER_ACCOUNT_LOCKOUT')  # Forces the user to change password on next login.
 
 # ------------------------------------------------------------------------------
 # SECURITY DIRECTIVES

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -26,6 +26,7 @@ from dojo.product.queries import get_authorized_product_members_for_user
 from dojo.group.queries import get_authorized_group_members_for_user
 from dojo.product_type.queries import get_authorized_product_type_members_for_user
 from dojo.authorization.roles_permissions import Permissions
+from dojo.decorators import dojo_ratelimit
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,8 @@ def api_v2_key(request):
 # #  user specific
 
 
+@dojo_ratelimit(key='post:username')
+@dojo_ratelimit(key='post:password')
 def login_view(request):
     if not settings.SHOW_LOGIN_FORM and settings.SOCIAL_LOGIN_AUTO_REDIRECT and sum([
         settings.GOOGLE_OAUTH_ENABLED,

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,3 +71,4 @@ hyperlink==21.0.0
 django-test-migrations==1.1.0
 djangosaml2==1.3.2
 drf-spectacular==0.17.2
+django-ratelimit==3.0.1


### PR DESCRIPTION
Dependent on #4783

Add the ability to rate limit the login page. 

Uses https://github.com/jsocol/django-ratelimit