### PR TITLE
add logic if external redis is used

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -102,8 +102,23 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if eq .Values.celery.broker "rabbitmq" }}
+            {{- if eq .Values.rabbitmq.enabled "true" }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
+            {{- else }}
+              name: {{ .Values.rabbitmq.existingPasswordSecret }}
+              key: {{ .Values.rabbitmq.secretPasswordKey }}  
+            {{- end }}            
+            {{- else if eq .Values.celery.broker "redis" }}
+            {{- if eq .Values.redis.enabled "true" }}
+              name: defectdojo-{{ .Values.celery.broker }}-specific
+              key: {{ .Values.celery.broker }}-password
+            {{- else }}
+              name: {{ .Values.redis.existingSecret }}
+              key: {{ .Values.redis.secretKey }}
+            {{- end }}  
+            {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -103,7 +103,7 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            {{- if eq .Values.rabbitmq.enabled "true" }}
+            {{- if .Values.rabbitmq.enabled }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}
@@ -111,7 +111,7 @@ spec:
               key: {{ .Values.rabbitmq.secretPasswordKey }}  
             {{- end }}            
             {{- else if eq .Values.celery.broker "redis" }}
-            {{- if eq .Values.redis.enabled "true" }}
+            {{- if .Values.redis.enabled }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -97,8 +97,23 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if eq .Values.celery.broker "rabbitmq" }}
+            {{- if eq .Values.rabbitmq.enabled "true" }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
+            {{- else }}
+              name: {{ .Values.rabbitmq.existingPasswordSecret }}
+              key: {{ .Values.rabbitmq.secretPasswordKey }}  
+            {{- end }}            
+            {{- else if eq .Values.celery.broker "redis" }}
+            {{- if eq .Values.redis.enabled "true" }}
+              name: defectdojo-{{ .Values.celery.broker }}-specific
+              key: {{ .Values.celery.broker }}-password
+            {{- else }}
+              name: {{ .Values.redis.existingSecret }}
+              key: {{ .Values.redis.secretKey }}
+            {{- end }}  
+            {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -98,7 +98,7 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            {{- if eq .Values.rabbitmq.enabled "true" }}
+            {{- if .Values.rabbitmq.enabled}}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}
@@ -106,7 +106,7 @@ spec:
               key: {{ .Values.rabbitmq.secretPasswordKey }}  
             {{- end }}            
             {{- else if eq .Values.celery.broker "redis" }}
-            {{- if eq .Values.redis.enabled "true" }}
+            {{- if .Values.redis.enabled }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -156,8 +156,23 @@ spec:
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
+            {{- if eq .Values.celery.broker "rabbitmq" }}
+            {{- if eq .Values.rabbitmq.enabled "true" }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
+            {{- else }}
+              name: {{ .Values.rabbitmq.existingPasswordSecret }}
+              key: {{ .Values.rabbitmq.secretPasswordKey }}  
+            {{- end }}            
+            {{- else if eq .Values.celery.broker "redis" }}
+            {{- if eq .Values.redis.enabled "true" }}
+              name: defectdojo-{{ .Values.celery.broker }}-specific
+              key: {{ .Values.celery.broker }}-password
+            {{- else }}
+              name: {{ .Values.redis.existingSecret }}
+              key: {{ .Values.redis.secretKey }}
+            {{- end }}  
+            {{- end }}
         {{- if .Values.django.uwsgi.enable_debug }}
         - name: DD_DEBUG
           value: 'True'

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -157,7 +157,7 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            {{- if eq .Values.rabbitmq.enabled "true" }}
+            {{- if .Values.rabbitmq.enabled }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}
@@ -165,7 +165,7 @@ spec:
               key: {{ .Values.rabbitmq.secretPasswordKey }}  
             {{- end }}            
             {{- else if eq .Values.celery.broker "redis" }}
-            {{- if eq .Values.redis.enabled "true" }}
+            {{- if .Values.redis.enabled }}
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -188,7 +188,7 @@ django:
     app_settings:
       processes: 2
       threads: 2
-    enable_debugpy: false  # this also requires DD_DEBUG to be set to True
+    enable_debug: false  # this also requires DD_DEBUG to be set to True
     certificates:
     # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
     # to create configMap `kubectl create  cm defectdojo-ca-certs --from-file=ca.crt`
@@ -355,6 +355,7 @@ rabbitmq:
     password: ""
     erlangCookie: ""
     existingPasswordSecret: defectdojo-rabbitmq-specific
+    secretPasswordKey: ""
     existingErlangSecret: defectdojo-rabbitmq-specific
   memoryHighWatermark:
     enabled: true


### PR DESCRIPTION
hi guys!
I've discovered the issue, that secret name for message broker is hardcoded in the helm chart when redis is used. I've added the logic to fix it.
I fixed the a typo in the values.yaml:  name for the django debug value, and added name of the key in the rabbimq secret.

This is a duplicate of https://github.com/DefectDojo/django-DefectDojo/pull/5533 but with merged recent changes from dev branch. 