### PR TITLE
Add EmptyDir for CeleryBeat into /run

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.23-dev
+version: 1.6.24-dev
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "2.5.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.24-dev
+version: 1.6.23-dev
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -38,6 +38,8 @@ spec:
       - name: {{ .Values.imagePullSecrets }}
       {{- end }}
       volumes:
+      - name: run
+        emptyDir: {}
       {{- range .Values.celery.extraVolumes }}
       - name: userconfig-{{ .name }}
         {{ .type }}:
@@ -82,6 +84,8 @@ spec:
           {{- toYaml .Values.securityContext.djangoSecurityContext | nindent 10 }}
         {{- end }}
         volumeMounts:
+        - name: run
+          mountPath: /run/defectdojo
         {{- range .Values.celery.extraVolumes }}
         - name: userconfig-{{ .name }}
           readOnly: true


### PR DESCRIPTION
This PR  mounts EmptyDir  into `/run/defectdojo` for CeleryBeat pod.

`    Mounts:
      /run/defectdojo from run (rw)
`

**Why it is important**: When using tools as Kaniko to build image using k8s, build will fail because kaniko can't break symlink for Read Only path (because k8s mounts secret inside of /run/[secrets]...that is symlink to /var/run/[secrets]) during the snapshot.

`
error building image: error building stage: failed to get filesystem from image: error removing var/run to make way for new symlink: unlinkat /var/run/secrets/kubernetes.io/serviceaccount/..data: read-only file system
`

 For that reason extra flag in kaniko should be in use to ignore snapshotting  of `/var`. But than snapshot doesn't include `/var/run/defectdojo`, and docker image at the end as resoult.

While in the django pod, there is already mount `/run/` to EmptyDir,  implementation for CeleryBeat is missing the same, and it results error in pod, because path `/var/run/defectdojo` is missing while is defined as target for `pid` in celery beat entrypoint    