### PR TITLE
Fix BulkEdit severity dropdown after #4766

### DIFF
--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -71,7 +71,7 @@
                     </button>
                     {% endif %}
                 </div>
-                <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
+                <ul class="dropdown-menu" style="overflow: hidden;" aria-labelledby="dropdownMenu1" id="bulk_edit">
                     <li class="dropdown-header">Choose wisely...</li>
                     <li style="padding-left: 8px;">
                         {% if product_tab %}
@@ -82,7 +82,7 @@
                             {% csrf_token %}
                             <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
                             <label style="display: block" for="severity">Severity</label>
-                            <select name="severity" id="severity" style="font-size: 80%">
+                            <select name="severity" data-container="body" id="severity" style="font-size: 80%">
                                 <option value="">Choose...</option>
                                 <option value="Info">Info</option>
                                 <option value="Low">Low</option>
@@ -815,4 +815,5 @@
 
     </script>
     {% include "dojo/filter_js_snippet.html" %}
+    {% include "dojo/snippets/selectpicker_in_dropdown.html" %}
 {% endblock %}

--- a/dojo/templates/dojo/snippets/selectpicker_in_dropdown.html
+++ b/dojo/templates/dojo/snippets/selectpicker_in_dropdown.html
@@ -1,0 +1,23 @@
+{% load static %}
+<script type="application/javascript">
+    $('.dropdown-menu').on('click', function(event) {
+        event.stopPropagation();
+    });
+
+
+    $('.selectpicker').selectpicker({
+        container: 'body'
+    });
+
+    $('body').on('click', function(event) {
+        var target = $(event.target);
+        if (target.parents('.bootstrap-select').length) {
+            event.stopPropagation();
+            $('.bootstrap-select.open').removeClass('open');
+        }
+        var hasClass = $('.bs-container').hasClass('open');
+        if (hasClass) {
+            $('.bs-container').removeClass('open');
+        }
+    });	
+</script>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -547,14 +547,14 @@
                     </button>
                 {% endif %}
             </div>
-            <ul class="dropdown-menu" aria-labelledby="dropdownMenu1" id="bulk_edit">
+            <ul class="dropdown-menu" style="overflow: hidden;" aria-labelledby="dropdownMenu1" id="bulk_edit">
                 <li class="dropdown-header">Choose wisely...</li>
                 <li style="padding-left: 8px;padding-right: 8px;">
                     <form action="{% url 'finding_bulk_update_all_product' product_tab.product.id %}" method="post" id="bulk_change_form">
                         {% csrf_token %}
                         <input type="hidden" name="return_url" value="{{ request.get_full_path }}" />
                         <label style="display: block" for="severity">Severity</label>
-                        <select name="severity" id="severity" style="font-size: 80%">
+                        <select name="severity" data-container="body" id="severity" style="font-size: 80%">
                             <option value="">Choose...</option>
                             <option value="Info">Info</option>
                             <option value="Low">Low</option>
@@ -1658,4 +1658,5 @@
 
     </script>
     {% include "dojo/filter_js_snippet.html" %}
+    {% include "dojo/snippets/selectpicker_in_dropdown.html" %}
 {% endblock %}


### PR DESCRIPTION
After #4766, all select fields were dynamically converted to select picker fields. It did not work so well for those that were contained within a drop down. 

Before:
https://user-images.githubusercontent.com/46459665/135797454-84f9fcdc-3046-4e63-8cc0-1b095b790490.mov

After:
https://user-images.githubusercontent.com/46459665/135798169-3f636d72-c21b-4f0a-9fa3-b91e4abf0dae.mov
