### PR TITLE
support multi-arch docker images and update base to debian bullseye

### DIFF
--- a/.github/workflows/release-2-tag-docker-push.yml
+++ b/.github/workflows/release-2-tag-docker-push.yml
@@ -108,6 +108,9 @@ jobs:
       - id: set-repo-org
         run: echo ::set-output name=repoorg::${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
@@ -131,6 +134,7 @@ jobs:
           docker-image: ${{ matrix.docker-image }}
         with:
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:latest
           file: ./Dockerfile.${{ env.docker-image }}
           context: .

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -5,13 +5,12 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.8.13-slim-bullseye@sha256:0e07cc072353e6b10de910d8acffa020a42467112ae6610aa90d6a3c56a74911 as base
+FROM python:3.8.13-slim-bullseye@sha256:08edff106b552a2d9bac5ad95db6a985598e29852b9efbc6c840db27fefc31ae as base
 FROM base as build
 WORKDIR /app
 RUN \
   apt-get -y update && \
   apt-get -y install --no-install-recommends \
-    gcc \
     build-essential \
     dnsutils \
     default-mysql-client \
@@ -25,6 +24,7 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 COPY requirements.txt ./
+
 # CPUCOUNT=1 is needed, otherwise the wheel for uwsgi won't always be build succesfully
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
 RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -4,8 +4,7 @@
 # The code for the build image should be identical with the code in
 # Dockerfile.django to use the caching mechanism of Docker.
 
-# Ref: https://devguide.python.org/#branchstatus
-FROM python:3.8.13-slim-bullseye@sha256:0e07cc072353e6b10de910d8acffa020a42467112ae6610aa90d6a3c56a74911 as base
+FROM python:3.8.13-slim-bullseye@sha256:08edff106b552a2d9bac5ad95db6a985598e29852b9efbc6c840db27fefc31ae as base
 FROM base as build
 WORKDIR /app
 RUN \
@@ -25,10 +24,10 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 COPY requirements.txt ./
+
 # CPUCOUNT=1 is needed, otherwise the wheel for uwsgi won't always be build succesfully
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
 RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
-
 
 FROM build AS collectstatic
 


### PR DESCRIPTION
This PR accomplishes two things:
1. Adapts the github workflows, so that both a multi-arch image is build, for both arm64 and amd64
2. Updates the base images of defectdojo-django and defectdojo-nginx docker images from debian buster to bullseye

For 1, an additional github action is added, to provide QEMU, which is used to provide emulated environments for building on architecture other than the host arch. Additionally, platforms need to be specified.

Closes #5525 