### PR TITLE
Set default_auto_field after migration to Django 3.2

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -301,6 +301,10 @@ else:
 if env('DD_TRACK_MIGRATIONS'):
     MIGRATION_MODULES = {'dojo': 'dojo.db_migrations'}
 
+# Default for automatically created id fields, 
+# see https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 # ------------------------------------------------------------------------------
 # MEDIA
 # ------------------------------------------------------------------------------

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -301,7 +301,7 @@ else:
 if env('DD_TRACK_MIGRATIONS'):
     MIGRATION_MODULES = {'dojo': 'dojo.db_migrations'}
 
-# Default for automatically created id fields, 
+# Default for automatically created id fields,
 # see https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 


### PR DESCRIPTION
fixes #5538

see https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys and https://docs.djangoproject.com/en/3.2/topics/db/models/#automatic-primary-key-fields