### PR TITLE
SARIF parser: Fix severity in rule and take into account the kind attribute

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -40,7 +40,8 @@ class SarifParser(object):
             run_date = self._get_last_invocation_date(run)
             for result in run.get('results', list()):
                 item = get_item(result, rules, artifacts, run_date)
-                items.append(item)
+                if item is not None:
+                    items.append(item)
         return items
 
     def _get_last_invocation_date(self, data):
@@ -228,6 +229,12 @@ def get_severity(result, rule):
 
 
 def get_item(result, rules, artifacts, run_date):
+
+    # see https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html / 3.27.9
+    kind = result.get('kind', 'fail')
+    if kind != 'fail':
+        return None
+
     # if there is a location get it
     file_path = None
     line = None

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -211,18 +211,20 @@ def get_references(rule):
 
 
 def get_severity(result, rule):
-    severity = result.get('level', 'warning')
+    severity = result.get('level')
     if severity is None and rule is not None:
         # get the severity from the rule
         if 'defaultConfiguration' in rule:
-            severity = rule['defaultConfiguration'].get('level', 'warning')
+            severity = rule['defaultConfiguration'].get('level')
 
-    if 'warning' == severity:
+    if 'note' == severity:
+        return 'Info'
+    elif 'warning' == severity:
         return 'Medium'
     elif 'error' == severity:
         return 'Critical'
     else:
-        return 'Info'
+        return 'Medium'
 
 
 def get_item(result, rules, artifacts, run_date):

--- a/dojo/unittests/scans/sarif/flawfinder.sarif
+++ b/dojo/unittests/scans/sarif/flawfinder.sarif
@@ -283,6 +283,7 @@
       "results": [
         {
           "ruleId": "FF1048",
+          "kind": "fail",
           "message": {
             "text": "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."
           },
@@ -1790,32 +1791,8 @@
         },
         {
           "ruleId": "FF1013",
-          "level": "note",
-          "message": {
-            "text": "buffer/char:Statically-sized arrays can be improperly restricted, leading to potential overflows or other issues (CWE-119!/CWE-120)."
-          },
-          "locations": [
-            {
-              "physicalLocation": {
-                "artifactLocation": {
-                  "uri": "src/cli_main.cc",
-                  "uriBaseId": "SRCROOT"
-                },
-                "region": {
-                  "startLine": 481,
-                  "startColumn": 7,
-                  "endColumn": 32,
-                  "snippet": {
-                    "text": "      char name[256], val[256];"
-                  }
-                }
-              }
-            }
-          ],
-          "fingerprints": {
-            "contextHash/v1": "f2de314a9ee6aee0f164f741d06c0ae628b87ccf9898285d866210d213bf3bd0"
-          },
-          "rank": 0.4
+          "kind": "pass",
+          "level": "note"
         },
         {
           "ruleId": "FF1021",

--- a/dojo/unittests/scans/sarif/flawfinder.sarif
+++ b/dojo/unittests/scans/sarif/flawfinder.sarif
@@ -16,7 +16,7 @@
                 "text": "This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."
               },
               "defaultConfiguration": {
-                "level": "warning"
+                "level": "error"
               },
               "helpUri": "https://cwe.mitre.org/data/definitions/327.html",
               "relationships": [
@@ -283,7 +283,6 @@
       "results": [
         {
           "ruleId": "FF1048",
-          "level": "warning",
           "message": {
             "text": "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327)."
           },

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -314,7 +314,7 @@ class TestSarifParser(TestCase):
         testfile = open("dojo/unittests/scans/sarif/flawfinder.sarif")
         parser = SarifParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertEqual(54, len(findings))
+        self.assertEqual(53, len(findings))
         for finding in findings:
             self.common_checks(finding)
         with self.subTest(i=0):
@@ -347,8 +347,8 @@ class TestSarifParser(TestCase):
             self.assertEqual(120, finding.cwe)
             self.assertEqual("FF1004", finding.vuln_id_from_tool)
             self.assertEqual('https://cwe.mitre.org/data/definitions/120.html', finding.references)
-        with self.subTest(i=53):
-            finding = findings[53]
+        with self.subTest(i=52):
+            finding = findings[52]
             self.assertEqual("buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).", finding.title)
             self.assertEqual("Critical", finding.severity)
             description = '''**Result message:** buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).

--- a/dojo/unittests/tools/test_sarif_parser.py
+++ b/dojo/unittests/tools/test_sarif_parser.py
@@ -320,7 +320,7 @@ class TestSarifParser(TestCase):
         with self.subTest(i=0):
             finding = findings[0]
             self.assertEqual("random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).", finding.title)
-            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("Critical", finding.severity)
             description = '''**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
 **Snippet:**
 ```      is.setstate(std::ios::failbit);```


### PR DESCRIPTION
There was a bug when there is no severity in the result but only in the rule. Because of the default in the `get` these findings always got the severity **Medium**. Now they get the default severity of the rule.

While reading the specification about severities I came across the `kind` attribute, which was not taken into account so far.