### PR TITLE
fixed nuclei templates parser

### DIFF
--- a/dojo/tools/nuclei/parser.py
+++ b/dojo/tools/nuclei/parser.py
@@ -24,12 +24,12 @@ class NucleiParser(object):
         else:
             dupes = {}
             for item in data:
-                template_id = item.get('templateID')
+                template_id = item.get('template_id')
                 info = item.get('info')
                 name = info.get('name')
                 severity = info.get('severity').title()
                 type = item.get('type')
-                matched = item.get('matched')
+                matched = item.get('matched_at')
                 if '://' in matched:
                     endpoint = Endpoint.from_uri(matched)
                 else:


### PR DESCRIPTION
Nuclei seems to change names of variables in json reports, fixed to match these names