### PR TITLE
fix custom severity for sonarqube

### DIFF
--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -93,7 +93,7 @@ class SonarQubeApiImporter(object):
                 line = issue.get('line')
                 rule_id = issue['rule']
                 rule = client.get_rule(rule_id)
-                severity = self.convert_sonar_severity(rule['severity'])
+                severity = self.convert_sonar_severity(issue['severity'])
                 description = self.clean_rule_description_html(rule['htmlDesc'])
                 cwe = self.clean_cwe(rule['htmlDesc'])
                 references = self.get_references(rule['htmlDesc'])


### PR DESCRIPTION
SonarQube allows admins to change the default severity for rules on a per-quality gate basis. The SonarQube API importer uses the default severity based on the data from the rule, rather than the (potentially) customized severity based on the issue.

This PR changes the severity derivation from rule to issue to allow custom severities to propagate into Defect Dojo.