### PR TITLE
Bugfix and enhancement for SLA notifications

### DIFF
--- a/dojo/templates/notifications/sla_breach.tpl
+++ b/dojo/templates/notifications/sla_breach.tpl
@@ -77,6 +77,14 @@
                 "text": "A SLA for a finding has been breached.",
                 "facts": [
                     {
+                        "name": "Product:",
+                        "value": "{{ finding.test.engagement.product.name }}"
+                    },
+                    {
+                        "name": "Engagement:",
+                        "value": "{{ finding.test.engagement.name }}"
+                    },
+                    {
                         "name": "Finding:",
                         "value": "{{ finding.title }}"
                     },

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1746,6 +1746,7 @@ def sla_compute_and_notify(*args, **kwargs):
             event='sla_breach',
             title=title,
             finding=finding,
+            url=reverse('view_finding', args=(finding.id,)),
             sla_age=sla_age
         )
 
@@ -1817,7 +1818,7 @@ def sla_compute_and_notify(*args, **kwargs):
                 jira_issue = None
                 if finding.has_jira_issue:
                     jira_issue = finding.jira_issue
-                elif finding.grouped:
+                elif finding.has_finding_group:
                     jira_issue = finding.finding_group.jira_issue
 
                 if jira_issue:


### PR DESCRIPTION
Fixes one bug and one enhancement:

- #4848 - Finding has no 'grouped' attribute when sending notifications
- #4871 - Add Product name in MS Teams notifications and enhance URL in View button for SLA Breach
