### PR TITLE
Improve detect-secrets parser

### DIFF
--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -32,7 +32,7 @@ class DetectSecretsParser(object):
                 line = item.get('line_number')
                 description = "Detected potential secret with the following related data:\n"
                 description += "**Filename:** " + file + "\n"
-                description += "**Line:** " + line + "\n"
+                description += "**Line:** " + str(line) + "\n"
                 description += "**Type:** " + type + "\n"
 
                 dupe_key = hashlib.sha256(

--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -30,6 +30,10 @@ class DetectSecretsParser(object):
                 hashed_secret = item.get('hashed_secret')
                 is_verified = item.get('is_verified')
                 line = item.get('line_number')
+                description = "Detected potential secret with the following related data:\n"
+                description += "**Filename:** " + file + "\n"
+                description += "**Line:** " + line + "\n"
+                description += "**Type:** " + type + "\n"
 
                 dupe_key = hashlib.sha256(
                     (type + file + str(line) + hashed_secret).encode('utf-8')
@@ -42,6 +46,8 @@ class DetectSecretsParser(object):
                     finding = Finding(
                         title=f"{type}",
                         test=test,
+                        description=description,
+                        cwe=798,
                         date=find_date,
                         severity="Medium",
                         verified=is_verified,

--- a/dojo/unittests/tools/test_detect_secrets_parser.py
+++ b/dojo/unittests/tools/test_detect_secrets_parser.py
@@ -28,6 +28,8 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("modules_images", finding.file_path)
             self.assertEqual(151, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(798, finding.cwe)
+            self.assertIsNotNone(finding.description)
             self.assertFalse(finding.false_p)
 
         with self.subTest(i=1):
@@ -39,6 +41,8 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("modules_images", finding.file_path)
             self.assertEqual(156, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(798, finding.cwe)
+            self.assertIsNotNone(finding.description)
             self.assertFalse(finding.false_p)
 
         with self.subTest(i=2):
@@ -50,6 +54,8 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("example/pkg/docker_registry_watcher/docker_config.go", finding.file_path)
             self.assertEqual(109, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(798, finding.cwe)
+            self.assertIsNotNone(finding.description)
             self.assertFalse(finding.false_p)
 
         with self.subTest(i=3):
@@ -61,4 +67,6 @@ class TestDetectSecretsParser(TestCase):
             self.assertEqual("example/pkg/docker_registry_watcher/docker_registry_watcher.go", finding.file_path)
             self.assertEqual(112, finding.line)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(798, finding.cwe)
+            self.assertIsNotNone(finding.description)
             self.assertTrue(finding.false_p)


### PR DESCRIPTION
## Motivation

The detect-secrets parser has not some basic information (like description or CWE code). This information can be useful to users in order to have a better UX and filter by more fields (like CWE).

## What do I contribute?

- [x] A description with some secret information
- [x] The CWE code

If someone detects more information to add, we can use this Pull Request to include it 😄  