### PR TITLE
feat(saml): configurable login button text

### DIFF
--- a/docs/content/en/integrations/social-authentication.md
+++ b/docs/content/en/integrations/social-authentication.md
@@ -242,6 +242,8 @@ homepage](https://github.com/IdentityPython/djangosaml2).
 
     {{< highlight python >}}
     DD_SAML2_ENABLED=(bool, **True**),
+    # SAML Login Button Text
+    DD_SAML2_LOGIN_BUTTON_TEXT=(str, 'Login with SAML'),
     # If the metadata can be accessed from a url, try the
     DD_SAML2_METADATA_AUTO_CONF_URL=(str, '<https://your_IdP.com/metadata.xml>'),
     # Otherwise, downlaod a copy of the metadata into an xml file, and
@@ -263,8 +265,7 @@ NOTE: *DD_SAML2_ATTRIBUTES_MAP* in k8s can be referenced as extraConfig (e.g. `D
 4.  Checkout the SAML section in dojo/`dojo/settings/settings.dist.py` and verfiy if it fits your requirement. If you need help, take a look at the [plugin
 documentation](https://djangosaml2.readthedocs.io/contents/setup.html#configuration).
 
-5.  Restart DefectDojo, and you should now see a **Login with SAML**
-    button on the login page.
+5.  Restart DefectDojo, and you should now see a **Login with SAML** button (default setting of DD_SAML2_LOGIN_BUTTON_TEXT) on the login page.
 
 NOTE: In the case when IDP is configured to use self signed (private) certificate,
 than CA needs to be specified by define environments variable

--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -12,6 +12,7 @@ def globalize_oauth_vars(request):
             'GITLAB_ENABLED': settings.GITLAB_OAUTH2_ENABLED,
             'AZUREAD_TENANT_OAUTH2_ENABLED': settings.AZUREAD_TENANT_OAUTH2_ENABLED,
             'SAML2_ENABLED': settings.SAML2_ENABLED,
+            'SAML2_LOGIN_BUTTON_TEXT': settings.SAML2_LOGIN_BUTTON_TEXT,
             'SAML2_LOGOUT_URL': settings.SAML2_LOGOUT_URL}
 
 

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -111,6 +111,7 @@ env = environ.Env(
     DD_SOCIAL_AUTH_GITLAB_API_URL=(str, 'https://gitlab.com'),
     DD_SOCIAL_AUTH_GITLAB_SCOPE=(list, ['api', 'read_user', 'openid', 'profile', 'email']),
     DD_SAML2_ENABLED=(bool, False),
+    DD_SAML2_LOGIN_BUTTON_TEXT=(str, 'Login with SAML'),
     # Optional: display the idp SAML Logout URL in DefectDojo
     DD_SAML2_LOGOUT_URL=(str, ''),
     # Metadata is required for SAML, choose either remote url or local file path
@@ -759,6 +760,7 @@ def saml2_attrib_map_format(dict):
 
 
 SAML2_ENABLED = env('DD_SAML2_ENABLED')
+SAML2_LOGIN_BUTTON_TEXT = env('DD_SAML2_LOGIN_BUTTON_TEXT')
 SAML2_LOGOUT_URL = env('DD_SAML2_LOGOUT_URL')
 if SAML2_ENABLED:
     import saml2

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -73,7 +73,7 @@
                 {% if SAML2_ENABLED is True %}
                     <div class="col-sm-offset-1 col-sm-2">
                         <button class="btn btn-success" type="button">
-                            <a id="oauth-login-saml" rel="nofollow" data-method="post" href="/saml2/login" style="color: rgb(255,255,255)">Login with SAML</a>
+                            <a id="oauth-login-saml" rel="nofollow" data-method="post" href="/saml2/login" style="color: rgb(255,255,255)">{{ SAML2_LOGIN_BUTTON_TEXT }}</a>
                         </button>
                     </div>
                 {% endif %}


### PR DESCRIPTION
Many companies have their own names for the SAML Service. Non technical user may don't know what SAML is. Now you can choose a custom name for the login button.

On behalf of DB Systel GmbH