### PR TITLE
Support Docker Compose V2

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,16 +67,16 @@ jobs:
 
       # phased startup so we can use the exit code from unit test container
       - name: Start MySQL
-        run: docker compose up -d
+        run: docker-compose up -d
 
       # no celery or initializer needed for unit tests
       - name: Unit tests
-        run: docker compose up --no-deps --exit-code-from uwsgi uwsgi
+        run: docker-compose up --no-deps --exit-code-from uwsgi uwsgi
 
       - name: Logs
         if: failure()
-        run: docker compose logs --tail="2500" uwsgi
+        run: docker-compose logs --tail="2500" uwsgi
 
       - name: Shutdown
         if: always()
-        run: docker compose down
+        run: docker-compose down

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -67,16 +67,16 @@ jobs:
 
       # phased startup so we can use the exit code from unit test container
       - name: Start MySQL
-        run: docker-compose up -d
+        run: docker compose up -d
 
       # no celery or initializer needed for unit tests
       - name: Unit tests
-        run: docker-compose up --no-deps --exit-code-from uwsgi uwsgi
+        run: docker compose up --no-deps --exit-code-from uwsgi uwsgi
 
       - name: Logs
         if: failure()
-        run: docker-compose logs --tail="2500" uwsgi
+        run: docker compose logs --tail="2500" uwsgi
 
       - name: Shutdown
         if: always()
-        run: docker-compose down
+        run: docker compose down

--- a/docker-compose.override.debug.yml
+++ b/docker-compose.override.debug.yml
@@ -7,8 +7,8 @@
           - '.:/app:z'
         environment:
           DD_DEBUG: 'True'
-          DD_ADMIN_USER: ${DD_ADMIN_USER:-admin}
-          DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-admin}
+          DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+          DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
         ports:
           - target: ${DD_DEBUG_PORT:-3000}
             published: ${DD_DEBUG_PORT:-3000}
@@ -24,8 +24,8 @@
         volumes:
           - '.:/app:z'
         environment:
-          DD_ADMIN_USER: ${DD_ADMIN_USER:-admin}
-          DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-admin}
+          DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+          DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
       nginx:
         volumes:
           - './dojo/static/dojo:/usr/share/nginx/html/static/dojo'

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -6,8 +6,8 @@ services:
     volumes:
       - '.:/app:z'
     environment:
-      DD_ADMIN_USER: ${DD_ADMIN_USER:-admin}
-      DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-admin}
+      DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
   celeryworker:
     volumes:
       - '.:/app:z'
@@ -18,8 +18,8 @@ services:
     volumes:
       - '.:/app:z'
     environment:
-      DD_ADMIN_USER: ${DD_ADMIN_USER:-admin}
-      DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-admin}
+      DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
   nginx:
     volumes:
       - './dojo/static/dojo:/usr/share/nginx/html/static/dojo'

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -5,43 +5,43 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.integration-tests
-    image: defectdojo/defectdojo-integration-tests:${INTEGRATION_TESTS_VERSION:-latest}
+    image: "defectdojo/defectdojo-integration-tests:${INTEGRATION_TESTS_VERSION:-latest}"
     depends_on:
       - nginx
       - uwsgi
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/app/docker/entrypoint-integration-tests.sh']
     volumes:
       - '.:/app:z'
-      - defectdojo_media_unittest:${DD_MEDIA_ROOT:-/app/media}
+      - "defectdojo_media_integration_test:${DD_MEDIA_ROOT:-/app/media}"
     environment:
       DD_BASE_URL: 'http://nginx:8080/'
-      DD_ADMIN_USER: ${DD_ADMIN_USER:-admin}
-      DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-AdminsLoveIntegrationtests!}
-      DD_SECRET_KEY: ${DD_SECRET_KEY:-.}
+      DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-AdminsLoveIntegrationtests!}"
+      DD_SECRET_KEY: "${DD_SECRET_KEY:-.}"
   nginx:
     volumes:
-      - defectdojo_media_unittest:/usr/share/nginx/html/media
+      - defectdojo_media_integration_test:/usr/share/nginx/html/media
   uwsgi:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-uwsgi-dev.sh']
     volumes:
       - '.:/app:z'
-      - defectdojo_media_unittest:${DD_MEDIA_ROOT:-/app/media}
+      - defectdojo_media_integration_test:${DD_MEDIA_ROOT:-/app/media}
     environment:
       DD_DEBUG: 'True'
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
-      DD_SECRET_KEY: ${DD_SECRET_KEY:-.}
+      DD_DATABASE_URL: "${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}"
+      DD_SECRET_KEY: "${DD_SECRET_KEY:-.}"
   celerybeat:
     environment:
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
+      DD_DATABASE_URL: "${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}"
   celeryworker:
     environment:
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
+      DD_DATABASE_URL: "${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}"
   initializer:
     environment:
       DD_INITIALIZE: 'true'
-      DD_DATABASE_URL: ${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}
-      DD_ADMIN_PASSWORD: ${DD_ADMIN_PASSWORD:-AdminsLoveIntegrationtests!}
-      DD_SECRET_KEY: ${DD_SECRET_KEY:-.}
+      DD_DATABASE_URL: "${DD_TEST_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo}"
+      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-AdminsLoveIntegrationtests!}"
+      DD_SECRET_KEY: "${DD_SECRET_KEY:-.}"
     volumes:
       - '.:/app:z'
   mysql:
@@ -51,9 +51,9 @@ services:
         protocol: tcp
         mode: host
     environment:
-      MYSQL_DATABASE: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
+      MYSQL_DATABASE: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
     volumes:
        - defectdojo_data_integration_tests:/var/lib/mysql
 volumes:
   defectdojo_data_integration_tests: {}
-  defectdojo_media_unittest: {}
+  defectdojo_media_integration_test: {}

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -10,11 +10,11 @@ services:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/app/docker/entrypoint-unit-tests-devDocker.sh']
     volumes:
       - '.:/app:z'
-      - defectdojo_media_unittest:${DD_MEDIA_ROOT:-/app/media}
+      - "defectdojo_media_unittest:${DD_MEDIA_ROOT:-/app/media}"
     environment:
       DD_DEBUG: 'True'
-      DD_TEST_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
-      DD_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
+      DD_TEST_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
+      DD_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
   celerybeat:
     image: busybox:1.34.0-musl
     entrypoint: ['echo', 'skipping', 'celery beat']
@@ -32,7 +32,7 @@ services:
         protocol: tcp
         mode: host
     environment:
-      MYSQL_DATABASE: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
+      MYSQL_DATABASE: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
     volumes:
        - defectdojo_data_unittest:/var/lib/mysql
 volumes:

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -10,11 +10,11 @@ services:
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/app/docker/entrypoint-unit-tests.sh']
     volumes:
       - '.:/app:z'
-      - defectdojo_media_unittest:${DD_MEDIA_ROOT:-/app/media}
+      - "defectdojo_media_unittest:${DD_MEDIA_ROOT:-/app/media}"
     environment:
       DD_DEBUG: 'True'
-      DD_TEST_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
-      DD_DATABASE_NAME: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
+      DD_TEST_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
+      DD_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
   celerybeat:
     image: busybox:1.34.0-musl
     entrypoint: ['echo', 'skipping', 'celery beat']
@@ -31,7 +31,7 @@ services:
         protocol: tcp
         mode: host
     environment:
-      MYSQL_DATABASE: ${DD_TEST_DATABASE_NAME:-test_defectdojo}
+      MYSQL_DATABASE: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
     volumes:
        - defectdojo_data_unittest:/var/lib/mysql
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.nginx
-    image: defectdojo/defectdojo-nginx:${NGINX_VERSION:-latest}
+    image: "defectdojo/defectdojo-nginx:${NGINX_VERSION:-latest}"
     depends_on:
       - uwsgi
     environment:
-      NGINX_METRICS_ENABLED: ${NGINX_METRICS_ENABLED:-false}
+      NGINX_METRICS_ENABLED: "${NGINX_METRICS_ENABLED:-false}"
     volumes:
       - defectdojo_media:/usr/share/nginx/html/media
     ports:
@@ -32,71 +32,71 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.django
-    image: defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}
+    image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     depends_on:
       - mysql
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-uwsgi.sh']
     environment:
       DD_DEBUG: 'False'
-      DD_DJANGO_METRICS_ENABLED: ${DD_DJANGO_METRICS_ENABLED:-False}
-      DD_ALLOWED_HOSTS: ${DD_ALLOWED_HOSTS:-*}
-      DD_DATABASE_URL: ${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}
-      DD_CELERY_BROKER_USER: ${DD_CELERY_BROKER_USER:-guest}
-      DD_CELERY_BROKER_PASSWORD: ${DD_CELERY_BROKER_USER:-guest}
-      DD_SECRET_KEY: ${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}
-      DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}
+      DD_DJANGO_METRICS_ENABLED: "${DD_DJANGO_METRICS_ENABLED:-False}"
+      DD_ALLOWED_HOSTS: "${DD_ALLOWED_HOSTS:-*}"
+      DD_DATABASE_URL: "${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}"
+      DD_CELERY_BROKER_USER: "${DD_CELERY_BROKER_USER:-guest}"
+      DD_CELERY_BROKER_PASSWORD: "${DD_CELERY_BROKER_USER:-guest}"
+      DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
+      DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
     volumes:
         - type: bind
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
-        - defectdojo_media:${DD_MEDIA_ROOT:-/app/media}
+        - "defectdojo_media:${DD_MEDIA_ROOT:-/app/media}"
   celerybeat:
-    image: defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}
+    image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     depends_on:
       - mysql
       - rabbitmq
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-celery-beat.sh']
     environment:
-      DD_DATABASE_URL: ${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}
-      DD_CELERY_BROKER_USER: ${DD_CELERY_BROKER_USER:-guest}
-      DD_CELERY_BROKER_PASSWORD: ${DD_CELERY_BROKER_USER:-guest}
-      DD_SECRET_KEY: ${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}
-      DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}
+      DD_DATABASE_URL: "${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}"
+      DD_CELERY_BROKER_USER: "${DD_CELERY_BROKER_USER:-guest}"
+      DD_CELERY_BROKER_PASSWORD: "${DD_CELERY_BROKER_USER:-guest}"
+      DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
+      DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
     volumes:
         - type: bind
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
   celeryworker:
-    image: defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}
+    image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     depends_on:
       - mysql
       - rabbitmq
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-celery-worker.sh']
     environment:
-      DD_DATABASE_URL: ${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}
-      DD_CELERY_BROKER_USER: ${DD_CELERY_BROKER_USER:-guest}
-      DD_CELERY_BROKER_PASSWORD: ${DD_CELERY_BROKER_USER:-guest}
-      DD_SECRET_KEY: ${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}
-      DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}
+      DD_DATABASE_URL: "${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}"
+      DD_CELERY_BROKER_USER: "${DD_CELERY_BROKER_USER:-guest}"
+      DD_CELERY_BROKER_PASSWORD: "${DD_CELERY_BROKER_USER:-guest}"
+      DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
+      DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
     volumes:
         - type: bind
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
-        - defectdojo_media:${DD_MEDIA_ROOT:-/app/media}
+        - "defectdojo_media:${DD_MEDIA_ROOT:-/app/media}"
   initializer:
-    image: defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}
+    image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     depends_on:
       - mysql
     entrypoint: ['/wait-for-it.sh', 'mysql:3306', '--', '/entrypoint-initializer.sh']
     environment:
-      DD_DATABASE_URL: ${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}
-      DD_ADMIN_USER: ${DD_ADMIN_USER:-admin}
-      DD_ADMIN_MAIL: ${DD_ADMIN_USER:-admin@defectdojo.local}
-      DD_ADMIN_FIRST_NAME: ${DD_ADMIN_FIRST_NAME:-Admin}
-      DD_ADMIN_LAST_NAME: ${DD_ADMIN_LAST_NAME:-User}
-      DD_INITIALIZE: ${DD_INITIALIZE:-true}
-      DD_SECRET_KEY: ${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}
-      DD_CREDENTIAL_AES_256_KEY: ${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}
+      DD_DATABASE_URL: "${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}"
+      DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+      DD_ADMIN_MAIL: "${DD_ADMIN_USER:-admin@defectdojo.local}"
+      DD_ADMIN_FIRST_NAME: "${DD_ADMIN_FIRST_NAME:-Admin}"
+      DD_ADMIN_LAST_NAME: "${DD_ADMIN_LAST_NAME:-User}"
+      DD_INITIALIZE: "${DD_INITIALIZE:-true}"
+      DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
+      DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
     volumes:
         - type: bind
           source: ./docker/extra_settings
@@ -105,10 +105,10 @@ services:
     image: mysql:5.7.35@sha256:7cf2e7d7ff876f93c8601406a5aa17484e6623875e64e7acc71432ad8e0a3d7e
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: 'yes'
-      DD_DATABASE_URL: ${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}
-      MYSQL_USER: ${DD_DATABASE_USER:-defectdojo}
-      MYSQL_PASSWORD: ${DD_DATABASE_PASSWORD:-defectdojo}
-      MYSQL_DATABASE: ${DD_DATABASE_NAME:-defectdojo}
+      DD_DATABASE_URL: "${DD_DATABASE_URL:-mysql://defectdojo:defectdojo@mysql:3306/defectdojo}"
+      MYSQL_USER: "${DD_DATABASE_USER:-defectdojo}"
+      MYSQL_PASSWORD: "${DD_DATABASE_PASSWORD:-defectdojo}"
+      MYSQL_DATABASE: "${DD_DATABASE_NAME:-defectdojo}"
     command: ['mysqld', '--character-set-server=utf8mb4', '--collation-server=utf8mb4_unicode_ci']
     volumes:
        - defectdojo_data:/var/lib/mysql


### PR DESCRIPTION
Fixes #4862

The new version of Docker Compose (see https://docs.docker.com/compose/cli-command/) behaves differently when there a special character like `*` in variables and throws error messages in these cases. This PR quotes all variables where input via environment variables is allowed and works with both versions of Docker Compose.