### PR TITLE
Allow to force login form

### DIFF
--- a/docs/content/en/integrations/social-authentication.md
+++ b/docs/content/en/integrations/social-authentication.md
@@ -315,6 +315,21 @@ Newly created users are neither staff nor superuser by default. The `is_staff` f
 `.*@example.com` will make `alice@example.com` a staff user, while `bob@partner.example.com` or `chris@example.org` will be non-staff users.
 
 
+## Login speed-up
+
+If you are using only one Social authentication and you are not using the standard login mechanism (`SHOW_LOGIN_FORM` is
+set to `False`), showing login page could be useless because every time user clicks on the only existing button on the
+page like "Login with SAML" (or another similar button). If you set `SOCIAL_LOGIN_AUTO_REDIRECT` to `True`, the login
+page is skipped and the user is automatically redirected to the identity provider's page.
+
+### Login form fallback
+
+If you are using "login speed-up", it can be useful to be able to login by the standard way, for example when an admin
+user needs to log in because of a change of some settings or permissions. Accessing
+[`<DD_HOST>/login?force_login_form`](https://<DD_HOST>/login?force_login_form) shows login form even "login speed-up" is
+enabled.
+
+
 ## Other Providers
 
 In an effort to accommodate as much generality as possible, it was

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -11,19 +11,19 @@
                 </div>
             {% endif %}
 
-            {% if SHOW_LOGIN_FORM %}
+            {% if SHOW_LOGIN_FORM or 'force_login_form' in request.GET %}
                {% include "dojo/form_fields.html" with form=form %}
             {% endif %}
 
             <!-- Button -->
             <div class="form-group">
-                {% if SHOW_LOGIN_FORM %}
+                {% if SHOW_LOGIN_FORM or 'force_login_form' in request.GET %}
                     <div class="col-sm-offset-1 col-sm-4" id="toggleBox" onclick="togglePassVisibility()">
                         <i class="fa fa-eye"></i>
                         <span><b>Show Password</b></span>
                     </div>
                 {% endif %}
-                {% if CLASSIC_AUTH_ENABLED and SHOW_LOGIN_FORM %}
+                {% if CLASSIC_AUTH_ENABLED and SHOW_LOGIN_FORM or 'force_login_form' in request.GET %}
                     <div class="col-sm-offset-1 col-sm-1">
                         <button class="btn btn-success">Login</button>
                     </div>

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -80,7 +80,7 @@ def login_view(request):
         settings.GITLAB_OAUTH2_ENABLED,
         settings.AUTH0_OAUTH2_ENABLED,
         settings.SAML2_ENABLED
-    ]) == 1:
+    ]) == 1 and not ('force_login_form' in request.GET):
         if settings.GOOGLE_OAUTH_ENABLED:
             social_auth = 'google-oauth2'
         elif settings.OKTA_OAUTH_ENABLED:


### PR DESCRIPTION
When `SHOW_LOGIN_FORM` is `False`, `SOCIAL_LOGIN_AUTO_REDIRECT` is `True` and there is only one "Social" or "SAML", the login page is skipped and the request is automatically redirected to IdP. However, sometimes it is useful to have available the standard method as last resort (e.g. `admin` user need to log in because of a change of some settings or permissions).

This PR allows forcing login page with form when `<DD_HOST>/login?force_login_form` is accessed.