### PR TITLE
Bugfix SLA days remaining

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2216,7 +2216,7 @@ class Finding(models.Model):
         from dojo.utils import get_system_setting
         sla_age = get_system_setting('sla_' + self.severity.lower())
         if sla_age:
-            sla_calculation = sla_age - self.age
+            sla_calculation = sla_age - self.sla_age
         return sla_calculation
 
     def sla_deadline(self):


### PR DESCRIPTION
The SLA days remaining are currently calculated using the Finding's date, even if the field `sla_start_date` is set. It's curious, because the message that appears when you move the mouse over the SLA number is well calculated using the `sla_start_date`. But the number of the SLA days was being calculated differently. It seems like a bug that would be fixed with this PR.
With this change, the SLA will be calculated using the date from sla_start_date when it's available.