### PR TITLE
Optimize view finding

### DIFF
--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -451,7 +451,7 @@
         </div>
         {% endif %}
     {% endif %}
-    {% if finding.static_finding or finding.line > 0 or finding.has_jira_configured or finding.has_jira_issue or finding.github_issue or finding.github_conf_new %}
+    {% if finding.file_path or finding.line > 0 or finding.has_jira_configured or finding.has_jira_issue or finding.github_issue or finding.github_conf_new or finding.finding_group or finding.component_name or finding.nb_occurences > 1 %}
     <div class="panel panel-default">
         <table id="error_notes" class="table-striped table table-condensed table-hover centered">
             <tr>
@@ -461,7 +461,7 @@
                 {% if finding.line %}
                 <th>Line Number</th>
                 {% endif %}
-                {% if finding.nb_occurences %}
+                {% if finding.nb_occurences > 1 %}
                 <th>Nb occurences</th>
                 {% endif %}
                 {% if finding.component_name %}
@@ -477,8 +477,8 @@
                 {% if finding.github_conf_new or finding.github_issue %}
                 <th>GitHub</th>
                 {% endif %}
-                {% if 'FEATURE_FINDING_GROUPS'|setting_enabled %}
-                    <th>Group</th>
+                {% if 'FEATURE_FINDING_GROUPS'|setting_enabled and finding.finding_group %}
+                <th>Group</th>
                 {% endif %}
             </tr>
             <tr>
@@ -498,7 +498,7 @@
                     </span>
                 </td>
                 {% endif %}
-                {% if finding.nb_occurences %}
+                {% if finding.nb_occurences > 1 %}
                 <td>
                     <span>
                         {{ finding.nb_occurences }}
@@ -562,14 +562,10 @@
                     {% endif %}
                     </td>
                 {% endif %}
-                {% if 'FEATURE_FINDING_GROUPS'|setting_enabled %}
+                {% if 'FEATURE_FINDING_GROUPS'|setting_enabled and finding.finding_group %}
                     <td>
-                        {% if finding.finding_group %}
-                            {{ finding.finding_group.name }}
-                            <i id="push_group_to_jira_{{ finding.finding_group.group.id }}" data-group-id="{{ finding.finding_group.id }}" class="fa fa-share-square push_group_to_jira" title="Update JIRA issue with current data from this group of findings."></i>
-                        {% else %}
-                            N
-                        {% endif %}
+                        {{ finding.finding_group.name }}
+                        <i id="push_group_to_jira_{{ finding.finding_group.group.id }}" data-group-id="{{ finding.finding_group.id }}" class="fa fa-share-square push_group_to_jira" title="Update JIRA issue with current data from this group of findings."></i>
                     </td>
                 {% endif %}
             </tr>


### PR DESCRIPTION
For some scans the view finding page can currently look like this:

![2021-09-29 16_34_46-View Finding _ DefectDojo](https://user-images.githubusercontent.com/2698502/135312063-c69c2857-5a13-4c34-a30a-771ff39cf7d2.png)

This finding of Dockle for example has no file or component and is not connected to Jira or GitHub. The second table shows there is 1 occurence of this finding in the scan and the finding is not in a group. Both information are not really important. With this PR the second table is only shown when any of the fields has a content, including nb_occurences is greater than 1.

This makes the user more focused on the important information of the finding.

