### PR TITLE
Semgrep: Add support for INFO severity

### DIFF
--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -68,6 +68,6 @@ class SemgrepParser(object):
         elif "ERROR" == val.upper():
             return "High"
         elif "INFO" == val.upper():
-            return "Informational"
+            return "Info"
         else:
             raise ValueError(f"Unknown value for severity: {val}")

--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -67,5 +67,7 @@ class SemgrepParser(object):
             return "Low"
         elif "ERROR" == val.upper():
             return "High"
+        elif "INFO" == val.upper():
+            return "Informational"
         else:
             raise ValueError(f"Unknown value for severity: {val}")


### PR DESCRIPTION
Updated semgrep parser.py because the Info severity tag was not recognised