### PR TITLE
Fix minor typo in k8s docs

### DIFF
--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -1,6 +1,6 @@
 # DefectDojo on Kubernetes
 
-DefetDojo Kubernetes utilizes [Helm](https://helm.sh/), a
+DefectDojo Kubernetes utilizes [Helm](https://helm.sh/), a
 package manager for Kubernetes. Helm Charts help you define, install, and
 upgrade even the most complex Kubernetes application.
 


### PR DESCRIPTION
Fixes a minor typo in the Kubernetes docs.