### PR TITLE
Revert permission changes for `test_type` and `development_environment`

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1516,7 +1516,7 @@ class DevelopmentEnvironmentViewSet(mixins.ListModelMixin,
     serializer_class = serializers.DevelopmentEnvironmentSerializer
     queryset = Development_Environment.objects.all()
     filter_backends = (DjangoFilterBackend,)
-    permission_classes = (permissions.UserHasConfigurationPermissionStaff, )
+    permission_classes = (IsAuthenticated, DjangoModelPermissions)
 
 
 # Authorization: object-based
@@ -1684,7 +1684,7 @@ class TestTypesViewSet(mixins.ListModelMixin,
     queryset = Test_Type.objects.all()
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('name',)
-    permission_classes = (permissions.UserHasConfigurationPermissionStaff, )
+    permission_classes = (IsAuthenticated, DjangoModelPermissions)
 
 
 @extend_schema_view(


### PR DESCRIPTION
Every user could read Test Types and Development Environments before release 2.6.0. Now it has accidentally been changed to staff users. As there is no sensitive data in these 2 classes and the read access is often helpful in CI/CD scenarios, the old behaviour is reinstated.