### PR TITLE
Change secrets severity in detect-secrets parser

### DIFF
--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -49,7 +49,7 @@ class DetectSecretsParser(object):
                         description=description,
                         cwe=798,
                         date=find_date,
-                        severity="Medium",
+                        severity="High",
                         verified=is_verified,
                         file_path=file,
                         line=line,

--- a/dojo/unittests/tools/test_detect_secrets_parser.py
+++ b/dojo/unittests/tools/test_detect_secrets_parser.py
@@ -22,7 +22,7 @@ class TestDetectSecretsParser(TestCase):
         with self.subTest(i=0):
             finding = findings[0]
             self.assertEqual("Secret Keyword", finding.title)
-            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("High", finding.severity)
             self.assertEqual(datetime.datetime(2021, 5, 19, 10, 40, 18, tzinfo=tzlocal()), finding.date)
             self.assertFalse(finding.verified)
             self.assertEqual("modules_images", finding.file_path)
@@ -35,7 +35,7 @@ class TestDetectSecretsParser(TestCase):
         with self.subTest(i=1):
             finding = findings[1]
             self.assertEqual("Secret Keyword", finding.title)
-            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("High", finding.severity)
             self.assertEqual(datetime.datetime(2021, 5, 19, 10, 40, 18, tzinfo=tzlocal()), finding.date)
             self.assertFalse(finding.verified)
             self.assertEqual("modules_images", finding.file_path)
@@ -48,7 +48,7 @@ class TestDetectSecretsParser(TestCase):
         with self.subTest(i=2):
             finding = findings[2]
             self.assertEqual("Secret Keyword", finding.title)
-            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("High", finding.severity)
             self.assertEqual(datetime.datetime(2021, 5, 19, 10, 40, 18, tzinfo=tzlocal()), finding.date)
             self.assertFalse(finding.verified)
             self.assertEqual("example/pkg/docker_registry_watcher/docker_config.go", finding.file_path)
@@ -61,7 +61,7 @@ class TestDetectSecretsParser(TestCase):
         with self.subTest(i=3):
             finding = findings[3]
             self.assertEqual("Secret Keyword", finding.title)
-            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("High", finding.severity)
             self.assertEqual(datetime.datetime(2021, 5, 19, 10, 40, 18, tzinfo=tzlocal()), finding.date)
             self.assertFalse(finding.verified)
             self.assertEqual("example/pkg/docker_registry_watcher/docker_registry_watcher.go", finding.file_path)


### PR DESCRIPTION
## Motivation
The severity assigned to secrets detected by `detect-secrets` tool should be `High` and not `Medium`.

## Why?

### MITRE 
Hardcoded secrets weakness (CWE-798) is one of the **top 25 Most Dangerous Software Weaknesses** according to the `MITRE 2020 CWE Top 25` report: https://cwe.mitre.org/top25/archive/2020/2020_cwe_top25.html

In the previous reference we can view this table:

![image](https://user-images.githubusercontent.com/43778014/133258251-0c26a3d0-fbde-4e7d-b6e3-210952301902.png)

Hardcoded secrets weakness (CWE-798) has a averaged CVSS of 8.76 (**High**).

### Gitleaks parser
The gitleaks parser has `High` severity by default (https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/tools/gitleaks/parser.py#L51).

## Summary
I think that is better use `High` severity by default because is closer to `Medium` for this vulnerability.
