### PR TITLE
Authz: Allow global maintainers/owner to add Product Types

### DIFF
--- a/docs/content/en/usage/permissions.md
+++ b/docs/content/en/usage/permissions.md
@@ -9,7 +9,7 @@ draft: false
 
 * Administrators (aka super users) have no limitations in the system. They can change all settings, manage users  and have read and write access to all data.
 * Staff users can add Product Types, and have access to data according to their role in a Product or Product Type. There is the parameter `AUTHORIZATION_STAFF_OVERRIDE` in the settings to give all staff users full access to all Products and Product Types.
-* Guest users have limited functionality available. They cannot add Product Types but have access to data according to their role in a Product or Product Type
+* Regular users have limited functionality available. They cannot add Product Types but have access to data according to their role in a Product or Product Type
 
 ## Product and Product Type permissions
 
@@ -19,7 +19,7 @@ Users can be assigned as members to Products and Product Types, giving them one 
 
 |                             | Reader | Writer | Maintainer | Owner | API Importer |
 |-----------------------------|:------:|:------:|:----------:|:-----:|:------------:|
-| Add Product Type <sup>1)</sup> |     |        |            |       |              |
+| Add Product Type            |        |        | <sup>1)</sup>           |<sup>1)</sup>       |              |
 | View Product Type           | x      | x      | x          | x     | x            |
 | Remove yourself as a member | x      | x      | x          | x     |              |
 | Manage Product Type members |        |        | x          | x     |              |
@@ -73,7 +73,7 @@ Users can be assigned as members to Products and Product Types, giving them one 
 | Delete Note                 |        | (x) <sup>2)</sub> | x          | x     |              |
 
 
-<sup>1)</sup> Every staff user and administrator can add Product Types. Guest users are not allowed to add Product Types.
+<sup>1)</sup> Every staff user and administrator can add Product Types. Regular users are not allowed to add Product Types, unless they are Global Owner or Maintainer.
 
 <sup>2)</sup> Every user is allowed to delete his own notes.
 
@@ -105,7 +105,7 @@ The membership of a group itself has a role that determines what permissions the
 | Add Group member as Owner   |        |            | x     |
 | Delete Group                |        |            | x     |
 
-<sup>1)</sup> Every staff user and administrator can add groups. Guest users are not allowed to add groups.
+<sup>1)</sup> Every staff user and administrator can add groups. Regular users are not allowed to add groups.
 
 The permissions to manage the roles of Products and Product types for a group is defined by the role of the user in the respective Product or Product Type.
 

--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -5,7 +5,7 @@ from dojo.importers.reimporter.utils import get_target_engagement_if_exists, get
 from dojo.models import Endpoint, Engagement, Finding, Product_Type, Product, Test, Dojo_Group
 from django.shortcuts import get_object_or_404
 from rest_framework import permissions, serializers
-from dojo.authorization.authorization import user_has_permission
+from dojo.authorization.authorization import user_has_global_permission, user_has_permission
 from dojo.authorization.roles_permissions import Permissions
 
 
@@ -215,7 +215,7 @@ class UserHasProductGroupPermission(permissions.BasePermission):
 class UserHasProductTypePermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method == 'POST':
-            return request.user.is_staff
+            return user_has_global_permission(request.user, Permissions.Product_Type_Add)
         else:
             return True
 

--- a/dojo/authorization/authorization_decorators.py
+++ b/dojo/authorization/authorization_decorators.py
@@ -2,7 +2,7 @@ import functools
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404
-from dojo.authorization.authorization import user_has_permission_or_403
+from dojo.authorization.authorization import user_has_global_permission_or_403, user_has_permission_or_403
 from dojo.user.helper import user_is_authorized as legacy_check
 
 
@@ -36,6 +36,21 @@ def user_is_authorized(model, permission, arg, legacy_permission=None, lookup="p
             elif not request.user.is_staff:
                 raise PermissionDenied()
 
+        return func(request, *args, **kwargs)
+
+    return _wrapped
+
+
+def user_has_global_permission(permission, func=None):
+    """Decorator for functions that ensures the user has a permission
+    """
+
+    if func is None:
+        return functools.partial(user_has_global_permission, permission)
+
+    @functools.wraps(func)
+    def _wrapped(request, *args, **kwargs):
+        user_has_global_permission_or_403(request.user, permission)
         return func(request, *args, **kwargs)
 
     return _wrapped

--- a/dojo/authorization/authorization_decorators.py
+++ b/dojo/authorization/authorization_decorators.py
@@ -7,7 +7,7 @@ from dojo.user.helper import user_is_authorized as legacy_check
 
 
 def user_is_authorized(model, permission, arg, legacy_permission=None, lookup="pk", func=None):
-    """Decorator for functions that ensures the user has permission on an object.
+    """Decorator for functions that ensures the user has an object permission.
     """
 
     if func is None:
@@ -42,7 +42,7 @@ def user_is_authorized(model, permission, arg, legacy_permission=None, lookup="p
 
 
 def user_has_global_permission(permission, func=None):
-    """Decorator for functions that ensures the user has a permission
+    """Decorator for functions that ensures the user has a (global) permission
     """
 
     if func is None:

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -33,6 +33,7 @@ class Permissions(IntEnum):
     Product_Type_Member_Add_Owner = 1005
     Product_Type_Edit = 1006
     Product_Type_Delete = 1007
+    Product_Type_Add = 1008
 
     Product_View = 1102
     Product_Member_Delete = 1103
@@ -446,5 +447,19 @@ def get_roles_with_permissions():
             Permissions.Product_API_Scan_Configuration_Add,
             Permissions.Product_API_Scan_Configuration_Edit,
             Permissions.Product_API_Scan_Configuration_Delete
+        }
+    }
+
+
+def get_global_roles_with_permissions():
+    """
+    Extra permissions for global roles, on top of the permissions granted to the "normal" roles above.
+    """
+    return {
+        Roles.Maintainer: {
+            Permissions.Product_Type_Add
+        },
+        Roles.Owner: {
+            Permissions.Product_Type_Add
         }
     }

--- a/dojo/endpoint/queries.py
+++ b/dojo/endpoint/queries.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Endpoint, Endpoint_Status, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
-from dojo.authorization.authorization import get_roles_for_permission, role_has_permission, \
-    get_groups
+from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission
 
 
 def get_authorized_endpoints(permission, queryset=None, user=None):
@@ -27,12 +26,8 @@ def get_authorized_endpoints(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return endpoints
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return endpoints
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return endpoints
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -87,12 +82,8 @@ def get_authorized_endpoint_status(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return endpoint_status
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return endpoint_status
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return endpoint_status
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(

--- a/dojo/engagement/queries.py
+++ b/dojo/engagement/queries.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Engagement, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
-from dojo.authorization.authorization import get_roles_for_permission, role_has_permission, \
-    get_groups
+from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission
 
 
 def get_authorized_engagements(permission):
@@ -20,12 +19,8 @@ def get_authorized_engagements(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Engagement.objects.all()
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Engagement.objects.all()
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Engagement.objects.all()
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(

--- a/dojo/finding/queries.py
+++ b/dojo/finding/queries.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Finding, Product_Member, Product_Type_Member, Stub_Finding, \
     Product_Group, Product_Type_Group
-from dojo.authorization.authorization import get_roles_for_permission, role_has_permission, \
-    get_groups
+from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission
 
 
 def get_authorized_findings(permission, queryset=None, user=None):
@@ -27,12 +26,8 @@ def get_authorized_findings(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return findings
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return findings
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return findings
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -82,12 +77,8 @@ def get_authorized_stub_findings(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Stub_Finding.objects.all()
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Stub_Finding.objects.all()
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Stub_Finding.objects.all()
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(

--- a/dojo/finding_group/queries.py
+++ b/dojo/finding_group/queries.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Finding_Group, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
-from dojo.authorization.authorization import get_roles_for_permission, role_has_permission, \
-    get_groups
+from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission
 
 
 def get_authorized_finding_groups(permission, queryset=None, user=None):
@@ -27,12 +26,8 @@ def get_authorized_finding_groups(permission, queryset=None, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return finding_groups
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return finding_groups
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return finding_groups
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -72,6 +72,42 @@
     }
   },
   {
+    "pk": 5,
+    "model": "auth.user",
+    "fields": {
+      "username": "user4",
+      "first_name": "",
+      "last_name": "",
+      "is_active": true,
+      "is_superuser": false,
+      "is_staff": false,
+      "last_login": null,
+      "groups": [],
+      "user_permissions": [],
+      "password": "pbkdf2_sha256$36000$pe8Ff8HrBPac$Lb3ee6/R9z/aL9nM+D2AXWTpIt9Pa9kcLueXxYNy1ZY=",
+      "email": "",
+      "date_joined": "2018-04-13T07:59:51.527Z"
+    }
+  },
+  {
+    "pk": 6,
+    "model": "auth.user",
+    "fields": {
+      "username": "user5",
+      "first_name": "",
+      "last_name": "",
+      "is_active": true,
+      "is_superuser": false,
+      "is_staff": false,
+      "last_login": null,
+      "groups": [],
+      "user_permissions": [],
+      "password": "pbkdf2_sha256$36000$pe8Ff8HrBPac$Lb3ee6/R9z/aL9nM+D2AXWTpIt9Pa9kcLueXxYNy1ZY=",
+      "email": "",
+      "date_joined": "2018-04-13T07:59:51.527Z"
+    }
+  },
+  {
     "pk": "2dqr18yqu9mzb87abk0okid75w2clakl",
     "model": "sessions.session",
     "fields": {
@@ -2194,6 +2230,30 @@
     }
   },
   {
+    "pk": "184770c4c3256aba904297610fbb4da3fa15ba34",
+    "model": "authtoken.token",
+    "fields": {
+      "user": 4,
+      "created": "2018-04-16T06:54:35.933Z"
+    }
+  },
+  {
+    "pk": "184770c4c3256aba904297610fbb4da3fa15ba35",
+    "model": "authtoken.token",
+    "fields": {
+      "user": 5,
+      "created": "2018-04-16T06:54:35.933Z"
+    }
+  },
+  {
+    "pk": "184770c4c3256aba904297610fbb4da3fa15ba36",
+    "model": "authtoken.token",
+    "fields": {
+      "user": 6,
+      "created": "2018-04-16T06:54:35.933Z"
+    }
+  },
+  {
     "pk": "1",
     "model": "dojo.dojo_group",
     "fields": {
@@ -2242,6 +2302,22 @@
     "fields": {
       "user": 1,
       "role": 4
+    }
+  },
+  {
+    "pk": 2,
+    "model": "dojo.global_role",
+    "fields": {
+      "user": 6,
+      "role": 4
+    }
+  },
+  {
+    "pk": 3,
+    "model": "dojo.global_role",
+    "fields": {
+      "user": 5,
+      "role": 5
     }
   },
   {

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -249,6 +249,7 @@ def express_new_jira(request):
                 issue_id = jform.cleaned_data.get('issue_key')
                 key_url = jira_server.strip('/') + '/rest/api/latest/issue/' + issue_id + '/transitions?expand=transitions.fields'
                 response = jira._session.get(key_url).json()
+                logger.debug('Retrieved JIRA issue succesfully')
                 open_key = close_key = None
                 for node in response['transitions']:
                     if node['to']['statusCategory']['name'] == 'To Do':
@@ -259,7 +260,7 @@ def express_new_jira(request):
                 logger.exception(e)  # already logged in jira_helper
                 messages.add_message(request,
                                     messages.ERROR,
-                                    'Unable to find Open/Close ID\'s. They will need to be found manually',
+                                    'Unable to find Open/Close ID\'s (invalid issue key specified?). They will need to be found manually',
                                     extra_tags='alert-danger')
                 return render(request, 'dojo/new_jira.html',
                                         {'jform': jform})

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3700,7 +3700,9 @@ admin.site.register(Cred_Mapping)
 admin.site.register(System_Settings, System_SettingsAdmin)
 admin.site.register(CWE)
 admin.site.register(Regulation)
-admin.site.register(Notifications)
+admin.site.register(Global_Role)
+admin.site.register(Role)
+admin.site.register(Dojo_Group)
 
 # SonarQube Integration
 admin.site.register(Sonarqube_Issue)

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -4,8 +4,9 @@ from django.db.models import Exists, OuterRef, Q
 from dojo.models import Product, Product_Member, Product_Type_Member, App_Analysis, \
     DojoMeta, Product_Group, Product_Type_Group, Languages, Engagement_Presets, \
     Product_API_Scan_Configuration
-from dojo.authorization.authorization import get_roles_for_permission, user_has_permission, \
-    role_has_permission, get_groups
+from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission, user_has_permission, \
+    role_has_permission
+
 from dojo.group.queries import get_authorized_groups
 from dojo.authorization.roles_permissions import Permissions
 
@@ -25,12 +26,8 @@ def get_authorized_products(permission, user=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Product.objects.all().order_by('name')
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Product.objects.all().order_by('name')
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Product.objects.all().order_by('name')
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -98,7 +95,7 @@ def get_authorized_product_members(permission):
     if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Member.objects.all().select_related('role')
 
-    if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+    if user_has_global_permission(user, permission):
         return Product_Member.objects.all().select_related('role')
 
     products = get_authorized_products(permission)
@@ -153,12 +150,8 @@ def get_authorized_app_analysis(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return App_Analysis.objects.all().order_by('name')
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return App_Analysis.objects.all().order_by('name')
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return App_Analysis.objects.all().order_by('name')
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -208,12 +201,8 @@ def get_authorized_dojo_meta(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return DojoMeta.objects.all().order_by('name')
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return DojoMeta.objects.all().order_by('name')
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return DojoMeta.objects.all().order_by('name')
 
         roles = get_roles_for_permission(permission)
         product_authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -319,12 +308,8 @@ def get_authorized_languages(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Languages.objects.all().order_by('language')
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Languages.objects.all().order_by('language')
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Languages.objects.all().order_by('language')
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -374,12 +359,8 @@ def get_authorized_engagement_presets(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Engagement_Presets.objects.all().order_by('title')
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Engagement_Presets.objects.all().order_by('title')
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Engagement_Presets.objects.all().order_by('title')
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -429,12 +410,8 @@ def get_authorized_product_api_scan_configurations(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Product_API_Scan_Configuration.objects.all()
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Product_API_Scan_Configuration.objects.all()
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Product_API_Scan_Configuration.objects.all()
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -3,7 +3,6 @@ import logging
 from django.contrib.admin.utils import NestedObjects
 from django.db import DEFAULT_DB_ALIAS
 from django.contrib import messages
-from django.contrib.auth.decorators import user_passes_test
 from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
@@ -19,7 +18,7 @@ from django.db.models.query import QuerySet
 from django.conf import settings
 from dojo.authorization.authorization import user_has_permission
 from dojo.authorization.roles_permissions import Permissions
-from dojo.authorization.authorization_decorators import user_is_authorized
+from dojo.authorization.authorization_decorators import user_has_global_permission, user_is_authorized
 from dojo.product_type.queries import get_authorized_product_types, get_authorized_members_for_product_type, \
     get_authorized_groups_for_product_type
 from dojo.product.queries import get_authorized_products
@@ -70,7 +69,7 @@ def prefetch_for_product_type(prod_types):
     return prefetch_prod_types
 
 
-@user_passes_test(lambda u: u.is_staff)
+@user_has_global_permission(Permissions.Product_Type_Add)
 def add_product_type(request):
     form = Product_TypeForm()
     if request.method == 'POST':

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -208,7 +208,7 @@
                                         <li><a href="{% url 'new_product' %}"> Add Product</a></li>
                                     {% endif %}
                                     <li><a href="{% url 'product_type' %}">All Product Types</a></li>
-                                    {% if request.user.is_staff %}
+                                    {% if "Product_Type_Add"|has_permission %}
                                         <li><a id="pop-out-add-product-type" href="{% url 'add_product_type' %}"> Add Product Type</a></li>
                                     {% endif %}
                                 </ul>

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -208,7 +208,7 @@
                                         <li><a href="{% url 'new_product' %}"> Add Product</a></li>
                                     {% endif %}
                                     <li><a href="{% url 'product_type' %}">All Product Types</a></li>
-                                    {% if "Product_Type_Add"|has_permission %}
+                                    {% if "Product_Type_Add"|has_global_permission %}
                                         <li><a id="pop-out-add-product-type" href="{% url 'add_product_type' %}"> Add Product Type</a></li>
                                     {% endif %}
                                 </ul>

--- a/dojo/templates/dojo/product_type.html
+++ b/dojo/templates/dojo/product_type.html
@@ -20,7 +20,7 @@
                             </button>
                             <ul class="dropdown-menu dropdown-menu-right" role="menu"
                                 aria-labelledby="dropdownMenu1">
-                                {% if "Product_Type_Add"|has_permission %}
+                                {% if "Product_Type_Add"|has_global_permission %}
                                     <li role="presentation">
                                         <a href="{% url 'add_product_type' %}">
                                             <i class="fa fa-plus"></i> Add Product Type

--- a/dojo/templates/dojo/product_type.html
+++ b/dojo/templates/dojo/product_type.html
@@ -20,7 +20,7 @@
                             </button>
                             <ul class="dropdown-menu dropdown-menu-right" role="menu"
                                 aria-labelledby="dropdownMenu1">
-                                {% if request.user.is_staff %}
+                                {% if "Product_Type_Add"|has_permission %}
                                     <li role="presentation">
                                         <a href="{% url 'add_product_type' %}">
                                             <i class="fa fa-plus"></i> Add Product Type

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -130,7 +130,7 @@
                             &nbsp;
                             <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
                                 <i class="fa fa-question-circle"></i></a>
-                            {% if has_object_permission:"Product_Type_Manage_Members" %}
+                            {% if pt|has_object_permission:"Product_Type_Manage_Members" %}
                             <div class="dropdown pull-right">
                                 <button class="btn btn-primary dropdown-toggle" label="Actions" type="button" id="dropdownMenuAddProductTypeMember"
                                         data-toggle="dropdown" aria-expanded="true" aria-label="Add Product Type Member">

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -130,7 +130,7 @@
                             &nbsp;
                             <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
                                 <i class="fa fa-question-circle"></i></a>
-                            {% if pt|has_object_permission:"Product_Type_Manage_Members" %}
+                            {% if has_object_permission:"Product_Type_Manage_Members" %}
                             <div class="dropdown pull-right">
                                 <button class="btn btn-primary dropdown-toggle" label="Actions" type="button" id="dropdownMenuAddProductTypeMember"
                                         data-toggle="dropdown" aria-expanded="true" aria-label="Add Product Type Member">

--- a/dojo/templatetags/authorization_tags.py
+++ b/dojo/templatetags/authorization_tags.py
@@ -1,7 +1,7 @@
 from django import template
 from crum import get_current_user
 from dojo.authorization.roles_permissions import Permissions
-from dojo.authorization.authorization import user_has_permission
+from dojo.authorization.authorization import user_has_global_permission, user_has_permission
 
 register = template.Library()
 
@@ -9,3 +9,8 @@ register = template.Library()
 @register.filter
 def has_object_permission(obj, permission):
     return user_has_permission(get_current_user(), obj, Permissions[permission])
+
+
+@register.filter
+def has_permission(permission):
+    return user_has_global_permission(get_current_user(), Permissions[permission])

--- a/dojo/templatetags/authorization_tags.py
+++ b/dojo/templatetags/authorization_tags.py
@@ -12,5 +12,5 @@ def has_object_permission(obj, permission):
 
 
 @register.filter
-def has_permission(permission):
+def has_global_permission(permission):
     return user_has_global_permission(get_current_user(), Permissions[permission])

--- a/dojo/test/queries.py
+++ b/dojo/test/queries.py
@@ -3,8 +3,7 @@ from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Test, Product_Member, Product_Type_Member, Test_Import, \
     Product_Group, Product_Type_Group
-from dojo.authorization.authorization import get_roles_for_permission, role_has_permission, \
-    get_groups
+from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission
 
 
 def get_authorized_tests(permission, product=None):
@@ -24,12 +23,8 @@ def get_authorized_tests(permission, product=None):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Test.objects.all()
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Test.objects.all()
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Test.objects.all()
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(
@@ -82,12 +77,8 @@ def get_authorized_test_imports(permission):
         if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
             return Test_Import.objects.all()
 
-        if hasattr(user, 'global_role') and user.global_role.role is not None and role_has_permission(user.global_role.role.id, permission):
+        if user_has_global_permission(user, permission):
             return Test_Import.objects.all()
-
-        for group in get_groups(user):
-            if hasattr(group, 'global_role') and group.global_role.role is not None and role_has_permission(group.global_role.role.id, permission):
-                return Test_Import.objects.all()
 
         roles = get_roles_for_permission(permission)
         authorized_product_type_roles = Product_Type_Member.objects.filter(

--- a/dojo/unittests/authorization/test_authorization.py
+++ b/dojo/unittests/authorization/test_authorization.py
@@ -6,7 +6,7 @@ from dojo.models import Dojo_User, Product_Type, Product_Type_Member, Product, P
     Test, Finding, Endpoint, Dojo_Group, Product_Group, Product_Type_Group, Role, Global_Role, Dojo_Group_Member, \
     Languages, App_Analysis, Stub_Finding
 import dojo.authorization.authorization
-from dojo.authorization.authorization import role_has_permission, get_roles_for_permission, \
+from dojo.authorization.authorization import role_has_permission, get_roles_for_permission, user_has_global_permission, \
     user_has_permission_or_403, user_has_permission, \
     RoleDoesNotExistError, PermissionDoesNotExistError
 from dojo.authorization.roles_permissions import Permissions, Roles
@@ -130,6 +130,13 @@ class TestAuthorization(TestCase):
         cls.group_member.group = cls.group3
         cls.group_member.user = cls.user4
         cls.group_member.role = Role.objects.get(id=Roles.Writer)
+
+        cls.user5 = Dojo_User()
+        cls.user5.id = 5
+        cls.global_role_user = Global_Role()
+        cls.global_role_user.id = 5
+        cls.global_role_user.user = cls.user5
+        cls.global_role_user.role = Role.objects.get(id=Roles.Owner)
 
     def test_role_has_permission_exception(self):
         with self.assertRaisesMessage(RoleDoesNotExistError,
@@ -495,6 +502,14 @@ class TestAuthorization(TestCase):
 
     def test_user_has_global_role_success(self):
         result = user_has_permission(self.user2, self.product, Permissions.Product_View)
+        self.assertTrue(result)
+
+    def test_user_has_global_role_global_permission_no_permission(self):
+        result = user_has_global_permission(self.user2, Permissions.Product_Type_Add)
+        self.assertFalse(result)
+
+    def test_user_has_global_role_global_permission_success(self):
+        result = user_has_global_permission(self.user5, Permissions.Product_Type_Add)
         self.assertTrue(result)
 
     @patch('dojo.models.Dojo_Group.objects')

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -482,6 +482,18 @@ class BaseClass():
             self.client = APIClient()
             self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
 
+        def setUp_global_reader(self):
+            testuser = User.objects.get(id=5)
+            token = Token.objects.get(user=testuser)
+            self.client = APIClient()
+            self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+
+        def setUp_global_owner(self):
+            testuser = User.objects.get(id=6)
+            token = Token.objects.get(user=testuser)
+            self.client = APIClient()
+            self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+
         @skipIfNotSubclass(ListModelMixin)
         def test_list_not_authorized(self):
             if not self.object_permission:
@@ -1475,6 +1487,18 @@ class ProductTypeTest(BaseClass.RESTEndpointTest):
 
         response = self.client.post(self.url, self.payload)
         self.assertEqual(403, response.status_code, response.content[:1000])
+
+    def test_create_not_authorized_reader(self):
+        self.setUp_global_reader()
+
+        response = self.client.post(self.url, self.payload)
+        self.assertEqual(403, response.status_code, response.content[:1000])
+
+    def test_create_authorized_owner(self):
+        self.setUp_global_owner()
+
+        response = self.client.post(self.url, self.payload)
+        self.assertEqual(201, response.status_code, response.content[:1000])
 
 
 class DojoGroupsTest(BaseClass.RESTEndpointTest):


### PR DESCRIPTION
We use a Product Types each external client that we build software for. Ideally some non-staff users can add new Product Types, or in our case the CICD process should be able to add new product types. Currently only staff users can add new product types. But I don't want to use a staff user for my CICD deployments or assign staff permissions to architect or project managers. I think Global Owners and Global Maintainers can basically edit all the findings / engagements / products, so I suggest to also let them add new Product Types.

This PR also extracts some repeated code into a central method. The specialty about this `Permission.Product_Type_Add` is that there is no object id to check the permissions against. Luckily @StefanFl agreed the PR was a good idea, let's hope my implementation pleases the German department of the Defect Dojo team :-)

The PR also changes the wording of `Guest` users in the docs to `Regular` users which I think is a more accurate name for these types of users.