### PR TITLE
fix javascript regex error detection

### DIFF
--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -319,11 +319,9 @@ class BaseTestCase(unittest.TestCase):
             Images are now working after https://github.com/DefectDojo/django-DefectDojo/pull/3954,
             but http://localhost:8080/static/dojo/img/zoom-in.cur still produces a 404
 
-            The addition of the trigger exception is due to the Report Builder tests. All of the moving objects are from javascrip
-            Tooltips are attached to each object and operate fine at human speeds. Selenium moves too fast for tooltips to be
-            cleaned up, edited, and displayed, so the issue is only present in the test
+            The addition of the trigger exception is due to the Report Builder tests.
             """
-            accepted_javascript_messages = r'(zoom\-in\.cur.*)404\ \(Not\ Found\)|Cannot read property \'trigger\' of null'
+            accepted_javascript_messages = r'(zoom\-in\.cur.*)404\ \(Not\ Found\)|Uncaught TypeError: Cannot read properties of null \(reading \'trigger\'\)'
 
             if (entry['level'] == 'SEVERE'):
                 # print(self.driver.current_url)  # TODO actually this seems to be the previous url


### PR DESCRIPTION
On the report builder we're seeing javascript errors since tuesday august 31st.

```
bootstrap.min.js:6 Uncaught TypeError: Cannot read properties of null (reading 'trigger')
    at HTMLDivElement.u (bootstrap.min.js:6)
    at HTMLDivElement.fn (jquery.js:5175)
    at HTMLDivElement.handle (bootstrap.min.js:6)
    at HTMLDivElement.dispatch (jquery.js:5430)
    at HTMLDivElement.elemData.handle (jquery.js:5234)
    at Object.trigger (jquery.js:8719)
    at HTMLDivElement.<anonymous> (jquery.js:8797)
    at Function.each (jquery.js:385)
    at jQuery.fn.init.each (jquery.js:207)
    at jQuery.fn.init.trigger (jquery.js:8796)
```

These happen with 2.2.0, 2.1.0 etc. We have a regex in the test suite that ignores this error, but the error message has changed slightly. This PR updates the regex. Also this error happens during manual usage, so I removed the comment about it only happening during integration tests. Apart from the error appearing in the javascript console, the report builders seems to work fin. So it _looks like_ we can keep ignoring this error. I guess we have to because we don't know where it's coming from as the stacktrace only contains bootstrap + jquery code paths.