### PR TITLE
Fix package.json errors with Yarn audit

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "DefectDojo",
+  "name": "defectdojo",
   "version": "2.4.0-dev",
+  "private": true,
   "dependencies": {
     "JUMFlot": "jumjum123/JUMFlot#*",
     "bootstrap": "^3.4.0",


### PR DESCRIPTION
These warnings breaks some audit tools:
```
(.venv) [damien@damien components]$ yarn audit
yarn audit v1.22.14
warning package.json: No license field
warning DefectDojo@2.4.0-dev: No license field
```
It break Horusec (one security tool I'm working on/new parser):
```
{HORUSEC_CLI} Error Yarn returned an error: ERROR_RUNNING_YARN_AUDIT{\"type\":\"warning\",\"data\":\"package.json: No license field\"}\r\n{\"type\":\"warning\",\"data\":\"DefectDojo@2.4.0-dev: No license field\"}\r\n
```
Also this PR use the good attribute to specify that we are not developing an npm library but it our own JS code (for Dojo).
https://flaviocopes.com/package-json/#private
```
private
if set to true prevents the app/package to be accidentally published on npm
```