### PR TITLE
Change Anchore Grype parser to allow matcher lists

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
Anchore Grype JSON file layout changes throw an error when trying to import due to matchers now being an array instead of an object.  

Modified the parser to support either a list or object.