### PR TITLE
improve history page layout

### DIFF
--- a/dojo/templates/dojo/action_history.html
+++ b/dojo/templates/dojo/action_history.html
@@ -31,7 +31,7 @@
                                 <td>{{ h.actor }}</td>
                                 <td>{{ h.timestamp }}</td>
                                 <td>
-                                    {{ h.changes|action_log_entry }}
+                                    {{ h.changes|action_log_entry|linebreaks}}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -312,8 +312,7 @@ def action_log_entry(value, autoescape=None):
     text = ''
     for k in history.keys():
         text += k.capitalize() + ' changed from "' + \
-                history[k][0] + '" to "' + history[k][1] + '"'
-
+                history[k][0] + '" to "' + history[k][1] + '". '
     return text
 
 

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -312,7 +312,7 @@ def action_log_entry(value, autoescape=None):
     text = ''
     for k in history.keys():
         text += k.capitalize() + ' changed from "' + \
-                history[k][0] + '" to "' + history[k][1] + '". '
+                history[k][0] + '" to "' + history[k][1] + '"\n'
     return text
 
 


### PR DESCRIPTION
fixes #5334 
The question is, if we really want to implement line breaks here.
It is possible with changing line 315 in dojo/templatetags/display_tags.py to:
`history[k][0] + '" to "' + history[k][1] + '". \n'`
and changing line 34 in dojo/templates/action_history.html to:
`<div style="white-space:pre;">{{ h.changes|action_log_entry }}</div>`

The thing is that linebreaks within a change are then also considered. (e.g. changing the description) Furthermore, a horizontal scroll bar could then appear if a linebreak was missing within a continuous text. (see attached screenshot)

However, I added a little improvement here.

![horizontal bar](https://user-images.githubusercontent.com/47991713/138765934-9b4ed044-08f2-48cd-b7a5-d9f92f2e91ad.png)
. 