### PR TITLE
Add support for tolerations

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -75,4 +75,8 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.initializer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   backoffLimit: 1


### PR DESCRIPTION
The `django-initializer` pod had no support for setting tolerations previously. This PR should fix that and add the ability to specify tolerations right in the `values.yml` file,  such as:

``` yaml
[...]
initializer:
  affinity: ...
  nodeSelector: ...
  tolerations: ...
```
[...]