### PR TITLE
Show descriptions for scan types on pages for import and re-import

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -33,7 +33,7 @@ from dojo.models import Finding, Product, Engagement, Test, \
     Check_List, Test_Import, Notes, \
     Risk_Acceptance, Development_Environment, Endpoint, \
     Cred_Mapping, Dojo_User, System_Settings, Note_Type, Product_API_Scan_Configuration
-from dojo.tools.factory import get_choices_sorted
+from dojo.tools.factory import get_scan_types_sorted
 from dojo.utils import add_error_message_to_response, add_success_message_to_response, get_page_items, add_breadcrumb, handle_uploaded_threat, \
     FileIterWrapper, get_cal_event, Product_Tab, is_scan_file_too_large, \
     get_system_setting, redirect_to_return_url_or_else, get_return_url
@@ -669,7 +669,7 @@ def import_scan_results(request, eid=None, pid=None):
          'title': title,
          'cred_form': cred_form,
          'jform': jform,
-         'scan_types': get_choices_sorted(),
+         'scan_types': get_scan_types_sorted(),
          })
 
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -28,7 +28,7 @@ from dojo.forms import NoteForm, TestForm, \
 from dojo.models import Finding, Finding_Group, Test, Note_Type, BurpRawRequestResponse, Endpoint, Stub_Finding, \
     Finding_Template, Cred_Mapping, Dojo_User, System_Settings, Test_Import, Product_API_Scan_Configuration
 
-from dojo.tools.factory import get_choices_sorted
+from dojo.tools.factory import get_choices_sorted, get_scan_types_sorted
 from dojo.utils import add_error_message_to_response, add_field_errors_to_response, add_success_message_to_response, get_page_items, get_page_items_and_count, add_breadcrumb, get_cal_event, process_notifications, get_system_setting, \
     Product_Tab, is_scan_file_too_large, get_words_for_field
 from dojo.notifications.helper import create_notification
@@ -685,5 +685,5 @@ def re_import_scan_results(request, tid):
                    'eid': engagement.id,
                    'additional_message': additional_message,
                    'jform': jform,
-                   'scan_types': get_choices_sorted(),
+                   'scan_types': get_scan_types_sorted(),
                    })

--- a/dojo/tools/azure_security_center_recommendations/parser.py
+++ b/dojo/tools/azure_security_center_recommendations/parser.py
@@ -14,7 +14,7 @@ class AzureSecurityCenterRecommendationsParser(object):
         return "Azure Security Center Recommendations Scan"
 
     def get_description_for_scan_types(self, scan_type):
-        return "Export of Azure Security Center Recommendations in CSV format."
+        return "Import of Microsoft Defender for Cloud (formerly known as Azure Security Center) recommendations in CSV format."
 
     def get_findings(self, file, test):
         if file.name.lower().endswith('.csv'):

--- a/dojo/tools/cobalt_api/parser.py
+++ b/dojo/tools/cobalt_api/parser.py
@@ -20,7 +20,7 @@ class CobaltApiParser(object):
         return SCAN_COBALTIO_API
 
     def get_description_for_scan_types(self, scan_type):
-        return "Cobalt.io API findings can be imported in JSON format (option --json)."
+        return "Cobalt.io findings can be directly imported using the Cobalt.io API. An API Scan Configuration has to be setup in the Product."
 
     def requires_file(self, scan_type):
         return False

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -35,18 +35,18 @@ def get_parser(scan_type):
     raise ValueError(f"Parser {scan_type} is not active")
 
 
-def get_choices_sorted():
-    res = list()
-    for key in PARSERS:
-        res.append((key, key))
-    return sorted(tuple(res), key=lambda x: x[1].lower())
-
-
 def get_scan_types_sorted():
     res = list()
     for key in PARSERS:
         res.append((key, PARSERS[key].get_description_for_scan_types(key)))
     return sorted(tuple(res), key=lambda x: x[0].lower())
+
+
+def get_choices_sorted():
+    res = list()
+    for key in PARSERS:
+        res.append((key, key))
+    return sorted(tuple(res), key=lambda x: x[1].lower())
 
 
 def requires_file(scan_type):

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -35,18 +35,11 @@ def get_parser(scan_type):
     raise ValueError(f"Parser {scan_type} is not active")
 
 
-def get_choices():
-    res = list()
-    for key in PARSERS:
-        res.append((key, PARSERS[key].get_label_for_scan_types(key)))
-    return tuple(res)
-
-
 def get_choices_sorted():
     res = list()
     for key in PARSERS:
-        res.append((key, key))
-    return sorted(tuple(res), key=lambda x: x[1].lower())
+        res.append((key, PARSERS[key].get_description_for_scan_types(key)))
+    return sorted(tuple(res), key=lambda x: x[0].lower())
 
 
 def requires_file(scan_type):

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -38,6 +38,13 @@ def get_parser(scan_type):
 def get_choices_sorted():
     res = list()
     for key in PARSERS:
+        res.append((key, key))
+    return sorted(tuple(res), key=lambda x: x[1].lower())
+
+
+def get_scan_types_sorted():
+    res = list()
+    for key in PARSERS:
         res.append((key, PARSERS[key].get_description_for_scan_types(key)))
     return sorted(tuple(res), key=lambda x: x[0].lower())
 

--- a/dojo/tools/sonarqube_api/parser.py
+++ b/dojo/tools/sonarqube_api/parser.py
@@ -13,7 +13,7 @@ class SonarQubeAPIParser(object):
         return SCAN_SONARQUBE_API
 
     def get_description_for_scan_types(self, scan_type):
-        return "Aggregates findings per cwe, title, description, file_path. SonarQube output file can be imported in HTML format. Generate with https://github.com/soprasteria/sonar-report version >= 1.1.0"
+        return "SonarQube findings can be directly imported using the SonarQube API. An API Scan Configuration has to be setup in the Product."
 
     def requires_file(self, scan_type):
         return False


### PR DESCRIPTION
The pages to import and re-import show a list of available scan types. Currently it shows the name of the scan type 2 times next to each other:

![2021-12-27 18_24_48-Import Scan Results _ DefectDojo](https://user-images.githubusercontent.com/2698502/147494232-91ea963d-7f42-4486-8c03-59c8ed5c01b2.png)

With this PR the list shows the name of the scan type with its description, which I think would have been the initial idea of that list:

![2021-12-27 18_20_20-Import Scan Results _ DefectDojo](https://user-images.githubusercontent.com/2698502/147494334-306efada-4532-4ad5-80c3-17eea9586deb.png)

Additionally 3 descriptions have changed because they where wrong or outdated and a method has been removed that was not used anymore.