### PR TITLE
Added API for Notifications and enhancements for MetaData API

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1,10 +1,10 @@
 from typing import List
 from drf_spectacular.utils import extend_schema_field
 from drf_yasg.utils import swagger_serializer_method
-from rest_framework.fields import DictField
+from rest_framework.fields import DictField, MultipleChoiceField
 
 from dojo.endpoint.utils import endpoint_filter
-from dojo.models import Finding_Group, Product, Engagement, Test, Finding, \
+from dojo.models import Dojo_User, Finding_Group, Product, Engagement, Test, Finding, \
     User, Stub_Finding, Risk_Acceptance, \
     Finding_Template, Test_Type, Development_Environment, NoteHistory, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
@@ -14,7 +14,7 @@ from dojo.models import Finding_Group, Product, Engagement, Test, Finding, \
     System_Settings, FileUpload, SEVERITY_CHOICES, Test_Import, \
     Test_Import_Finding_Action, Product_Type_Member, Product_Member, \
     Product_Group, Product_Type_Group, Dojo_Group, Role, Global_Role, Dojo_Group_Member, \
-    Language_Type, Languages, Notifications
+    Language_Type, Languages, Notifications, NOTIFICATION_CHOICES
 
 from dojo.forms import ImportScanForm
 from dojo.tools.factory import requires_file
@@ -1473,8 +1473,51 @@ class FindingNoteSerializer(serializers.Serializer):
 
 
 class NotificationsSerializer(serializers.ModelSerializer):
+    product = serializers.PrimaryKeyRelatedField(queryset=Product.objects.all(),
+                                                 required=False,
+                                                 default=None,
+                                                 allow_null=True)
+    user = serializers.PrimaryKeyRelatedField(queryset=Dojo_User.objects.all(),
+                                                 required=False,
+                                                 default=None,
+                                                 allow_null=True)
+    product_type_added = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    product_added = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    engagement_added = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    test_added = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    scan_added = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    jira_update = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    upcoming_engagement = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    stale_engagement = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    auto_close_engagement = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    close_engagement = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    user_mentioned = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    code_review = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    review_requested = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    other = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    sla_breach = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
+    risk_acceptance_expiration = MultipleChoiceField(choices=NOTIFICATION_CHOICES)
 
     class Meta:
         model = Notifications
         fields = '__all__'
 
+    def validate(self, data):
+        user = None
+        product = None
+
+        if self.instance is not None:
+            user = self.instance.user
+            product = self.instance.product
+
+        if 'user' in data:
+            user = data.get('user')
+        if 'product' in data:
+            product = data.get('product')
+
+        if self.instance is None or user != self.instance.user or product != self.instance.product:
+            notifications = Notifications.objects.filter(user=user, product=product).count()
+            if notifications > 0:
+                raise ValidationError("Notification for user and product already exists")
+
+        return data

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -14,7 +14,7 @@ from dojo.models import Finding_Group, Product, Engagement, Test, Finding, \
     System_Settings, FileUpload, SEVERITY_CHOICES, Test_Import, \
     Test_Import_Finding_Action, Product_Type_Member, Product_Member, \
     Product_Group, Product_Type_Group, Dojo_Group, Role, Global_Role, Dojo_Group_Member, \
-    Language_Type, Languages
+    Language_Type, Languages, Notifications
 
 from dojo.forms import ImportScanForm
 from dojo.tools.factory import requires_file
@@ -1470,3 +1470,11 @@ class SystemSettingsSerializer(TaggitSerializer, serializers.ModelSerializer):
 
 class FindingNoteSerializer(serializers.Serializer):
     note_id = serializers.IntegerField()
+
+
+class NotificationsSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Notifications
+        fields = '__all__'
+

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -17,7 +17,7 @@ from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema, no_body
 import base64
 from dojo.engagement.services import close_engagement, reopen_engagement
-from dojo.models import Language_Type, Languages, Product, Product_Type, Engagement, Test, Test_Import, Test_Type, Finding, \
+from dojo.models import Language_Type, Languages, Notifications, Product, Product_Type, Engagement, Test, Test_Import, Test_Type, Finding, \
     User, Stub_Finding, Finding_Template, Notes, \
     JIRA_Issue, Tool_Product_Settings, Tool_Configuration, Tool_Type, \
     Endpoint, JIRA_Project, JIRA_Instance, DojoMeta, Development_Environment, \
@@ -2290,3 +2290,17 @@ class SystemSettingsViewSet(mixins.ListModelMixin,
     permission_classes = (permissions.IsSuperUser, DjangoModelPermissions)
     serializer_class = serializers.SystemSettingsSerializer
     queryset = System_Settings.objects.all()
+
+
+# Authorization: superuser
+class NottificationsViewSet(mixins.ListModelMixin,
+                            mixins.RetrieveModelMixin,
+                            mixins.DestroyModelMixin,
+                            mixins.CreateModelMixin,
+                            mixins.UpdateModelMixin,
+                            viewsets.GenericViewSet):
+    serializer_class = serializers.NotificationsSerializer
+    queryset = Notifications.objects.all()
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'user', 'product')
+    permission_classes = (permissions.IsSuperUser, DjangoModelPermissions)

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1118,18 +1118,34 @@ class SonarqubeProductViewSet(mixins.ListModelMixin,
 
 
 # Authorization: object-based
-class DojoMetaViewSet(mixins.ListModelMixin,
-                     mixins.RetrieveModelMixin,
-                     mixins.DestroyModelMixin,
-                     mixins.CreateModelMixin,
-                     mixins.UpdateModelMixin,
-                     viewsets.GenericViewSet):
+@extend_schema_view(
+    list=extend_schema(parameters=[
+            OpenApiParameter("prefetch", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False,
+                                description="List of fields for which to prefetch model instances and add those to the response"),
+    ],
+    ),
+    retrieve=extend_schema(parameters=[
+            OpenApiParameter("prefetch", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False,
+                                description="List of fields for which to prefetch model instances and add those to the response"),
+    ],
+    )
+)
+class DojoMetaViewSet(prefetch.PrefetchListMixin,
+                      prefetch.PrefetchRetrieveMixin,
+                      mixins.ListModelMixin,
+                      mixins.RetrieveModelMixin,
+                      mixins.DestroyModelMixin,
+                      mixins.CreateModelMixin,
+                      mixins.UpdateModelMixin,
+                      viewsets.GenericViewSet):
     serializer_class = serializers.MetaSerializer
     queryset = DojoMeta.objects.none()
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('id', 'product', 'endpoint', 'name', 'finding')
+    filter_fields = ('id', 'product', 'endpoint', 'finding', 'name', 'value')
     if settings.FEATURE_AUTHORIZATION_V2:
         permission_classes = (IsAuthenticated, permissions.UserHasDojoMetaPermission)
+    swagger_schema = prefetch.get_prefetch_schema(["metadata_list", "metadata_read"],
+        serializers.MetaSerializer).to_schema()
 
     def get_queryset(self):
         return get_authorized_dojo_meta(Permissions.Product_View)
@@ -2293,14 +2309,30 @@ class SystemSettingsViewSet(mixins.ListModelMixin,
 
 
 # Authorization: superuser
-class NottificationsViewSet(mixins.ListModelMixin,
-                            mixins.RetrieveModelMixin,
-                            mixins.DestroyModelMixin,
-                            mixins.CreateModelMixin,
-                            mixins.UpdateModelMixin,
-                            viewsets.GenericViewSet):
+@extend_schema_view(
+    list=extend_schema(parameters=[
+            OpenApiParameter("prefetch", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False,
+                                description="List of fields for which to prefetch model instances and add those to the response"),
+    ],
+    ),
+    retrieve=extend_schema(parameters=[
+            OpenApiParameter("prefetch", OpenApiTypes.STR, OpenApiParameter.QUERY, required=False,
+                                description="List of fields for which to prefetch model instances and add those to the response"),
+    ],
+    )
+)
+class NotificationsViewSet(prefetch.PrefetchListMixin,
+                           prefetch.PrefetchRetrieveMixin,
+                           mixins.ListModelMixin,
+                           mixins.RetrieveModelMixin,
+                           mixins.DestroyModelMixin,
+                           mixins.CreateModelMixin,
+                           mixins.UpdateModelMixin,
+                           viewsets.GenericViewSet):
     serializer_class = serializers.NotificationsSerializer
     queryset = Notifications.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'user', 'product')
     permission_classes = (permissions.IsSuperUser, DjangoModelPermissions)
+    swagger_schema = prefetch.get_prefetch_schema(["notifications_list", "notifications_read"],
+        serializers.NotificationsSerializer).to_schema()

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -2323,5 +2323,14 @@
         "code": 5,
         "created": "2018-04-16T06:54:35.940Z"
     }
+  },
+  {
+    "pk": 1,
+    "model": "dojo.notifications",
+    "fields": {
+      "product": 1,
+      "user": 2,
+      "product_type_added": ["slack"]
+    }
   }
 ]

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -20,7 +20,7 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     SonarqubeProductViewSet, RegulationsViewSet, ProductTypeMemberViewSet, ProductMemberViewSet, \
     DojoGroupViewSet, ProductGroupViewSet, ProductTypeGroupViewSet, RoleViewSet, GlobalRoleViewSet, \
     DojoGroupMemberViewSet, ImportLanguagesView, LanguageTypeViewSet, LanguageViewSet, \
-    NottificationsViewSet
+    NotificationsViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -109,7 +109,7 @@ v2_api.register(r'regulations', RegulationsViewSet)
 v2_api.register(r'language_types', LanguageTypeViewSet)
 v2_api.register(r'languages', LanguageViewSet)
 v2_api.register(r'import-languages', ImportLanguagesView, basename='importlanguages')
-v2_api.register(r'notifications', NottificationsViewSet, basename='notifications')
+v2_api.register(r'notifications', NotificationsViewSet, basename='notifications')
 
 ur = []
 ur += dev_env_urls

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -19,7 +19,8 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     AppAnalysisViewSet, EndpointStatusViewSet, SonarqubeIssueViewSet, SonarqubeIssueTransitionViewSet, \
     SonarqubeProductViewSet, RegulationsViewSet, ProductTypeMemberViewSet, ProductMemberViewSet, \
     DojoGroupViewSet, ProductGroupViewSet, ProductTypeGroupViewSet, RoleViewSet, GlobalRoleViewSet, \
-    DojoGroupMemberViewSet, ImportLanguagesView, LanguageTypeViewSet, LanguageViewSet
+    DojoGroupMemberViewSet, ImportLanguagesView, LanguageTypeViewSet, LanguageViewSet, \
+    NottificationsViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -108,6 +109,7 @@ v2_api.register(r'regulations', RegulationsViewSet)
 v2_api.register(r'language_types', LanguageTypeViewSet)
 v2_api.register(r'languages', LanguageViewSet)
 v2_api.register(r'import-languages', ImportLanguagesView, basename='importlanguages')
+v2_api.register(r'notifications', NottificationsViewSet, basename='notifications')
 
 ur = []
 ur += dev_env_urls


### PR DESCRIPTION
This PR contains 2 enhancements for the API:

- Added `/notifications` endpoint: Fixes  #4827
- Enhanced `/metadata` endpoint: A user asked on Slack to search for products via their metadata (https://owasp.slack.com/archives/C2P5BA8MN/p1627868437022900). This PR makes metadata searchable by values and introduces a prefetch for related objects.
