### PR TITLE
Go to user view after user add

### DIFF
--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -103,7 +103,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">Product Type Members</h4>
+                    <h4 class="pull-left">Product Type Membership</h4>
                     &nbsp;
                     <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
                         <i class="fa fa-question-circle"></i></a>
@@ -176,7 +176,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">Product Members</h4>
+                    <h4 class="pull-left">Product Membership</h4>
                     &nbsp;
                     <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/" target="_blank">
                         <i class="fa fa-question-circle"></i></a>
@@ -250,7 +250,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">Group Members</h4>
+                    <h4 class="pull-left">Group Membership</h4>
                     &nbsp;
                     <a href="https://defectdojo.github.io/django-DefectDojo/usage/permissions/#groups" target="_blank">
                         <i class="fa fa-question-circle"></i></a>

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -302,9 +302,9 @@ def add_user(request):
                         pt.save()
             messages.add_message(request,
                                  messages.SUCCESS,
-                                 'User added successfully, you may edit if necessary.',
+                                 'User added successfully.',
                                  extra_tags='alert-success')
-            return HttpResponseRedirect(reverse('edit_user', args=(user.id,)))
+            return HttpResponseRedirect(reverse('view_user', args=(user.id,)))
         else:
             messages.add_message(request,
                                  messages.ERROR,

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -59,7 +59,7 @@ class UserTest(BaseTestCase):
         # Query the site to determine if the user has been created
 
         # Assert ot the query to dtermine status of failure
-        self.assertTrue(self.is_success_message_present(text='User added successfully, you may edit if necessary.') or
+        self.assertTrue(self.is_success_message_present(text='User added successfully.') or
             self.is_help_message_present(text='A user with that username already exists.'))
 
     def login_standard_page(self):


### PR DESCRIPTION
#5499

Adding a user behaves differently from other dialogues. When you add all other objects, you get redirected to the page to view the object. But when you add an user, you stay on that page and can edit the user. This gets changed with this PR and the user is redirected to the view user page, so they can add the user to a group, product or product type there.