### PR TITLE
Fix alias paths in nginx config

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,11 +27,11 @@ http {
     location = /50x.html {
       root /usr/share/nginx/html;
     }
-    location /static {
-      alias /usr/share/nginx/html/static;
+    location /static/ {
+      alias /usr/share/nginx/html/static/;
     }
-    location /media {
-        alias /usr/share/nginx/html/media;
+    location /media/ {
+        alias /usr/share/nginx/html/media/;
     }
     location / {
       include /run/defectdojo/uwsgi_pass;

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -44,11 +44,11 @@ http {
     location = /50x.html {
         root                    /usr/share/nginx/html;
     }
-    location /static {
-      alias /usr/share/nginx/html/static;
+    location /static/ {
+      alias /usr/share/nginx/html/static/;
     }
-    location /media {
-      alias /usr/share/nginx/html/media;
+    location /media/ {
+      alias /usr/share/nginx/html/media/;
     }
     location / {
       include /run/defectdojo/uwsgi_pass;


### PR DESCRIPTION
This is a best practice change for nginx config. There is no misconfiguration at the moment.

There are two reasons for making these changes:
1. It is recommended by the official docs.
2. Prevents path traversal bugs that might happen due to future changes in configs:
```
// not vulnerable to path traversal (current)
 location /static {
      alias /usr/share/nginx/html/static;

// vulnerable to path traversal (example)
 location /static {
      alias /usr/share/nginx/html/static/;
```


Docs & References:
https://nginx.org/en/docs/http/ngx_http_core_module.html#alias
https://github.com/yandex/gixy/blob/master/docs/en/plugins/aliastraversal.md
https://blog.detectify.com/2020/11/10/common-nginx-misconfigurations/
