### PR TITLE
Truncate Path, Query and Fragment Endpoint Fields to their Max Column Length

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1396,8 +1396,8 @@ class Endpoint(models.Model):
             host=url.host if url.host != '' else None,
             port=url.port,
             path='/'.join(url.path)[:500] if url.path not in [None, (), ('',)] else None,
-            query=query_string[:1000] if query_string != None and query_string != '' else None,
-            fragment=url.fragment[:500] if url.fragment != None and url.fragment != '' else None
+            query=query_string[:1000] if query_string is not None and query_string != '' else None,
+            fragment=url.fragment[:500] if url.fragment is not None and url.fragment != '' else None
         )
 
     def get_absolute_url(self):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1395,9 +1395,9 @@ class Endpoint(models.Model):
             userinfo=':'.join(url.userinfo) if url.userinfo not in [(), ('',)] else None,
             host=url.host if url.host != '' else None,
             port=url.port,
-            path='/'.join(url.path) if url.path not in [(), ('',)] else None,
-            query=query_string if query_string != '' else None,
-            fragment=url.fragment if url.fragment != '' else None
+            path='/'.join(url.path)[:500] if url.path not in [None, (), ('',)] else None,
+            query=query_string[:1000] if query_string != None and query_string != '' else None,
+            fragment=url.fragment[:500] if url.fragment != None and url.fragment != '' else None
         )
 
     def get_absolute_url(self):

--- a/dojo/unittests/test_endpoint_model.py
+++ b/dojo/unittests/test_endpoint_model.py
@@ -28,6 +28,15 @@ class TestEndpointModel(TestCase):
         self.assertEqual(endpoint.query, 'key1=value&no_value_key')
         self.assertEqual(endpoint.fragment, 'fragment1')
 
+    def test_truncates_large_attributes(self):
+        path = "foo" * 1000
+        query = "bar" * 1000
+        fragment = "baz" * 1000
+        endpoint = Endpoint.from_uri('http://alice@foo.bar:8080/{}?{}#{}'.format(path, query, fragment))
+        self.assertEqual(len(endpoint.path), 500)
+        self.assertEqual(len(endpoint.query), 1000)
+        self.assertEqual(len(endpoint.fragment), 500)
+
     def test_noscheme(self):
         endpoint = Endpoint.from_uri('//' + 'localhost:22')
         self.assertIsNone(endpoint.protocol)


### PR DESCRIPTION
Hi 👋

I noticed that some ZAP reports weren't importing correctly, because the http queries in the endpoints DefectDojo was trying to create were to long for the database schema. I discussed the issue briefly in the slack channel: https://owasp.slack.com/archives/C2P5BA8MN/p1629462343181800

This PR truncates the path, query and fragment attributes to the max length specified in for the database columns.