### PR TITLE
Deduplication settings for Semgrep and Generic Findings Import

### DIFF
--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -303,7 +303,7 @@
     "pk": 120,
     "model": "dojo.test_type",
     "fields": {
-        "name": "Generic Findings Import"
+        "name": "Xanitizer Scan"
     }
   },
   {

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1070,6 +1070,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'SARIF': True,
     'Hadolint Dockerfile check': True,
     'Semgrep JSON Report': True,
+    'Generic Findings Import': True,
 }
 
 # List of fields that are known to be usable in hash_code computation)
@@ -1152,6 +1153,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Azure Security Center Recommendations Scan': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Hadolint Dockerfile check': DEDUPE_ALGO_HASH_CODE,
     'Semgrep JSON Report': DEDUPE_ALGO_HASH_CODE,
+    'Generic Findings Import': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1068,7 +1068,8 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'AWS Security Hub Scan': True,
     'Meterian Scan': True,
     'SARIF': True,
-    'Hadolint Dockerfile check': True
+    'Hadolint Dockerfile check': True,
+    'Semgrep JSON Report': True,
 }
 
 # List of fields that are known to be usable in hash_code computation)
@@ -1150,6 +1151,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'SARIF': DEDUPE_ALGO_HASH_CODE,
     'Azure Security Center Recommendations Scan': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'Hadolint Dockerfile check': DEDUPE_ALGO_HASH_CODE,
+    'Semgrep JSON Report': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')

--- a/dojo/unittests/test_deduplication_logic.py
+++ b/dojo/unittests/test_deduplication_logic.py
@@ -111,7 +111,7 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 #                       1: dojo.Endpoint.None dojo.Finding.None 1 2020-07-01 00:00:00+00:00 2020-07-01 17:45:39.791907+00:00 False None None False False False ftp://localhost/ High Impact Test Finding
 #       engagement 6: April monthly engagement (dedupe_inside: True)
 #       engagement 3: weekly engagement (dedupe_inside: True)
-#               test 33: Generic Findings Import (algo=legacy, dynamic=False)
+#               test 33: Xanitizer Scan Findings Import (algo=legacy, dynamic=False)
 #               findings:
 #                       22  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: False: dup_id: None: hash_code: 9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa: eps: 0: notes: []: uid: None
 #                       23  : "Low Impact Test Find": Low  : act: True : ver: True : mit: False: dup: True : dup_id: 22  : hash_code: 9aca00affd340c4da02c934e7e3106a45c6ad0911da479daae421b3b28a2c1aa: eps: 0: notes: []: uid: None

--- a/tests/dedupe_scans/dedupe_cross_1.csv
+++ b/tests/dedupe_scans/dedupe_cross_1.csv
@@ -1,4 +1,4 @@
 Date,Title,CweId,Url,Severity,Description,Mitigation,Impact,References,Active,Verified,FalsePositive,Duplicate
 01/30/2018,Matching title and Endpoints (DUPE),23,https://www.same.com/samesies,Critical,Test Description,,,,False,False,False,False
-01/30/2018,Matching title not Endpoints,23,https://www.weird.com/so-weird,Critical,Test Description,,,,False,False,False,False
+01/30/2018,Matching title not Description,23,https://www.weird.com/so-weird,Critical,Test Description,,,,False,False,False,False
 01/30/2018,Differing title and Endpoints,24,https://www.same.com/samesies,Critical,Test Description,,,,False,False,False,False

--- a/tests/dedupe_scans/dedupe_endpoint_1.xml
+++ b/tests/dedupe_scans/dedupe_endpoint_1.xml
@@ -17,7 +17,7 @@
 
 	<Vulnerability>
 		<ID></ID>
-		<Name>Matching title not Endpoints</Name>
+		<Name>Matching title not Description</Name>
 		<Date></Date>
 		<Status></Status>
 		<Type></Type>
@@ -26,7 +26,7 @@
 		<CVSSv3></CVSSv3>
 		<Risk>CRITICAL</Risk>
 		<URL>https://www.same.com/samesies</URL>
-		<Description>Test Description</Description>
+		<Description>Different Description</Description>
 		<PoC></PoC>
 	</Vulnerability>
 


### PR DESCRIPTION
fixes #5312

Re-imports swallow findings, when deduplication is not set in the System Settings (default) and there is no `DEDUPLICATION_ALGORITHM_PER_PARSER` setting for the parser. This PR sets `DEDUPLICATION_ALGORITHM_PER_PARSER` to `DEDUPE_ALGO_HASH_CODE` for Semgrep and the generic import.