### PR TITLE
Reinstate copying of extra_settings

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -29,6 +29,7 @@ RUN pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 FROM base as django
 WORKDIR /app
 ARG uid=1001
+ARG gid=1337
 ARG appuser=defectdojo
 ENV appuser ${appuser}
 RUN \
@@ -88,10 +89,14 @@ RUN \
   true
 USER root
 RUN \
+    addgroup --gid ${gid} ${appuser} && \
     adduser --system --no-create-home --disabled-password --gecos '' \
-        --uid ${uid} ${appuser} && \
+        --uid ${uid} --gid ${gid} ${appuser} && \
     chown -R root:root /app && \
     chmod -R u+rwX,go+rX,go-w /app && \
+    # Allow for bind mounting local_settings.py and other setting overrides
+    chown -R root:${appuser} /app/dojo/settings && \
+    chmod -R 775 /app/dojo/settings && \
     mkdir /var/run/${appuser} && \
     chown ${appuser} /var/run/${appuser} && \
 	  chmod g=u /var/run/${appuser} && \


### PR DESCRIPTION
Copying of files in `docker/extra_settings` as described in https://defectdojo.github.io/django-DefectDojo/getting_started/configuration/#local_settingspy-not-with-kubernetes isn't working anymore with release 2.6.0. 