### PR TITLE
Set Argon2 as default password hasher

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -397,6 +397,23 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
+# Make Argon2 the default password hasher by listing it first
+# Unfortunately Django doesn't provide the default built-in
+# PASSWORD_HASHERS list here as a variable which we could modify,
+# so we have to list all the hashers present in Django :-(
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.Argon2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+    'django.contrib.auth.hashers.BCryptPasswordHasher',
+    'django.contrib.auth.hashers.SHA1PasswordHasher',
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+    'django.contrib.auth.hashers.UnsaltedSHA1PasswordHasher',
+    'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
+    'django.contrib.auth.hashers.CryptPasswordHasher',
+]
+
 SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_details',
     'dojo.pipeline.social_uid',

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,3 +73,4 @@ django-test-migrations==1.1.0
 djangosaml2==1.3.4
 drf-spectacular==0.19.0
 django-ratelimit==3.0.1
+argon2-cffi==21.1.0


### PR DESCRIPTION
In line with the OWASP Password Storage Cheat Sheet, we switch to `Argon2` as the default password hashing algorithm.

This is a Django setting. Existing password hashes will be rehashed when the user logs in. Password hashes for inactive users will not be rehashed as we don't know the password. We could wrap these hashes inside a Argon2 password hasher, but would require a custom wrapper for each possible password hashing algorithm. Also the example provided by Django on how to do this seems to be incomplete: https://docs.djangoproject.com/en/3.2/topics/auth/passwords/#password-upgrading-without-requiring-a-login (shouldn't the `verify` method be updated as well to cope with the wrapping?).

If admins want their users to reset their password, they will have to inform them an request them to change their password. Defect Dojo currently doesn't have a Forgot Password flow, as Django doesn't provide this out-of-the-box. Once we have implemented that, it will be easier to just reset all user passwords and route the users to the Forgot Password flow. See https://github.com/DefectDojo/django-DefectDojo/issues/5204

PS Most of the time applications/business/sites require all users to reset their password, everybody concludes they must be hacked. So be careful :-) 

![image](https://user-images.githubusercontent.com/4426050/135665279-7df9b17a-364e-4889-95e6-6ca77493b476.png)
