### PR TITLE
Bugfix: For Snyk parser, preserve file paths with @ in package name 

### DIFF
--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -87,9 +87,9 @@ class SnykParser(object):
         vulnPath = ''
         for index, item in enumerate(vulnerability['from']):
             if index == 0:
-                vulnPath += item.split("@")[0]
+                vulnPath += "@".join(item.split("@")[0:-1])
             else:
-                vulnPath += " > " + item.split("@")[0]
+                vulnPath += " > " + "@".join(item.split("@")[0:-1])
 
         # create the finding object
         finding = Finding(

--- a/unittests/scans/snyk/single_project_one_vuln_with_ampersands.json
+++ b/unittests/scans/snyk/single_project_one_vuln_with_ampersands.json
@@ -1,0 +1,168 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-07-24T12:05:01.916784Z",
+      "credit": [
+        "reeser"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution in `zipObjectDeep` due to an incomplete fix for [CVE-2020-8203](https://snyk.io/vuln/SNYK-JS-LODASH-567746).\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.20 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4874)\n",
+      "disclosureTime": "2020-07-24T12:00:52Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.17.20"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-LODASH-590103",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "js",
+      "malicious": false,
+      "modificationTime": "2020-08-16T12:11:40.402299Z",
+      "moduleName": "lodash",
+      "packageManager": "npm",
+      "packageName": "lodash",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-08-16T13:09:06Z",
+      "references": [
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/lodash/lodash/issues/4874"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<4.17.20"
+        ]
+      },
+      "severity": "critical",
+      "severityWithCritical": "critical",
+      "socialTrendAlert": false,
+      "title": "Prototype Pollution",
+      "from": [
+        "myproject@0.1.0",
+        "@angular/localize@11.0.4",
+        "@babel/core@7.8.3",
+        "lodash@4.17.13"
+      ],
+      "upgradePath": [
+        false,
+        "@angular/localize@11.0.4",
+        "@babel/core@7.8.3",
+        "lodash@4.17.20"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "lodash",
+      "version": "4.17.13"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 65,
+  "org": "myorg",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.22.1\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "npm",
+  "ignoreSettings": {
+    "adminOnly": true,
+    "reasonRequired": true,
+    "disregardFilesystemIgnores": true
+  },
+  "summary": "1 critical severity vulnerable dependency path",
+  "severityThreshold": "critical",
+  "remediation": {
+    "unresolved": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-07-24T12:05:01.916784Z",
+        "credit": [
+          "reeser"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\nAffected versions of this package are vulnerable to Prototype Pollution in `zipObjectDeep` due to an incomplete fix for [CVE-2020-8203](https://snyk.io/vuln/SNYK-JS-LODASH-567746).\n\n## Details\n\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\n\nThere are two main ways in which the pollution of prototypes occurs:\n\n-   Unsafe `Object` recursive merge\n    \n-   Property definition by path\n    \n\n### Unsafe Object recursive merge\n\nThe logic of a vulnerable recursive merge function follows the following high-level model:\n```\nmerge (target, source)\n\n  foreach property of source\n\n    if property exists and is an object on both the target and the source\n\n      merge(target[property], source[property])\n\n    else\n\n      target[property] = source[property]\n```\n<br>  \n\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\n\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\n\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\n\n### Property definition by path\n\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\n\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\n\n## Types of attacks\n\nThere are a few methods by which Prototype Pollution can be manipulated:\n\n| Type |Origin  |Short description |\n|--|--|--|\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\n\n## Affected environments\n\nThe following environments are susceptible to a Prototype Pollution attack:\n\n-   Application server\n    \n-   Web server\n    \n\n## How to prevent\n\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\n    \n2.  Require schema validation of JSON input.\n    \n3.  Avoid using unsafe recursive merge functions.\n    \n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\n    \n5.  As a best practice use `Map` instead of `Object`.\n\n### For more information on this vulnerability type:\n\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\nUpgrade `lodash` to version 4.17.20 or higher.\n## References\n- [GitHub Issue](https://github.com/lodash/lodash/issues/4874)\n",
+        "disclosureTime": "2020-07-24T12:00:52Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.17.20"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-LODASH-590103",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "malicious": false,
+        "modificationTime": "2020-08-16T12:11:40.402299Z",
+        "moduleName": "lodash",
+        "packageManager": "npm",
+        "packageName": "lodash",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-16T13:09:06Z",
+        "references": [
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/lodash/lodash/issues/4874"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<4.17.20"
+          ]
+        },
+        "severity": "critical",
+        "severityWithCritical": "critical",
+        "socialTrendAlert": false,
+        "title": "Prototype Pollution",
+        "from": [
+          "myproject@0.1.0",
+          "@angular/localize@11.0.4",
+          "@babel/core@7.8.3",
+          "lodash@4.17.13"
+        ],
+        "upgradePath": [
+          false,
+          "@angular/localize@11.0.4",
+          "@babel/core@7.8.3",
+          "lodash@4.17.20"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "isPinnable": false,
+        "isRuntime": false,
+        "name": "lodash",
+        "version": "4.17.13"
+      }
+    ],
+    "upgrade": {},
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 1,
+  "projectName": "myproject",
+  "displayTargetFile": "package-lock.json",
+  "path": "/home/foo/workspace"
+}

--- a/unittests/tools/test_snyk_parser.py
+++ b/unittests/tools/test_snyk_parser.py
@@ -85,6 +85,18 @@ class TestSnykParser(DojoTestCase):
             "com.test:myframework > org.apache.santuario:xmlsec", finding.file_path
         )
 
+    def test_snykParser_file_path_with_ampersand_is_preserved(self):
+        testfile = open("unittests/scans/snyk/single_project_one_vuln_with_ampersands.json")
+        parser = SnykParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(findings))
+        finding = findings[0]
+        self.assertEqual(
+            "myproject > @angular/localize > @babel/core > lodash",
+            finding.file_path
+        )
+
     def test_snykParser_allprojects_issue4277(self):
         """Report to linked to issue 4277"""
         testfile = open("unittests/scans/snyk/all_projects_issue4277.json")


### PR DESCRIPTION
The Snyk parser uses the `file_path` field to show dependency paths. Many package names include ampersands in them, which are not being preserved due to truncation when trimming out version numbers. This PR preserves the packages names in the `file_path` field.

### Before
![snyk-parser-before](https://user-images.githubusercontent.com/10931391/150248710-0f9ec821-616e-41e6-bd82-fc5a49199a88.png)

### After
![snyk-parser-after](https://user-images.githubusercontent.com/10931391/150248720-06ab6419-7a5b-4e75-bfc9-e5c55ec546d8.png)

