### PR TITLE
[HELM] Mount media to permanent storage

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.3.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.14-dev
+version: 1.6.15-dev
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -43,6 +43,10 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.imagePullSecrets }}
       {{- end }}
+      {{- if .Values.django.mediaPersistentVolume.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.django.mediaPersistentVolume.fsGroup | default 1001 }}
+      {{- end }}
       volumes:
       - name: run
         emptyDir: {}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -63,11 +63,11 @@ spec:
           path: {{ .hostPath }}
           {{- end }}
       {{- end }}
-      {{- if .Values.persistentVolume.enabled }}
-      - name: {{ .Values.persistentVolume.name }}
-        {{- if eq .Values.persistentVolume.type "pvc"  }}
+      {{- if .Values.django.mediaPersistentVolume.enabled }}
+      - name: {{ .Values.django.mediaPersistentVolume.name }}
+        {{- if eq .Values.django.mediaPersistentVolume.type "pvc"  }}
         persistentVolumeClaim:
-          claimName: {{ .Values.persistentVolume.persistentVolumeClaim }}
+          claimName: {{ .Values.django.mediaPersistentVolume.persistentVolumeClaim }}
         {{ else }}
         emptyDir: {}
         {{- end }}
@@ -122,6 +122,10 @@ spec:
           mountPath: {{ .path }}
           subPath: {{ .subPath }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.django.mediaPersistentVolume.enabled }}
+        - name: {{ .Values.django.mediaPersistentVolume.name }}
+          mountPath: {{.Values.extraConfigs.DD_MEDIA_ROOT | default "/app/media" | quote }}
         {{- end }}
         ports:
         - name: http
@@ -205,6 +209,10 @@ spec:
           mountPath: {{ .path }}
           subPath: {{ .subPath }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.django.mediaPersistentVolume.enabled }}
+        - name: {{ .Values.django.mediaPersistentVolume.name }}
+          mountPath: /usr/share/nginx/html/media
         {{- end }}
         ports:
         - name: http

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -63,6 +63,15 @@ spec:
           path: {{ .hostPath }}
           {{- end }}
       {{- end }}
+      {{- if .Values.persistentVolume.enabled }}
+      - name: {{ .Values.persistentVolume.name }}
+        {{- if eq .Values.persistentVolume.type "pvc"  }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistentVolume.persistentVolumeClaim }}
+        {{ else }}
+        emptyDir: {}
+        {{- end }}
+      {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -234,7 +234,7 @@ django:
 
   extraVolumes: []
 
-  # This feature needs more preparation before can be enabled, please visit Kubernetes.md#Persistent volumes
+  # This feature needs more preparation before can be enabled, please visit KUBERNETES.md#media-persistent-volume
   mediaPersistentVolume:
     enabled: true
     name: media

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -231,8 +231,15 @@ django:
   #   "File", "Socket", "CharDevice", "BlockDevice"
   # - `hostPath` - only for hostPath, file or directory from local host
   # @type: array<map>
+
   extraVolumes: []
 
+  # This feature needs more preparation before can be enabled, please visit Kubernetes.md#Persistent volumes
+  persistentVolume:
+    name: dd-volume
+    enabled: true
+    type: emptyDir # could be emptyDir (not for production) or pvc
+    persistentVolumeClaim: dd-pvc # in case if pvc specified
 
 initializer:
   run: true

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -235,11 +235,11 @@ django:
   extraVolumes: []
 
   # This feature needs more preparation before can be enabled, please visit Kubernetes.md#Persistent volumes
-  persistentVolume:
-    name: dd-volume
+  mediaPersistentVolume:
     enabled: true
+    name: media
     type: emptyDir # could be emptyDir (not for production) or pvc
-    persistentVolumeClaim: dd-pvc # in case if pvc specified
+    persistentVolumeClaim: media # in case if pvc specified
 
 initializer:
   run: true
@@ -387,3 +387,4 @@ redis:
 # NOTE  This is just an exmaple, do not store sensitive data in plain text form, better inject it during the deployment/upgrade by --set extraSecrets.secret=someSecret
 # extraSecrets:
 #   DD_SOCIAL_AUTH_AUTH0_SECRET: 'xxx'
+extraConfigs: {}

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -270,7 +270,7 @@ django:
 
 In example above, we want that media content is preserved  to `pvc` named `persistentVolumeClaim`.
 
-NOTE: PersistrentVolume needs to be created before helm installation is triggered.
+NOTE: PersistrentVolume needs to be prepared in front before helm installation/update is triggered.
 
 ### Installation
 

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -253,9 +253,24 @@ If you want to encrypt the traffic to the nginx server you can use the option `-
 Be aware that the traffic to the database and celery broker are unencrypted at the moment.
 
 
-### Persistent volumes
+### Media persistent volume
 
-By default DefectDojo helm installation doesn't support persistent storage for storing images (dynamicly uploaded by users)  
+By default DefectDojo helm installation doesn't support persistent storage for storing images (dynamically uploaded by users). By default it uses emptyDir, which is ephemeral by its nature, and doesn't support multiple replicas of django pods, so should not be in use for production.
+
+To enable persistence of the media storage that supports R/W many, should be in use as backend storage like S3, NFS, glusterfs etc.
+
+```bash
+django:
+  mediaPersistentVolume:
+    enabled: true
+    name: media
+    type: pvc # could be emptyDir (not for production) or pvc
+    persistentVolumeClaim: media # in case if pvc specified
+```
+
+In example above, we want that media content is preserved  to `pvc` named `persistentVolumeClaim`.
+
+NOTE: PersistrentVolume needs to be created before helm installation is triggered.
 
 ### Installation
 

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -255,9 +255,9 @@ Be aware that the traffic to the database and celery broker are unencrypted at t
 
 ### Media persistent volume
 
-By default DefectDojo helm installation doesn't support persistent storage for storing images (dynamically uploaded by users). By default it uses emptyDir, which is ephemeral by its nature, and doesn't support multiple replicas of django pods, so should not be in use for production.
+By default, DefectDojo helm installation doesn't support persistent storage for storing images (dynamically uploaded by users). By default, it uses emptyDir, which is ephemeral by its nature and doesn't support multiple replicas of django pods, so should not be in use for production.
 
-To enable persistence of the media storage that supports R/W many, should be in use as backend storage like S3, NFS, glusterfs etc.
+To enable persistence of the media storage that supports R/W many, should be in use as backend storage like S3, NFS, glusterfs et
 
 ```bash
 django:
@@ -268,7 +268,7 @@ django:
     persistentVolumeClaim: media # in case if pvc specified
 ```
 
-In example above, we want that media content is preserved  to `pvc` named `persistentVolumeClaim`.
+In the example above, we want that media content to be preserved to `pvc` named `persistentVolumeClaim`.
 
 NOTE: PersistrentVolume needs to be prepared in front before helm installation/update is triggered.
 

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -25,7 +25,7 @@ You should now be able to see the chart.
 
 ```
 $ helm search repo defectdojo
-NAME                      	CHART VERSION	APP VERSION	DESCRIPTION                                      
+NAME                      	CHART VERSION	APP VERSION	DESCRIPTION
 helm-charts/defectdojo	    1.5.1        	1.14.0-dev 	A Helm chart for Kubernetes to install DefectDojo
 ```
 
@@ -251,6 +251,11 @@ With the TLS certificate from your Kubernetes cluster all traffic to you cluster
 If you want to encrypt the traffic to the nginx server you can use the option `--set nginx.tls.enabled=true` and `--set nginx.tls.generateCertificate=true` to generate a self signed certificate and use the https config. The option to add you own pregenerated certificate is generelly possible but not implemented in the helm chart yet.
 
 Be aware that the traffic to the database and celery broker are unencrypted at the moment.
+
+
+### Persistent volumes
+
+By default DefectDojo helm installation doesn't support persistent storage for storing images (dynamicly uploaded by users)  
 
 ### Installation
 


### PR DESCRIPTION
This PR is based on https://github.com/DefectDojo/django-DefectDojo/pull/4823 from @TheocharisPetros (kudos), and includes:

- mounting of media to nginx and uwsgi container
- kubernetes explanation
- default values

Does not include:
- volume creation from storage class, is uses already existing PVC, just to allow more freedom for different types of k8s clusters

Together with this, I will add example in Community Contribs, one example how minIO can be utilized for enable r/w many.

 