### PR TITLE
[GHA - release] Bump chart version when merging master back to dev

### DIFF
--- a/.github/workflows/new-release-master-into-dev.yml
+++ b/.github/workflows/new-release-master-into-dev.yml
@@ -46,6 +46,8 @@ jobs:
           sed -ri "s/__version__ = '.*'/__version__ = '${{ github.event.inputs.release_number_dev }}'/" dojo/__init__.py
           sed -ri "s/appVersion: \".*\"/appVersion: \"${{ github.event.inputs.release_number_dev }}\"/" helm/defectdojo/Chart.yaml
           sed -ri "s/\"version\": \".*\"/\"version\": \"${{ github.event.inputs.release_number_dev }}\"/" components/package.json
+          CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml)
+          sed -r "s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')/" helm/defectdojo/Chart.yaml
       - name: Check numbers
         run: |
           grep version dojo/__init__.py

--- a/.github/workflows/new-release-master-into-dev.yml
+++ b/.github/workflows/new-release-master-into-dev.yml
@@ -47,7 +47,7 @@ jobs:
           sed -ri "s/appVersion: \".*\"/appVersion: \"${{ github.event.inputs.release_number_dev }}\"/" helm/defectdojo/Chart.yaml
           sed -ri "s/\"version\": \".*\"/\"version\": \"${{ github.event.inputs.release_number_dev }}\"/" components/package.json
           CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml)
-          sed -r "s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')/" helm/defectdojo/Chart.yaml
+          sed -ri "s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')/" helm/defectdojo/Chart.yaml
       - name: Check numbers
         run: |
           grep version dojo/__init__.py

--- a/.github/workflows/new-release-master-into-dev.yml
+++ b/.github/workflows/new-release-master-into-dev.yml
@@ -47,7 +47,7 @@ jobs:
           sed -ri "s/appVersion: \".*\"/appVersion: \"${{ github.event.inputs.release_number_dev }}\"/" helm/defectdojo/Chart.yaml
           sed -ri "s/\"version\": \".*\"/\"version\": \"${{ github.event.inputs.release_number_dev }}\"/" components/package.json
           CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml)
-          sed -ri "s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')/" helm/defectdojo/Chart.yaml
+          sed -ri "s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')-dev/" helm/defectdojo/Chart.yaml
       - name: Check numbers
         run: |
           grep version dojo/__init__.py

--- a/.github/workflows/new-release-pr.yml
+++ b/.github/workflows/new-release-pr.yml
@@ -52,6 +52,10 @@ jobs:
           sed -ri "s/__version__ = '.*'/__version__ = '${{ github.event.inputs.release_number }}'/" dojo/__init__.py
           sed -ri "s/appVersion: \".*\"/appVersion: \"${{ github.event.inputs.release_number }}\"/" helm/defectdojo/Chart.yaml
           sed -ri "s/\"version\": \".*\"/\"version\": \"${{ github.event.inputs.release_number }}\"/" components/package.json
+          # remove the -dev suffix to make it the new final version in master
+          CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml)
+          sed -ri "s/version: \S+/version: ${CURRENT_CHART_VERSION%-*}/" helm/defectdojo/Chart.yaml
+
       - name: Check numbers
         run: |
           grep version dojo/__init__.py

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.1.0"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.10
+version: 1.6.10-dev
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.1.0"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.10-dev
+version: 1.6.10
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap


### PR DESCRIPTION
Submitted against `master` for immediate effect, addresses #4920.

An issue we've been having is at https://github.com/DefectDojo/django-DefectDojo/runs/3173934689?check_suite_focus=true

This PR will check the current chart version with 
```
CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml)
```

and then smartly increment it and also adding a `-dev` suffix (per @valentijnscholten's feedback)
```
sed -r "s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')/" helm/defectdojo/Chart.yaml
```

(I did not come up with that last regex, some people are smarter than me)

Since we're now adding a `-dev` suffix to the chart's version, that suffix is removed automatically when we submit the first PR from `dev`->`master`.