### PR TITLE
Enhanced endpoint selection and creation

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -260,19 +260,9 @@ def add_endpoint(request, pid):
                                  messages.SUCCESS,
                                  'Endpoint added successfully.',
                                  extra_tags='alert-success')
-            if '_popup' in request.GET:
-                resp = '<script type="text/javascript">opener.emptyEndpoints(window);</script>'
-                for endpoint in endpoints:
-                    resp += '<script type="text/javascript">opener.dismissAddAnotherPopupDojo(window, "%s", "%s");</script>' \
-                            % (escape(endpoint._get_pk_val()), escape(endpoint))
-                resp += '<script type="text/javascript">window.close();</script>'
-                return HttpResponse(resp)
-            else:
-                return HttpResponseRedirect(reverse('endpoint') + "?product=" + pid)
+            return HttpResponseRedirect(reverse('endpoint') + "?product=" + pid)
 
-    product_tab = None
-    if '_popup' not in request.GET:
-        product_tab = Product_Tab(product.id, "Add Endpoint", tab="endpoints")
+    product_tab = Product_Tab(product.id, "Add Endpoint", tab="endpoints")
 
     return render(request, template, {
         'product_tab': product_tab,

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -5,9 +5,8 @@ from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
-from django.http import HttpResponseRedirect, HttpResponse
+from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
-from django.utils.html import escape
 from django.utils import timezone
 from django.contrib.admin.utils import NestedObjects
 from django.db import DEFAULT_DB_ALIAS

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -610,7 +610,7 @@ def import_scan_results(request, eid=None, pid=None):
             error = False
 
             # Save newly added endpoints
-            added_endpoints = save_endpoints_to_add(form.endpoints_to_add_list, product)
+            added_endpoints = save_endpoints_to_add(form.endpoints_to_add_list, engagement.product)
 
             try:
                 importer = Importer()

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -53,6 +53,7 @@ from dojo.engagement.queries import get_authorized_engagements
 from dojo.authorization.authorization_decorators import user_is_authorized
 from dojo.importers.importer.importer import DojoDefaultImporter as Importer
 import dojo.notifications.helper as notifications_helper
+from dojo.endpoint.utils import save_endpoints_to_add
 
 
 logger = logging.getLogger(__name__)
@@ -608,10 +609,13 @@ def import_scan_results(request, eid=None, pid=None):
             push_to_jira = push_all_jira_issues or (jform and jform.cleaned_data.get('push_to_jira'))
             error = False
 
+            # Save newly added endpoints
+            added_endpoints = save_endpoints_to_add(form.endpoints_to_add_list, product)
+
             try:
                 importer = Importer()
                 test, finding_count, closed_finding_count = importer.import_scan(scan, scan_type, engagement, user, environment, active=active, verified=verified, tags=tags,
-                            minimum_severity=minimum_severity, endpoints_to_add=form.cleaned_data['endpoints'], scan_date=scan_date,
+                            minimum_severity=minimum_severity, endpoints_to_add=list(form.cleaned_data['endpoints']) + added_endpoints, scan_date=scan_date,
                             version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, push_to_jira=push_to_jira,
                             close_old_findings=close_old_findings, group_by=group_by, api_scan_configuration=api_scan_configuration)
 

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -1182,11 +1182,11 @@ def ad_hoc_finding(request, pid):
     push_all_jira_issues = jira_helper.is_push_all_issues(test)
     jform = None
     gform = None
-    form = AdHocFindingForm(initial={'date': timezone.now().date()}, req_resp=None)
+    form = AdHocFindingForm(initial={'date': timezone.now().date()}, req_resp=None, product=prod)
     use_jira = jira_helper.get_jira_project(test) is not None
 
     if request.method == 'POST':
-        form = AdHocFindingForm(request.POST, req_resp=None)
+        form = AdHocFindingForm(request.POST, req_resp=None, product=prod)
         if (form['active'].value() is False or form['false_p'].value()) and form['duplicate'].value() is False:
             closing_disabled = Note_Type.objects.filter(is_mandatory=True, is_active=True).count()
             if closing_disabled != 0:
@@ -1319,10 +1319,6 @@ def ad_hoc_finding(request, pid):
             else:
                 return HttpResponseRedirect(reverse('add_findings', args=(test.id,)))
         else:
-            if 'endpoints' in form.cleaned_data:
-                form.fields['endpoints'].queryset = form.cleaned_data['endpoints']
-            else:
-                form.fields['endpoints'].queryset = Endpoint.objects.none()
             form_error = True
             add_error_message_to_response('The form has errors, please correct them below.')
             add_field_errors_to_response(jform)

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -16,7 +16,6 @@ from django.db.models import Sum, Count, Q, Max
 from django.contrib.admin.utils import NestedObjects
 from django.db import DEFAULT_DB_ALIAS, connection
 
-from dojo.endpoint.utils import endpoint_get_or_create
 from dojo.templatetags.display_tags import get_level
 from dojo.filters import ProductEngagementFilter, ProductFilter, EngagementFilter, MetricsEndpointFilter, MetricsFindingFilter, ProductComponentFilter
 from dojo.forms import ProductForm, EngForm, DeleteProductForm, DojoMetaDataForm, JIRAProjectForm, JIRAFindingForm, AdHocFindingForm, \
@@ -45,6 +44,7 @@ from dojo.authorization.authorization_decorators import user_is_authorized
 from dojo.product.queries import get_authorized_products, get_authorized_members_for_product, get_authorized_groups_for_product
 from dojo.product_type.queries import get_authorized_members_for_product_type, get_authorized_groups_for_product_type
 from dojo.tool_config.factory import create_API
+import dojo.finding.helper as finding_helper
 
 logger = logging.getLogger(__name__)
 
@@ -1215,48 +1215,9 @@ def ad_hoc_finding(request, pid):
                 new_finding.severity)
             new_finding.tags = form.cleaned_data['tags']
             new_finding.save()
-            new_finding.endpoints.set(form.cleaned_data['endpoints'])
-            for endpoint in form.cleaned_data['endpoints']:
-                eps, created = Endpoint_Status.objects.get_or_create(
-                    finding=new_finding,
-                    endpoint=endpoint)
-                endpoint.endpoint_status.add(eps)
-                new_finding.endpoint_status.add(eps)
 
-            for endpoint in new_finding.unsaved_endpoints:
-                ep, created = endpoint_get_or_create(
-                    protocol=endpoint.protocol,
-                    userinfo=endpoint.userinfo,
-                    host=endpoint.host,
-                    port=endpoint.port,
-                    path=endpoint.path,
-                    query=endpoint.query,
-                    fragment=endpoint.fragment,
-                    product=test.engagement.product)
-                eps, created = Endpoint_Status.objects.get_or_create(
-                    finding=new_finding,
-                    endpoint=ep)
-                ep.endpoint_status.add(eps)
-
-                new_finding.endpoints.add(ep)
-                new_finding.endpoint_status.add(eps)
-            for endpoint in form.cleaned_data['endpoints']:
-                ep, created = endpoint_get_or_create(
-                    protocol=endpoint.protocol,
-                    userinfo=endpoint.userinfo,
-                    host=endpoint.host,
-                    port=endpoint.port,
-                    path=endpoint.path,
-                    query=endpoint.query,
-                    fragment=endpoint.fragment,
-                    product=test.engagement.product)
-                eps, created = Endpoint_Status.objects.get_or_create(
-                    finding=new_finding,
-                    endpoint=ep)
-                ep.endpoint_status.add(eps)
-
-                new_finding.endpoints.add(ep)
-                new_finding.endpoint_status.add(eps)
+            # Save and add new endpoints
+            finding_helper.add_endpoints(new_finding, form)
 
             new_finding.save()
             # Push to jira?

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -8,7 +8,10 @@
 {% endblock %}
 {% block add_styles %}
     {{ block.super }}
-    .select2 .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
+    .chosen-container {
+    width: 70% !important;
+    }
+    .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
     width: 70% !important;
     }
 {% endblock %}
@@ -80,9 +83,6 @@
             });
         });
         $('#add_id_endpoints').attr('href', "{% url 'add_endpoint' pid %}?_popup");
-        {% if not form_error %}
-            $('#id_endpoints').find('option').remove();
-        {% endif %}
     </script>
 
 

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -72,14 +72,16 @@
                     elem.id = "req"
                 }
 
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    hideIcons: ["side-by-side", "fullscreen"]
-                });
-                mde.render();
+                if (elem.name != 'endpoints_to_add') {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        hideIcons: ["side-by-side", "fullscreen"]
+                    });
+                    mde.render();
+                }
             });
         });
         $('#add_id_endpoints').attr('href', "{% url 'add_endpoint' pid %}?_popup");

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -84,7 +84,6 @@
                 }
             });
         });
-        $('#add_id_endpoints').attr('href', "{% url 'add_endpoint' pid %}?_popup");
     </script>
 
 

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -98,8 +98,6 @@
         $.hotkeys.options.filterInputAcceptingElements = false;
         $.hotkeys.options.filterTextInputs = false;
 
-        $('#add_id_endpoints').attr('href', "{% url 'add_endpoint' test.engagement.product.id %}?_popup");
-
         $(document).bind('keydown', 'ctrl+s', function (event) {
             if (event.preventDefault) {
                 event.preventDefault();
@@ -121,19 +119,21 @@
                     elem.id = "req"
                 }
 
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-                mde.render();
+                if (elem.name != 'endpoints_to_add') {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
 
         $("#add_finding").submit(function () {

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -99,9 +99,6 @@
         $.hotkeys.options.filterTextInputs = false;
 
         $('#add_id_endpoints').attr('href', "{% url 'add_endpoint' test.engagement.product.id %}?_popup");
-        {% if not form_error %}
-            $('#id_endpoints').find('option').remove();
-        {% endif %}
 
         $(document).bind('keydown', 'ctrl+s', function (event) {
             if (event.preventDefault) {

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -43,8 +43,6 @@
         $.hotkeys.options.filterInputAcceptingElements = false;
         $.hotkeys.options.filterTextInputs = false;
 
-        $('#add_id_endpoints').attr('href', '/endpoints/{{ finding.test.engagement.product.id }}/add?_popup');
-
         $(function () {
             $("textarea").each(function (index, elem) {
 

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -132,8 +132,6 @@
         $.hotkeys.options.filterInputAcceptingElements = false;
         $.hotkeys.options.filterTextInputs = false;
 
-        $('#add_id_endpoints').attr('href', '/endpoints/{{ finding.test.engagement.product.id }}/add?_popup');
-
         function displayMitigated() {
             var elMitigated = $('#id_mitigated_0').closest('.form-group'),
                 elMitigatedBy = $('#id_mitigated_by').closest('.form-group'),
@@ -168,19 +166,21 @@
                     elem.id = "req"
                 }
 
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-                mde.render();
+                if (elem.name != 'endpoints_to_add') {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
 
             displayMitigated();

--- a/dojo/templates/dojo/import_scan_results.html
+++ b/dojo/templates/dojo/import_scan_results.html
@@ -68,7 +68,5 @@
 	$ = django.jQuery;
 	$.hotkeys.options.filterInputAcceptingElements = false;
 	$.hotkeys.options.filterTextInputs = false;
-	$('#add_id_endpoints').attr('href', '/endpoints/{{ product_tab.product.id }}/add?_popup');
-
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -48,9 +48,6 @@
         $.hotkeys.options.filterTextInputs = false;
 
         $('#add_id_endpoints').attr('href', '/endpoints/{{ test.engagement.product.id }}/add?_popup');
-        {% if not form_error %}
-            $('#id_endpoints').find('option').remove();
-        {% endif %}
 
         $(function () {
             $("textarea").each(function (index, elem) {

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -47,8 +47,6 @@
         $.hotkeys.options.filterInputAcceptingElements = false;
         $.hotkeys.options.filterTextInputs = false;
 
-        $('#add_id_endpoints').attr('href', '/endpoints/{{ test.engagement.product.id }}/add?_popup');
-
         $(function () {
             $("textarea").each(function (index, elem) {
 
@@ -57,19 +55,21 @@
                     elem.id = "req"
                 }
 
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-                mde.render();
+                if (elem.name != 'endpoints_to_add') {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
         });
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -21,12 +21,12 @@ from django.contrib.admin.utils import NestedObjects
 from django.db import DEFAULT_DB_ALIAS
 
 from dojo.filters import TemplateFindingFilter, FindingFilter, TestImportFilter
-from dojo.forms import NoteForm, TestForm, FindingForm, \
+from dojo.forms import NoteForm, TestForm, \
     DeleteTestForm, AddFindingForm, TypedNoteForm, \
     ReImportScanForm, JIRAFindingForm, JIRAImportScanForm, \
     FindingBulkUpdateForm
 from dojo.models import Finding, Finding_Group, Test, Note_Type, BurpRawRequestResponse, Endpoint, Stub_Finding, \
-    Finding_Template, Cred_Mapping, Dojo_User, System_Settings, Endpoint_Status, Test_Import, Product_API_Scan_Configuration
+    Finding_Template, Cred_Mapping, Dojo_User, System_Settings, Test_Import, Product_API_Scan_Configuration
 
 from dojo.tools.factory import get_choices_sorted
 from dojo.utils import add_error_message_to_response, add_field_errors_to_response, add_success_message_to_response, get_page_items, get_page_items_and_count, add_breadcrumb, get_cal_event, process_notifications, get_system_setting, \
@@ -388,14 +388,9 @@ def add_findings(request, tid):
                 new_finding.severity)
             new_finding.tags = form.cleaned_data['tags']
             new_finding.save(dedupe_option=False, push_to_jira=False)
-            for ep in form.cleaned_data['endpoints']:
-                eps, created = Endpoint_Status.objects.get_or_create(
-                    finding=new_finding,
-                    endpoint=ep)
-                ep.endpoint_status.add(eps)
 
-                new_finding.endpoints.add(ep)
-                new_finding.endpoint_status.add(eps)
+            # Save and add new endpoints
+            finding_helper.add_endpoints(new_finding, form)
 
             # Push to jira?
             push_to_jira = False
@@ -484,7 +479,7 @@ def add_temp_finding(request, tid, fid):
 
     if request.method == 'POST':
 
-        form = FindingForm(request.POST, template=True, req_resp=None)
+        form = AddFindingForm(request.POST, req_resp=None, product=test.engagement.product)
         if jira_helper.get_jira_project(test):
             jform = JIRAFindingForm(push_all=jira_helper.is_push_all_issues(test), prefix='jiraform', jira_project=jira_helper.get_jira_project(test), finding_form=form)
             logger.debug('jform valid: %s', jform.is_valid())
@@ -516,14 +511,10 @@ def add_temp_finding(request, tid, fid):
             finding_helper.update_finding_status(new_finding, request.user)
 
             new_finding.save(dedupe_option=False, false_history=False)
-            for ep in form.cleaned_data['endpoints']:
-                eps, created = Endpoint_Status.objects.get_or_create(
-                    finding=new_finding,
-                    endpoint=ep)
-                ep.endpoint_status.add(eps)
 
-                new_finding.endpoints.add(ep)
-                new_finding.endpoint_status.add(eps)
+            # Save and add new endpoints
+            finding_helper.add_endpoints(new_finding, form)
+
             new_finding.save(false_history=True)
             if 'jiraform-push_to_jira' in request.POST:
                 jform = JIRAFindingForm(request.POST, prefix='jiraform', instance=new_finding, push_all=push_all_jira_issues, jira_project=jira_helper.get_jira_project(test), finding_form=form)
@@ -546,7 +537,7 @@ def add_temp_finding(request, tid, fid):
                                  extra_tags='alert-danger')
 
     else:
-        form = FindingForm(template=True, req_resp=None, initial={'active': False,
+        form = AddFindingForm(req_resp=None, product=test.engagement.product, initial={'active': False,
                                     'date': timezone.now().date(),
                                     'verified': False,
                                     'false_p': False,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -352,12 +352,12 @@ def add_findings(request, tid):
     test = Test.objects.get(id=tid)
     form_error = False
     jform = None
-    form = AddFindingForm(initial={'date': timezone.now().date()}, req_resp=None)
+    form = AddFindingForm(initial={'date': timezone.now().date()}, req_resp=None, product=test.engagement.product)
     push_all_jira_issues = jira_helper.is_push_all_issues(test)
     use_jira = jira_helper.get_jira_project(test) is not None
 
     if request.method == 'POST':
-        form = AddFindingForm(request.POST, req_resp=None)
+        form = AddFindingForm(request.POST, req_resp=None, product=test.engagement.product)
         if (form['active'].value() is False or form['false_p'].value()) and form['duplicate'].value() is False:
             closing_disabled = Note_Type.objects.filter(is_mandatory=True, is_active=True).count()
             if closing_disabled != 0:
@@ -452,10 +452,6 @@ def add_findings(request, tid):
             else:
                 return HttpResponseRedirect(reverse('add_findings', args=(test.id,)))
         else:
-            if 'endpoints' in form.cleaned_data:
-                form.fields['endpoints'].queryset = form.cleaned_data['endpoints']
-            else:
-                form.fields['endpoints'].queryset = Endpoint.objects.none()
             form_error = True
             add_error_message_to_response('The form has errors, please correct them below.')
             add_field_errors_to_response(jform)

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -282,19 +282,7 @@ class ProductTest(BaseTestCase):
         driver.execute_script("document.getElementsByName('impact')[0].style.display = 'inline'")
         driver.find_element_by_name("impact").send_keys(Keys.TAB, "This has a very critical effect on production")
         # Add an endpoint
-        main_window_handle = driver.current_window_handle
-        driver.find_element_by_id("add_id_endpoints").click()
-        popup_window = None
-        while not popup_window:
-            for handle in driver.window_handles:
-                if handle != main_window_handle:
-                    popup_window = handle
-                    break
-        driver.switch_to.window(popup_window)
-        driver.find_element_by_id("id_endpoint").clear()
-        driver.find_element_by_id("id_endpoint").send_keys("product.finding.com")
-        driver.find_element_by_css_selector("input.btn.btn-primary").click()
-        driver.switch_to.window(main_window_handle)
+        driver.find_element_by_id("id_endpoints_to_add").send_keys("product.finding.com")
         # "Click" the Done button to Add the finding with other defaults
         with WaitForPageLoad(driver, timeout=30):
             driver.find_element_by_xpath("//input[@name='_Finished']").click()
@@ -302,6 +290,9 @@ class ProductTest(BaseTestCase):
 
         # Assert to the query to dtermine status of failure
         self.assertTrue(self.is_text_present_on_page(text='App Vulnerable to XSS'))
+        # Select and click on the finding to check if endpoint has been added
+        driver.find_element_by_link_text("App Vulnerable to XSS").click()
+        self.assertTrue(self.is_text_present_on_page(text='product.finding.com'))
 
     @on_exception_html_source_logger
     def test_add_product_endpoints(self):

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -172,19 +172,7 @@ class TestUnitTest(BaseTestCase):
         driver.execute_script("document.getElementsByName('impact')[0].style.display = 'inline'")
         driver.find_element_by_name("impact").send_keys(Keys.TAB, "This has a very critical effect on production2")
         # Add an endpoint
-        main_window_handle = driver.current_window_handle
-        driver.find_element_by_id("add_id_endpoints").click()
-        popup_window = None
-        while not popup_window:
-            for handle in driver.window_handles:
-                if handle != main_window_handle:
-                    popup_window = handle
-                    break
-        driver.switch_to.window(popup_window)
-        driver.find_element_by_id("id_endpoint").clear()
-        driver.find_element_by_id("id_endpoint").send_keys("product2.finding.com")
-        driver.find_element_by_css_selector("input.btn.btn-primary").click()
-        driver.switch_to.window(main_window_handle)
+        driver.find_element_by_id("id_endpoints_to_add").send_keys("product2.finding.com")
         # "Click" the Done button to Add the finding with other defaults
         with WaitForPageLoad(driver, timeout=30):
             driver.find_element_by_xpath("//input[@name='_Finished']").click()
@@ -192,6 +180,9 @@ class TestUnitTest(BaseTestCase):
 
         # Assert to the query to dtermine status of failure
         self.assertTrue(self.is_text_present_on_page(text='App Vulnerable to XSS2'))
+        # Select and click on the finding to check if endpoint has been added
+        driver.find_element_by_link_text("App Vulnerable to XSS2").click()
+        self.assertTrue(self.is_text_present_on_page(text='product2.finding.com'))
 
     def test_add_stub_finding(self):
         # Login to the site.


### PR DESCRIPTION
fixes  #5278, #5279 and #5291

This PR changes the behaviour of the multiselectbox "Systems / Endpoints" in various dialogues for findings and imports:

- The multiselectbox behaves now as all other multiselectboxes in DefectDojo, showing the available endpoints and let the user select some of them.
   ![2021-10-23 11_08_25-Add Finding _ DefectDojo](https://user-images.githubusercontent.com/2698502/138550371-0982d375-05e0-43a7-ba85-a921c2f77b5c.png)

- The popup to add new endpoints has been removed. The UI experience was not good, users couldn't see in the dialogue what they have been added after closing the popup. Instead there is now a textbox where the user can enter new endpoints line by line.
   ![2021-10-23 11_08_56-Add Finding _ DefectDojo](https://user-images.githubusercontent.com/2698502/138550393-80757b33-94db-425f-aea7-42cd9ca16f58.png)
  