### PR TITLE
UI improvements

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -71,6 +71,18 @@ a {
 .btn-primary:hover {
     background-color: #38434d!important;
 }
+
+.btn-secondary {
+    color: #fff;
+    background-color: #546474;
+	border-style: none!important;
+}
+
+.btn-secondary:hover {
+    color: #fff;
+    background-color: #38434d!important;
+}
+
 /*
 .btn-primary.active.focus, .btn-primary.active:focus, .btn-primary.active:hover, .btn-primary:active.focus, .btn-primary:active:focus, .btn-primary:active:hover, .open > .dropdown-toggle.btn-primary.focus, .open > .dropdown-toggle.btn-primary:focus, .open > .dropdown-toggle.btn-primary:hover {
     background-color: transparent!important;

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -27,13 +27,13 @@
         {% if submit == 'report' %}
             {% query_string_as_hidden %}
             <div class="inline-block" style="vertical-align: text-top">
-                <button class="btn btn-primary" name="_generate" type="submit">
+                <button class="btn btn-secondary" name="_generate" type="submit">
                     <i class="fa fa-file-text-o"></i> Generate Report
                 </button>
             </div>
         {% else %}
             <div class="inline-block" style="vertical-align: text-top">
-                <button id="apply" class="btn btn-sm btn-primary">
+                <button id="apply" class="btn btn-sm btn-secondary">
                     <i class="fa fa-filter"></i> Apply Filters
                 </button>
                 &nbsp;

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -11,6 +11,7 @@
                     <h3 class="has-filters">
                         {{ filter_name }} Findings
                         <div class="dropdown pull-right">
+                            &nbsp;
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
                         </div>
                         <form method="get" action="{% url 'quick_report' %}" class="pull-right">

--- a/dojo/templates/dojo/paging_snippet.html
+++ b/dojo/templates/dojo/paging_snippet.html
@@ -24,8 +24,8 @@
                     <!-- Split button -->
                     &nbsp;
                     <div class="btn-group">
-                        <button type="button" class="btn btn-sm btn-primary">Page Size</button>
-                        <button type="button" class="btn-sm btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <button type="button" class="btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            Page Size
                             <span class="caret"></span>
                             <span class="sr-only">Toggle Dropdown</span>
                         </button>

--- a/dojo/templates/dojo/profile.html
+++ b/dojo/templates/dojo/profile.html
@@ -45,6 +45,9 @@
                 <div class="panel-heading">
                     <div class="clearfix">
                         <h4 class="pull-left">Groups</h4>
+                        &nbsp;
+                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                            <i class="fa fa-question-circle"></i></a>
                         {% if request.user.is_superuser %}
                         <div class="dropdown pull-right">
                             <button class="btn btn-primary dropdown-toggle" aria-label="Actions" type="button" id="dropdownMenuAddGroupMember"
@@ -59,9 +62,6 @@
                                     </a>
                                 </li>
                             </ul>
-                            &nbsp;
-                            <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                                <i class="fa fa-question-circle text-low"></i></a>
                         </div>
                         {% endif %}
                     </div>

--- a/dojo/templates/dojo/report_filter_snippet.html
+++ b/dojo/templates/dojo/report_filter_snippet.html
@@ -13,7 +13,7 @@
         {% endfor %}
 
         <div class="inline-block" style="vertical-align: text-top">
-            <button class="btn btn-sm btn-primary">
+            <button class="btn btn-sm btn-secondary">
                 <i class="fa fa-filter"></i> Apply Filters
             </button>
             &nbsp;

--- a/dojo/templates/dojo/snippets/comments.html
+++ b/dojo/templates/dojo/snippets/comments.html
@@ -2,17 +2,17 @@
 {% load display_tags %}
 {% load authorization_tags %}
 <div class="panel panel-default table-responsive">
-    <div class="panel-comments">
+    <div class="panel-heading">
         <h4>Notes <span class="pull-right"><a data-toggle="collapse" href="#vuln_notes"><i
                 class="glyphicon glyphicon-chevron-up"></i></a></span></h4>
     </div>
     {% if object|has_object_permission:"Note_Add" or user|is_authorized_for_staff:object %}
-    <div id="vuln_notes" class="panel-body">
+    <div id="vuln_notes" class="panel-body collapse in">
       <form class="form-horizontal" action="" method="post">{% csrf_token %}
           {% include "dojo/form_fields.html" with form=form %}
           <div class="form-group">
               <div class="col-sm-offset-2 col-sm-10">
-                  <input class="btn btn-primary" label="Add Note" type="submit" id="add_note" value="Add Note"/>
+                  <input class="btn btn-secondary" label="Add Note" type="submit" id="add_note" value="Add Note"/>
               </div>
           </div>
       </form>

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -463,7 +463,9 @@
                     {% if eng.engagement_type == "Interactive" and system_settings.enable_checklists %}
                         <div class="panel panel-default">
                             <div class="panel-heading">
-                                <h4> Checklist<span class="pull-right"><a name="collapsible" data-toggle="collapse" href="#add_feat_check_list">
+                                <h4> Checklist<span class="pull-right">
+                                    &nbsp;
+                                    <a name="collapsible" data-toggle="collapse" href="#add_feat_check_list">
                                     <i class="glyphicon glyphicon-chevron-down"></i></a></span>
                                     {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_delete:eng %}
                                         {% if check %}
@@ -532,6 +534,7 @@
                         <div class="panel panel-default">
                             <div class="panel-heading">
                                 <h4>Questionnaires<span class="pull-right">
+                                    &nbsp;
                                     <a name="collapsible" data-toggle="collapse" href="#add_feat_survey">
                                     <i class="glyphicon glyphicon-chevron-down"></i></a></span>
                                     {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}
@@ -668,6 +671,7 @@
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <h4>Files<span class="pull-right">
+                                &nbsp;
                                 <a data-toggle="collapse" href="#add_feat_files">
                                 <i class="glyphicon glyphicon-chevron-down"></i></a></span>
                                 {% if eng|has_object_permission:"Engagement_Edit" or user|is_authorized_for_staff:eng %}

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -588,7 +588,7 @@
                                     {% include "dojo/form_fields.html" with form=form %}
                                     <div class="form-group">
                                         <div class="col-sm-offset-2 col-sm-10">
-                                            <input class="btn btn-primary" type="submit" id="add_note" label="Add Notes" value="Add Note"/>
+                                            <input class="btn btn-secondary" type="submit" id="add_note" label="Add Notes" value="Add Note"/>
                                         </div>
                                     </div>
                                 </form>

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -636,6 +636,7 @@
                     </i>
                     <span class="pull-right">
                         <button id="show-filters" data-toggle="collapse" data-target="#the-filters-wrapper" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
+                        &nbsp;
                         <a data-toggle="collapse" href="#the-filters-wrapper"><i class="glyphicon glyphicon-chevron-down"></i></a>
                     </span>
                 </h4>

--- a/dojo/templates/dojo/view_group.html
+++ b/dojo/templates/dojo/view_group.html
@@ -46,6 +46,9 @@
             <div class="panel-heading">
                 <div class="clearfix">
                     <h4 class="pull-left">Members</h4>
+                    &nbsp;
+                    <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/#groups" target="_blank">
+                        <i class="fa fa-question-circle"></i></a>
                     {% if group|has_object_permission:"Group_Manage_Members" %}
                     <div class="dropdown pull-right">
                         <button class="btn btn-primary dropdown-toggle" aria-label="Actions" type="button" id="dropdownMenuAddGroupMember"
@@ -60,8 +63,6 @@
                                 </a>
                             </li>
                         </ul>
-                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/#groups" target="_blank">
-                            <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}
                 </div>
@@ -118,6 +119,9 @@
             <div class="panel-heading">
                 <div class="clearfix">
                     <h4 class="pull-left">Product Type Groups</h4>
+                    &nbsp;
+                    <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                        <i class="fa fa-question-circle"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
                         <button class="btn btn-primary dropdown-toggle" aria-label="Actions" type="button" id="dropdownMenuAddProductTypeGroup"
@@ -132,8 +136,6 @@
                                 </a>
                             </li>
                         </ul>
-                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                            <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}
                 </div>
@@ -191,6 +193,9 @@
             <div class="panel-heading">
                 <div class="clearfix">
                     <h4 class="pull-left">Product Groups</h4>
+                    &nbsp;
+                    <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                        <i class="fa fa-question-circle"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
                         <button class="btn btn-primary dropdown-toggle" aria-label="Actions" type="button"  id="dropdownMenuAddProductGroup"
@@ -205,9 +210,6 @@
                                 </a>
                             </li>
                         </ul>
-                        &nbsp;
-                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                            <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}
                 </div>

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -252,6 +252,9 @@
         <div class="panel-heading">
             <div class="clearfix">
                 <h4 class="pull-left">Members</h4>
+                &nbsp;
+                <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                    <i class="fa fa-question-circle"></i></a>
                 {% if prod|has_object_permission:"Product_Manage_Members" %}
                 <div class="dropdown pull-right">
                     <button class="btn btn-primary dropdown-toggle" label="Actions" type="button" id="dropdownMenuAddProductMember"
@@ -266,9 +269,6 @@
                             </a>
                         </li>
                     </ul>
-                    &nbsp;
-                    <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                        <i class="fa fa-question-circle text-low"></i></a>
                 </div>
                 {% endif %}
             </div>
@@ -340,6 +340,9 @@
           <div class="panel-heading">
               <div class="clearfix">
                   <h4 class="pull-left">Groups</h4>
+                  &nbsp;
+                  <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                      <i class="fa fa-question-circle"></i></a>
                   {% if prod|has_object_permission:"Product_Group_Add" %}
                   <div class="dropdown pull-right">
                       <button class="btn btn-primary dropdown-toggle" label="Actions" type="button" id="dropdownMenuAddProductGroup"
@@ -354,9 +357,6 @@
                               </a>
                           </li>
                       </ul>
-                      &nbsp;
-                      <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                          <i class="fa fa-question-circle text-low"></i></a>
                   </div>
                   {% endif %}
               </div>

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -128,6 +128,9 @@
                     <div class="panel-heading">
                         <div class="clearfix">
                             <h4 class="pull-left">Members</h4>
+                            &nbsp;
+                            <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                                <i class="fa fa-question-circle"></i></a>
                             {% if pt|has_object_permission:"Product_Type_Manage_Members" %}
                             <div class="dropdown pull-right">
                                 <button class="btn btn-primary dropdown-toggle" label="Actions" type="button" id="dropdownMenuAddProductTypeMember"
@@ -142,9 +145,6 @@
                                         </a>
                                     </li>
                                 </ul>
-                                &nbsp;
-                                <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                                    <i class="fa fa-question-circle text-low"></i></a>
                             </div>
                             {% endif %}
                         </div>
@@ -201,6 +201,9 @@
                 <div class="panel-heading">
                     <div class="clearfix">
                         <h4 class="pull-left">Groups</h4>
+                        &nbsp;
+                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                            <i class="fa fa-question-circle"></i></a>
                         {% if pt|has_object_permission:"Product_Type_Group_Add" %}
                         <div class="dropdown pull-right">
                             <button class="btn btn-primary dropdown-toggle" label="Actions" type="button" id="dropdownMenuAddProductTypeGroup"
@@ -215,9 +218,6 @@
                                     </a>
                                 </li>
                             </ul>
-                            &nbsp;
-                            <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                                <i class="fa fa-question-circle text-low"></i></a>
                         </div>
                         {% endif %}
                     </div>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -220,6 +220,7 @@
                         </i>
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#import-history-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
+                            &nbsp;
                             <span class="pull-right">
                                 <a data-toggle="collapse" href="#import_history">
                                     <i class="glyphicon glyphicon-chevron-down"></i>
@@ -463,7 +464,7 @@
                 <h4 class="has-filters"> Findings ({{findings.total_count}}) <small>{{ test.id|get_severity_count:"test" }}</small>
                     <div class="dropdown pull-right"></div>
                     <div id="test-pulldown" class="dropdown pull-right">
-                        <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
+                        &nbsp;<button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
                         {% if test|has_object_permission:"Finding_Add" or user|is_authorized_for_change:test %}
                         <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                 data-toggle="dropdown" aria-expanded="true">
@@ -1113,8 +1114,8 @@
     <div class="col-md-12" id="cred">
         <div class="panel panel-default">
             <div class="panel-heading">
-                <h4>Files<span class="pull-right">
-                <a data-toggle="collapse" href="#add_feat_files">
+                <h4>Files<span class="pull-right">&nbsp;
+                    <a data-toggle="collapse" href="#add_feat_files">
                     <i class="glyphicon glyphicon-chevron-down"></i></a></span>
                     {% if test|has_object_permission:"Test_Edit" or user|is_authorized_for_staff:test %}
                     <a title="Manage Files" name="Manage Files" class="btn btn-sm btn-primary pull-right"

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -105,6 +105,9 @@
             <div class="panel-heading">
                 <div class="clearfix">
                     <h4 class="pull-left">Product Type Members</h4>
+                    &nbsp;
+                    <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                        <i class="fa fa-question-circle"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
                         <button class="btn btn-primary dropdown-toggle" aria-label="Actions" type="button" id="dropdownMenuAddProductTypeMember"
@@ -119,9 +122,6 @@
                                 </a>
                             </li>
                         </ul>
-                        &nbsp;
-                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                            <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}
                 </div>
@@ -178,6 +178,9 @@
             <div class="panel-heading">
                 <div class="clearfix">
                     <h4 class="pull-left">Product Members</h4>
+                    &nbsp;
+                    <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
+                        <i class="fa fa-question-circle"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
                         <button class="btn btn-primary dropdown-toggle" aria-label="Actions" type="button"  id="dropdownMenuAddProductMember"
@@ -192,9 +195,6 @@
                                 </a>
                             </li>
                         </ul>
-                        &nbsp;
-                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
-                            <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}
                 </div>
@@ -252,6 +252,9 @@
             <div class="panel-heading">
                 <div class="clearfix">
                     <h4 class="pull-left">Group Members</h4>
+                    &nbsp;
+                    <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/#groups" target="_blank">
+                        <i class="fa fa-question-circle"></i></a>
                     {% if request.user.is_superuser %}
                     <div class="dropdown pull-right">
                         <button class="btn btn-primary dropdown-toggle" aria-label="Actions" type="button" id="dropdownMenuAddGroupMember"
@@ -266,9 +269,6 @@
                                 </a>
                             </li>
                         </ul>
-                        &nbsp;
-                        <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/#groups" target="_blank">
-                            <i class="fa fa-question-circle text-low"></i></a>
                     </div>
                     {% endif %}
                 </div>

--- a/tests/group_test.py
+++ b/tests/group_test.py
@@ -42,7 +42,7 @@ class GroupTest(BaseTestCase):
         driver.find_element_by_id("id_name").clear()
         driver.find_element_by_id("id_name").send_keys("Group Name")
         # click on 'apply filter' button
-        driver.find_element_by_css_selector("button.btn.btn-sm.btn-primary").click()
+        driver.find_element_by_css_selector("button.btn.btn-sm.btn-secondary").click()
         # only the needed group is now available, proceed with opening the context menu and clicking 'Edit' button
         driver.find_element_by_id("dropdownMenuGroup").click()
         driver.find_element_by_id("editGroup").click()
@@ -138,7 +138,7 @@ class GroupTest(BaseTestCase):
         driver.find_element_by_id("id_name").clear()
         driver.find_element_by_id("id_name").send_keys("Another Name")
         # click on 'apply filter' button
-        driver.find_element_by_css_selector("button.btn.btn-sm.btn-primary").click()
+        driver.find_element_by_css_selector("button.btn.btn-sm.btn-secondary").click()
         # only the needed group is now available, proceed with clicking 'Delete' button
         driver.find_element_by_id("dropdownMenuGroup").click()
         driver.find_element_by_id("deleteGroup").click()

--- a/tests/product_group_test.py
+++ b/tests/product_group_test.py
@@ -147,7 +147,7 @@ class ProductGroupTest(BaseTestCase):
         driver.find_element_by_id("id_name").clear()
         driver.find_element_by_id("id_name").send_keys("Group Name")
         # click on 'apply filter' button
-        driver.find_element_by_css_selector("button.btn.btn-sm.btn-primary").click()
+        driver.find_element_by_css_selector("button.btn.btn-sm.btn-secondary").click()
         # only the needed group is now available, proceed with opening the context menu and clicking 'Edit' button
         driver.find_element_by_id("dropdownMenuGroup").click()
         driver.find_element_by_id("viewGroup").click()

--- a/tests/product_type_group_test.py
+++ b/tests/product_type_group_test.py
@@ -146,7 +146,7 @@ class ProductTypeGroupTest(BaseTestCase):
         driver.find_element_by_id("id_name").clear()
         driver.find_element_by_id("id_name").send_keys("Group Name")
         # click on 'apply filter' button
-        driver.find_element_by_css_selector("button.btn.btn-sm.btn-primary").click()
+        driver.find_element_by_css_selector("button.btn.btn-sm.btn-secondary").click()
         # only the needed group is now available, proceed with opening the context menu and clicking 'Edit' button
         driver.find_element_by_id("dropdownMenuGroup").click()
         driver.find_element_by_id("viewGroup").click()

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -58,7 +58,7 @@ class UserTest(BaseTestCase):
         driver.find_element_by_id("id_username").clear()
         driver.find_element_by_id("id_username").send_keys("propersahm")
         # click on 'apply filter' button
-        driver.find_element_by_css_selector("button.btn.btn-sm.btn-primary").click()
+        driver.find_element_by_css_selector("button.btn.btn-sm.btn-secondary").click()
         # only the needed user is now available, proceed with opening the context menu and clicking 'Edit' button
         driver.find_element_by_id("dropdownMenuUser").click()
         driver.find_element_by_id("editUser").click()
@@ -86,7 +86,7 @@ class UserTest(BaseTestCase):
         driver.find_element_by_id("id_username").clear()
         driver.find_element_by_id("id_username").send_keys("propersahm")
         # click on 'apply filter' button
-        driver.find_element_by_css_selector("button.btn.btn-sm.btn-primary").click()
+        driver.find_element_by_css_selector("button.btn.btn-sm.btn-secondary").click()
         # only the needed user is now available, proceed with clicking 'View' button
         driver.find_element_by_id("dropdownMenuUser").click()
         driver.find_element_by_id("viewUser").click()


### PR DESCRIPTION
Inspired by #5074 I implemented some more UI improvements. The examples here show how it looks with this PR:

- Gaps were missing between some icons:
![2021-09-13 17_41_11-Findings _ DefectDojo](https://user-images.githubusercontent.com/2698502/133115225-1f083981-5aac-4c4a-9537-c176f7b2f83a.png)
![2021-09-13 17_50_24-View Finding _ DefectDojo](https://user-images.githubusercontent.com/2698502/133116011-e2d7dbf7-c8c8-4392-bad8-c8d519d4b0c7.png)

- Put **Page Size** and icon in one button, looks cleaner and **Page Size** was a button without functionality:
![2021-09-13 17_41_35-Findings _ DefectDojo](https://user-images.githubusercontent.com/2698502/133115229-0d75ab55-603f-439f-97f6-fd72e0a20b55.png)

- **Apply Filters** button wasn't visible anymore because it was white:
![2021-09-13 17_41_57-Findings _ DefectDojo](https://user-images.githubusercontent.com/2698502/133115233-ed3a40bd-9bcd-4104-b641-a8a2324468c8.png)

- Moved the questions marks further left behind the titles of the heading and made them white:
![2021-09-13 17_44_00-View Product Type _ DefectDojo](https://user-images.githubusercontent.com/2698502/133115234-99f8ea11-3f35-4f10-b688-c90d26ea9591.png)

- The **Notes** header in findings and tests is now blue as all the other headings:
![2021-09-13 19_15_18-View Finding _ DefectDojo](https://user-images.githubusercontent.com/2698502/133127997-123566df-76f7-44b3-b795-45edd61555d6.png)