### PR TITLE
Allow API importer to edit Tests and Engagements

### DIFF
--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -108,6 +108,11 @@ class Permissions(IntEnum):
     Technology_Edit = 2406
     Technology_Delete = 2407
 
+    Product_API_Scan_Configuration_View = 2502
+    Product_API_Scan_Configuration_Add = 2503
+    Product_API_Scan_Configuration_Edit = 2506
+    Product_API_Scan_Configuration_Delete = 2507
+
     @classmethod
     def has_value(cls, value):
         try:
@@ -184,6 +189,10 @@ class Permissions(IntEnum):
     def get_technology_permissions(cls):
         return {Permissions.Technology_View, Permissions.Technology_Edit, Permissions.Technology_Delete}
 
+    @classmethod
+    def get_product_api_scan_configuration_permissions(cls):
+        return {Permissions.Product_API_Scan_Configuration_View, Permissions.Product_API_Scan_Configuration_Edit, Permissions.Product_API_Scan_Configuration_Delete}
+
 
 def get_roles_with_permissions():
     return {
@@ -200,7 +209,8 @@ def get_roles_with_permissions():
             Permissions.Product_Type_Group_View,
             Permissions.Group_View,
             Permissions.Language_View,
-            Permissions.Technology_View
+            Permissions.Technology_View,
+            Permissions.Product_API_Scan_Configuration_View
         },
         Roles.API_Importer: {
             Permissions.Product_Type_View,
@@ -265,7 +275,9 @@ def get_roles_with_permissions():
 
             Permissions.Technology_View,
             Permissions.Technology_Add,
-            Permissions.Technology_Edit
+            Permissions.Technology_Edit,
+
+            Permissions.Product_API_Scan_Configuration_View
         },
         Roles.Maintainer: {
             Permissions.Product_Type_Add_Product,
@@ -340,7 +352,12 @@ def get_roles_with_permissions():
             Permissions.Technology_View,
             Permissions.Technology_Add,
             Permissions.Technology_Edit,
-            Permissions.Technology_Delete
+            Permissions.Technology_Delete,
+
+            Permissions.Product_API_Scan_Configuration_View,
+            Permissions.Product_API_Scan_Configuration_Add,
+            Permissions.Product_API_Scan_Configuration_Edit,
+            Permissions.Product_API_Scan_Configuration_Delete
         },
         Roles.Owner: {
             Permissions.Product_Type_Add_Product,
@@ -423,6 +440,11 @@ def get_roles_with_permissions():
             Permissions.Technology_View,
             Permissions.Technology_Add,
             Permissions.Technology_Edit,
-            Permissions.Technology_Delete
+            Permissions.Technology_Delete,
+
+            Permissions.Product_API_Scan_Configuration_View,
+            Permissions.Product_API_Scan_Configuration_Add,
+            Permissions.Product_API_Scan_Configuration_Edit,
+            Permissions.Product_API_Scan_Configuration_Delete
         }
     }


### PR DESCRIPTION
a typical usecase (for me) is that from ci/cd jobs some addition info is put into a Test or Engagement, i.e. updating the build url with the url of the latest build, adding a description after an import has created an engagement, etc.