### PR TITLE
add defectdojo license to yarn package.json

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,7 @@
 {
   "name": "defectdojo",
   "version": "2.5.0-dev",
+  "license" : "BSD-3-Clause",
   "private": true,
   "dependencies": {
     "JUMFlot": "jumjum123/JUMFlot#*",


### PR DESCRIPTION
We have a yarn package, so it should contain our license.

On behalf of DB Systel GmbH