### PR TITLE
Use additional test types for GitLab SAST

### DIFF
--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -312,26 +312,30 @@ class DojoDefaultImporter(object):
             # so a report that have the label 'CodeScanner' will be changed to 'CodeScanner Scan (SARIF)'
             test_type_name = scan_type
             if len(tests) > 0:
-                test_type_name = tests[0].type + " Scan"
-                if tests[0].type and tests[0].type != scan_type:
-                    test_type_name = f"{test_type_name} ({scan_type})"
-            test = self.create_test(scan_type, test_type_name, engagement, lead, environment, scan_date=scan_date, tags=tags,
-                                version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
-                                sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
-            # This part change the name of the Test
-            # we get it from the data of the parser
-            test_raw = tests[0]
-            if test_raw.name:
-                test.name = test_raw.name
-                test.save()
+                if tests[0].type:
+                    test_type_name = tests[0].type + " Scan"
+                    if tests[0].type and tests[0].type != scan_type:
+                        test_type_name = f"{test_type_name} ({scan_type})"
 
-            logger.debug('IMPORT_SCAN parser v2: Parse findings (aggregate)')
-            # currently we only support import one Test
-            # so for parser that support multiple tests (like SARIF)
-            # we aggregate all the findings into one uniq test
-            parsed_findings = []
-            for test_raw in tests:
-                parsed_findings.extend(test_raw.findings)
+                test = self.create_test(scan_type, test_type_name, engagement, lead, environment, scan_date=scan_date, tags=tags,
+                                    version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, now=now,
+                                    sonarqube_config=sonarqube_config, cobaltio_config=cobaltio_config)
+                # This part change the name of the Test
+                # we get it from the data of the parser
+                test_raw = tests[0]
+                if test_raw.name:
+                    test.name = test_raw.name
+                    test.save()
+
+                logger.debug('IMPORT_SCAN parser v2: Parse findings (aggregate)')
+                # currently we only support import one Test
+                # so for parser that support multiple tests (like SARIF)
+                # we aggregate all the findings into one uniq test
+                parsed_findings = []
+                for test_raw in tests:
+                    parsed_findings.extend(test_raw.findings)
+            else:
+                logger.info(f'No tests found in import for {scan_type}')
         else:
             logger.debug('IMPORT_SCAN: Create Test')
             # by default test_type == scan_type

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -314,7 +314,7 @@ class DojoDefaultImporter(object):
             if len(tests) > 0:
                 if tests[0].type:
                     test_type_name = tests[0].type + " Scan"
-                    if tests[0].type and tests[0].type != scan_type:
+                    if tests[0].type != scan_type:
                         test_type_name = f"{test_type_name} ({scan_type})"
 
                 test = self.create_test(scan_type, test_type_name, engagement, lead, environment, scan_date=scan_date, tags=tags,

--- a/dojo/unittests/test_importers_importer.py
+++ b/dojo/unittests/test_importers_importer.py
@@ -6,6 +6,7 @@ from dojo.importers.importer.importer import DojoDefaultImporter as Importer
 from dojo.models import Engagement, Product, Product_Type, User
 from dojo.tools.factory import get_parser
 from dojo.tools.sarif.parser import SarifParser
+from dojo.tools.gitlab_sast.parser import GitlabSastParser
 
 
 class TestDojoDefaultImporter(TestCase):
@@ -94,4 +95,36 @@ class TestDojoDefaultImporter(TestCase):
 
         self.assertEqual(f"SpotBugs Scan ({scan_type})", test.test_type.name)
         self.assertEqual(56, len_new_findings)
+        self.assertEqual(0, len_closed_findings)
+
+    def test_import_scan_without_test_scan_type(self):
+        # GitLabSastParser implements get_tests but report has no scanner name
+        scan = open("dojo/unittests/scans/gitlab_sast/gl-sast-report-1-vuln.json")
+        scan_type = GitlabSastParser().get_scan_types()[0]
+
+        user, _ = User.objects.get_or_create(username="admin")
+        user_reporter, _ = User.objects.get_or_create(username="user_reporter")
+
+        product_type, _ = Product_Type.objects.get_or_create(name="test2")
+        product, _ = Product.objects.get_or_create(
+            name="TestDojoDefaultImporter2",
+            prod_type=product_type,
+        )
+
+        engagement, _ = Engagement.objects.get_or_create(
+            name="Test Create Engagement2",
+            product=product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+
+        importer = Importer()
+        scan_date = timezone.make_aware(datetime.datetime(2021, 9, 1), timezone.get_default_timezone())
+        test, len_new_findings, len_closed_findings = importer.import_scan(scan, scan_type, engagement, lead=None, environment=None, active=True, verified=True, tags=None, minimum_severity=None,
+                    user=user, endpoints_to_add=None, scan_date=scan_date, version=None, branch_tag=None, build_id=None,
+                    commit_hash=None, push_to_jira=None, close_old_findings=False, group_by=None, sonarqube_config=None,
+                    cobaltio_config=None)
+
+        self.assertEqual("GitLab SAST Report", test.test_type.name)
+        self.assertEqual(1, len_new_findings)
         self.assertEqual(0, len_closed_findings)

--- a/dojo/unittests/tools/test_gitlab_sast_parser.py
+++ b/dojo/unittests/tools/test_gitlab_sast_parser.py
@@ -73,3 +73,27 @@ class TestGitlabSastParser(TestCase):
         self.assertEqual(1, len(findings))
         finding = findings[0]
         self.assertEqual("[None severity] Potential XSS vulnerability", finding.title)
+
+    def test_without_scan(self):
+        testfile = open("dojo/unittests/scans/gitlab_sast/gl-sast-report-1-vuln.json")
+        parser = GitlabSastParser()
+        tests = parser.get_tests(None, testfile)
+        self.assertEqual(1, len(tests))
+        test = tests[0]
+        self.assertIsNone(test.name)
+        self.assertIsNone(test.type)
+        self.assertIsNone(test.version)
+        findings = test.findings
+        self.assertEqual(1, len(findings))
+
+    def test_with_scan(self):
+        testfile = open("dojo/unittests/scans/gitlab_sast/gl-sast-report-confidence.json")
+        parser = GitlabSastParser()
+        tests = parser.get_tests(None, testfile)
+        self.assertEqual(1, len(tests))
+        test = tests[0]
+        self.assertEqual("njsscan", test.name)
+        self.assertEqual("njsscan", test.type)
+        self.assertEqual("0.1.9", test.version)
+        findings = test.findings
+        self.assertEqual(8, len(findings))


### PR DESCRIPTION
GitLab SAST is a kind of a meta format, similar to SARIF. GitLab SAST uses other Open Source tools to scan the code and reports the results in its own json format. This PR uses the mechanism introduced with #5121 to make the name of the real scanner available as the test type.

While doing this I discovered two possible NullPointerExceptions in the importer:
- Theoratically there could be no test given back by the parser
- There can be no name for the new test type. This can happen with GitLab SAST because the information about the real scanner is optional. In this case the original name of the Test_Type will be used, like **Sarif** or **GitLab SAST Report**