### PR TITLE
Remove setup.py from GHA

### DIFF
--- a/.github/workflows/new-release-master-into-dev.yml
+++ b/.github/workflows/new-release-master-into-dev.yml
@@ -49,7 +49,6 @@ jobs:
       - name: Check numbers
         run: |
           grep version dojo/__init__.py
-          grep version setup.py
           grep appVersion helm/defectdojo/Chart.yaml
           grep version components/package.json
       - name: Push version changes


### PR DESCRIPTION
The "merge back into dev" GHA failed because the file no longer exists.
