### PR TITLE
Update dropdown menu of Tool Type page

### DIFF
--- a/dojo/templates/dojo/tool_type.html
+++ b/dojo/templates/dojo/tool_type.html
@@ -18,7 +18,7 @@
                                 aria-labelledby="dropdownMenu1">
                                     <li role="presentation">
                                         <a href="{% url 'add_tool_type' %}">
-                                            <i class="fa fa-plus"></i> Add Tool Configuration
+                                            <i class="fa fa-plus"></i> Add Tool Type
                                         </a>
                                     </li>
                             </ul>


### PR DESCRIPTION
In the dropdown menu of the _Tool Type_ page it says "Add Tool Configuration" (seemingly copied from the _Tool Configuration_ page). I updated it to say "Add Tool Type".

| Before | After |
| --- | --- |
| <img width="958" alt="before" src="https://user-images.githubusercontent.com/3742559/133085738-78e61a57-80c7-43c0-a0b4-fc902bbcc7d8.png"> | <img width="958" alt="after" src="https://user-images.githubusercontent.com/3742559/133085719-7f4c8945-91b6-46ac-8499-8f39889397ea.png"> |

Relatedly, I noticed what seems like a similar mistake in [`regulations_config.html`](https://github.com/DefectDojo/django-DefectDojo/blob/b44af80ddfb4535eba85b72e5ec707e96db61996/dojo/templates/dojo/regulations_config.html#L21) (also [the title](https://github.com/DefectDojo/django-DefectDojo/blob/b44af80ddfb4535eba85b72e5ec707e96db61996/dojo/templates/dojo/regulations_config.html#L10)). However, I was not able to find this page in the UI so I couldn't test it and hence I didn't include a fix for it in this PR.


