### PR TITLE
Fix 0120 migration when no SQ is configured

### DIFF
--- a/dojo/db_migrations/0120_sonarqube_test_and_clean.py
+++ b/dojo/db_migrations/0120_sonarqube_test_and_clean.py
@@ -13,11 +13,14 @@ def sq_clean(apps, schema_editor):
 
     sqtc = Tool_Configuration_model.objects.filter(tool_type__in=tts).first()
 
-    for sq in Sonarqube_Product_model.objects.filter(sonarqube_tool_config__isnull=True):
-        logger.warning('Setting Product SonarQube Configuration for product {} to only existing SonarQube Tool '
-                    'Configuration'.format(sq.product.pk))
-        sq.sonarqube_tool_config = sqtc
-        sq.save()
+    if sqtc:
+        for sq in Sonarqube_Product_model.objects.filter(sonarqube_tool_config__isnull=True):
+            logger.info('Setting Product SonarQube Configuration for product {} to only existing SonarQube Tool '
+                        'Configuration'.format(sq.product.pk))
+            sq.sonarqube_tool_config = sqtc
+            sq.save()
+    else:
+        logger.warning('No SonarQube tool config found, not updating any product SonaqQube configurations')
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Fix exception during migration:

```
[31/Aug/2021 17:53:55] WARNING [dojo.db_migrations.0120_sonarqube_test_and_clean:18] Setting Product SonarQube Configuration for product 229 to only existing SonarQube Tool Configuration
  Applying dojo.0120_sonarqube_test_and_clean...Traceback (most recent call last):
  File "/home/dojo/venv/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/home/dojo/venv/lib/python3.7/site-packages/django/db/backends/mysql/base.py", line 73, in execute
    return self.cursor.execute(query, args)
  File "/home/dojo/venv/lib/python3.7/site-packages/MySQLdb/cursors.py", line 206, in execute
    res = self._query(query)
  File "/home/dojo/venv/lib/python3.7/site-packages/MySQLdb/cursors.py", line 319, in _query
    db.query(q)
  File "/home/dojo/venv/lib/python3.7/site-packages/MySQLdb/connections.py", line 259, in query
    _mysql.connection.query(self, query)
MySQLdb._exceptions.OperationalError: (1138, 'Invalid use of NULL value')

The above exception was the direct cause of the following exception:
```