### PR TITLE
use relative/portable path for test_rest_framework test file

### DIFF
--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -1605,7 +1605,7 @@ class ImportLanguagesTest(BaseClass.RESTEndpointTest):
         self.viewset = ImportLanguagesView
         self.payload = {
             'product': 1,
-            'file': open("/app/dojo/unittests/files/defectdojo_cloc.json")
+            'file': open("dojo/unittests/files/defectdojo_cloc.json")
         }
         self.object_permission = True
         self.permission_check_class = Languages


### PR DESCRIPTION
this allows the unit tests to be run outside docker where there's no such thing as `/app/dojo/........`