### PR TITLE
Fix problem with duplicate projects in GitLab pipeline

### DIFF
--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -98,8 +98,13 @@ def update_product_access(backend, uid, user=None, social=None, *args, **kwargs)
         # For each project: create a new product or update product's authorized_users
         for project in projects:
             if project.path_with_namespace not in user_product_names:
-                # Create new product
-                product, created = Product.objects.get_or_create(name=project.path_with_namespace, prod_type=product_type)
+                try:
+                    # Check if there is a product with the name of the GitLab project
+                    product = Product.objects.get(name=project.path_with_namespace)
+                except Product.DoesNotExist:
+                    # If not, create a product with that name and the GitLab product type
+                    product = Product(name=project.path_with_namespace, prod_type=product_type)
+                    product.save()
                 if not settings.FEATURE_AUTHORIZATION_V2:
                     product.authorized_users.add(user)
                     product.save()


### PR DESCRIPTION
see https://owasp.slack.com/archives/C2P5BA8MN/p1635770164087400

The GitLab pipeline to update product access fails if there is a product with the name of a GitLab project exists but is in the wrong product type.

I cannot test it so it needs a very thorough code review.