### PR TITLE
SonarQube: use severity from issue instead of rule

### DIFF
--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -75,8 +75,6 @@ class SonarQubeApiImporter(object):
                 line = issue.get('line')
                 rule_id = issue['rule']
                 rule = client.get_rule(rule_id)
-                #severity = self.convert_sonar_severity(rule['severity'])
-                #Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule for better behavior
                 severity = self.convert_sonar_severity(issue['severity'])
                 description = self.clean_rule_description_html(rule['htmlDesc'])
                 cwe = self.clean_cwe(rule['htmlDesc'])

--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -78,7 +78,7 @@ class SonarQubeApiImporter(object):
                 #severity = self.convert_sonar_severity(rule['severity'])
                 # Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule 
                 severity = self.convert_sonar_severity(issue['severity'])
-            	description = self.clean_rule_description_html(rule['htmlDesc'])
+		        description = self.clean_rule_description_html(rule['htmlDesc'])
                 cwe = self.clean_cwe(rule['htmlDesc'])
                 references = self.get_references(rule['htmlDesc'])
 

--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -78,7 +78,7 @@ class SonarQubeApiImporter(object):
                 #severity = self.convert_sonar_severity(rule['severity'])
                 # Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule 
                 severity = self.convert_sonar_severity(issue['severity'])
-		description = self.clean_rule_description_html(rule['htmlDesc'])
+            	description = self.clean_rule_description_html(rule['htmlDesc'])
                 cwe = self.clean_cwe(rule['htmlDesc'])
                 references = self.get_references(rule['htmlDesc'])
 

--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -76,9 +76,9 @@ class SonarQubeApiImporter(object):
                 rule_id = issue['rule']
                 rule = client.get_rule(rule_id)
                 #severity = self.convert_sonar_severity(rule['severity'])
-                # Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule 
+                #Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule for better behavior
                 severity = self.convert_sonar_severity(issue['severity'])
-		        description = self.clean_rule_description_html(rule['htmlDesc'])
+                description = self.clean_rule_description_html(rule['htmlDesc'])
                 cwe = self.clean_cwe(rule['htmlDesc'])
                 references = self.get_references(rule['htmlDesc'])
 

--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -75,8 +75,10 @@ class SonarQubeApiImporter(object):
                 line = issue.get('line')
                 rule_id = issue['rule']
                 rule = client.get_rule(rule_id)
-                severity = self.convert_sonar_severity(rule['severity'])
-                description = self.clean_rule_description_html(rule['htmlDesc'])
+                #severity = self.convert_sonar_severity(rule['severity'])
+                # Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule 
+                severity = self.convert_sonar_severity(issue['severity'])
+		description = self.clean_rule_description_html(rule['htmlDesc'])
                 cwe = self.clean_cwe(rule['htmlDesc'])
                 references = self.get_references(rule['htmlDesc'])
 


### PR DESCRIPTION
Changed the code to show updated severity of the vulnerability rather than the vulnerability severity of the rule for better behavior for sonarqube_api