### PR TITLE
main(tests): remove rabbitmq from unit-tests

### DIFF
--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -54,9 +54,6 @@ services:
       MYSQL_DATABASE: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
     volumes:
        - defectdojo_data_integration_tests:/var/lib/mysql
-  rabbitmq:
-    image: busybox:1.34.0-musl
-    entrypoint: ['echo', 'skipping', 'rabbitmq']
 volumes:
   defectdojo_data_integration_tests: {}
   defectdojo_media_integration_test: {}

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -54,6 +54,9 @@ services:
       MYSQL_DATABASE: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
     volumes:
        - defectdojo_data_integration_tests:/var/lib/mysql
+  rabbitmq:
+    image: busybox:1.34.0-musl
+    entrypoint: ['echo', 'skipping', 'rabbitmq']
 volumes:
   defectdojo_data_integration_tests: {}
   defectdojo_media_integration_test: {}

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -24,7 +24,6 @@ services:
   initializer:
     image: busybox:1.34.0-musl
     entrypoint: ['echo', 'skipping', 'initializer']
-
   mysql:
     ports:
       - target: 3306
@@ -35,6 +34,9 @@ services:
       MYSQL_DATABASE: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
     volumes:
        - defectdojo_data_unittest:/var/lib/mysql
+  rabbitmq:
+    image: busybox:1.34.0-musl
+    entrypoint: ['echo', 'skipping', 'rabbitmq']
 volumes:
   defectdojo_data_unittest: {}
   defectdojo_media_unittest: {}

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -15,6 +15,13 @@ services:
       DD_DEBUG: 'True'
       DD_TEST_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
       DD_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
+      DD_CELERY_BROKER_SCHEME: 'sqla+sqlite'
+      DD_CELERY_BROKER_USER: ''
+      DD_CELERY_BROKER_PASSWORD: ''
+      DD_CELERY_BROKER_HOST: ''
+      DD_CELERY_BROKER_PORT: "-1"
+      DD_CELERY_BROKER_PATH: '/dojo.celerydb.sqlite'
+      DD_CELERY_BROKER_PARAMS: ''
   celerybeat:
     image: busybox:1.34.0-musl
     entrypoint: ['echo', 'skipping', 'celery beat']

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -34,6 +34,9 @@ services:
       MYSQL_DATABASE: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
     volumes:
        - defectdojo_data_unittest:/var/lib/mysql
+  rabbitmq:
+    image: busybox:1.34.0-musl
+    entrypoint: ['echo', 'skipping', 'rabbitmq']
 volumes:
   defectdojo_data_unittest: {}
   defectdojo_media_unittest: {}

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -15,6 +15,13 @@ services:
       DD_DEBUG: 'True'
       DD_TEST_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
       DD_DATABASE_NAME: "${DD_TEST_DATABASE_NAME:-test_defectdojo}"
+      DD_CELERY_BROKER_SCHEME: 'sqla+sqlite'
+      DD_CELERY_BROKER_USER: ''
+      DD_CELERY_BROKER_PASSWORD: ''
+      DD_CELERY_BROKER_HOST: ''
+      DD_CELERY_BROKER_PORT: "-1"
+      DD_CELERY_BROKER_PATH: '/dojo.celerydb.sqlite'
+      DD_CELERY_BROKER_PARAMS: ''
   celerybeat:
     image: busybox:1.34.0-musl
     entrypoint: ['echo', 'skipping', 'celery beat']


### PR DESCRIPTION
Using build in sqlite database for unit tests instead of a separate rabbitmq.