### PR TITLE
Nessus parser: Fix error when fqdn is missing

### DIFF
--- a/dojo/tools/nessus/parser.py
+++ b/dojo/tools/nessus/parser.py
@@ -210,7 +210,7 @@ class NessusXMLParser(object):
                         find.unsaved_endpoints = list()
                         dupes[dupe_key] = find
 
-                    if '://' in fqdn:
+                    if fqdn and '://' in fqdn:
                         endpoint = Endpoint.from_uri(fqdn)
                     else:
                         if protocol == 'general':


### PR DESCRIPTION
Fixes following error when fqdn is missing in XML:

```
ERROR [dojo.importers.utils:27] argument of type 'NoneType' is not iterable
Traceback (most recent call last):
  File "/app/./dojo/importers/utils.py", line 16, in parse_findings
    parsed_findings = parser.get_findings(scan, test)
  File "/app/./dojo/tools/nessus/parser.py", line 254, in get_findings
    return NessusXMLParser().get_findings(filename, test)
  File "/app/./dojo/tools/nessus/parser.py", line 213, in get_findings
    if '://' in fqdn:
TypeError: argument of type 'NoneType' is not iterable
```