### PR TITLE
add support for more than one hostname in defectdojo

### DIFF
--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
   DD_ADMIN_MAIL: {{ .Values.admin.Mail | default "admin@defectdojo.local" }}
   DD_ADMIN_FIRST_NAME: {{ .Values.admin.FirstName | default "Admin" }}
   DD_ADMIN_LAST_NAME: {{ .Values.admin.LastName | default "User" }}
-  DD_ALLOWED_HOSTS: {{ .Values.host }}
+  DD_ALLOWED_HOSTS: "{{- join "," .Values.hosts }}"
   DD_CELERY_BROKER_SCHEME: {{ if eq .Values.celery.broker "rabbitmq" }}amqp{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ template "redis.scheme" . }}{{ end }}
   DD_CELERY_BROKER_USER: '{{ if eq .Values.celery.broker "rabbitmq" }}user{{ end }}'
   DD_CELERY_BROKER_HOST: {{ if eq .Values.celery.broker "rabbitmq" }}{{ .Release.Name }}-rabbitmq{{ else if eq .Values.celery.broker "redis" }}{{ template "redis.hostname" . }}{{ end }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -1,4 +1,5 @@
 {{- $fullName := include "defectdojo.fullname" . -}}
+{{- $hostName := index .Values.hosts 0}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -193,7 +194,7 @@ spec:
             port: http
             httpHeaders:
             - name: Host
-              value: {{ .Values.host }}
+              value: {{ $hostName }}
           failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds }}
@@ -250,7 +251,7 @@ spec:
             {{- end }}
             httpHeaders:
             - name: Host
-              value: {{ .Values.host }}
+              value: {{ $hostName  }}
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 6
@@ -264,7 +265,7 @@ spec:
             {{- end }}
             httpHeaders:
             - name: Host
-              value: {{ .Values.host }}
+              value: {{ $hostName }}
           failureThreshold: {{ .Values.django.uwsgi.livenessProbe.failureThreshold }}
           initialDelaySeconds: {{ .Values.django.uwsgi.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.django.uwsgi.livenessProbe.periodSeconds }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -20,7 +20,10 @@ createPostgresqlSecret: false
 # Option to use "postgresql" or "mysql" database type, by default "mysql" is chosen
 # Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select
 database: postgresql
-host: defectdojo.default.minikube.local
+hosts:
+  - defectdojo.default.minikube.local
+  - defectdojo.example.com
+
 imagePullPolicy: Always
 # Where to pull the defectDojo images from. Defaults to "defectdojo/*" repositories on hub.docker.com
 repositoryPrefix: defectdojo


### PR DESCRIPTION
This is a simple hack to deal with a real annoyance I had with leveraging DD's API for submitting within k8s and having a different public/gated web frontend.

It won't help those who already use this helm deployment model. But it seems easy enough to adjust to it.