### PR TITLE
Fix deduplication config check

### DIFF
--- a/dojo/management/commands/validatededupeconfig.py
+++ b/dojo/management/commands/validatededupeconfig.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
     help = 'Validate deduplication logic in settings'
 
     def handle(self, *args, **options):
-        for each_var in settings.HASHCODE_FIELDS_PER_SCANNER:
-            for each_ind in each_var:
-                if each_ind not in settings.HASHCODE_ALLOWED_FIELDS:
-                    deduplicationLogger.error("compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. " "Using default fields")
+        for scanner in settings.HASHCODE_FIELDS_PER_SCANNER:
+            for field in settings.HASHCODE_FIELDS_PER_SCANNER.get(scanner):
+                if field not in settings.HASHCODE_ALLOWED_FIELDS:
+                    deduplicationLogger.error(f"Configuration error in HASHCODE_FIELDS_PER_SCANNER: Element {field} is not in the allowed list HASHCODE_ALLOWED_FIELDS for {scanner}. " "Using default fields")


### PR DESCRIPTION
PR #4963 invented a check of the hashcode configuration. Unfortunately the checks were broken and resulted in a lot of messages during startup of a new instance. With this PR there is only a message when there is an unallowed field in the configuration and the names of field and scanner are part of the error message.

Log before this PR:
```
2021-09-16T12:10:21.2599632Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2613437Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2616467Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2619413Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2623005Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2626017Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2629392Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2634359Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2637079Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2639789Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2642467Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
2021-09-16T12:10:21.2645158Z [36minitializer_1        |[0m [16/Sep/2021 12:10:21] ERROR [dojo.specific-loggers.deduplication:17] compute_hash_code - configuration error: some elements of HASHCODE_FIELDS_PER_SCANNER are not in the allowed list HASHCODE_ALLOWED_FIELDS. Using default fields
... another 570 lines that have been cut here

```