### PR TITLE
Semgrep: Add support for INFO severity

### DIFF
--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -68,6 +68,6 @@ class SemgrepParser(object):
         elif "ERROR" == val.upper():
             return "High"
         elif "INFO" == val.upper():
-            return "Informational"
+            return "Info"
         else:
             raise ValueError(f"Unknown value for severity: {val}")

--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -67,5 +67,7 @@ class SemgrepParser(object):
             return "Low"
         elif "ERROR" == val.upper():
             return "High"
+        elif "INFO" == val.upper():
+            return "Informational"
         else:
             raise ValueError(f"Unknown value for severity: {val}")

--- a/dojo/unittests/scans/semgrep/many_findings.json
+++ b/dojo/unittests/scans/semgrep/many_findings.json
@@ -130,7 +130,7 @@
             "https://capec.mitre.org/data/definitions/463.html"
           ]
         },
-        "severity": "WARNING",
+        "severity": "INFO",
         "fix": "javax crypto Cipher.getInstance(\"AES/GCM/NoPadding\");",
         "lines": "\t\t\tjavax.crypto.Cipher c = javax.crypto.Cipher.getInstance(\"DES/CBC/PKCS5Padding\");"
       }

--- a/dojo/unittests/tools/test_semgrep_parser.py
+++ b/dojo/unittests/tools/test_semgrep_parser.py
@@ -40,7 +40,7 @@ class TestSemgrepParser(TestCase):
         self.assertEqual("javax crypto Cipher.getInstance(\"AES/GCM/NoPadding\");", finding.mitigation)
         self.assertEqual("java.lang.security.audit.cbc-padding-oracle.cbc-padding-oracle", finding.vuln_id_from_tool)
         finding = findings[2]
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Info", finding.severity)
         self.assertEqual("src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01150.java", finding.file_path)
         self.assertEqual(66, finding.line)
         self.assertEqual(696, finding.cwe)


### PR DESCRIPTION
Recreated from #4818 

Updated semgrep parser.py to support the INFO severity