### PR TITLE
GHA workflows: don't persist git credentials

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -20,6 +20,7 @@ jobs:
         # more info https://github.community/t/github-actions-are-severely-limited-on-prs/18179/16
         # we checkout merge_commit here as this contains all new code from dev also. we don't need to compare against base_commit
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           # repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          persist-credentials: false
           submodules: recursive  # Fetch the Docsy theme
           fetch-depth: 0         # Fetch all history for .GitInfo and .Lastmod
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Read Docker Image Identifiers
         id: read-docker-image-identifiers

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Read Docker Image Identifiers
         id: read-docker-image-identifiers

--- a/.github/workflows/new-release-chart.yml
+++ b/.github/workflows/new-release-chart.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       release_number:
         description: 'Release number'
-        required: true  
+        required: true
 
 jobs:
   release-chart:

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - name: Checkout Source
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
       - name: Get changed UML files
         id: getfile
         run: |

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Set up Helm

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       # - name: Read Docker Image Identifiers
       #   id: read-docker-image-identifiers


### PR DESCRIPTION
best practice for security