### PR TITLE
Skip false positives from detect-secrets report

### DIFF
--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -25,8 +25,6 @@ class DetectSecretsParser(object):
             find_date = dateutil.parser.parse(data.get('generated_at'))
         for detect_file in data.get('results'):
             for item in data.get('results').get(detect_file):
-                if 'is_secret' in item and item['is_secret'] is False:
-                    continue
                 type = item.get('type')
                 file = item.get('filename')
                 hashed_secret = item.get('hashed_secret')
@@ -50,6 +48,7 @@ class DetectSecretsParser(object):
                         file_path=file,
                         line=line,
                         nb_occurences=1,
+                        false_p='is_secret' in item and item['is_secret'] is False,
                     )
                     dupes[dupe_key] = finding
         return list(dupes.values())

--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -25,6 +25,8 @@ class DetectSecretsParser(object):
             find_date = dateutil.parser.parse(data.get('generated_at'))
         for detect_file in data.get('results'):
             for item in data.get('results').get(detect_file):
+                if 'is_secret' in item and item['is_secret'] == False:
+                    continue
                 type = item.get('type')
                 file = item.get('filename')
                 hashed_secret = item.get('hashed_secret')

--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -25,7 +25,7 @@ class DetectSecretsParser(object):
             find_date = dateutil.parser.parse(data.get('generated_at'))
         for detect_file in data.get('results'):
             for item in data.get('results').get(detect_file):
-                if 'is_secret' in item and item['is_secret'] == False:
+                if 'is_secret' in item and item['is_secret'] is False:
                     continue
                 type = item.get('type')
                 file = item.get('filename')

--- a/dojo/unittests/scans/detect_secrets/many_findings.json
+++ b/dojo/unittests/scans/detect_secrets/many_findings.json
@@ -109,7 +109,8 @@
         "filename": "modules_images",
         "hashed_secret": "535850f35566365fddf9eb01a0d36962c0ffed8c",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 156,
+        "is_secret": true
       }
     ],
     "example/pkg/docker_registry_watcher/docker_config.go": [
@@ -127,7 +128,8 @@
         "filename": "example/pkg/docker_registry_watcher/docker_registry_watcher.go",
         "hashed_secret": "b732fb611fd46a38e8667f9972e0cde777fbe37f",
         "is_verified": false,
-        "line_number": 112
+        "line_number": 112,
+        "is_secret": false
       }
     ]
   },

--- a/dojo/unittests/tools/test_detect_secrets_parser.py
+++ b/dojo/unittests/tools/test_detect_secrets_parser.py
@@ -28,6 +28,7 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("modules_images", finding.file_path)
             self.assertEqual(151, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertFalse(finding.false_p)
 
         with self.subTest(i=1):
             finding = findings[1]
@@ -38,6 +39,7 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("modules_images", finding.file_path)
             self.assertEqual(156, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertFalse(finding.false_p)
 
         with self.subTest(i=2):
             finding = findings[2]
@@ -48,6 +50,7 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("example/pkg/docker_registry_watcher/docker_config.go", finding.file_path)
             self.assertEqual(109, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertFalse(finding.false_p)
 
         with self.subTest(i=3):
             finding = findings[3]
@@ -58,3 +61,4 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("example/pkg/docker_registry_watcher/docker_registry_watcher.go", finding.file_path)
             self.assertEqual(112, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertTrue(finding.false_p)


### PR DESCRIPTION
This Pull Request includes a fix in [detect-secrets](https://github.com/Yelp/detect-secrets) parser to skip the findings established as False Positive. For that, I check the value of the `is_secret` field:

- If the `is_secret` field is not present, the finding could be a real secret.
- If the `is_secret` field it's true, the finding it's a real secret.
- If the `is_secret` field it's false, the finding it's a false positive.

The reference to the `is_secret` field can be checked in this [link](https://github.com/Yelp/detect-secrets/blob/b206dc29f274839ebd3c522fed19448c9b8f3f70/detect_secrets/core/potential_secret.py#L40).