### PR TITLE
Revamp of the Anchore Grype parser

### DIFF
--- a/dojo/tools/anchore_grype/parser.py
+++ b/dojo/tools/anchore_grype/parser.py
@@ -1,5 +1,4 @@
 import json
-from packageurl import PackageURL
 
 from dojo.models import Finding
 
@@ -21,47 +20,136 @@ class AnchoreGrypeParser(object):
 
     def get_findings(self, file, test):
         data = json.load(file)
-        dupes = dict()
+        findings = []
         for item in data.get("matches", []):
-            cve = item["vulnerability"]["id"]
-            severity = self._convert_severity(item["vulnerability"]["severity"])
-            purl = PackageURL.from_string(item["artifact"]["purl"])
-            description = ""
-            description += f"\n**CVE:** {cve}"
-            if type(item["matchDetails"]) is dict:
-                description += f'\n**Matcher:** {item["matchDetails"]["matcher"]}'
-            else:
-                description += '\n**Matchers:**'
-                for matchers in item["matchDetails"]:
-                    description += f'\n * {matchers["matcher"]}'
-            description += f"\n**PURL:** {purl}"
-            description += "\n**Paths:**\n"
-            for match_path in item["artifact"]["locations"]:
-                description += f'\n * {match_path["path"]}'
+            vulnerability = item['vulnerability']
+            vuln_id = vulnerability["id"]
+            vuln_namespace = vulnerability.get('namespace', None)
+            vuln_datasource = vulnerability.get('dataSource', None)
+            vuln_severity = self._convert_severity(vulnerability["severity"])
+            vuln_urls = vulnerability.get('urls', None)
+            vuln_description = vulnerability.get('description', None)
+            vuln_fix_versions = None
+            fix = vulnerability.get('fix', None)
+            if fix:
+                vuln_fix_versions = fix.get('versions', None)
+            vuln_cvss = vulnerability.get('cvss', None)
 
-            dupe_key = cve
-            if dupe_key in dupes:
-                find = dupes[dupe_key]
-                find.nb_occurences += 1
+            rel_id = None
+            rel_datasource = None
+            rel_urls = None
+            rel_description = None
+            related_vulnerabilities = item.get('relatedVulnerabilities', None)
+            if related_vulnerabilities:
+                related_vulnerability = related_vulnerabilities[0]
+                rel_id = related_vulnerability.get('id')
+                rel_datasource = related_vulnerability.get('dataSource', None)
+                rel_urls = related_vulnerability.get('urls', None)
+                rel_description = related_vulnerability.get('description', None)
+            rel_cvss = related_vulnerability.get('cvss', None)
+
+            match_matcher = None
+            matches = item['matchDetails']
+            if matches:
+                match_matcher = matches[0]['matcher']
+                if match_matcher.endswith('-matcher'):
+                    match_matcher = match_matcher.replace('-matcher', '')
+
+            artifact = item['artifact']
+            artifact_name = artifact.get('name', None)
+            artifact_version = artifact.get('version', None)
+            artifact_purl = artifact.get('purl', None)
+
+            cve = self.get_cve(vuln_id, rel_id)
+            finding_title = f'{cve} in {artifact_name}:{artifact_version}'
+
+            finding_description = f'**Vulnerability Id:** {vuln_id}'
+            if vuln_namespace:
+                finding_description += f'\n**Vulnerability Namespace:** {vuln_namespace}'
+            if vuln_description:
+                finding_description += f'\n**Vulnerability Description:** {vuln_description}'
+            if rel_id and rel_id != vuln_id:
+                finding_description += f'\n**Related Vulnerability Id:** {rel_id}'
+            if rel_description and rel_description != vuln_description:
+                finding_description += f'\n**Related Vulnerability Description:** {rel_description}'
+            if matches:
+                if len(matches) == 1:
+                    finding_description += f"\n**Matcher:** {matches[0]['matcher']}"
+                else:
+                    finding_description += '\n**Matchers:**'
+                    for match in matches:
+                        finding_description += f"\n- {match['matcher']}"
+
+            if artifact_purl:
+                finding_description += f'\n**Package URL:** {artifact_purl}'
+
+            if cve.startswith('CVE'):
+                finding_cve = cve
             else:
-                dupes[dupe_key] = Finding(
-                    title=f"Vulnerable component ({purl.name}:{purl.version}) {cve}",
-                    description=description,
-                    cve=cve,
-                    severity=severity,
-                    impact="No impact provided",
-                    mitigation="No mitigation provided",
-                    references="[{}](https://nvd.nist.gov/vuln/detail/{})".format(
-                        cve, cve
-                    ),
+                finding_cve = None
+
+            finding_mitigation = None
+            if vuln_fix_versions:
+                finding_mitigation = 'Upgrade to version: '
+                if len(vuln_fix_versions) == 1:
+                    finding_mitigation += vuln_fix_versions[0]
+                else:
+                    for fix_version in vuln_fix_versions:
+                        finding_mitigation += f'\n- {fix_version}'
+
+            finding_references = ''
+            if vuln_datasource:
+                finding_references += f'**Vulnerability Datasource:** {vuln_datasource}\n'
+            if vuln_urls:
+                if len(vuln_urls) == 1:
+                    if vuln_urls[0] != vuln_datasource:
+                        finding_references += f'**Vulnerability URL:** {vuln_urls[0]}\n'
+                else:
+                    finding_references += '**Vulnerability URLs:**\n'
+                    for url in vuln_urls:
+                        if url != vuln_datasource:
+                            finding_references += f'- {url}\n'
+            if rel_datasource:
+                finding_references += f'**Related Vulnerability Datasource:** {rel_datasource}\n'
+            if rel_urls:
+                if len(rel_urls) == 1:
+                    if rel_urls[0] != vuln_datasource:
+                        finding_references += f'**Related Vulnerability URL:** {rel_urls[0]}\n'
+                else:
+                    finding_references += '**Related Vulnerability URLs:**\n'
+                    for url in rel_urls:
+                        if url != vuln_datasource:
+                            finding_references += f'- {url}\n'
+            if finding_references[-1] == '\n':
+                finding_references = finding_references[:-1]
+
+            if match_matcher:
+                finding_tags = [match_matcher]
+            else:
+                finding_tags = None
+
+            finding_cvss3_score, finding_cvss3 = self.get_cvss(vuln_cvss)
+            if not finding_cvss3_score:
+                finding_cvss3_score, finding_cvss3 = self.get_cvss(rel_cvss)
+
+            findings.append(Finding(
+                    title=finding_title,
+                    description=finding_description,
+                    cve=finding_cve,
+                    cwe=1352,
+                    cvssv3=finding_cvss3,
+                    cvssv3_score=finding_cvss3_score,
+                    severity=vuln_severity,
+                    mitigation=finding_mitigation,
+                    references=finding_references,
+                    component_name=artifact_name,
+                    component_version=artifact_version,
+                    tags=finding_tags,
                     static_finding=True,
                     dynamic_finding=False,
-                    component_name=purl.name,
-                    component_version=purl.version,
-                    vuln_id_from_tool=cve,
-                    nb_occurences=1,
-                )
-        return list(dupes.values())
+                   ))
+
+        return findings
 
     def _convert_severity(self, val):
         if "Unknown" == val:
@@ -70,3 +158,20 @@ class AnchoreGrypeParser(object):
             return "Info"
         else:
             return val.title()
+
+    def get_cve(self, vuln_id, rel_id):
+        if vuln_id and vuln_id.startswith('CVE'):
+            return vuln_id
+        elif rel_id and rel_id.startswith('CVE'):
+            return rel_id
+        else:
+            return vuln_id
+
+    def get_cvss(self, cvss):
+        if cvss:
+            for cvss_item in cvss:
+                if cvss_item['version'].startswith('3'):
+                    score = cvss_item['metrics']['baseScore']
+                    vector = cvss_item['vector']
+                    return score, vector
+        return None, None

--- a/dojo/tools/anchore_grype/parser.py
+++ b/dojo/tools/anchore_grype/parser.py
@@ -181,6 +181,5 @@ class AnchoreGrypeParser(object):
                 vector = cvss_item['vector']
                 cvss_objects = cvss_parser.parse_cvss_from_text(vector)
                 if len(cvss_objects) > 0 and type(cvss_objects[0]) == CVSS3:
-                    vector = cvss_item['vector']
                     return vector
         return None

--- a/dojo/tools/anchore_grype/parser.py
+++ b/dojo/tools/anchore_grype/parser.py
@@ -20,7 +20,6 @@ class AnchoreGrypeParser(object):
 
     def get_findings(self, file, test):
         data = json.load(file)
-        findings = []
         dupes = dict()
         for item in data.get("matches", []):
             vulnerability = item['vulnerability']

--- a/dojo/tools/anchore_grype/parser.py
+++ b/dojo/tools/anchore_grype/parser.py
@@ -1,4 +1,6 @@
 import json
+from cvss import parser as cvss_parser
+from cvss.cvss3 import CVSS3
 
 from dojo.models import Finding
 
@@ -176,7 +178,9 @@ class AnchoreGrypeParser(object):
     def get_cvss(self, cvss):
         if cvss:
             for cvss_item in cvss:
-                if cvss_item['version'].startswith('3'):
+                vector = cvss_item['vector']
+                cvss_objects = cvss_parser.parse_cvss_from_text(vector)
+                if len(cvss_objects) > 0 and type(cvss_objects[0]) == CVSS3:
                     vector = cvss_item['vector']
                     return vector
         return None

--- a/unittests/scans/anchore_grype/check_all_fields.json
+++ b/unittests/scans/anchore_grype/check_all_fields.json
@@ -1,0 +1,727 @@
+{
+    "matches": [
+     {
+      "vulnerability": {
+       "id": "CVE-2004-0971",
+       "dataSource": "https://security-tracker.debian.org/tracker/CVE-2004-0971",
+       "namespace": "debian:10",
+       "severity": "Negligible",
+       "urls": [
+        "https://security-tracker.debian.org/tracker/CVE-2004-0971"
+       ],
+       "cvss": [],
+       "fix": {
+        "versions": [],
+        "state": "not-fixed"
+       },
+       "advisories": []
+      },
+      "relatedVulnerabilities": [
+       {
+        "id": "CVE-2004-0971",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2004-0971",
+        "namespace": "nvd",
+        "severity": "Low",
+        "urls": [
+         "http://www.securityfocus.com/bid/11289",
+         "http://www.gentoo.org/security/en/glsa/glsa-200410-24.xml",
+         "http://www.redhat.com/support/errata/RHSA-2005-012.html",
+         "http://www.trustix.org/errata/2004/0050",
+         "http://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=136304",
+         "https://exchange.xforce.ibmcloud.com/vulnerabilities/17583",
+         "https://oval.cisecurity.org/repository/search/definition/oval%3Aorg.mitre.oval%3Adef%3A10497",
+         "https://lists.apache.org/thread.html/rc713534b10f9daeee2e0990239fa407e2118e4aa9e88a7041177497c@%3Cissues.guacamole.apache.org%3E"
+        ],
+        "description": "The krb5-send-pr script in the kerberos5 (krb5) package in Trustix Secure Linux 1.5 through 2.1, and possibly other operating systems, allows local users to overwrite files via a symlink attack on temporary files.",
+        "cvss": [
+         {
+          "version": "2.0",
+          "vector": "AV:L/AC:L/Au:N/C:N/I:P/A:N",
+          "metrics": {
+           "baseScore": 2.1,
+           "exploitabilityScore": 3.9,
+           "impactScore": 2.9
+          },
+          "vendorMetadata": {}
+         }
+        ]
+       }
+      ],
+      "matchDetails": [
+       {
+        "matcher": "dpkg-matcher",
+        "searchedBy": {
+         "distro": {
+          "type": "debian",
+          "version": "10"
+         },
+         "namespace": "debian:10",
+         "package": {
+          "name": "krb5",
+          "version": "1.17-3+deb10u3"
+         }
+        },
+        "found": {
+         "versionConstraint": "none (deb)"
+        }
+       }
+      ],
+      "artifact": {
+       "name": "libgssapi-krb5-2",
+       "version": "1.17-3+deb10u3",
+       "type": "deb",
+       "locations": [
+        {
+         "path": "/var/lib/dpkg/status",
+         "layerID": "sha256:88a5584c6af8c220f94abb05315c2695505c8b9e2344a0aa879721b871d32b03"
+        },
+        {
+         "path": "/var/lib/dpkg/info/libgssapi-krb5-2:amd64.md5sums",
+         "layerID": "sha256:88a5584c6af8c220f94abb05315c2695505c8b9e2344a0aa879721b871d32b03"
+        },
+        {
+         "path": "/usr/share/doc/libgssapi-krb5-2/copyright",
+         "layerID": "sha256:88a5584c6af8c220f94abb05315c2695505c8b9e2344a0aa879721b871d32b03"
+        }
+       ],
+       "language": "",
+       "licenses": [
+        "GPL-2"
+       ],
+       "cpes": [
+        "cpe:2.3:a:libgssapi-krb5-2:libgssapi-krb5-2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi-krb5-2:libgssapi_krb5_2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi_krb5_2:libgssapi-krb5-2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi_krb5_2:libgssapi_krb5_2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi-krb5:libgssapi-krb5-2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi-krb5:libgssapi_krb5_2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi_krb5:libgssapi-krb5-2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi_krb5:libgssapi_krb5_2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi:libgssapi-krb5-2:1.17-3+deb10u3:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libgssapi:libgssapi_krb5_2:1.17-3+deb10u3:*:*:*:*:*:*:*"
+       ],
+       "purl": "pkg:deb/debian/libgssapi-krb5-2@1.17-3+deb10u3?arch=amd64",
+       "metadata": {
+        "Source": "krb5"
+       }
+      }
+     },
+     {
+      "vulnerability": {
+       "id": "CVE-2021-32626",
+       "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-32626",
+       "namespace": "nvd",
+       "severity": "High",
+       "urls": [
+        "https://github.com/redis/redis/commit/666ed7facf4524bf6d19b11b20faa2cf93fdf591",
+        "https://github.com/redis/redis/security/advisories/GHSA-p486-xggp-782c",
+        "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VL5KXFN3ATM7IIM7Q4O4PWTSRGZ5744Z/",
+        "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HTYQ5ZF37HNGTZWVNJD3VXP7I6MEEF42/",
+        "https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E",
+        "https://security.netapp.com/advisory/ntap-20211104-0003/",
+        "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WR5WKJWXD4D6S3DJCZ56V74ESLTDQRAB/",
+        "https://www.debian.org/security/2021/dsa-5001"
+       ],
+       "description": "Redis is an open source, in-memory database that persists on disk. In affected versions specially crafted Lua scripts executing in Redis can cause the heap-based Lua stack to be overflowed, due to incomplete checks for this condition. This can result with heap corruption and potentially remote code execution. This problem exists in all versions of Redis with Lua scripting support, starting from 2.6. The problem is fixed in versions 6.2.6, 6.0.16 and 5.0.14. For users unable to update an additional workaround to mitigate the problem without patching the redis-server executable is to prevent users from executing Lua scripts. This can be done using ACL to restrict EVAL and EVALSHA commands.",
+       "cvss": [
+        {
+         "version": "2.0",
+         "vector": "AV:N/AC:L/Au:S/C:P/I:P/A:P",
+         "metrics": {
+          "baseScore": 6.5,
+          "exploitabilityScore": 8,
+          "impactScore": 6.4
+         },
+         "vendorMetadata": {}
+        },
+        {
+         "version": "3.1",
+         "vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+         "metrics": {
+          "baseScore": 8.8,
+          "exploitabilityScore": 2.8,
+          "impactScore": 5.9
+         },
+         "vendorMetadata": {}
+        }
+       ],
+       "fix": {
+        "versions": ["fix_1", "fix_2"],
+        "state": "wont-fix"
+       },
+       "advisories": []
+      },
+      "relatedVulnerabilities": [],
+      "matchDetails": [
+       {
+        "matcher": "python-matcher",
+        "searchedBy": {
+         "namespace": "nvd",
+         "cpes": [
+          "cpe:2.3:a:redis:redis:4.0.2:*:*:*:*:*:*:*"
+         ]
+        },
+        "found": {
+         "versionConstraint": ">= 2.6, < 5.0.14 || >= 6.0.0, < 6.0.16 || >= 6.2.0, < 6.2.6 (unknown)",
+         "cpes": [
+          "cpe:2.3:a:redis:redis:*:*:*:*:*:*:*:*"
+         ]
+        }
+       },
+       {
+           "matcher": "python2-matcher",
+           "searchedBy": {
+            "namespace": "nvd",
+            "cpes": [
+             "cpe:2.3:a:redis:redis:4.0.2:*:*:*:*:*:*:*"
+            ]
+           },
+           "found": {
+            "versionConstraint": ">= 2.6, < 5.0.14 || >= 6.0.0, < 6.0.16 || >= 6.2.0, < 6.2.6 (unknown)",
+            "cpes": [
+             "cpe:2.3:a:redis:redis:*:*:*:*:*:*:*:*"
+            ]
+           }
+          }
+         ],
+      "artifact": {
+       "name": "redis",
+       "version": "4.0.2",
+       "type": "python",
+       "locations": [
+        {
+         "path": "/usr/local/lib/python3.8/site-packages/redis-4.0.2.dist-info/METADATA",
+         "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+        },
+        {
+         "path": "/usr/local/lib/python3.8/site-packages/redis-4.0.2.dist-info/RECORD",
+         "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+        },
+        {
+         "path": "/usr/local/lib/python3.8/site-packages/redis-4.0.2.dist-info/top_level.txt",
+         "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+        }
+       ],
+       "language": "python",
+       "licenses": [
+        "MIT"
+       ],
+       "cpes": [
+        "cpe:2.3:a:python-redis:python-redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python-redis:python_redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python_redis:python-redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python_redis:python_redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:redis_inc_:python-redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:redis_inc_:python_redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python:python-redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python:python_redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python-redis:redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python_redis:redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:redis:python-redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:redis:python_redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:oss:python-redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:oss:python_redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:redis_inc_:redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python:redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:redis:redis:4.0.2:*:*:*:*:*:*:*",
+        "cpe:2.3:a:oss:redis:4.0.2:*:*:*:*:*:*:*"
+       ],
+       "purl": "pkg:pypi/redis@4.0.2",
+       "metadata": null
+      }
+     },
+     {
+      "vulnerability": {
+       "id": "CVE-2021-33574",
+       "dataSource": "https://security-tracker.debian.org/tracker/CVE-2021-33574",
+       "namespace": "debian:10",
+       "severity": "Critical",
+       "urls": [
+        "https://security-tracker.debian.org/tracker/CVE-2021-33574"
+       ],
+       "cvss": [],
+       "fix": {
+        "versions": [],
+        "state": "wont-fix"
+       },
+       "advisories": []
+      },
+      "relatedVulnerabilities": [
+       {
+        "id": "CVE-2021-33574",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-33574",
+        "namespace": "nvd",
+        "severity": "Critical",
+        "urls": [
+         "https://sourceware.org/bugzilla/show_bug.cgi?id=27896",
+         "https://sourceware.org/bugzilla/show_bug.cgi?id=27896#c1",
+         "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RBUUWUGXVILQXVWEOU7N42ICHPJNAEUP/",
+         "https://security.netapp.com/advisory/ntap-20210629-0005/",
+         "https://security.gentoo.org/glsa/202107-07",
+         "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KJYYIMDDYOHTP2PORLABTOHYQYYREZDD/"
+        ],
+        "description": "The mq_notify function in the GNU C Library (aka glibc) versions 2.32 and 2.33 has a use-after-free. It may use the notification thread attributes object (passed through its struct sigevent parameter) after it has been freed by the caller, leading to a denial of service (application crash) or possibly unspecified other impact.",
+        "cvss": [
+         {
+          "version": "2.0",
+          "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+          "metrics": {
+           "baseScore": 7.5,
+           "exploitabilityScore": 10,
+           "impactScore": 6.4
+          },
+          "vendorMetadata": {}
+         },
+         {
+          "version": "3.1",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "metrics": {
+           "baseScore": 9.8,
+           "exploitabilityScore": 3.9,
+           "impactScore": 5.9
+          },
+          "vendorMetadata": {}
+         }
+        ]
+       }
+      ],
+      "matchDetails": [
+       {
+        "matcher": "dpkg-matcher",
+        "searchedBy": {
+         "distro": {
+          "type": "debian",
+          "version": "10"
+         },
+         "namespace": "debian:10",
+         "package": {
+          "name": "glibc",
+          "version": "2.28-10"
+         }
+        },
+        "found": {
+         "versionConstraint": "none (deb)"
+        }
+       }
+      ],
+      "artifact": {
+       "name": "libc-bin",
+       "version": "2.28-10",
+       "type": "deb",
+       "locations": [
+        {
+         "path": "/var/lib/dpkg/status",
+         "layerID": "sha256:88a5584c6af8c220f94abb05315c2695505c8b9e2344a0aa879721b871d32b03"
+        },
+        {
+         "path": "/var/lib/dpkg/info/libc-bin.md5sums",
+         "layerID": "sha256:d000633a56813933cb0ac5ee3246cf7a4c0205db6290018a169d7cb096581046"
+        },
+        {
+         "path": "/var/lib/dpkg/info/libc-bin.conffiles",
+         "layerID": "sha256:d000633a56813933cb0ac5ee3246cf7a4c0205db6290018a169d7cb096581046"
+        },
+        {
+         "path": "/usr/share/doc/libc-bin/copyright",
+         "layerID": "sha256:d000633a56813933cb0ac5ee3246cf7a4c0205db6290018a169d7cb096581046"
+        }
+       ],
+       "language": "",
+       "licenses": [
+        "GPL-2",
+        "LGPL-2.1"
+       ],
+       "cpes": [
+        "cpe:2.3:a:libc-bin:libc-bin:2.28-10:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libc-bin:libc_bin:2.28-10:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libc_bin:libc-bin:2.28-10:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libc_bin:libc_bin:2.28-10:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libc:libc-bin:2.28-10:*:*:*:*:*:*:*",
+        "cpe:2.3:a:libc:libc_bin:2.28-10:*:*:*:*:*:*:*"
+       ],
+       "purl": "pkg:deb/debian/libc-bin@2.28-10?arch=amd64",
+       "metadata": {
+        "Source": "glibc"
+       }
+      }
+     },
+     {
+      "vulnerability": {
+       "id": "CVE-2021-33574",
+       "dataSource": "https://security-tracker.debian.org/tracker/CVE-2021-33574",
+       "namespace": "debian:10",
+       "severity": "Critical",
+       "urls": [
+        "https://security-tracker.debian.org/tracker/CVE-2021-33574"
+       ],
+       "cvss": [],
+       "fix": {
+        "versions": [],
+        "state": "wont-fix"
+       },
+       "advisories": []
+      },
+      "relatedVulnerabilities": [
+       {
+        "id": "CVE-2021-33574",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-33574",
+        "namespace": "nvd",
+        "severity": "Critical",
+        "urls": [
+         "https://sourceware.org/bugzilla/show_bug.cgi?id=27896",
+         "https://sourceware.org/bugzilla/show_bug.cgi?id=27896#c1",
+         "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RBUUWUGXVILQXVWEOU7N42ICHPJNAEUP/",
+         "https://security.netapp.com/advisory/ntap-20210629-0005/",
+         "https://security.gentoo.org/glsa/202107-07",
+         "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KJYYIMDDYOHTP2PORLABTOHYQYYREZDD/"
+        ],
+        "description": "The mq_notify function in the GNU C Library (aka glibc) versions 2.32 and 2.33 has a use-after-free. It may use the notification thread attributes object (passed through its struct sigevent parameter) after it has been freed by the caller, leading to a denial of service (application crash) or possibly unspecified other impact.",
+        "cvss": [
+         {
+          "version": "2.0",
+          "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+          "metrics": {
+           "baseScore": 7.5,
+           "exploitabilityScore": 10,
+           "impactScore": 6.4
+          },
+          "vendorMetadata": {}
+         },
+         {
+          "version": "3.1",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "metrics": {
+           "baseScore": 9.8,
+           "exploitabilityScore": 3.9,
+           "impactScore": 5.9
+          },
+          "vendorMetadata": {}
+         }
+        ]
+       }
+      ],
+      "matchDetails": [
+       {
+        "matcher": "dpkg-matcher",
+        "searchedBy": {
+         "distro": {
+          "type": "debian",
+          "version": "10"
+         },
+         "namespace": "debian:10",
+         "package": {
+          "name": "glibc",
+          "version": "2.28-10"
+         }
+        },
+        "found": {
+         "versionConstraint": "none (deb)"
+        }
+       }
+      ],
+      "artifact": {
+       "name": "libc6",
+       "version": "2.28-10",
+       "type": "deb",
+       "locations": [
+        {
+         "path": "/var/lib/dpkg/status",
+         "layerID": "sha256:88a5584c6af8c220f94abb05315c2695505c8b9e2344a0aa879721b871d32b03"
+        },
+        {
+         "path": "/var/lib/dpkg/info/libc6:amd64.md5sums",
+         "layerID": "sha256:d000633a56813933cb0ac5ee3246cf7a4c0205db6290018a169d7cb096581046"
+        },
+        {
+         "path": "/var/lib/dpkg/info/libc6:amd64.conffiles",
+         "layerID": "sha256:d000633a56813933cb0ac5ee3246cf7a4c0205db6290018a169d7cb096581046"
+        },
+        {
+         "path": "/usr/share/doc/libc6/copyright",
+         "layerID": "sha256:d000633a56813933cb0ac5ee3246cf7a4c0205db6290018a169d7cb096581046"
+        }
+       ],
+       "language": "",
+       "licenses": [
+        "GPL-2",
+        "LGPL-2.1"
+       ],
+       "cpes": [
+        "cpe:2.3:a:libc6:libc6:2.28-10:*:*:*:*:*:*:*"
+       ],
+       "purl": "pkg:deb/debian/libc6@2.28-10?arch=amd64",
+       "metadata": {
+        "Source": "glibc"
+       }
+      }
+     },
+     {
+      "vulnerability": {
+       "id": "GHSA-v6rh-hp5x-86rv",
+       "dataSource": "https://github.com/advisories/GHSA-v6rh-hp5x-86rv",
+       "namespace": "github:python",
+       "severity": "High",
+       "urls": [
+        "https://github.com/advisories/GHSA-v6rh-hp5x-86rv"
+       ],
+       "description": "Potential bypass of an upstream access control based on URL paths in Django",
+       "cvss": [],
+       "fix": {
+        "versions": [
+         "3.2.10"
+        ],
+        "state": "fixed"
+       },
+       "advisories": []
+      },
+      "relatedVulnerabilities": [
+       {
+        "id": "CVE-2021-44420",
+        "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-44420",
+        "namespace": "nvd",
+        "severity": "High",
+        "urls": [
+         "https://docs.djangoproject.com/en/3.2/releases/security/",
+         "https://www.openwall.com/lists/oss-security/2021/12/07/1",
+         "https://www.djangoproject.com/weblog/2021/dec/07/security-releases/",
+         "https://groups.google.com/forum/#!forum/django-announce"
+        ],
+        "description": "In Django 2.2 before 2.2.25, 3.1 before 3.1.14, and 3.2 before 3.2.10, HTTP requests for URLs with trailing newlines could bypass upstream access control based on URL paths.",
+        "cvss": [
+         {
+          "version": "2.0",
+          "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+          "metrics": {
+           "baseScore": 7.5,
+           "exploitabilityScore": 10,
+           "impactScore": 6.4
+          },
+          "vendorMetadata": {}
+         },
+         {
+          "version": "3.1",
+          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "metrics": {
+           "baseScore": 7.3,
+           "exploitabilityScore": 3.9,
+           "impactScore": 3.4
+          },
+          "vendorMetadata": {}
+         }
+        ]
+       }
+      ],
+      "matchDetails": [
+       {
+        "matcher": "python-matcher",
+        "searchedBy": {
+         "language": "python",
+         "namespace": "github:python"
+        },
+        "found": {
+         "versionConstraint": ">=3.2,<3.2.10 (python)"
+        }
+       }
+      ],
+      "artifact": {
+       "name": "Django",
+       "version": "3.2.9",
+       "type": "python",
+       "locations": [
+        {
+         "path": "/usr/local/lib/python3.8/site-packages/Django-3.2.9.dist-info/METADATA",
+         "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+        },
+        {
+         "path": "/usr/local/lib/python3.8/site-packages/Django-3.2.9.dist-info/RECORD",
+         "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+        },
+        {
+         "path": "/usr/local/lib/python3.8/site-packages/Django-3.2.9.dist-info/top_level.txt",
+         "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+        }
+       ],
+       "language": "python",
+       "licenses": [
+        "BSD-3-Clause"
+       ],
+       "cpes": [
+        "cpe:2.3:a:django_software_foundation:python-Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:django_software_foundation:python_Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:django_software_foundation:Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python-Django:python-Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python-Django:python_Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python_Django:python-Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python_Django:python_Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:foundation:python-Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:foundation:python_Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:Django:python-Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:Django:python_Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python-Django:Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python:python-Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python:python_Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python_Django:Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:foundation:Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:Django:Django:3.2.9:*:*:*:*:*:*:*",
+        "cpe:2.3:a:python:Django:3.2.9:*:*:*:*:*:*:*"
+       ],
+       "purl": "pkg:pypi/Django@3.2.9",
+       "metadata": null
+      }
+     }
+    ],
+    "source": {
+     "type": "image",
+     "target": {
+      "userInput": "vulnerable-image:latest",
+      "imageID": "sha256:ce9898fd214aef9c994a42624b09056bdce3ff4a8e3f68dc242d967b80fcbeee",
+      "manifestDigest": "sha256:9d8825ab20ac86b40eb71495bece1608a302fb180384740697a28c2b0a5a0fc6",
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "tags": [
+       "vulnerable-image:latest"
+      ],
+      "imageSize": 707381791,
+      "layers": [
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:d000633a56813933cb0ac5ee3246cf7a4c0205db6290018a169d7cb096581046",
+        "size": 69238554
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:55ad5d8b8f0f48507b98793ce81733f50a8a05f0bc047361557ae7d00878d1e3",
+        "size": 7049056
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:4e74918601aaa951d324b4ca13aad782843e717a7b1e11183b47df2f402dd5f4",
+        "size": 28480732
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:de9b19e6cd4958c84cad9d100996d5b1d34de0abbd070fd95b14ada6185ab652",
+        "size": 0
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:6858b25d5a73ff800f097f9917cf6720ff1aeea25717e18bda4fa679a27f2524",
+        "size": 9489681
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:480e165552627baa9a7e6bf733887dbc5fb970cb65f56609de26034ab9324fbb",
+        "size": 0
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:88a5584c6af8c220f94abb05315c2695505c8b9e2344a0aa879721b871d32b03",
+        "size": 180401350
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:f7a04af01f3935d2566a6adf954df0fd0af8fa2c7d9d8002c462f5e60414cecf",
+        "size": 71038612
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:b61eb60b69c5f5873cf0ffc2cf3c9695db823e17b7b824a9d61556f6618bff38",
+        "size": 1641
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a",
+        "size": 310195098
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:5e2fd8ef39d445b19026e62e9ae3e8c0cf20968fbd128ed81709e5237c61813d",
+        "size": 18156
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:4447e1abeba62a0283a74fec9b05aa70599c4f31d1d9fde9da65a9ad70f3b5f9",
+        "size": 1853
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:3a3754be14e5b46a63dd8169f113e86d348b0ed6ba9ceb0dbbd60b0fd3bd8704",
+        "size": 13646541
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:8b75640adc87dcce00108c011fd78c637ba43bfe2cd8e71b4989d2895db932bf",
+        "size": 356
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:5416baa01a2213ef375a26665b0b6ff1872b33299570cfda8188c0641e375ea0",
+        "size": 1920700
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:3946602aacfcfcc40c2857ca17b6b254795f529b0d0190fbe5c96e9b68517b32",
+        "size": 0
+       },
+       {
+        "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+        "digest": "sha256:23f38aecad5ec4b885e28a5dc80472a134c0fc9af3bdb8d69873ece4f218e31b",
+        "size": 15899461
+       }
+      ],
+      "manifest": "eyJzY2hlbWFWZXJzaW9uIjoyLCJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmRpc3RyaWJ1dGlvbi5tYW5pZmVzdC52Mitqc29uIiwiY29uZmlnIjp7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuY29udGFpbmVyLmltYWdlLnYxK2pzb24iLCJzaXplIjoxMjk1NywiZGlnZXN0Ijoic2hhMjU2OmNlOTg5OGZkMjE0YWVmOWM5OTRhNDI2MjRiMDkwNTZiZGNlM2ZmNGE4ZTNmNjhkYzI0MmQ5NjdiODBmY2JlZWUifSwibGF5ZXJzIjpbeyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6NzI1MzE0NTYsImRpZ2VzdCI6InNoYTI1NjpkMDAwNjMzYTU2ODEzOTMzY2IwYWM1ZWUzMjQ2Y2Y3YTRjMDIwNWRiNjI5MDAxOGExNjlkN2NiMDk2NTgxMDQ2In0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6NzM3Njg5NiwiZGlnZXN0Ijoic2hhMjU2OjU1YWQ1ZDhiOGYwZjQ4NTA3Yjk4NzkzY2U4MTczM2Y1MGE4YTA1ZjBiYzA0NzM2MTU1N2FlN2QwMDg3OGQxZTMifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjoyOTM4MjY1NiwiZGlnZXN0Ijoic2hhMjU2OjRlNzQ5MTg2MDFhYWE5NTFkMzI0YjRjYTEzYWFkNzgyODQzZTcxN2E3YjFlMTExODNiNDdkZjJmNDAyZGQ1ZjQifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjo0NjA4LCJkaWdlc3QiOiJzaGEyNTY6ZGU5YjE5ZTZjZDQ5NThjODRjYWQ5ZDEwMDk5NmQ1YjFkMzRkZTBhYmJkMDcwZmQ5NWIxNGFkYTYxODVhYjY1MiJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjEwMDY4OTkyLCJkaWdlc3QiOiJzaGEyNTY6Njg1OGIyNWQ1YTczZmY4MDBmMDk3Zjk5MTdjZjY3MjBmZjFhZWVhMjU3MTdlMThiZGE0ZmE2NzlhMjdmMjUyNCJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjIwNDgsImRpZ2VzdCI6InNoYTI1Njo0ODBlMTY1NTUyNjI3YmFhOWE3ZTZiZjczMzg4N2RiYzVmYjk3MGNiNjVmNTY2MDlkZTI2MDM0YWI5MzI0ZmJiIn0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MTgyOTM0NTI4LCJkaWdlc3QiOiJzaGEyNTY6ODhhNTU4NGM2YWY4YzIyMGY5NGFiYjA1MzE1YzI2OTU1MDVjOGI5ZTIzNDRhMGFhODc5NzIxYjg3MWQzMmIwMyJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjcxMTY0NDE2LCJkaWdlc3QiOiJzaGEyNTY6ZjdhMDRhZjAxZjM5MzVkMjU2NmE2YWRmOTU0ZGYwZmQwYWY4ZmEyYzdkOWQ4MDAyYzQ2MmY1ZTYwNDE0Y2VjZiJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjQwOTYsImRpZ2VzdCI6InNoYTI1NjpiNjFlYjYwYjY5YzVmNTg3M2NmMGZmYzJjZjNjOTY5NWRiODIzZTE3YjdiODI0YTlkNjE1NTZmNjYxOGJmZjM4In0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MzI2OTAxMjQ4LCJkaWdlc3QiOiJzaGEyNTY6YjFkNDQ1NWNmODJiMTVhNTBiMDA2ZmU4N2JkMjlmNjk0YzhmOTE1NTQ1NjI1M2ViNjdmZGQxNTViNWVkY2Y0YSJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjI2MTEyLCJkaWdlc3QiOiJzaGEyNTY6NWUyZmQ4ZWYzOWQ0NDViMTkwMjZlNjJlOWFlM2U4YzBjZjIwOTY4ZmJkMTI4ZWQ4MTcwOWU1MjM3YzYxODEzZCJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjU2MzIsImRpZ2VzdCI6InNoYTI1Njo0NDQ3ZTFhYmViYTYyYTAyODNhNzRmZWM5YjA1YWE3MDU5OWM0ZjMxZDFkOWZkZTlkYTY1YTlhZDcwZjNiNWY5In0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MTUxNzI2MDgsImRpZ2VzdCI6InNoYTI1NjozYTM3NTRiZTE0ZTViNDZhNjNkZDgxNjlmMTEzZTg2ZDM0OGIwZWQ2YmE5Y2ViMGRiYmQ2MGIwZmQzYmQ4NzA0In0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MzU4NCwiZGlnZXN0Ijoic2hhMjU2OjhiNzU2NDBhZGM4N2RjY2UwMDEwOGMwMTFmZDc4YzYzN2JhNDNiZmUyY2Q4ZTcxYjQ5ODlkMjg5NWRiOTMyYmYifSx7Im1lZGlhVHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC5kb2NrZXIuaW1hZ2Uucm9vdGZzLmRpZmYudGFyLmd6aXAiLCJzaXplIjoxOTU4NDAwLCJkaWdlc3QiOiJzaGEyNTY6NTQxNmJhYTAxYTIyMTNlZjM3NWEyNjY2NWIwYjZmZjE4NzJiMzMyOTk1NzBjZmRhODE4OGMwNjQxZTM3NWVhMCJ9LHsibWVkaWFUeXBlIjoiYXBwbGljYXRpb24vdm5kLmRvY2tlci5pbWFnZS5yb290ZnMuZGlmZi50YXIuZ3ppcCIsInNpemUiOjUxMjAsImRpZ2VzdCI6InNoYTI1NjozOTQ2NjAyYWFjZmNmY2M0MGMyODU3Y2ExN2I2YjI1NDc5NWY1MjliMGQwMTkwZmJlNWM5NmU5YjY4NTE3YjMyIn0seyJtZWRpYVR5cGUiOiJhcHBsaWNhdGlvbi92bmQuZG9ja2VyLmltYWdlLnJvb3Rmcy5kaWZmLnRhci5nemlwIiwic2l6ZSI6MTc0NzkxNjgsImRpZ2VzdCI6InNoYTI1NjoyM2YzOGFlY2FkNWVjNGI4ODVlMjhhNWRjODA0NzJhMTM0YzBmYzlhZjNiZGI4ZDY5ODczZWNlNGYyMThlMzFiIn1dfQ==",
+      "config": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImNvbmZpZyI6eyJVc2VyIjoiMTAwMSIsIkVudiI6WyJQQVRIPS91c3IvbG9jYWwvYmluOi91c3IvbG9jYWwvc2JpbjovdXNyL2xvY2FsL2JpbjovdXNyL3NiaW46L3Vzci9iaW46L3NiaW46L2JpbiIsIkxBTkc9Qy5VVEYtOCIsIkdQR19LRVk9RTNGRjI4MzlDMDQ4QjI1QzA4NERFQkU5QjI2OTk1RTMxMDI1MDU2OCIsIlBZVEhPTl9WRVJTSU9OPTMuOC4xMiIsIlBZVEhPTl9QSVBfVkVSU0lPTj0yMS4yLjQiLCJQWVRIT05fR0VUX1BJUF9VUkw9aHR0cHM6Ly9naXRodWIuY29tL3B5cGEvZ2V0LXBpcC9yYXcvYzIwYjBjZmQ2NDNjZDRhMTkyNDZjY2YyMDRlMjk5N2FmNzBmNmIyMS9wdWJsaWMvZ2V0LXBpcC5weSIsIlBZVEhPTl9HRVRfUElQX1NIQTI1Nj1mYTZmM2ZiOTNjY2UyMzRjZDRlOGRkMmJlYjU0YTUxYWI5YzI0NzY1M2I1Mjg1NWE0OGRkNDRlNmIyMWZmMjhiIiwiYXBwdXNlcj1kZWZlY3Rkb2pvIiwiRERfQURNSU5fVVNFUj1hZG1pbiIsIkREX0FETUlOX01BSUw9YWRtaW5AZGVmZWN0ZG9qby5sb2NhbCIsIkREX0FETUlOX1BBU1NXT1JEPSIsIkREX0FETUlOX0ZJUlNUX05BTUU9QWRtaW5pc3RyYXRvciIsIkREX0FETUlOX0xBU1RfTkFNRT1Vc2VyIiwiRERfQUxMT1dFRF9IT1NUUz0qIiwiRERfQ0VMRVJZX0JFQVRfU0NIRURVTEVfRklMRU5BTUU9L3J1bi9jZWxlcnktYmVhdC1zY2hlZHVsZSIsIkREX0NFTEVSWV9CUk9LRVJfU0NIRU1FPWFtcXAiLCJERF9DRUxFUllfQlJPS0VSX1VTRVI9ZGVmZWN0ZG9qbyIsIkREX0NFTEVSWV9CUk9LRVJfUEFTU1dPUkQ9ZGVmZWN0ZG9qbyIsIkREX0NFTEVSWV9CUk9LRVJfSE9TVD1yYWJiaXRtcSIsIkREX0NFTEVSWV9CUk9LRVJfUE9SVD01NjcyIiwiRERfQ0VMRVJZX0JST0tFUl9QQVRIPS8vIiwiRERfQ0VMRVJZX0xPR19MRVZFTD1JTkZPIiwiRERfQ0VMRVJZX1dPUktFUl9QT09MX1RZUEU9c29sbyIsIkREX0RBVEFCQVNFX0VOR0lORT1kamFuZ28uZGIuYmFja2VuZHMubXlzcWwiLCJERF9EQVRBQkFTRV9IT1NUPW15c3FsIiwiRERfREFUQUJBU0VfTkFNRT1kZWZlY3Rkb2pvIiwiRERfREFUQUJBU0VfUEFTU1dPUkQ9ZGVmZWN0ZG9qbyIsIkREX0RBVEFCQVNFX1BPUlQ9MzMwNiIsIkREX0RBVEFCQVNFX1VTRVI9ZGVmZWN0ZG9qbyIsIkREX0lOSVRJQUxJWkU9dHJ1ZSIsIkREX1VXU0dJX01PREU9c29ja2V0IiwiRERfVVdTR0lfRU5EUE9JTlQ9MC4wLjAuMDozMDMxIiwiRERfVVdTR0lfTlVNX09GX1BST0NFU1NFUz0yIiwiRERfVVdTR0lfTlVNX09GX1RIUkVBRFM9MiIsIkREX1RSQUNLX01JR1JBVElPTlM9VHJ1ZSIsIkREX0RKQU5HT19NRVRSSUNTX0VOQUJMRUQ9RmFsc2UiXSwiRW50cnlwb2ludCI6WyIvZW50cnlwb2ludC11d3NnaS5zaCJdLCJXb3JraW5nRGlyIjoiL2FwcCIsIk9uQnVpbGQiOm51bGx9LCJjcmVhdGVkIjoiMjAyMS0xMi0yNFQwNjo1NDo0NC4yMTk5MjAzWiIsImhpc3RvcnkiOlt7ImNyZWF0ZWQiOiIyMDIxLTA5LTAzVDAxOjIxOjQ2LjUxMTMxMzY1NloiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgQUREIGZpbGU6NGZmODVkOWY2YWEyNDY3NDY5MTJkYjYyZGVhMDJlYjcxNzUwNDc0YmIyOTYxMWU3NzA1MTZhMWZjZDIxN2FkZCBpbiAvICJ9LHsiY3JlYXRlZCI6IjIwMjEtMDktMDNUMDE6MjE6NDYuOTM1MTQ1ODMzWiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jICMobm9wKSAgQ01EIFtcImJhc2hcIl0iLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0wOS0wM1QwMTo0NDoyNC43MTQ0MDA4MDVaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApICBFTlYgUEFUSD0vdXNyL2xvY2FsL2JpbjovdXNyL2xvY2FsL3NiaW46L3Vzci9sb2NhbC9iaW46L3Vzci9zYmluOi91c3IvYmluOi9zYmluOi9iaW4iLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0wOS0wM1QwMTo0NDoyNC45MjMwMjU3NzRaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgIyhub3ApICBFTlYgTEFORz1DLlVURi04IiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjEtMDktMDNUMDI6MjY6MjguNzI4MzgxMTE5WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jIHNldCAtZXV4OyBcdGFwdC1nZXQgdXBkYXRlOyBcdGFwdC1nZXQgaW5zdGFsbCAteSAtLW5vLWluc3RhbGwtcmVjb21tZW5kcyBcdFx0Y2EtY2VydGlmaWNhdGVzIFx0XHRuZXRiYXNlIFx0OyBcdHJtIC1yZiAvdmFyL2xpYi9hcHQvbGlzdHMvKiJ9LHsiY3JlYXRlZCI6IjIwMjEtMDktMDNUMDI6MjY6MjkuMTU5NzM2MDM2WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jICMobm9wKSAgRU5WIEdQR19LRVk9RTNGRjI4MzlDMDQ4QjI1QzA4NERFQkU5QjI2OTk1RTMxMDI1MDU2OCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWQiOiIyMDIxLTA5LTAzVDAyOjI2OjI5LjQ4NzEzNTc5MVoiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIEVOViBQWVRIT05fVkVSU0lPTj0zLjguMTIiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0wOS0wM1QwMjozNzowMy4zNjAwMjM2NTdaIiwiY3JlYXRlZF9ieSI6Ii9iaW4vc2ggLWMgc2V0IC1leCBcdFx0XHUwMDI2XHUwMDI2IHNhdmVkQXB0TWFyaz1cIiQoYXB0LW1hcmsgc2hvd21hbnVhbClcIiBcdFx1MDAyNlx1MDAyNiBhcHQtZ2V0IHVwZGF0ZSBcdTAwMjZcdTAwMjYgYXB0LWdldCBpbnN0YWxsIC15IC0tbm8taW5zdGFsbC1yZWNvbW1lbmRzIFx0XHRkcGtnLWRldiBcdFx0Z2NjIFx0XHRsaWJibHVldG9vdGgtZGV2IFx0XHRsaWJiejItZGV2IFx0XHRsaWJjNi1kZXYgXHRcdGxpYmV4cGF0MS1kZXYgXHRcdGxpYmZmaS1kZXYgXHRcdGxpYmdkYm0tZGV2IFx0XHRsaWJsem1hLWRldiBcdFx0bGlibmN1cnNlc3c1LWRldiBcdFx0bGlicmVhZGxpbmUtZGV2IFx0XHRsaWJzcWxpdGUzLWRldiBcdFx0bGlic3NsLWRldiBcdFx0bWFrZSBcdFx0dGstZGV2IFx0XHR1dWlkLWRldiBcdFx0d2dldCBcdFx0eHotdXRpbHMgXHRcdHpsaWIxZy1kZXYgXHRcdCQoY29tbWFuZCAtdiBncGcgXHUwMDNlIC9kZXYvbnVsbCB8fCBlY2hvICdnbnVwZyBkaXJtbmdyJykgXHRcdFx1MDAyNlx1MDAyNiB3Z2V0IC1PIHB5dGhvbi50YXIueHogXCJodHRwczovL3d3dy5weXRob24ub3JnL2Z0cC9weXRob24vJHtQWVRIT05fVkVSU0lPTiUlW2Etel0qfS9QeXRob24tJFBZVEhPTl9WRVJTSU9OLnRhci54elwiIFx0XHUwMDI2XHUwMDI2IHdnZXQgLU8gcHl0aG9uLnRhci54ei5hc2MgXCJodHRwczovL3d3dy5weXRob24ub3JnL2Z0cC9weXRob24vJHtQWVRIT05fVkVSU0lPTiUlW2Etel0qfS9QeXRob24tJFBZVEhPTl9WRVJTSU9OLnRhci54ei5hc2NcIiBcdFx1MDAyNlx1MDAyNiBleHBvcnQgR05VUEdIT01FPVwiJChta3RlbXAgLWQpXCIgXHRcdTAwMjZcdTAwMjYgZ3BnIC0tYmF0Y2ggLS1rZXlzZXJ2ZXIgaGtwczovL2tleXMub3BlbnBncC5vcmcgLS1yZWN2LWtleXMgXCIkR1BHX0tFWVwiIFx0XHUwMDI2XHUwMDI2IGdwZyAtLWJhdGNoIC0tdmVyaWZ5IHB5dGhvbi50YXIueHouYXNjIHB5dGhvbi50YXIueHogXHRcdTAwMjZcdTAwMjYgeyBjb21tYW5kIC12IGdwZ2NvbmYgXHUwMDNlIC9kZXYvbnVsbCBcdTAwMjZcdTAwMjYgZ3BnY29uZiAtLWtpbGwgYWxsIHx8IDo7IH0gXHRcdTAwMjZcdTAwMjYgcm0gLXJmIFwiJEdOVVBHSE9NRVwiIHB5dGhvbi50YXIueHouYXNjIFx0XHUwMDI2XHUwMDI2IG1rZGlyIC1wIC91c3Ivc3JjL3B5dGhvbiBcdFx1MDAyNlx1MDAyNiB0YXIgLXhKQyAvdXNyL3NyYy9weXRob24gLS1zdHJpcC1jb21wb25lbnRzPTEgLWYgcHl0aG9uLnRhci54eiBcdFx1MDAyNlx1MDAyNiBybSBweXRob24udGFyLnh6IFx0XHRcdTAwMjZcdTAwMjYgY2QgL3Vzci9zcmMvcHl0aG9uIFx0XHUwMDI2XHUwMDI2IGdudUFyY2g9XCIkKGRwa2ctYXJjaGl0ZWN0dXJlIC0tcXVlcnkgREVCX0JVSUxEX0dOVV9UWVBFKVwiIFx0XHUwMDI2XHUwMDI2IC4vY29uZmlndXJlIFx0XHQtLWJ1aWxkPVwiJGdudUFyY2hcIiBcdFx0LS1lbmFibGUtbG9hZGFibGUtc3FsaXRlLWV4dGVuc2lvbnMgXHRcdC0tZW5hYmxlLW9wdGltaXphdGlvbnMgXHRcdC0tZW5hYmxlLW9wdGlvbi1jaGVja2luZz1mYXRhbCBcdFx0LS1lbmFibGUtc2hhcmVkIFx0XHQtLXdpdGgtc3lzdGVtLWV4cGF0IFx0XHQtLXdpdGgtc3lzdGVtLWZmaSBcdFx0LS13aXRob3V0LWVuc3VyZXBpcCBcdFx1MDAyNlx1MDAyNiBtYWtlIC1qIFwiJChucHJvYylcIiBcdFx0TERGTEFHUz1cIi1XbCwtLXN0cmlwLWFsbFwiIFx0XHUwMDI2XHUwMDI2IG1ha2UgaW5zdGFsbCBcdFx1MDAyNlx1MDAyNiBybSAtcmYgL3Vzci9zcmMvcHl0aG9uIFx0XHRcdTAwMjZcdTAwMjYgZmluZCAvdXNyL2xvY2FsIC1kZXB0aCBcdFx0XFwoIFx0XHRcdFxcKCAtdHlwZSBkIC1hIFxcKCAtbmFtZSB0ZXN0IC1vIC1uYW1lIHRlc3RzIC1vIC1uYW1lIGlkbGVfdGVzdCBcXCkgXFwpIFx0XHRcdC1vIFxcKCAtdHlwZSBmIC1hIFxcKCAtbmFtZSAnKi5weWMnIC1vIC1uYW1lICcqLnB5bycgLW8gLW5hbWUgJyouYScgXFwpIFxcKSBcdFx0XHQtbyBcXCggLXR5cGUgZiAtYSAtbmFtZSAnd2luaW5zdC0qLmV4ZScgXFwpIFx0XHRcXCkgLWV4ZWMgcm0gLXJmICd7fScgKyBcdFx0XHUwMDI2XHUwMDI2IGxkY29uZmlnIFx0XHRcdTAwMjZcdTAwMjYgYXB0LW1hcmsgYXV0byAnLionIFx1MDAzZSAvZGV2L251bGwgXHRcdTAwMjZcdTAwMjYgYXB0LW1hcmsgbWFudWFsICRzYXZlZEFwdE1hcmsgXHRcdTAwMjZcdTAwMjYgZmluZCAvdXNyL2xvY2FsIC10eXBlIGYgLWV4ZWN1dGFibGUgLW5vdCBcXCggLW5hbWUgJyp0a2ludGVyKicgXFwpIC1leGVjIGxkZCAne30nICc7JyBcdFx0fCBhd2sgJy89XHUwMDNlLyB7IHByaW50ICQoTkYtMSkgfScgXHRcdHwgc29ydCAtdSBcdFx0fCB4YXJncyAtciBkcGtnLXF1ZXJ5IC0tc2VhcmNoIFx0XHR8IGN1dCAtZDogLWYxIFx0XHR8IHNvcnQgLXUgXHRcdHwgeGFyZ3MgLXIgYXB0LW1hcmsgbWFudWFsIFx0XHUwMDI2XHUwMDI2IGFwdC1nZXQgcHVyZ2UgLXkgLS1hdXRvLXJlbW92ZSAtbyBBUFQ6OkF1dG9SZW1vdmU6OlJlY29tbWVuZHNJbXBvcnRhbnQ9ZmFsc2UgXHRcdTAwMjZcdTAwMjYgcm0gLXJmIC92YXIvbGliL2FwdC9saXN0cy8qIFx0XHRcdTAwMjZcdTAwMjYgcHl0aG9uMyAtLXZlcnNpb24ifSx7ImNyZWF0ZWQiOiIyMDIxLTA5LTAzVDAyOjM3OjA0Ljc1MTg0MTA2WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jIGNkIC91c3IvbG9jYWwvYmluIFx0XHUwMDI2XHUwMDI2IGxuIC1zIGlkbGUzIGlkbGUgXHRcdTAwMjZcdTAwMjYgbG4gLXMgcHlkb2MzIHB5ZG9jIFx0XHUwMDI2XHUwMDI2IGxuIC1zIHB5dGhvbjMgcHl0aG9uIFx0XHUwMDI2XHUwMDI2IGxuIC1zIHB5dGhvbjMtY29uZmlnIHB5dGhvbi1jb25maWcifSx7ImNyZWF0ZWQiOiIyMDIxLTA5LTAzVDAyOjM3OjA1LjAxNTg5MDAxMVoiLCJjcmVhdGVkX2J5IjoiL2Jpbi9zaCAtYyAjKG5vcCkgIEVOViBQWVRIT05fUElQX1ZFUlNJT049MjEuMi40IiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjEtMDktMDNUMDI6Mzc6MDUuMzA4MDEwMDc5WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jICMobm9wKSAgRU5WIFBZVEhPTl9HRVRfUElQX1VSTD1odHRwczovL2dpdGh1Yi5jb20vcHlwYS9nZXQtcGlwL3Jhdy9jMjBiMGNmZDY0M2NkNGExOTI0NmNjZjIwNGUyOTk3YWY3MGY2YjIxL3B1YmxpYy9nZXQtcGlwLnB5IiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjEtMDktMDNUMDI6Mzc6MDUuNTU2MDE2NjY0WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jICMobm9wKSAgRU5WIFBZVEhPTl9HRVRfUElQX1NIQTI1Nj1mYTZmM2ZiOTNjY2UyMzRjZDRlOGRkMmJlYjU0YTUxYWI5YzI0NzY1M2I1Mjg1NWE0OGRkNDRlNmIyMWZmMjhiIiwiZW1wdHlfbGF5ZXIiOnRydWV9LHsiY3JlYXRlZCI6IjIwMjEtMDktMDNUMDI6Mzc6MjQuMjMwMDM3NDU5WiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jIHNldCAtZXg7IFx0XHRzYXZlZEFwdE1hcms9XCIkKGFwdC1tYXJrIHNob3dtYW51YWwpXCI7IFx0YXB0LWdldCB1cGRhdGU7IFx0YXB0LWdldCBpbnN0YWxsIC15IC0tbm8taW5zdGFsbC1yZWNvbW1lbmRzIHdnZXQ7IFx0XHR3Z2V0IC1PIGdldC1waXAucHkgXCIkUFlUSE9OX0dFVF9QSVBfVVJMXCI7IFx0ZWNobyBcIiRQWVRIT05fR0VUX1BJUF9TSEEyNTYgKmdldC1waXAucHlcIiB8IHNoYTI1NnN1bSAtLWNoZWNrIC0tc3RyaWN0IC07IFx0XHRhcHQtbWFyayBhdXRvICcuKicgXHUwMDNlIC9kZXYvbnVsbDsgXHRbIC16IFwiJHNhdmVkQXB0TWFya1wiIF0gfHwgYXB0LW1hcmsgbWFudWFsICRzYXZlZEFwdE1hcms7IFx0YXB0LWdldCBwdXJnZSAteSAtLWF1dG8tcmVtb3ZlIC1vIEFQVDo6QXV0b1JlbW92ZTo6UmVjb21tZW5kc0ltcG9ydGFudD1mYWxzZTsgXHRybSAtcmYgL3Zhci9saWIvYXB0L2xpc3RzLyo7IFx0XHRweXRob24gZ2V0LXBpcC5weSBcdFx0LS1kaXNhYmxlLXBpcC12ZXJzaW9uLWNoZWNrIFx0XHQtLW5vLWNhY2hlLWRpciBcdFx0XCJwaXA9PSRQWVRIT05fUElQX1ZFUlNJT05cIiBcdDsgXHRwaXAgLS12ZXJzaW9uOyBcdFx0ZmluZCAvdXNyL2xvY2FsIC1kZXB0aCBcdFx0XFwoIFx0XHRcdFxcKCAtdHlwZSBkIC1hIFxcKCAtbmFtZSB0ZXN0IC1vIC1uYW1lIHRlc3RzIC1vIC1uYW1lIGlkbGVfdGVzdCBcXCkgXFwpIFx0XHRcdC1vIFx0XHRcdFxcKCAtdHlwZSBmIC1hIFxcKCAtbmFtZSAnKi5weWMnIC1vIC1uYW1lICcqLnB5bycgXFwpIFxcKSBcdFx0XFwpIC1leGVjIHJtIC1yZiAne30nICs7IFx0cm0gLWYgZ2V0LXBpcC5weSJ9LHsiY3JlYXRlZCI6IjIwMjEtMDktMDNUMDI6Mzc6MjQuNTUxNzU5OTQxWiIsImNyZWF0ZWRfYnkiOiIvYmluL3NoIC1jICMobm9wKSAgQ01EIFtcInB5dGhvbjNcIl0iLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0xMi0yMlQwNTo0MToxNS4zNzQxNDA1WiIsImNyZWF0ZWRfYnkiOiJXT1JLRElSIC9hcHAiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjEtMTItMjJUMDU6NDk6MzcuNTkwNjM4NFoiLCJjcmVhdGVkX2J5IjoiQVJHIHVpZD0xMDAxIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0xMi0yMlQwNTo0OTozNy41OTA2Mzg0WiIsImNyZWF0ZWRfYnkiOiJBUkcgYXBwdXNlcj1kZWZlY3Rkb2pvIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0xMi0yMlQwNTo0OTozNy41OTA2Mzg0WiIsImNyZWF0ZWRfYnkiOiJFTlYgYXBwdXNlcj1kZWZlY3Rkb2pvIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0xMi0yMlQwNTo0OTozNy41OTA2Mzg0WiIsImNyZWF0ZWRfYnkiOiJSVU4gfDIgdWlkPTEwMDEgYXBwdXNlcj1kZWZlY3Rkb2pvIC9iaW4vc2ggLWMgYXB0LWdldCAteSB1cGRhdGUgXHUwMDI2XHUwMDI2ICAgbWtkaXIgLXAgL3Vzci9zaGFyZS9tYW4vbWFuMSAvdXNyL3NoYXJlL21hbi9tYW43IFx1MDAyNlx1MDAyNiAgIGFwdC1nZXQgLXkgaW5zdGFsbCAtLW5vLWluc3RhbGwtcmVjb21tZW5kcyAgICAgbGlib3BlbmpwMi03ICAgICBsaWJqcGVnNjIgICAgIGxpYnRpZmY1ICAgICBkbnN1dGlscyAgICAgZGVmYXVsdC1teXNxbC1jbGllbnQgICAgIGxpYm1hcmlhZGIzICAgICB4bWxzZWMxICAgICBnaXQgICAgIHV1aWQtcnVudGltZSAgICAgcG9zdGdyZXNxbC1jbGllbnQgICAgIFx1MDAyNlx1MDAyNiAgIGFwdC1nZXQgY2xlYW4gXHUwMDI2XHUwMDI2ICAgcm0gLXJmIC92YXIvbGliL2FwdC9saXN0cyBcdTAwMjZcdTAwMjYgICB0cnVlICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjEtMTItMjRUMDY6NTQ6MTUuNzMxNTk4NFoiLCJjcmVhdGVkX2J5IjoiQ09QWSAvdG1wL3doZWVscyAvdG1wL3doZWVscyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIxLTEyLTI0VDA2OjU0OjE1LjgwOTY0MjZaIiwiY3JlYXRlZF9ieSI6IkNPUFkgcmVxdWlyZW1lbnRzLnR4dCAuLyAjIGJ1aWxka2l0IiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAifSx7ImNyZWF0ZWQiOiIyMDIxLTEyLTI0VDA2OjU0OjM4LjY3NTI2ODlaIiwiY3JlYXRlZF9ieSI6IlJVTiB8MiB1aWQ9MTAwMSBhcHB1c2VyPWRlZmVjdGRvam8gL2Jpbi9zaCAtYyBwaXAzIGluc3RhbGwgXHQtLW5vLWNhY2hlLWRpciBcdC0tbm8taW5kZXggICAtLWZpbmQtbGlua3M9L3RtcC93aGVlbHMgICAtciAuL3JlcXVpcmVtZW50cy50eHQgIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMS0xMi0yNFQwNjo1NDozOC44MjQ5ODk3WiIsImNyZWF0ZWRfYnkiOiJDT1BZIGRvY2tlci9lbnRyeXBvaW50LWNlbGVyeS1iZWF0LnNoIGRvY2tlci9lbnRyeXBvaW50LWNlbGVyeS13b3JrZXIuc2ggZG9ja2VyL2VudHJ5cG9pbnQtaW5pdGlhbGl6ZXIuc2ggZG9ja2VyL2VudHJ5cG9pbnQtdXdzZ2kuc2ggZG9ja2VyL2VudHJ5cG9pbnQtdXdzZ2ktZGV2LnNoIGRvY2tlci9lbnRyeXBvaW50LXVuaXQtdGVzdHMuc2ggZG9ja2VyL2VudHJ5cG9pbnQtdW5pdC10ZXN0cy1kZXZEb2NrZXIuc2ggZG9ja2VyL3dhaXQtZm9yLWl0LnNoIGRvY2tlci9jZXJ0cy8qIC8gIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMS0xMi0yNFQwNjo1NDozOC45MDczNzk4WiIsImNyZWF0ZWRfYnkiOiJDT1BZIHdzZ2kucHkgbWFuYWdlLnB5IGRvY2tlci91bml0LXRlc3RzLnNoIC4vICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjEtMTItMjRUMDY6NTQ6MzkuMjE3MTAyNloiLCJjcmVhdGVkX2J5IjoiQ09QWSBkb2pvLyAuL2Rvam8vICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjEtMTItMjRUMDY6NTQ6MzkuMjkzOTUyOFoiLCJjcmVhdGVkX2J5IjoiQ09QWSBkb2NrZXIvZXh0cmFfZml4dHVyZXMvKiAvYXBwL2Rvam8vZml4dHVyZXMvICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjEtMTItMjRUMDY6NTQ6MzkuMzgzMTE4MloiLCJjcmVhdGVkX2J5IjoiQ09QWSB0ZXN0cy8gLi90ZXN0cy8gIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMS0xMi0yNFQwNjo1NDozOS45MTEzODg4WiIsImNyZWF0ZWRfYnkiOiJSVU4gfDIgdWlkPTEwMDEgYXBwdXNlcj1kZWZlY3Rkb2pvIC9iaW4vc2ggLWMgcm0gLWYgL3JlYWRtZS50eHQgXHUwMDI2XHUwMDI2ICAgcm0gLWYgZG9qby9maXh0dXJlcy9yZWFkbWUudHh0IFx1MDAyNlx1MDAyNiAgIG1rZGlyIC1wIGRvam8vbWlncmF0aW9ucyBcdTAwMjZcdTAwMjYgICBjaG1vZCBnPXUgZG9qby9taWdyYXRpb25zIFx1MDAyNlx1MDAyNiAgIHRydWUgIyBidWlsZGtpdCIsImNvbW1lbnQiOiJidWlsZGtpdC5kb2NrZXJmaWxlLnYwIn0seyJjcmVhdGVkIjoiMjAyMS0xMi0yNFQwNjo1NDozOS45MTEzODg4WiIsImNyZWF0ZWRfYnkiOiJVU0VSIHJvb3QiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWQiOiIyMDIxLTEyLTI0VDA2OjU0OjQ0LjIxOTkyMDNaIiwiY3JlYXRlZF9ieSI6IlJVTiB8MiB1aWQ9MTAwMSBhcHB1c2VyPWRlZmVjdGRvam8gL2Jpbi9zaCAtYyBhZGR1c2VyIC0tc3lzdGVtIC0tbm8tY3JlYXRlLWhvbWUgLS1kaXNhYmxlZC1wYXNzd29yZCAtLWdlY29zICcnICAgICAgICAgLS11aWQgJHt1aWR9ICR7YXBwdXNlcn0gXHUwMDI2XHUwMDI2ICAgICBjaG93biAtUiByb290OnJvb3QgL2FwcCBcdTAwMjZcdTAwMjYgICAgIGNobW9kIC1SIHUrcndYLGdvK3JYLGdvLXcgL2FwcCBcdTAwMjZcdTAwMjYgICAgIG1rZGlyIC92YXIvcnVuLyR7YXBwdXNlcn0gXHUwMDI2XHUwMDI2ICAgICBjaG93biAke2FwcHVzZXJ9IC92YXIvcnVuLyR7YXBwdXNlcn0gXHUwMDI2XHUwMDI2IFx0ICBjaG1vZCBnPXUgL3Zhci9ydW4vJHthcHB1c2VyfSBcdTAwMjZcdTAwMjYgICAgIG1rZGlyIC1wIG1lZGlhL3RocmVhdCBcdTAwMjZcdTAwMjYgY2hvd24gLVIgJHt1aWR9IG1lZGlhICMgYnVpbGRraXQiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCJ9LHsiY3JlYXRlZCI6IjIwMjEtMTItMjRUMDY6NTQ6NDQuMjE5OTIwM1oiLCJjcmVhdGVkX2J5IjoiVVNFUiAxMDAxIiwiY29tbWVudCI6ImJ1aWxka2l0LmRvY2tlcmZpbGUudjAiLCJlbXB0eV9sYXllciI6dHJ1ZX0seyJjcmVhdGVkIjoiMjAyMS0xMi0yNFQwNjo1NDo0NC4yMTk5MjAzWiIsImNyZWF0ZWRfYnkiOiJFTlYgRERfQURNSU5fVVNFUj1hZG1pbiBERF9BRE1JTl9NQUlMPWFkbWluQGRlZmVjdGRvam8ubG9jYWwgRERfQURNSU5fUEFTU1dPUkQ9IEREX0FETUlOX0ZJUlNUX05BTUU9QWRtaW5pc3RyYXRvciBERF9BRE1JTl9MQVNUX05BTUU9VXNlciBERF9BTExPV0VEX0hPU1RTPSogRERfQ0VMRVJZX0JFQVRfU0NIRURVTEVfRklMRU5BTUU9L3J1bi9jZWxlcnktYmVhdC1zY2hlZHVsZSBERF9DRUxFUllfQlJPS0VSX1NDSEVNRT1hbXFwIEREX0NFTEVSWV9CUk9LRVJfVVNFUj1kZWZlY3Rkb2pvIEREX0NFTEVSWV9CUk9LRVJfUEFTU1dPUkQ9ZGVmZWN0ZG9qbyBERF9DRUxFUllfQlJPS0VSX0hPU1Q9cmFiYml0bXEgRERfQ0VMRVJZX0JST0tFUl9QT1JUPTU2NzIgRERfQ0VMRVJZX0JST0tFUl9QQVRIPS8vIEREX0NFTEVSWV9MT0dfTEVWRUw9SU5GTyBERF9DRUxFUllfV09SS0VSX1BPT0xfVFlQRT1zb2xvIEREX0RBVEFCQVNFX0VOR0lORT1kamFuZ28uZGIuYmFja2VuZHMubXlzcWwgRERfREFUQUJBU0VfSE9TVD1teXNxbCBERF9EQVRBQkFTRV9OQU1FPWRlZmVjdGRvam8gRERfREFUQUJBU0VfUEFTU1dPUkQ9ZGVmZWN0ZG9qbyBERF9EQVRBQkFTRV9QT1JUPTMzMDYgRERfREFUQUJBU0VfVVNFUj1kZWZlY3Rkb2pvIEREX0lOSVRJQUxJWkU9dHJ1ZSBERF9VV1NHSV9NT0RFPXNvY2tldCBERF9VV1NHSV9FTkRQT0lOVD0wLjAuMC4wOjMwMzEgRERfVVdTR0lfTlVNX09GX1BST0NFU1NFUz0yIEREX1VXU0dJX05VTV9PRl9USFJFQURTPTIgRERfVFJBQ0tfTUlHUkFUSU9OUz1UcnVlIEREX0RKQU5HT19NRVRSSUNTX0VOQUJMRUQ9RmFsc2UiLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfSx7ImNyZWF0ZWQiOiIyMDIxLTEyLTI0VDA2OjU0OjQ0LjIxOTkyMDNaIiwiY3JlYXRlZF9ieSI6IkVOVFJZUE9JTlQgW1wiL2VudHJ5cG9pbnQtdXdzZ2kuc2hcIl0iLCJjb21tZW50IjoiYnVpbGRraXQuZG9ja2VyZmlsZS52MCIsImVtcHR5X2xheWVyIjp0cnVlfV0sIm9zIjoibGludXgiLCJyb290ZnMiOnsidHlwZSI6ImxheWVycyIsImRpZmZfaWRzIjpbInNoYTI1NjpkMDAwNjMzYTU2ODEzOTMzY2IwYWM1ZWUzMjQ2Y2Y3YTRjMDIwNWRiNjI5MDAxOGExNjlkN2NiMDk2NTgxMDQ2Iiwic2hhMjU2OjU1YWQ1ZDhiOGYwZjQ4NTA3Yjk4NzkzY2U4MTczM2Y1MGE4YTA1ZjBiYzA0NzM2MTU1N2FlN2QwMDg3OGQxZTMiLCJzaGEyNTY6NGU3NDkxODYwMWFhYTk1MWQzMjRiNGNhMTNhYWQ3ODI4NDNlNzE3YTdiMWUxMTE4M2I0N2RmMmY0MDJkZDVmNCIsInNoYTI1NjpkZTliMTllNmNkNDk1OGM4NGNhZDlkMTAwOTk2ZDViMWQzNGRlMGFiYmQwNzBmZDk1YjE0YWRhNjE4NWFiNjUyIiwic2hhMjU2OjY4NThiMjVkNWE3M2ZmODAwZjA5N2Y5OTE3Y2Y2NzIwZmYxYWVlYTI1NzE3ZTE4YmRhNGZhNjc5YTI3ZjI1MjQiLCJzaGEyNTY6NDgwZTE2NTU1MjYyN2JhYTlhN2U2YmY3MzM4ODdkYmM1ZmI5NzBjYjY1ZjU2NjA5ZGUyNjAzNGFiOTMyNGZiYiIsInNoYTI1Njo4OGE1NTg0YzZhZjhjMjIwZjk0YWJiMDUzMTVjMjY5NTUwNWM4YjllMjM0NGEwYWE4Nzk3MjFiODcxZDMyYjAzIiwic2hhMjU2OmY3YTA0YWYwMWYzOTM1ZDI1NjZhNmFkZjk1NGRmMGZkMGFmOGZhMmM3ZDlkODAwMmM0NjJmNWU2MDQxNGNlY2YiLCJzaGEyNTY6YjYxZWI2MGI2OWM1ZjU4NzNjZjBmZmMyY2YzYzk2OTVkYjgyM2UxN2I3YjgyNGE5ZDYxNTU2ZjY2MThiZmYzOCIsInNoYTI1NjpiMWQ0NDU1Y2Y4MmIxNWE1MGIwMDZmZTg3YmQyOWY2OTRjOGY5MTU1NDU2MjUzZWI2N2ZkZDE1NWI1ZWRjZjRhIiwic2hhMjU2OjVlMmZkOGVmMzlkNDQ1YjE5MDI2ZTYyZTlhZTNlOGMwY2YyMDk2OGZiZDEyOGVkODE3MDllNTIzN2M2MTgxM2QiLCJzaGEyNTY6NDQ0N2UxYWJlYmE2MmEwMjgzYTc0ZmVjOWIwNWFhNzA1OTljNGYzMWQxZDlmZGU5ZGE2NWE5YWQ3MGYzYjVmOSIsInNoYTI1NjozYTM3NTRiZTE0ZTViNDZhNjNkZDgxNjlmMTEzZTg2ZDM0OGIwZWQ2YmE5Y2ViMGRiYmQ2MGIwZmQzYmQ4NzA0Iiwic2hhMjU2OjhiNzU2NDBhZGM4N2RjY2UwMDEwOGMwMTFmZDc4YzYzN2JhNDNiZmUyY2Q4ZTcxYjQ5ODlkMjg5NWRiOTMyYmYiLCJzaGEyNTY6NTQxNmJhYTAxYTIyMTNlZjM3NWEyNjY2NWIwYjZmZjE4NzJiMzMyOTk1NzBjZmRhODE4OGMwNjQxZTM3NWVhMCIsInNoYTI1NjozOTQ2NjAyYWFjZmNmY2M0MGMyODU3Y2ExN2I2YjI1NDc5NWY1MjliMGQwMTkwZmJlNWM5NmU5YjY4NTE3YjMyIiwic2hhMjU2OjIzZjM4YWVjYWQ1ZWM0Yjg4NWUyOGE1ZGM4MDQ3MmExMzRjMGZjOWFmM2JkYjhkNjk4NzNlY2U0ZjIxOGUzMWIiXX19",
+      "repoDigests": []
+     }
+    },
+    "distro": {
+     "name": "debian",
+     "version": "10",
+     "idLike": ""
+    },
+    "descriptor": {
+     "name": "grype",
+     "version": "0.28.0",
+     "configuration": {
+      "configPath": "",
+      "output": "json",
+      "file": "",
+      "output-template-file": "",
+      "quiet": false,
+      "check-for-app-update": true,
+      "only-fixed": false,
+      "scope": "Squashed",
+      "log": {
+       "structured": false,
+       "level": "",
+       "file": ""
+      },
+      "db": {
+       "cache-dir": "/home/user/.cache/grype/db",
+       "update-url": "https://toolbox-data.anchore.io/grype/databases/listing.json",
+       "ca-cert": "",
+       "auto-update": true,
+       "validate-by-hash-on-start": false
+      },
+      "dev": {
+       "profile-cpu": false,
+       "profile-mem": false
+      },
+      "fail-on-severity": "",
+      "registry": {
+       "insecure-skip-tls-verify": false,
+       "insecure-use-http": false,
+       "auth": []
+      },
+      "ignore": null,
+      "exclude": []
+     },
+     "db": {
+      "built": "2021-12-24T08:14:02Z",
+      "schemaVersion": 3,
+      "location": "/home/user/.cache/grype/db/3",
+      "checksum": "sha256:6c4777e1acea787e5335ccee6b5e4562cd1767b9cca138c07e0802efb2a74162",
+      "error": null
+     }
+    }
+   }
+   

--- a/unittests/scans/anchore_grype/check_all_fields.json
+++ b/unittests/scans/anchore_grype/check_all_fields.json
@@ -568,7 +568,121 @@
        "purl": "pkg:pypi/Django@3.2.9",
        "metadata": null
       }
+    },
+    {
+     "vulnerability": {
+      "id": "GHSA-v6rh-hp5x-86rv",
+      "dataSource": "https://github.com/advisories/GHSA-v6rh-hp5x-86rv",
+      "namespace": "github:python",
+      "severity": "High",
+      "urls": [
+       "https://github.com/advisories/GHSA-v6rh-hp5x-86rv"
+      ],
+      "description": "Potential bypass of an upstream access control based on URL paths in Django",
+      "cvss": [],
+      "fix": {
+       "versions": [
+        "3.2.10"
+       ],
+       "state": "fixed"
+      },
+      "advisories": []
+     },
+     "relatedVulnerabilities": [
+      {
+       "id": "CVE-2021-44420",
+       "dataSource": "https://nvd.nist.gov/vuln/detail/CVE-2021-44420",
+       "namespace": "nvd",
+       "severity": "High",
+       "urls": [
+        "https://docs.djangoproject.com/en/3.2/releases/security/",
+        "https://www.openwall.com/lists/oss-security/2021/12/07/1",
+        "https://www.djangoproject.com/weblog/2021/dec/07/security-releases/",
+        "https://groups.google.com/forum/#!forum/django-announce"
+       ],
+       "description": "In Django 2.2 before 2.2.25, 3.1 before 3.1.14, and 3.2 before 3.2.10, HTTP requests for URLs with trailing newlines could bypass upstream access control based on URL paths.",
+       "cvss": [
+        {
+         "version": "2.0",
+         "vector": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+         "metrics": {
+          "baseScore": 7.5,
+          "exploitabilityScore": 10,
+          "impactScore": 6.4
+         },
+         "vendorMetadata": {}
+        },
+        {
+         "version": "3.1",
+         "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+         "metrics": {
+          "baseScore": 7.3,
+          "exploitabilityScore": 3.9,
+          "impactScore": 3.4
+         },
+         "vendorMetadata": {}
+        }
+       ]
+      }
+     ],
+     "matchDetails": [
+      {
+       "matcher": "python-matcher",
+       "searchedBy": {
+        "language": "python",
+        "namespace": "github:python"
+       },
+       "found": {
+        "versionConstraint": ">=3.2,<3.2.10 (python)"
+       }
+      }
+     ],
+     "artifact": {
+      "name": "Django",
+      "version": "3.2.9",
+      "type": "python",
+      "locations": [
+       {
+        "path": "/usr/local/lib/python3.8/site-packages/Django-3.2.9.dist-info/METADATA",
+        "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+       },
+       {
+        "path": "/usr/local/lib/python3.8/site-packages/Django-3.2.9.dist-info/RECORD",
+        "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+       },
+       {
+        "path": "/usr/local/lib/python3.8/site-packages/Django-3.2.9.dist-info/top_level.txt",
+        "layerID": "sha256:b1d4455cf82b15a50b006fe87bd29f694c8f9155456253eb67fdd155b5edcf4a"
+       }
+      ],
+      "language": "python",
+      "licenses": [
+       "BSD-3-Clause"
+      ],
+      "cpes": [
+       "cpe:2.3:a:django_software_foundation:python-Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:django_software_foundation:python_Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:django_software_foundation:Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python-Django:python-Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python-Django:python_Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python_Django:python-Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python_Django:python_Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:foundation:python-Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:foundation:python_Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:Django:python-Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:Django:python_Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python-Django:Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python:python-Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python:python_Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python_Django:Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:foundation:Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:Django:Django:3.2.9:*:*:*:*:*:*:*",
+       "cpe:2.3:a:python:Django:3.2.9:*:*:*:*:*:*:*"
+      ],
+      "purl": "pkg:pypi/Django@3.2.9",
+      "metadata": null
      }
+    }
     ],
     "source": {
      "type": "image",

--- a/unittests/tools/test_anchore_grype_parser.py
+++ b/unittests/tools/test_anchore_grype_parser.py
@@ -19,7 +19,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         parser = AnchoreGrypeParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertEqual(388, len(findings))
+        self.assertEqual(1509, len(findings))
         for finding in findings:
             self.assertIn(finding.severity, Finding.SEVERITIES)
             self.assertIsNotNone(finding.cve)
@@ -29,6 +29,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
                 self.assertEqual("libgnutls-openssl27", finding.component_name)
                 self.assertEqual("3.6.7-4+deb10u5", finding.component_version)
                 found = True
+                break
         self.assertTrue(found)
 
     def test_grype_parser_with_one_criticle_vuln_has_one_findings(self):
@@ -37,7 +38,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         parser = AnchoreGrypeParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertEqual(387, len(findings))
+        self.assertEqual(1567, len(findings))
         for finding in findings:
             self.assertIn(finding.severity, Finding.SEVERITIES)
             self.assertIsNotNone(finding.cve)
@@ -47,6 +48,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
                 self.assertEqual("2.28-10", finding.component_version)
                 self.assertEqual("Info", finding.severity)
                 found = True
+                break
         self.assertTrue(found)
 
     def test_grype_parser_with_many_vulns3(self):
@@ -55,17 +57,17 @@ class TestAnchoreGrypeParser(DojoTestCase):
         parser = AnchoreGrypeParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertEqual(259, len(findings))
+        self.assertEqual(327, len(findings))
         for finding in findings:
             self.assertIn(finding.severity, Finding.SEVERITIES)
             self.assertIsNotNone(finding.cve)
             if finding.vuln_id_from_tool == "CVE-2011-3389":
-                print('hallo')
                 self.assertEqual("CVE-2011-3389", finding.cve)
                 self.assertEqual("Medium", finding.severity)
                 self.assertEqual("libgnutls30", finding.component_name)
                 self.assertEqual("3.6.7-4+deb10u5", finding.component_version)
                 found = True
+                break
         self.assertTrue(found)
 
     def test_grype_parser_with_new_matcher_list(self):
@@ -86,3 +88,164 @@ class TestAnchoreGrypeParser(DojoTestCase):
                 self.assertEqual("3.2.0", finding.component_version)
                 found = True
         self.assertTrue(found)
+
+    def test_check_all_fields(self):
+        testfile = open("unittests/scans/anchore_grype/check_all_fields.json")
+        parser = AnchoreGrypeParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(5, len(findings))
+
+        finding = findings[0]
+        self.assertEqual('CVE-2004-0971 in libgssapi-krb5-2:1.17-3+deb10u3', finding.title)
+        description = '''**Vulnerability Id:** CVE-2004-0971
+**Vulnerability Namespace:** debian:10
+**Related Vulnerability Description:** The krb5-send-pr script in the kerberos5 (krb5) package in Trustix Secure Linux 1.5 through 2.1, and possibly other operating systems, allows local users to overwrite files via a symlink attack on temporary files.
+**Matcher:** dpkg-matcher
+**Package URL:** pkg:deb/debian/libgssapi-krb5-2@1.17-3+deb10u3?arch=amd64'''
+        self.assertEqual(description, finding.description)
+        self.assertEqual('CVE-2004-0971', finding.cve)
+        self.assertEqual(1352, finding.cwe)
+        self.assertIsNone(finding.cvssv3)
+        self.assertIsNone(finding.cvssv3_score)
+        self.assertEqual('Info', finding.severity)
+        self.assertIsNone(finding.mitigation)
+        references = '''**Vulnerability Datasource:** https://security-tracker.debian.org/tracker/CVE-2004-0971
+**Related Vulnerability Datasource:** https://nvd.nist.gov/vuln/detail/CVE-2004-0971
+**Related Vulnerability URLs:**
+- http://www.securityfocus.com/bid/11289
+- http://www.gentoo.org/security/en/glsa/glsa-200410-24.xml
+- http://www.redhat.com/support/errata/RHSA-2005-012.html
+- http://www.trustix.org/errata/2004/0050
+- http://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=136304
+- https://exchange.xforce.ibmcloud.com/vulnerabilities/17583
+- https://oval.cisecurity.org/repository/search/definition/oval%3Aorg.mitre.oval%3Adef%3A10497
+- https://lists.apache.org/thread.html/rc713534b10f9daeee2e0990239fa407e2118e4aa9e88a7041177497c@%3Cissues.guacamole.apache.org%3E'''
+        self.assertEqual(references, finding.references)
+        self.assertEqual('libgssapi-krb5-2', finding.component_name)
+        self.assertEqual('1.17-3+deb10u3', finding.component_version)
+        self.assertEqual('CVE-2004-0971', finding.vuln_id_from_tool)
+        self.assertEqual(['dpkg'], finding.tags)
+
+        finding = findings[1]
+        self.assertEqual('CVE-2021-32626 in redis:4.0.2', finding.title)
+        description = '''**Vulnerability Id:** CVE-2021-32626
+**Vulnerability Namespace:** nvd
+**Vulnerability Description:** Redis is an open source, in-memory database that persists on disk. In affected versions specially crafted Lua scripts executing in Redis can cause the heap-based Lua stack to be overflowed, due to incomplete checks for this condition. This can result with heap corruption and potentially remote code execution. This problem exists in all versions of Redis with Lua scripting support, starting from 2.6. The problem is fixed in versions 6.2.6, 6.0.16 and 5.0.14. For users unable to update an additional workaround to mitigate the problem without patching the redis-server executable is to prevent users from executing Lua scripts. This can be done using ACL to restrict EVAL and EVALSHA commands.
+**Matchers:**
+- python-matcher
+- python2-matcher
+**Package URL:** pkg:pypi/redis@4.0.2'''
+        self.assertEqual(description, finding.description)
+        self.assertEqual('CVE-2021-32626', finding.cve)
+        self.assertEqual(1352, finding.cwe)
+        self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H', finding.cvssv3)
+        self.assertEqual(8.8, finding.cvssv3_score)
+        self.assertEqual('High', finding.severity)
+        mitigation = '''Upgrade to version:
+- fix_1
+- fix_2'''
+        self.assertEqual(mitigation, finding.mitigation)
+        references = '''**Vulnerability Datasource:** https://nvd.nist.gov/vuln/detail/CVE-2021-32626
+**Vulnerability URLs:**
+- https://github.com/redis/redis/commit/666ed7facf4524bf6d19b11b20faa2cf93fdf591
+- https://github.com/redis/redis/security/advisories/GHSA-p486-xggp-782c
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/VL5KXFN3ATM7IIM7Q4O4PWTSRGZ5744Z/
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/HTYQ5ZF37HNGTZWVNJD3VXP7I6MEEF42/
+- https://lists.apache.org/thread.html/r75490c61c2cb7b6ae2c81238fd52ae13636c60435abcd732d41531a0@%3Ccommits.druid.apache.org%3E
+- https://security.netapp.com/advisory/ntap-20211104-0003/
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/WR5WKJWXD4D6S3DJCZ56V74ESLTDQRAB/
+- https://www.debian.org/security/2021/dsa-5001'''
+        self.assertEqual(references, finding.references)
+        self.assertEqual('redis', finding.component_name)
+        self.assertEqual('4.0.2', finding.component_version)
+        self.assertEqual('CVE-2021-32626', finding.vuln_id_from_tool)
+        self.assertEqual(['python', 'python2'], finding.tags)
+
+        finding = findings[2]
+        self.assertEqual('CVE-2021-33574 in libc-bin:2.28-10', finding.title)
+        description = '''**Vulnerability Id:** CVE-2021-33574
+**Vulnerability Namespace:** debian:10
+**Related Vulnerability Description:** The mq_notify function in the GNU C Library (aka glibc) versions 2.32 and 2.33 has a use-after-free. It may use the notification thread attributes object (passed through its struct sigevent parameter) after it has been freed by the caller, leading to a denial of service (application crash) or possibly unspecified other impact.
+**Matcher:** dpkg-matcher
+**Package URL:** pkg:deb/debian/libc-bin@2.28-10?arch=amd64'''
+        self.assertEqual(description, finding.description)
+        self.assertEqual('CVE-2021-33574', finding.cve)
+        self.assertEqual(1352, finding.cwe)
+        self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', finding.cvssv3)
+        self.assertEqual(9.8, finding.cvssv3_score)
+        self.assertEqual('Critical', finding.severity)
+        self.assertIsNone(finding.mitigation)
+        references = '''**Vulnerability Datasource:** https://security-tracker.debian.org/tracker/CVE-2021-33574
+**Related Vulnerability Datasource:** https://nvd.nist.gov/vuln/detail/CVE-2021-33574
+**Related Vulnerability URLs:**
+- https://sourceware.org/bugzilla/show_bug.cgi?id=27896
+- https://sourceware.org/bugzilla/show_bug.cgi?id=27896#c1
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RBUUWUGXVILQXVWEOU7N42ICHPJNAEUP/
+- https://security.netapp.com/advisory/ntap-20210629-0005/
+- https://security.gentoo.org/glsa/202107-07
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KJYYIMDDYOHTP2PORLABTOHYQYYREZDD/'''
+        self.assertEqual(references, finding.references)
+        self.assertEqual('libc-bin', finding.component_name)
+        self.assertEqual('2.28-10', finding.component_version)
+        self.assertEqual('CVE-2021-33574', finding.vuln_id_from_tool)
+        self.assertEqual(['dpkg'], finding.tags)
+
+        finding = findings[3]
+        self.assertEqual('CVE-2021-33574 in libc6:2.28-10', finding.title)
+        description = '''**Vulnerability Id:** CVE-2021-33574
+**Vulnerability Namespace:** debian:10
+**Related Vulnerability Description:** The mq_notify function in the GNU C Library (aka glibc) versions 2.32 and 2.33 has a use-after-free. It may use the notification thread attributes object (passed through its struct sigevent parameter) after it has been freed by the caller, leading to a denial of service (application crash) or possibly unspecified other impact.
+**Matcher:** dpkg-matcher
+**Package URL:** pkg:deb/debian/libc6@2.28-10?arch=amd64'''
+        self.assertEqual(description, finding.description)
+        self.assertEqual('CVE-2021-33574', finding.cve)
+        self.assertEqual(1352, finding.cwe)
+        self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', finding.cvssv3)
+        self.assertEqual(9.8, finding.cvssv3_score)
+        self.assertEqual('Critical', finding.severity)
+        self.assertIsNone(finding.mitigation)
+        references = '''**Vulnerability Datasource:** https://security-tracker.debian.org/tracker/CVE-2021-33574
+**Related Vulnerability Datasource:** https://nvd.nist.gov/vuln/detail/CVE-2021-33574
+**Related Vulnerability URLs:**
+- https://sourceware.org/bugzilla/show_bug.cgi?id=27896
+- https://sourceware.org/bugzilla/show_bug.cgi?id=27896#c1
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/RBUUWUGXVILQXVWEOU7N42ICHPJNAEUP/
+- https://security.netapp.com/advisory/ntap-20210629-0005/
+- https://security.gentoo.org/glsa/202107-07
+- https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/KJYYIMDDYOHTP2PORLABTOHYQYYREZDD/'''
+        self.assertEqual(references, finding.references)
+        self.assertEqual('libc6', finding.component_name)
+        self.assertEqual('2.28-10', finding.component_version)
+        self.assertEqual('CVE-2021-33574', finding.vuln_id_from_tool)
+        self.assertEqual(['dpkg'], finding.tags)
+
+        finding = findings[4]
+        self.assertEqual('CVE-2021-44420 in Django:3.2.9', finding.title)
+        description = '''**Vulnerability Id:** GHSA-v6rh-hp5x-86rv
+**Vulnerability Namespace:** github:python
+**Vulnerability Description:** Potential bypass of an upstream access control based on URL paths in Django
+**Related Vulnerability Id:** CVE-2021-44420
+**Related Vulnerability Description:** In Django 2.2 before 2.2.25, 3.1 before 3.1.14, and 3.2 before 3.2.10, HTTP requests for URLs with trailing newlines could bypass upstream access control based on URL paths.
+**Matcher:** python-matcher
+**Package URL:** pkg:pypi/Django@3.2.9'''
+        self.assertEqual(description, finding.description)
+        self.assertEqual('CVE-2021-44420', finding.cve)
+        self.assertEqual(1352, finding.cwe)
+        self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L', finding.cvssv3)
+        self.assertEqual(7.3, finding.cvssv3_score)
+        self.assertEqual('High', finding.severity)
+        mitigation = 'Upgrade to version: 3.2.10'
+        self.assertEqual(mitigation, finding.mitigation)
+        references = '''**Vulnerability Datasource:** https://github.com/advisories/GHSA-v6rh-hp5x-86rv
+**Related Vulnerability Datasource:** https://nvd.nist.gov/vuln/detail/CVE-2021-44420
+**Related Vulnerability URLs:**
+- https://docs.djangoproject.com/en/3.2/releases/security/
+- https://www.openwall.com/lists/oss-security/2021/12/07/1
+- https://www.djangoproject.com/weblog/2021/dec/07/security-releases/
+- https://groups.google.com/forum/#!forum/django-announce'''
+        self.assertEqual(references, finding.references)
+        self.assertEqual('Django', finding.component_name)
+        self.assertEqual('3.2.9', finding.component_version)
+        self.assertEqual('GHSA-v6rh-hp5x-86rv', finding.vuln_id_from_tool)
+        self.assertEqual(['python'], finding.tags)

--- a/unittests/tools/test_anchore_grype_parser.py
+++ b/unittests/tools/test_anchore_grype_parser.py
@@ -126,6 +126,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('1.17-3+deb10u3', finding.component_version)
         self.assertEqual('CVE-2004-0971', finding.vuln_id_from_tool)
         self.assertEqual(['dpkg'], finding.tags)
+        self.assertEqual(1, finding.nb_occurences)
 
         finding = findings[1]
         self.assertEqual('CVE-2021-32626 in redis:4.0.2', finding.title)
@@ -161,6 +162,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('4.0.2', finding.component_version)
         self.assertEqual('CVE-2021-32626', finding.vuln_id_from_tool)
         self.assertEqual(['python', 'python2'], finding.tags)
+        self.assertEqual(1, finding.nb_occurences)
 
         finding = findings[2]
         self.assertEqual('CVE-2021-33574 in libc-bin:2.28-10', finding.title)
@@ -190,6 +192,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('2.28-10', finding.component_version)
         self.assertEqual('CVE-2021-33574', finding.vuln_id_from_tool)
         self.assertEqual(['dpkg'], finding.tags)
+        self.assertEqual(1, finding.nb_occurences)
 
         finding = findings[3]
         self.assertEqual('CVE-2021-33574 in libc6:2.28-10', finding.title)
@@ -219,6 +222,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('2.28-10', finding.component_version)
         self.assertEqual('CVE-2021-33574', finding.vuln_id_from_tool)
         self.assertEqual(['dpkg'], finding.tags)
+        self.assertEqual(1, finding.nb_occurences)
 
         finding = findings[4]
         self.assertEqual('CVE-2021-44420 in Django:3.2.9', finding.title)
@@ -249,3 +253,4 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('3.2.9', finding.component_version)
         self.assertEqual('GHSA-v6rh-hp5x-86rv', finding.vuln_id_from_tool)
         self.assertEqual(['python'], finding.tags)
+        self.assertEqual(2, finding.nb_occurences)

--- a/unittests/tools/test_anchore_grype_parser.py
+++ b/unittests/tools/test_anchore_grype_parser.py
@@ -141,7 +141,6 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('CVE-2021-32626', finding.cve)
         self.assertEqual(1352, finding.cwe)
         self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H', finding.cvssv3)
-        self.assertEqual(8.8, finding.cvssv3_score)
         self.assertEqual('High', finding.severity)
         mitigation = '''Upgrade to version:
 - fix_1
@@ -175,7 +174,6 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('CVE-2021-33574', finding.cve)
         self.assertEqual(1352, finding.cwe)
         self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', finding.cvssv3)
-        self.assertEqual(9.8, finding.cvssv3_score)
         self.assertEqual('Critical', finding.severity)
         self.assertIsNone(finding.mitigation)
         references = '''**Vulnerability Datasource:** https://security-tracker.debian.org/tracker/CVE-2021-33574
@@ -205,7 +203,6 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('CVE-2021-33574', finding.cve)
         self.assertEqual(1352, finding.cwe)
         self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', finding.cvssv3)
-        self.assertEqual(9.8, finding.cvssv3_score)
         self.assertEqual('Critical', finding.severity)
         self.assertIsNone(finding.mitigation)
         references = '''**Vulnerability Datasource:** https://security-tracker.debian.org/tracker/CVE-2021-33574
@@ -237,7 +234,6 @@ class TestAnchoreGrypeParser(DojoTestCase):
         self.assertEqual('CVE-2021-44420', finding.cve)
         self.assertEqual(1352, finding.cwe)
         self.assertEqual('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L', finding.cvssv3)
-        self.assertEqual(7.3, finding.cvssv3_score)
         self.assertEqual('High', finding.severity)
         mitigation = 'Upgrade to version: 3.2.10'
         self.assertEqual(mitigation, finding.mitigation)


### PR DESCRIPTION
This PR is basically a rewrite of the Anchore Grype parser:

- The reports contain a lot of information that was not stored in the findings so far. Now the findings are much richer than before.
- Internal deduplication was based on CVE only. When you have several components with the same CVE, they had been stored in one finding under one component name. Now the internal deduplication is done by the title, which contains CVE, component name and component version.