### PR TITLE
Install chromium driver in Python

### DIFF
--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -28,14 +28,7 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 
-RUN pip install --no-cache-dir selenium requests
-
-# Installing Chromium Driver and Selenium for test automation
-RUN LATEST_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE) && \
-    wget -O /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/$LATEST_VERSION/chromedriver_linux64.zip && \
-    unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/ && \
-    rm /tmp/chromedriver.zip && \
-    chmod 777 /usr/local/bin/chromedriver;
+RUN pip install --no-cache-dir selenium requests chromedriver-autoinstaller
 
 COPY docker/wait-for-it.sh \
   docker/entrypoint-integration-tests.sh \
@@ -44,6 +37,12 @@ COPY docker/wait-for-it.sh \
 COPY tests/ ./tests/
 
 RUN chmod -R 0777 /app
+
+# These 2 lines are needed for the chromium driver 
+RUN chmod -R ugo+w /usr/local/lib/python3.8/site-packages
+RUN mkdir /.local
+RUN chmod -R ugo+w /.local
+
 USER 1001
 ENV \
   DD_ADMIN_USER=admin \

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -1,4 +1,5 @@
 from selenium import webdriver
+import chromedriver_autoinstaller
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -48,6 +49,9 @@ def set_suite_settings(suite, jira=False, github=False, block_execution=False):
 class BaseTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
+
+        chromedriver_autoinstaller.install()
+
         global dd_driver
         if not dd_driver:
             # setupModule and tearDownModule are not working in our scenario, so for now we use setupClass and a global variable


### PR DESCRIPTION
Today the integration tests were not running anymore, because the latest chrome driver didn't support the current stable chromium browser, see https://github.com/DefectDojo/django-DefectDojo/runs/3192403317?check_suite_focus=true

According to https://chromedriver.chromium.org/downloads/version-selection the method how the chromium driver was selected is not reliable:

> In addition, the version of ChromeDriver for the current stable release of Chrome can be found at https://chromedriver.storage.googleapis.com/LATEST_RELEASE. However, using on this file may be less reliable than methods described above.

The Python library [chromedriver-autoinstaller](https://pypi.org/project/chromedriver-autoinstaller/) installs automatically the driver for the currently installed chromium browser and seems to be the better solution. 