### PR TITLE
add build arg for userid integration tests

### DIFF
--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -45,7 +45,8 @@ COPY tests/ ./tests/
 
 RUN chmod -R 0777 /app
 
-USER 1001
+ARG uid=1001
+USER ${uid}
 ENV \
   DD_ADMIN_USER=admin \
   DD_ADMIN_PASSWORD='' \


### PR DESCRIPTION
as part of #5424 I noticed the integration tests are running hardcode as user `1001`. I am not saying this PR is the solution to all problems, but still helpful I think to make the userid a build argument so people can locally select the right user id in order to be able to access the filesystem correctly for example to write logs or screenshots during the integration tests.