### PR TITLE
feat(helm): add ingressClassName value to ingress resource

### DIFF
--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -28,6 +28,11 @@ metadata:
   {{- end }}
 {{- end }}
 spec:
+{{- if semverCompare ">=1.19.0" .Capabilities.KubeVersion.GitVersion }}
+   {{- if .Values.django.ingress.ingressClassName }}
+   ingressClassName: {{ .Values.django.ingress.ingressClassName }}
+   {{- end }}
+{{- end }}
 {{- if .Values.django.ingress.activateTLS }}
   tls:
   - hosts:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -147,6 +147,7 @@ django:
   affinity: {}
   ingress:
     enabled: true
+    ingressClassName: ""
     activateTLS: true
     secretName: defectdojo-tls
     annotations: {}


### PR DESCRIPTION
Hello,

this PR will introduce the ingressClassName to the ingress template.
Docs on this: https://kubernetes.io/docs/concepts/services-networking/ingress/

I added a semverCompare since it is available beginning k8s 1.18 and only on v1 of ingress resource and we also make this check for deciding what apiGroup to use.

if `.Values.django.ingress.ingressClassName` is either non-existent or empty, the key will not appear in ingress resource