### PR TITLE
Update release-drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,10 +6,14 @@ categories:
   - title: '💣 Breaking changes'
     labels:
       - 'Breaking Changes'
-  - title: '🚩 Requires settings changes, database migration, hash code recomputation'
+  - title: '🚩 Changes to `settings.dist.py` / `local_settings.py`
     labels:
       - 'settings_changes'
+  - title: '🚩 Database migration'
+    labels:
       - 'New Migration'
+  - title: '🚩 Requires hash code recomputation'
+    labels:
       - 'hashcode-update-needed'
   - title: '🚩 Security'
     labels:


### PR DESCRIPTION
(against master branch)

I've updated the language and split the section into 3 sections which makes it more clear I think as recomputing hash codes for examples is not related to database migrations etc.