### PR TITLE
Update the nginx-prometheus-exporter entrypoint

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -102,7 +102,7 @@ spec:
       - name: metrics
         image: {{ .Values.monitoring.prometheus.image }}
         imagePullPolicy: {{ .Values.monitoring.prometheus.imagePullPolicy }}
-        command: [ '/usr/bin/exporter', '-nginx.scrape-uri', 'http://127.0.0.1:8080/nginx_status']
+        command: [ '/usr/bin/nginx-prometheus-exporter', '-nginx.scrape-uri', 'http://127.0.0.1:8080/nginx_status']
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
Fix #5414 

The entrypoint has been changed between version 0.8.0 and 0.9.0 of the nginx-prometheus-exporter

