### PR TITLE
Facelift: borders for panels with lists

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -593,6 +593,11 @@ form ul#id_accepted_findings input {
   border-color: #546474;
 }
 
+.pagination-in-panel {
+    margin-left: 10px!important;
+    margin-right: 10px!important;
+}
+
 #risk_acceptance table form {
     margin: 0;
 }

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -29,9 +29,8 @@
         <div id="the-filters-{{status}}" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
             {% include "dojo/filter_snippet.html" with form=filter.form %}
         </div>
-    </div>
 
-    <div class="clearfix">
+        <div class="clearfix pagination-in-panel">
             {% include "dojo/paging_snippet.html" with page=engs prefix=prefix page_size=True %}
         </div>
         {% if engs %}
@@ -266,8 +265,9 @@
             </div>
         {% endif %}
 
-    <div class="clearfix">
-        {% include "dojo/paging_snippet.html" with page=engs prefix=prefix page_size=True %}
+        <div class="clearfix pagination-in-panel">
+            {% include "dojo/paging_snippet.html" with page=engs prefix=prefix page_size=True %}
+        </div>
     </div>
 </div>
 {% block postscript %}

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -249,9 +249,8 @@
         <div class="panel-heading">
             <h4>Active Verified Findings</h4>
         </div>
-    </div>
     {% if findings %}
-    <div class="clearfix">
+    <div class="clearfix pagination-in-panel">
         {% include "dojo/paging_snippet.html" with page=findings page_size=True %}
     </div>
     <div class="table-responsive panel panel-default">
@@ -293,12 +292,13 @@
                 </tbody>
             </table>
         </div>
-    <div class="clearfix">
+    <div class="clearfix pagination-in-panel">
         {% include "dojo/paging_snippet.html" with page=findings page_size=True %}
     </div>
     {% else %}
         <p class="text-center">No findings found.</p>
     {% endif %}
+    </div>
 {% endblock %}
 {% block postscript %}
     {{ block.super }}

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -229,9 +229,8 @@
                         <div id="the-filters" class="is-filters panel-body collapse {% if filter.form.has_changed %}in{% endif %}">
                             {% include "dojo/filter_snippet.html" with form=filter.form %}
                         </div>
-                    </div>
                     {% if tests %}
-                        <div class="clearfix">
+                        <div class="clearfix pagination-in-panel">
                             {% include "dojo/paging_snippet.html" with page=tests page_size=True %}
                         </div>
                         <div class="table-responsive">
@@ -343,14 +342,15 @@
                                 </tbody>
                             </table>
                         </div>
-                        <div class="clearfix">
+                        <div class="clearfix pagination-in-panel">
                             {% include "dojo/paging_snippet.html" with page=tests page_size=True %}
                         </div>
                     {% else %}
                         <div class="panel-body">
-                            <small class="text-muted"><em>No tests found.</em></small>
+                            <small class="text-muted"><em>No Tests found.</em></small>
                         </div>
                     {% endif %}
+                    </div>
                 </div>
             </div>
             <div class="row">

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -72,7 +72,7 @@
                     </div>
                 </div>
                 {% if products %}
-                    <div class="clearfix" style="margin-left: 10px; margin-right: 10px;">
+                    <div class="clearfix pagination-in-panel">
                         {% include "dojo/paging_snippet.html" with page=products page_size=True %}
                     </div>
                     <div class="table-responsive">
@@ -116,7 +116,7 @@
                             </tbody>
                         </table>
                     </div>
-                    <div class="clearfix" style="margin-left: 10px; margin-right: 10px;">
+                    <div class="clearfix pagination-in-panel">
                         {% include "dojo/paging_snippet.html" with page=products page_size=True %}
                     </div>
                 {% else %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -496,16 +496,14 @@
         <div id="the-filters" class="is-filters panel-body collapse">
             {% include "dojo/filter_snippet.html" with form=filtered.form %}
         </div>
-    </div>
-    {% if findings %}
-        <div class="clearfix">
+        {% if findings %}
+        <div class="clearfix pagination-in-panel">
             {% include "dojo/paging_snippet.html" with page=findings prefix='findings' page_size=True %}
         </div>
-
         {% if test|has_object_permission:"Finding_Edit" or test|has_object_permission:"Finding_Delete" %}
         <div class="dropdown hidden" style="padding-bottom: 5px;" id="bulk_edit_menu">
             {% if test|has_object_permission:"Finding_Edit" %}
-                <button class="btn btn-info btn-sm btn-primary dropdown-toggle" type="button" id="dropdownMenu2"
+                <button class="btn btn-info btn-sm btn-secondary dropdown-toggle" type="button" id="dropdownMenu2"
                         data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                     Bulk Edit
                     <span class="caret"></span>
@@ -513,14 +511,14 @@
             {% endif %}
             <div class="btn-group mr-2" role="group" aria-label="Bulk Actions">
                 {% if product_tab and not 'DISABLE_FINDING_MERGE'|setting_enabled %}
-                    <button type="button" id="merge_findings" class="btn btn-info btn-sm btn-primary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
+                    <button type="button" id="merge_findings" class="btn btn-info btn-sm btn-secondary" data-toggle="tooltip" data-placement="bottom" title="Merge Findings">
                         <a class="white-color merge" href="#" alt="Merge Findings">
                             <i class="fa fa-compress"></i>
                         </a>
                     </button>
                 {% endif %}
                 {% if test|has_object_permission:"Finding_Delete" %}
-                    <button type="button" class="btn btn-info btn-sm btn-primary" data-toggle="tooltip" data-placement="bottom" title="Delete Findings">
+                    <button type="button" class="btn btn-info btn-sm btn-secondary" data-toggle="tooltip" data-placement="bottom" title="Delete Findings">
                         <a class="white-color delete-bulk" href="#" alt="Delete Findings">
                             <i class="fa fa-trash"></i>
                         </a>
@@ -619,9 +617,7 @@
             </ul>
         </div>
         {% endif %}
-    {% endif %}
-    <div class="panel panel-default table-responsive">
-        {% if findings %}
+        <div class="table-responsive">
             <table id="test_findings" class="table-striped tablesorter-bootstrap table table-condensed table-hover">
                 <thead>
                         <tr>
@@ -907,16 +903,16 @@
                 {% endfor %}
                 </tbody>
             </table>
+            <div class="clearfix pagination-in-panel">
+                {% include "dojo/paging_snippet.html" with page=findings prefix='findings' page_size=True %}
+            </div>
+        </div>
         {% else %}
             <div class="panel-body">
                 <p class="text-center">No findings found.</p>
             </div>
         {% endif %}
-        <div class="clearfix">
-            {% include "dojo/paging_snippet.html" with page=findings prefix='findings' page_size=True %}
-        </div>
-
-     </div>
+    </div>
 
      <div class="panel panel-default table-responsive potential-finding">
             <div class="panel-heading">


### PR DESCRIPTION
In some views there are separate panels, where some of them have borders and others, with lists and paginations, don't have borders or partially have borders. One example is the list of Findings in the Test views:

![2022-01-21 17_22_24-Test _ DefectDojo](https://user-images.githubusercontent.com/2698502/150563504-125c571c-b547-4298-91c2-3285894ea514.png)

With this PR the user interface looks more consistent, having borders around every block, when there are multiple blocks on one page. This is the list of Findings in a Test with the PR:

![2022-01-21 17_20_01-Test _ DefectDojo](https://user-images.githubusercontent.com/2698502/150563803-4a6cc72d-2e2d-46eb-bd85-578f567fe016.png)

These dialogues have been touched (all in the Product view):
- Engagement list (lists of active / paused / closed Engagements)
- Engagement details (list of Tests)
- Test details (list of Findings)
- Endpoint / Host details (list of Findings)