### PR TITLE
Give readers the permission to add notes

### DIFF
--- a/docs/content/en/usage/permissions.md
+++ b/docs/content/en/usage/permissions.md
@@ -69,13 +69,13 @@ Users can be assigned as members to Products and Product Types, giving them one 
 |                             |        |        |            |       |              |
 | View Note History           | x      | x      | x          | x     |              |
 | Add Note                    | x      | x      | x          | x     |              |
-| Edit Note                   |        | x      | x          | x     |              |
-| Delete Note                 |        | (x) <sup>2)</sub> | x          | x     |              |
+| Edit Note                   | (x) <sup>2)</sub> | x                 | x          | x     |              |
+| Delete Note                 | (x) <sup>2)</sub> | (x) <sup>2)</sub> | x          | x     |              |
 
 
 <sup>1)</sup> Every staff user and administrator can add Product Types. Regular users are not allowed to add Product Types, unless they are Global Owner or Maintainer.
 
-<sup>2)</sup> Every user is allowed to delete his own notes.
+<sup>2)</sup> Every user is allowed to edit and delete his own notes.
 
 The role of a user within a Product Type is inherited by all Products of that Product Type, unless the user is explicitly defined as a member of a Product with a different role. In that case, if a user doesn't have a certain right for the Product Type, it is then checked if he has the right for the Product.
 

--- a/docs/content/en/usage/permissions.md
+++ b/docs/content/en/usage/permissions.md
@@ -68,7 +68,7 @@ Users can be assigned as members to Products and Product Types, giving them one 
 | View Components             | x      | x      | x          | x     | x            |
 |                             |        |        |            |       |              |
 | View Note History           | x      | x      | x          | x     |              |
-| Add Note                    |        | x      | x          | x     |              |
+| Add Note                    | x      | x      | x          | x     |              |
 | Edit Note                   |        | x      | x          | x     |              |
 | Delete Note                 |        | (x) <sup>2)</sub> | x          | x     |              |
 

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -206,6 +206,7 @@ def get_roles_with_permissions():
             Permissions.Finding_Group_View,
             Permissions.Endpoint_View,
             Permissions.Component_View,
+            Permissions.Note_Add,
             Permissions.Product_Group_View,
             Permissions.Product_Type_Group_View,
             Permissions.Group_View,

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -289,6 +289,7 @@ def view_finding(request, fid):
     if note_type_activation:
         available_note_types = find_available_notetypes(notes)
     if request.method == 'POST':
+        user_has_permission_or_403(request.user, finding, Permissions.Note_Add)
         if note_type_activation:
             form = TypedNoteForm(request.POST, available_note_types=available_note_types)
         else:

--- a/dojo/notes/urls.py
+++ b/dojo/notes/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^notes/(?P<id>\d+)/delete/(?P<page>[\w-]+)/(?P<objid>\d+)$', views.delete_issue, name='delete_note'),
-    url(r'^notes/(?P<id>\d+)/edit/(?P<page>[\w-]+)/(?P<objid>\d+)$', views.edit_issue, name='edit_note'),
+    url(r'^notes/(?P<id>\d+)/delete/(?P<page>[\w-]+)/(?P<objid>\d+)$', views.delete_note, name='delete_note'),
+    url(r'^notes/(?P<id>\d+)/edit/(?P<page>[\w-]+)/(?P<objid>\d+)$', views.edit_note, name='edit_note'),
     url(r'^notes/(?P<id>\d+)/history/(?P<page>[\w-]+)/(?P<objid>\d+)$', views.note_history, name='note_history')
                 ]

--- a/dojo/notes/views.py
+++ b/dojo/notes/views.py
@@ -18,7 +18,7 @@ from dojo.authorization.roles_permissions import Permissions
 logger = logging.getLogger(__name__)
 
 
-def delete_issue(request, id, page, objid):
+def delete_note(request, id, page, objid):
     note = get_object_or_404(Notes, id=id)
     reverse_url = None
     object_id = None
@@ -57,7 +57,7 @@ def delete_issue(request, id, page, objid):
     return HttpResponseRedirect(reverse(reverse_url, args=(object_id, )))
 
 
-def edit_issue(request, id, page, objid):
+def edit_note(request, id, page, objid):
     note = get_object_or_404(Notes, id=id)
     reverse_url = None
     object_id = None


### PR DESCRIPTION
solves #5581

There is no harm in letting users with a `Reader` role adding notes. Includes a missing permission check, which doesn't change a lot because a user need a `Reader` role anyway to call this view method. Nevertheless it shall be there for completeness.