### PR TITLE
Removal of `AUTHORIZATION_STAFF_OVERRIDE`

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -65,6 +65,10 @@ If you have installed DefectDojo on "iron" and wish to upgrade the installation,
 
 This release is a breaking change regarding the Choctaw Hog parser. As the maintainers of this project unified multiple parsers under the RustyHog parser, we now support the parsing of Choctaw Hog JSON output files through the Rusty Hog parser. Furthermore, we also support Gottingen Hog JSON output files with the RustyHog parser.
 
+The functionality using the flag `AUTHORIZATION_STAFF_OVERRIDE` has been removed. The same result can be achieved with giving the staff users
+a global Owner role. To make that easier you can run a migration script with ``./manage.py migrate staff_users``. This script creates a group
+for all staff users and sets the global Owner role, if `AUTHORIZATION_STAFF_OVERRIDE` is set to True.
+
 ## Upgrading to DefectDojo Version 2.6.x.
 
 There are no special instruction for upgrading to 2.6.0. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.6.0) for the contents of the release.

--- a/docs/content/en/usage/permissions.md
+++ b/docs/content/en/usage/permissions.md
@@ -8,7 +8,7 @@ draft: false
 ## System-wide permissions
 
 * Administrators (aka super users) have no limitations in the system. They can change all settings, manage users  and have read and write access to all data.
-* Staff users can add Product Types, and have access to data according to their role in a Product or Product Type. There is the parameter `AUTHORIZATION_STAFF_OVERRIDE` in the settings to give all staff users full access to all Products and Product Types.
+* Staff users can add Product Types, and have access to data according to their role in a Product or Product Type.
 * Regular users have limited functionality available. They cannot add Product Types but have access to data according to their role in a Product or Product Type
 
 ## Product and Product Type permissions

--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -48,7 +48,7 @@ class UserHasDojoGroupPermission(permissions.BasePermission):
         if request.method == 'GET':
             return user_has_configuration_permission(request.user, 'auth.view_group', 'staff')
         elif request.method == 'POST':
-            return user_has_configuration_permission(request.user, 'auth.create_group', 'staff')
+            return user_has_configuration_permission(request.user, 'auth.add_group', 'staff')
         else:
             return True
 

--- a/dojo/authorization/authorization.py
+++ b/dojo/authorization/authorization.py
@@ -28,9 +28,6 @@ def user_has_permission(user, obj, permission):
     if user.is_superuser:
         return True
 
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return True
-
     if isinstance(obj, Product_Type) or isinstance(obj, Product):
         # Global roles are only relevant for product types, products and their dependent objects
         if user_has_global_permission(user, permission):
@@ -114,9 +111,6 @@ def user_has_global_permission(user, permission):
         return False
 
     if user.is_superuser:
-        return True
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return True
 
     if user.is_staff and permission == Permissions.Product_Type_Add:

--- a/dojo/endpoint/queries.py
+++ b/dojo/endpoint/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Endpoint, Endpoint_Status, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
@@ -20,9 +19,6 @@ def get_authorized_endpoints(permission, queryset=None, user=None):
         endpoints = queryset
 
     if user.is_superuser:
-        return endpoints
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return endpoints
 
     if user_has_global_permission(user, permission):
@@ -71,9 +67,6 @@ def get_authorized_endpoint_status(permission, queryset=None, user=None):
         endpoint_status = queryset
 
     if user.is_superuser:
-        return endpoint_status
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return endpoint_status
 
     if user_has_global_permission(user, permission):

--- a/dojo/engagement/queries.py
+++ b/dojo/engagement/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Engagement, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
@@ -13,9 +12,6 @@ def get_authorized_engagements(permission):
         return Engagement.objects.none()
 
     if user.is_superuser:
-        return Engagement.objects.all()
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Engagement.objects.all()
 
     if user_has_global_permission(user, permission):

--- a/dojo/finding/queries.py
+++ b/dojo/finding/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Finding, Product_Member, Product_Type_Member, Stub_Finding, \
     Product_Group, Product_Type_Group
@@ -20,9 +19,6 @@ def get_authorized_findings(permission, queryset=None, user=None):
         findings = queryset
 
     if user.is_superuser:
-        return findings
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return findings
 
     if user_has_global_permission(user, permission):
@@ -66,9 +62,6 @@ def get_authorized_stub_findings(permission):
         return Stub_Finding.objects.none()
 
     if user.is_superuser:
-        return Stub_Finding.objects.all()
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Stub_Finding.objects.all()
 
     if user_has_global_permission(user, permission):

--- a/dojo/finding_group/queries.py
+++ b/dojo/finding_group/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Finding_Group, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
@@ -20,9 +19,6 @@ def get_authorized_finding_groups(permission, queryset=None, user=None):
         finding_groups = queryset
 
     if user.is_superuser:
-        return finding_groups
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return finding_groups
 
     if user_has_global_permission(user, permission):

--- a/dojo/group/queries.py
+++ b/dojo/group/queries.py
@@ -15,9 +15,6 @@ def get_authorized_groups(permission):
     if user.is_superuser:
         return Dojo_Group.objects.all().order_by('name')
 
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Dojo_Group.objects.all().order_by('name')
-
     roles = get_roles_for_permission(permission)
     authorized_roles = Dojo_Group_Member.objects.filter(group=OuterRef('pk'),
         user=user,
@@ -33,9 +30,6 @@ def get_authorized_group_members(permission):
         return Dojo_Group_Member.objects.none()
 
     if user.is_superuser:
-        return Dojo_Group_Member.objects.all().select_related('role')
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Dojo_Group_Member.objects.all().select_related('role')
 
     groups = get_authorized_groups(permission)

--- a/dojo/group/queries.py
+++ b/dojo/group/queries.py
@@ -1,6 +1,5 @@
 from crum import get_current_user
 from django.db.models import Exists, OuterRef
-from django.conf import settings
 from dojo.models import Dojo_Group, Dojo_Group_Member, Product_Group, Product_Type_Group, Role
 from dojo.authorization.authorization import get_roles_for_permission
 from dojo.authorization.roles_permissions import Permissions

--- a/dojo/jira_link/queries.py
+++ b/dojo/jira_link/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import JIRA_Issue, JIRA_Project, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
@@ -17,9 +16,6 @@ def get_authorized_jira_projects(permission, user=None):
     jira_projects = JIRA_Project.objects.all()
 
     if user.is_superuser:
-        return jira_projects
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return jira_projects
 
     if user_has_global_permission(user, permission):
@@ -89,9 +85,6 @@ def get_authorized_jira_issues(permission):
     jira_issues = JIRA_Issue.objects.all()
 
     if user.is_superuser:
-        return jira_issues
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return jira_issues
 
     if user_has_global_permission(user, permission):

--- a/dojo/management/commands/migrate_staff_users.py
+++ b/dojo/management/commands/migrate_staff_users.py
@@ -1,0 +1,98 @@
+import logging
+import sys
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.contrib.auth.models import Permission
+
+from dojo.models import Dojo_Group, Dojo_Group_Member, Dojo_User, Global_Role, Role
+
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    This management command creates a group for staff users with all configuration
+    permissions staff users had in previous releases and global owner role if
+    AUTHORIZATION_STAFF_OVERRIDE is set to True.
+    """
+    help = 'Usage: manage.py migrate_staff_users'
+
+    def handle(self, *args, **options):
+
+        # If group already exists, then the migration has been running before
+        group_name = 'Staff users'
+        groups = Dojo_Group.objects.filter(name=group_name).count()
+        if groups > 0:
+            sys.exit(f'Group {group_name} already exists, migration aborted')
+
+        # The superuser with the lowest id will be set as the owner of the group
+        users = Dojo_User.objects.filter(is_superuser=True).order_by('id')
+        if len(users) == 0:
+            sys.exit('No superuser found, migration aborted')
+        user = users[0]
+
+        group = Dojo_Group(name=group_name, description='Migrated staff users')
+        group.save()
+
+        owner_role = Role.objects.get(is_owner=True)
+
+        owner = Dojo_Group_Member(
+            user=user,
+            group=group,
+            role=owner_role,
+        )
+        owner.save()
+
+        # All staff users are made to members of the group
+        reader_role = Role.objects.get(name='Reader')
+        staff_users = Dojo_User.objects.filter(is_staff=True)
+        for staff_user in staff_users:
+            if staff_user != owner.user:
+                member = Dojo_Group_Member(
+                    user=staff_user,
+                    group=group,
+                    role=reader_role,
+                )
+                member.save()
+
+        # If AUTHORIZATION_STAFF_OVERRIDE is True, then the group is made a global owner
+        if settings.AUTHORIZATION_STAFF_OVERRIDE:
+            global_role = Global_Role(group=group, role=owner_role)
+            global_role.save()
+
+        permissions_list = Permission.objects.all()
+        permissions = {}
+        for permission in permissions_list:
+            permissions[permission.codename] = permission
+
+        # Set the same configuration permissions, staff users had in previous releases
+        auth_group = group.auth_group
+        if not auth_group:
+            sys.exit('Group has no auth_group, migration aborted')
+
+        auth_group.permissions.add(permissions['view_group'])
+        auth_group.permissions.add(permissions['add_group'])
+        auth_group.permissions.add(permissions['view_development_environment'])
+        auth_group.permissions.add(permissions['add_development_environment'])
+        auth_group.permissions.add(permissions['change_development_environment'])
+        auth_group.permissions.add(permissions['delete_development_environment'])
+        auth_group.permissions.add(permissions['view_finding_template'])
+        auth_group.permissions.add(permissions['add_finding_template'])
+        auth_group.permissions.add(permissions['change_finding_template'])
+        auth_group.permissions.add(permissions['delete_finding_template'])
+        auth_group.permissions.add(permissions['view_engagement_survey'])
+        auth_group.permissions.add(permissions['add_engagement_survey'])
+        auth_group.permissions.add(permissions['change_engagement_survey'])
+        auth_group.permissions.add(permissions['delete_engagement_survey'])
+        auth_group.permissions.add(permissions['view_question'])
+        auth_group.permissions.add(permissions['add_question'])
+        auth_group.permissions.add(permissions['change_question'])
+        auth_group.permissions.add(permissions['delete_question'])
+        auth_group.permissions.add(permissions['view_test_type'])
+        auth_group.permissions.add(permissions['add_test_type'])
+        auth_group.permissions.add(permissions['change_test_type'])
+        auth_group.permissions.add(permissions['delete_test_type'])
+        auth_group.permissions.add(permissions['view_user'])
+
+        logger.info(f'Migrated {len(staff_users)} staff users')

--- a/dojo/management/commands/migrate_staff_users.py
+++ b/dojo/management/commands/migrate_staff_users.py
@@ -94,5 +94,6 @@ class Command(BaseCommand):
         auth_group.permissions.add(permissions['change_test_type'])
         auth_group.permissions.add(permissions['delete_test_type'])
         auth_group.permissions.add(permissions['view_user'])
+        auth_group.permissions.add(permissions['add_product_type'])
 
         logger.info(f'Migrated {len(staff_users)} staff users')

--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Product, Product_Member, Product_Type_Member, App_Analysis, \
     DojoMeta, Product_Group, Product_Type_Group, Languages, Engagement_Presets, \
@@ -20,9 +19,6 @@ def get_authorized_products(permission, user=None):
         return Product.objects.none()
 
     if user.is_superuser:
-        return Product.objects.all().order_by('name')
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product.objects.all().order_by('name')
 
     if user_has_global_permission(user, permission):
@@ -85,9 +81,6 @@ def get_authorized_product_members(permission):
     if user.is_superuser:
         return Product_Member.objects.all().select_related('role')
 
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Product_Member.objects.all().select_related('role')
-
     if user_has_global_permission(user, permission):
         return Product_Member.objects.all().select_related('role')
 
@@ -102,9 +95,6 @@ def get_authorized_product_members_for_user(user, permission):
         return Product_Member.objects.none()
 
     if request_user.is_superuser:
-        return Product_Member.objects.filter(user=user).select_related('role', 'product')
-
-    if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Member.objects.filter(user=user).select_related('role', 'product')
 
     if hasattr(request_user, 'global_role') and request_user.global_role.role is not None and role_has_permission(request_user.global_role.role.id, permission):
@@ -123,9 +113,6 @@ def get_authorized_product_groups(permission):
     if user.is_superuser:
         return Product_Group.objects.all().select_related('role')
 
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Product_Group.objects.all()
-
     products = get_authorized_products(permission)
     return Product_Group.objects.filter(product__in=products).select_related('role')
 
@@ -137,9 +124,6 @@ def get_authorized_app_analysis(permission):
         return App_Analysis.objects.none()
 
     if user.is_superuser:
-        return App_Analysis.objects.all().order_by('name')
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return App_Analysis.objects.all().order_by('name')
 
     if user_has_global_permission(user, permission):
@@ -181,9 +165,6 @@ def get_authorized_dojo_meta(permission):
         return DojoMeta.objects.none()
 
     if user.is_superuser:
-        return DojoMeta.objects.all().order_by('name')
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return DojoMeta.objects.all().order_by('name')
 
     if user_has_global_permission(user, permission):
@@ -278,9 +259,6 @@ def get_authorized_languages(permission):
     if user.is_superuser:
         return Languages.objects.all().order_by('language')
 
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Languages.objects.all().order_by('language')
-
     if user_has_global_permission(user, permission):
         return Languages.objects.all().order_by('language')
 
@@ -322,9 +300,6 @@ def get_authorized_engagement_presets(permission):
     if user.is_superuser:
         return Engagement_Presets.objects.all().order_by('title')
 
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Engagement_Presets.objects.all().order_by('title')
-
     if user_has_global_permission(user, permission):
         return Engagement_Presets.objects.all().order_by('title')
 
@@ -364,9 +339,6 @@ def get_authorized_product_api_scan_configurations(permission):
         return Product_API_Scan_Configuration.objects.none()
 
     if user.is_superuser:
-        return Product_API_Scan_Configuration.objects.all()
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_API_Scan_Configuration.objects.all()
 
     if user_has_global_permission(user, permission):

--- a/dojo/product_type/queries.py
+++ b/dojo/product_type/queries.py
@@ -1,6 +1,5 @@
 from crum import get_current_user
 from django.db.models import Exists, OuterRef, Q
-from django.conf import settings
 from dojo.models import Product_Type, Product_Type_Member, Product_Type_Group
 from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission, user_has_permission, \
     role_has_permission
@@ -15,9 +14,6 @@ def get_authorized_product_types(permission):
         return Product_Type.objects.none()
 
     if user.is_superuser:
-        return Product_Type.objects.all().order_by('name')
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Type.objects.all().order_by('name')
 
     if user_has_global_permission(user, permission):
@@ -67,9 +63,6 @@ def get_authorized_product_type_members(permission):
     if user.is_superuser:
         return Product_Type_Member.objects.all().select_related('role')
 
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Product_Type_Member.objects.all().select_related('role')
-
     if user_has_global_permission(user, permission):
         return Product_Type_Member.objects.all().select_related('role')
 
@@ -86,9 +79,6 @@ def get_authorized_product_type_members_for_user(user, permission):
     if request_user.is_superuser:
         return Product_Type_Member.objects.filter(user=user).select_related('role', 'product_type')
 
-    if request_user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Product_Type_Member.objects.filter(user=user).select_related('role', 'product_type')
-
     if hasattr(request_user, 'global_role') and request_user.global_role.role is not None and role_has_permission(request_user.global_role.role.id, permission):
         return Product_Type_Member.objects.filter(user=user).select_related('role', 'product_type')
 
@@ -103,9 +93,6 @@ def get_authorized_product_type_groups(permission):
         return Product_Type_Group.objects.none()
 
     if user.is_superuser:
-        return Product_Type_Group.objects.all().select_related('role')
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Product_Type_Group.objects.all().select_related('role')
 
     product_types = get_authorized_product_types(permission)

--- a/dojo/test/queries.py
+++ b/dojo/test/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Test, Product_Member, Product_Type_Member, Test_Import, \
     Product_Group, Product_Type_Group
@@ -18,9 +17,6 @@ def get_authorized_tests(permission, product=None):
 
     if user.is_superuser:
         return tests
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
-        return Test.objects.all()
 
     if user_has_global_permission(user, permission):
         return Test.objects.all()
@@ -66,9 +62,6 @@ def get_authorized_test_imports(permission):
         return Test_Import.objects.none()
 
     if user.is_superuser:
-        return Test_Import.objects.all()
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Test_Import.objects.all()
 
     if user_has_global_permission(user, permission):

--- a/dojo/tool_product/queries.py
+++ b/dojo/tool_product/queries.py
@@ -1,5 +1,4 @@
 from crum import get_current_user
-from django.conf import settings
 from django.db.models import Exists, OuterRef, Q
 from dojo.models import Tool_Product_Settings, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group
@@ -13,9 +12,6 @@ def get_authorized_tool_product_settings(permission):
         return Tool_Product_Settings.objects.none()
 
     if user.is_superuser:
-        return Tool_Product_Settings.objects.all()
-
-    if user.is_staff and settings.AUTHORIZATION_STAFF_OVERRIDE:
         return Tool_Product_Settings.objects.all()
 
     if user_has_global_permission(user, permission):

--- a/unittests/authorization/test_authorization.py
+++ b/unittests/authorization/test_authorization.py
@@ -205,16 +205,6 @@ class TestAuthorization(DojoTestCase):
 
         self.user.is_superuser = False
 
-    @override_settings(AUTHORIZATION_STAFF_OVERRIDE=True)
-    def test_user_has_permission_staff_override(self):
-        self.user.is_staff = True
-
-        result = user_has_permission(self.user, self.product_type, Permissions.Product_Type_Delete)
-
-        self.assertTrue(result)
-
-        self.user.is_staff = False
-
     @patch('dojo.models.Product_Type_Member.objects')
     def test_user_has_permission_product_type_success(self, mock_foo):
         mock_foo.select_related.return_value = mock_foo

--- a/unittests/authorization/test_authorization_decorators.py
+++ b/unittests/authorization/test_authorization_decorators.py
@@ -1,7 +1,6 @@
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.test.utils import override_settings
 from ..dojo_test_case import DojoTestCase
 from unittest.mock import patch, Mock
 from dojo.models import Product_Type
@@ -45,17 +44,6 @@ class TestAuthorizationDecorators(DojoTestCase):
         mock_shortcuts_get.return_value = self.product_type
 
         self.user.is_superuser = True
-
-        self.decorated_func(self.request, 1)
-
-        mock_shortcuts_get.assert_called_once()
-
-    @patch('dojo.authorization.authorization_decorators.get_object_or_404')
-    @override_settings(AUTHORIZATION_STAFF_OVERRIDE=True)
-    def test_authorization_staff_override(self, mock_shortcuts_get):
-        mock_shortcuts_get.return_value = self.product_type
-
-        self.user.is_staff = True
 
         self.decorated_func(self.request, 1)
 


### PR DESCRIPTION
The functionality using the flag `AUTHORIZATION_STAFF_OVERRIDE` has been removed. The same result can be achieved with giving the staff users a global Owner role. To make that easier administrators can run a migration script with `./manage.py migrate staff_users`. This script creates a group for all staff users and sets the global Owner role, if `AUTHORIZATION_STAFF_OVERRIDE` is set to True.

The migration script already prepares the configuration permissions for staff users as well.