### PR TITLE
Rendering of references is corrupted when the same URL occurs more than one time

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2523,10 +2523,15 @@ class Finding(models.Model):
         if self.references is None:
             return None
         matches = re.findall(r'([\(|\[]?(https?):((//)|(\\\\))+([\w\d:#@%/;$~_?\+-=\\\.&](#!)?)*[\)|\]]?)', self.references)
+
+        processed_matches = []
         for match in matches:
             # Check if match isn't already a markdown link
-            if not (match[0].startswith('[') or match[0].startswith('(')):
+            # Only replace the same matches one time, otherwise the links will be corrupted
+            if not (match[0].startswith('[') or match[0].startswith('(')) and not match[0] in processed_matches:
                 self.references = self.references.replace(match[0], create_bleached_link(match[0], match[0]), 1)
+                processed_matches.append(match[0])
+
         return self.references
 
 


### PR DESCRIPTION
When there is the same URL more than one time in the references of a finding, the rendering of the references produced weird results. That's becauce the first URL in the references got replaced multiple times. With this PR only one occurrence of a URL gets rendered with a proper HTML link, all others stay untouched.

Someone could imagine a more sophisticated solution, but it's a rare case and there is at least one link for each URL to click on.