### PR TITLE
fix duplicate notification urls

### DIFF
--- a/dojo/notifications/urls.py
+++ b/dojo/notifications/urls.py
@@ -3,6 +3,6 @@ from . import views
 
 urlpatterns = [
     url(r'^notifications$', views.personal_notifications, name='notifications'),
-    url(r'^notifications/system$', views.system_notifications, name='notifications'),
-    url(r'^notifications/personal$', views.personal_notifications, name='notifications')
+    url(r'^notifications/system$', views.system_notifications, name='system_notifications'),
+    url(r'^notifications/personal$', views.personal_notifications, name='personal_notifications')
 ]


### PR DESCRIPTION
some non-unique names where used for urls. Only the first one of these 3 was used, so I renamed the bottom 2.

as raised in #5513 