### PR TITLE
filter out products without configs

### DIFF
--- a/dojo/db_migrations/0131_migrate_sonarcube_cobalt.py
+++ b/dojo/db_migrations/0131_migrate_sonarcube_cobalt.py
@@ -6,7 +6,7 @@ from dojo.models import Sonarqube_Product, Cobaltio_Product, Product_API_Scan_Co
 
 
 def migrate_sonarqube(apps, schema_editor):
-    sq_products = Sonarqube_Product.objects.all()
+    sq_products = Sonarqube_Product.objects.filter(sonarqube_tool_config__isnull=False)
     for sq_product in sq_products:
         api_scan_configuration = Product_API_Scan_Configuration()
         api_scan_configuration.product = sq_product.product
@@ -22,7 +22,7 @@ def migrate_sonarqube(apps, schema_editor):
 
 
 def migrate_cobalt_io(apps, schema_editor):
-    cobalt_products = Cobaltio_Product.objects.all()
+    cobalt_products = Cobaltio_Product.objects.all(cobaltio_tool_config__isnull=False)
     for cobalt_product in cobalt_products:
         api_scan_configuration = Product_API_Scan_Configuration()
         api_scan_configuration.product = cobalt_product.product

--- a/dojo/db_migrations/0131_migrate_sonarcube_cobalt.py
+++ b/dojo/db_migrations/0131_migrate_sonarcube_cobalt.py
@@ -22,7 +22,7 @@ def migrate_sonarqube(apps, schema_editor):
 
 
 def migrate_cobalt_io(apps, schema_editor):
-    cobalt_products = Cobaltio_Product.objects.all(cobaltio_tool_config__isnull=False)
+    cobalt_products = Cobaltio_Product.objects.filter(cobaltio_tool_config__isnull=False)
     for cobalt_product in cobalt_products:
         api_scan_configuration = Product_API_Scan_Configuration()
         api_scan_configuration.product = cobalt_product.product


### PR DESCRIPTION
fixes
```
 Applying dojo.0131_migrate_sonarcube_cobalt...Traceback (most recent call last):
  File "./manage.py", line 11, in <module>
    execute_from_command_line(sys.argv)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/core/management/base.py", line 330, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/core/management/base.py", line 371, in execute
    output = self.handle(*args, **options)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/core/management/base.py", line 85, in wrapped
    res = handle_func(*args, **kwargs)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/core/management/commands/migrate.py", line 243, in handle
    post_migrate_state = executor.migrate(
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/db/migrations/executor.py", line 117, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/db/migrations/executor.py", line 227, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/db/migrations/migration.py", line 121, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/db/migrations/operations/special.py", line 190, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/home/valentijn/dd/dojo/db_migrations/0131_migrate_sonarcube_cobalt.py", line 13, in migrate_sonarqube
    api_scan_configuration.tool_configuration = sq_product.sonarqube_tool_config
  File "/home/valentijn/venv/lib/python3.8/site-packages/django/db/models/fields/related_descriptors.py", line 197, in __get__
    raise self.RelatedObjectDoesNotExist(
dojo.models.RelatedObjectDoesNotExist: Sonarqube_Product has no sonarqube_tool_config.
```

I think this case can happen in some weird cases due to the bug we had in the sonarqube migration a while ago