### PR TITLE
APIv2: Add preview of elements that will be affected by DELETE

### DIFF
--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -1,0 +1,35 @@
+from rest_framework.response import Response
+from django.db import DEFAULT_DB_ALIAS
+from django.contrib.admin.utils import NestedObjects
+from drf_spectacular.utils import extend_schema
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.decorators import action
+from rest_framework import status
+import itertools
+
+
+class DeletePreviewModelMixin:
+    @extend_schema(
+        methods=['GET'],
+    )
+    @swagger_auto_schema(
+        method='get',
+    )
+    @action(detail=True, methods=["get"])
+    def delete_preview(self, request, pk=None):
+        object = self.get_object()
+
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([object])
+        rels = collector.nested()
+
+        def flatten(elem):
+            if isinstance(elem, list):
+                return itertools.chain.from_iterable(map(flatten, elem))
+            else:
+                return [elem]
+
+        rels = [{"model": type(x).__name__, "id": x.id, "name": str(x)} for x in flatten(rels)]
+
+        return Response(rels,
+                        status=status.HTTP_200_OK)

--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -29,7 +29,14 @@ class DeletePreviewModelMixin:
             else:
                 return [elem]
 
-        rels = [{"model": type(x).__name__, "id": x.id, "name": str(x)} for x in flatten(rels)]
+        rels = [
+            {
+                "model": type(x).__name__,
+                "id": x.id if hasattr(x, 'id') else -1,  # Because of "'Token' object has no attribute 'id'" and None is not Int
+                "name": str(x)
+            }
+            for x in flatten(rels)
+        ]
 
         return Response(rels,
                         status=status.HTTP_200_OK)

--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -37,9 +37,9 @@ class DeletePreviewModelMixin:
             {
                 "model": type(x).__name__,
                 "id": x.id if hasattr(x, 'id') else None,
-                "name": str(x)
+                "name": str(x) if not isinstance(x, Token) else "<APITokenIsHidden>"
             }
-            for x in flatten(rels) if not isinstance(x, Token)
+            for x in flatten(rels)
         ]
 
         # next part is inspired by original implementation of ListModelMixin

--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -5,15 +5,18 @@ from drf_spectacular.utils import extend_schema
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import action
 from rest_framework import status
+from dojo.api_v2 import serializers
 import itertools
 
 
 class DeletePreviewModelMixin:
     @extend_schema(
         methods=['GET'],
+        responses={status.HTTP_200_OK: serializers.DeletePreviewSerializer(many=True)}
     )
     @swagger_auto_schema(
         method='get',
+        responses={status.HTTP_200_OK: serializers.DeletePreviewSerializer(many=True)}
     )
     @action(detail=True, methods=["get"])
     def delete_preview(self, request, pk=None):
@@ -32,11 +35,19 @@ class DeletePreviewModelMixin:
         rels = [
             {
                 "model": type(x).__name__,
-                "id": x.id if hasattr(x, 'id') else -1,  # Because of "'Token' object has no attribute 'id'" and None is not Int
+                "id": x.id if hasattr(x, 'id') else None,
                 "name": str(x)
             }
             for x in flatten(rels)
         ]
 
-        return Response(rels,
+        # next part is inspired by original implementation of ListModelMixin
+        page = self.paginate_queryset(rels)
+        if page is not None:
+            serializer = serializers.DeletePreviewSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = serializers.DeletePreviewSerializer(queryset, many=True)
+
+        return Response(serializer.data,
                         status=status.HTTP_200_OK)

--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework import status
 from dojo.api_v2 import serializers
 import itertools
+from rest_framework.authtoken.models import Token
 
 
 class DeletePreviewModelMixin:
@@ -38,7 +39,7 @@ class DeletePreviewModelMixin:
                 "id": x.id if hasattr(x, 'id') else None,
                 "name": str(x)
             }
-            for x in flatten(rels)
+            for x in flatten(rels) if not isinstance(x, Token)
         ]
 
         # next part is inspired by original implementation of ListModelMixin

--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -16,9 +16,9 @@ class DeletePreviewModelMixin:
     )
     @swagger_auto_schema(
         method='get',
-        responses={status.HTTP_200_OK: serializers.DeletePreviewSerializer(many=True)}
+        responses={'default': serializers.DeletePreviewSerializer(many=True)}
     )
-    @action(detail=True, methods=["get"], filter_backends=[])
+    @action(detail=True, methods=["get"], filter_backends=[], suffix='List')
     def delete_preview(self, request, pk=None):
         object = self.get_object()
 

--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -18,7 +18,7 @@ class DeletePreviewModelMixin:
         method='get',
         responses={status.HTTP_200_OK: serializers.DeletePreviewSerializer(many=True)}
     )
-    @action(detail=True, methods=["get"])
+    @action(detail=True, methods=["get"], filter_backends=[])
     def delete_preview(self, request, pk=None):
         object = self.get_object()
 

--- a/dojo/api_v2/mixins.py
+++ b/dojo/api_v2/mixins.py
@@ -1,13 +1,12 @@
-from rest_framework.response import Response
 from django.db import DEFAULT_DB_ALIAS
 from django.contrib.admin.utils import NestedObjects
 from drf_spectacular.utils import extend_schema
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import action
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 from dojo.api_v2 import serializers
 import itertools
-from rest_framework.authtoken.models import Token
 
 
 class DeletePreviewModelMixin:
@@ -42,13 +41,7 @@ class DeletePreviewModelMixin:
             for x in flatten(rels)
         ]
 
-        # next part is inspired by original implementation of ListModelMixin
         page = self.paginate_queryset(rels)
-        if page is not None:
-            serializer = serializers.DeletePreviewSerializer(page, many=True)
-            return self.get_paginated_response(serializer.data)
 
-        serializer = serializers.DeletePreviewSerializer(queryset, many=True)
-
-        return Response(serializer.data,
-                        status=status.HTTP_200_OK)
+        serializer = serializers.DeletePreviewSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1946,3 +1946,9 @@ class UserProfileSerializer(serializers.Serializer):
     dojo_group_member = DojoGroupMemberSerializer(many=True)
     product_type_member = ProductTypeMemberSerializer(many=True)
     product_member = ProductMemberSerializer(many=True)
+
+
+class DeletePreviewSerializer(serializers.Serializer):
+    model = serializers.CharField(read_only=True)
+    id = serializers.IntegerField(read_only=True, allow_null=True)
+    name = serializers.CharField(read_only=True)

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -42,7 +42,7 @@ from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from datetime import datetime
 from dojo.utils import get_period_counts_legacy, get_system_setting, get_setting, async_delete
-from dojo.api_v2 import serializers, permissions, prefetch, schema
+from dojo.api_v2 import serializers, permissions, prefetch, schema, mixins as dojo_mixins
 import dojo.jira_link.helper as jira_helper
 import logging
 import tagulous
@@ -95,7 +95,8 @@ class DojoGroupViewSet(prefetch.PrefetchListMixin,
                        mixins.DestroyModelMixin,
                        mixins.UpdateModelMixin,
                        mixins.CreateModelMixin,
-                       viewsets.GenericViewSet):
+                       viewsets.GenericViewSet,
+                       dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.DojoGroupSerializer
     queryset = Dojo_Group.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -128,7 +129,8 @@ class DojoGroupMemberViewSet(prefetch.PrefetchListMixin,
                            mixins.CreateModelMixin,
                            mixins.DestroyModelMixin,
                            mixins.UpdateModelMixin,
-                           viewsets.GenericViewSet):
+                           viewsets.GenericViewSet,
+                           dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.DojoGroupMemberSerializer
     queryset = Dojo_Group_Member.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -154,7 +156,8 @@ class GlobalRoleViewSet(prefetch.PrefetchListMixin,
                         mixins.DestroyModelMixin,
                         mixins.UpdateModelMixin,
                         mixins.CreateModelMixin,
-                        viewsets.GenericViewSet):
+                        viewsets.GenericViewSet,
+                        dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.GlobalRoleSerializer
     queryset = Global_Role.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -170,7 +173,8 @@ class EndPointViewSet(mixins.ListModelMixin,
                       mixins.UpdateModelMixin,
                       mixins.DestroyModelMixin,
                       mixins.CreateModelMixin,
-                      viewsets.GenericViewSet):
+                      viewsets.GenericViewSet,
+                      dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.EndpointSerializer
     queryset = Endpoint.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -215,7 +219,8 @@ class EndpointStatusViewSet(mixins.ListModelMixin,
                       mixins.UpdateModelMixin,
                       mixins.DestroyModelMixin,
                       mixins.CreateModelMixin,
-                      viewsets.GenericViewSet):
+                      viewsets.GenericViewSet,
+                      dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.EndpointStatusSerializer
     queryset = Endpoint_Status.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -234,7 +239,8 @@ class EngagementViewSet(mixins.ListModelMixin,
                         mixins.DestroyModelMixin,
                         mixins.CreateModelMixin,
                         ra_api.AcceptedRisksMixin,
-                        viewsets.GenericViewSet):
+                        viewsets.GenericViewSet,
+                        dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.EngagementSerializer
     queryset = Engagement.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -417,7 +423,8 @@ class AppAnalysisViewSet(mixins.ListModelMixin,
                         mixins.UpdateModelMixin,
                         mixins.DestroyModelMixin,
                         mixins.CreateModelMixin,
-                        viewsets.GenericViewSet):
+                        viewsets.GenericViewSet,
+                        dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.AppAnalysisSerializer
     queryset = App_Analysis.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -434,7 +441,8 @@ class FindingTemplatesViewSet(mixins.ListModelMixin,
                               mixins.UpdateModelMixin,
                               mixins.CreateModelMixin,
                               mixins.DestroyModelMixin,
-                              viewsets.GenericViewSet):
+                              viewsets.GenericViewSet,
+                              dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.FindingTemplateSerializer
     queryset = Finding_Template.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -467,7 +475,8 @@ class FindingViewSet(prefetch.PrefetchListMixin,
                      mixins.DestroyModelMixin,
                      mixins.CreateModelMixin,
                      ra_api.AcceptedFindingsMixin,
-                     viewsets.GenericViewSet):
+                     viewsets.GenericViewSet,
+                     dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.FindingSerializer
     queryset = Finding.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1018,7 +1027,8 @@ class JiraInstanceViewSet(mixins.ListModelMixin,
                                 mixins.DestroyModelMixin,
                                 mixins.UpdateModelMixin,
                                 mixins.CreateModelMixin,
-                                viewsets.GenericViewSet):
+                                viewsets.GenericViewSet,
+                                dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.JIRAInstanceSerializer
     queryset = JIRA_Instance.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1032,7 +1042,8 @@ class JiraIssuesViewSet(mixins.ListModelMixin,
                         mixins.DestroyModelMixin,
                         mixins.CreateModelMixin,
                         mixins.UpdateModelMixin,
-                        viewsets.GenericViewSet):
+                        viewsets.GenericViewSet,
+                        dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.JIRAIssueSerializer
     queryset = JIRA_Issue.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1049,7 +1060,8 @@ class JiraProjectViewSet(mixins.ListModelMixin,
                   mixins.DestroyModelMixin,
                   mixins.UpdateModelMixin,
                   mixins.CreateModelMixin,
-                  viewsets.GenericViewSet):
+                  viewsets.GenericViewSet,
+                  dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.JIRAProjectSerializer
     queryset = JIRA_Project.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1068,7 +1080,8 @@ class SonarqubeIssueViewSet(mixins.ListModelMixin,
                                 mixins.DestroyModelMixin,
                                 mixins.UpdateModelMixin,
                                 mixins.CreateModelMixin,
-                                viewsets.GenericViewSet):
+                                viewsets.GenericViewSet,
+                                dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.SonarqubeIssueSerializer
     queryset = Sonarqube_Issue.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1082,7 +1095,8 @@ class SonarqubeIssueTransitionViewSet(mixins.ListModelMixin,
                         mixins.DestroyModelMixin,
                         mixins.CreateModelMixin,
                         mixins.UpdateModelMixin,
-                        viewsets.GenericViewSet):
+                        viewsets.GenericViewSet,
+                        dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.SonarqubeIssueTransitionSerializer
     queryset = Sonarqube_Issue_Transition.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1097,7 +1111,8 @@ class ProductAPIScanConfigurationViewSet(mixins.ListModelMixin,
                   mixins.DestroyModelMixin,
                   mixins.UpdateModelMixin,
                   mixins.CreateModelMixin,
-                  viewsets.GenericViewSet):
+                  viewsets.GenericViewSet,
+                  dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ProductAPIScanConfigurationSerializer
     queryset = Product_API_Scan_Configuration.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1129,7 +1144,8 @@ class DojoMetaViewSet(prefetch.PrefetchListMixin,
                       mixins.DestroyModelMixin,
                       mixins.CreateModelMixin,
                       mixins.UpdateModelMixin,
-                      viewsets.GenericViewSet):
+                      viewsets.GenericViewSet,
+                      dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.MetaSerializer
     queryset = DojoMeta.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1176,7 +1192,8 @@ class ProductViewSet(prefetch.PrefetchListMixin,
                      mixins.CreateModelMixin,
                      mixins.DestroyModelMixin,
                      mixins.UpdateModelMixin,
-                     viewsets.GenericViewSet):
+                     viewsets.GenericViewSet,
+                     dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ProductSerializer
     # TODO: prefetch
     queryset = Product.objects.none()
@@ -1255,7 +1272,8 @@ class ProductMemberViewSet(prefetch.PrefetchListMixin,
                            mixins.CreateModelMixin,
                            mixins.DestroyModelMixin,
                            mixins.UpdateModelMixin,
-                           viewsets.GenericViewSet):
+                           viewsets.GenericViewSet,
+                           dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ProductMemberSerializer
     queryset = Product_Member.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1301,7 +1319,8 @@ class ProductGroupViewSet(prefetch.PrefetchListMixin,
                           mixins.CreateModelMixin,
                           mixins.DestroyModelMixin,
                           mixins.UpdateModelMixin,
-                          viewsets.GenericViewSet):
+                          viewsets.GenericViewSet,
+                          dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ProductGroupSerializer
     queryset = Product_Group.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1347,7 +1366,8 @@ class ProductTypeViewSet(prefetch.PrefetchListMixin,
                          mixins.CreateModelMixin,
                          mixins.UpdateModelMixin,
                          mixins.DestroyModelMixin,
-                         viewsets.GenericViewSet):
+                         viewsets.GenericViewSet,
+                         dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ProductTypeSerializer
     queryset = Product_Type.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1429,7 +1449,8 @@ class ProductTypeMemberViewSet(prefetch.PrefetchListMixin,
                                mixins.CreateModelMixin,
                                mixins.DestroyModelMixin,
                                mixins.UpdateModelMixin,
-                               viewsets.GenericViewSet):
+                               viewsets.GenericViewSet,
+                               dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ProductTypeMemberSerializer
     queryset = Product_Type_Member.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1484,7 +1505,8 @@ class ProductTypeGroupViewSet(prefetch.PrefetchListMixin,
                               mixins.CreateModelMixin,
                               mixins.DestroyModelMixin,
                               mixins.UpdateModelMixin,
-                              viewsets.GenericViewSet):
+                              viewsets.GenericViewSet,
+                              dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ProductTypeGroupSerializer
     queryset = Product_Type_Group.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1516,7 +1538,8 @@ class StubFindingsViewSet(mixins.ListModelMixin,
                           mixins.CreateModelMixin,
                           mixins.UpdateModelMixin,
                           mixins.DestroyModelMixin,
-                          viewsets.GenericViewSet):
+                          viewsets.GenericViewSet,
+                          dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.StubFindingSerializer
     queryset = Stub_Finding.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1539,7 +1562,8 @@ class DevelopmentEnvironmentViewSet(mixins.ListModelMixin,
                                     mixins.CreateModelMixin,
                                     mixins.DestroyModelMixin,
                                     mixins.UpdateModelMixin,
-                                    viewsets.GenericViewSet):
+                                    viewsets.GenericViewSet,
+                                    dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.DevelopmentEnvironmentSerializer
     queryset = Development_Environment.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1553,7 +1577,8 @@ class TestsViewSet(mixins.ListModelMixin,
                    mixins.DestroyModelMixin,
                    mixins.CreateModelMixin,
                    ra_api.AcceptedRisksMixin,
-                   viewsets.GenericViewSet):
+                   viewsets.GenericViewSet,
+                   dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.TestSerializer
     queryset = Test.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1742,7 +1767,8 @@ class TestImportViewSet(prefetch.PrefetchListMixin,
                       mixins.UpdateModelMixin,
                       mixins.CreateModelMixin,
                       mixins.DestroyModelMixin,
-                      viewsets.GenericViewSet):
+                      viewsets.GenericViewSet,
+                      dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.TestImportSerializer
     queryset = Test_Import.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1790,7 +1816,8 @@ class ToolConfigurationsViewSet(mixins.ListModelMixin,
                                 mixins.CreateModelMixin,
                                 mixins.UpdateModelMixin,
                                 mixins.DestroyModelMixin,
-                                viewsets.GenericViewSet):
+                                viewsets.GenericViewSet,
+                                dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ToolConfigurationSerializer
     queryset = Tool_Configuration.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1804,7 +1831,8 @@ class ToolProductSettingsViewSet(mixins.ListModelMixin,
                                  mixins.DestroyModelMixin,
                                  mixins.CreateModelMixin,
                                  mixins.UpdateModelMixin,
-                                 viewsets.GenericViewSet):
+                                 viewsets.GenericViewSet,
+                                 dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ToolProductSettingsSerializer
     queryset = Tool_Product_Settings.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -1822,7 +1850,8 @@ class ToolTypesViewSet(mixins.ListModelMixin,
                        mixins.DestroyModelMixin,
                        mixins.CreateModelMixin,
                        mixins.UpdateModelMixin,
-                       viewsets.GenericViewSet):
+                       viewsets.GenericViewSet,
+                       dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.ToolTypeSerializer
     queryset = Tool_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1836,7 +1865,8 @@ class RegulationsViewSet(mixins.ListModelMixin,
                          mixins.CreateModelMixin,
                          mixins.DestroyModelMixin,
                          mixins.UpdateModelMixin,
-                         viewsets.GenericViewSet):
+                         viewsets.GenericViewSet,
+                         dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.RegulationSerializer
     queryset = Regulation.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1850,7 +1880,8 @@ class UsersViewSet(mixins.CreateModelMixin,
                    mixins.ListModelMixin,
                    mixins.RetrieveModelMixin,
                    mixins.DestroyModelMixin,
-                   viewsets.GenericViewSet):
+                   viewsets.GenericViewSet,
+                   dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.UserSerializer
     queryset = User.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -1885,7 +1916,8 @@ class UserContactInfoViewSet(prefetch.PrefetchListMixin,
                              mixins.ListModelMixin,
                              mixins.RetrieveModelMixin,
                              mixins.DestroyModelMixin,
-                             viewsets.GenericViewSet):
+                             viewsets.GenericViewSet,
+                             dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.UserContactInfoSerializer
     queryset = UserContactInfo.objects.all()
     swagger_schema = prefetch.get_prefetch_schema(["user_contact_infos_list", "user_contact_infos_read"],
@@ -2006,7 +2038,8 @@ class LanguageTypeViewSet(mixins.ListModelMixin,
                           mixins.CreateModelMixin,
                           mixins.DestroyModelMixin,
                           mixins.UpdateModelMixin,
-                          viewsets.GenericViewSet):
+                          viewsets.GenericViewSet,
+                          dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.LanguageTypeSerializer
     queryset = Language_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -2034,7 +2067,8 @@ class LanguageViewSet(prefetch.PrefetchListMixin,
                       mixins.DestroyModelMixin,
                       mixins.UpdateModelMixin,
                       mixins.CreateModelMixin,
-                      viewsets.GenericViewSet):
+                      viewsets.GenericViewSet,
+                      dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.LanguageSerializer
     queryset = Languages.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -2117,7 +2151,8 @@ class NoteTypeViewSet(mixins.ListModelMixin,
                        mixins.DestroyModelMixin,
                        mixins.CreateModelMixin,
                        mixins.UpdateModelMixin,
-                       viewsets.GenericViewSet):
+                       viewsets.GenericViewSet,
+                       dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.NoteTypeSerializer
     queryset = Note_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -2466,7 +2501,8 @@ class NotificationsViewSet(prefetch.PrefetchListMixin,
                            mixins.DestroyModelMixin,
                            mixins.CreateModelMixin,
                            mixins.UpdateModelMixin,
-                           viewsets.GenericViewSet):
+                           viewsets.GenericViewSet,
+                           dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.NotificationsSerializer
     queryset = Notifications.objects.all()
     filter_backends = (DjangoFilterBackend,)
@@ -2481,7 +2517,8 @@ class EngagementPresetsViewset(mixins.ListModelMixin,
                          mixins.UpdateModelMixin,
                          mixins.DestroyModelMixin,
                          mixins.CreateModelMixin,
-                         viewsets.GenericViewSet):
+                         viewsets.GenericViewSet,
+                         dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.EngagementPresetsSerializer
     queryset = Engagement_Presets.objects.none()
     filter_backends = (DjangoFilterBackend,)
@@ -2498,7 +2535,8 @@ class NetworkLocationsViewset(mixins.ListModelMixin,
                               mixins.UpdateModelMixin,
                               mixins.DestroyModelMixin,
                               mixins.CreateModelMixin,
-                              viewsets.GenericViewSet):
+                              viewsets.GenericViewSet,
+                              dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.NetworkLocationsSerializer
     queryset = Network_Locations.objects.all()
     filter_backends = (DjangoFilterBackend,)

--- a/unittests/test_apiv2_methods.py
+++ b/unittests/test_apiv2_methods.py
@@ -16,7 +16,7 @@ class ApiEndpointMethods(DojoTestCase):
     def test_is_defined(self):
 
         for reg, _, _ in sorted(self.registry):
-            if reg in ['import-scan', 'reimport-scan', 'notes', 'system_settings', 'users', 'roles', 'import-languages', 'endpoint_meta_import', 'test_types']:
+            if reg in ['import-scan', 'reimport-scan', 'notes', 'system_settings', 'roles', 'import-languages', 'endpoint_meta_import', 'test_types']:
                 continue
 
             for method in ['get', 'post']:
@@ -26,3 +26,6 @@ class ApiEndpointMethods(DojoTestCase):
             for method in ['get', 'put', 'patch', 'delete']:
                 self.assertIsNotNone(self.schema["paths"][BASE_API_URL + '/' + reg + '/{id}/'].get(method),
                                      "Endpoint: {}, Method: {}".format(reg, method))
+
+            self.assertIsNotNone(self.schema["paths"].get(BASE_API_URL + '/' + reg + '/{id}/delete_preview/', {}).get('get'),
+                             "Endpoint: {}, Method: get - delete_preview".format(reg))

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -446,17 +446,18 @@ class BaseClass():
             self.assertFalse('ssh' in response.data)
             self.assertFalse('api_key' in response.data)
 
-            self.assertIsInstance(response.data, list)
-            self.assertTrue(len(response.data) > 0, "Length: {}".format(len(response.data)))
+            self.assertIsInstance(response.data['results'], list)
+            self.assertTrue(len(response.data['results']) > 0, "Length: {}".format(len(response.data['results'])))
 
-            for obj in response.data:
+            for obj in response.data['results']:
                 self.assertIsInstance(obj, dict)
                 self.assertTrue(len(obj), 3)
                 self.assertIsInstance(obj['model'], str)
-                self.assertIsInstance(obj['id'], int)
+                if obj['id']:  # It needs to be None or int
+                    self.assertIsInstance(obj['id'], int)
                 self.assertIsInstance(obj['name'], str)
 
-            self.assertEqual(self.deleted_objects, len(response.data), response.content[:1000])
+            self.assertEqual(self.deleted_objects, len(response.data['results']), response.content[:1000])
 
         @skipIfNotSubclass(PrefetchRetrieveMixin)
         def test_detail_prefetch(self):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -436,8 +436,6 @@ class BaseClass():
             relative_url = self.url + '%s/delete_preview/' % current_objects['results'][0]['id']
             response = self.client.get(relative_url)
             # print('delete_preview response.data')
-            print(relative_url)
-            print(response.data)
 
             self.assertEqual(200, response.status_code, response.content[:1000])
 
@@ -457,6 +455,8 @@ class BaseClass():
                 self.assertIsInstance(obj['model'], str)
                 self.assertIsInstance(obj['id'], int)
                 self.assertIsInstance(obj['name'], str)
+
+            self.assertEqual(self.deleted_objects, len(response.data), response.content[:1000])
 
         @skipIfNotSubclass(PrefetchRetrieveMixin)
         def test_detail_prefetch(self):
@@ -767,6 +767,7 @@ class AppAnalysisTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Technology_Add
         self.permission_update = Permissions.Technology_Edit
         self.permission_delete = Permissions.Technology_Delete
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -793,6 +794,7 @@ class EndpointStatusTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Endpoint_Edit
         self.permission_update = Permissions.Endpoint_Edit
         self.permission_delete = Permissions.Endpoint_Edit
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_create_unsuccessful(self):
@@ -871,6 +873,7 @@ class EndpointTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Endpoint_Add
         self.permission_update = Permissions.Endpoint_Edit
         self.permission_delete = Permissions.Endpoint_Delete
+        self.deleted_objects = 2
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -901,6 +904,7 @@ class EngagementTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Engagement_Add
         self.permission_update = Permissions.Engagement_Edit
         self.permission_delete = Permissions.Engagement_Delete
+        self.deleted_objects = 23
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1014,6 +1018,7 @@ class FindingsTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Finding_Add
         self.permission_update = Permissions.Finding_Edit
         self.permission_delete = Permissions.Finding_Delete
+        self.deleted_objects = 2
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_duplicate(self):
@@ -1053,6 +1058,7 @@ class FindingMetadataTest(BaseClass.RESTEndpointTest):
         self.viewset = FindingViewSet
         self.payload = {}
         self.test_type = TestType.STANDARD
+        self.deleted_objects = 3
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def setUp(self):
@@ -1123,6 +1129,7 @@ class FindingTemplatesTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'references': 'some reference'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1152,6 +1159,7 @@ class JiraInstancesTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'epic_name_id': 1}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1174,6 +1182,7 @@ class JiraIssuesTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Finding_Edit
         self.permission_update = Permissions.Finding_Edit
         self.permission_delete = Permissions.Finding_Edit
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1200,6 +1209,7 @@ class JiraProjectTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Product_Edit
         self.permission_update = Permissions.Product_Edit
         self.permission_delete = Permissions.Product_Edit
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1218,6 +1228,7 @@ class SonarqubeIssueTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'key': 'AREwS5n5TxsFUNm31CxP'}
         self.test_type = TestType.STANDARD
+        self.deleted_objects = 2
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1259,6 +1270,7 @@ class Product_API_Scan_ConfigurationTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Product_API_Scan_Configuration_Add
         self.permission_update = Permissions.Product_API_Scan_Configuration_Edit
         self.permission_delete = Permissions.Product_API_Scan_Configuration_Delete
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1285,6 +1297,7 @@ class ProductTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Product_Type_Add_Product
         self.permission_update = Permissions.Product_Edit
         self.permission_delete = Permissions.Product_Delete
+        self.deleted_objects = 16
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1310,6 +1323,7 @@ class StubFindingsTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Finding_Add
         self.permission_update = Permissions.Finding_Edit
         self.permission_delete = Permissions.Finding_Delete
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1343,6 +1357,7 @@ class TestsTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Test_Add
         self.permission_update = Permissions.Test_Edit
         self.permission_delete = Permissions.Test_Delete
+        self.deleted_objects = 18
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1368,6 +1383,7 @@ class ToolConfigurationsTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'ssh': 'test string'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 2
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1393,6 +1409,7 @@ class ToolProductSettingsTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Product_Edit
         self.permission_update = Permissions.Product_Edit
         self.permission_delete = Permissions.Product_Edit
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1410,6 +1427,7 @@ class ToolTypesTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'description': 'changed description'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 3
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1430,6 +1448,7 @@ class NoteTypesTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'description': 'changed description'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1469,6 +1488,7 @@ class UsersTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {"first_name": "test changed"}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 17
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1489,6 +1509,7 @@ class UserContactInfoTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {"title": "Lady"}
         self.test_type = TestType.STANDARD
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2140,6 +2161,7 @@ class ProductTypeTest(BaseClass.RESTEndpointTest):
         self.permission_check_class = Product_Type
         self.permission_update = Permissions.Product_Type_Edit
         self.permission_delete = Permissions.Product_Type_Delete
+        self.deleted_objects = 20
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_create_object_not_authorized(self):
@@ -2178,6 +2200,7 @@ class DojoGroupsTest(BaseClass.RESTEndpointTest):
         self.permission_check_class = Dojo_Group
         self.permission_update = Permissions.Group_Edit
         self.permission_delete = Permissions.Group_Delete
+        self.deleted_objects = 4
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_list_object_not_authorized(self):
@@ -2220,6 +2243,7 @@ class DojoGroupsUsersTest(BaseClass.MemberEndpointTest):
         self.permission_create = Permissions.Group_Manage_Members
         self.permission_update = Permissions.Group_Manage_Members
         self.permission_delete = Permissions.Group_Member_Delete
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2249,6 +2273,7 @@ class GlobalRolesTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'role': 3}
         self.test_type = TestType.STANDARD
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2271,6 +2296,7 @@ class ProductTypeMemberTest(BaseClass.MemberEndpointTest):
         self.permission_create = Permissions.Product_Type_Manage_Members
         self.permission_update = Permissions.Product_Type_Manage_Members
         self.permission_delete = Permissions.Product_Type_Member_Delete
+        self.deleted_objects = 1
         BaseClass.MemberEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2293,6 +2319,7 @@ class ProductMemberTest(BaseClass.MemberEndpointTest):
         self.permission_create = Permissions.Product_Manage_Members
         self.permission_update = Permissions.Product_Manage_Members
         self.permission_delete = Permissions.Product_Member_Delete
+        self.deleted_objects = 1
         BaseClass.MemberEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2315,6 +2342,7 @@ class ProductTypeGroupTest(BaseClass.MemberEndpointTest):
         self.permission_create = Permissions.Product_Type_Group_Add
         self.permission_update = Permissions.Product_Type_Group_Edit
         self.permission_delete = Permissions.Product_Type_Group_Delete
+        self.deleted_objects = 1
         BaseClass.MemberEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2337,6 +2365,7 @@ class ProductGroupTest(BaseClass.MemberEndpointTest):
         self.permission_create = Permissions.Product_Group_Add
         self.permission_update = Permissions.Product_Group_Edit
         self.permission_delete = Permissions.Product_Group_Delete
+        self.deleted_objects = 1
         BaseClass.MemberEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2355,6 +2384,7 @@ class LanguageTypeTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'color': 'blue'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 2
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2382,6 +2412,7 @@ class LanguageTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Language_Add
         self.permission_update = Permissions.Language_Edit
         self.permission_delete = Permissions.Language_Delete
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2439,6 +2470,7 @@ class NotificationsTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {'product_added': ["alert", "msteams"]}
         self.test_type = TestType.STANDARD
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2484,6 +2516,7 @@ class DevelopmentEnvironmentTest(BaseClass.AuthenticatedViewTest):
         }
         self.update_fields = {'name': 'Test_2'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_delete(self):
@@ -2506,4 +2539,5 @@ class TestTypeTest(BaseClass.AuthenticatedViewTest):
         }
         self.update_fields = {'name': 'Test_2'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
+        self.deleted_objects = 1
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -436,8 +436,8 @@ class BaseClass():
             relative_url = self.url + '%s/delete_preview/' % current_objects['results'][0]['id']
             response = self.client.get(relative_url)
             # print('delete_preview response.data')
-            # print(relative_url)
-            # print(response.data)
+            print(relative_url)
+            print(response.data)
 
             self.assertEqual(200, response.status_code, response.content[:1000])
 
@@ -454,7 +454,9 @@ class BaseClass():
             for obj in response.data:
                 self.assertIsInstance(obj, dict)
                 self.assertTrue(len(obj), 3)
-                self.assertIsInstance(list(obj.values())[0], str)
+                self.assertIsInstance(list(obj.values())[0], str) # model
+                self.assertIsInstance(list(obj.values())[1], int) # id
+                self.assertIsInstance(list(obj.values())[2], str) # name
 
         @skipIfNotSubclass(PrefetchRetrieveMixin)
         def test_detail_prefetch(self):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -874,7 +874,7 @@ class EndpointTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Endpoint_Add
         self.permission_update = Permissions.Endpoint_Edit
         self.permission_delete = Permissions.Endpoint_Delete
-        self.deleted_objects = 2
+        self.deleted_objects = 3
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -905,7 +905,7 @@ class EngagementTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Engagement_Add
         self.permission_update = Permissions.Engagement_Edit
         self.permission_delete = Permissions.Engagement_Delete
-        self.deleted_objects = 23
+        self.deleted_objects = 24
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1298,7 +1298,7 @@ class ProductTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Product_Type_Add_Product
         self.permission_update = Permissions.Product_Edit
         self.permission_delete = Permissions.Product_Delete
-        self.deleted_objects = 16
+        self.deleted_objects = 17
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -1358,7 +1358,7 @@ class TestsTest(BaseClass.RESTEndpointTest):
         self.permission_create = Permissions.Test_Add
         self.permission_update = Permissions.Test_Edit
         self.permission_delete = Permissions.Test_Delete
-        self.deleted_objects = 18
+        self.deleted_objects = 19
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
 
@@ -2162,7 +2162,7 @@ class ProductTypeTest(BaseClass.RESTEndpointTest):
         self.permission_check_class = Product_Type
         self.permission_update = Permissions.Product_Type_Edit
         self.permission_delete = Permissions.Product_Type_Delete
-        self.deleted_objects = 20
+        self.deleted_objects = 21
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_create_object_not_authorized(self):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -454,9 +454,9 @@ class BaseClass():
             for obj in response.data:
                 self.assertIsInstance(obj, dict)
                 self.assertTrue(len(obj), 3)
-                self.assertIsInstance(list(obj.values())[0], str) # model
-                self.assertIsInstance(list(obj.values())[1], int) # id
-                self.assertIsInstance(list(obj.values())[2], str) # name
+                self.assertIsInstance(obj['model'], str)
+                self.assertIsInstance(obj['id'], int)
+                self.assertIsInstance(obj['name'], str)
 
         @skipIfNotSubclass(PrefetchRetrieveMixin)
         def test_detail_prefetch(self):


### PR DESCRIPTION
`GET apiv2/{model}/{id}/delete_preview`

https://owasp.slack.com/archives/C014H3ZV9U6/p1639241564073500

## Example

```json
{
  "count": 123,
  "next": "http://DD/api/v2/users/1/delete_preview/?offset=2&limit=4",
  "previous": "http://DD/api/v2/users/1/delete_preview/?offset=10&limit=4",
  "results": [
      {
        "model": "User",
        "id": 1,
        "name": "admin"
      },
      {
        "model": "Product_Type_Member",
        "id": 1,
        "name": "Product_Type_Member object (1)"
      },
      {
        "model": "Alerts",
        "id": 4,
        "name": "Alerts object (4)"
      },
      {
        "model": "Alerts",
        "id": 2,
        "name": "Alerts object (2)"
      }
  ]
}
```

## TODO
- [x]  add pagination
- [x]  fix schema