### PR TITLE
merge master into dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,23 +27,22 @@ Steps to reproduce the behavior:
 A clear and concise description of what you expected to happen.
 
 **Deployment method** *(select with an `X`)*
-- [ ] Docker
+- [ ] Docker Compose
 - [ ] Kubernetes
 - [ ] GoDojo
-- [ ] setup.bash / legacy-setup.bash
 
 **Environment information**
  - Operating System: [e.g. Ubuntu 18.04]
- - DefectDojo Commit Message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
+ - DefectDojo version (see footer) or commit message: [use `git show -s --format="[%ci] %h: %s [%d]"`]
 
-**Sample scan files** (optional)
+**Logs** 
+Use `docker-compose logs` (or similar, depending on your deployment method) to get the logs and add the relevant sections here showing the error occurring (if applicable).
+
+**Sample scan files**
 If applicable, add sample scan files to help reproduce your problem.
 
-**Screenshots** (optional)
+**Screenshots**
 If applicable, add screenshots to help explain your problem.
-
-**Console logs** (optional)
-If applicable, add console logs to help explain your problem.
 
 **Additional context** (optional)
 Add any other context about the problem here.

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: github-pages
 on:
   push:
     branches:
-      - master
+      - dev
 
 # Taken from https://github.com/marketplace/actions/hugo-setup#%EF%B8%8F-workflow-for-autoprefixer-and-postcss-cli
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: github-pages
 on:
   push:
     branches:
-      - dev
+      - master
 
 # Taken from https://github.com/marketplace/actions/hugo-setup#%EF%B8%8F-workflow-for-autoprefixer-and-postcss-cli
 jobs:


### PR DESCRIPTION
There were some commits against `master`, just making sure `dev` is in sync so we don't get conflicts on release day.