### PR TITLE
Updated all dockerfiles to match the django dockerfile so UID/GIDs are consistent across dockerfiles

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -27,11 +27,15 @@ COPY requirements.txt ./
 RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
 FROM base as django
+
 WORKDIR /app
+
+# Setup defectdojo user and group with 1337 UID/GID
 ARG uid=1337
 ARG gid=1337
 ARG appuser=defectdojo
 ENV appuser ${appuser}
+
 RUN \
   apt-get -y update && \
   # ugly fix to install postgresql-client without errors
@@ -53,6 +57,8 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
   true
+
+# Python installs from build for requirements.txt
 COPY --from=build /tmp/wheels /tmp/wheels
 COPY requirements.txt ./
 RUN pip3 install \
@@ -61,33 +67,34 @@ RUN pip3 install \
   --find-links=/tmp/wheels \
   -r ./requirements.txt
 
-COPY \
-  docker/entrypoint-celery-beat.sh \
-  docker/entrypoint-celery-worker.sh \
-  docker/entrypoint-initializer.sh \
-  docker/entrypoint-uwsgi.sh \
-  docker/entrypoint-uwsgi-dev.sh \
-  docker/entrypoint-unit-tests.sh \
-  docker/entrypoint-unit-tests-devDocker.sh \
-  docker/wait-for-it.sh \
-  docker/certs/* \
-  /
-COPY wsgi.py manage.py docker/unit-tests.sh ./
-COPY dojo/ ./dojo/
-
+# Copy over needed files from source code
+COPY docker/entrypoint-celery-beat.sh /
+COPY docker/entrypoint-celery-worker.sh /
+COPY docker/entrypoint-initializer.sh /
+COPY docker/entrypoint-uwsgi.sh /
+COPY docker/entrypoint-uwsgi-dev.sh /
+COPY docker/entrypoint-unit-tests.sh /
+COPY docker/entrypoint-unit-tests-devDocker.sh /
+COPY docker/wait-for-it.sh /
+COPY docker/certs/* /
+COPY wsgi.py manage.py docker/unit-tests.sh /app/
+COPY dojo/ /app/dojo/
 # Add extra fixtures to docker image which are loaded by the initializer
 COPY docker/extra_fixtures/* /app/dojo/fixtures/
-
+# Copy over tests
 COPY tests/ ./tests/
+
 RUN \
   # Remove placeholder copied from docker/certs
   rm -f /readme.txt && \
   # Remove placeholder copied from docker/extra_fixtures
   rm -f dojo/fixtures/readme.txt && \
   mkdir -p dojo/migrations && \
-  chmod g=u dojo/migrations && \
+  chmod g+x dojo/migrations && \
   true
+
 USER root
+
 RUN \
     # Set a known user and group with a higher number uid/git
     addgroup --gid ${gid} ${appuser} && \
@@ -97,6 +104,7 @@ RUN \
     chmod -R u+rwX,go+rX,go-w /app && \
     # Allow for bind mounting local_settings.py and other setting overrides
     chown root:${appuser} /app/dojo/settings && \
+    chown root:${appuser} /app/dojo/migrations && \
     chmod 775 /app/dojo/settings && \
     # Allow ${appuser} to run entrypoint scripts
     chown root:defectdojo /entrypoint-* && \
@@ -104,7 +112,9 @@ RUN \
     mkdir /var/run/${appuser} && \
     chown ${appuser}:${appuser} /var/run/${appuser} && \
     mkdir -p media/threat && chown -R ${appuser}:${appuser} media
+
 USER ${uid}
+
 ENV \
   DD_ADMIN_USER=admin \
   DD_ADMIN_MAIL=admin@defectdojo.local \
@@ -141,8 +151,11 @@ ENV \
   DD_UWSGI_NUM_OF_THREADS="2" \
   DD_TRACK_MIGRATIONS="True" \
   DD_DJANGO_METRICS_ENABLED="False"
+
 ENTRYPOINT ["/entrypoint-uwsgi.sh"]
 
 FROM django as django-unittests
+
 USER root
+
 COPY unittests/ ./unittests/

--- a/Dockerfile.integration-tests
+++ b/Dockerfile.integration-tests
@@ -37,18 +37,35 @@ RUN \
   chmod -R 0755 .
 WORKDIR /app
 
-COPY docker/wait-for-it.sh \
-  docker/entrypoint-integration-tests.sh \
-  /
-
+# Copy over runtime scripts and tests
+COPY docker/wait-for-it.sh /
+COPY docker/entrypoint-integration-tests.sh /app/docker/
 COPY tests/ ./tests/
 
-RUN chmod -R 0777 /app
+# Setup defectdojo user & group
+ARG uid=1337
+ARG gid=1337
+ARG appuser=defectdojo
+ENV appuser ${appuser}
 
-ARG uid=1001
-USER ${uid}
+# Setup container user and file permissions
+RUN \
+  addgroup --gid ${gid} ${appuser} && \
+  adduser --no-create-home --disabled-password \
+          --gecos 'DefectDojo' --uid ${uid} --gid ${gid} ${appuser} && \
+  chown -R root:${appuser} /app && \
+  chmod -R 0775 /app && \
+  chown root:${appuser} /app/docker/entrypoint-* && \
+  chmod 0775 /app/docker/entrypoint* && \
+  chown root:${appuser} /wait-for-it.sh && \
+  cp -a /app/docker/entrypoint-integration-tests.sh /entrypoint-integration-tests.sh && \
+  chmod 0755 /wait-for-it.sh
+
+USER ${appuser}
+
 ENV \
   DD_ADMIN_USER=admin \
   DD_ADMIN_PASSWORD='' \
   DD_BASE_URL="http://localhost:8080/"
+
 CMD ["/entrypoint-integration-tests.sh"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -65,20 +65,36 @@ COPY dojo/ ./dojo/
 
 RUN env DD_SECRET_KEY='.' python3 manage.py collectstatic --noinput && true
 
-FROM nginx:1.21.5-alpine@sha256:eb05700fe7baa6890b74278e39b66b2ed1326831f9ec3ed4bdc6361a4ac2f333
-ARG uid=1001
+FROM nginx:1.21.4-alpine@sha256:12aa12ec4a8ca049537dd486044b966b0ba6cd8890c4c900ccb5e7e630e03df0
+
+# Setup defectdojo user & group
+ARG uid=1337
+ARG gid=1337
 ARG appuser=defectdojo
+ENV appuser ${appuser}
+
 COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf nginx/nginx_TLS.conf /etc/nginx/
-COPY docker/entrypoint-nginx.sh /
+COPY docker/entrypoint-nginx.sh /entrypoint-nginx.sh
+
+# Setup container user and file permissions
 RUN \
+  adduser -H -D -g 'DefectDojo' -u ${uid} -g ${appuser} ${appuser} && \
+  chown root:${appuser} /entrypoint-* && \
+  chmod 0755 /entrypoint* && \
   apk add --no-cache openssl && \
-  chmod -R g=u /var/cache/nginx && \
+  chmod -R g+x /var/cache/nginx && \
   mkdir /var/run/defectdojo && \
-  chmod -R g=u /var/run/defectdojo && \
+  chown -R root:${appuser} /var/run/defectdojo && \
+  chmod -R g+wx /var/run/defectdojo && \
   mkdir -p /etc/nginx/ssl && \
-  chmod -R g=u /etc/nginx && \
+  chown -R root:${appuser} /etc/nginx/ssl && \
+  chmod -R g+wx /etc/nginx && \
+  chown -R root:${appuser} /var/cache/nginx && \
+  chmod -R g+wx /var/cache/nginx && \
+  mkdir -p /etc/nginx/ssl && \
   true
+
 ENV \
   DD_UWSGI_PASS="uwsgi_server" \
   DD_UWSGI_HOST="uwsgi" \
@@ -88,6 +104,9 @@ ENV \
   NGINX_METRICS_ENABLED="false" \
   METRICS_HTTP_AUTH_USER="" \
   METRICS_HTTP_AUTH_PASSWORD=""
+
 USER ${uid}
+
 EXPOSE 8080
+
 ENTRYPOINT ["/entrypoint-nginx.sh"]

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -6,12 +6,13 @@ services:
       context: ./
       dockerfile: Dockerfile.integration-tests
     image: "defectdojo/defectdojo-integration-tests:${INTEGRATION_TESTS_VERSION:-latest}"
+    user: defectdojo # Make user explicit as integration test won't be run in prod
     depends_on:
       - nginx
       - uwsgi
-    entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/app/docker/entrypoint-integration-tests.sh']
+    entrypoint: ['/wait-for-it.sh', 'mysql:3306', '-t', '30', '--', '/entrypoint-integration-tests.sh']
     volumes:
-      - '.:/app:z'
+      - '.:/app:z' # :z means a shared volume
       - "defectdojo_media_integration_test:${DD_MEDIA_ROOT:-/app/media}"
     environment:
       DD_BASE_URL: 'http://nginx:8080/'


### PR DESCRIPTION
Mostly doing 2 things:
(1) Making all the dockerfile match in terms of UID/GID for the defectdojo user & group
(2) Cleaned up the formatting of the dockerfiles to make them more readable & added comments

Additionally, I move the entrypoint script in the integration container to / to be consistent will all other entrypoint scripts.