### PR TITLE
Deprecation notice for legacy authorization

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -6,10 +6,10 @@ weight: 5
 ---
 
 {{% alert title="Deprecation notice" color="warning" %}}
-Legacy authorization will be removed with version 2.5.0. If you have set 
-`FEATURE_AUTHORIZATION_V2` to `False` in your local configuration, remove this
-local setting before and start using the new authorization as described in 
-[Permissions]({{< ref "/usage/permissions" >}}).
+Legacy authorization will be removed with version 2.5.0 / end of November 2021.
+If you have set `FEATURE_AUTHORIZATION_V2` to `False` in your local configuration,
+remove this local setting before and start using the new authorization as described
+in [Permissions]({{< ref "/usage/permissions" >}}).
 {{% /alert %}}
 
 Docker-compose

--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -8,8 +8,16 @@ weight: 5
 {{% alert title="Deprecation notice" color="warning" %}}
 Legacy authorization will be removed with version 2.5.0 / end of November 2021.
 If you have set `FEATURE_AUTHORIZATION_V2` to `False` in your local configuration,
-remove this local setting before and start using the new authorization as described
+remove this local setting and start using the new authorization as described
 in [Permissions]({{< ref "/usage/permissions" >}}).
+
+Users have been migrated to the new authorization with release 2.0.0 but you can
+the migration again with
+
+`./manage.py migrate_authorization_v2`
+
+See [Authorization](https://defectdojo.github.io/django-DefectDojo/getting_started/upgrading/#authorization)
+for more details about the migration.
 {{% /alert %}}
 
 Docker-compose

--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -5,6 +5,12 @@ draft: false
 weight: 5
 ---
 
+{{% alert title="Deprecation notice" color="warning" %}}
+Legacy authorization will be removed with version 2.5.0. If you have set 
+`FEATURE_AUTHORIZATION_V2` to `False` in your local configuration, remove this
+local setting before and start using the new authorization as described in 
+[Permissions]({{< ref "/usage/permissions" >}}).
+{{% /alert %}}
 
 Docker-compose
 --------------

--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -12,7 +12,7 @@ remove this local setting and start using the new authorization as described
 in [Permissions]({{< ref "/usage/permissions" >}}).
 
 Users have been migrated to the new authorization with release 2.0.0 but you can
-the migration again with
+run the migration again with
 
 `./manage.py migrate_authorization_v2`
 

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -55,8 +55,8 @@ def dashboard(request: HttpRequest) -> HttpResponse:
         unassigned_surveys = None
 
     if request.user.is_superuser and not settings.FEATURE_AUTHORIZATION_V2:
-        message = '''Legacy authorization will be removed with version 2.5.0. If you
-                     have set `FEATURE_AUTHORIZATION_V2` to `False` in your local
+        message = '''Legacy authorization will be removed with version 2.5.0 / end of November 2021.
+                     If you have set `FEATURE_AUTHORIZATION_V2` to `False` in your local
                      configuration, remove this local setting before and start using
                      the new authorization.'''
         messages.add_message(request, messages.WARNING, message, extra_tags='alert-warning')

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -4,6 +4,8 @@ from typing import Dict
 
 from dateutil.relativedelta import relativedelta
 
+from django.conf import settings
+from django.contrib import messages
 from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse, HttpRequest
 from django.shortcuts import render
@@ -51,6 +53,13 @@ def dashboard(request: HttpRequest) -> HttpResponse:
             .filter(Q(engagement__isnull=True) | Q(engagement__in=engagements))
     else:
         unassigned_surveys = None
+
+    if request.user.is_superuser and not settings.FEATURE_AUTHORIZATION_V2:
+        message = '''Legacy authorization will be removed with version 2.5.0. If you
+                     have set `FEATURE_AUTHORIZATION_V2` to `False` in your local
+                     configuration, remove this local setting before and start using
+                     the new authorization.'''
+        messages.add_message(request, messages.WARNING, message, extra_tags='alert-warning')
 
     add_breadcrumb(request=request, clear=True)
     return render(request, 'dojo/dashboard.html', {

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -57,7 +57,7 @@ def dashboard(request: HttpRequest) -> HttpResponse:
     if request.user.is_superuser and not settings.FEATURE_AUTHORIZATION_V2:
         message = '''Legacy authorization will be removed with version 2.5.0 / end of November 2021.
                      If you have set `FEATURE_AUTHORIZATION_V2` to `False` in your local
-                     configuration, remove this local setting before and start using
+                     configuration, remove this local setting and start using
                      the new authorization.'''
         messages.add_message(request, messages.WARNING, message, extra_tags='alert-warning')
 


### PR DESCRIPTION
The deprecation notice for the legacy authorization will be shown:

- on top of the upgrading page in the documentation
- on top of the dashboard in the UI for superusers when the legacy authorization is still active

Additionally we might want to add the notice to the release notes for the next releases.