### PR TITLE
Added Dependency Check Suppression parsing

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -313,13 +313,13 @@ python manage.py test dojo.unittests --keepdb
 Run all the tests from a python file. Example:
 
 ```
-python manage.py test dojo.unittests.test_dependency_check_parser --keepdb
+python manage.py test dojo.unittests.tools.test_dependency_check_parser --keepdb
 ```
 
 Run a single test. Example:
 
 ```
-python manage.py test dojo.unittests.test_dependency_check_parser.TestDependencyCheckParser.test_parse_without_file_has_no_findings --keepdb
+python manage.py test dojo.unittests.tools.test_dependency_check_parser.TestDependencyCheckParser.test_parse_file_with_no_vulnerabilities_has_no_findings --keepdb
 ```
 
 ## Running the integration-tests

--- a/dojo/unittests/tools/test_dependency_check_parser.py
+++ b/dojo/unittests/tools/test_dependency_check_parser.py
@@ -595,6 +595,103 @@ class TestDependencyCheckParser(TestCase):
                         <software>cpe:/a:component3:component3:1.0</software>
                     </vulnerableSoftware>
                 </vulnerability>
+                <suppressedVulnerability source="NVD">
+                    <name>CVE-2019-7238</name>
+                    <cvssV2>
+                        <score>7.5</score>
+                        <accessVector>NETWORK</accessVector>
+                        <accessComplexity>LOW</accessComplexity>
+                        <authenticationr>NONE</authenticationr>
+                        <confidentialImpact>PARTIAL</confidentialImpact>
+                        <integrityImpact>PARTIAL</integrityImpact>
+                        <availabilityImpact>PARTIAL</availabilityImpact>
+                        <severity>HIGH</severity>
+                        <version>2.0</version>
+                        <exploitabilityScore>10.0</exploitabilityScore>
+                        <impactScore>6.4</impactScore>
+                    </cvssV2>
+                    <cvssV3>
+                        <baseScore>9.8</baseScore>
+                        <attackVector>NETWORK</attackVector>
+                        <attackComplexity>LOW</attackComplexity>
+                        <privilegesRequired>NONE</privilegesRequired>
+                        <userInteraction>NONE</userInteraction>
+                        <scope>UNCHANGED</scope>
+                        <confidentialityImpact>HIGH</confidentialityImpact>
+                        <integrityImpact>HIGH</integrityImpact>
+                        <availabilityImpact>HIGH</availabilityImpact>
+                        <baseSeverity>CRITICAL</baseSeverity>
+                        <exploitabilityScore>3.9</exploitabilityScore>
+                        <impactScore>5.9</impactScore>
+                        <version>3.0</version>
+                    </cvssV3>
+                    <cwes>
+                        <cwe>NVD-CWE-noinfo</cwe>
+                    </cwes>
+                    <description>Sonatype Nexus Repository Manager before 3.15.0 has Incorrect Access Control.</description>
+                    <references>
+                        <reference>
+                        <source>MISC</source>
+                        <url>https://support.sonatype.com/hc/en-us/articles/360017310793-CVE-2019-7238-Nexus-Repository-Manager-3-Missing-Access-Controls-and-Remote-Code-Execution-February-5th-2019</url>
+                        <name>https://support.sonatype.com/hc/en-us/articles/360017310793-CVE-2019-7238-Nexus-Repository-Manager-3-Missing-Access-Controls-and-Remote-Code-Execution-February-5th-2019</name>
+                        </reference>
+                    </references>
+                    <vulnerableSoftware>
+                        <software matched="true" versionEndExcluding="3.15.0">cpe:2.3:a:sonatype:nexus:*:*:*:*:*:*:*:*</software>
+                    </vulnerableSoftware>
+                </suppressedVulnerability>
+                <suppressedVulnerability source="NVD">
+                    <name>CVE-2017-1000487</name>
+                    <cvssV2>
+                        <score>7.5</score>
+                        <accessVector>NETWORK</accessVector>
+                        <accessComplexity>LOW</accessComplexity>
+                        <authenticationr>NONE</authenticationr>
+                        <confidentialImpact>PARTIAL</confidentialImpact>
+                        <integrityImpact>PARTIAL</integrityImpact>
+                        <availabilityImpact>PARTIAL</availabilityImpact>
+                        <severity>HIGH</severity>
+                        <version>2.0</version>
+                        <exploitabilityScore>10.0</exploitabilityScore>
+                        <impactScore>6.4</impactScore>
+                        <acInsufInfo>true</acInsufInfo>
+                    </cvssV2>
+                    <cvssV3>
+                        <baseScore>9.8</baseScore>
+                        <attackVector>NETWORK</attackVector>
+                        <attackComplexity>LOW</attackComplexity>
+                        <privilegesRequired>NONE</privilegesRequired>
+                        <userInteraction>NONE</userInteraction>
+                        <scope>UNCHANGED</scope>
+                        <confidentialityImpact>HIGH</confidentialityImpact>
+                        <integrityImpact>HIGH</integrityImpact>
+                        <availabilityImpact>HIGH</availabilityImpact>
+                        <baseSeverity>CRITICAL</baseSeverity>
+                        <exploitabilityScore>3.9</exploitabilityScore>
+                        <impactScore>5.9</impactScore>
+                        <version>3.1</version>
+                    </cvssV3>
+                    <cwes>
+                        <cwe>CWE-78</cwe>
+                    </cwes>
+                    <description>Plexus-utils before 3.0.16 is vulnerable to command injection because it does not correctly process the contents of double quoted strings.</description>
+                    <notes>This is our reason for not to upgrade it.</notes>
+                    <references>
+                        <reference>
+                        <source>MLIST</source>
+                        <url>https://lists.debian.org/debian-lts-announce/2018/01/msg00011.html</url>
+                        <name>[debian-lts-announce] 20180109 [SECURITY] [DLA 1237-1] plexus-utils2 security update</name>
+                        </reference>
+                        <reference>
+                        <source>DEBIAN</source>
+                        <url>https://www.debian.org/security/2018/dsa-4146</url>
+                        <name>DSA-4146</name>
+                        </reference>
+                    </references>
+                    <vulnerableSoftware>
+                        <software matched="true" versionEndExcluding="3.0.16">cpe:2.3:a:plexus-utils_project:plexus-utils:*:*:*:*:*:*:*:*</software>
+                    </vulnerableSoftware>
+                </suppressedVulnerability>
             </vulnerabilities>
         </dependency>
     </dependencies>
@@ -604,7 +701,8 @@ class TestDependencyCheckParser(TestCase):
         parser = DependencyCheckParser()
         findings = parser.get_findings(testfile, Test())
         items = findings
-        self.assertEqual(9, len(items))
+        
+        self.assertEqual(11, len(items))
         # test also different component_name formats
 
         # identifier -> package url java + 2 relateddependencies
@@ -633,6 +731,7 @@ class TestDependencyCheckParser(TestCase):
             items[1].mitigation,
             "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description"
         )
+        self.assertEqual(items[1].tags, "related")
 
         self.assertEqual(
             items[2].title,
@@ -731,6 +830,21 @@ class TestDependencyCheckParser(TestCase):
             items[8].mitigation,
             "Update jquery:3.1.1 to at least the version recommended in the description"
         )
+
+        # Tests for two suppressed vulnerabilities,
+        # One for Suppressed with notes, the other is without.
+        self.assertEqual(items[9].active, False)
+        self.assertEqual(items[9].is_mitigated, True)
+        self.assertEqual(items[9].risk_accepted, True)
+        self.assertEqual(items[9].mitigation,        
+                    '**This vulnerability is mitigated and/or suppressed:** Document on why we are suppressing this vulnerability is missing!')
+
+        self.assertEqual(items[10].active, False)
+        self.assertEqual(items[10].is_mitigated, True)
+        self.assertEqual(items[10].risk_accepted, True)
+        self.assertEqual(items[10].mitigation,
+                     '**This vulnerability is mitigated and/or suppressed:** This is our reason for not to upgrade it.')
+
 
         # evidencecollected -> multiple product + multiple version
         # TODO? Seems like since v6.0.0 there's always a packageurl


### PR DESCRIPTION
* Dependency Suppressions are now parsed.
* If the suppression has no notes, it'll tag it
  [missingdoc]
* If the suppression has notes, it'll populate
  the mitigation field with it.
* Also added some tests related to parsing
* Fixed Docker.md with correct examples

Overall I modified the dependency checker to parse suppression fields coming from the XML file. 

If it has notes about the suppression, it will populate the migrations with the note, it'll mark the finding Inactive, and Risk Accepted. 
If it doesn't have notes, it'll still mark it as Inactive, Risk Accepted but will also tag the finding as "missingdoc"

I also added some tests related. 

I don't do much PRs as I don't consider myself a good programmer. I hope I'm doing everything right :) Thanks!