### PR TITLE
Change Anchore Grype parser to allow matcher lists

### DIFF
--- a/dojo/tools/anchore_grype/parser.py
+++ b/dojo/tools/anchore_grype/parser.py
@@ -28,7 +28,12 @@ class AnchoreGrypeParser(object):
             purl = PackageURL.from_string(item["artifact"]["purl"])
             description = ""
             description += f"\n**CVE:** {cve}"
-            description += f'\n**Matcher:** {item["matchDetails"]["matcher"]}'
+            if type(item["matchDetails"]) is dict:
+                description += f'\n**Matcher:** {item["matchDetails"]["matcher"]}'
+            else:
+                description += '\n**Matchers:**'
+                for matchers in item["matchDetails"]:
+                    description += f'\n * {matchers["matcher"]}'
             description += f"\n**PURL:** {purl}"
             description += "\n**Paths:**\n"
             for match_path in item["artifact"]["locations"]:


### PR DESCRIPTION
Anchore Grype JSON file layout changes throw an error when trying to import due to matchers now being an array instead of an object.

Modified the parser to support either a list or object.