### PR TITLE
Endpoint: Fix report generation

### DIFF
--- a/dojo/reports/urls.py
+++ b/dojo/reports/urls.py
@@ -16,6 +16,8 @@ urlpatterns = [
         name='test_report'),
     url(r'^endpoint/(?P<eid>\d+)/report$', views.endpoint_report,
         name='endpoint_report'),
+    url(r'^endpoint/host/(?P<eid>\d+)/report$', views.endpoint_host_report,
+        name='endpoint_host_report'),
     url(r'^product/report$',
         views.product_findings_report, name='product_findings_report'),
     url(r'^reports/cover$',

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -205,7 +205,13 @@ def test_report(request, tid):
 @user_is_authorized(Endpoint, Permissions.Endpoint_View, 'eid', 'view')
 def endpoint_report(request, eid):
     endpoint = get_object_or_404(Endpoint, id=eid)
-    return generate_report(request, endpoint)
+    return generate_report(request, endpoint, False)
+
+
+@user_is_authorized(Endpoint, Permissions.Endpoint_View, 'eid', 'view')
+def endpoint_host_report(request, eid):
+    endpoint = get_object_or_404(Endpoint, id=eid)
+    return generate_report(request, endpoint, True)
 
 
 @user_is_authorized(Product, Permissions.Product_View, 'pid', 'view')
@@ -335,7 +341,7 @@ def product_endpoint_report(request, pid):
                    })
 
 
-def generate_report(request, obj):
+def generate_report(request, obj, host_view=False):
     user = Dojo_User.objects.get(id=request.user.id)
     product_type = None
     product = None
@@ -399,7 +405,6 @@ def generate_report(request, obj):
     if include_disclaimer and len(disclaimer) == 0:
         disclaimer = 'Please configure in System Settings.'
     generate = "_generate" in request.GET
-    host_view = "host_view" in request.GET
     report_name = str(obj)
     report_type = type(obj).__name__
     add_breadcrumb(title="Generate Report", top_level=False, request=request)

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -71,7 +71,7 @@
                                     </li>
                                     <li role="separator" class="divider"></li>
                                     <li role="presentation">
-                                        <a href="{% url 'endpoint_report' endpoint.id %}">
+                                        <a href="{% url 'endpoint_report' endpoint.id %}?active=1">
                                             <i class="fa fa-file-text-o"></i> Report
                                         </a>
                                     </li>
@@ -85,7 +85,7 @@
                                 {% endif %}
                               {% else %}
                                 <li role="presentation">
-                                    <a href="{% url 'endpoint_report' endpoint.id %}?host_view">
+                                    <a href="{% url 'endpoint_host_report' endpoint.id %}?&active=1">
                                         <i class="fa fa-file-text-o"></i> Report
                                     </a>
                                 </li>
@@ -127,8 +127,13 @@
 
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">{{ all_findings|length }}</span>
-                                    <span><a href="{% url 'endpoint_report' endpoint.id %}">endpoint
-                                        finding{{ all_findings|length|pluralize }} <i
+                                    <span>
+                                      {% if not host_view %}
+                                        <a href="{% url 'endpoint_report' endpoint.id %}">
+                                      {% else %}
+                                        <a href="{% url 'endpoint_host_report' endpoint.id %}">
+                                      {% endif %}
+                                            endpoint finding{{ all_findings|length|pluralize }} <i
                                                 class="fa fa-arrow-circle-right"></i></a>
                                     </span>
                                 </div>


### PR DESCRIPTION
Fix #4936

How: On report request: 
- show only active findings
- persist "host_view" (it was removed on click "apply filter")

One more: fix link on the top of graph
![image](https://user-images.githubusercontent.com/5609770/129477510-ad08a16c-c2ff-49e3-b33b-a12757d18c23.png)
