### PR TITLE
Add organizational blocks around metrics.js files

### DIFF
--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -196,7 +196,9 @@
         <script src="{% static "JUMFlot/javascripts/jquery.flot.mouse.js" %}"></script>
         <script src="{% static "JUMFlot/javascripts/jquery.flot.bubbles.js" %}"></script>
     {% endif %}
-    <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% block metrics %}
+        <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% endblock metrics %}
     <script>
         $(function () {
             setInterval(function () {

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -242,7 +242,9 @@
         <script src="{% static "JUMFlot/javascripts/jquery.flot.mouse.js" %}"></script>
         <script src="{% static "JUMFlot/javascripts/jquery.flot.bubbles.js" %}"></script>
     {% endif %}
-    <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% block metrics %}
+        <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% endblock metrics %}
     <script>
         $(function () {
             var critical = "{{critical}}";

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -647,7 +647,9 @@
     {% include "dojo/filter_js_snippet.html" %}
     <script src="{% static "justgage/raphael.min.js" %}"></script>
     <script src="{% static "justgage/justgage.js" %}"></script>
-    <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% block metrics %}
+        <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% endblock metrics %}
     <script>
         $('.gaugeloop').each(function () {
             j_obj = $(this);

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -311,7 +311,9 @@
         <script src="{{ host }}{% static "JUMFlot/javascripts/jquery.flot.mouse.js" %}"></script>
         <script src="{{ host }}{% static "JUMFlot/javascripts/jquery.flot.bubbles.js" %}"></script>
     {% endif %}
-    <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% block metrics %}
+        <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% endblock metrics %}
     <script type="text/javascript">
         $(function () {
             var critical = 0;

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -479,7 +479,9 @@
     {% endif %}
     <script src="{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{% static "jquery.flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
-    <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% block metrics %}
+        <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% endblock metrics %}
     <script type="text/javascript">
         $(function () {
             if (document.referrer.indexOf('simple_search') > 0) {

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -309,7 +309,9 @@
     <script src="{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
     <script src="{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
-    <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% block metrics %}
+        <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% endblock metrics %}
     <script type="text/javascript">
         $(function () {
             $(document).on('click', '.panel-heading button.clickable', function (e) {

--- a/dojo/templates/dojo/view_engineer.html
+++ b/dojo/templates/dojo/view_engineer.html
@@ -581,7 +581,9 @@
     <script src="{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{% static "jquery.flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
     <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% block metrics %}
+        <script src="{% static "dojo/js/metrics.js" %}"></script>
+    {% endblock metrics %}
     <script>
         $(function () {
             var critical = [];

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -592,7 +592,9 @@
   <script src="{% static "jquery.flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
   <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
   <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
-  <script src="{% static "dojo/js/metrics.js" %}"></script>
+  {% block metrics %}
+      <script src="{% static "dojo/js/metrics.js" %}"></script>
+  {% endblock metrics %}
   <script type="text/javascript">
     $(function() {
       if (document.referrer.indexOf('simple_search') > 0) {


### PR DESCRIPTION
Add some blocks around the metrics page to organize them and easily swap the file out for custom colors

Here are some docs on template inheritance: https://docs.djangoproject.com/en/3.2/ref/templates/language/#template-inheritance