### PR TITLE
Add Leak URL to Gitleaks parser

### DIFF
--- a/dojo/tools/gitleaks/parser.py
+++ b/dojo/tools/gitleaks/parser.py
@@ -48,6 +48,8 @@ class GitleaksParser(object):
                     line = issue["lineNumber"]
                 if "operation" in issue:
                     description += "**Operation:** " + issue["operation"] + "\n"
+                if "leakURL" in issue:
+                    description += "**Leak URL:** [" + issue["leakURL"] + "](" + issue["leakURL"] + ")\n"
                 description += "\n**String Found:**\n" + issue["line"].replace(issue["offender"], "REDACTED") + "\n"
 
                 severity = "High"


### PR DESCRIPTION
Gitleaks provides a link to the line of code that the leak was found, they call this the Leak URL. This is apart of the scan import as `leakURL`([source](https://pkg.go.dev/github.com/ed-wp/gitleaks/v7@v7.6.0/scan#Leak)), so we just need to add it to the description. I am not sure when this feature was added to Gitleaks, so I added a guard around it in the case that users are using an older version to ensure this doesn't break backwards compatibility.