### PR TITLE
Display "Banner" on dashboard when skipping login form

### DIFF
--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -4,6 +4,8 @@ from typing import Dict
 
 from dateutil.relativedelta import relativedelta
 
+from django.conf import settings
+from django.contrib import messages
 from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse, HttpRequest
 from django.shortcuts import render
@@ -11,7 +13,7 @@ from django.utils import timezone
 
 from django.db.models import Count, Q
 from dojo.utils import add_breadcrumb, get_punchcard_data
-from dojo.models import Answered_Survey
+from dojo.models import Answered_Survey, BannerConf
 from dojo.authorization.roles_permissions import Permissions
 from dojo.engagement.queries import get_authorized_engagements
 from dojo.finding.queries import get_authorized_findings
@@ -51,6 +53,16 @@ def dashboard(request: HttpRequest) -> HttpResponse:
             .filter(Q(engagement__isnull=True) | Q(engagement__in=engagements))
     else:
         unassigned_surveys = None
+
+    if not settings.SHOW_LOGIN_FORM:
+        banner_config = BannerConf.objects.get()
+        if banner_config and banner_config.banner_enable:
+            messages.add_message(
+                    request,
+                    messages.INFO,
+                    banner_config.banner_message,
+                    extra_tags="alert-banner",
+                )
 
     add_breadcrumb(request=request, clear=True)
     return render(request, 'dojo/dashboard.html', {

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -58,11 +58,11 @@ def dashboard(request: HttpRequest) -> HttpResponse:
         banner_config = BannerConf.objects.get()
         if banner_config and banner_config.banner_enable:
             messages.add_message(
-                    request,
-                    messages.INFO,
-                    banner_config.banner_message,
-                    extra_tags="alert-banner",
-                )
+                request,
+                messages.INFO,
+                banner_config.banner_message,
+                extra_tags="alert-banner",
+            )
 
     add_breadcrumb(request=request, clear=True)
     return render(request, 'dojo/dashboard.html', {

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1648,3 +1648,8 @@ input[type=number]::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
 }
+
+.alert-banner {
+    background-color: #f5f5f5;
+    border: #e3e3e3;
+} 


### PR DESCRIPTION
### "Problem"
When the login screen is skipped for social login via `DD_SOCIAL_AUTH_SHOW_LOGIN_FORM` banners are never visible to users.

### Solution
Added a check if the login screen is displayed and banner is configured. When login screen has been skipped, and the banner has been configured, display the banner on the dashboard.

Added a new alert class `.alert-banner` to mirror the `.well` class used for login page banners.

### For Consideration
This implementation will _always_ display the banner anytime the user goes to the dashboard. This differs from the current once per form-based-login display of the banner. This implementation is based on the _assumption_ that when enabling a banner, one would want it to be displayed regularly to users until the banner is disabled.

### Images
Login Page
![DefectDojoLoginBanner](https://user-images.githubusercontent.com/19413468/147721217-34d84464-6d3d-49e3-8a17-5484ca746a90.png)

Dashboard Addition
![DefectDojoDashboardBanner](https://user-images.githubusercontent.com/19413468/147721229-8b46ca19-8c6d-4b7a-a910-e28171039734.png)

