### PR TITLE
Two problems with reviews for findings

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -487,7 +487,7 @@ def defect_finding_review(request, fid):
             new_note.date = now
             new_note.save()
             finding.notes.add(new_note)
-            finding.under_defect_review = False
+            finding.under_review = False
             defect_choice = form.cleaned_data['defect_choice']
 
             if defect_choice == "Close Finding":
@@ -963,7 +963,7 @@ def request_finding_review(request, fid):
                 reverse('view_finding', args=(finding.id, )))
 
     else:
-        form = ReviewFindingForm()
+        form = ReviewFindingForm(finding=finding)
 
     product_tab = Product_Tab(finding.test.engagement.product.id, title="Review Finding", tab="findings")
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1510,6 +1510,16 @@ class ReviewFindingForm(forms.Form):
                                      'required, please use the text area '
                                      'below to provide documentation.')})
 
+    def __init__(self, *args, **kwargs):
+        finding = None
+        if 'finding' in kwargs:
+            finding = kwargs.pop('finding')
+
+        super(ReviewFindingForm, self).__init__(*args, **kwargs)
+
+        if finding is not None and settings.FEATURE_AUTHORIZATION_V2:
+            self.fields['reviewers'].queryset = get_authorized_users_for_product_and_product_type(None, finding.test.engagement.product, Permissions.Finding_Edit)
+
     class Meta:
         fields = ['reviewers', 'entry']
 


### PR DESCRIPTION
Reviews for findings had 2 problems that are fixed here:

- When a review gets requested, the attribute `under_review` in the finding is set to `True`. When the review is finished, this attribute was not set back to `False`.
- All staff users could be selected for review. This doesn't make sense anymore with the new authorization. Now all users can be selected who have the `Finding_Edit` permission.

While working on these problems I found 2 issue with selecting users by product and permission:

- The group membership was implemented wrongly
- Global roles where not implemented