### PR TITLE
update tagulous to 1.3.1 instead of hotfix commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ django-debug-toolbar==3.2.2
 django-debug-toolbar-request-history==0.1.4
 vcrpy==4.1.1
 vcrpy-unittest==0.1.7
-git+https://github.com/nschlemm/django-tagulous.git@250b88c68507b39da7b5a88798e49805b94e81b8#egg=django-tagulous
+django-tagulous==1.3.1
 PyJWT==2.3.0
 cvss==2.3
 django-fieldsignals==0.7.0


### PR DESCRIPTION
their bug is fixed in this release so we no longer need to install that specific hotfix commit