### PR TITLE
Improve bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ A clear and concise description of what you expected to happen.
  - DefectDojo version (see footer) or commit message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
 
 **Logs** 
-Use `docker-compose logs` to get the logs and add the relevant sections here showing the error occurring (if applicable)
+Use `docker-compose logs` to get the logs and add the relevant sections here showing the error occurring (if applicable).
 
 **Sample scan files**
 If applicable, add sample scan files to help reproduce your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ A clear and concise description of what you expected to happen.
 
 **Environment information**
  - Operating System: [e.g. Ubuntu 18.04]
- - DefectDojo Version (see footer) or commit Message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
+ - DefectDojo version (see footer) or commit message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
 
 **Logs** 
 Use `docker-compose logs` to get the logs and add the relevant sections here showing the error occurring (if applicable)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,7 +36,7 @@ A clear and concise description of what you expected to happen.
  - DefectDojo version (see footer) or commit message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
 
 **Logs** 
-Use `docker-compose logs` to get the logs and add the relevant sections here showing the error occurring (if applicable).
+Use `docker-compose logs` (or similar, depending on your deployment method) to get the logs and add the relevant sections here showing the error occurring (if applicable).
 
 **Sample scan files**
 If applicable, add sample scan files to help reproduce your problem.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,16 +34,16 @@ A clear and concise description of what you expected to happen.
 
 **Environment information**
  - Operating System: [e.g. Ubuntu 18.04]
- - DefectDojo Commit Message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
+ - DefectDojo Version (see footer) or commit Message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
 
-**Sample scan files** (optional)
+**Logs** 
+Use `docker-compose logs` to get the logs and add the relevant sections here showing the error occurring (if applicable)
+
+**Sample scan files**
 If applicable, add sample scan files to help reproduce your problem.
 
-**Screenshots** (optional)
+**Screenshots**
 If applicable, add screenshots to help explain your problem.
-
-**Console logs** (optional)
-If applicable, add console logs to help explain your problem.
 
 **Additional context** (optional)
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,10 +27,9 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Deployment method** *(select with an `X`)*
-- [ ] Docker
+- [ ] Docker Compose
 - [ ] Kubernetes
 - [ ] GoDojo
-- [ ] setup.bash / legacy-setup.bash
 
 **Environment information**
  - Operating System: [e.g. Ubuntu 18.04]


### PR DESCRIPTION
We lately see a lot of "poor quality" bug reports without any info, or people not familiar with retrieveing the commit message of their Dojo install. This PR:

- Makes adding logs mandatory for bugs;
- Allows adding version number instead of commit message to make it easier for regular users using versioned releases;
- Remove setup.bash as deployment method;

Against master for immediate effect.