### PR TITLE
Repair stub findings

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1168,7 +1168,7 @@ def apply_template_to_finding(request, fid, tid):
             reverse('view_finding', args=(finding.id, )))
 
 
-@user_is_authorized(Finding, Permissions.Finding_Add, 'tid', 'staff')
+@user_is_authorized(Test, Permissions.Finding_Add, 'tid', 'staff')
 def add_stub_finding(request, tid):
     test = get_object_or_404(Test, id=tid)
     form = StubFindingForm()
@@ -1210,7 +1210,7 @@ def add_stub_finding(request, tid):
     return HttpResponseRedirect(reverse('view_test', args=(tid, )))
 
 
-@user_is_authorized(Finding, Permissions.Finding_Delete, 'fid', 'staff')
+@user_is_authorized(Stub_Finding, Permissions.Finding_Delete, 'fid', 'staff')
 def delete_stub_finding(request, fid):
     finding = get_object_or_404(Stub_Finding, id=fid)
     form = DeleteStubFindingForm(instance=finding)
@@ -1236,7 +1236,7 @@ def delete_stub_finding(request, fid):
         return HttpResponseForbidden()
 
 
-@user_is_authorized(Finding, Permissions.Finding_Edit, 'fid', 'staff')
+@user_is_authorized(Stub_Finding, Permissions.Finding_Edit, 'fid', 'staff')
 def promote_to_finding(request, fid):
     finding = get_object_or_404(Stub_Finding, id=fid)
     test = finding.test

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -31,7 +31,7 @@
         {% endif %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
-                <input class="btn btn-primary" type="submit" value="Promote Finding"/>&nbsp;&nbsp;
+                <input class="btn btn-primary" id="submit" type="submit" value="Promote Finding"/>&nbsp;&nbsp;
             </div>
         </div>
     </form>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -995,7 +995,7 @@
                                       style="display: inline" class="form-inline form">
                                     {% csrf_token %}
                                     <input type="hidden" name="id" value="{{ finding.id }}"/>
-                                    <button name="stub_finding_delete type="submit" class="btn btn-danger btn-sm delete-finding">
+                                    <button name="stub_finding_delete" type="submit" class="btn btn-danger btn-sm delete-finding">
                                         Delete
                                     </button>
                                 </form>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -969,7 +969,7 @@
                 <tbody>
                 {% for finding in stub_findings %}
                     <tr>
-                        <td>
+                        <td name="stub_finding_name">
                             {% if test|has_object_permission:"Finding_Add" or user|is_authorized_for_change:test %}
                             <a href="{% url 'promote_to_finding' finding.id %}">{{ finding.title }}</a></td>
                             {% else %}
@@ -995,7 +995,7 @@
                                       style="display: inline" class="form-inline form">
                                     {% csrf_token %}
                                     <input type="hidden" name="id" value="{{ finding.id }}"/>
-                                    <button type="submit" class="btn btn-danger btn-sm delete-finding">
+                                    <button name="stub_finding_delete type="submit" class="btn btn-danger btn-sm delete-finding">
                                         Delete
                                     </button>
                                 </form>

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -195,6 +195,40 @@ class TestUnitTest(BaseTestCase):
         # Assert to the query to dtermine status of failure
         self.assertTrue(self.is_text_present_on_page(text='App Vulnerable to XSS2'))
 
+    def test_add_and_promote_stub_finding(self):
+        # Login to the site.
+        driver = self.driver
+        # Navigate to the engagement page
+        self.goto_active_engagements_overview(driver)
+        # Select a previously created engagement title
+        driver.find_element_by_partial_link_text("Beta Test").click()
+        driver.find_element_by_partial_link_text("Quick Security Testing").click()
+
+        # Enter the title of the stub finding
+        # Keep a good practice of clearing field before entering value
+        driver.find_element_by_id("quick_add_finding").clear()
+        driver.find_element_by_id("quick_add_finding").send_keys("App Vulnerable to XSS3")
+        # Click on Add Potential Finding
+        driver.find_element_by_id("the_button").click()
+
+        # There are timing problems with the AJAX call, so we navigate back to the engagement and test pages
+        self.goto_active_engagements_overview(driver)
+        # Select a previously created engagement title
+        driver.find_element_by_partial_link_text("Beta Test").click()
+        driver.find_element_by_partial_link_text("Quick Security Testing").click()
+        # Query the site to determine if the stub finding has been added
+        self.assertTrue(driver.find_elements_by_name("stub_finding_name"))
+
+        driver.find_elements_by_name("stub_finding_name")[0].click()
+        self.assertEqual(driver.find_element_by_id("id_title").get_attribute('value'), 'App Vulnerable to XSS3')
+        # finding Description
+        driver.find_element_by_id("id_cvssv3_score").send_keys(Keys.TAB, Keys.TAB, "This is a promoted stub finding")
+        # "Click" the Done button to Edit the finding
+        driver.find_element_by_id("submit").click()
+
+        # Assert ot the query to dtermine status of failure
+        self.assertTrue(self.is_success_message_present(text='Finding promoted successfully'))
+
     def test_delete_test(self):
         # Login to the site. Password will have to be modified
         # to match an admin password in your own container
@@ -229,6 +263,7 @@ def suite():
     suite.addTest(TestUnitTest('test_create_test'))
     suite.addTest(TestUnitTest('test_edit_test'))
     suite.addTest(TestUnitTest('test_add_test_finding'))
+    suite.addTest(TestUnitTest('test_add_and_promote_stub_finding'))
     # suite.addTest(TestUnitTest('test_add_note'))
     # suite.addTest(TestUnitTest('test_delete_test'))
     suite.addTest(ProductTest('test_delete_product'))

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -195,11 +195,11 @@ class TestUnitTest(BaseTestCase):
         # Assert to the query to dtermine status of failure
         self.assertTrue(self.is_text_present_on_page(text='App Vulnerable to XSS2'))
 
-    def test_add_and_promote_stub_finding(self):
+    def test_add_stub_finding(self):
         # Login to the site.
         driver = self.driver
-        # Navigate to the engagement page
-        self.goto_active_engagements_overview(driver)
+
+        # Select the previously created test
         # Select a previously created engagement title
         driver.find_element_by_partial_link_text("Beta Test").click()
         driver.find_element_by_partial_link_text("Quick Security Testing").click()
@@ -211,23 +211,46 @@ class TestUnitTest(BaseTestCase):
         # Click on Add Potential Finding
         driver.find_element_by_id("the_button").click()
 
-        # There are timing problems with the AJAX call, so we navigate back to the engagement and test pages
+    def test_add_and_promote_stub_finding(self):
+
+        self.test_add_stub_finding()
+
+        driver = self.driver
+
+        # Select the previously created test
         self.goto_active_engagements_overview(driver)
-        # Select a previously created engagement title
         driver.find_element_by_partial_link_text("Beta Test").click()
         driver.find_element_by_partial_link_text("Quick Security Testing").click()
-        # Query the site to determine if the stub finding has been added
-        self.assertTrue(driver.find_elements_by_name("stub_finding_name"))
 
+        # Click on link of finding name to promote to finding
         driver.find_elements_by_name("stub_finding_name")[0].click()
+        # Check we have the correct stub finding
         self.assertEqual(driver.find_element_by_id("id_title").get_attribute('value'), 'App Vulnerable to XSS3')
-        # finding Description
+        # Edit finding Description
         driver.find_element_by_id("id_cvssv3_score").send_keys(Keys.TAB, Keys.TAB, "This is a promoted stub finding")
         # "Click" the Done button to Edit the finding
         driver.find_element_by_id("submit").click()
 
         # Assert ot the query to dtermine status of failure
         self.assertTrue(self.is_success_message_present(text='Finding promoted successfully'))
+
+    def test_add_and_delete_stub_finding(self):
+
+        self.test_add_stub_finding()    
+
+        driver = self.driver
+
+        # Select the previously created test
+        self.goto_active_engagements_overview(driver)
+        driver.find_element_by_partial_link_text("Beta Test").click()
+        driver.find_element_by_partial_link_text("Quick Security Testing").click()
+
+        # Click on Delete butten
+        driver.find_elements_by_name("stub_finding_delete")[0].click()
+        # Accept popup
+        driver.switch_to.alert.accept()
+        # Check the stub finding is deleted
+        self.assertFalse(driver.find_elements_by_name("stub_finding_name"))
 
     def test_delete_test(self):
         # Login to the site. Password will have to be modified
@@ -264,6 +287,7 @@ def suite():
     suite.addTest(TestUnitTest('test_edit_test'))
     suite.addTest(TestUnitTest('test_add_test_finding'))
     suite.addTest(TestUnitTest('test_add_and_promote_stub_finding'))
+    suite.addTest(TestUnitTest('test_add_and_delete_stub_finding'))
     # suite.addTest(TestUnitTest('test_add_note'))
     # suite.addTest(TestUnitTest('test_delete_test'))
     suite.addTest(ProductTest('test_delete_product'))

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -236,7 +236,7 @@ class TestUnitTest(BaseTestCase):
 
     def test_add_and_delete_stub_finding(self):
 
-        self.test_add_stub_finding()    
+        self.test_add_stub_finding()
 
         driver = self.driver
 


### PR DESCRIPTION
Fixes #5075

This fix includes an integration tests to add and promote stub findings. There is no test to delete a stub finding because I haven't had the time to find out how Selenium works with a modal dialogue.