### PR TITLE
changed the severity to display the severity of the vulnerability when using sonarqube_api

### DIFF
--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -75,8 +75,10 @@ class SonarQubeApiImporter(object):
                 line = issue.get('line')
                 rule_id = issue['rule']
                 rule = client.get_rule(rule_id)
-                severity = self.convert_sonar_severity(rule['severity'])
-                description = self.clean_rule_description_html(rule['htmlDesc'])
+                #severity = self.convert_sonar_severity(rule['severity'])
+                # Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule 
+                severity = self.convert_sonar_severity(issue['severity'])
+		description = self.clean_rule_description_html(rule['htmlDesc'])
                 cwe = self.clean_cwe(rule['htmlDesc'])
                 references = self.get_references(rule['htmlDesc'])
 


### PR DESCRIPTION
changed the severity to display the severity of the vulnerability rather than the rules severity, in this way if the user has updated sonarqube_api finding that will be reflected in defect dojo 