### PR TITLE
Fix: Solar Appscreener - add line property

### DIFF
--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -43,11 +43,13 @@ class SolarAppscreenerParser(object):
             finding.severity = row.get('Severity Level', 'Info')
             finding.file_path = row.get('File', '')
             finding.sast_source_file_path = row.get('File', '')
-            finding.sast_source_line = row.get('Line', '')
+            finding.line = row.get('Line', '')
 
-            if not finding.sast_source_line.isdigit():
-                finding.sast_source_line = finding.sast_source_line.split(
+            if not finding.line.isdigit():
+                finding.line = finding.line.split(
                     "-")[0]
+
+            finding.sast_source_line = finding.line
 
             if finding is not None:
                 if finding.title is None:
@@ -55,8 +57,8 @@ class SolarAppscreenerParser(object):
                 if finding.description is None:
                     finding.description = ""
 
-                key = hashlib.sha256((finding.title + '|' + finding.sast_source_file_path +
-                                     '|' + finding.sast_source_line).encode("utf-8")).hexdigest()
+                key = hashlib.sha256((finding.title + '|' + finding.file_path +
+                                     '|' + finding.line).encode("utf-8")).hexdigest()
 
                 if key not in dupes:
                     dupes[key] = finding

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -46,8 +46,7 @@ class SolarAppscreenerParser(object):
             finding.line = row.get('Line', '')
 
             if not finding.line.isdigit():
-                finding.line = finding.line.split(
-                    "-")[0]
+                finding.line = int(finding.line.split("-")[0])
 
             finding.sast_source_line = finding.line
 

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -46,7 +46,9 @@ class SolarAppscreenerParser(object):
             finding.line = row.get('Line', '')
 
             if not finding.line.isdigit():
-                finding.line = int(finding.line.split("-")[0])
+                finding.line = finding.line.split("-")[0]
+
+            finding.line = int(finding.line)
 
             finding.sast_source_line = finding.line
 
@@ -57,7 +59,7 @@ class SolarAppscreenerParser(object):
                     finding.description = ""
 
                 key = hashlib.sha256((finding.title + '|' + finding.file_path +
-                                     '|' + finding.line).encode("utf-8")).hexdigest()
+                                     '|' + finding.line.__str__()).encode("utf-8")).hexdigest()
 
                 if key not in dupes:
                     dupes[key] = finding

--- a/unittests/tools/test_solar_appscreener_parser.py
+++ b/unittests/tools/test_solar_appscreener_parser.py
@@ -27,7 +27,7 @@ class TestSolarAppscreenerParser(DojoTestCase):
         self.assertEqual("Hardcoded password", finding.title)
         self.assertEqual("Critical", finding.severity)
         self.assertEqual("misc/shared.php", finding.file_path)
-        self.assertEqual("151", finding.line)
+        self.assertEqual(151, finding.line)
         self.assertEqual("misc/shared.php", finding.sast_source_file_path)
         self.assertEqual(151, finding.sast_source_line)
 

--- a/unittests/tools/test_solar_appscreener_parser.py
+++ b/unittests/tools/test_solar_appscreener_parser.py
@@ -26,6 +26,8 @@ class TestSolarAppscreenerParser(DojoTestCase):
         self.assertEqual(1, len(findings))
         self.assertEqual("Hardcoded password", finding.title)
         self.assertEqual("Critical", finding.severity)
+        self.assertEqual("misc/shared.php", finding.file_path)
+        self.assertEqual("151", finding.line)
         self.assertEqual("misc/shared.php", finding.sast_source_file_path)
         self.assertEqual("151", finding.sast_source_line)
 
@@ -42,15 +44,21 @@ class TestSolarAppscreenerParser(DojoTestCase):
         self.assertEqual(3, len(findings))
         self.assertEqual("Hardcoded password", finding.title)
         self.assertEqual("Critical", finding.severity)
+        self.assertEqual("misc/shared.php", finding.file_path)
+        self.assertEqual("151", finding.line)
         self.assertEqual("misc/shared.php", finding.sast_source_file_path)
         self.assertEqual("151", finding.sast_source_line)
         finding = findings[1]
         self.assertEqual("Internal information leak", finding.title)
         self.assertEqual("Medium", finding.severity)
+        self.assertEqual("index.php", finding.file_path)
+        self.assertEqual("5", finding.line)
         self.assertEqual("index.php", finding.sast_source_file_path)
         self.assertEqual("5", finding.sast_source_line)
         finding = findings[2]
         self.assertEqual("Trust boundary violation", finding.title)
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("index.php", finding.sast_source_file_path)
-        self.assertEqual("51", finding.sast_source_line)
+        self.assertEqual("51", finding.sast_source_line),
+        self.assertEqual("index.php", finding.file_path)
+        self.assertEqual("51", finding.line)

--- a/unittests/tools/test_solar_appscreener_parser.py
+++ b/unittests/tools/test_solar_appscreener_parser.py
@@ -29,7 +29,7 @@ class TestSolarAppscreenerParser(DojoTestCase):
         self.assertEqual("misc/shared.php", finding.file_path)
         self.assertEqual("151", finding.line)
         self.assertEqual("misc/shared.php", finding.sast_source_file_path)
-        self.assertEqual("151", finding.sast_source_line)
+        self.assertEqual(151, finding.sast_source_line)
 
     def test_solar_appscreener_parser_with_many_vuln_has_many_findings(self):
         testfile = open(
@@ -45,20 +45,20 @@ class TestSolarAppscreenerParser(DojoTestCase):
         self.assertEqual("Hardcoded password", finding.title)
         self.assertEqual("Critical", finding.severity)
         self.assertEqual("misc/shared.php", finding.file_path)
-        self.assertEqual("151", finding.line)
+        self.assertEqual(151, finding.line)
         self.assertEqual("misc/shared.php", finding.sast_source_file_path)
-        self.assertEqual("151", finding.sast_source_line)
+        self.assertEqual(151, finding.sast_source_line)
         finding = findings[1]
         self.assertEqual("Internal information leak", finding.title)
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("index.php", finding.file_path)
-        self.assertEqual("5", finding.line)
+        self.assertEqual(5, finding.line)
         self.assertEqual("index.php", finding.sast_source_file_path)
-        self.assertEqual("5", finding.sast_source_line)
+        self.assertEqual(5, finding.sast_source_line)
         finding = findings[2]
         self.assertEqual("Trust boundary violation", finding.title)
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("index.php", finding.sast_source_file_path)
-        self.assertEqual("51", finding.sast_source_line),
+        self.assertEqual(51, finding.sast_source_line),
         self.assertEqual("index.php", finding.file_path)
-        self.assertEqual("51", finding.line)
+        self.assertEqual(51, finding.line)


### PR DESCRIPTION
Parcer specified finding.sast_source_line property instead of finding.line - fixed.
Now specify both.