### PR TITLE
Bring unique_id_from_tool back to Finding filter

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -188,8 +188,6 @@ def get_finding_filter_fields(metrics=False, similar=False):
     if similar:
         fields.extend([
             'id',
-            'unique_id_from_tool',
-            'vuln_id_from_tool',
             'hash_code'
         ])
 
@@ -228,6 +226,8 @@ def get_finding_filter_fields(metrics=False, similar=False):
                 'has_component',
                 'has_notes',
                 'file_path',
+                'unique_id_from_tool',
+                'vuln_id_from_tool',
     ])
 
     if similar:


### PR DESCRIPTION
Fixes #4822

There was another user asking for the same thing on Slack and I can see the point of having the `unique_id_from_tool` in the filter. Same goes for `vuln_id_from_tool` so I moved this as well.