### PR TITLE
Fixed multiple comma/space separated tags issue via API call

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -27,6 +27,7 @@ from django.contrib.auth.password_validation import validate_password
 from django.utils import timezone
 import datetime
 import six
+import re
 from django.utils.translation import ugettext_lazy as _
 import json
 import dojo.jira_link.helper as jira_helper
@@ -104,21 +105,16 @@ class TagListSerializerField(serializers.ListField):
         if not isinstance(data, list):
             self.fail('not_a_list', input_type=type(data).__name__)
 
-        # data_safe = []
+        data_safe = []
         for s in data:
             if not isinstance(s, six.string_types):
                 self.fail('not_a_str')
 
             self.child.run_validation(s)
 
-            # if ' ' in s or ',' in s:
-            #     s = '"%s"' % s
+            data_safe += re.split('[, ]', s)
 
-            # data_safe.append(s)
-
-        # internal_value = ','.join(data_safe)
-
-        internal_value = tagulous.utils.render_tags(data)
+        internal_value = tagulous.utils.render_tags(data_safe)
 
         return internal_value
         # return data

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -27,7 +27,6 @@ from django.contrib.auth.password_validation import validate_password
 from django.utils import timezone
 import datetime
 import six
-import re
 from django.utils.translation import ugettext_lazy as _
 import json
 import dojo.jira_link.helper as jira_helper
@@ -112,7 +111,7 @@ class TagListSerializerField(serializers.ListField):
 
             self.child.run_validation(s)
 
-            data_safe += re.split('[, ]', s)
+            data_safe += tagulous.utils.parse_tags(s, max_count=0, space_delimiter=True)
 
         internal_value = tagulous.utils.render_tags(data_safe)
 

--- a/dojo/unittests/test_rest_framework.py
+++ b/dojo/unittests/test_rest_framework.py
@@ -353,7 +353,7 @@ class BaseClass():
                 tag_list = []
                 for tag_string in self.payload.get('tags', None):
                     tag_list += tagulous.utils.parse_tags(tag_string, max_count=0, space_delimiter=True)
-                
+
                 self.assertEqual(len(tag_list), len(response.data.get('tags', None)))
                 for tag in tag_list:
                     # logger.debug('looking for tag %s in tag list %s', tag, response.data['tags'])

--- a/dojo/unittests/test_tags.py
+++ b/dojo/unittests/test_tags.py
@@ -155,61 +155,69 @@ class TagTests(DojoAPITestCase):
         return self.test_finding_put_remove_tags_non_existent()
 
     def test_finding_create_tags_with_commas(self):
-        tags = ['one,two']
+        tags = ['tag1,tag2']
         finding_id = self.create_finding_with_tags(tags)
         response = self.get_finding_tags_api(finding_id)
 
-        # the old django-tagging library was splitting this tag into 2 tags
-        # with djangotagulous the tag does no longer get split up and we cannot modify tagulous
-        # to keep doing the old behaviour. so this is a small incompatibility, but only for
-        # tags with commas, so should be minor trouble
-        #
-        # self.assertEqual(2, len(response.get('tags')))
-        self.assertEqual(1, len(response.get('tags')))
+        # Tagulous tag string parser tokenizes tag string values by both commas and spaces.
+        # If a tag string contains both spaces and commas, commas take higher priority.
+        # If a tag name contains a space or comma, it should be escaped by "" for clarity.
+        # Therefore, ['tag1,tag2'] would render two tags, 'tag1' and 'tag2', using commas as the delimiter.
+
+        self.assertEqual(2, len(response.get('tags')))
         # print("response['tags']:" + str(response['tags']))
-        self.assertTrue('one' in str(response['tags']))
-        self.assertTrue('two' in str(response['tags']))
+        self.assertTrue('tag1' in str(response['tags']))
+        self.assertTrue('tag2' in str(response['tags']))
 
     def test_finding_create_tags_with_commas_quoted(self):
-        tags = ['"one,two"']
+        tags = ['"tag1,tag2"']
         finding_id = self.create_finding_with_tags(tags)
         response = self.get_finding_tags_api(finding_id)
 
-        # no splitting due to quotes
+        # Tagulous tag string parser tokenizes tag string values by both commas and spaces.
+        # If a tag string contains both spaces and commas, commas take higher priority.
+        # If a tag name contains a space or comma, it should be escaped by "" for clarity.
+        # Therefore, ['"tag1,tag2"'] renders one tag, 'tag1,tag2', because it is escaped by "".
+
         self.assertEqual(len(tags), len(response.get('tags', None)))
         for tag in tags:
             logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
             # with django-tagging the quotes were stripped, with tagulous they remain
-            # self.assertTrue(tag.strip('\"') in response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertTrue(tag.strip('\"') in response['tags'])
+            # self.assertTrue(tag in response['tags'])
 
     def test_finding_create_tags_with_spaces(self):
-        tags = ['one two']
+        tags = ['tag1 tag2']
         finding_id = self.create_finding_with_tags(tags)
         response = self.get_finding_tags_api(finding_id)
 
-        # the old django-tagging library was splitting this tag into 2 tags
-        # with djangotagulous the tag does no longer get split up and we cannot modify tagulous
-        # to keep doing the old behaviour. so this is a small incompatibility, but only for
-        # tags with commas, so should be minor trouble
+        # Tagulous tag string parser tokenizes tag string values by both commas and spaces.
+        # If a tag string contains both spaces and commas, commas take higher priority.
+        # If a tag name contains a space or comma, it should be escaped by "" for clarity.
+        # Therefore, ['tag1 tag2'] renders two tags, 'tag1' and 'tag2', using spaces as the delimiter.
+
         # self.assertEqual(2, len(response.get('tags')))
-        self.assertEqual(1, len(response.get('tags')))
-        self.assertTrue('one' in str(response['tags']))
-        self.assertTrue('two' in str(response['tags']))
+        self.assertEqual(2, len(response.get('tags')))
+        self.assertTrue('tag1' in str(response['tags']))
+        self.assertTrue('tag2' in str(response['tags']))
         # finding.tags: [<Tag: one>, <Tag: two>]
 
     def test_finding_create_tags_with_spaces_quoted(self):
-        tags = ['"one two"']
+        tags = ['"tag1 tag2"']
         finding_id = self.create_finding_with_tags(tags)
         response = self.get_finding_tags_api(finding_id)
 
-        # no splitting due to quotes
+        # Tagulous tag string parser tokenizes tag string values by both commas and spaces.
+        # If a tag string contains both spaces and commas, commas take higher priority.
+        # If a tag name contains a space or comma, it should be escaped by "" for clarity.
+        # Therefore, ['"tag1 tag2"'] renders one tag, 'tag1 tag2', because it is escaped by "".
+
         self.assertEqual(len(tags), len(response.get('tags', None)))
         for tag in tags:
             logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
             # with django-tagging the quotes were stripped, with tagulous they remain
-            # self.assertTrue(tag.strip('\"') in response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertTrue(tag.strip('\"') in response['tags'])
+            # self.assertTrue(tag in response['tags'])
 
         # finding.tags: <QuerySet [<Tag: one two>]>
 


### PR DESCRIPTION
Previously, an API call with tags in the format of "test:tag1,test:tag2,test:tag3" would import as one tag of "test:tag1,test:tag2,test:tag3"

With this fix, tags of this format will now import as regular looking tags, i.e. "test:tag1", "test:tag2", "test:tag3"