### PR TITLE
Fix files API

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -367,14 +367,14 @@ class EngagementViewSet(mixins.ListModelMixin,
     )
     @swagger_auto_schema(
         method='get',
-        responses={status.HTTP_200_OK: serializers.FileSerializer}
+        responses={status.HTTP_200_OK: serializers.EngagementToFilesSerializer}
     )
     @swagger_auto_schema(
-        methods=['post', 'patch'],
+        method='post',
         request_body=serializers.AddNewFileOptionSerializer,
-        responses={status.HTTP_200_OK: serializers.FileSerializer}
+        responses={status.HTTP_201_CREATED: serializers.FileSerializer}
     )
-    @action(detail=True, methods=["get", "post", "patch"])
+    @action(detail=True, methods=["get", "post"], parser_classes=(MultiPartParser,))
     def files(self, request, pk=None):
         engagement = self.get_object()
         if request.method == 'POST':
@@ -383,33 +383,20 @@ class EngagementViewSet(mixins.ListModelMixin,
                 title = new_file.validated_data['title']
                 file = new_file.validated_data['file']
             else:
-                return Response(new_file.errors,
-                    status=status.HTTP_400_BAD_REQUEST)
+                return Response(new_file.errors, status=status.HTTP_400_BAD_REQUEST)
 
             file = FileUpload(title=title, file=file)
             file.save()
             engagement.files.add(file)
 
-            serialized_file = serializers.FileSerializer({
-                "title": title, "file": file,
-            })
-            result = serializers.EngagementToFilesSerializer({
-                "engagement_id": engagement, "files": [serialized_file.data]
-            })
-            return Response(serialized_file.data,
-                status=status.HTTP_200_OK)
+            serialized_file = serializers.FileSerializer(file)
+            return Response(serialized_file.data, status=status.HTTP_201_CREATED)
+
         files = engagement.files.all()
-
-        serialized_files = []
-        if files:
-            serialized_files = serializers.EngagementToFilesSerializer({
-                    "engagement_id": engagement, "files": files
-            })
-            return Response(serialized_files.data,
-                    status=status.HTTP_200_OK)
-
-        return Response(serialized_files,
-                status=status.HTTP_200_OK)
+        serialized_files = serializers.EngagementToFilesSerializer({
+            "engagement_id": engagement, "files": files
+        })
+        return Response(serialized_files.data, status=status.HTTP_200_OK)
 
 
 # These are technologies in the UI and the API!
@@ -677,18 +664,18 @@ class FindingViewSet(prefetch.PrefetchListMixin,
     @extend_schema(
         methods=['POST'],
         request=serializers.AddNewFileOptionSerializer,
-        responses={status.HTTP_201_CREATED: serializers.FindingToFilesSerializer}
+        responses={status.HTTP_201_CREATED: serializers.FileSerializer}
     )
     @swagger_auto_schema(
         method='get',
         responses={status.HTTP_200_OK: serializers.FindingToFilesSerializer}
     )
     @swagger_auto_schema(
-        methods=['post', 'patch'],
+        method='post',
         request_body=serializers.AddNewFileOptionSerializer,
-        responses={status.HTTP_200_OK: serializers.FindingToFilesSerializer}
+        responses={status.HTTP_201_CREATED: serializers.FileSerializer}
     )
-    @action(detail=True, methods=["get", "post", "patch"])
+    @action(detail=True, methods=["get", "post"], parser_classes=(MultiPartParser,))
     def files(self, request, pk=None):
         finding = self.get_object()
         if request.method == 'POST':
@@ -697,33 +684,20 @@ class FindingViewSet(prefetch.PrefetchListMixin,
                 title = new_file.validated_data['title']
                 file = new_file.validated_data['file']
             else:
-                return Response(new_file.errors,
-                    status=status.HTTP_400_BAD_REQUEST)
+                return Response(new_file.errors, status=status.HTTP_400_BAD_REQUEST)
 
             file = FileUpload(title=title, file=file)
             file.save()
             finding.files.add(file)
 
-            serialized_file = serializers.FileSerializer({
-                "title": title, "file": file,
-            })
-            result = serializers.FindingToFilesSerializer({
-                "finding_id": finding, "files": [serialized_file.data]
-            })
-            return Response(serialized_file.data,
-                status=status.HTTP_200_OK)
+            serialized_file = serializers.FileSerializer(file)
+            return Response(serialized_file.data, status=status.HTTP_201_CREATED)
+
         files = finding.files.all()
-
-        serialized_files = []
-        if files:
-            serialized_files = serializers.FindingToFilesSerializer({
-                    "finding_id": finding, "files": files
-            })
-            return Response(serialized_files.data,
-                    status=status.HTTP_200_OK)
-
-        return Response(serialized_files,
-                status=status.HTTP_200_OK)
+        serialized_files = serializers.FindingToFilesSerializer({
+            "finding_id": finding, "files": files
+        })
+        return Response(serialized_files.data, status=status.HTTP_200_OK)
 
     @extend_schema(
         request=serializers.FindingNoteSerializer,
@@ -1663,11 +1637,11 @@ class TestsViewSet(mixins.ListModelMixin,
         responses={status.HTTP_200_OK: serializers.TestToFilesSerializer}
     )
     @swagger_auto_schema(
-        methods=['post', 'patch'],
+        method='post',
         request_body=serializers.AddNewFileOptionSerializer,
-        responses={status.HTTP_200_OK: serializers.FileSerializer}
+        responses={status.HTTP_201_CREATED: serializers.FileSerializer}
     )
-    @action(detail=True, methods=["get", "post", "patch"])
+    @action(detail=True, methods=["get", "post"], parser_classes=(MultiPartParser,))
     def files(self, request, pk=None):
         test = self.get_object()
         if request.method == 'POST':
@@ -1676,33 +1650,20 @@ class TestsViewSet(mixins.ListModelMixin,
                 title = new_file.validated_data['title']
                 file = new_file.validated_data['file']
             else:
-                return Response(new_file.errors,
-                    status=status.HTTP_400_BAD_REQUEST)
+                return Response(new_file.errors, status=status.HTTP_400_BAD_REQUEST)
 
             file = FileUpload(title=title, file=file)
             file.save()
             test.files.add(file)
 
-            serialized_file = serializers.FileSerializer({
-                "title": title, "file": file,
-            })
-            result = serializers.TestToFilesSerializer({
-                "test_id": test, "files": [serialized_file.data]
-            })
-            return Response(serialized_file.data,
-                status=status.HTTP_200_OK)
+            serialized_file = serializers.FileSerializer(file)
+            return Response(serialized_file.data, status=status.HTTP_201_CREATED)
+
         files = test.files.all()
-
-        serialized_files = []
-        if files:
-            serialized_files = serializers.TestToFilesSerializer({
-                    "test_id": test, "files": files
-            })
-            return Response(serialized_files.data,
-                    status=status.HTTP_200_OK)
-
-        return Response(serialized_files,
-                status=status.HTTP_200_OK)
+        serialized_files = serializers.TestToFilesSerializer({
+            "test_id": test, "files": files
+        })
+        return Response(serialized_files.data, status=status.HTTP_200_OK)
 
 
 # Authorization: authenticated users

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -765,7 +765,7 @@ class FindingFilesTest(DojoAPITestCase):
                 "file": open(str(path) + '/scans/acunetix/one_finding.xml')
             }
             response = self.client.post('/api/v2/' + level + '/files/', payload)
-            self.assertEqual(200, response.status_code, response.data)
+            self.assertEqual(201, response.status_code, response.data)
             self.assertEqual(FileUpload.objects.count(), length + 1)
 
     def test_request_response_get(self):


### PR DESCRIPTION
fixes #5502

The API to upload files to engagements, tests and findings is actually working, but the implementation made it hard to figure out how and generated a not very useful swagger description. With the new implementation the swagger description is consistent with other file uploads. There are 2 changes to the API:

- The return code for a successful ``post`` has been changed to 201 (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201)
- The ``patch`` method didn't work at all and has been deleted.