### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For detailed documentation you can visit
 ## Getting Started
 
 We recommend checking out the
-[Core Data Classes](https://defectdojo.github.io/usage/models/) document to
+[Core Data Classes](https://defectdojo.github.io/django-DefectDojo/usage/models/) document to
 learn the terminology of DefectDojo and the
 [getting started guide](https://defectdojo.github.io/django-DefectDojo/getting_started/)
 for setting up a new installation.


### PR DESCRIPTION
Fix broken link with correct URL.
Searched the rest of the repo for similar links and appears to be the only occurrence