### PR TITLE
Add support for context region snippets in SARIF parser

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -185,6 +185,10 @@ def get_snippet(result):
                 if 'snippet' in location['physicalLocation']['region']:
                     if 'text' in location['physicalLocation']['region']['snippet']:
                         snippet = location['physicalLocation']['region']['snippet']['text']
+            if snippet == None and 'contextRegion' in location['physicalLocation']:
+                if 'snippet' in in location['physicalLocation']['contextRegion']:
+                    if 'text' in location['physicalLocation']['contextRegion']['snippet']:
+                        snippet = location['physicalLocation']['contextRegion']['snippet']['text']
     return snippet
 
 

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -186,7 +186,7 @@ def get_snippet(result):
                     if 'text' in location['physicalLocation']['region']['snippet']:
                         snippet = location['physicalLocation']['region']['snippet']['text']
             if snippet == None and 'contextRegion' in location['physicalLocation']:
-                if 'snippet' in in location['physicalLocation']['contextRegion']:
+                if 'snippet' in location['physicalLocation']['contextRegion']:
                     if 'text' in location['physicalLocation']['contextRegion']['snippet']:
                         snippet = location['physicalLocation']['contextRegion']['snippet']['text']
     return snippet


### PR DESCRIPTION
Some tools that output SARIF files put the only available code snippet in the **contextRegion** propery instead of the region propery. An example is CodeQL with the `--sarif-add-file-contents` flag set.
This change will attempt to extract a snippet in the contextRegion propery if none was found in the region propery.

As per the [specification](http://docs.oasis-open.org/sarif/sarif/v2.0/csprd01/sarif-v2.0-csprd01.html) section 3.21.5, a contextRegion will only exist if the region exists, hence the order of checking.