### PR TITLE
Fix integration test for export of findings

### DIFF
--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -14,6 +14,7 @@ import re
 dd_driver = None
 dd_driver_options = None
 
+
 def on_exception_html_source_logger(func):
     def wrapper(self, *args, **kwargs):
         try:

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -14,7 +14,6 @@ import re
 dd_driver = None
 dd_driver_options = None
 
-
 def on_exception_html_source_logger(func):
     def wrapper(self, *args, **kwargs):
         try:
@@ -52,6 +51,9 @@ class BaseTestCase(unittest.TestCase):
 
         chromedriver_autoinstaller.install()
 
+        # Path for automatic downloads, mapped to the media path
+        cls.export_path = 'media'
+
         global dd_driver
         if not dd_driver:
             # setupModule and tearDownModule are not working in our scenario, so for now we use setupClass and a global variable
@@ -80,7 +82,7 @@ class BaseTestCase(unittest.TestCase):
             desired['goog:loggingPrefs'] = {'browser': 'ALL'}
 
             # set automatic downloads to test csv and excel export
-            prefs = {"download.default_directory": '/tmp'}
+            prefs = {"download.default_directory": cls.export_path}
             dd_driver_options.add_experimental_option("prefs", prefs)
 
             # change path of chromedriver according to which directory you have chromedriver.

--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -63,6 +63,16 @@ class FindingTest(BaseTestCase):
 
         self.assertIn("<title>Finding Report</title>", driver.page_source)
 
+    def check_file(self, file_name):
+        file_found = False
+        for i in range(1, 30):
+            time.sleep(1)
+            if Path(file_name).is_file():
+                file_found = True
+                break
+        self.assertTrue(file_found, f'Cannot find {file_name}')
+        os.remove(file_name)
+
     def test_csv_export(self):
         driver = self.driver
         driver.get(self.base_url + "finding")
@@ -70,13 +80,7 @@ class FindingTest(BaseTestCase):
         driver.find_element_by_id("downloadMenu").click()
         driver.find_element_by_id("csv_export").click()
 
-        file_found = False
-        for i in range(1, 20):
-            time.sleep(1)
-            if Path("/tmp/findings.csv").is_file():
-                file_found = True
-                break
-        self.assertTrue(file_found, 'Couldn\'t find /tmp/findings.csv')
+        self.check_file(f'{self.export_path}/findings.csv')
 
     def test_excel_export(self):
         driver = self.driver
@@ -85,13 +89,7 @@ class FindingTest(BaseTestCase):
         driver.find_element_by_id("downloadMenu").click()
         driver.find_element_by_id("excel_export").click()
 
-        file_found = False
-        for i in range(1, 20):
-            time.sleep(1)
-            if Path("/tmp/findings.xlsx").is_file():
-                file_found = True
-                break
-        self.assertTrue(file_found, 'Couldn\'t find /tmp/findings.xlsx')
+        self.check_file(f'{self.export_path}/findings.xlsx')
 
     @on_exception_html_source_logger
     def test_edit_finding(self):


### PR DESCRIPTION
This integration test fails from time to time on GitHub. With this PR:

- The file will be written into the `media` folder, which is mapped as a volume by Docker Compose
- The waiting time is increased to 30 seconds. If the file exists before that, the test continues immediately, otherwise the integration tests have failed and will be stopped anyway.