### PR TITLE
fix publish_date formatting issue while saving finding

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1061,7 +1061,7 @@ class FindingForm(forms.ModelForm):
     mitigated = SplitDateTimeField(required=False, help_text='Date and time when the flaw has been fixed')
     mitigated_by = forms.ModelChoiceField(required=True, queryset=User.objects.all(), initial=get_current_user)
 
-    publish_date = forms.DateField(widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}), required=False)
+    publish_date = forms.DateTimeField(widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}), required=False)
 
     # the onyl reliable way without hacking internal fields to get predicatble ordering is to make it explicit
     field_order = ('title', 'group', 'date', 'sla_start_date', 'cwe', 'cve', 'severity', 'cvssv3', 'cvssv3_score', 'description', 'mitigation', 'impact',


### PR DESCRIPTION
fixes https://github.com/DefectDojo/django-DefectDojo/issues/4906 

publish_date is declared as DateTimeField in models.py, so should be declared accordingly in forms.py