### PR TITLE
Integration test idempotency

### DIFF
--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -39,6 +39,10 @@ function success() {
     echo "Success: $1 test passed\n"
 }
 
+function reload() {
+  touch /app/dojo/settings/settings.py
+}
+
 echo "IT FILENAME: $DD_INTEGRATION_TEST_FILENAME"
 if [[ ! -z "$DD_INTEGRATION_TEST_FILENAME" ]]; then
     test=$DD_INTEGRATION_TEST_FILENAME
@@ -210,6 +214,20 @@ else
     else
         fail $test
     fi
+
+    test="Read only user profile test"
+    echo "Preparing configuration: USER_PROFILE_EDITABLE=True"
+    echo "USER_PROFILE_EDITABLE=Frue" > /app/dojo/settings/local_settings.py
+    reload
+
+    echo "Running $test"
+    if python3 tests/user_standard_test.py ; then
+        success $test
+    else
+        fail $test
+    fi
+    echo "USER_PROFILE_EDITABLE=True" > /app/dojo/settings/local_settings.py
+    reload
 
 
 # The below tests are commented out because they are still an unstable work in progress

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -39,10 +39,6 @@ function success() {
     echo "Success: $1 test passed\n"
 }
 
-function reload() {
-  touch /app/dojo/settings/settings.py
-}
-
 echo "IT FILENAME: $DD_INTEGRATION_TEST_FILENAME"
 if [[ ! -z "$DD_INTEGRATION_TEST_FILENAME" ]]; then
     test=$DD_INTEGRATION_TEST_FILENAME
@@ -214,20 +210,6 @@ else
     else
         fail $test
     fi
-
-    test="Read only user profile test"
-    echo "Preparing configuration: USER_PROFILE_EDITABLE=True"
-    echo "USER_PROFILE_EDITABLE=Frue" > /app/dojo/settings/local_settings.py
-    reload
-
-    echo "Running $test"
-    if python3 tests/user_standard_test.py ; then
-        success $test
-    else
-        fail $test
-    fi
-    echo "USER_PROFILE_EDITABLE=True" > /app/dojo/settings/local_settings.py
-    reload
 
 
 # The below tests are commented out because they are still an unstable work in progress

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -206,7 +206,7 @@ class BaseTestCase(unittest.TestCase):
             WebDriverWait(self.driver, 30).until(EC.presence_of_element_located((By.ID, wrapper_id)))
 
     def is_element_by_css_selector_present(self, selector, text=None):
-        elems = self.driver.find_elements_by_css_selector(selector)
+        elems = self.driver.find_elements(by=By.CSS_SELECTOR, value=selector)
         if len(elems) == 0:
             # print('no elements!')
             return False
@@ -235,6 +235,9 @@ class BaseTestCase(unittest.TestCase):
 
     def is_error_message_present(self, text=None):
         return self.is_element_by_css_selector_present('.alert-danger', text=text)
+
+    def is_help_message_present(self, text=None):
+        return self.is_element_by_css_selector_present('.help-block', text=text)
 
     def is_text_present_on_page(self, text):
         # DEBUG: couldn't find:  Product type added successfully. path:  //*[contains(text(),'Product type added successfully.')]

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -141,14 +141,21 @@ class UserTest(BaseTestCase):
         actions.move_to_element(configuration_menu).perform()
         wait.until(EC.visibility_of_element_located((By.LINK_TEXT, "Notifications"))).click()
 
+        originally_selected = { 
+            'product_added': driver.find_element_by_xpath("//input[@name='product_added' and @value='mail']").is_selected(),
+            'scan_added': driver.find_element_by_xpath("//input[@name='scan_added' and @value='mail']").is_selected()
+        }
+
         driver.find_element_by_xpath("//input[@name='product_added' and @value='mail']").click()
         driver.find_element_by_xpath("//input[@name='scan_added' and @value='mail']").click()
 
         driver.find_element_by_css_selector("input.btn.btn-primary").click()
 
         self.assertTrue(self.is_success_message_present(text='Settings saved'))
-        self.assertTrue(driver.find_element_by_xpath("//input[@name='product_added' and @value='mail']").is_selected())
-        self.assertTrue(driver.find_element_by_xpath("//input[@name='scan_added' and @value='mail']").is_selected())
+        self.assertNotEqual(originally_selected['product_added'],
+            driver.find_element_by_xpath("//input[@name='product_added' and @value='mail']").is_selected())
+        self.assertNotEqual(originally_selected['scan_added'],
+            driver.find_element_by_xpath("//input[@name='scan_added' and @value='mail']").is_selected())
 
     def test_standard_user_login(self):
         self.login_standard_page()

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -141,7 +141,7 @@ class UserTest(BaseTestCase):
         actions.move_to_element(configuration_menu).perform()
         wait.until(EC.visibility_of_element_located((By.LINK_TEXT, "Notifications"))).click()
 
-        originally_selected = { 
+        originally_selected = {
             'product_added': driver.find_element_by_xpath("//input[@name='product_added' and @value='mail']").is_selected(),
             'scan_added': driver.find_element_by_xpath("//input[@name='scan_added' and @value='mail']").is_selected()
         }

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -60,7 +60,7 @@ class UserTest(BaseTestCase):
 
         # Assert ot the query to dtermine status of failure
         self.assertTrue(self.is_success_message_present(text='User added successfully, you may edit if necessary.') or
-            self.is_success_message_present(text='A user with that username already exists.'))
+            self.is_help_message_present(text='A user with that username already exists.'))
 
     def login_standard_page(self):
         driver = self.driver


### PR DESCRIPTION
## Problem(s)
Two tests were reliably failing when re-running integration tests on the same database following an unsuccessful previous run. This is mitigated by simply destroying and re-initalizing the database, but that didn't appear to be the intention in documentation or code.

1. tests.test_user.test_create_user was failing if the user already existed as the "A user with that username already exists." text was not within a 'success' type field.
2. tests.test_user.test_user_notifications_change was failing if the test had already run as the checkboxes were already selected, when clicked again they were un-selected and the test only validated they were 'checked'.
3. ~docker/entrypoint-integration-tests.sh attempts to run tests/user_standard_test.py which does not exist. This run also sets the value `Frue` in local_settings.py which is not a valid value causing parse errors.~

## Solution(s):
1. The `or` case on tests.test_user.test_create_user now correctly checks that the "A user with that username already exists." message exists within an element with the `help-block` class. A helper method was added for this similar to success/fail message checks.
2. The test now checks the current state and validates that the state has changed after save. This was based on the 'changed' name of the test. I'm open to setting a desired state before executing and ensuring we go from 0 to 1 for example instead of just seeing the bit flipped.
3. ~The test setup for the missing file was removed and the unused reload function was removed. I believe based on the lack of this test in GitHub actions for integration tests and the existence of read-only vs editable user tests in test.test_user this is not necessary. Please let me know if that is not the case and I can remove this edit for this PR.~