### PR TITLE
Fix ssl_labs and nsp parsers, correct occurences of `self.items`.

### DIFF
--- a/dojo/tools/blackduck_component_risk/parser.py
+++ b/dojo/tools/blackduck_component_risk/parser.py
@@ -20,8 +20,7 @@ class BlackduckComponentRiskParser(object):
 
     def get_findings(self, filename, test):
         """
-        Function initializes the parser with a file and sets the
-        self.items (eventually).
+        Function initializes the parser with a file and returns the items.
         :param filename: Input in Defect Dojo
         :param test:
         """

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -24,7 +24,6 @@ class NpmAuditParser(object):
 
     def parse_json(self, json_output):
         if json_output is None:
-            self.items = []
             return
         try:
             data = json_output.read()

--- a/dojo/tools/nsp/parser.py
+++ b/dojo/tools/nsp/parser.py
@@ -15,13 +15,11 @@ class NspParser(object):
         return "Node Security Platform (NSP) output file can be imported in JSON format."
 
     def get_findings(self, json_output, test):
-
         tree = self.parse_json(json_output)
-
         if tree:
-            self.items = [data for data in self.get_items(tree, test)]
+            return self.get_items(tree, test)
         else:
-            self.items = []
+            return []
 
     def parse_json(self, json_output):
         try:

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -20,7 +20,6 @@ class PhpSymfonySecurityCheckParser(object):
 
     def parse_json(self, json_file):
         if json_file is None:
-            self.items = []
             return
         try:
             data = json_file.read()

--- a/dojo/tools/ssl_labs/parser.py
+++ b/dojo/tools/ssl_labs/parser.py
@@ -27,6 +27,7 @@ class SSLlabsParser(object):
         find_date = datetime.now()
         dupes = {}
 
+        # FIXME - This is a pointless loop!
         for host in data:
             ssl_endpoints = []
             hostName = ""
@@ -194,7 +195,7 @@ class SSLlabsParser(object):
 
                 find.unsaved_endpoints.append(Endpoint(host=hostName, port=port, protocol=protocol))
 
-            self.items = list(dupes.values())
+            return list(dupes.values())
 
     # Criticality rating
     # Grades: https://github.com/ssllabs/research/wiki/SSL-Server-Rating-Guide

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -56,7 +56,6 @@ class TwistlockCSVParser(object):
 
     def parse(self, filename, test):
         if filename is None:
-            self.items = ()
             return
         content = filename.read()
         dupes = dict()


### PR DESCRIPTION
In e515c0e4030efec056e0ab5536ffe7b6fcf715db, the expected behaviour of the `get_findings` method changed. Instead of setting `self.items`, it is instead expected to return the items.

The `ssl_labs` and `nsp` parsers didn't seem to have been updated to this behaviour, causing errors when they are used. This PR fixes this behaviour.

In addition, `self.items` was sometimes set or mentioned in comments but not used, I've removed these.


Also, you'll notice the *FIXME* comment above the loop in the `ssl_labs` parser. The loop always returns at the end of the first iteration so this should be replaced with code to simply get and parse the first item if this behaviour is kept. However, I feel like it would make more sense to trigger an error if there are multiple reports, since some won't be handled?
Another alternative would be to extract only the entry with the correct host matching the endpoint of the import, however that seems like overkill for something that's not likely to happen!