### PR TITLE
Fix links in installation.md to point to existing files in dev

### DIFF
--- a/docs/content/en/getting_started/installation.md
+++ b/docs/content/en/getting_started/installation.md
@@ -7,11 +7,11 @@ weight: 2
 
 ## Docker Compose install (recommended)
 
-See instructions in [DOCKER.md](<https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/DOCKER.md>)
+See instructions in [DOCKER.md](<https://github.com/DefectDojo/django-DefectDojo/blob/dev/readme-docs/DOCKER.md>)
 
 ## Kubernetes install
 
-See instructions in [KUBERNETES.md](<https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/KUBERNETES.md>)
+See instructions in [KUBERNETES.md](<https://github.com/DefectDojo/django-DefectDojo/blob/dev/readme-docs/KUBERNETES.md>)
 
 ## Local install with godojo
 


### PR DESCRIPTION
Cleaned up and corrected https://github.com/DefectDojo/django-DefectDojo/pull/5158 to now point to dev in order to fix https://defectdojo.github.io/django-DefectDojo/getting_started/installation/