### PR TITLE
order findings last 7 days by -date

### DIFF
--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -46,7 +46,7 @@
                         </div>
                     </div>
                 </div>
-                <a href="{% url 'all_findings' %}?duplicate=2&date=2">
+                <a href="{% url 'all_findings' %}?duplicate=2&date=2%o=-date">
                     <div class="panel-footer">
                         <span class="pull-left">View Finding Details</span>
                         <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -46,7 +46,7 @@
                         </div>
                     </div>
                 </div>
-                <a href="{% url 'all_findings' %}?duplicate=2&date=2%o=-date">
+                <a href="{% url 'all_findings' %}?duplicate=2&date=2&o=-date">
                     <div class="panel-footer">
                         <span class="pull-left">View Finding Details</span>
                         <span class="pull-right"><i class="fa fa-arrow-circle-right"></i></span>


### PR DESCRIPTION
On the dashboard there's the number of findings created in the last 7 days. When clicking on the number the user is presented a list of findings ordered by `numerical severity, -date, title`.

I think it's make more sense to order just by `-date` in this case.