### PR TITLE
fix(helm): allow disabling initializer job

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.initializer.run  }}
 {{- $fullName := include "defectdojo.fullname" . -}}
 apiVersion: batch/v1
 kind: Job
@@ -86,3 +87,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
   backoffLimit: 1
+{{- end }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -18,6 +18,10 @@ spec:
         defectdojo.org/component: initializer
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+      {{- with .Values.initializer.annotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ $fullName }}
       {{- if .Values.imagePullSecrets }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -247,6 +247,7 @@ django:
 
 initializer:
   run: true
+  annotations: {}
   keepSeconds: 60
   affinity: {}
   nodeSelector: {}


### PR DESCRIPTION
There is `initializer.run: true` in default **values.yaml**, but it isn't used anywhere.

I'd like to add the opportunity to disable the initializer job.
Also, it would be great to make it possible to add annotations to the initializer job.

UPD: annotations support for init job was added :)