### PR TITLE
Removal of `is_staff` for various functionalities

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -722,7 +722,7 @@ class FindingViewSet(prefetch.PrefetchListMixin,
         else:
             return Response({"error": "('note_id') parameter missing"},
                 status=status.HTTP_400_BAD_REQUEST)
-        if note.author.username == request.user.username or request.user.is_staff:
+        if note.author.username == request.user.username or request.user.is_superuser:
             finding.notes.remove(note)
             note.delete()
         else:

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
@@ -356,25 +355,22 @@ def edit_meta_data(request, eid):
 def endpoint_bulk_update_all(request, pid=None):
     if request.method == "POST":
         endpoints_to_update = request.POST.getlist('endpoints_to_update')
-        finds = Endpoint.objects.filter(id__in=endpoints_to_update).order_by("endpoint_meta__product__id")
-        total_endpoint_count = finds.count()
+        endpoints = Endpoint.objects.filter(id__in=endpoints_to_update).order_by("endpoint_meta__product__id")
+        total_endpoint_count = endpoints.count()
 
         if request.POST.get('delete_bulk_endpoints') and endpoints_to_update:
 
-            if pid is None:
-                if not request.user.is_staff:
-                    raise PermissionDenied
-            else:
+            if pid is not None:
                 product = get_object_or_404(Product, id=pid)
                 user_has_permission_or_403(request.user, product, Permissions.Endpoint_Delete)
 
-            finds = get_authorized_endpoints(Permissions.Endpoint_Delete, finds, request.user)
+            endpoints = get_authorized_endpoints(Permissions.Endpoint_Delete, endpoints, request.user)
 
-            skipped_endpoint_count = total_endpoint_count - finds.count()
-            deleted_endpoint_count = finds.count()
+            skipped_endpoint_count = total_endpoint_count - endpoints.count()
+            deleted_endpoint_count = endpoints.count()
 
             product_calc = list(Product.objects.filter(endpoint__id__in=endpoints_to_update).distinct())
-            finds.delete()
+            endpoints.delete()
             for prod in product_calc:
                 calculate_grade(prod)
 
@@ -389,22 +385,19 @@ def endpoint_bulk_update_all(request, pid=None):
         else:
             if endpoints_to_update:
 
-                if pid is None:
-                    if not request.user.is_staff:
-                        raise PermissionDenied
-                else:
+                if pid is not None:
                     product = get_object_or_404(Product, id=pid)
                     user_has_permission_or_403(request.user, product, Permissions.Finding_Edit)
 
-                finds = get_authorized_endpoints(Permissions.Endpoint_Edit, finds, request.user)
+                endpoints = get_authorized_endpoints(Permissions.Endpoint_Edit, endpoints, request.user)
 
-                skipped_endpoint_count = total_endpoint_count - finds.count()
-                updated_endpoint_count = finds.count()
+                skipped_endpoint_count = total_endpoint_count - endpoints.count()
+                updated_endpoint_count = endpoints.count()
 
                 if skipped_endpoint_count > 0:
                     add_error_message_to_response('Skipped mitigation of {} endpoints because you are not authorized.'.format(skipped_endpoint_count))
 
-                for endpoint in finds:
+                for endpoint in endpoints:
                     endpoint.mitigated = not endpoint.mitigated
                     endpoint.save()
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -533,8 +533,8 @@ def import_scan_results(request, eid=None, pid=None):
     elif pid:
         product = get_object_or_404(Product, id=pid)
         engagement_or_product = product
-    elif not user.is_staff:
-        raise PermissionDenied
+    else:
+        raise Exception('Either Engagement or Product has to be provided')
 
     user_has_permission_or_403(user, engagement_or_product, Permissions.Import_Scan_Result)
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1743,10 +1743,7 @@ def finding_bulk_update_all(request, pid=None):
         if request.POST.get('delete_bulk_findings'):
             if form.is_valid() and finding_to_update:
 
-                if pid is None:
-                    if not request.user.is_staff:
-                        raise PermissionDenied
-                else:
+                if pid is not None:
                     product = get_object_or_404(Product, id=pid)
                     user_has_permission_or_403(request.user, product, Permissions.Finding_Delete)
 
@@ -1772,10 +1769,7 @@ def finding_bulk_update_all(request, pid=None):
         else:
             if form.is_valid() and finding_to_update:
 
-                if pid is None:
-                    if not request.user.is_staff:
-                        raise PermissionDenied
-                else:
+                if pid is not None:
                     product = get_object_or_404(Product, id=pid)
                     user_has_permission_or_403(request.user, product, Permissions.Finding_Edit)
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -750,11 +750,11 @@ class EngForm(forms.ModelForm):
 
         if product:
             self.fields['preset'] = forms.ModelChoiceField(help_text="Settings and notes for performing this engagement.", required=False, queryset=Engagement_Presets.objects.filter(product=product))
-            self.fields['lead'].queryset = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
+            self.fields['lead'].queryset = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View).filter(is_active=True)
         else:
             self.fields['lead'].queryset = User.objects.filter(is_active=True)
 
-        self.fields['product'].queryset = get_authorized_products(Permissions.Engagement_Add).filter(is_active=True)
+        self.fields['product'].queryset = get_authorized_products(Permissions.Engagement_Add)
 
         # Don't show CICD fields on a interactive engagement
         if cicd is False:

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -752,9 +752,9 @@ class EngForm(forms.ModelForm):
             self.fields['preset'] = forms.ModelChoiceField(help_text="Settings and notes for performing this engagement.", required=False, queryset=Engagement_Presets.objects.filter(product=product))
             self.fields['lead'].queryset = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
         else:
-            self.fields['lead'].queryset = User.objects.exclude(is_staff=False)
+            self.fields['lead'].queryset = User.objects.filter(is_active=True)
 
-        self.fields['product'].queryset = get_authorized_products(Permissions.Engagement_Add)
+        self.fields['product'].queryset = get_authorized_products(Permissions.Engagement_Add).filter(is_active=True)
 
         # Don't show CICD fields on a interactive engagement
         if cicd is False:
@@ -826,10 +826,10 @@ class TestForm(forms.ModelForm):
 
         if obj:
             product = get_product(obj)
-            self.fields['lead'].queryset = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View)
+            self.fields['lead'].queryset = get_authorized_users_for_product_and_product_type(None, product, Permissions.Product_View).filter(is_active=True)
             self.fields['api_scan_configuration'].queryset = Product_API_Scan_Configuration.objects.filter(product=product)
         else:
-            self.fields['lead'].queryset = User.objects.exclude(is_staff=False)
+            self.fields['lead'].queryset = User.objects.filter(is_active=True)
 
     class Meta:
         model = Test
@@ -1553,7 +1553,7 @@ class ClearFindingReviewForm(forms.ModelForm):
 
 
 class ReviewFindingForm(forms.Form):
-    reviewers = forms.ModelMultipleChoiceField(queryset=Dojo_User.objects.filter(is_staff=True, is_active=True),
+    reviewers = forms.ModelMultipleChoiceField(queryset=Dojo_User.objects.filter(is_active=True),
                                                help_text="Select all users who can review Finding.")
     entry = forms.CharField(
         required=True, max_length=2400,

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -70,7 +70,7 @@ def create_notification(event=None, **kwargs):
                 queryset=Notifications.objects.filter(Q(product_id=product) | Q(product__isnull=True)),
                 to_attr="applicable_notifications"
             )).annotate(applicable_notifications_count=Count('notifications__id', filter=Q(notifications__product_id=product) | Q(notifications__product__isnull=True)))\
-                .filter((Q(applicable_notifications_count__gt=0) | Q(is_superuser=True) | Q(is_staff=True)))
+                .filter((Q(applicable_notifications_count__gt=0) | Q(is_superuser=True)))
 
             # only send to authorized users or admin/superusers
             if product:
@@ -82,7 +82,7 @@ def create_notification(event=None, **kwargs):
                 # send notifications to user after merging possible multiple notifications records (i.e. personal global + personal product)
                 # kwargs.update({'user': user})
                 applicable_notifications = user.applicable_notifications
-                if user.is_staff or user.is_superuser:
+                if user.is_superuser:
                     # admin users get all system notifications
                     applicable_notifications.append(system_notifications)
 
@@ -337,7 +337,7 @@ def get_slack_user_id(user_email):
 def log_alert(e, notification_type=None, *args, **kwargs):
     # no try catch here, if this fails we need to show an error
 
-    users = Dojo_User.objects.filter((Q(is_superuser=True) | Q(is_staff=True)))
+    users = Dojo_User.objects.filter(is_superuser=True)
     for user in users:
         alert = Alerts(
             user_id=user,

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -10,7 +10,6 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.core.exceptions import PermissionDenied
 from django.http import Http404, HttpResponseForbidden, HttpResponse, QueryDict
 from django.shortcuts import render, get_object_or_404
 from django.utils import timezone
@@ -373,12 +372,14 @@ def generate_report(request, obj, host_view=False):
         user_has_permission_or_403(request.user, obj, Permissions.Test_View)
     elif type(obj).__name__ == "Endpoint":
         user_has_permission_or_403(request.user, obj, Permissions.Endpoint_View)
-    elif type(obj).__name__ == "QuerySet" or type(obj).__name__ == "CastTaggedQuerySet":
+    elif type(obj).__name__ == "QuerySet" or type(obj).__name__ == "CastTaggedQuerySet" or type(obj).__name__ == "TagulousCastTaggedQuerySet":
         # authorization taken care of by only selecting findings from product user is authed to see
         pass
     else:
-        if not request.user.is_staff:
-            raise PermissionDenied
+        if obj is None:
+            raise Exception('No object is given to generate report for')
+        else:
+            raise Exception(f'Report cannot be generated for object of type {type(obj).__name__}')
 
     report_format = request.GET.get('report_type', 'AsciiDoc')
     include_finding_notes = int(request.GET.get('include_finding_notes', 0))

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -694,14 +694,13 @@ def answer_empty_survey(request, esid):
     settings = System_Settings.objects.all()[0]
 
     if not settings.allow_anonymous_survey_repsonse:
-        auth = request.user.is_staff
-        if not auth:
+        if not request.user.is_authenticated:
             messages.add_message(request,
                                  messages.ERROR,
                                  'You must be logged in to answer questionnaire. Otherwise, enable anonymous response in system settings.',
                                  extra_tags='alert-danger')
             # will render 403
-            raise PermissionDenied
+            raise PermissionDenied()
 
     questions = [q.get_form()(prefix=str(q.id),
                               engagement_survey=engagement_survey,

--- a/dojo/templates/dojo/add_user.html
+++ b/dojo/templates/dojo/add_user.html
@@ -27,21 +27,6 @@
 {% endblock %}
 {% block postscript %}
     {{ block.super }}
-    {% if to_add or to_edit and not to_edit.is_staff %}
-        <script type="application/javascript">
-            $(function () {
-                $('#id_authorized_products').chosen({'placeholder_text_multiple': 'Select some products...'});
-                $('#id_authorized_product_types').chosen({'placeholder_text_multiple': 'Select some product types...'});
-            });
-        </script>
-    {% else %}
-        <script type="application/javascript">
-            $(function () {
-                $('#id_authorized_products').parents(".form-group").remove();
-                $('#id_authorized_product_types').parents(".form-group").remove();
-            });
-        </script>
-    {% endif %}
     {% if not user.is_superuser %}
         <script type="application/javascript">
             $(function () {

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -12,7 +12,7 @@
                         {{ name }}
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
-                            {% if request.user.is_staff or product_tab and product_tab.product|has_object_permission:"Endpoint_Add" %}
+                            {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Endpoint_Add" %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa fa-wrench"></span>
@@ -46,12 +46,12 @@
                         <form action="{% url 'endpoints_bulk_all' %}" method="post" id="bulk_change_form">
                     {% endif %}
                         {% csrf_token %}
-                        {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
+                        {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
 						<button class="btn btn-sm btn-primary" type="submit" id="remedy_endpoint" title="Mitigate Endpoints">
                 Bulk Mitigate
             </button>
                         {% endif %}
-                        {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Endpoint_Delete" %}
+                        {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Endpoint_Delete" %}
 						<button type="button" class="btn btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Delete Endpoint">
 								<a class="white-color delete-bulk" href="#" alt="Delete Endpoints">
 								<i class="fa fa-trash"></i>
@@ -69,7 +69,7 @@
                     <table id="endpoints"
                            class="tablesorter-bootstrap table table-condensed table-striped table-hover">
                         <tr>
-                            {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
+                            {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
                             <th class="hidden-sm centered" title="Select all visible endpoint." id="bulk_edit">
                                 <form class="inline-form centered" action="#">
                                     <input type="checkbox" title="Select All" name="select_all" id="select_all"></input>
@@ -90,7 +90,7 @@
 
                         {% for e in endpoints %}
                             <tr>
-                                {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
+                                {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
                                 <td class="hidden-sm centered">
                                     <form action="#">
                                         <input type="checkbox" title= "Select_{{ e.id }}" name="select_{{ e.id }}"

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -46,9 +46,9 @@
                 <div class="clearfix">
                     {% include "dojo/paging_snippet.html" with page=findings page_size=True %}
                 </div>
-            {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
+            {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
             <div class="dropdown hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
-                {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
+                {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
                     <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
                             data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                         Bulk Edit
@@ -63,7 +63,7 @@
                       </a>
                     </button>
                     {% endif %}
-                    {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Finding_Delete" %}
+                    {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Finding_Delete" %}
                     <button type="button" class="btn btn-sm  btn-primary" data-toggle="tooltip" data-placement="bottom" title="Delete Findings">
                       <a class="white-color delete-bulk" href="#" alt="Delete Findings">
                         <i class="fa fa-trash"></i>
@@ -159,7 +159,7 @@
                            class="tablesorter-bootstrap table table-condensed table-striped table-hover">
                         <thead>
                         <tr>
-                          {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
+                          {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
                           <th class="hidden-sm centered" title="Select all visible findings.">
                               <div class="dropdown">
                                   <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
@@ -217,7 +217,7 @@
                         <tbody>
                         {% for finding in findings %}
                             <tr class="{% if finding.active %}active_finding{% else %}inactive_finding{% endif %}">
-                                {% if user.is_staff or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
+                                {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
                                   <td class="hidden-sm centered">
                                     <form action="#">
                                         <input type="checkbox" name="select_{{ finding.id }}" id="{{ finding.id }}"

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -502,7 +502,7 @@
             {% include "dojo/paging_snippet.html" with page=findings prefix='findings' page_size=True %}
         </div>
 
-        {% if user.is_staff or test|has_object_permission:"Finding_Edit" %}
+        {% if test|has_object_permission:"Finding_Edit" or test|has_object_permission:"Finding_Delete" %}
         <div class="dropdown hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
             {% if test|has_object_permission:"Finding_Edit" %}
                 <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1321,7 +1321,7 @@ def process_notifications(request, note, parent_url, parent_title):
         User.objects.filter(username=username).get()
         for username in usernames_to_check
         if User.objects.filter(is_active=True, username=username).exists()
-    ]  # is_staff also?
+    ]
 
     if len(note.entry) > 200:
         note.entry = note.entry[:200]


### PR DESCRIPTION
This PR removes some checks of the `is_staff` flag, where the functionality can either be used by all users or gets restricted to superusers:

- Staff users where allowed to delete any notes with the API. This has been restricted to superusers.
- Bulk edits and deletes for Endpoints, Tests and Findings where restricted to staff users. Since the bulk operations respect the permissions of the user for each object, it is save to make it available to all users.
- There was an unnecessary check that only staff users can import Findings without providing an Engagement or Product. This would not work anyway, so an exception is raised in this case.
- Only staff users could be selected as the lead for an Engagement. This has been changed to all users, but only active users can be selected.
- System notifications where send to all superusers and all staff users. They now will be sent to superusers only.
- The request to generate a report without giving a valid object to specify the content of the report was permitted for staff users, but generated an exception later in the code. Now the exception is raised explicitly.
- `is_staff` was used to check if a user is logged in to answer a survey. This has been changed to check `is_authenticated`.