### PR TITLE
Fix database migration for deletion of development environments

### DIFF
--- a/dojo/db_migrations/0142_environment_delete.py
+++ b/dojo/db_migrations/0142_environment_delete.py
@@ -7,7 +7,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dojo', '0140_auth_group'),
+        ('dojo', '0141_enable_user_profile_editable'),
     ]
 
     operations = [


### PR DESCRIPTION
The rename of a db migration was missed with the last round of merges, causing a conflict when running the initializer.