### PR TITLE
optimize GHA unit test

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -61,7 +61,7 @@ jobs:
 
       # phased startup so we can use the exit code from unit test container
       - name: Start MySQL
-        run: docker-compose up -d
+        run: docker-compose up -d mysql
 
       # no celery or initializer needed for unit tests
       - name: Unit tests


### PR DESCRIPTION
I noticed that unit test runs for recent PRs in GHA seem to build the `nginx` image from scratch, even though it's declared as `busybox` in the docker compose override. I don't understand why, but the easier fix is to just not start `nginx` (nor `celerybeat`, `celeryworker`, `initializer`, `rabbitmq`) during unit tests. Those are not needed.