### PR TITLE
Paginated Product list in Product Type details

### DIFF
--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -100,6 +100,7 @@ def view_product_type(request, ptid):
     members = get_authorized_members_for_product_type(pt, Permissions.Product_Type_View)
     groups = get_authorized_groups_for_product_type(pt, Permissions.Product_Type_View)
     products = get_authorized_products(Permissions.Product_View).filter(prod_type=pt)
+    products = get_page_items(request, products, 25)
     add_breadcrumb(title="View Product Type", top_level=False, request=request)
     return render(request, 'dojo/view_product_type.html', {
         'name': 'View Product Type',

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -72,6 +72,9 @@
                     </div>
                 </div>
                 {% if products %}
+                    <div class="clearfix" style="margin-left: 10px; margin-right: 10px;">
+                        {% include "dojo/paging_snippet.html" with page=products page_size=True %}
+                    </div>
                     <div class="table-responsive">
                         <table class="tablesorter-bootstrap table table-condensed table-striped">
                             <thead>
@@ -112,6 +115,9 @@
                             {% endfor %}
                             </tbody>
                         </table>
+                    </div>
+                    <div class="clearfix" style="margin-left: 10px; margin-right: 10px;">
+                        {% include "dojo/paging_snippet.html" with page=products page_size=True %}
                     </div>
                 {% else %}
                     <div class="panel-body">


### PR DESCRIPTION
fixes #5778

When a Product Type has many Products, it can lead to long loading times in the details view, because the list of products wasn't paginated. This gets fixed with this PR.