### PR TITLE
Updated django dockerfile to work with bind mounts for local_settings.py

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -144,4 +144,5 @@ ENV \
 ENTRYPOINT ["/entrypoint-uwsgi.sh"]
 
 FROM django as django-unittests
+USER root
 COPY unittests/ ./unittests/

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -28,7 +28,8 @@ RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
 FROM base as django
 WORKDIR /app
-ARG uid=1001
+ARG uid=1337
+ARG gid=1337
 ARG appuser=defectdojo
 ENV appuser ${appuser}
 RUN \
@@ -88,14 +89,21 @@ RUN \
   true
 USER root
 RUN \
-    adduser --system --no-create-home --disabled-password --gecos '' \
-        --uid ${uid} ${appuser} && \
+    # Set a known user and group with a higher number uid/git
+    addgroup --gid ${gid} ${appuser} && \
+    adduser --no-create-home --disabled-password --shell /usr/sbin/nologin \
+            --gecos 'DefectDojo' --uid ${uid} --gid ${gid} ${appuser} && \
     chown -R root:root /app && \
     chmod -R u+rwX,go+rX,go-w /app && \
+    # Allow for bind mounting local_settings.py and other setting overrides
+    chown root:${appuser} /app/dojo/settings && \
+    chmod 775 /app/dojo/settings && \
+    # Allow ${appuser} to run entrypoint scripts
+    chown root:defectdojo /entrypoint-* && \
+    chmod g+x /entrypoint-* && \
     mkdir /var/run/${appuser} && \
-    chown ${appuser} /var/run/${appuser} && \
-	  chmod g=u /var/run/${appuser} && \
-    mkdir -p media/threat && chown -R ${uid} media
+    chown ${appuser}:${appuser} /var/run/${appuser} && \
+    mkdir -p media/threat && chown -R ${uid}:${gid} media
 USER ${uid}
 ENV \
   DD_ADMIN_USER=admin \

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -103,7 +103,7 @@ RUN \
     chmod g+x /entrypoint-* && \
     mkdir /var/run/${appuser} && \
     chown ${appuser}:${appuser} /var/run/${appuser} && \
-    mkdir -p media/threat && chown -R ${uid}:${gid} media
+    mkdir -p media/threat && chown -R ${appuser}:${appuser} media
 USER ${uid}
 ENV \
   DD_ADMIN_USER=admin \

--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -91,7 +91,7 @@ USER root
 RUN \
     # Set a known user and group with a higher number uid/git
     addgroup --gid ${gid} ${appuser} && \
-    adduser --no-create-home --disabled-password --shell /usr/sbin/nologin \
+    adduser --no-create-home --disabled-password \
             --gecos 'DefectDojo' --uid ${uid} --gid ${gid} ${appuser} && \
     chown -R root:root /app && \
     chmod -R u+rwX,go+rX,go-w /app && \


### PR DESCRIPTION
Recent change (Pull Request #5284) changed /app to be owned by root.  This broke the ability for docker-compose installs to bind mount a local_settings.py into the container.

To address this, I've added a defectdojo user and group with a UID and GID of 1337.  This allows /apps/dojo/settings to be writable by the defectdojo group so local_settings.py can be copied in by the entrypoint script.

I also moved the UID from 1001 to 1337 so that it has a much reduced chance of colliding with a OS user if you want to chown the host files that are bind mounted as a host OS user with a UID that matches the UID in the container.  1337 would require 337 local users vs 1 local user for 1001.