### PR TITLE
fix: support Aquasecurity's cloudsploit "region" as list 

### DIFF
--- a/dojo/tools/cloudsploit/parser.py
+++ b/dojo/tools/cloudsploit/parser.py
@@ -28,9 +28,13 @@ class CloudsploitParser(object):
         dupes = dict()
         for item in data:
             title = item['title']
+            if type(item['region']) is str:
+                region = item['region']
+            elif type(item['region']) is list:
+                region = ','.join(item['region'])
             description = "**Finding** : " + item['message'] + "\n" + \
                 "**Resource** : " + item['resource'] + "\n" + \
-                "**Region** : " + item['region']
+                "**Region** : " + region
             severity = self.convert_severity(item['status'])
             finding = Finding(
                 title=title,

--- a/dojo/unittests/scans/cloudsploit/cloudsploit_many_vul.json
+++ b/dojo/unittests/scans/cloudsploit/cloudsploit_many_vul.json
@@ -48,5 +48,17 @@
         "region": "us-east-1",
         "status": "OK",
         "message": "No ACM certificates found"
+    },
+    {
+        "plugin": "cloudfrontWafEnabled",
+        "category": "CloudFront",
+        "title": "CloudFront WAF Enabled",
+        "description": "Ensures CloudFront distributions have WAF enabled.",
+        "resource": "arn:aws:cloudfront::Ah6oophiekoongah",
+        "region": [
+            "global"
+        ],
+        "status": "FAIL",
+        "message": "The Cloudfront Distribution does not have WAF enabled"
     }
 ]

--- a/dojo/unittests/tools/test_cloudsploit_parser.py
+++ b/dojo/unittests/tools/test_cloudsploit_parser.py
@@ -24,4 +24,4 @@ class TestCloudsploitParser(TestCase):
         parser = CloudsploitParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertEqual(5, len(findings))
+        self.assertEqual(6, len(findings))


### PR DESCRIPTION
fix: in Aquasecurity's cloudsploit scan result "region" can be either… a string of a list of strings