### PR TITLE
View engagement: fix sonarqubce config error

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1450,7 +1450,7 @@ class Sonarqube_Product(models.Model):
     )
 
     def __str__(self):
-        return '{} | {}'.format(self.sonarqube_tool_config.name, self.sonarqube_project_key)
+        return '{} | {}'.format(self.sonarqube_tool_config.name if hasattr(self, 'sonarqube_tool_config') else '', self.sonarqube_project_key)
 
 
 class Cobaltio_Product(models.Model):


### PR DESCRIPTION
viewing engagements (and possible other functions) were broken if a product didn't have a sonarqube config

```
  File "/home/dojo/venv/lib/python3.7/site-packages/django/forms/models.py", line 1157, in __iter__
    yield self.choice(obj)
  File "/home/dojo/venv/lib/python3.7/site-packages/django/forms/models.py", line 1171, in choice
    self.field.label_from_instance(obj),
  File "/home/dojo/venv/lib/python3.7/site-packages/django/forms/models.py", line 1240, in label_from_instance
    return str(obj)
  File "./dojo/models.py", line 1454, in __str__
    return '{} | {}'.format(self.sonarqube_tool_config.name if self.sonarqube_tool_config else '', self.sonarqube_project_key)
  File "/home/dojo/venv/lib/python3.7/site-packages/django/db/models/fields/related_descriptors.py", line 198, in __get__
    "%s has no %s." % (self.field.model.__name__, self.field.name)

Exception Type: RelatedObjectDoesNotExist at /engagement/1338
Exception Value: Sonarqube_Product has no sonarqube_tool_config.
```