### PR TITLE
Update to Django 3.2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ django-slack==5.17.6
 django-tagging==0.5.0
 django-watson==1.6.0
 django-prometheus==2.1.0
-Django==3.2.9
+Django==3.2.10
 djangorestframework==3.12.4
 gunicorn==20.1.0
 html2text==2020.1.16


### PR DESCRIPTION
dependabot missed release 3.2.10 of Django, maybe because we declined 4.0

This Django version fixes a vulnerability.