### PR TITLE
Add support for including multiple setting files via extra_settings

### DIFF
--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -11,32 +11,6 @@ do
 done
 echo
 
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.dist.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.dist.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.dist.py
-fi
-
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.py
-fi
-
-FILE=/app/docker/extra_settings/local_settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's local_settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/local_settings.py
-fi
-
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls -I README.md /app/docker/extra_settings)
 NUM_FILES=$(echo "$FILES" | wc -l)

--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -37,6 +37,18 @@ if test -f "$FILE"; then
     cp "$FILE" /app/dojo/settings/local_settings.py
 fi
 
+# Allow for bind-mount multiple settings.py overrides
+FILES=$(ls -I README.md /app/docker/extra_settings)
+NUM_FILES=$(echo "$FILES" | wc -l)
+if [ "$NUM_FILES" -gt "1" ]; then
+    COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
+    echo "============================================================"
+    echo "     Overriding DefectDojo's local_settings.py with multiple"
+    echo "     Files: $COMMA_LIST"
+    echo "============================================================"
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+fi
+
 # do the check with Django stack
 python3 manage.py check
 

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -37,6 +37,18 @@ if test -f "$FILE"; then
     cp "$FILE" /app/dojo/settings/local_settings.py
 fi
 
+# Allow for bind-mount multiple settings.py overrides
+FILES=$(ls -I README.md /app/docker/extra_settings)
+NUM_FILES=$(echo "$FILES" | wc -l)
+if [ "$NUM_FILES" -gt "1" ]; then
+    COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
+    echo "============================================================"
+    echo "     Overriding DefectDojo's local_settings.py with multiple"
+    echo "     Files: $COMMA_LIST"
+    echo "============================================================"
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+fi
+
 if [ "${DD_CELERY_WORKER_POOL_TYPE}" = "prefork" ]; then
   EXTRA_PARAMS="--autoscale=${DD_CELERY_WORKER_AUTOSCALE_MAX},${DD_CELERY_WORKER_AUTOSCALE_MIN}
     --prefetch-multiplier=${DD_CELERY_WORKER_PREFETCH_MULTIPLIER}"

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -11,32 +11,6 @@ do
 done
 echo
 
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.dist.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.dist.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.dist.py
-fi
-
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.py
-fi
-
-FILE=/app/docker/extra_settings/local_settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's local_settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/local_settings.py
-fi
-
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls -I README.md /app/docker/extra_settings)
 NUM_FILES=$(echo "$FILES" | wc -l)

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -13,33 +13,6 @@ initialize_data()
     python3 manage.py initialize_permissions
 }
 
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.dist.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.dist.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.dist.py
-fi
-
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.py
-fi
-
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/local_settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's local_settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/local_settings.py
-fi
-
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls -I README.md /app/docker/extra_settings)
 NUM_FILES=$(echo "$FILES" | wc -l)

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -40,6 +40,18 @@ if test -f "$FILE"; then
     cp "$FILE" /app/dojo/settings/local_settings.py
 fi
 
+# Allow for bind-mount multiple settings.py overrides
+FILES=$(ls -I README.md /app/docker/extra_settings)
+NUM_FILES=$(echo "$FILES" | wc -l)
+if [ "$NUM_FILES" -gt "1" ]; then
+    COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
+    echo "============================================================"
+    echo "     Overriding DefectDojo's local_settings.py with multiple"
+    echo "     Files: $COMMA_LIST"
+    echo "============================================================"
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+fi
+
 umask 0002
 
 if [ "${DD_INITIALIZE}" = false ]

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -27,6 +27,18 @@ if test -f "$FILE"; then
     cp "$FILE" /app/dojo/settings/local_settings.py
 fi
 
+# Allow for bind-mount multiple settings.py overrides
+FILES=$(ls -I README.md /app/docker/extra_settings)
+NUM_FILES=$(echo "$FILES" | wc -l)
+if [ "$NUM_FILES" -gt "1" ]; then
+    COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
+    echo "============================================================"
+    echo "     Overriding DefectDojo's local_settings.py with multiple"
+    echo "     Files: $COMMA_LIST"
+    echo "============================================================"
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+fi
+
 umask 0002
 
 # do the check with Django stack

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,32 +1,5 @@
 #!/bin/sh
 
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.dist.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.dist.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.dist.py
-fi
-
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/settings.py
-fi
-
-# Allow for bind-mount setting.py overrides
-FILE=/app/docker/extra_settings/local_settings.py
-if test -f "$FILE"; then
-    echo "============================================================"
-    echo "     Overriding DefectDojo's local_settings.py with $FILE."
-    echo "============================================================"
-    cp "$FILE" /app/dojo/settings/local_settings.py
-fi
-
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls -I README.md /app/docker/extra_settings)
 NUM_FILES=$(echo "$FILES" | wc -l)


### PR DESCRIPTION
I have found that only a single settings file is acceptable for copying a settings file from the host machine in `docker/extra_settings` to the container.

This PR allows for multiple files to be copied over at once via bound mounts