### PR TITLE
Custom Test_Type for parsers (modify "Found by" dynamicaly)

### DIFF
--- a/docs/content/en/integrations/import.md
+++ b/docs/content/en/integrations/import.md
@@ -773,6 +773,15 @@ OASIS Static Analysis Results Interchange Format (SARIF). SARIF is
 supported by many tools. More details about the format here:
 <https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif>
 
+{{% alert title="Information" color="info" %}}
+SARIF parser customize the Test_Type with data from the report.
+For example, a report with `Dockle` as a driver name will produce a Test with a Test_Type named `Dockle Scan (SARIF)`
+{{% /alert %}}
+
+{{% alert title="Warning" color="warning" %}}
+Current implementation is limited and will aggregate all the finding in the SARIF file in one single report.
+{{% /alert %}}
+
 ### ScoutSuite
 
 Multi-Cloud security auditing tool. It uses APIs exposed by cloud

--- a/docs/content/en/integrations/import.md
+++ b/docs/content/en/integrations/import.md
@@ -774,12 +774,12 @@ supported by many tools. More details about the format here:
 <https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif>
 
 {{% alert title="Information" color="info" %}}
-SARIF parser customize the Test_Type with data from the report.
+SARIF parser customizes the Test_Type with data from the report.
 For example, a report with `Dockle` as a driver name will produce a Test with a Test_Type named `Dockle Scan (SARIF)`
 {{% /alert %}}
 
 {{% alert title="Warning" color="warning" %}}
-Current implementation is limited and will aggregate all the finding in the SARIF file in one single report.
+Current implementation is limited and will aggregate all the findings in the SARIF file in one single report.
 {{% /alert %}}
 
 ### ScoutSuite

--- a/dojo/db_migrations/0123_scan_type.py
+++ b/dojo/db_migrations/0123_scan_type.py
@@ -1,0 +1,17 @@
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dojo', '0122_cobaltio_product'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='test',
+            name='scan_type',
+            field=models.TextField(null=True),
+        ),
+    ]

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -27,12 +27,12 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 class DojoDefaultImporter(object):
 
-    def create_test(self, scan_type, test_type_str, engagement, lead, environment, tags=None,
+    def create_test(self, scan_type, test_type_name, engagement, lead, environment, tags=None,
                     scan_date=None, version=None, branch_tag=None, build_id=None, commit_hash=None, now=timezone.now(),
                     sonarqube_config=None, cobaltio_config=None):
 
         test_type, created = Test_Type.objects.get_or_create(
-            name=test_type_str)
+            name=test_type_name)
 
         if created:
             logger.info('Created new Test_Type with name %s because a report is being imported', test_type.name)

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -309,7 +309,7 @@ class DojoDefaultImporter(object):
             #
             # we also aggregate the label of the Test_type to show the user the original scan_type
             # only if they are different. This is to support meta format like SARIF
-            # so a report that have the label 'CodeScanner' will be changed to 'SARIF > CodeScanner'
+            # so a report that have the label 'CodeScanner' will be changed to 'CodeScanner Scan (SARIF)'
             test_type_name = scan_type
             if len(tests) > 0:
                 test_type_name = tests[0].type + " Scan"
@@ -318,12 +318,17 @@ class DojoDefaultImporter(object):
             test = self.create_test(scan_type, test_type_name, engagement, lead, environment, scan_date=scan_date, tags=tags,
                                 version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
                                 sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
+            # This part change the name of the Test
+            # we get it from the data of the parser
             test_raw = tests[0]
             if test_raw.name:
                 test.name = test_raw.name
                 test.save()
 
             logger.debug('IMPORT_SCAN parser v2: Parse findings (aggregate)')
+            # currently we only support import one Test
+            # so for parser that support multiple tests (like SARIF)
+            # we aggregate all the findings into one uniq test
             parsed_findings = []
             for test_raw in tests:
                 parsed_findings.extend(test_raw.findings)

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -19,18 +19,20 @@ import dojo.jira_link.helper as jira_helper
 import base64
 import logging
 
+from dojo.tools.factory import get_parser
+
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
 
 class DojoDefaultImporter(object):
 
-    def create_test(self, scan_type, engagement, lead, environment, tags=None,
+    def create_test(self, scan_type, test_type_str, engagement, lead, environment, tags=None,
                     scan_date=None, version=None, branch_tag=None, build_id=None, commit_hash=None, now=timezone.now(),
                     sonarqube_config=None, cobaltio_config=None):
 
         test_type, created = Test_Type.objects.get_or_create(
-            name=scan_type)
+            name=test_type_str)
 
         if created:
             logger.info('Created new Test_Type with name %s because a report is being imported', test_type.name)
@@ -39,6 +41,7 @@ class DojoDefaultImporter(object):
             engagement=engagement,
             lead=lead,
             test_type=test_type,
+            scan_type=scan_type,
             target_start=scan_date if scan_date else now.date(),
             target_end=scan_date if scan_date else now.date(),
             environment=environment,
@@ -67,15 +70,15 @@ class DojoDefaultImporter(object):
         logger.debug('starting import of %i items.', len(items) if items else 0)
         i = 0
         for item in items:
-            sev = item.severity
-            if sev == 'Information' or sev == 'Informational':
-                sev = 'Info'
+            # FIXME hack to remove when all parsers have unit tests for this attribute
+            if item.severity.lower().startswith('info') and item.severity != 'Info':
+                item.severity = 'Info'
 
-            item.severity = sev
-            item.numerical_severity = Finding.get_numerical_severity(sev)
+            item.numerical_severity = Finding.get_numerical_severity(item.severity)
 
-            if minimum_severity and (Finding.SEVERITIES[sev] >
+            if minimum_severity and (Finding.SEVERITIES[item.severity] >
                     Finding.SEVERITIES[minimum_severity]):
+                # finding's severity is below the configured threshold : ignoring the finding
                 continue
 
             item.test = test
@@ -292,13 +295,38 @@ class DojoDefaultImporter(object):
         if cobaltio_config and cobaltio_config.product != engagement.product:
             raise ValidationError('"cobaltio_config" has to be from same product as "engagement"')
 
-        logger.debug('IMPORT_SCAN: Create Test')
-        test = self.create_test(scan_type, engagement, lead, environment, scan_date=scan_date, tags=tags,
-                            version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
-                            sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
+        # check if the parser that handle the scan_type manage tests
+        parser = get_parser(scan_type)
+        if hasattr(parser, 'get_tests'):
+            logger.debug('IMPORT_SCAN parser v2: Create Test and parse findings')
+            tests = parser.get_tests(scan_type, scan)
+            # for now we only consider the first test in the list and artificially aggregate all findings of all tests
+            # this is the same as the old behavior as current import/reimporter implementation doesn't handle the case
+            # when there is more than 1 test
+            test_type_str = scan_type
+            if len(tests) > 0:
+                test_type_str = tests[0].type
+            test = self.create_test(scan_type, test_type_str, engagement, lead, environment, scan_date=scan_date, tags=tags,
+                                version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
+                                sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
+            if test_raw.name:
+                test.name = test_raw.name
+                test.save()
 
-        logger.debug('IMPORT_SCAN: Parse findings')
-        parsed_findings = importer_utils.parse_findings(scan, test, active, verified, scan_type)
+            logger.debug('IMPORT_SCAN parser v2: Parse findings (aggregate)')
+            parsed_findings = []
+            for test_raw in tests:
+                parsed_findings.extend(test_raw.findings)
+        else:
+            logger.debug('IMPORT_SCAN: Create Test')
+            # by default test_type == scan_type
+            test = self.create_test(scan_type, scan_type, engagement, lead, environment, scan_date=scan_date, tags=tags,
+                                version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
+                                sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
+
+            logger.debug('IMPORT_SCAN: Parse findings')
+            parser = get_parser(scan_type)
+            parsed_findings = parser.get_findings(scan, test)
 
         logger.debug('IMPORT_SCAN: Processing findings')
         new_findings = self.process_parsed_findings(test, parsed_findings, scan_type, user, active,

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -312,9 +312,9 @@ class DojoDefaultImporter(object):
             # so a report that have the label 'CodeScanner' will be changed to 'SARIF > CodeScanner'
             test_type_str = scan_type
             if len(tests) > 0:
-                test_type_str = tests[0].type
+                test_type_str = tests[0].type + " Scan"
                 if tests[0].type and tests[0].type != scan_type:
-                    test_type_str = scan_type + " > " + test_type_str
+                    test_type_str = f"{test_type_str} ({scan_type})"
             test = self.create_test(scan_type, test_type_str, engagement, lead, environment, scan_date=scan_date, tags=tags,
                                 version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
                                 sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -309,6 +309,7 @@ class DojoDefaultImporter(object):
             test = self.create_test(scan_type, test_type_str, engagement, lead, environment, scan_date=scan_date, tags=tags,
                                 version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
                                 sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
+            test_raw = tests[0]
             if test_raw.name:
                 test.name = test_raw.name
                 test.save()

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -310,12 +310,12 @@ class DojoDefaultImporter(object):
             # we also aggregate the label of the Test_type to show the user the original scan_type
             # only if they are different. This is to support meta format like SARIF
             # so a report that have the label 'CodeScanner' will be changed to 'SARIF > CodeScanner'
-            test_type_str = scan_type
+            test_type_name = scan_type
             if len(tests) > 0:
-                test_type_str = tests[0].type + " Scan"
+                test_type_name = tests[0].type + " Scan"
                 if tests[0].type and tests[0].type != scan_type:
-                    test_type_str = f"{test_type_str} ({scan_type})"
-            test = self.create_test(scan_type, test_type_str, engagement, lead, environment, scan_date=scan_date, tags=tags,
+                    test_type_name = f"{test_type_name} ({scan_type})"
+            test = self.create_test(scan_type, test_type_name, engagement, lead, environment, scan_date=scan_date, tags=tags,
                                 version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
                                 sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
             test_raw = tests[0]

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -296,6 +296,9 @@ class DojoDefaultImporter(object):
             raise ValidationError('"cobaltio_config" has to be from same product as "engagement"')
 
         # check if the parser that handle the scan_type manage tests
+        # if yes, we parse the data first
+        # after that we customize the Test_Type to reflect the data
+        # This allow us to support some meta-formats like SARIF or the generic format
         parser = get_parser(scan_type)
         if hasattr(parser, 'get_tests'):
             logger.debug('IMPORT_SCAN parser v2: Create Test and parse findings')

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -306,9 +306,15 @@ class DojoDefaultImporter(object):
             # for now we only consider the first test in the list and artificially aggregate all findings of all tests
             # this is the same as the old behavior as current import/reimporter implementation doesn't handle the case
             # when there is more than 1 test
+            #
+            # we also aggregate the label of the Test_type to show the user the original scan_type
+            # only if they are different. This is to support meta format like SARIF
+            # so a report that have the label 'CodeScanner' will be changed to 'SARIF > CodeScanner'
             test_type_str = scan_type
             if len(tests) > 0:
                 test_type_str = tests[0].type
+                if tests[0].type and tests[0].type != scan_type:
+                    test_type_str = scan_type + " > " + test_type_str
             test = self.create_test(scan_type, test_type_str, engagement, lead, environment, scan_date=scan_date, tags=tags,
                                 version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
                                 sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -323,7 +323,7 @@ class DojoDefaultReImporter(object):
                 parsed_findings.extend(test_raw.findings)
         else:
             logger.debug('REIMPORT_SCAN: Parse findings')
-            parsed_findings = importer_utils.parse_findings(scan, test, active, verified, scan_type)
+            parsed_findings = parser.get_findings(scan, test)
 
         logger.debug('REIMPORT_SCAN: Processing findings')
         new_findings, reactivated_findings, findings_to_mitigate, untouched_findings = \

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -1,22 +1,19 @@
+import base64
 import datetime
+import logging
 
-from dojo.endpoint.utils import endpoint_get_or_create
-from dojo.importers import utils as importer_utils
-from dojo.models import Notes, Finding, \
-    BurpRawRequestResponse, \
-    Endpoint_Status, \
-    Test_Import
-
-from dojo.utils import get_current_user
-
-from django.core.exceptions import MultipleObjectsReturned, ValidationError
-from django.conf import settings
-from django.utils import timezone
-import dojo.notifications.helper as notifications_helper
 import dojo.finding.helper as finding_helper
 import dojo.jira_link.helper as jira_helper
-import base64
-import logging
+import dojo.notifications.helper as notifications_helper
+from django.conf import settings
+from django.core.exceptions import MultipleObjectsReturned, ValidationError
+from django.utils import timezone
+from dojo.endpoint.utils import endpoint_get_or_create
+from dojo.importers import utils as importer_utils
+from dojo.models import (BurpRawRequestResponse, Endpoint_Status, Finding,
+                         Notes, Test_Import)
+from dojo.tools.factory import get_parser
+from dojo.utils import get_current_user
 
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
@@ -39,21 +36,22 @@ class DojoDefaultReImporter(object):
         unchanged_items = []
 
         logger.debug('starting reimport of %i items.', len(items) if items else 0)
-        from dojo.importers.reimporter.utils import get_deduplication_algorithm_from_conf, match_new_finding_to_existing_finding, update_endpoint_status
+        from dojo.importers.reimporter.utils import (
+            get_deduplication_algorithm_from_conf,
+            match_new_finding_to_existing_finding, update_endpoint_status)
         deduplication_algorithm = get_deduplication_algorithm_from_conf(scan_type)
 
         i = 0
         logger.debug('STEP 1: looping over findings from the reimported report and trying to match them to existing findings')
         deduplicationLogger.debug('Algorithm used for matching new findings to existing findings: %s', deduplication_algorithm)
         for item in items:
-            sev = item.severity
-            if sev == 'Information' or sev == 'Informational':
-                sev = 'Info'
+            # FIXME hack to remove when all parsers have unit tests for this attribute
+            if item.severity.lower().startswith('info') and item.severity != 'Info':
+                item.severity = 'Info'
 
-            item.severity = sev
-            item.numerical_severity = Finding.get_numerical_severity(sev)
+            item.numerical_severity = Finding.get_numerical_severity(item.severity)
 
-            if (Finding.SEVERITIES[sev] >
+            if minimum_severity and (Finding.SEVERITIES[item.severity] >
                     Finding.SEVERITIES[minimum_severity]):
                 # finding's severity is below the configured threshold : ignoring the finding
                 continue
@@ -312,8 +310,20 @@ class DojoDefaultReImporter(object):
                 test.cobaltio_config = cobaltio_config
                 test.save()
 
-        logger.debug('REIMPORT_SCAN: Parse findings')
-        parsed_findings = importer_utils.parse_findings(scan, test, active, verified, scan_type)
+        # check if the parser that handle the scan_type manage tests
+        parser = get_parser(scan_type)
+        if hasattr(parser, 'get_tests'):
+            logger.debug('REIMPORT_SCAN parser v2: Create parse findings')
+            tests = parser.get_tests(scan_type, scan)
+            # for now we only consider the first test in the list and artificially aggregate all findings of all tests
+            # this is the same as the old behavior as current import/reimporter implementation doesn't handle the case
+            # when there is more than 1 test
+            parsed_findings = []
+            for test_raw in tests:
+                parsed_findings.extend(test_raw.findings)
+        else:
+            logger.debug('REIMPORT_SCAN: Parse findings')
+            parsed_findings = importer_utils.parse_findings(scan, test, active, verified, scan_type)
 
         logger.debug('REIMPORT_SCAN: Processing findings')
         new_findings, reactivated_findings, findings_to_mitigate, untouched_findings = \

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -1,28 +1,8 @@
 from dojo.utils import max_safe
-from dojo.tools.factory import get_parser
 from dojo.models import IMPORT_CLOSED_FINDING, IMPORT_CREATED_FINDING, IMPORT_REACTIVATED_FINDING, Test_Import, Test_Import_Finding_Action
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-def parse_findings(scan, test, active, verified, scan_type):
-    try:
-        parser = get_parser(scan_type)
-        parsed_findings = parser.get_findings(scan, test)
-        return parsed_findings
-    except SyntaxError as se:
-        logger.exception(se)
-        logger.warn("Error in parser: {}".format(str(se)))
-        raise
-    except ValueError as ve:
-        logger.exception(ve)
-        logger.warn("Error in parser: {}".format(str(ve)))
-        raise
-    except Exception as e:
-        logger.exception(e)
-        logger.warn("Error in parser: {}".format(str(e)))
-        raise
 
 
 def update_timestamps(test, scan_date, version, branch_tag, build_id, commit_hash, now, scan_date_time):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1474,6 +1474,7 @@ class Test(models.Model):
     engagement = models.ForeignKey(Engagement, editable=False, on_delete=models.CASCADE)
     lead = models.ForeignKey(User, editable=True, null=True, on_delete=models.RESTRICT)
     test_type = models.ForeignKey(Test_Type, on_delete=models.CASCADE)
+    scan_type = models.TextField(null=True)
     title = models.CharField(max_length=255, null=True, blank=True)
     description = models.TextField(null=True, blank=True)
     target_start = models.DateTimeField()

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1054,7 +1054,8 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'SpotBugs Scan': False,
     'Scout Suite Scan': True,
     'AWS Security Hub Scan': True,
-    'Meterian Scan': True
+    'Meterian Scan': True,
+    'SARIF': True
 }
 
 # List of fields that are known to be usable in hash_code computation)
@@ -1132,6 +1133,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Cloudsploit Scan': DEDUPE_ALGO_HASH_CODE,
     'KICS Scan': DEDUPE_ALGO_HASH_CODE,
     'Azure Security Center Scan': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
+    'SARIF': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -666,7 +666,13 @@ def re_import_scan_results(request, tid):
                          "mitigated.  The process attempts to identify the differences, however manual verification " \
                          "is highly recommended."
     test = get_object_or_404(Test, id=tid)
-    scan_type = test.test_type.name
+    # by default we keep a trace of the scan_type used to create the test
+    # if it's not here, we use the "name" of the test type
+    # this feature exists to provide custom label for tests for some parsers
+    if test.scan_type:
+        scan_type = test.scan_type
+    else:
+        scan_type = test.test_type.name
     engagement = test.engagement
     form = ReImportScanForm(test=test)
     jform = None

--- a/dojo/tools/parser_test.py
+++ b/dojo/tools/parser_test.py
@@ -1,0 +1,5 @@
+class ParserTest(object):
+    def __init__(self, name: str, type: str, version: str):
+        self.name = name
+        self.type = type
+        self.version = version

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -3,6 +3,7 @@ import logging
 import re
 import textwrap
 import dateutil.parser
+from dojo.tools.parser_test import ParserTest
 from dojo.models import Finding
 
 logger = logging.getLogger(__name__)
@@ -26,25 +27,40 @@ class SarifParser(object):
         return "SARIF report file can be imported in SARIF format."
 
     def get_findings(self, filehandle, test):
+        """For simple interface of parser contract we just aggregate everything"""
         tree = json.load(filehandle)
-        return self.get_items(tree, test)
-
-    def get_items(self, tree, test):
         items = list()
-        # for each runs
+        # for each runs we just aggregate everything
         for run in tree.get('runs', list()):
-            # load rules
-            rules = get_rules(run)
-            artifacts = get_artifacts(run)
-            # get the timestamp of the run if possible
-            run_date = self._get_last_invocation_date(run)
-            for result in run.get('results', list()):
-                item = get_item(result, rules, artifacts, run_date)
-                if item is not None:
-                    items.append(item)
+            items.extend(self.__get_items_from_run(run))
         return items
 
-    def _get_last_invocation_date(self, data):
+    def get_tests(self, scan_type, handle):
+        tree = json.load(handle)
+        tests = list()
+        for run in tree.get('runs', list()):
+            test = ParserTest(
+                name=run['tool']['driver']['name'],
+                type=run['tool']['driver']['name'],
+                version=run['tool']['driver'].get('version'),
+            )
+            test.findings = self.__get_items_from_run(run)
+            tests.append(test)
+        return tests
+
+    def __get_items_from_run(self, run):
+        items = list()
+        # load rules
+        rules = get_rules(run)
+        artifacts = get_artifacts(run)
+        # get the timestamp of the run if possible
+        run_date = self.__get_last_invocation_date(run)
+        for result in run.get('results', list()):
+            item = get_item(result, rules, artifacts, run_date)
+            items.append(item)
+        return items
+
+    def __get_last_invocation_date(self, data):
         invocations = data.get('invocations', [])
         if len(invocations) == 0:
             return None

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -57,7 +57,8 @@ class SarifParser(object):
         run_date = self.__get_last_invocation_date(run)
         for result in run.get('results', list()):
             item = get_item(result, rules, artifacts, run_date)
-            items.append(item)
+            if item is not None:
+                items.append(item)
         return items
 
     def __get_last_invocation_date(self, data):

--- a/dojo/unittests/scans/sarif/appendix_k1_double.sarif
+++ b/dojo/unittests/scans/sarif/appendix_k1_double.sarif
@@ -1,0 +1,23 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "CodeScanner"
+        }
+      },
+      "results": [
+      ]
+    },
+    {
+      "tool": {
+        "driver": {
+          "name": "OtherScanner"
+        }
+      },
+      "results": [
+      ]
+    }
+  ]
+}

--- a/dojo/unittests/scans/sarif/spotbugs.sarif
+++ b/dojo/unittests/scans/sarif/spotbugs.sarif
@@ -1,0 +1,1894 @@
+{
+    "version": "2.1.0",
+    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+    "runs": [
+        {
+            "tool": {
+                "extensions": [
+                    {
+                        "version": "4.4.0",
+                        "name": "edu.umd.cs.findbugs.plugins.core",
+                        "shortDescription": {
+                            "text": "Core SpotBugs plugin"
+                        },
+                        "informationUri": "https://github.com/spotbugs",
+                        "organization": "SpotBugs project"
+                    }
+                ],
+                "driver": {
+                    "name": "SpotBugs",
+                    "version": "4.4.0",
+                    "language": "en",
+                    "rules": [
+                        {
+                            "id": "DMI_HARDCODED_ABSOLUTE_FILENAME",
+                            "shortDescription": {
+                                "text": "Code contains a hard coded reference to an absolute pathname."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "Hard coded reference to an absolute pathname in {0}."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#DMI_HARDCODED_ABSOLUTE_FILENAME",
+                            "properties": {
+                                "tags": [
+                                    "STYLE"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "DM_DEFAULT_ENCODING",
+                            "shortDescription": {
+                                "text": "Reliance on default encoding."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "Found reliance on default encoding in {0}: {1}."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#DM_DEFAULT_ENCODING",
+                            "properties": {
+                                "tags": [
+                                    "I18N"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "WMI_WRONG_MAP_ITERATOR",
+                            "shortDescription": {
+                                "text": "Inefficient use of keySet iterator instead of entrySet iterator."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "{0} makes inefficient use of keySet iterator instead of entrySet iterator."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#WMI_WRONG_MAP_ITERATOR",
+                            "properties": {
+                                "tags": [
+                                    "PERFORMANCE"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "EI_EXPOSE_REP",
+                            "shortDescription": {
+                                "text": "May expose internal representation by returning reference to mutable object."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "{0} may expose internal representation by returning {1}."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#EI_EXPOSE_REP",
+                            "properties": {
+                                "tags": [
+                                    "MALICIOUS_CODE"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "EI_EXPOSE_REP2",
+                            "shortDescription": {
+                                "text": "May expose internal representation by incorporating reference to mutable object."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "{0} may expose internal representation by storing an externally mutable object into {1}."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#EI_EXPOSE_REP2",
+                            "properties": {
+                                "tags": [
+                                    "MALICIOUS_CODE"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "MS_FINAL_PKGPROTECT",
+                            "shortDescription": {
+                                "text": "Field should be both final and package protected."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "{0} should be both final and package protected."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#MS_FINAL_PKGPROTECT",
+                            "properties": {
+                                "tags": [
+                                    "MALICIOUS_CODE"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "MS_PKGPROTECT",
+                            "shortDescription": {
+                                "text": "Field should be package protected."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "{0} should be package protected."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#MS_PKGPROTECT",
+                            "properties": {
+                                "tags": [
+                                    "MALICIOUS_CODE"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "SF_SWITCH_NO_DEFAULT",
+                            "shortDescription": {
+                                "text": "Switch statement found where default case is missing."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "Switch statement found in {0} where default case is missing."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#SF_SWITCH_NO_DEFAULT",
+                            "properties": {
+                                "tags": [
+                                    "STYLE"
+                                ]
+                            }
+                        },
+                        {
+                            "id": "NM_METHOD_NAMING_CONVENTION",
+                            "shortDescription": {
+                                "text": "Method names should start with a lower case letter."
+                            },
+                            "messageStrings": {
+                                "default": {
+                                    "text": "The method name {0} doesn\u0027t start with a lower case letter."
+                                }
+                            },
+                            "helpUri": "https://spotbugs.readthedocs.io/en/latest/bugDescriptions.html#NM_METHOD_NAMING_CONVENTION",
+                            "properties": {
+                                "tags": [
+                                    "BAD_PRACTICE"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "invocations": [
+                {
+                    "exitCode": 3,
+                    "exitSignalName": "ERROR,MISSING CLASS,BUGS FOUND",
+                    "executionSuccessful": false,
+                    "toolConfigurationNotifications": [
+                        {
+                            "descriptor": {
+                                "id": "spotbugs-missing-classes"
+                            },
+                            "message": {
+                                "text": "Classes needed for analysis were missing: [org.antlr.v4.runtime.ParserRuleContext, org.antlr.v4.runtime.Lexer, org.antlr.v4.runtime.tree.ParseTreeListener, org.antlr.v4.runtime.Parser, org.antlr.v4.runtime.atn.ATN, org.antlr.v4.runtime.atn.PredictionContextCache, org.antlr.v4.runtime.CharStream, org.antlr.v4.runtime.RuleContext, org.antlr.v4.runtime.atn.LexerATNSimulator, org.antlr.v4.runtime.atn.ATNSimulator, org.antlr.v4.runtime.TokenSource, org.antlr.v4.runtime.ANTLRInputStream, org.antlr.v4.runtime.CommonTokenStream, org.antlr.v4.runtime.Token, org.antlr.v4.runtime.TokenStream, org.antlr.v4.runtime.atn.ParserATNSimulator, org.antlr.v4.runtime.ANTLRErrorStrategy, org.antlr.v4.runtime.NoViableAltException, org.antlr.v4.runtime.tree.TerminalNode, org.antlr.v4.runtime.tree.ErrorNode, org.antlr.v4.runtime.dfa.DFA, org.antlr.v4.runtime.RecognitionException]"
+                            },
+                            "level": "error"
+                        }
+                    ]
+                }
+            ],
+            "results": [
+                {
+                    "ruleId": "DMI_HARDCODED_ABSOLUTE_FILENAME",
+                    "ruleIndex": 0,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.main(String[])"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 23
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "main(String[])",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "Boot.main(String[])"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "DM_DEFAULT_ENCODING",
+                    "ruleIndex": 1,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.writeFrags(Log, String)",
+                            "new java.io.FileWriter(File)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 104
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "new java.io.FileWriter(File)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "new java.io.FileWriter(File)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "DM_DEFAULT_ENCODING",
+                    "ruleIndex": 1,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.writeSnipers(Log, String)",
+                            "new java.io.FileWriter(File)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 125
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "new java.io.FileWriter(File)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "new java.io.FileWriter(File)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "DM_DEFAULT_ENCODING",
+                    "ruleIndex": 1,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.writeSuicides(Log, String)",
+                            "new java.io.FileWriter(File)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 84
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "new java.io.FileWriter(File)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "new java.io.FileWriter(File)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "DM_DEFAULT_ENCODING",
+                    "ruleIndex": 1,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.writeTeamkills(Log, String)",
+                            "new java.io.FileWriter(File)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 64
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "new java.io.FileWriter(File)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "new java.io.FileWriter(File)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "WMI_WRONG_MAP_ITERATOR",
+                    "ruleIndex": 2,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.getTopFrag(Log, boolean)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 210
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "getTopFrag(Log, boolean)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "Boot.getTopFrag(Log, boolean)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "WMI_WRONG_MAP_ITERATOR",
+                    "ruleIndex": 2,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.getTopSuicide(Log)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 166
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "getTopSuicide(Log)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "Boot.getTopSuicide(Log)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "WMI_WRONG_MAP_ITERATOR",
+                    "ruleIndex": 2,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Boot.getTopTeamkill(Log)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Boot.java"
+                                },
+                                "region": {
+                                    "startLine": 246
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "getTopTeamkill(Log)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "Boot.getTopTeamkill(Log)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "EI_EXPOSE_REP",
+                    "ruleIndex": 3,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Log.getMatchs()",
+                            "matchs"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Log.java"
+                                },
+                                "region": {
+                                    "startLine": 9
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "matchs",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "Log.matchs"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "EI_EXPOSE_REP2",
+                    "ruleIndex": 4,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Log.setMatchs(List)",
+                            "matchs"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Log.java"
+                                },
+                                "region": {
+                                    "startLine": 13
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "matchs",
+                                    "kind": "variable",
+                                    "fullyQualifiedName": "Log.setMatchs(List)#matchs"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "EI_EXPOSE_REP",
+                    "ruleIndex": 3,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Match.getMatchLines()",
+                            "matchLines"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Match.java"
+                                },
+                                "region": {
+                                    "startLine": 9
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "matchLines",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "Match.matchLines"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "EI_EXPOSE_REP2",
+                    "ruleIndex": 4,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "Match.setMatchLines(List)",
+                            "matchLines"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "Match.java"
+                                },
+                                "region": {
+                                    "startLine": 13
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "matchLines",
+                                    "kind": "variable",
+                                    "fullyQualifiedName": "Match.setMatchLines(List)#matchLines"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "MS_FINAL_PKGPROTECT",
+                    "ruleIndex": 5,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticLexer.modeNames"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticLexer.java"
+                                },
+                                "region": {
+                                    "startLine": 40
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "modeNames",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "XonoticLexer.modeNames"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "MS_PKGPROTECT",
+                    "ruleIndex": 6,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticLexer._decisionToDFA"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticLexer.java"
+                                },
+                                "region": {
+                                    "startLine": 536
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "_decisionToDFA",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "XonoticLexer._decisionToDFA"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "MS_PKGPROTECT",
+                    "ruleIndex": 6,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticLexer.ruleNames"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticLexer.java"
+                                },
+                                "region": {
+                                    "startLine": 68
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "ruleNames",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "XonoticLexer.ruleNames"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "MS_PKGPROTECT",
+                    "ruleIndex": 6,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticLexer.tokenNames"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticLexer.java"
+                                },
+                                "region": {
+                                    "startLine": 44
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "tokenNames",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "XonoticLexer.tokenNames"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "SF_SWITCH_NO_DEFAULT",
+                    "ruleIndex": 7,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticLexer.WS_action(RuleContext, int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticLexer.java"
+                                },
+                                "region": {
+                                    "startLine": 114,
+                                    "endLine": 115
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "WS_action(RuleContext, int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticLexer.WS_action(RuleContext, int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "SF_SWITCH_NO_DEFAULT",
+                    "ruleIndex": 7,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticLexer.action(RuleContext, int, int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticLexer.java"
+                                },
+                                "region": {
+                                    "startLine": 109,
+                                    "endLine": 110
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "action(RuleContext, int, int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticLexer.action(RuleContext, int, int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "MS_PKGPROTECT",
+                    "ruleIndex": 6,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser._decisionToDFA"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 2088
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "_decisionToDFA",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "XonoticParser._decisionToDFA"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "MS_PKGPROTECT",
+                    "ruleIndex": 6,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser.ruleNames"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 74
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "ruleNames",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "XonoticParser.ruleNames"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "MS_PKGPROTECT",
+                    "ruleIndex": 6,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser.tokenNames"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 40
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "tokenNames",
+                                    "kind": "member",
+                                    "fullyQualifiedName": "XonoticParser.tokenNames"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "SF_SWITCH_NO_DEFAULT",
+                    "ruleIndex": 7,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser.frag_someone()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 928,
+                                    "endLine": 1023
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "frag_someone()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser.frag_someone()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "SF_SWITCH_NO_DEFAULT",
+                    "ruleIndex": 7,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser.match_line()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 333,
+                                    "endLine": 468
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "match_line()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser.match_line()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_betrayedContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1331
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_betrayedContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_betrayedContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1333
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_betrayedContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_ending_spreeContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1386
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_ending_spreeContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_first_bloodContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1107
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_first_bloodContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_sniped_someoneContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 834
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_sniped_someoneContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_sniped_someoneContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 836
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_sniped_someoneContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_someoneContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 898
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_someoneContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_someoneContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 900
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_someoneContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_specialContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 722
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_specialContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_specialContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 724
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_specialContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_suicide2Context.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1286
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_suicide2Context.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Frag_suicideContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1191
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Frag_suicideContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Line_triple_fragContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1147
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Line_triple_fragContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$MatchContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 157
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$MatchContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$MatchContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 159
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$MatchContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Match_line_changed_teamContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1569
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Match_line_changed_teamContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Match_line_changed_teamContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1571
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Match_line_changed_teamContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Match_line_connectedContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1617
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Match_line_connectedContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Match_line_disconnectedContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1655
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Match_line_disconnectedContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Match_line_is_nowContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1694
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Match_line_is_nowContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Match_line_is_nowContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1696
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Match_line_is_nowContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Match_winsContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1737
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Match_winsContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Not_fragContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 781
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Not_fragContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Not_fragContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 783
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Not_fragContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Paused_gameContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 595
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Paused_gameContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Picked_upContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 640
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Picked_upContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Picked_upContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 642
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Picked_upContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Player_stats_rec_failedContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 541
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Player_stats_rec_failedContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Player_stats_rec_failedContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 543
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Player_stats_rec_failedContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Somebody_sayContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 488
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Somebody_sayContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Somebody_sayContext.Word(int)"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 490
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word(int)",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Somebody_sayContext.Word(int)"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$Unlocked_rageContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1068
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$Unlocked_rageContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "ruleId": "NM_METHOD_NAMING_CONVENTION",
+                    "ruleIndex": 8,
+                    "message": {
+                        "id": "default",
+                        "arguments": [
+                            "XonoticParser$You_cannotContext.Word()"
+                        ]
+                    },
+                    "level": "note",
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {
+                                    "uri": "XonoticParser.java"
+                                },
+                                "region": {
+                                    "startLine": 1925
+                                }
+                            },
+                            "logicalLocations": [
+                                {
+                                    "name": "Word()",
+                                    "kind": "function",
+                                    "fullyQualifiedName": "XonoticParser$You_cannotContext.Word()"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "originalUriBaseIds": {}
+        }
+    ]
+}

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -1,8 +1,8 @@
 from django.test import TestCase
 from django.utils import timezone
-from dojo.importers import utils as importer_utils
 from dojo.importers.importer.importer import DojoDefaultImporter as Importer
 from dojo.models import Engagement, Product, Product_Type, User
+from dojo.tools.factory import get_parser
 
 
 class TestDojoDefaultImporter(TestCase):
@@ -42,11 +42,8 @@ class TestDojoDefaultImporter(TestCase):
         test = importer.create_test(scan_type, scan_type, engagement, lead, environment)
 
         # parse the findings
-        active = False
-        verified = False
-        parsed_findings = importer_utils.parse_findings(
-            scan, test, active, verified, scan_type
-        )
+        parser = get_parser(scan_type)
+        parsed_findings = parser.get_findings(scan, test)
 
         # process
         minimum_severity = "Info"

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -87,7 +87,11 @@ class TestDojoDefaultImporter(TestCase):
 
         importer = Importer()
         scan_date = timezone.make_aware(datetime.datetime(2021, 9, 1), timezone.get_default_timezone())
-        importer.import_scan(scan, scan_type, engagement, lead=None, environment=None, active=True, verified=True, tags=None, minimum_severity=None,
+        test, len_new_findings, len_closed_findings = importer.import_scan(scan, scan_type, engagement, lead=None, environment=None, active=True, verified=True, tags=None, minimum_severity=None,
                     user=user, endpoints_to_add=None, scan_date=scan_date, version=None, branch_tag=None, build_id=None,
                     commit_hash=None, push_to_jira=None, close_old_findings=False, group_by=None, sonarqube_config=None,
                     cobaltio_config=None)
+
+        self.assertEqual("SpotBugs", test.test_type.name)
+        self.assertEqual(56, len_new_findings)
+        self.assertEqual(0, len_closed_findings)

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -86,7 +86,8 @@ class TestDojoDefaultImporter(TestCase):
         )
 
         importer = Importer()
+        scan_date = timezone.make_aware(datetime.datetime(2021, 9, 1), timezone.get_default_timezone())
         importer.import_scan(scan, scan_type, engagement, lead=None, environment=None, active=True, verified=True, tags=None, minimum_severity=None,
-                    user=user, endpoints_to_add=None, scan_date=datetime.date(2021, 9, 1), version=None, branch_tag=None, build_id=None,
+                    user=user, endpoints_to_add=None, scan_date=scan_date, version=None, branch_tag=None, build_id=None,
                     commit_hash=None, push_to_jira=None, close_old_findings=False, group_by=None, sonarqube_config=None,
                     cobaltio_config=None)

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -92,6 +92,6 @@ class TestDojoDefaultImporter(TestCase):
                     commit_hash=None, push_to_jira=None, close_old_findings=False, group_by=None, sonarqube_config=None,
                     cobaltio_config=None)
 
-        self.assertEqual(f"{scan_type} > SpotBugs", test.test_type.name)
+        self.assertEqual(f"SpotBugs Scan ({scan_type})", test.test_type.name)
         self.assertEqual(56, len_new_findings)
         self.assertEqual(0, len_closed_findings)

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -47,6 +47,8 @@ class TestDojoDefaultImporter(TestCase):
 
         # process
         minimum_severity = "Info"
+        active = True
+        verified = True
         new_findings = importer.process_parsed_findings(
             test,
             parsed_findings,

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -38,7 +38,8 @@ class TestDojoDefaultImporter(TestCase):
         importer = Importer()
 
         # create the test
-        test = importer.create_test(scan_type, engagement, lead, environment)
+        # by defaut test_type == scan_type
+        test = importer.create_test(scan_type, scan_type, engagement, lead, environment)
 
         # parse the findings
         active = False

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -92,6 +92,6 @@ class TestDojoDefaultImporter(TestCase):
                     commit_hash=None, push_to_jira=None, close_old_findings=False, group_by=None, sonarqube_config=None,
                     cobaltio_config=None)
 
-        self.assertEqual("SpotBugs", test.test_type.name)
+        self.assertEqual(f"{scan_type} > SpotBugs", test.test_type.name)
         self.assertEqual(56, len_new_findings)
         self.assertEqual(0, len_closed_findings)

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -339,7 +339,7 @@ class TestSarifParser(TestCase):
                 "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).",
                 finding.title,
             )
-            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("Critical", finding.severity)
             description = """**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
 **Snippet:**
 ```      is.setstate(std::ios::failbit);```
@@ -369,8 +369,8 @@ class TestSarifParser(TestCase):
             self.assertEqual(120, finding.cwe)
             self.assertEqual("FF1004", finding.vuln_id_from_tool)
             self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
-        with self.subTest(i=53):
-            finding = findings[53]
+        with self.subTest(i=52):
+            finding = findings[52]
             self.assertEqual(
                 "buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).",
                 finding.title,
@@ -393,7 +393,7 @@ class TestSarifParser(TestCase):
         tests = parser.get_tests(parser.get_scan_types()[0], testfile)
         self.assertEqual(1, len(tests))
         findings = tests[0].findings
-        self.assertEqual(54, len(findings))
+        self.assertEqual(53, len(findings))
         for finding in findings:
             self.common_checks(finding)
         with self.subTest(i=0):
@@ -402,7 +402,7 @@ class TestSarifParser(TestCase):
                 "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).",
                 finding.title,
             )
-            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("Critical", finding.severity)
             description = """**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
 **Snippet:**
 ```      is.setstate(std::ios::failbit);```

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -454,11 +454,11 @@ class TestSarifParser(TestCase):
         self.assertEqual(2, len(tests))
         with self.subTest(test=0):
             test = tests[0]
-            self.assertEqual("CodeScanner", test.test_type.name)
+            self.assertEqual("CodeScanner", test.type)
             findings = test.findings
             self.assertEqual(0, len(findings))
         with self.subTest(test=1):
             test = tests[1]
-            self.assertEqual("OtherScanner", test.test_type.name)
+            self.assertEqual("OtherScanner", test.type)
             findings = test.findings
             self.assertEqual(0, len(findings))

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -1,3 +1,4 @@
+from os import path
 import datetime
 from django.test import TestCase
 
@@ -18,7 +19,9 @@ class TestSarifParser(TestCase):
 
     def test_example_report(self):
         testfile = open(
-            "dojo/unittests/scans/sarif/DefectDojo_django-DefectDojo__2020-12-11_13 42 10__export.sarif"
+            path.join(
+                path.dirname(__file__), "../scans/sarif/DefectDojo_django-DefectDojo__2020-12-11_13 42 10__export.sarif"
+            )
         )
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
@@ -27,7 +30,7 @@ class TestSarifParser(TestCase):
             self.common_checks(finding)
 
     def test_example2_report(self):
-        testfile = open("dojo/unittests/scans/sarif/appendix_k.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
@@ -35,54 +38,50 @@ class TestSarifParser(TestCase):
         self.assertEqual("collections/list.h", item.file_path)
         self.assertEqual(15, item.line)
         self.assertEqual("Critical", item.severity)
-        description = '''**Result message:** Variable "ptr" was used without being initialized. It was declared [here](0).
+        description = """**Result message:** Variable "ptr" was used without being initialized. It was declared [here](0).
 **Snippet:**
 ```add_core(ptr, offset, val);
     return;```
 **Rule short description:** A variable was used without being initialized.
-**Rule full description:** A variable was used without being initialized. This can result in runtime errors such as null reference exceptions.'''
+**Rule full description:** A variable was used without being initialized. This can result in runtime errors such as null reference exceptions."""
         self.assertEqual(description, item.description)
         self.assertEqual(datetime.datetime(2016, 7, 16, 14, 19, 1, tzinfo=datetime.timezone.utc), item.date)
         for finding in findings:
             self.common_checks(finding)
 
     def test_example_k1_report(self):
-        testfile = open("dojo/unittests/scans/sarif/appendix_k1.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k1.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(0, len(findings))
 
     def test_example_k2_report(self):
-        testfile = open("dojo/unittests/scans/sarif/appendix_k2.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k2.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
         item = findings[0]
-        self.assertEqual(
-            'Variable "count" was used without being initialized.', item.title
-        )
+        self.assertEqual('Variable "count" was used without being initialized.', item.title)
         self.assertEqual("src/collections/list.cpp", item.file_path)
         self.assertEqual(15, item.line)
-        description = '''**Result message:** Variable "count" was used without being initialized.
-**Rule full description:** A variable was used without being initialized. This can result in runtime errors such as null reference exceptions.'''
+        description = """**Result message:** Variable "count" was used without being initialized.
+**Rule full description:** A variable was used without being initialized. This can result in runtime errors such as null reference exceptions."""
         self.assertEquals(description, item.description)
         for finding in findings:
             self.common_checks(finding)
 
     def test_example_k3_report(self):
-        testfile = open("dojo/unittests/scans/sarif/appendix_k3.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k3.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
         item = findings[0]
-        self.assertEqual(
-            'The insecure method "Crypto.Sha1.Encrypt" should not be used.', item.title
-        )
+        self.assertEqual('The insecure method "Crypto.Sha1.Encrypt" should not be used.', item.title)
         for finding in findings:
             self.common_checks(finding)
 
     def test_example_k4_report_mitigation(self):
-        testfile = open("dojo/unittests/scans/sarif/appendix_k4.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k4.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(1, len(findings))
@@ -90,14 +89,16 @@ class TestSarifParser(TestCase):
             self.common_checks(finding)
         with self.subTest(i=0):
             finding = findings[0]
-            self.assertEqual('Variable "ptr" was used without being initialized. It was declared [here](0).', finding.title)
-            self.assertEqual('C2001', finding.vuln_id_from_tool)
-            self.assertEqual('collections/list.h', finding.file_path)
-            self.assertEqual('Initialize the variable to null', finding.mitigation)
+            self.assertEqual(
+                'Variable "ptr" was used without being initialized. It was declared [here](0).', finding.title
+            )
+            self.assertEqual("C2001", finding.vuln_id_from_tool)
+            self.assertEqual("collections/list.h", finding.file_path)
+            self.assertEqual("Initialize the variable to null", finding.mitigation)
 
     def test_example_report_ms(self):
         """Report file come from Microsoft SARIF sdk on GitHub"""
-        testfile = open("dojo/unittests/scans/sarif/SuppressionTestCurrent.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/SuppressionTestCurrent.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(4, len(findings))
@@ -107,9 +108,7 @@ class TestSarifParser(TestCase):
             self.common_checks(finding)
 
     def test_example_report_semgrep(self):
-        testfile = open(
-            "dojo/unittests/scans/sarif/semgrepowasp-benchmark-sample.sarif"
-        )
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/semgrepowasp-benchmark-sample.sarif"))
         test = Test()
         parser = SarifParser()
         findings = parser.get_findings(testfile, test)
@@ -123,7 +122,7 @@ class TestSarifParser(TestCase):
             self.common_checks(finding)
 
     def test_example_report_scanlift_dependency_check(self):
-        testfile = open("dojo/unittests/scans/sarif/dependency_check.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/dependency_check.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(13, len(findings))
@@ -135,14 +134,17 @@ class TestSarifParser(TestCase):
         )
         # finding 6
         item = findings[6]
-        self.assertEqual("CVE-2019-11358 - jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of [...]", item.title)
+        self.assertEqual(
+            "CVE-2019-11358 - jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of [...]",
+            item.title,
+        )
         self.assertEqual("Critical", item.severity)
         self.assertEqual("CVE-2019-11358", item.cve)
         for finding in findings:
             self.common_checks(finding)
 
     def test_example_report_scanlift_bash(self):
-        testfile = open("dojo/unittests/scans/sarif/bash-report.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/bash-report.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(27, len(findings))
@@ -166,7 +168,7 @@ class TestSarifParser(TestCase):
             self.common_checks(finding)
 
     def test_example_report_taint_python(self):
-        testfile = open("dojo/unittests/scans/sarif/taint-python-report.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/taint-python-report.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(11, len(findings))
@@ -198,7 +200,7 @@ class TestSarifParser(TestCase):
 
     def test_njsscan(self):
         """Generated with opensecurity/njsscan (https://github.com/ajinabraham/njsscan)"""
-        testfile = open("dojo/unittests/scans/sarif/njsscan.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/njsscan.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(2, len(findings))
@@ -225,7 +227,7 @@ class TestSarifParser(TestCase):
 
     def test_dockle(self):
         """Generated with goodwithtech/dockle (https://github.com/goodwithtech/dockle)"""
-        testfile = open("dojo/unittests/scans/sarif/dockle_0_3_15.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/dockle_0_3_15.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(4, len(findings))
@@ -235,37 +237,45 @@ class TestSarifParser(TestCase):
             finding = findings[0]
             self.assertEqual("CIS-DI-0010", finding.vuln_id_from_tool)
             self.assertEqual("Critical", finding.severity)
-            description = '''**Result message:** Suspicious ENV key found : DD_ADMIN_PASSWORD, Suspicious ENV key found : DD_CELERY_BROKER_PASSWORD, Suspicious ENV key found : DD_DATABASE_PASSWORD
-**Rule short description:** Do not store credential in ENVIRONMENT vars/files'''
+            description = """**Result message:** Suspicious ENV key found : DD_ADMIN_PASSWORD, Suspicious ENV key found : DD_CELERY_BROKER_PASSWORD, Suspicious ENV key found : DD_DATABASE_PASSWORD
+**Rule short description:** Do not store credential in ENVIRONMENT vars/files"""
             self.assertEqual(description, finding.description)
-            self.assertEqual('https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0010', finding.references)
+            self.assertEqual(
+                "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0010", finding.references
+            )
         with self.subTest(i=1):
             finding = findings[1]
             self.assertEqual("CIS-DI-0005", finding.vuln_id_from_tool)
             self.assertEqual("Info", finding.severity)
-            description = '''**Result message:** export DOCKER_CONTENT_TRUST=1 before docker pull/build
-**Rule short description:** Enable Content trust for Docker'''
+            description = """**Result message:** export DOCKER_CONTENT_TRUST=1 before docker pull/build
+**Rule short description:** Enable Content trust for Docker"""
             self.assertEqual(description, finding.description)
-            self.assertEqual('https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0005', finding.references)
+            self.assertEqual(
+                "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0005", finding.references
+            )
         with self.subTest(i=2):
             finding = findings[2]
             self.assertEqual("CIS-DI-0006", finding.vuln_id_from_tool)
             self.assertEqual("Info", finding.severity)
-            description = '''**Result message:** not found HEALTHCHECK statement
-**Rule short description:** Add HEALTHCHECK instruction to the container image'''
+            description = """**Result message:** not found HEALTHCHECK statement
+**Rule short description:** Add HEALTHCHECK instruction to the container image"""
             self.assertEqual(description, finding.description)
-            self.assertEqual('https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0006', finding.references)
+            self.assertEqual(
+                "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0006", finding.references
+            )
         with self.subTest(i=3):
             finding = findings[3]
             self.assertEqual("CIS-DI-0008", finding.vuln_id_from_tool)
             self.assertEqual("Info", finding.severity)
-            description = '''**Result message:** setuid file: urwxr-xr-x usr/bin/chfn, setuid file: urwxr-xr-x usr/bin/chsh, setuid file: urwxr-xr-x usr/bin/passwd, setuid file: urwxr-xr-x bin/umount, setuid file: urwxr-xr-x bin/mount, setgid file: grwxr-xr-x usr/bin/wall, setgid file: grwxr-xr-x usr/bin/expiry, setuid file: urwxr-xr-x bin/su, setgid file: grwxr-xr-x sbin/unix_chkpwd, setuid file: urwxr-xr-x usr/bin/gpasswd, setgid file: grwxr-xr-x usr/bin/chage, setuid file: urwxr-xr-x usr/bin/newgrp
-**Rule short description:** Confirm safety of setuid/setgid files'''
+            description = """**Result message:** setuid file: urwxr-xr-x usr/bin/chfn, setuid file: urwxr-xr-x usr/bin/chsh, setuid file: urwxr-xr-x usr/bin/passwd, setuid file: urwxr-xr-x bin/umount, setuid file: urwxr-xr-x bin/mount, setgid file: grwxr-xr-x usr/bin/wall, setgid file: grwxr-xr-x usr/bin/expiry, setuid file: urwxr-xr-x bin/su, setgid file: grwxr-xr-x sbin/unix_chkpwd, setuid file: urwxr-xr-x usr/bin/gpasswd, setgid file: grwxr-xr-x usr/bin/chage, setuid file: urwxr-xr-x usr/bin/newgrp
+**Rule short description:** Confirm safety of setuid/setgid files"""
             self.assertEqual(description, finding.description)
-            self.assertEqual('https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0008', finding.references)
+            self.assertEqual(
+                "https://github.com/goodwithtech/dockle/blob/master/CHECKPOINT.md#CIS-DI-0008", finding.references
+            )
 
     def test_mobsfscan(self):
-        testfile = open("dojo/unittests/scans/sarif/mobsfscan.json")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/mobsfscan.json"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(9, len(findings))
@@ -273,7 +283,7 @@ class TestSarifParser(TestCase):
             self.common_checks(finding)
 
     def test_gitleaks(self):
-        testfile = open("dojo/unittests/scans/sarif/gitleaks_7.5.0.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/gitleaks_7.5.0.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(8, len(findings))
@@ -283,35 +293,41 @@ class TestSarifParser(TestCase):
             finding = findings[0]
             self.assertEqual("AWS Access Key secret detected", finding.title)
             self.assertEqual("Medium", finding.severity)
-            description = '''**Result message:** AWS Access Key secret detected
+            description = """**Result message:** AWS Access Key secret detected
 **Snippet:**
-```      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\",```'''
+```      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\",```"""
             self.assertEqual(description, finding.description)
-            self.assertEqual("dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_1_vuln.json", finding.file_path)
+            self.assertEqual(
+                "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_1_vuln.json",
+                finding.file_path,
+            )
             self.assertEqual(13, finding.line)
         with self.subTest(i=3):
             finding = findings[3]
             self.assertEqual("AWS Access Key secret detected", finding.title)
             self.assertEqual("Medium", finding.severity)
-            description = '''**Result message:** AWS Access Key secret detected
+            description = """**Result message:** AWS Access Key secret detected
 **Snippet:**
-```      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\",```'''
+```      \"raw_source_code_extract\": \"AKIAIOSFODNN7EXAMPLE\",```"""
             self.assertEqual(description, finding.description)
-            self.assertEqual("dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_3_vuln.json", finding.file_path)
+            self.assertEqual(
+                "dojo/unittests/scans/gitlab_secret_detection_report/gitlab_secret_detection_report_3_vuln.json",
+                finding.file_path,
+            )
             self.assertEqual(44, finding.line)
         with self.subTest(i=7):
             finding = findings[7]
             self.assertEqual("AWS Access Key secret detected", finding.title)
             self.assertEqual("Medium", finding.severity)
-            description = '''**Result message:** AWS Access Key secret detected
+            description = """**Result message:** AWS Access Key secret detected
 **Snippet:**
-```        self.assertEqual(\"AWS\\nAKIAIOSFODNN7EXAMPLE\", first_finding.description)```'''
+```        self.assertEqual(\"AWS\\nAKIAIOSFODNN7EXAMPLE\", first_finding.description)```"""
             self.assertEqual(description, finding.description)
             self.assertEqual("dojo/unittests/tools/test_gitlab_secret_detection_report_parser.py", finding.file_path)
             self.assertEqual(37, finding.line)
 
     def test_flawfinder(self):
-        testfile = open("dojo/unittests/scans/sarif/flawfinder.sarif")
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/flawfinder.sarif"))
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(53, len(findings))
@@ -319,28 +335,97 @@ class TestSarifParser(TestCase):
             self.common_checks(finding)
         with self.subTest(i=0):
             finding = findings[0]
-            self.assertEqual("random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).", finding.title)
-            self.assertEqual("Critical", finding.severity)
-            description = '''**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
+            self.assertEqual(
+                "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).",
+                finding.title,
+            )
+            self.assertEqual("Medium", finding.severity)
+            description = """**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
 **Snippet:**
 ```      is.setstate(std::ios::failbit);```
 **Rule name:** random/setstate
-**Rule short description:** This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).'''
+**Rule short description:** This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."""
             self.assertEqual(description, finding.description)
             self.assertEqual("src/tree/param.cc", finding.file_path)
             self.assertEqual(29, finding.line)
             self.assertEqual(327, finding.cwe)
             self.assertEqual("FF1048", finding.vuln_id_from_tool)
-            self.assertEqual('https://cwe.mitre.org/data/definitions/327.html', finding.references)
+            self.assertEqual("https://cwe.mitre.org/data/definitions/327.html", finding.references)
         with self.subTest(i=20):
             finding = findings[20]
-            self.assertEqual("buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120).", finding.title)
+            self.assertEqual(
+                "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120).",
+                finding.title,
+            )
             self.assertEqual("Info", finding.severity)
-            description = '''**Result message:** buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120).
+            description = """**Result message:** buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120).
 **Snippet:**
 ```    std::memcpy(dptr, dmlc::BeginPtr(buffer_) + buffer_ptr_, size);```
 **Rule name:** buffer/memcpy
-**Rule short description:** Does not check for buffer overflows when copying to destination (CWE-120).'''
+**Rule short description:** Does not check for buffer overflows when copying to destination (CWE-120)."""
+            self.assertEqual(description, finding.description)
+            self.assertEqual("src/common/io.cc", finding.file_path)
+            self.assertEqual(31, finding.line)
+            self.assertEqual(120, finding.cwe)
+            self.assertEqual("FF1004", finding.vuln_id_from_tool)
+            self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
+        with self.subTest(i=53):
+            finding = findings[53]
+            self.assertEqual(
+                "buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).",
+                finding.title,
+            )
+            self.assertEqual("Critical", finding.severity)
+            description = """**Result message:** buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).
+**Snippet:**
+```      if (sscanf(argv[i], "%[^=]=%s", name, val) == 2) {```
+**Rule name:** buffer/sscanf
+**Rule short description:** The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20)."""
+            self.assertEqual(description, finding.description)
+            self.assertEqual("src/cli_main.cc", finding.file_path)
+            self.assertEqual(482, finding.line)
+            self.assertEqual("FF1021", finding.vuln_id_from_tool)
+            self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
+
+    def test_flawfinder_interfacev2(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/flawfinder.sarif"))
+        parser = SarifParser()
+        tests = parser.get_tests(parser.get_scan_types()[0], testfile)
+        self.assertEqual(1, len(tests))
+        findings = tests[0].findings
+        self.assertEqual(54, len(findings))
+        for finding in findings:
+            self.common_checks(finding)
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual(
+                "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).",
+                finding.title,
+            )
+            self.assertEqual("Medium", finding.severity)
+            description = """**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
+**Snippet:**
+```      is.setstate(std::ios::failbit);```
+**Rule name:** random/setstate
+**Rule short description:** This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."""
+            self.assertEqual(description, finding.description)
+            self.assertEqual("src/tree/param.cc", finding.file_path)
+            self.assertEqual(29, finding.line)
+            self.assertEqual(327, finding.cwe)
+            self.assertEqual("FF1048", finding.vuln_id_from_tool)
+            self.assertEqual("https://cwe.mitre.org/data/definitions/327.html", finding.references)
+        with self.subTest(i=20):
+            finding = findings[20]
+            self.assertEqual(
+                "buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120).",
+                finding.title,
+            )
+            self.assertEqual("Info", finding.severity)
+            description = """**Result message:** buffer/memcpy:Does not check for buffer overflows when copying to destination (CWE-120).
+**Snippet:**
+```    std::memcpy(dptr, dmlc::BeginPtr(buffer_) + buffer_ptr_, size);```
+**Rule name:** buffer/memcpy
+**Rule short description:** Does not check for buffer overflows when copying to destination (CWE-120)."""
             self.assertEqual(description, finding.description)
             self.assertEqual("src/common/io.cc", finding.file_path)
             self.assertEqual(31, finding.line)
@@ -351,13 +436,29 @@ class TestSarifParser(TestCase):
             finding = findings[52]
             self.assertEqual("buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).", finding.title)
             self.assertEqual("Critical", finding.severity)
-            description = '''**Result message:** buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).
+            description = """**Result message:** buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).
 **Snippet:**
 ```      if (sscanf(argv[i], "%[^=]=%s", name, val) == 2) {```
 **Rule name:** buffer/sscanf
-**Rule short description:** The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).'''
+**Rule short description:** The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20)."""
             self.assertEqual(description, finding.description)
             self.assertEqual("src/cli_main.cc", finding.file_path)
             self.assertEqual(482, finding.line)
             self.assertEqual("FF1021", finding.vuln_id_from_tool)
-            self.assertEqual('https://cwe.mitre.org/data/definitions/120.html', finding.references)
+            self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
+
+    def test_appendix_k1_double_interfacev2(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k1_double.sarif"))
+        parser = SarifParser()
+        tests = parser.get_tests(parser.get_scan_types()[0], testfile)
+        self.assertEqual(2, len(tests))
+        with self.subTest(test=0):
+            test = tests[0]
+            self.assertEqual("CodeScanner", test.test_type.name)
+            findings = test.findings
+            self.assertEqual(0, len(findings))
+        with self.subTest(test=1):
+            test = tests[1]
+            self.assertEqual("OtherScanner", test.test_type.name)
+            findings = test.findings
+            self.assertEqual(0, len(findings))


### PR DESCRIPTION
## Description

Add feature to customize `Test` from parser data.

This will allow some parsers to handle meta-format like SARIF.

Fixes #3797

## Implementation

1. Test: added a `scan_type` attribute to save the scan_type used during import as string
2. Importer/Reimporter: add a new method `get_tests()` for parsers that are able to build findings **and** tests
3. The importer now take into account the data of the parsers to create the Test.

The core of the modifications are in `dojo/importers/importer/importer.py`.
I implemented like this:
```
 *if the parser support creating Test* =>
   1. we parse the findings and tests
   2. we create the test with these data (with a customized type and name)
 * else *
   <old behavior>
```

Once this PR is merged I plan to add more attributes like description and more parsers that support this new interface like the generic parser.

## Screenshots
For ex:
![image](https://user-images.githubusercontent.com/1694940/133936737-cbf5a33e-d39c-4d6a-a6d6-b56531b7678c.png)

The name of the Test can come from the data now (ex for SARIF test file):
![image](https://user-images.githubusercontent.com/1694940/134028758-1e2678b4-9e4f-4c49-9ff2-afa9ddd12707.png)

