### PR TITLE
Add flag to enable/disable a parser

### DIFF
--- a/dojo/db_migrations/0115_test_type_active.py
+++ b/dojo/db_migrations/0115_test_type_active.py
@@ -1,0 +1,17 @@
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dojo', '0114_cyclonedx_vuln_uniqu'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='test_type',
+            name='active',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/dojo/db_migrations/0116_test_type_active.py
+++ b/dojo/db_migrations/0116_test_type_active.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dojo', '0114_cyclonedx_vuln_uniqu'),
+        ('dojo', '0115_language_types'),
     ]
 
     operations = [

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -555,6 +555,7 @@ class Test_Type(models.Model):
     name = models.CharField(max_length=200, unique=True)
     static_tool = models.BooleanField(default=False)
     dynamic_tool = models.BooleanField(default=False)
+    active = models.BooleanField(default=True)
 
     def __str__(self):
         return self.name

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -41,11 +41,7 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
 def get_choices():
     res = list()
     for key in PARSERS:
-        test_type, created = Test_Type.objects.get_or_create(name=key)
-        if created:
-            test_type.save()
-        if test_type.active:
-            res.append((key, PARSERS[key].get_label_for_scan_types(key)))
+        res.append((key, PARSERS[key].get_label_for_scan_types(key)))
     return tuple(res)
 
 

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -31,6 +31,8 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
         test_type, created = Test_Type.objects.get_or_create(name=scan_type)
         if created:
             test_type.save()
+        if not test_type.active:
+            raise ValueError(f"Parser {scan_type} is not active")
         return PARSERS[scan_type]
     else:
         raise ValueError(f'Unknown Test Type {scan_type}')
@@ -39,7 +41,11 @@ def import_parser_factory(file, test, active, verified, scan_type=None):
 def get_choices():
     res = list()
     for key in PARSERS:
-        res.append((key, PARSERS[key].get_label_for_scan_types(key)))
+        test_type, created = Test_Type.objects.get_or_create(name=key)
+        if created:
+            test_type.save()
+        if test_type.active:
+            res.append((key, PARSERS[key].get_label_for_scan_types(key)))
     return tuple(res)
 
 


### PR DESCRIPTION
Add a flag `active` in `Test_Type` entity to disable or enable a parser. `True` by default.

I made the modification aligned with the current behavior, i.e. default to "all parser enabled", but it will be easy to block one parser by API or directly in DB for now.
  