### PR TITLE
Use endpoint status to determine vulnerable endpoints

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -36,6 +36,8 @@ def process_endpoints_view(request, host_view=False, vulnerable=False):
     if vulnerable:
         endpoints = Endpoint.objects.filter(finding__active=True, finding__verified=True, finding__false_p=False,
                                      finding__duplicate=False, finding__out_of_scope=False, mitigated=False)
+        endpoint_status = Endpoint_Status.objects.filter(mitigated=False)
+        endpoints = endpoints.filter(endpoint_status__in=endpoint_status)
     else:
         endpoints = Endpoint.objects.all()
 

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -325,7 +325,7 @@ def add_meta_data(request, eid):
                                  'Metadata added successfully.',
                                  extra_tags='alert-success')
             if 'add_another' in request.POST:
-                return HttpResponseRedirect(reverse('add_meta_data', args=(eid,)))
+                return HttpResponseRedirect(reverse('add_endpoint_meta_data', args=(eid,)))
             else:
                 return HttpResponseRedirect(reverse('view_endpoint', args=(eid,)))
     else:

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -58,7 +58,7 @@ def process_endpoints_view(request, host_view=False, vulnerable=False):
         view_name = "All"
 
     if host_view:
-        view_name += " Endpoint Hosts"
+        view_name += " Hosts"
     else:
         view_name += " Endpoints"
 

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -124,13 +124,11 @@ def process_endpoint_view(request, eid, host_view=False):
         endpoint_metadata = None
         all_findings = endpoint.host_findings()
         active_findings = endpoint.host_active_findings()
-        closed_findings = endpoint.host_closed_findings()
     else:
         endpoints = None
         endpoint_metadata = dict(endpoint.endpoint_meta.values_list('name', 'value'))
         all_findings = endpoint.findings()
         active_findings = endpoint.active_findings()
-        closed_findings = endpoint.closed_findings()
 
     if all_findings:
         start_date = timezone.make_aware(datetime.combine(all_findings.last().date, datetime.min.time()))
@@ -142,6 +140,9 @@ def process_endpoint_view(request, eid, host_view=False):
     months_between = (r.years * 12) + r.months
     # include current month
     months_between += 1
+
+    # A closed findings is needed for get_periods_counts, but they are not relevant in the endpoint view
+    closed_findings = Finding.objects.none()
 
     monthly_counts = get_period_counts(active_findings, all_findings, closed_findings, None, months_between, start_date,
                                        relative_delta='months')

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -36,8 +36,7 @@ def process_endpoints_view(request, host_view=False, vulnerable=False):
     if vulnerable:
         endpoints = Endpoint.objects.filter(finding__active=True, finding__verified=True, finding__false_p=False,
                                      finding__duplicate=False, finding__out_of_scope=False, mitigated=False)
-        endpoint_status = Endpoint_Status.objects.filter(mitigated=False)
-        endpoints = endpoints.filter(endpoint_status__in=endpoint_status)
+        endpoints = endpoints.filter(endpoint_status__mitigated=False)
     else:
         endpoints = Endpoint.objects.all()
 

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -141,7 +141,7 @@ def process_endpoint_view(request, eid, host_view=False):
     # include current month
     months_between += 1
 
-    # A closed findings is needed for get_periods_counts, but they are not relevant in the endpoint view
+    # closed_findings is needed as a parameter for get_periods_counts, but they are not relevant in the endpoint view
     closed_findings = Finding.objects.none()
 
     monthly_counts = get_period_counts(active_findings, all_findings, closed_findings, None, months_between, start_date,

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -218,6 +218,7 @@ def get_finding_filter_fields(metrics=False, similar=False):
                 'test__test_type',
                 'test__engagement__version',
                 'test__version',
+                'endpoints',
                 'status',
                 'active',
                 'verified',
@@ -1146,6 +1147,10 @@ class FindingFilter(FindingFilterWithTags):
     test__engagement = ModelMultipleChoiceFilter(
         queryset=Engagement.objects.none(),
         label="Engagement")
+
+    endpoints = ModelMultipleChoiceFilter(
+        queryset=Endpoint.objects.none(),
+        label="Endpoint")
 
     test = ModelMultipleChoiceFilter(
         queryset=Test.objects.none(),

--- a/dojo/finding/urls.py
+++ b/dojo/finding/urls.py
@@ -14,7 +14,7 @@ urlpatterns = [
     #     name='finding_bulk_update_all_test'),
     url(r'^finding/open$', views.open_findings,
         name='open_findings'),
-    url(r'^finding/open$', views.verified_findings,
+    url(r'^finding/verified$', views.verified_findings,
         name='verified_findings'),
     url(r'^product/(?P<pid>\d+)/finding/open$', views.open_findings,
         name='product_open_findings'),

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1342,18 +1342,29 @@ class Endpoint(models.Model):
     def findings_count(self):
         return self.findings().count()
 
+    def endpoint_status_list(self):
+        return Endpoint_Status.objects.filter(endpoint=self)
+
+    def active_endpoint_status_list(self):
+        return self.endpoint_status_list().filter(mitigated=False)
+
     def active_findings(self):
-        return self.findings().filter(active=True,
+        findings = self.findings().filter(active=True,
                                       verified=True,
                                       out_of_scope=False,
                                       mitigated__isnull=True,
                                       false_p=False,
                                       duplicate=False).order_by('numerical_severity')
+        findings = findings.filter(endpoint_status__in=self.active_endpoint_status_list())
+        return findings
 
     def active_findings_count(self):
         return self.active_findings().count()
 
     def closed_findings(self):
+        print('-------------------------------------')
+        print(self.findings().filter(mitigated__isnull=False))
+        print('-------------------------------------')
         return self.findings().filter(mitigated__isnull=False)
 
     def closed_findings_count(self):
@@ -1380,13 +1391,21 @@ class Endpoint(models.Model):
     def host_findings_count(self):
         return self.host_finding().count()
 
+    def host_endpoint_status_list(self):
+        return Endpoint_Status.objects.filter(endpoint__in=self.host_endpoints())
+
+    def host_active_endpoint_status_list(self):
+        return self.host_endpoint_status_list().filter(mitigated=False)
+
     def host_active_findings(self):
-        return self.host_findings().filter(active=True,
+        findings = self.host_findings().filter(active=True,
                                            verified=True,
                                            out_of_scope=False,
                                            mitigated__isnull=True,
                                            false_p=False,
                                            duplicate=False).order_by('numerical_severity')
+        findings = findings.filter(endpoint_status__in=self.host_active_endpoint_status_list())
+        return findings
 
     def host_active_findings_count(self):
         return self.host_active_findings().count()

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1342,12 +1342,6 @@ class Endpoint(models.Model):
     def findings_count(self):
         return self.findings().count()
 
-    def endpoint_status_list(self):
-        return Endpoint_Status.objects.filter(endpoint=self)
-
-    def active_endpoint_status_list(self):
-        return self.endpoint_status_list().filter(mitigated=False)
-
     def active_findings(self):
         findings = self.findings().filter(active=True,
                                       verified=True,
@@ -1355,7 +1349,7 @@ class Endpoint(models.Model):
                                       mitigated__isnull=True,
                                       false_p=False,
                                       duplicate=False).order_by('numerical_severity')
-        findings = findings.filter(endpoint_status__in=self.active_endpoint_status_list())
+        findings = findings.filter(endpoint_status__mitigated=False)
         return findings
 
     def active_findings_count(self):
@@ -1382,12 +1376,6 @@ class Endpoint(models.Model):
     def host_findings_count(self):
         return self.host_finding().count()
 
-    def host_endpoint_status_list(self):
-        return Endpoint_Status.objects.filter(endpoint__in=self.host_endpoints())
-
-    def host_active_endpoint_status_list(self):
-        return self.host_endpoint_status_list().filter(mitigated=False)
-
     def host_active_findings(self):
         findings = self.host_findings().filter(active=True,
                                            verified=True,
@@ -1395,7 +1383,7 @@ class Endpoint(models.Model):
                                            mitigated__isnull=True,
                                            false_p=False,
                                            duplicate=False).order_by('numerical_severity')
-        findings = findings.filter(endpoint_status__in=self.host_active_endpoint_status_list())
+        findings = findings.filter(endpoint_status__mitigated=False)
         return findings
 
     def host_active_findings_count(self):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1361,15 +1361,6 @@ class Endpoint(models.Model):
     def active_findings_count(self):
         return self.active_findings().count()
 
-    def closed_findings(self):
-        print('-------------------------------------')
-        print(self.findings().filter(mitigated__isnull=False))
-        print('-------------------------------------')
-        return self.findings().filter(mitigated__isnull=False)
-
-    def closed_findings_count(self):
-        return self.closed_findings().count()
-
     def host_endpoints(self):
         return Endpoint.objects.filter(host=self.host,
                                        product=self.product).distinct()
@@ -1409,12 +1400,6 @@ class Endpoint(models.Model):
 
     def host_active_findings_count(self):
         return self.host_active_findings().count()
-
-    def host_closed_findings(self):
-        return self.host_findings().filter(mitigated__isnull=False)
-
-    def host_closed_findings_count(self):
-        return self.host_closed_findings().count()
 
     def get_breadcrumbs(self):
         bc = self.product.get_breadcrumbs()

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1236,10 +1236,6 @@ span.pull-right.clickable i.glyphicon-chevron-up, span.pull-right.clickable i.gl
     color: #546474;
 }
 
-table.finding-endpoints {
-    font-size: 13px;
-}
-
 .finding-description {
     max-height: 500px;
     overflow-y: scroll;

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -283,13 +283,13 @@
                                             <a href="{% url 'endpoint' %}">All Endpoints</a>
                                         </li>
                                         <li>
-                                            <a href="{% url 'endpoint_host' %}">All Endpoint Hosts</a>
+                                            <a href="{% url 'endpoint_host' %}">All Hosts</a>
                                         </li>
                                         <li>
                                             <a href="{% url 'vulnerable_endpoints' %}">Vulnerable Endpoints</a>
                                         </li>
                                         <li>
-                                            <a href="{% url 'vulnerable_endpoint_hosts' %}">Vulnerable Endpoint Hosts</a>
+                                            <a href="{% url 'vulnerable_endpoint_hosts' %}">Vulnerable Hosts</a>
                                         </li>
                                         {% if request.user.is_staff %}
                                             <li>

--- a/dojo/templates/dojo/add_endpoint_meta_data.html
+++ b/dojo/templates/dojo/add_endpoint_meta_data.html
@@ -4,6 +4,7 @@
 {% block content %}
     {{ block.super }}
     <h3> Add Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
+    <br />
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">

--- a/dojo/templates/dojo/add_product_meta_data.html
+++ b/dojo/templates/dojo/add_product_meta_data.html
@@ -4,6 +4,7 @@
 {% block content %}
     {{ block.super }}
     <h3> Add {{ product.name }} Custom Fields</h3>
+    <br />
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">

--- a/dojo/templates/dojo/edit_endpoint_meta_data.html
+++ b/dojo/templates/dojo/edit_endpoint_meta_data.html
@@ -13,7 +13,7 @@
                     <input type="text" class="form-control" id="cfv_{{ cf.id }}" name="cfv_{{ cf.id }}"
                            value="{{ cf.value }}">
                     <span for="cfv_{{ cf.id }}">Delete</span>
-                    <input type="checkbox" label="Delete Checkbox" name="delete_cfv_{{ cf.id }}" id="delete_cfv_{{ cf.id }}"/>
+                    <input type="checkbox" label="Delete Checkbox" name="delete_cfv_{{ cf.id }}" id="delete_cfv_{{ cf.id }}" aria-label="Delete"/>
                 </div>
             </div>
         {% endfor %}

--- a/dojo/templates/dojo/edit_endpoint_meta_data.html
+++ b/dojo/templates/dojo/edit_endpoint_meta_data.html
@@ -4,22 +4,18 @@
 {% block content %}
     {{ block.super }}
     <h3> Edit Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
-    <p>
-        Use the form below to edit the values in each of the metadata fields.  To remove a field, leave the value blank.
-    </p>
     <br/>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% for cf in endpoint.endpoint_meta.all %}
-
             <div class="form-group">
                 <label class="col-sm-2 control-label" for="cfv_{{ cf.id }}">{{ cf.name }}</label>
                 <div class="col-sm-10">
                     <input type="text" class="form-control" id="cfv_{{ cf.id }}" name="cfv_{{ cf.id }}"
                            value="{{ cf.value }}">
+                    <span for="cfv_{{ cf.id }}">Delete</span>
+                    <input type="checkbox" label="Delete Checkbox" name="delete_cfv_{{ cf.id }}" id="delete_cfv_{{ cf.id }}"/>
                 </div>
             </div>
-
-
         {% endfor %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">

--- a/dojo/templates/dojo/edit_product_meta_data.html
+++ b/dojo/templates/dojo/edit_product_meta_data.html
@@ -3,14 +3,10 @@
 
 {% block content %}
     {{ block.super }}
-    <h3> Edit {{ product.name }} Metadata</h3>
-    <p>
-        Use the form below to edit the values in each of the metadata fields.  To remove a field, leave the value blank.
-    </p>
+    <h3> Edit Product ({{ product.name }}) Metadata</h3>
     <br/>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% for cf in product.product_meta.all %}
-
             <div class="form-group">
                 <label class="col-sm-2 control-label" for="cfv_{{ cf.id }}">{{ cf.name }}</label>
                 <div class="col-sm-10">

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -84,7 +84,7 @@
                             {% if not product_tab %}
                                 <th>{% dojo_sort request 'Product' 'product' 'asc' %}</th>
                             {% endif %}
-							<th nowrap="nowrap">Open Findings</th>
+							<th class="text-center" nowrap="nowrap">Active Verified Findings</th>
 							<th>Status</th>
                         </tr>
 
@@ -121,24 +121,20 @@
                                     </sup>
                                   </td>
                                 {% endif %}
-                                <td>
+                                <td class="text-center">
                                   {% if host_view %}
-                                    {% if e.host_active_findings_count > 0 %}
                                       {{ e.host_active_findings_count }}
-                                    {% else %}
-                                      No Open, Active Findings
-                                    {% endif %}
                                   {% else %}
                                     {% if e.active_findings_count > 0 %}
-                                      <a href="{% url 'open_findings' %}?endpoints={{ e.id }}">{{ e.active_findings_count }}</a>
+                                      <a href="{% url 'verified_findings' %}?endpoints={{ e.id }}">{{ e.active_findings_count }}</a>
                                     {% else %}
-                                      No Open, Active Findings
+                                      0
                                     {% endif %}
                                   {% endif %}
                                 </td>
                                 <td>
                                   {% if host_view %}
-                                    {{ e.host_mitigated_endpoints_count }} / {{ e.host_endpoints_count }} Mitigated Endpoints
+                                    {{ e.host_mitigated_endpoints_count }} / {{ e.host_endpoints_count }} mitigated endpoints
                                   {% else %}
                                     {% if e.mitigated %}
                                       Mitigated
@@ -146,7 +142,7 @@
                                       {% if e.active_findings_count > 0 %}
                                         Vulnerable
                                       {% else %}
-                                        No Open, Active Findings
+                                        No active verified findings
                                       {% endif %}
                                     {% endif %}
                                   {% endif %}
@@ -159,7 +155,11 @@
                     {% include "dojo/paging_snippet.html" with page=endpoints page_size=True %}
                 </div>
             {% else %}
-                <h5> No endpoints </h5>
+                {% if host_view %}
+                    <h5> No hosts </h5>
+                {% else %}
+                    <h5> No endpoints </h5>
+                {% endif %}
             {% endif %}
         </div>
     </div>

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -179,9 +179,9 @@
                                 <td>{% if item %}
                                       <a data-toggle="tooltip" data-placement="top" data-original-title="{{ item }}" href="{% url 'view_endpoint' item.id %}">
                                       {% if item.vulnerable %}
-                                        <span style="color:OrangeRed" class="fa fa-unlock"></span>
+                                        <span style="color:OrangeRed" class="fa fa-thumbs-down"></span>
                                       {% else %}
-                                        <span class="fa fa-lock"></span>
+                                        <span class="fa fa-thumbs-up"></span>
                                       {% endif %}
                                       &nbsp;{{ item|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
                                     {% endif %}

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load navigation_tags %}
 {% load humanize %}
 {% load display_tags %}
 {% load authorization_tags %}
@@ -18,23 +19,20 @@
             <div class="clearfix">
                 <h4 class="pull-left finding-title">
                     {% if host_view %}
-                      {{ endpoint.host }} -
-                      {{ endpoint.host_mitigated_endpoints_count }} / {{ endpoint.host_endpoints_count }} Mitigated Endpoints
+                      Host: {{ endpoint.host }} -
+                      {{ endpoint.host_mitigated_endpoints_count }} / {{ endpoint.host_endpoints_count }} mitigated endpoints
                     {% else %}
-                      {{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %} -
+                      Endpoint: {{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %} -
                       {% if endpoint.mitigated %}
                         Mitigated
                       {% else %}
                         {% if endpoint.active_findings_count > 0 %}
                           Vulnerable
                         {% else %}
-                          No Open, Active Findings
+                          No active verified findings
                         {% endif %}
                       {% endif %}
                     {% endif %}
-                    <span class="text-muted endpoint_product">
-                        <a href="{% url 'view_product' endpoint.product.id %}">{{ endpoint.product }}</a>
-                    </span>
                 </h4>
 
 
@@ -169,9 +167,9 @@
         </div>
     </div>
 
-    <div class="panel panel-default endpoints table-responsive">
+    <div class="panel panel-default table-responsive">
         {% if host_view %}
-            <div class="panel-heading">Endpoints</div>
+            <div class="panel-heading"><h4>Endpoints</h4></div>
             {% if endpoints %}
                 {% colgroup endpoints into 3 cols as grouped_items %}
                 <table class="table-striped table table table-condensed table-hover finding-endpoints">
@@ -181,11 +179,11 @@
                                 <td>{% if item %}
                                       <a data-toggle="tooltip" data-placement="top" data-original-title="{{ item }}" href="{% url 'view_endpoint' item.id %}">
                                       {% if item.vulnerable %}
-                                        &#10005;
+                                        <span style="color:OrangeRed" class="fa fa-unlock"></span>
                                       {% else %}
-                                        &#10003;
+                                        <span class="fa fa-lock"></span>
                                       {% endif %}
-                                      {{ item|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
+                                      &nbsp;{{ item|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
                                     {% endif %}
                                 </td>
                             {% endfor %}
@@ -198,14 +196,14 @@
                 </div>
             {% endif %}
         {% else %}
-            <div class="panel-heading">Host</div>
-            <div id="vuln_endpoints" class="panel-body endpoint-panel table-responsive">
+            <div class="panel-heading"><h4>Host</h4></div>
+            <div id="vuln_endpoints" class="panel-body table-responsive">
                 <a data-toggle="tooltip" data-placement="top" data-original-title="{{ endpoint.host }}" href="{% url 'view_endpoint_host' endpoint.id %}">{{ endpoint.host }}</a>
             </div>
         {% endif %}
     </div>
 
-    {% if not host_view and endpoint.tags %}
+    {% if not host_view and endpoint.tags.all %}
         <div class="panel panel-default tags">
             <div class="panel-heading">
                 <h4>Tags</h4>
@@ -253,47 +251,58 @@
 
     <div class="panel panel-default table-responsive">
         <div class="panel-heading">
-            <h4>Active Findings</h4>
+            <h4>Active Verified Findings</h4>
         </div>
-        {% if findings %}
-            <table id="findings" class="tablesorter-bootstrap table table-striped table-bordered">
+    </div>
+    {% if findings %}
+    <div class="clearfix">
+        {% include "dojo/paging_snippet.html" with page=findings page_size=True %}
+    </div>
+    <div class="table-responsive panel panel-default">
+        <table id="findings" class="tablesorter-bootstrap table table-striped">
                 <thead>
                 <tr>
                     <th>Title</th>
-                    <th>Date</th>
-                    <th>Severity</th>
-                    <th>Age</th>
+                    <th class="text-center">Severity</th>
+                    <th class="text-center">Date</th>
+                    <th class="text-center">Age</th>
+                    <th>Found by</th>
                 </tr>
                 </thead>
                 <tbody>
                 {% for finding in findings %}
                     <tr>
-                        <td>
+                        <td> 
                             <a href="{% url 'view_finding' finding.id %}">{{ finding.title }}</a>
                         </td>
-                        <td>
+                        <td class="text-center">
+                            <span class="label severity severity-{{ finding.severity }}">
+                            {{ finding.severity }}
+                            </span>
+                        </td>
+                        <td class="text-center">
                             {{ finding.date }}
                         </td>
-                        <td>
-                            {{ finding.severity }}
+                        <td class="text-center">
+                            {{ finding.age }}
                         </td>
                         <td>
-                            {{ finding.age }}
+                            {% for scanner in finding.found_by.all %}
+                            {{ scanner }}
+                            {% endfor %}
                         </td>
                     </tr>
                 {% endfor %}
 
                 </tbody>
             </table>
-            <div class="clearfix">
-                {% include "dojo/paging_snippet.html" with page=findings %}
-            </div>
-        {% else %}
-            <p class="text-center">No findings found.</p>
-        {% endif %}
-
+        </div>
+    <div class="clearfix">
+        {% include "dojo/paging_snippet.html" with page=findings page_size=True %}
     </div>
-
+    {% else %}
+        <p class="text-center">No findings found.</p>
+    {% endif %}
 {% endblock %}
 {% block postscript %}
     {{ block.super }}


### PR DESCRIPTION
Until now the endpoint status hasn't been used to determine if an endpoint is vulnerable. With this PR an endpoint is marked as vulnerable, when it has active / verified findings and their endpoint status is not mitigated. Additionally this PR contains some tlc for the endpoint dialogues and a bugfix for editing metadata.

![2021-10-25 19_59_52-All Endpoints _ DefectDojo](https://user-images.githubusercontent.com/2698502/138747320-d6f32a6d-3b62-4832-b89a-e5bc03fab3dd.png)

![2021-10-25 19_58_43-Endpoint _ DefectDojo](https://user-images.githubusercontent.com/2698502/138747265-f601cc28-fec7-41af-bb10-ba72c24d21db.png)

![2021-10-25 19_59_25-Host _ DefectDojo](https://user-images.githubusercontent.com/2698502/138747291-350e55dc-7f52-46f0-ab4d-60838d51bc5b.png)


