### PR TITLE
Extend scan_date functionality to Endpoints created at import time

### DIFF
--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -146,8 +146,7 @@ def add_endpoints_to_unsaved_finding(finding, test, endpoints, **kwargs):
             eps, created = Endpoint_Status.objects.get_or_create(
                 finding=finding,
                 endpoint=ep,
-                date=finding.date,
-                last_modified=finding.date)
+                date=finding.date)
         except (MultipleObjectsReturned):
             pass
 

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -145,7 +145,9 @@ def add_endpoints_to_unsaved_finding(finding, test, endpoints, **kwargs):
         try:
             eps, created = Endpoint_Status.objects.get_or_create(
                 finding=finding,
-                endpoint=ep)
+                endpoint=ep,
+                date=finding.date,
+                last_modified=finding.date)
         except (MultipleObjectsReturned):
             pass
 


### PR DESCRIPTION
Extended behavior from #5547 to apply to endpoint status objects as well as findings