### PR TITLE
safety-parser: configurable offline mode

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -160,6 +160,9 @@ env = environ.Env(
     DD_MAX_ALERTS_PER_USER=(int, 999),
     DD_TAG_PREFETCHING=(bool, True),
     DD_QUALYS_WAS_WEAKNESS_IS_VULN=(bool, False),
+    # when enabeld safety parser will download latest vuln db during runtime
+    # otherwise data is loaded from dojo/tools/safety/insecure_full.json
+    DD_SAFETY_PARSER_ONLINE_DB=(bool, True),
     # when enabled in sytem settings,  every minute a job run to delete excess duplicates
     # we limit the amount of duplicates that can be deleted in a single run of that job
     # to prevent overlapping runs of that job from occurrring
@@ -1251,6 +1254,9 @@ QUALYS_WAS_WEAKNESS_IS_VULN = env("DD_QUALYS_WAS_WEAKNESS_IS_VULN")
 # Create a unique finding for all findings in qualys WAS parser
 # If using this, lines for Qualys WAS deduplication functions must be un-commented
 QUALYS_WAS_UNIQUE_ID = False
+
+# Deside if parser should download latest db or use offline version
+SAFETY_PARSER_ONLINE_DB = env("DD_SAFETY_PARSER_ONLINE_DB")
 
 SERIALIZATION_MODULES = {
     'xml': 'tagulous.serializers.xml_serializer',

--- a/dojo/tools/safety/parser.py
+++ b/dojo/tools/safety/parser.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import urllib
+from django.conf import settings
 
 from dojo.models import Finding
 
@@ -20,13 +21,17 @@ class SafetyParser(object):
 
     def get_safetydb(self):
         """Grab Safety DB for CVE lookup"""
-        url = "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json"
-        try:
-            response = urllib.request.urlopen(url)
-            return json.load(response)
-        except urllib.error.URLError as e:
-            logger.warn("Error Message: %s", e)
-            logger.warn("Could not resolve %s. Fallback is using the offline version from dojo/tools/safety/insecure_full.json.", url)
+        if settings.SAFETY_PARSER_ONLINE_DB:
+            url = "https://raw.githubusercontent.com/pyupio/safety-db/master/data/insecure_full.json"
+            try:
+                response = urllib.request.urlopen(url)
+                return json.load(response)
+            except urllib.error.URLError as e:
+                logger.warn("Error Message: %s", e)
+                logger.warn("Could not resolve %s. Fallback is using the offline version from dojo/tools/safety/insecure_full.json.", url)
+                with open("dojo/tools/safety/insecure_full.json", "r") as insecure_full:
+                    return json.load(insecure_full)
+        else:
             with open("dojo/tools/safety/insecure_full.json", "r") as insecure_full:
                 return json.load(insecure_full)
 


### PR DESCRIPTION
When using the safety parser in environments without internet connection it take a while until the parser using the fallback offline mode. Now you can configure to use offline mode only.

On behalf of DB Systel GmbH