### PR TITLE
Updated semgrep parser.py due to Info error when importing scan results

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ See [Wrappers](WRAPPERS.md)
 
 
 ## Release and branch model
+
+We release every month on the last Tuesday. These release are minor releases, i.e. 2.0.0 to 2.1.0. In between there might be bugfix/hotfix/patch releases when needed, i.e. 2.0.1.
+
 See [Release and branch model](BRANCHING-MODEL.md)
 
 

--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -67,5 +67,7 @@ class SemgrepParser(object):
             return "Low"
         elif "ERROR" == val.upper():
             return "High"
+        elif "INFO" == val.upper():
+            return "Info"
         else:
             raise ValueError(f"Unknown value for severity: {val}")

--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -68,6 +68,6 @@ class SemgrepParser(object):
         elif "ERROR" == val.upper():
             return "High"
         elif "INFO" == val.upper():
-            return "Info"
+            return "Informational"
         else:
             raise ValueError(f"Unknown value for severity: {val}")


### PR DESCRIPTION
The Info severity was not recognised by the semgrep parser because it was not included in the code. It was thus implemented.