### PR TITLE
Fix newline characters in the summary (Jira issue)

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -617,7 +617,7 @@ def add_jira_issue(obj, *args, **kwargs):
                 'project': {
                     'key': jira_project.project_key
                 },
-                'summary': jira_summary(obj),
+                'summary': jira_summary(obj).replace('\r', '').replace('\n', ''),
                 'description': jira_description(obj),
                 'issuetype': {
                     'name': jira_instance.default_issue_type


### PR DESCRIPTION
Added `.replace('\r', '').replace('\n', '')` to summary.

Alternative: using `autofix` in JIRA config. (see https://jira.readthedocs.io/en/master/_modules/jira/config.html?highlight=autofix)

This bug depends on Finding titles. In my case, the Semgrep import put newlines characters in title.

Log fragment:
```
celeryworker_1  | 2021-08-18T12:02:33.806344825Z 
celeryworker_1  | 2021-08-18T12:02:34.778273729Z [18/Aug/2021 12:02:34] ERROR [dojo.jira_link.helper:711] JiraError HTTP 400 url: https://grib-test.atlassian.net/rest/api/2/issue
celeryworker_1  | 2021-08-18T12:02:34.778312271Z 	text: The summary is invalid because it contains newline characters.
celeryworker_1  | 2021-08-18T12:02:34.778337818Z 	
celeryworker_1  | 2021-08-18T12:02:34.778347416Z 	response headers = {'Server': 'AtlassianProxy/1.19.3.1', 'cache-control': 'no-cache, no-store, no-transform', 'Content-Type': 'application/json;charset=UTF-8', 'Strict-Transport-Security': 'max-age=315360000; includeSubDomains; preload', 'Date': 'Wed, 18 Aug 2021 12:02:34 GMT', ....................many headers}
celeryworker_1  | 2021-08-18T12:02:34.778365961Z 	response text = {"errorMessages":[],"errors":{"summary":"The summary is invalid because it contains newline characters."}}
celeryworker_1  | 2021-08-18T12:02:34.778377652Z Traceback (most recent call last):
celeryworker_1  | 2021-08-18T12:02:34.778384836Z   File "/app/dojo/jira_link/helper.py", line 670, in add_jira_issue
celeryworker_1  | 2021-08-18T12:02:34.778391789Z     new_issue = jira.create_issue(fields)
```
