### PR TITLE
Remove nonexisting file reference in sample data

### DIFF
--- a/dojo/fixtures/defect_dojo_sample_data.json
+++ b/dojo/fixtures/defect_dojo_sample_data.json
@@ -17910,9 +17910,7 @@
         "endpoints": [],
         "reviewers": [],
         "notes": [],
-        "files": [
-            2
-        ],
+        "files": [],
         "found_by": [
             12
         ]
@@ -18854,9 +18852,7 @@
         "endpoints": [],
         "reviewers": [],
         "notes": [],
-        "files": [
-            1
-        ],
+        "files": [],
         "found_by": [
             3
         ]


### PR DESCRIPTION
There are two references to a file uploads on a finding that do not exist in the fixtures file. Removing them allows the fixtures to run again without failure