### PR TITLE
Fix file upload on Kubernetes deployment

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -46,6 +46,8 @@ spec:
       volumes:
       - name: run
         emptyDir: {}
+      - name: media
+        emptyDir: {}
       {{- if  .Values.django.uwsgi.certificates.enabled }}
       - name: cert-mount
         configMap:
@@ -90,6 +92,8 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run/defectdojo
+        - name: media
+          mountPath: /app/media/
         {{- if  .Values.django.uwsgi.certificates.enabled }}
         - name: cert-mount
           mountPath: {{ .Values.django.uwsgi.certificates.certMountPath }}
@@ -169,6 +173,8 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run/defectdojo
+        - name: media
+          mountPath: /usr/share/nginx/html/media
         ports:
         - name: http
           protocol: TCP


### PR DESCRIPTION
Currently on Kubernetes deployment (via the Official HELM chart) the file and image upload functionalities do not work.

Once you upload an image or a file, the document is stored on the /app/media path of the uwsgi server but it is not accessible by the Nginx component (serving the file via the /usr/share/nginx/html/media path) resulting in error 404 once you try to view the image.

The above issue happens because there is no shared volume between uwsgi container and the Nginx container, resulting to Nginx not been able to fetch and serve the files.