### PR TITLE
Two bugfixes for engagemens lists

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -84,7 +84,7 @@ def engagement_calendar(request):
 def engagement(request):
     products = get_authorized_products(Permissions.Engagement_View).distinct()
     engagements = Engagement.objects.filter(
-        product__in=products
+        product__in=products, active=True
     ).select_related(
         'product',
         'product__prod_type',

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -79,7 +79,8 @@
                                     {% endif %}
                                     <td> {{ e.status }} </td>
                                     <td> {{ e.target_start }} - {{ e.target_end }}
-                                        {% if e.is_overdue %}<sup><div class="tag-label warning-color">{{ e.target_end|overdue }} overdue</div></sup>
+                                        {% if e.is_overdue and e.active %}
+                                        <sup><div class="tag-label warning-color">{{ e.target_end|overdue }} overdue</div></sup>
                                         {% endif %}
                                     </td>
                                     <td> {{ e.lead.first_name }} {{ e.lead.last_name }}</td>


### PR DESCRIPTION
Russel Butturini reported 2 problems with engagement lists on Slack (https://owasp.slack.com/archives/C2P5BA8MN/p1627400327160700):

- The active engagements view shows all engagements (even those marked as completed).
- One other thing of note is that closed engagements show the "past due" designation even though they are closed.

This PR fixes both bugs.