### PR TITLE
Reversed x-axis on Product's Detailed Metrics Page

### DIFF
--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -1563,6 +1563,8 @@ function open_close_weekly(opened, closed, accepted, ticks) {
     var options = {
         xaxes: [{
             ticks: ticks,
+            transform: function(v) { return -v; },
+            inverseTransform: function(v) { return -v; }
         }],
         yaxes: [{
             min: 0
@@ -1604,6 +1606,8 @@ function severity_weekly(critical, high, medium, low, info, ticks) {
     var options = {
         xaxes: [{
             ticks: ticks,
+            transform: function(v) { return -v; },
+            inverseTransform: function(v) { return -v; }
         }],
         yaxes: [{
             min: 0
@@ -1654,6 +1658,8 @@ function severity_counts_weekly(critical, high, medium, ticks) {
     var options = {
         xaxes: [{
             ticks: ticks,
+            transform: function(v) { return -v; },
+            inverseTransform: function(v) { return -v; }
         }],
         yaxes: [{
             min: 0


### PR DESCRIPTION
Previously, some of the plots on the Detailed Metrics page displayed dates with the most recent date on the far left side of the x-axis.
<img width="1817" alt="Screen Shot 2021-12-16 at 1 41 02 PM" src="https://user-images.githubusercontent.com/76979297/146440932-0e0396dd-45f2-408a-b342-038c89eefc4c.png">

With this change, these plots will display the most recent dates on the far right side of the x-axis.
<img width="1815" alt="Screen Shot 2021-12-16 at 1 44 27 PM" src="https://user-images.githubusercontent.com/76979297/146440986-4712f479-7e11-4d3e-a297-cff497fb6c00.png">

