### PR TITLE
Close old findings of same service only

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1230,10 +1230,15 @@ class ImportScanSerializer(serializers.Serializer):
         default=None,
         queryset=User.objects.all())
     tags = TagListSerializerField(required=False)
-    close_old_findings = serializers.BooleanField(required=False, default=False)
+    close_old_findings = serializers.BooleanField(required=False, default=False,
+        help_text="Select if old findings no longer present in the report get closed as mitigated when importing. "
+                  "If service has been set, only the findings for this service will be closed.")
     push_to_jira = serializers.BooleanField(default=False)
     environment = serializers.CharField(required=False)
-    version = serializers.CharField(required=False)
+    version = serializers.CharField(required=False,
+        help_text="A service is a self-contained piece of functionality within a Product. "
+                  "This is an optional field which is used in deduplication and closing of old findings when set. "
+                  "This affects the whole engagement/product depending on your deduplication scope.")
     build_id = serializers.CharField(required=False)
     branch_tag = serializers.CharField(required=False)
     commit_hash = serializers.CharField(required=False)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1235,16 +1235,16 @@ class ImportScanSerializer(serializers.Serializer):
                   "If service has been set, only the findings for this service will be closed.")
     push_to_jira = serializers.BooleanField(default=False)
     environment = serializers.CharField(required=False)
-    version = serializers.CharField(required=False,
-        help_text="A service is a self-contained piece of functionality within a Product. "
-                  "This is an optional field which is used in deduplication and closing of old findings when set. "
-                  "This affects the whole engagement/product depending on your deduplication scope.")
+    version = serializers.CharField(required=False)
     build_id = serializers.CharField(required=False)
     branch_tag = serializers.CharField(required=False)
     commit_hash = serializers.CharField(required=False)
     api_scan_configuration = serializers.PrimaryKeyRelatedField(allow_null=True, default=None,
                                                           queryset=Product_API_Scan_Configuration.objects.all())
-    service = serializers.CharField(required=False)
+    service = serializers.CharField(required=False,
+        help_text="A service is a self-contained piece of functionality within a Product. "
+                  "This is an optional field which is used in deduplication and closing of old findings when set. "
+                  "This affects the whole engagement/product depending on your deduplication scope.")
 
     group_by = serializers.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text='Choose an option to automatically group new findings by the chosen option.')
 
@@ -1371,7 +1371,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
     commit_hash = serializers.CharField(required=False)
     api_scan_configuration = serializers.PrimaryKeyRelatedField(allow_null=True, default=None,
                                                           queryset=Product_API_Scan_Configuration.objects.all())
-    service = serializers.CharField(required=False)
+    service = serializers.CharField(required=False,
+        help_text="A service is a self-contained piece of functionality within a Product. "
+                  "This is an optional field which is used in deduplication and closing of old findings when set. "
+                  "This affects the whole engagement/product depending on your deduplication scope.")
     environment = serializers.CharField(required=False)
     lead = serializers.PrimaryKeyRelatedField(
         allow_null=True,

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -395,7 +395,9 @@ class ImportScanForm(forms.Form):
     commit_hash = forms.CharField(max_length=100, required=False, help_text="Commit that was scanned.")
     build_id = forms.CharField(max_length=100, required=False, help_text="ID of the build that was scanned.")
     api_scan_configuration = forms.ModelChoiceField(Product_API_Scan_Configuration.objects, required=False, label='API Scan Configuration')
-    service = forms.CharField(max_length=200, required=False, help_text="A service is a self-contained piece of functionality within a Product. This is an optional field which is used in deduplication of findings when set.")
+    service = forms.CharField(max_length=200, required=False,
+        help_text="A service is a self-contained piece of functionality within a Product. "
+                  "This is an optional field which is used in deduplication and closing of old findings when set.")
     tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
@@ -403,7 +405,8 @@ class ImportScanForm(forms.Form):
         label="Choose report file",
         required=False)
 
-    close_old_findings = forms.BooleanField(help_text="Select if old findings no longer present in the report get closed as mitigated when importing."
+    close_old_findings = forms.BooleanField(help_text="Select if old findings no longer present in the report get closed as mitigated when importing. "
+                                                        "If service has been set, only the findings for this service will be closed. "
                                                         "This affects the whole engagement/product depending on your deduplication scope.",
                                             required=False, initial=False)
 

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -170,7 +170,7 @@ class DojoDefaultImporter(object):
             return [serializers.serialize('json', [finding, ]) for finding in new_findings]
         return new_findings
 
-    def close_old_findings(self, test, scan_date_time, user, push_to_jira=None):
+    def close_old_findings(self, test, scan_date_time, user, push_to_jira=None, service=None):
         old_findings = []
         # Close old active findings that are not reported by this scan.
         new_hash_codes = test.finding_set.values('hash_code')
@@ -179,18 +179,32 @@ class DojoDefaultImporter(object):
         # Would it make more sense to exclude duplicates? But the deduplication process can be unfinished because it's
         # run in a celery async task...
         if test.engagement.deduplication_on_engagement:
-            old_findings = Finding.objects.exclude(test=test) \
-                                            .exclude(hash_code__in=new_hash_codes) \
-                                            .filter(test__engagement=test.engagement,
-                                                test__test_type=test.test_type,
-                                                active=True)
+            if service:
+                old_findings = Finding.objects.exclude(test=test) \
+                                                .exclude(hash_code__in=new_hash_codes) \
+                                                .filter(test__engagement=test.engagement,
+                                                    test__test_type=test.test_type,
+                                                    active=True, service=service)
+            else:
+                old_findings = Finding.objects.exclude(test=test) \
+                                                .exclude(hash_code__in=new_hash_codes) \
+                                                .filter(test__engagement=test.engagement,
+                                                    test__test_type=test.test_type,
+                                                    active=True)
         else:
             # TODO BUG? this will violate the deduplication_on_engagement setting for other engagements
-            old_findings = Finding.objects.exclude(test=test) \
-                                            .exclude(hash_code__in=new_hash_codes) \
-                                            .filter(test__engagement__product=test.engagement.product,
-                                                test__test_type=test.test_type,
-                                                active=True)
+            if service:
+                old_findings = Finding.objects.exclude(test=test) \
+                                                .exclude(hash_code__in=new_hash_codes) \
+                                                .filter(test__engagement__product=test.engagement.product,
+                                                    test__test_type=test.test_type,
+                                                    active=True, service=service)
+            else:
+                old_findings = Finding.objects.exclude(test=test) \
+                                                .exclude(hash_code__in=new_hash_codes) \
+                                                .filter(test__engagement__product=test.engagement.product,
+                                                    test__test_type=test.test_type,
+                                                    active=True)
 
         for old_finding in old_findings:
             old_finding.active = False
@@ -323,7 +337,7 @@ class DojoDefaultImporter(object):
         closed_findings = []
         if close_old_findings:
             logger.debug('IMPORT_SCAN: Closing findings no longer present in scan report')
-            closed_findings = self.close_old_findings(test, scan_date, user=user, push_to_jira=push_to_jira)
+            closed_findings = self.close_old_findings(test, scan_date, user=user, push_to_jira=push_to_jira, service=service)
 
         logger.debug('IMPORT_SCAN: Updating test/engagement timestamps')
         importer_utils.update_timestamps(test, version, branch_tag, build_id, commit_hash, now, scan_date)

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -197,7 +197,7 @@ class DojoDefaultImporter(object):
         if service:
             old_findings = old_findings.filter(service=service)
         else:
-            old_findings = old_findings.filter(Q(service=True) | Q(service__exact=''))
+            old_findings = old_findings.filter(Q(service__isnull=True) | Q(service__exact=''))
 
         for old_finding in old_findings:
             old_finding.active = False

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -424,7 +424,8 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
     def import_scan_with_params(self, filename, scan_type='ZAP Scan', engagement=1, minimum_severity='Low', active=True, verified=True,
                                 push_to_jira=None, endpoint_to_add=None, tags=None, close_old_findings=False, group_by=None, engagement_name=None,
-                                product_name=None, product_type_name=None, auto_create_context=None, expected_http_status_code=201, test_title=None, scan_date=None):
+                                product_name=None, product_type_name=None, auto_create_context=None, expected_http_status_code=201, test_title=None,
+                                scan_date=None, service=None):
         payload = {
                 "minimum_severity": minimum_severity,
                 "active": active,
@@ -467,6 +468,9 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
 
         if scan_date is not None:
             payload['scan_date'] = scan_date
+
+        if service is not None:
+            payload['service'] = service
 
         return self.import_scan(payload, expected_http_status_code)
 


### PR DESCRIPTION
implements #5618

When a `service` is specified and **Close old findings** is set as well while importing a scan, only the old findings of the same service shall be closed.