### PR TITLE
Better support SARIF ruleId attribute

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -80,7 +80,7 @@ def search_cwe(value, cwes):
 def get_rule_cwes(rule):
     cwes = []
     # data of the specification
-    if 'relationships' in rule: # and type(rule['relationships']) == list and len(rule['relationships'])>0:
+    if 'relationships' in rule and type(rule['relationships']) == list and len(rule['relationships'])>0:
         for relationship in rule['relationships']:
             value = relationship['target']['id']
             search_cwe(value, cwes)
@@ -201,7 +201,7 @@ def get_item(result, rules, artifacts, run_date):
         if len(cwes_extracted) > 0:
             cwes = cwes_extracted
         elif len(cwes_properties_extracted) > 0:
-            cwes = cwes_properties_extracted 
+            cwes = cwes_properties_extracted
 
     finding = Finding(
         title=textwrap.shorten(title, 150),

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -80,7 +80,7 @@ def search_cwe(value, cwes):
 def get_rule_cwes(rule):
     cwes = []
     # data of the specification
-    if 'relationships' in rule and type(rule['relationships']) == list and len(rule['relationships'])>0:
+    if 'relationships' in rule and type(rule['relationships']) == list:
         for relationship in rule['relationships']:
             value = relationship['target']['id']
             search_cwe(value, cwes)

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -156,14 +156,14 @@ def get_item(result, rules, artifacts, run_date):
                 line = location['physicalLocation']['region']['startLine']
 
     # test rule link
-    rule = rules.get(result['ruleId'])
-    title = result['ruleId']
+    rule = rules.get(result.get('ruleId'))
+    title = result.get('ruleId')
+    description = ''
     if 'message' in result:
         description = get_message_from_multiformatMessageString(
             result['message'], rule)
         if len(description) < 150:
             title = description
-    description = ''
     severity = get_severity(result.get('level', 'warning'))
     if rule is not None:
         # get the severity from the rule
@@ -195,8 +195,6 @@ def get_item(result, rules, artifacts, run_date):
         description=description,
         mitigation=mitigation,
         references=references,
-        # for now we only support when the id of the rule is a CVE
-        cve=cve_try(result['ruleId']),
         cwe=cwes[-1],
         static_finding=True,  # by definition
         dynamic_finding=False,  # by definition
@@ -206,6 +204,8 @@ def get_item(result, rules, artifacts, run_date):
 
     if 'ruleId' in result:
         finding.vuln_id_from_tool = result['ruleId']
+        # for now we only support when the id of the rule is a CVE
+        finding.cve = cve_try(result['ruleId'])
 
     if run_date:
         finding.date = run_date

--- a/dojo/unittests/scans/sarif/appendix_k4.sarif
+++ b/dojo/unittests/scans/sarif/appendix_k4.sarif
@@ -1,0 +1,745 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "runs": [
+    {
+      "automationId": {
+        "guid": "BC650830-A9FE-44CB-8818-AD6C387279A0",
+        "id": "Nightly code scan/2018-10-08"
+      },
+      "baselineGuid": "0A106451-C9B1-4309-A7EE-06988B95F723",
+      "runAggregates": [
+        {
+          "id": "Build/14.0.1.2/Release/20160716-13:22:18",
+          "correlationGuid": "26F138B6-6014-4D3D-B174-6E1ACE9439F3"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "CodeScanner",
+          "fullName": "CodeScanner 1.1 for Microsoft Windows (R) (en-US)",
+          "version": "2.1",
+          "semanticVersion": "2.1.0",
+          "dottedQuadFileVersion": "2.1.0.0",
+          "releaseDateUtc": "2019-03-17",
+          "organization": "Example Corporation",
+          "product": "Code Scanner",
+          "productSuite": "Code Quality Tools",
+          "shortDescription": {
+            "text": "A scanner for code."
+          },
+          "fullDescription": {
+            "text": "A really great scanner for all your code."
+          },
+          "properties": {
+            "copyright": "Copyright (c) 2017 by Example Corporation."
+          },
+          "globalMessageStrings": {
+            "variableDeclared": {
+              "text": "Variable \"{0}\" was declared here.",
+              "markdown": " Variable `{0}` was declared here."
+            }
+          },
+          "rules": [
+            {
+              "id": "C2001",
+              "deprecatedIds": [
+                "CA2000"
+              ],
+              "defaultConfiguration": {
+                "level": "error",
+                "rank": 95
+              },
+              "shortDescription": {
+                "text": "A variable was used without being initialized."
+              },
+              "fullDescription": {
+                "text": "A variable was used without being initialized. This can result\nin runtime errors such as null reference exceptions."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Variable \"{0}\" was used without being initialized.\nIt was declared [here]({1}).",
+                  "markdown": "Variable `{0}` was used without being initialized.\nIt was declared [here]({1})."
+                }
+              }
+            }
+          ],
+          "notifications": [
+            {
+              "id": "start",
+              "shortDescription": {
+                "text": "The run started."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Run started."
+                }
+              }
+            },
+            {
+              "id": "end",
+              "shortDescription": {
+                "text": "The run ended."
+              },
+              "messageStrings": {
+                "default": {
+                  "text": "Run ended."
+                }
+              }
+            }
+          ],
+          "language": "en-US"
+        },
+        "extensions": [
+          {
+            "name": "CodeScanner Security Rules",
+            "version": "3.1",
+            "rules": [
+              {
+                "id": "S0001",
+                "defaultConfiguration": {
+                  "level": "error"
+                },
+                "shortDescription": {
+                  "text": "Do not use weak cryptographic algorithms."
+                },
+                "messageStrings": {
+                  "default": {
+                    "text": "The cryptographic algorithm '{0}' should not be used."
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "language": "en-US",
+      "versionControlProvenance": [
+        {
+          "repositoryUri": "https://github.com/example-corp/browser",
+          "revisionId": "5da53fbb2a0aaa12d648b73984acc9aac2e11c2a",
+          "mappedTo": {
+            "uriBaseId": "PROJECTROOT"
+          }
+        }
+      ],
+      "originalUriBaseIds": {
+        "PROJECTROOT": {
+          "uri": "file://build.example.com/work/"
+        },
+        "SRCROOT": {
+          "uri": " src/",
+          "uriBaseId": "PROJECTROOT"
+        },
+        "BINROOT": {
+          "uri": " bin/",
+          "uriBaseId": "PROJECTROOT"
+        }
+      },
+      "invocations": [
+        {
+          "commandLine": "CodeScanner @build/collections.rsp",
+          "responseFiles": [
+            {
+              "uri": "build/collections.rsp",
+              "uriBaseId": "SRCROOT",
+              "index": 0
+            }
+          ],
+          "startTimeUtc": "2016-07-16T14:18:25Z",
+          "endTimeUtc": "2016-07-16T14:19:01Z",
+          "machine": "BLD01",
+          "account": "buildAgent",
+          "processId": 1218,
+          "fileName": "/bin/tools/CodeScanner",
+          "workingDirectory": {
+            "uri": "file:///home/buildAgent/src"
+          },
+          "environmentVariables": {
+            "PATH": "/usr/local/bin:/bin:/bin/tools:/home/buildAgent/bin",
+            "HOME": "/home/buildAgent",
+            "TZ": "EST"
+          },
+          "toolConfigurationNotifications": [
+            {
+              "descriptor": {
+                "id": "UnknownRule"
+              },
+              "associatedRule": {
+                "ruleId": "ABC0001"
+              },
+              "level": "warning",
+              "message": {
+                "text": "Could not disable rule \"ABC0001\" because\nthere is no rule with that id."
+              }
+            }
+          ],
+          "toolExecutionNotifications": [
+            {
+              "descriptor": {
+                "id": "CTN0001"
+              },
+              "level": "note",
+              "message": {
+                "text": "Run started."
+              }
+            },
+            {
+              "descriptor": {
+                "id": "CTN9999"
+              },
+              "associatedRule": {
+                "id": "C2001",
+                "index": 0
+              },
+              "level": "error",
+              "message": {
+                "text": "Exception evaluating rule \"C2001\". Rule disabled;\nrun continues."
+              },
+              "locations": [
+                {
+                  "physicalLocation": {
+                    "artifactLocation": {
+                      "uri": "crypto/hash.cpp",
+                      "uriBaseId": "SRCROOT",
+                      "index": 4
+                    }
+                  }
+                }
+              ],
+              "threadId": 52,
+              "timeUtc": "2016-07-16T14:18:43.119Z",
+              "exception": {
+                "kind": "ExecutionEngine.RuleFailureException",
+                "message": "Unhandled exception during rule evaluation.",
+                "stack": {
+                  "frames": [
+                    {
+                      "location": {
+                        "message": {
+                          "text": "Exception thrown"
+                        },
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName":
+                              "Rules.SecureHashAlgorithmRule.Evaluate"
+                          }
+                        ],
+                        "physicalLocation": {
+                          "address": {
+                            "offset": 4244988
+                          }
+                        }
+                      },
+                      "module": "RuleLibrary",
+                      "threadId": 52
+                    },
+                    {
+                      "location": {
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName":
+                              "ExecutionEngine.Engine.EvaluateRule"
+                          }
+                        ],
+                        "physicalLocation": {
+                          "address": {
+                            "offset": 4245514
+                          }
+                        }
+                      },
+                      "module": "ExecutionEngine",
+                      "threadId": 52
+                    }
+                  ]
+                },
+                "innerExceptions": [
+                  {
+                    "kind": "System.ArgumentException",
+                    "message": "length is < 0"
+                  }
+                ]
+              }
+            },
+            {
+              "descriptor": {
+                "id": "CTN0002"
+              },
+              "level": "note",
+              "message": {
+                "text": "Run ended."
+              }
+            }
+          ],
+          "exitCode": 0,
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "build/collections.rsp",
+            "uriBaseId": "SRCROOT"
+          },
+          "mimeType": "text/plain",
+          "length": 81,
+          "contents": {
+            "text": "-input src/collections/*.cpp -log out/collections.sarif -rules all -disable C9999"
+          }
+        },
+        {
+          "location": {
+            "uri": "application/main.cpp",
+            "uriBaseId": "SRCROOT"
+          },
+          "sourceLanguage": "cplusplus",
+          "length": 1742,
+          "hashes": {
+            "sha-256": "cc8e6a99f3eff00adc649fee132ba80fe333ea5a"
+          }
+        },
+        {
+          "location": {
+            "uri": "collections/list.cpp",
+            "uriBaseId": "SRCROOT"
+          },
+          "sourceLanguage": "cplusplus",
+          "length": 980,
+          "hashes": {
+            "sha-256": "b13ce2678a8807ba0765ab94a0ecd394f869bc81"
+          }
+        },
+        {
+          "location": {
+            "uri": "collections/list.h",
+            "uriBaseId": "SRCROOT"
+          },
+          "sourceLanguage": "cplusplus",
+          "length": 24656,
+          "hashes": {
+            "sha-256": "849be119aaba4e9f88921a99e3036fb6c2a8144a"
+          }
+        },
+        {
+          "location": {
+            "uri": "crypto/hash.cpp",
+            "uriBaseId": "SRCROOT"
+          },
+          "sourceLanguage": "cplusplus",
+          "length": 1424,
+          "hashes": {
+            "sha-256": "3ffe2b77dz255cdf95f97d986d7a6ad8f287eaed"
+          }
+        },
+        {
+          "location": {
+            "uri": "app.zip",
+            "uriBaseId": "BINROOT"
+          },
+          "mimeType": "application/zip",
+          "length": 310450,
+          "hashes": {
+            "sha-256": "df18a5e74b6b46ddaa23ad7271ee2b7c5731cbe1"
+          }
+        },
+        {
+          "location": {
+            "uri": "/docs/intro.docx"
+          },
+          "mimeType":
+             "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          "parentIndex": 5,
+          "offset": 17522,
+          "length": 4050
+        }
+      ],
+      "logicalLocations": [
+        {
+          "name": "add",
+          "fullyQualifiedName": "collections::list::add",
+          "decoratedName": "?add@list@collections@@QAEXH@Z",
+          "kind": "function",
+          "parentIndex": 1
+        },
+        {
+          "name": "list",
+          "fullyQualifiedName": "collections::list",
+          "kind": "type",
+          "parentIndex": 2
+        },
+        {
+          "name": "collections",
+          "kind": "namespace"
+        },
+        {
+          "name": "add_core",
+          "fullyQualfiedName": "collections::list::add_core",
+          "decoratedName": "?add_core@list@collections@@QAEXH@Z",
+          "kind": "function",
+          "parentIndex": 1
+        },
+        {
+          "fullyQualifiedName": "main",
+          "kind": "function"
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "C2001",
+          "ruleIndex": 0,
+          "kind": "fail",
+          "level": "error",
+          "message": {
+            "id": "default",
+            "arguments": [
+              "ptr",
+              "0"
+            ]
+          },
+          "suppressions": [
+            {
+              "kind": "external",
+              "status": "accepted"
+            }
+          ],
+          "baselineState": "unchanged",
+          "rank": 95,
+          "analysisTarget": {
+            "uri": "collections/list.cpp",
+            "uriBaseId": "SRCROOT",
+            "index": 2
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "collections/list.h",
+                  "uriBaseId": "SRCROOT",
+                  "index": 3
+                },
+                "region": {
+                  "startLine": 15,
+                  "startColumn": 9,
+                  "endLine": 15,
+                  "endColumn": 10,
+                  "charLength": 1,
+                  "charOffset": 254,
+                  "snippet": {
+                    "text": "add_core(ptr, offset, val);\n    return;"
+                  }
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "collections::list::add",
+                  "index": 0
+                }
+              ]
+            }
+          ],
+          "relatedLocations": [
+            {
+              "id": 0,
+              "message": {
+                "id": "variableDeclared",
+                "arguments": [
+                  "ptr"
+                ]
+              },
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "collections/list.h",
+                  "uriBaseId": "SRCROOT",
+                  "index": 3
+                },
+                "region": {
+                  "startLine": 8,
+                  "startColumn": 5
+                }
+              },
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "collections::list::add",
+                  "index": 0
+                }
+              ]
+            }
+          ],
+          "codeFlows": [
+            {
+              "message": {
+                "text": "Path from declaration to usage"
+              },
+ 
+              "threadFlows": [
+                {
+                  "id": "thread-52",
+                  "locations": [
+                    {
+                      "importance": "essential",
+                      "location": {
+                        "message": {
+                          "text": "Variable \"ptr\" declared.",
+                          "markdown": "Variable `ptr` declared."
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri":"collections/list.h",
+                            "uriBaseId": "SRCROOT",
+                            "index": 3
+                          },
+                          "region": {
+                            "startLine": 15,
+                            "snippet": {
+                              "text": "int *ptr;"
+                            }
+                          }
+                        },
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "collections::list::add",
+                            "index": 0
+                          }
+                        ]
+                      },
+                      "module": "platform"
+                    },
+                    {
+                      "state": {
+                        "y": {
+                          "text": "2"
+                        },
+                        "z": {
+                          "text": "4"
+                        },
+                        "y + z": {
+                          "text": "6"
+                        },
+                        "q": {
+                          "text": "7"
+                        }
+                      },
+                      "importance": "unimportant",
+                      "location": {
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri":"collections/list.h",
+                            "uriBaseId": "SRCROOT",
+                            "index": 3
+                          },
+                          "region": {
+                            "startLine": 15,
+                            "snippet": {
+                             "text": "offset = (y + z) * q + 1;"
+                            }
+                          }
+                        },
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "collections::list::add",
+                            "index": 0
+                          }
+                        ],
+                        "annotations": [
+                          {
+                            "startLine": 15,
+                            "startColumn": 13,
+                            "endColumn": 19,
+                            "message": {
+                              "text": "(y + z) = 42",
+                              "markdown": "`(y + z) = 42`"
+                            }
+                          }
+                        ]
+                      },
+                      "module": "platform"
+                    },
+                    {
+                      "importance": "essential",
+                      "location": {
+                        "message": {
+                          "text": "Uninitialized variable \"ptr\" passed to\nmethod \"add_core\".",
+                          "markdown": "Uninitialized variable `ptr` passed to\nmethod `add_core`."
+                        },
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri":"collections/list.h",
+                            "uriBaseId": "SRCROOT",
+                            "index": 3
+                          },
+                          "region": {
+                            "startLine": 25,
+                            "snippet": {
+                              "text": "add_core(ptr, offset, val)"
+                            }
+                          }
+                        },
+                        "logicalLocations": [
+                          {
+                            "fullyQualifiedName": "collections::list::add",
+                            "index": 0
+                          }
+                        ]
+                      },
+                      "module": "platform"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "stacks": [
+            {
+              "message": {
+                "text": "Call stack resulting from usage of uninitialized variable."
+              },
+              "frames": [
+                {
+                  "location": {
+                    "message": {
+                      "text": "Exception thrown."
+                    },
+                    "physicalLocation": {
+                      "artifactLocation": {
+                        "uri": "collections/list.h",
+                        "uriBaseId": "SRCROOT",
+                        "index": 3
+                      },
+                      "region": {
+                        "startLine": 110,
+                        "startColumn": 15
+                      },
+                      "address": {
+                        "offset": 4229178
+                      }
+                    },
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "collections::list::add_core",
+                        "index": 0
+                      }
+                    ]
+                  },
+                  "module": "platform",
+                  "threadId": 52,
+                  "parameters": [ "null", "0", "14" ]
+                },
+                {
+                  "location": {
+                    "physicalLocation": {
+                      "artifactLocation": {
+                        "uri": "collections/list.h",
+                        "uriBaseId": "SRCROOT",
+                        "index": 3
+                      },
+                      "region": {
+                        "startLine": 43,
+                        "startColumn": 15
+                      },
+                      "address": {
+                        "offset": 4229268
+                      }
+                    },
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "collections::list::add",
+                        "index": 0
+                      }
+                    ]
+                  },
+                  "module": "platform",
+                  "threadId": 52,
+                  "parameters": [ "14" ]
+                },
+                {
+                  "location": {
+                    "physicalLocation": {
+                      "artifactLocation": {
+                        "uri": "application/main.cpp",
+                        "uriBaseId": "SRCROOT",
+                        "index": 1
+                      },
+                      "region": {
+                        "startLine": 28,
+                        "startColumn": 9
+                      },
+                      "address": {
+                        "offset": 4229836
+                      }
+                    },
+                    "logicalLocations": [
+                      {
+                        "fullyQualifiedName": "main",
+                        "index": 4
+                      }
+                    ]
+                  },
+                  "module": "application",
+                  "threadId": 52
+                }
+              ]
+            }
+          ],
+          "addresses": [
+            {
+              "baseAddress": 4194304,
+              "fullyQualifiedName": "collections.dll",
+              "kind": "module",
+              "section": ".text"
+            },
+            {
+              "offset": 100,
+              "fullyQualifiedName": "collections.dll!collections::list::add",
+              "kind": "function",
+              "parentIndex": 0
+            },
+            {
+              "offset": 22,
+              "fullyQualifiedName": "collections.dll!collections::list::add+0x16",
+              "parentIndex": 1
+            }
+          ],
+          "fixes": [
+            {
+              "description": {
+                "text": "Initialize the variable to null"
+              },
+              "artifactChanges": [
+                {
+                  "artifactLocation": {
+                    "uri": "collections/list.h",
+                    "uriBaseId": "SRCROOT",
+                    "index": 3
+                  },
+                  "replacements": [
+                    {
+                      "deletedRegion": {
+                        "startLine": 42
+                      },
+                      "insertedContent": {
+                        "text": "A different line\n"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "hostedViewerUri":
+            "https://www.example.com/viewer/3918d370-c636-40d8-bf23-8c176043a2df",
+          "workItemUris": [
+            "https://github.com/example/project/issues/42",
+            "https://github.com/example/project/issues/54"
+          ],
+          "provenance": {
+            "firstDetectionTimeUtc": "2016-07-15T14:20:42Z",
+            "firstDetectionRunGuid": "8F62D8A0-C14F-4516-9959-1A663BA6FB99",
+            "lastDetectionTimeUtc": "2016-07-16T14:20:42Z",
+            "lastDetectionRunGuid": "BC650830-A9FE-44CB-8818-AD6C387279A0",
+            "invocationIndex": 0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/dojo/unittests/scans/sarif/flawfinder.sarif
+++ b/dojo/unittests/scans/sarif/flawfinder.sarif
@@ -1,0 +1,1863 @@
+{
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Flawfinder",
+          "version": "2.0.19",
+          "informationUri": "https://dwheeler.com/flawfinder/",
+          "rules": [
+            {
+              "id": "FF1048",
+              "name": "random/setstate",
+              "shortDescription": {
+                "text": "This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/327.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-327",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1021",
+              "name": "buffer/sscanf",
+              "shortDescription": {
+                "text": "The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20)."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/120.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-120",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                },
+                {
+                  "target": {
+                    "id": "CWE-20",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1022",
+              "name": "buffer/strlen",
+              "shortDescription": {
+                "text": "Does not handle strings that are not \\0-terminated; if given one it may perform an over-read (it could cause a crash if unprotected) (CWE-126)."
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/126.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-126",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1004",
+              "name": "buffer/memcpy",
+              "shortDescription": {
+                "text": "Does not check for buffer overflows when copying to destination (CWE-120)."
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/120.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-120",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1013",
+              "name": "buffer/char",
+              "shortDescription": {
+                "text": "Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/119.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-119",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "incomparable"
+                  ]
+                },
+                {
+                  "target": {
+                    "id": "CWE-120",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1019",
+              "name": "format/snprintf",
+              "shortDescription": {
+                "text": "If format strings can be influenced by an attacker, they can be exploited, and note that sprintf variations do not always \\0-terminate (CWE-134)."
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/134.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-134",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1071",
+              "name": "buffer/equal",
+              "shortDescription": {
+                "text": "Function does not check the second iterator for over-read conditions (CWE-126)."
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/126.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-126",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1029",
+              "name": "buffer/read",
+              "shortDescription": {
+                "text": "Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/120.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-120",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                },
+                {
+                  "target": {
+                    "id": "CWE-20",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "FF1047",
+              "name": "integer/atoi",
+              "shortDescription": {
+                "text": "Unless checked, the resulting number can exceed the expected range (CWE-190)."
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://cwe.mitre.org/data/definitions/190.html",
+              "relationships": [
+                {
+                  "target": {
+                    "id": "CWE-190",
+                    "toolComponent": {
+                      "name": "CWE",
+                      "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+                    }
+                  },
+                  "kinds": [
+                    "relevant"
+                  ]
+                }
+              ]
+            }
+          ],
+          "supportedTaxonomies": [
+            {
+              "name": "CWE",
+              "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+            }
+          ]
+        }
+      },
+      "columnKind": "utf16CodeUnits",
+      "results": [
+        {
+          "ruleId": "FF1048",
+          "level": "warning",
+          "message": {
+            "text": "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/tree/param.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 29,
+                  "startColumn": 10,
+                  "endColumn": 38,
+                  "snippet": {
+                    "text": "      is.setstate(std::ios::failbit);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "e6c1ad2b1d96ffc4035ed8df070600566ad240b8ded025dac30620f3fd4aa9fd"
+          },
+          "rank": 0.6000000000000001
+        },
+        {
+          "ruleId": "FF1048",
+          "level": "warning",
+          "message": {
+            "text": "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/tree/param.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 75,
+                  "startColumn": 10,
+                  "endColumn": 38,
+                  "snippet": {
+                    "text": "      is.setstate(std::ios::failbit);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "e6c1ad2b1d96ffc4035ed8df070600566ad240b8ded025dac30620f3fd4aa9fd"
+          },
+          "rank": 0.6000000000000001
+        },
+        {
+          "ruleId": "FF1021",
+          "level": "note",
+          "message": {
+            "text": "buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/metric/rank_metric.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 242,
+                  "startColumn": 11,
+                  "endColumn": 49,
+                  "snippet": {
+                    "text": "      if (sscanf(param, \"%u[-]?\", &topn) == 1) {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "b1699f70cbe95f1be3407d87c85c98bf7097f3f33cf818154d5e61eee41843f2"
+          },
+          "rank": 0.0
+        },
+        {
+          "ruleId": "FF1022",
+          "level": "note",
+          "message": {
+            "text": "buffer/strlen:Does not handle strings that are not \\0-terminated; if given one it may perform an over-read (it could cause a crash if unprotected) (CWE-126)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/metric/rank_metric.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 249,
+                  "startColumn": 17,
+                  "endColumn": 45,
+                  "snippet": {
+                    "text": "      if (param[strlen(param) - 1] == '-') {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "c7c4126bddc0d49577ae5a4d906aab9ca66253072a724a93caa4e728a7b3da59"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/data/data.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 899,
+                  "startColumn": 10,
+                  "endColumn": 80,
+                  "snippet": {
+                    "text": "    std::memcpy(dmlc::BeginPtr(data_vec) + top, dmlc::BeginPtr(batch_data_vec),"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "51934c5f14bd500ce7e1f897ccec31ae4d11027a44960cd722263d9ad131ce9a"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/data/data.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1051,
+                  "startColumn": 10,
+                  "endColumn": 42,
+                  "snippet": {
+                    "text": "    std::memcpy(dmlc::BeginPtr(data)+beg,"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "1146e92de0a163c7a465646a9d6d8e0556f097185c4509ea5380975effc6f246"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/data/data.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 1059,
+                  "startColumn": 10,
+                  "endColumn": 42,
+                  "snippet": {
+                    "text": "    std::memcpy(dmlc::BeginPtr(data)+beg,"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "1146e92de0a163c7a465646a9d6d8e0556f097185c4509ea5380975effc6f246"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/base64.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 197,
+                  "startColumn": 12,
+                  "endColumn": 29,
+                  "snippet": {
+                    "text": "  unsigned char buf_prev[2];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "33794969672c3808e1221c3ca916300a056fc8269f3c6bd2ea01b6b7e7e1f5b5"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/base64.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 255,
+                  "startColumn": 12,
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "  unsigned char buf[4];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "6e710741b3492f6816ae4e97fc6cb0b89b0cbd9ed187b1c24a93b16de168fe6d"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/timer.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 33,
+                  "startColumn": 5,
+                  "endColumn": 22,
+                  "snippet": {
+                    "text": "    char buffer[255];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "466849fbb37ae26ee192cffef5ec576006b4f0c50503c9a56b662d7543ed147f"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1019",
+          "level": "note",
+          "message": {
+            "text": "format/snprintf:If format strings can be influenced by an attacker, they can be exploited, and note that sprintf variations do not always \\0-terminate (CWE-134)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/timer.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 34,
+                  "startColumn": 5,
+                  "endColumn": 65,
+                  "snippet": {
+                    "text": "    snprintf(buffer, sizeof(buffer), \"%s:\\t %fs\", label.c_str(),"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "3b993b2db67bca5c6e3c5234154661582fe0149607dd198b27d3a96bccd22e6a"
+          },
+          "rank": 0.0
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 59,
+                  "startColumn": 3,
+                  "endColumn": 51,
+                  "snippet": {
+                    "text": "  char number[NumericLimits<float>::kToCharsSize];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "3db5ecd47314395f8262ab3537b395ca42e4b727b90b4af7de5a1c56f12b6717"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 64,
+                  "startColumn": 8,
+                  "endColumn": 65,
+                  "snippet": {
+                    "text": "  std::memcpy(stream_->data() + ori_size, number, end - number);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "782baf2689f30cc5471712407dc419757600a24064e4a281663917d42a9a1512"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 68,
+                  "startColumn": 3,
+                  "endColumn": 58,
+                  "snippet": {
+                    "text": "  char i2s_buffer_[NumericLimits<int64_t>::kToCharsSize];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "a072b22a5eea5360e654081d63a9c6c929cbd625c380c7d6ac45ba30976b8825"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 76,
+                  "startColumn": 8,
+                  "endColumn": 64,
+                  "snippet": {
+                    "text": "  std::memcpy(stream_->data() + ori_size, i2s_buffer_, digits);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "21a3e23750502d9511783114c2b572abbe5c3a58fbeb15d606437c59318d2c23"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 115,
+                  "startColumn": 7,
+                  "endColumn": 19,
+                  "snippet": {
+                    "text": "      char buf[8];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "794dd086f29fe8304359c335f25d99574851f607ff35b5fa940ffbc8b6b35d2c"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1019",
+          "level": "note",
+          "message": {
+            "text": "format/snprintf:If format strings can be influenced by an attacker, they can be exploited, and note that sprintf variations do not always \\0-terminate (CWE-134)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 116,
+                  "startColumn": 7,
+                  "endColumn": 48,
+                  "snippet": {
+                    "text": "      snprintf(buf, sizeof buf, \"\\\\u%04x\", ch);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "c7825bbe6afbc248295f415acbaaa498040aa7a53e6dade9f6141b0c7a83c538"
+          },
+          "rank": 0.0
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 126,
+                  "startColumn": 8,
+                  "endColumn": 66,
+                  "snippet": {
+                    "text": "  std::memcpy(stream_->data() + s, buffer.data(), buffer.size());"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "f5775d61d873e88f0de80a6393b06d88936f27960606b2d18b0c01bf4797d240"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1071",
+          "level": "note",
+          "message": {
+            "text": "buffer/equal:Function does not check the second iterator for over-read conditions (CWE-126)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/json.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 252,
+                  "startColumn": 15,
+                  "endColumn": 62,
+                  "snippet": {
+                    "text": "  return std::equal(arr.cbegin(), arr.cend(), vec_.cbegin());"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "d53c714e2a35fb03beb2e458db157bb2b4afb8375fbc55e1a628f62b6df57229"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 26,
+                  "startColumn": 10,
+                  "endColumn": 71,
+                  "snippet": {
+                    "text": "    std::memcpy(dptr, dmlc::BeginPtr(buffer_) + buffer_ptr_, nbuffer);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "4f5ebfd18b4716c728295925cc5c7187bb24d40f874238d09c9d9fd28d32aca9"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 31,
+                  "startColumn": 10,
+                  "endColumn": 68,
+                  "snippet": {
+                    "text": "    std::memcpy(dptr, dmlc::BeginPtr(buffer_) + buffer_ptr_, size);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "327fc54b75ab37bbbb31a1b71431aaefa8137ff755acc103685ad5adf88f5dda"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 45,
+                  "startColumn": 10,
+                  "endColumn": 66,
+                  "snippet": {
+                    "text": "    std::memcpy(dptr, dmlc::BeginPtr(buffer_), buffer_.length());"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "2415c4dfcc23c956815c7a20576af99bb7fa74e8b959dd2a26a5779483b88be0"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 48,
+                  "startColumn": 10,
+                  "endColumn": 68,
+                  "snippet": {
+                    "text": "    std::memcpy(dptr, dmlc::BeginPtr(buffer_) + buffer_ptr_, size);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "327fc54b75ab37bbbb31a1b71431aaefa8137ff755acc103685ad5adf88f5dda"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 60,
+                  "startColumn": 13,
+                  "endColumn": 18,
+                  "snippet": {
+                    "text": "    total = read;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "8dcdce5b0fa24ce8e0a05a20da785c67cf4a8c7dbfcb77a5369cac80b906a86e"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 61,
+                  "startColumn": 9,
+                  "endColumn": 23,
+                  "snippet": {
+                    "text": "    if (read < size) {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "7a546fcabe3a89c3fb809a0e2359edd6295112c6e7d6f8b9b75a2f67a285e995"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 71,
+                  "startColumn": 15,
+                  "endColumn": 20,
+                  "snippet": {
+                    "text": "  pointer_ += read;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "110ed830f83f218f8637a270b04b163230e094fa9f25d3caeab98d4701bd50ee"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 72,
+                  "startColumn": 10,
+                  "endColumn": 15,
+                  "snippet": {
+                    "text": "  return read;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "fe0938d5dd649f8904dd8fd1d308ead7aebeec466f821ef897ae01c46d1550a6"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 122,
+                  "startColumn": 9,
+                  "endColumn": 37,
+                  "snippet": {
+                    "text": "    ifs.read(&buffer[0], file_size);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "82558a2a3ce4f06113e3fd175f1a5990dee0240a67ff651d87661442c38eacfc"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 136,
+                  "startColumn": 14,
+                  "endColumn": 19,
+                  "snippet": {
+                    "text": "    total += read;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "824618c0b006a0cd2c1127719a37dc36c39dabf46fa1e4a3fd828dae0f8d831a"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/io.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 137,
+                  "startColumn": 9,
+                  "endColumn": 23,
+                  "snippet": {
+                    "text": "    if (read < size) {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "7a546fcabe3a89c3fb809a0e2359edd6295112c6e7d6f8b9b75a2f67a285e995"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 59,
+                  "startColumn": 18,
+                  "endColumn": 40,
+                  "snippet": {
+                    "text": "static constexpr char kItoaLut[200] = {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "2dab0388fa51233c5aaaacb076e8d1e2f4ab617d08a24f9943c5a6b3f7431053"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 90,
+                  "startColumn": 8,
+                  "endColumn": 38,
+                  "snippet": {
+                    "text": "  std::memcpy(&t, &from, sizeof(To));"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "1f1a1c5a0201d09e5be85906b9500fc0374054ec9f3543a45b773e28cfcdff51"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 603,
+                  "startColumn": 12,
+                  "endColumn": 74,
+                  "snippet": {
+                    "text": "      std::memcpy(result + index + out_length - i - 1, kItoaLut + c0, 2);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "4378536f29f4c1abc735e0258b44067a4cbe4e143b505134ef05e360a09dc065"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 604,
+                  "startColumn": 12,
+                  "endColumn": 74,
+                  "snippet": {
+                    "text": "      std::memcpy(result + index + out_length - i - 3, kItoaLut + c1, 2);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "f0bd1843d3b825a9d34f4340d4be6e5d3b85a8661a249bdb2a180e1697e887dd"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 610,
+                  "startColumn": 12,
+                  "endColumn": 73,
+                  "snippet": {
+                    "text": "      std::memcpy(result + index + out_length - i - 1, kItoaLut + c, 2);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "cf85bd9af6551b5b86487ac6c50a998bb036bd81b216a08f31470faf88e9c4d0"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 640,
+                  "startColumn": 12,
+                  "endColumn": 58,
+                  "snippet": {
+                    "text": "      std::memcpy(result + index, kItoaLut + 2 * exp, 2);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "b3ec2ddc947bb6d73a46fb4c0861cc37ee8c29f615e8c77964adce043ba79c96"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 652,
+                  "startColumn": 12,
+                  "endColumn": 39,
+                  "snippet": {
+                    "text": "      std::memcpy(result, u8\"NaN\", 3);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "0319d1523f800936f20357bc03cdf387423e9d4f751de4d9810e88262b0e5e8b"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 659,
+                  "startColumn": 12,
+                  "endColumn": 51,
+                  "snippet": {
+                    "text": "      std::memcpy(result + sign, u8\"Infinity\", 8);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "1c32f784bcda4f81fa2ce35da260df2431c28530ad097ccbc69bc05f201dc12b"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/charconv.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 662,
+                  "startColumn": 10,
+                  "endColumn": 44,
+                  "snippet": {
+                    "text": "    std::memcpy(result + sign, u8\"0E0\", 3);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "fd019151c106948e63717e082685514fc8a4c7c369999d236508120fb40b104b"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/version.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 43,
+                  "startColumn": 40,
+                  "endColumn": 45,
+                  "snippet": {
+                    "text": "  std::string verstr { u8\"version:\" }, read;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "1c6d4c6b0c9c564483a1bc5a1bdea7a13294528ed500b1f9e8fe5b5010e1613a"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/version.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 44,
+                  "startColumn": 3,
+                  "endColumn": 33,
+                  "snippet": {
+                    "text": "  read.resize(verstr.size(), 0);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "75a5e0d06e487a8aeca65855ee885c8931c12ab1d6e4e935ecbf6bd97ce2efcb"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/version.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 46,
+                  "startColumn": 22,
+                  "endColumn": 69,
+                  "snippet": {
+                    "text": "  CHECK_EQ(fi->Read(&read[0], verstr.size()), verstr.size()) << msg;"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "535823cf701cadc93c70a868ace12f5f306da8f3582b69d18e70e71dad290120"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1029",
+          "level": "note",
+          "message": {
+            "text": "buffer/read:Check buffer boundaries if used in a loop including recursive loops (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/version.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 47,
+                  "startColumn": 17,
+                  "endColumn": 24,
+                  "snippet": {
+                    "text": "  if (verstr != read) {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "7f0a1daa01ba92d0321de75884b318341b288f5161c7e803cde17eef898526ce"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1004",
+          "level": "note",
+          "message": {
+            "text": "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/common/quantile.h",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 180,
+                  "startColumn": 10,
+                  "endColumn": 55,
+                  "snippet": {
+                    "text": "    std::memcpy(data, src.data, sizeof(Entry) * size);"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "e373da8e9e747f9443118b424a47913c30cfe74685ce7cb061d0066f3ad38d40"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/c_api/c_api.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 71,
+                  "startColumn": 7,
+                  "endColumn": 54,
+                  "snippet": {
+                    "text": "      char chars[NumericLimits<float>::kToCharsSize];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "76a19aadcfb91e133cc48bafcebfa58febfcb6b5dfd9699d4d61fd67a3dc6e9e"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/learner.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 105,
+                  "startColumn": 5,
+                  "endColumn": 53,
+                  "snippet": {
+                    "text": "    char floats[NumericLimits<float>::kToCharsSize];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "b1e2ee9cf54c7c728a446a3800148eb7581ef3c44e5e6b7ae9fc0a78a6578c7c"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/learner.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 111,
+                  "startColumn": 5,
+                  "endColumn": 57,
+                  "snippet": {
+                    "text": "    char integers[NumericLimits<int64_t>::kToCharsSize];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "1e35cc4018aab8a8eb0dd37eadddd9f4454f018a4b360af350d6f046460b560e"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1071",
+          "level": "note",
+          "message": {
+            "text": "buffer/equal:Function does not check the second iterator for over-read conditions (CWE-126)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/learner.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 514,
+                  "startColumn": 19,
+                  "endColumn": 73,
+                  "snippet": {
+                    "text": "             std::equal(postfix.rbegin(), postfix.rend(), key.rbegin());"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "90fdfe9e4cba38cfbb108efd323d53f922ee9a0e731aa504fa918204d25d9896"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1047",
+          "level": "note",
+          "message": {
+            "text": "integer/atoi:Unless checked, the resulting number can exceed the expected range (CWE-190)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/learner.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 622,
+                  "startColumn": 11,
+                  "endColumn": 81,
+                  "snippet": {
+                    "text": "      if (atoi(cfg_[\"num_class\"].c_str()) > 1 && cfg_.count(\"objective\") == 0) {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "d34e6328b5a331d9600dff5132a85df924fab61e183c8259107ecb49bc521001"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1071",
+          "level": "note",
+          "message": {
+            "text": "buffer/equal:Function does not check the second iterator for over-read conditions (CWE-126)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/learner.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 823,
+                  "startColumn": 17,
+                  "endColumn": 83,
+                  "snippet": {
+                    "text": "      if (!std::equal(multi.cbegin(), multi.cend(), tparam_.objective.cbegin())) {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "0ceea29b46b2a3d028790f13dfaf6a400686192e5a87f4ff7cdaf375023ec4c4"
+          },
+          "rank": 0.2
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/cli_main.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 142,
+                  "startColumn": 9,
+                  "endColumn": 26,
+                  "snippet": {
+                    "text": "        char evname[256];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "ce329a896b6141aa0320de37774a6e1696e14cc3e17cead261008ef722f135c3"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1021",
+          "level": "note",
+          "message": {
+            "text": "buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/cli_main.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 143,
+                  "startColumn": 18,
+                  "endColumn": 68,
+                  "snippet": {
+                    "text": "        CHECK_EQ(sscanf(kv.first.c_str(), \"eval[%[^]]\", evname), 1)"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "a01d5fa16410a823f5d85f372456bf4a96436ead4a1fe25447e7499aabccff0a"
+          },
+          "rank": 0.0
+        },
+        {
+          "ruleId": "FF1013",
+          "level": "note",
+          "message": {
+            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/cli_main.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 481,
+                  "startColumn": 7,
+                  "endColumn": 32,
+                  "snippet": {
+                    "text": "      char name[256], val[256];"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "f2de314a9ee6aee0f164f741d06c0ae628b87ccf9898285d866210d213bf3bd0"
+          },
+          "rank": 0.4
+        },
+        {
+          "ruleId": "FF1021",
+          "level": "error",
+          "message": {
+            "text": "buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20)."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/cli_main.cc",
+                  "uriBaseId": "SRCROOT"
+                },
+                "region": {
+                  "startLine": 482,
+                  "startColumn": 11,
+                  "endColumn": 57,
+                  "snippet": {
+                    "text": "      if (sscanf(argv[i], \"%[^=]=%s\", name, val) == 2) {"
+                  }
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "contextHash/v1": "ad8408027235170e870e7662751a01386beb2d2ed8beb75dd4ba8e4a70e91d65"
+          },
+          "rank": 0.8
+        }
+      ],
+      "externalPropertyFileReferences": {
+        "taxonomies": [
+          {
+            "location": {
+              "uri": "https://raw.githubusercontent.com/sarif-standard/taxonomies/main/CWE_v4.4.sarif"
+            },
+            "guid": "FFC64C90-42B6-44CE-8BEB-F6B7DAE649E5"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/dojo/unittests/scans/sarif/gitleaks_7.5.0.sarif
+++ b/dojo/unittests/scans/sarif/gitleaks_7.5.0.sarif
@@ -1,0 +1,386 @@
+{
+ "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json",
+ "version": "2.1.0",
+ "runs": [
+  {
+   "tool": {
+    "driver": {
+     "name": "Gitleaks",
+     "semanticVersion": "v7.4.0",
+     "rules": [
+      {
+       "id": "AWS Access Key",
+       "name": "AWS Access Key"
+      },
+      {
+       "id": "AWS Secret Key",
+       "name": "AWS Secret Key"
+      },
+      {
+       "id": "AWS MWS key",
+       "name": "AWS MWS key"
+      },
+      {
+       "id": "Facebook Secret Key",
+       "name": "Facebook Secret Key"
+      },
+      {
+       "id": "Facebook Client ID",
+       "name": "Facebook Client ID"
+      },
+      {
+       "id": "Twitter Secret Key",
+       "name": "Twitter Secret Key"
+      },
+      {
+       "id": "Twitter Client ID",
+       "name": "Twitter Client ID"
+      },
+      {
+       "id": "Github Personal Access Token",
+       "name": "Github Personal Access Token"
+      },
+      {
+       "id": "Github OAuth Access Token",
+       "name": "Github OAuth Access Token"
+      },
+      {
+       "id": "Github App Token",
+       "name": "Github App Token"
+      },
+      {
+       "id": "Github Refresh Token",
+       "name": "Github Refresh Token"
+      },
+      {
+       "id": "LinkedIn Client ID",
+       "name": "LinkedIn Client ID"
+      },
+      {
+       "id": "LinkedIn Secret Key",
+       "name": "LinkedIn Secret Key"
+      },
+      {
+       "id": "Slack",
+       "name": "Slack"
+      },
+      {
+       "id": "Asymmetric Private Key",
+       "name": "Asymmetric Private Key"
+      },
+      {
+       "id": "Google API key",
+       "name": "Google API key"
+      },
+      {
+       "id": "Google (GCP) Service Account",
+       "name": "Google (GCP) Service Account"
+      },
+      {
+       "id": "Heroku API key",
+       "name": "Heroku API key"
+      },
+      {
+       "id": "MailChimp API key",
+       "name": "MailChimp API key"
+      },
+      {
+       "id": "Mailgun API key",
+       "name": "Mailgun API key"
+      },
+      {
+       "id": "PayPal Braintree access token",
+       "name": "PayPal Braintree access token"
+      },
+      {
+       "id": "Picatic API key",
+       "name": "Picatic API key"
+      },
+      {
+       "id": "SendGrid API Key",
+       "name": "SendGrid API Key"
+      },
+      {
+       "id": "Slack Webhook",
+       "name": "Slack Webhook"
+      },
+      {
+       "id": "Stripe API key",
+       "name": "Stripe API key"
+      },
+      {
+       "id": "Square access token",
+       "name": "Square access token"
+      },
+      {
+       "id": "Square OAuth secret",
+       "name": "Square OAuth secret"
+      },
+      {
+       "id": "Twilio API key",
+       "name": "Twilio API key"
+      },
+      {
+       "id": "Dynatrace ttoken",
+       "name": "Dynatrace ttoken"
+      },
+      {
+       "id": "Shopify shared secret",
+       "name": "Shopify shared secret"
+      },
+      {
+       "id": "Shopify access token",
+       "name": "Shopify access token"
+      },
+      {
+       "id": "Shopify custom app access token",
+       "name": "Shopify custom app access token"
+      },
+      {
+       "id": "Shopify private app access token",
+       "name": "Shopify private app access token"
+      },
+      {
+       "id": "PyPI upload token",
+       "name": "PyPI upload token"
+      }
+     ]
+    }
+   },
+   "results": [
+    {
+     "message": {
+      "text": "AWS Access Key secret detected"
+     },
+     "properties": {
+      "commit": "6d127980966808f7413935678e079dcd7fedf9c2",
+      "offender": "AKIAIOSFODNN7EXAMPLE",
+      "date": "2021-07-15T22:00:32+07:00",
+      "author": "Bhurinat Wangsutthitham",
+      "email": "nate.bwangsut@gmail.com",
+      "commitMessage": "feat: added GitLab secret detection report parser (#4605)\n\n* feat: added GitLab secret detection report parser\r\n\r\n* fix: Flake8 compliance\r\n\r\n* fix: remove entry from test_type.json\r\n\r\n* fix: change severity on parser\r\n\r\n* fix: update findings description field for raw_source_code\r\n\r\n* fix: add unique_id_from_tool for findings\r\n\r\n* fix: remove autoimported module\r\n\r\n* fix: typo\r\n\r\n* test: added unittests for unique_id_from_tool field\r\n\r\n* fix: Flake8 compliant\r\n\r\n* test: add testing for findings date\r\n\r\n* fix: datetime bug parser",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_1_vuln.json"
+        },
+        "region": {
+         "startLine": 13,
+         "snippet": {
+          "text": "      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\","
+         }
+        }
+       }
+      }
+     ]
+    },
+    {
+     "message": {
+      "text": "AWS Access Key secret detected"
+     },
+     "properties": {
+      "commit": "8bbcdfd743c5695bdd7d3bc21aa9417131a7ab12",
+      "offender": "AKIAIOSFODNN7EXAMPLE",
+      "date": "2021-07-27T11:19:31-05:00",
+      "author": "Cody Maffucci",
+      "email": "46459665+Maffooch@users.noreply.github.com",
+      "commitMessage": "Merge pull request #4877 from DefectDojo/release/2.1.0\n\nRelease/2.1.0",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_1_vuln.json"
+        },
+        "region": {
+         "startLine": 13,
+         "snippet": {
+          "text": "      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\","
+         }
+        }
+       }
+      }
+     ]
+    },
+    {
+     "message": {
+      "text": "Asymmetric Private Key secret detected"
+     },
+     "properties": {
+      "commit": "8bbcdfd743c5695bdd7d3bc21aa9417131a7ab12",
+      "offender": "-----BEGIN OPENSSH PRIVATE KEY-----",
+      "date": "2021-07-27T11:19:31-05:00",
+      "author": "Cody Maffucci",
+      "email": "46459665+Maffooch@users.noreply.github.com",
+      "commitMessage": "Merge pull request #4877 from DefectDojo/release/2.1.0\n\nRelease/2.1.0",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_3_vuln.json"
+        },
+        "region": {
+         "startLine": 13,
+         "snippet": {
+          "text": "      \"raw_source_code_extract\": \"-----BEGIN OPENSSH PRIVATE KEY-----\","
+         }
+        }
+       }
+      }
+     ]
+    },
+    {
+     "message": {
+      "text": "AWS Access Key secret detected"
+     },
+     "properties": {
+      "commit": "8bbcdfd743c5695bdd7d3bc21aa9417131a7ab12",
+      "offender": "AKIAIOSFODNN7EXAMPLE",
+      "date": "2021-07-27T11:19:31-05:00",
+      "author": "Cody Maffucci",
+      "email": "46459665+Maffooch@users.noreply.github.com",
+      "commitMessage": "Merge pull request #4877 from DefectDojo/release/2.1.0\n\nRelease/2.1.0",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_3_vuln.json"
+        },
+        "region": {
+         "startLine": 44,
+         "snippet": {
+          "text": "      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\","
+         }
+        }
+       }
+      }
+     ]
+    },
+    {
+     "message": {
+      "text": "AWS Access Key secret detected"
+     },
+     "properties": {
+      "commit": "8bbcdfd743c5695bdd7d3bc21aa9417131a7ab12",
+      "offender": "AKIAIOSFODNN7EXAMPLE",
+      "date": "2021-07-27T11:19:31-05:00",
+      "author": "Cody Maffucci",
+      "email": "46459665+Maffooch@users.noreply.github.com",
+      "commitMessage": "Merge pull request #4877 from DefectDojo/release/2.1.0\n\nRelease/2.1.0",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/tools/test_gitlab_secret_detection_report_parser.py"
+        },
+        "region": {
+         "startLine": 37,
+         "snippet": {
+          "text": "        self.assertEqual(\"AWS\\nAKIAIOSFODNN7EXAMPLE\", first_finding.description)"
+         }
+        }
+       }
+      }
+     ]
+    },
+    {
+     "message": {
+      "text": "Asymmetric Private Key secret detected"
+     },
+     "properties": {
+      "commit": "6d127980966808f7413935678e079dcd7fedf9c2",
+      "offender": "-----BEGIN OPENSSH PRIVATE KEY-----",
+      "date": "2021-07-15T22:00:32+07:00",
+      "author": "Bhurinat Wangsutthitham",
+      "email": "nate.bwangsut@gmail.com",
+      "commitMessage": "feat: added GitLab secret detection report parser (#4605)\n\n* feat: added GitLab secret detection report parser\r\n\r\n* fix: Flake8 compliance\r\n\r\n* fix: remove entry from test_type.json\r\n\r\n* fix: change severity on parser\r\n\r\n* fix: update findings description field for raw_source_code\r\n\r\n* fix: add unique_id_from_tool for findings\r\n\r\n* fix: remove autoimported module\r\n\r\n* fix: typo\r\n\r\n* test: added unittests for unique_id_from_tool field\r\n\r\n* fix: Flake8 compliant\r\n\r\n* test: add testing for findings date\r\n\r\n* fix: datetime bug parser",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_3_vuln.json"
+        },
+        "region": {
+         "startLine": 13,
+         "snippet": {
+          "text": "      \"raw_source_code_extract\": \"-----BEGIN OPENSSH PRIVATE KEY-----\","
+         }
+        }
+       }
+      }
+     ]
+    },
+    {
+     "message": {
+      "text": "AWS Access Key secret detected"
+     },
+     "properties": {
+      "commit": "6d127980966808f7413935678e079dcd7fedf9c2",
+      "offender": "AKIAIOSFODNN7EXAMPLE",
+      "date": "2021-07-15T22:00:32+07:00",
+      "author": "Bhurinat Wangsutthitham",
+      "email": "nate.bwangsut@gmail.com",
+      "commitMessage": "feat: added GitLab secret detection report parser (#4605)\n\n* feat: added GitLab secret detection report parser\r\n\r\n* fix: Flake8 compliance\r\n\r\n* fix: remove entry from test_type.json\r\n\r\n* fix: change severity on parser\r\n\r\n* fix: update findings description field for raw_source_code\r\n\r\n* fix: add unique_id_from_tool for findings\r\n\r\n* fix: remove autoimported module\r\n\r\n* fix: typo\r\n\r\n* test: added unittests for unique_id_from_tool field\r\n\r\n* fix: Flake8 compliant\r\n\r\n* test: add testing for findings date\r\n\r\n* fix: datetime bug parser",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_3_vuln.json"
+        },
+        "region": {
+         "startLine": 44,
+         "snippet": {
+          "text": "      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\","
+         }
+        }
+       }
+      }
+     ]
+    },
+    {
+     "message": {
+      "text": "AWS Access Key secret detected"
+     },
+     "properties": {
+      "commit": "6d127980966808f7413935678e079dcd7fedf9c2",
+      "offender": "AKIAIOSFODNN7EXAMPLE",
+      "date": "2021-07-15T22:00:32+07:00",
+      "author": "Bhurinat Wangsutthitham",
+      "email": "nate.bwangsut@gmail.com",
+      "commitMessage": "feat: added GitLab secret detection report parser (#4605)\n\n* feat: added GitLab secret detection report parser\r\n\r\n* fix: Flake8 compliance\r\n\r\n* fix: remove entry from test_type.json\r\n\r\n* fix: change severity on parser\r\n\r\n* fix: update findings description field for raw_source_code\r\n\r\n* fix: add unique_id_from_tool for findings\r\n\r\n* fix: remove autoimported module\r\n\r\n* fix: typo\r\n\r\n* test: added unittests for unique_id_from_tool field\r\n\r\n* fix: Flake8 compliant\r\n\r\n* test: add testing for findings date\r\n\r\n* fix: datetime bug parser",
+      "repo": "."
+     },
+     "locations": [
+      {
+       "physicalLocation": {
+        "artifactLocation": {
+         "uri": "dojo/unittests/tools/test_gitlab_secret_detection_report_parser.py"
+        },
+        "region": {
+         "startLine": 37,
+         "snippet": {
+          "text": "        self.assertEqual(\"AWS\\nAKIAIOSFODNN7EXAMPLE\", first_finding.description)"
+         }
+        }
+       }
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -23,7 +23,6 @@ class TestSarifParser(TestCase):
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(510, len(findings))
-        item = findings[0]
         for finding in findings:
             self.common_checks(finding)
 
@@ -272,3 +271,37 @@ class TestSarifParser(TestCase):
             self.assertEqual("AWS Access Key secret detected", finding.description)
             self.assertEqual("dojo/unittests/tools/test_gitlab_secret_detection_report_parser.py", finding.file_path)
             self.assertEqual(37, finding.line)
+
+    def test_flawfinder(self):
+        testfile = open("dojo/unittests/scans/sarif/flawfinder.sarif")
+        parser = SarifParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(54, len(findings))
+        for finding in findings:
+            self.common_checks(finding)
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual("random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).", finding.description)
+            self.assertEqual("src/tree/param.cc", finding.file_path)
+            self.assertEqual(29, finding.line)
+            self.assertEqual(327, finding.cwe)
+            self.assertEqual("FF1048", finding.vuln_id_from_tool)
+        with self.subTest(i=20):
+            finding = findings[20]
+            self.assertEqual("buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120).", finding.title)
+            self.assertEqual("Info", finding.severity)
+            self.assertEqual("Does not check for buffer overflows when copying to destination (CWE-120).", finding.description)
+            self.assertEqual("src/common/io.cc", finding.file_path)
+            self.assertEqual(31, finding.line)
+            self.assertEqual(120, finding.cwe)
+            self.assertEqual("FF1004", finding.vuln_id_from_tool)
+        with self.subTest(i=53):
+            finding = findings[53]
+            self.assertEqual("buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).", finding.title)
+            self.assertEqual("Critical", finding.severity)
+            self.assertEqual("The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).", finding.description)
+            self.assertEqual("src/cli_main.cc", finding.file_path)
+            self.assertEqual(482, finding.line)
+            self.assertEqual("FF1021", finding.vuln_id_from_tool)

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -243,3 +243,32 @@ class TestSarifParser(TestCase):
         self.assertEqual(9, len(findings))
         for finding in findings:
             self.common_checks(finding)
+
+    def test_gitleaks(self):
+        testfile = open("dojo/unittests/scans/sarif/gitleaks_7.5.0.sarif")
+        parser = SarifParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(8, len(findings))
+        for finding in findings:
+            self.common_checks(finding)
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual("AWS Access Key secret detected", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("AWS Access Key secret detected", finding.description)
+            self.assertEqual("dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_1_vuln.json", finding.file_path)
+            self.assertEqual(13, finding.line)
+        with self.subTest(i=3):
+            finding = findings[3]
+            self.assertEqual("AWS Access Key secret detected", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("AWS Access Key secret detected", finding.description)
+            self.assertEqual("dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_3_vuln.json", finding.file_path)
+            self.assertEqual(44, finding.line)
+        with self.subTest(i=7):
+            finding = findings[7]
+            self.assertEqual("AWS Access Key secret detected", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("AWS Access Key secret detected", finding.description)
+            self.assertEqual("dojo/unittests/tools/test_gitlab_secret_detection_report_parser.py", finding.file_path)
+            self.assertEqual(37, finding.line)

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -78,6 +78,20 @@ class TestSarifParser(TestCase):
         for finding in findings:
             self.common_checks(finding)
 
+    def test_example_k4_report_mitigation(self):
+        testfile = open("dojo/unittests/scans/sarif/appendix_k4.sarif")
+        parser = SarifParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+        for finding in findings:
+            self.common_checks(finding)
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual('Variable "ptr" was used without being initialized. It was declared [here](0).', finding.title)
+            self.assertEqual('C2001', finding.vuln_id_from_tool)
+            self.assertEqual('collections/list.h', finding.file_path)
+            self.assertEqual('Initialize the variable to null', finding.mitigation)
+
     def test_example_report_ms(self):
         """Report file come from Microsoft SARIF sdk on GitHub"""
         testfile = open("dojo/unittests/scans/sarif/SuppressionTestCurrent.sarif")


### PR DESCRIPTION
According to specification, attribute `ruleId` could be missing from reports. (cf https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317643 )

> Not all existing analysis tools emit the equivalent of a ruleId in their output. 

This PR allow to import reports for tools that don't emit `ruleId` properly (like Gitleaks `7.5.0` which we use for a new unit tests) 

### Work done
- [x] better support attribute `ruleId` when tools doesn't set it cleanly (missing, reference but no data, etc...)
- [x] implement `mitigation` attribute
