### PR TITLE
test_rest_framework: generate openapi3 schema only once

### DIFF
--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -64,7 +64,7 @@ def get_open_api3_json_schema():
     return schema
 
 
-# use ugly global to aboid generating the schema for every test/method (it's slow)
+# use ugly global to avoid generating the schema for every test/method (as it's slow)
 global open_api3_json_schema
 open_api3_json_schema = get_open_api3_json_schema()
 


### PR DESCRIPTION
The unit tests are extremely slow lately. One reason is that for each test (each `test_xxx` method) the OpenAPI3 schema is generated. Probably this has become slower since some updates to `drf-spectacular`.

This PR generates the schema once at the beginning of the test run.

before:
```
----------------------------------------------------------------------
Ran 443 tests in 533.860s
```

after:
```
----------------------------------------------------------------------
Ran 443 tests in 160.662s
```

This should help making the unit tests run faster on GitHub actions, although it might not account for the full slowdown that we are seeing there recently.