### PR TITLE
Update Jira Integration docs for Jira Server

### DIFF
--- a/docs/content/en/integrations/jira.md
+++ b/docs/content/en/integrations/jira.md
@@ -28,7 +28,8 @@ Enabling the Webhook
 1.  Visit <https://>\<**YOUR JIRA URL**\>/plugins/servlet/webhooks
 2.  Click \'Create a Webhook\'
 3.  For the field labeled \'URL\' enter: <https://>\<**YOUR DOJO
-    DOMAIN**\>/webhook/
+    DOMAIN**\>/jira/webhook/<**YOUR GENERATED WEBHOOK SECRET**>
+    This value can be found under Defect Dojo System settings
 4.  Under \'Comments\' enable \'Created\'. Under Issue enable
     \'Updated\'.
 
@@ -38,6 +39,8 @@ Configurations in Dojo
 1.  Navigate to the System Settings from the menu on the left side
     or by directly visiting \<your url\>/system\_settings.
 2.  Enable \'Enable JIRA integration\' and click submit.
+3.  For the webhook created in Enabling the Webhook, enable
+    \'Enable JIRA web hook\' and click submit.
 
 Adding JIRA to Dojo
 -------------------
@@ -46,7 +49,9 @@ Adding JIRA to Dojo
 2.  Select \'Add Configuration\' from the drop-down.
 3.  If you use Jira Cloud, you will need to generate an [API token
     for Jira](https://id.atlassian.com/manage/api-tokens) to use as
-    the password
+    the password. If you use Jira Server, you will need to provide a
+    username and password for Defect Dojo to authenticate to Jira; a
+    username and Jira Personal Access Token will not necessarily work.
 4.  To obtain the \'open status key\' and \'closed status key\'
     visit <https://>\<**YOUR JIRA
     URL**\>/rest/api/latest/issue/\<**ANY VALID ISSUE


### PR DESCRIPTION
Fixes to documentation snags I ran into while scoping or performing the Jira integration against a Jira Server instance
Done on DD v2.4.1 (in case docs are actually correct in the latest release and I should just upgrade)