### PR TITLE
Async Import: Fix group_by flag

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -22,7 +22,7 @@ def we_want_async(*args, func=None, **kwargs):
         logger.debug('dojo_async_task %s: running task in the foreground as sync=True has been found as kwarg', func)
         return False
 
-    user = get_current_user()
+    user = kwargs.get('async_user', get_current_user())
     logger.debug('user: %s', user)
 
     if Dojo_User.wants_block_execution(user):
@@ -38,6 +38,9 @@ def we_want_async(*args, func=None, **kwargs):
 def dojo_async_task(func):
     @wraps(func)
     def __wrapper__(*args, **kwargs):
+        from dojo.utils import get_current_user
+        user = get_current_user()
+        kwargs['async_user'] = user
         if we_want_async(*args, func=func, **kwargs):
             return func.delay(*args, **kwargs)
         else:

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -245,10 +245,12 @@ def group_findings_by(finds, finding_group_by_option):
     return affected_groups, grouped, skipped, groups_created
 
 
-def add_finding_to_auto_group(finding, group_by, user=None):
+def add_finding_to_auto_group(finding, group_by, **kwargs):
     test = finding.test
     name = get_group_by_group_name(finding, group_by)
-    creator = user if user else get_current_user()
+    creator = get_current_user()
+    if not creator:
+        creator = kwargs.get('async_user', None)
     finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name)
     if created:
         logger.debug('Created Finding Group %d:%s for test %d:%s', finding_group.id, finding_group, test.id, test)

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -245,10 +245,11 @@ def group_findings_by(finds, finding_group_by_option):
     return affected_groups, grouped, skipped, groups_created
 
 
-def add_finding_to_auto_group(finding, group_by):
+def add_finding_to_auto_group(finding, group_by, user=None):
     test = finding.test
     name = get_group_by_group_name(finding, group_by)
-    finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=get_current_user(), name=name)
+    creator = user if user else get_current_user()
+    finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name)
     if created:
         logger.debug('Created Finding Group %d:%s for test %d:%s', finding_group.id, finding_group, test.id, test)
     finding_group.findings.add(finding)

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -108,7 +108,7 @@ class DojoDefaultImporter(object):
             item.save(dedupe_option=False)
 
             if settings.FEATURE_FINDING_GROUPS and group_by:
-                finding_helper.add_finding_to_auto_group(item, group_by, user=user)
+                finding_helper.add_finding_to_auto_group(item, group_by, **kwargs)
 
             if (hasattr(item, 'unsaved_req_resp') and
                     len(item.unsaved_req_resp) > 0):
@@ -317,7 +317,6 @@ class DojoDefaultImporter(object):
             # Indicate that the test is not complete yet as endpoints will still be rolling in.
             test.percent_complete = 50
             test.save()
-            importer_utils.update_test_progress(test)
         else:
             new_findings = self.process_parsed_findings(test, parsed_findings, scan_type, user, active,
                                                             verified, minimum_severity=minimum_severity,
@@ -344,6 +343,9 @@ class DojoDefaultImporter(object):
         updated_count = len(new_findings) + len(closed_findings)
         if updated_count > 0:
             notifications_helper.notify_scan_added(test, updated_count, new_findings=new_findings, findings_mitigated=closed_findings)
+
+        logger.debug('IMPORT_SCAN: Updating Test progress')
+        importer_utils.update_test_progress(test)
 
         logger.debug('IMPORT_SCAN: Done')
 

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -108,7 +108,7 @@ class DojoDefaultImporter(object):
             item.save(dedupe_option=False)
 
             if settings.FEATURE_FINDING_GROUPS and group_by:
-                finding_helper.add_finding_to_auto_group(item, group_by)
+                finding_helper.add_finding_to_auto_group(item, group_by, user=user)
 
             if (hasattr(item, 'unsaved_req_resp') and
                     len(item.unsaved_req_resp) > 0):

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -150,7 +150,7 @@ class DojoDefaultReImporter(object):
 
                 # only new items get auto grouped to avoid confusion around already existing items that are already grouped
                 if settings.FEATURE_FINDING_GROUPS and group_by:
-                    finding_helper.add_finding_to_auto_group(item, group_by, user=user)
+                    finding_helper.add_finding_to_auto_group(item, group_by, **kwargs)
 
                 finding_added_count += 1
                 new_items.append(item)

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -150,7 +150,7 @@ class DojoDefaultReImporter(object):
 
                 # only new items get auto grouped to avoid confusion around already existing items that are already grouped
                 if settings.FEATURE_FINDING_GROUPS and group_by:
-                    finding_helper.add_finding_to_auto_group(item, group_by)
+                    finding_helper.add_finding_to_auto_group(item, group_by, user=user)
 
                 finding_added_count += 1
                 new_items.append(item)

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -166,6 +166,6 @@ def add_endpoints_to_unsaved_finding(finding, test, endpoints, **kwargs):
 # and after endpoint task, so this should only run after all the other ones are done
 @dojo_async_task
 @app.task()
-def update_test_progress(test):
+def update_test_progress(test, **kwargs):
     test.percent_complete = 100
     test.save()

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1028,7 +1028,7 @@ def jira_check_attachment(issue, source_file_name):
 @dojo_async_task
 @app.task
 @dojo_model_from_id(model=Engagement)
-def close_epic(eng, push_to_jira):
+def close_epic(eng, push_to_jira, **kwargs):
     engagement = eng
     if not is_jira_enabled():
         return False
@@ -1070,7 +1070,7 @@ def close_epic(eng, push_to_jira):
 @dojo_async_task
 @app.task
 @dojo_model_from_id(model=Engagement)
-def update_epic(engagement):
+def update_epic(engagement, **kwargs):
     logger.debug('trying to update jira EPIC for %d:%s', engagement.id, engagement.name)
 
     if not is_jira_configured_and_enabled(engagement):
@@ -1101,7 +1101,7 @@ def update_epic(engagement):
 @dojo_async_task
 @app.task
 @dojo_model_from_id(model=Engagement)
-def add_epic(engagement):
+def add_epic(engagement, **kwargs):
     logger.debug('trying to create a new jira EPIC for %d:%s', engagement.id, engagement.name)
 
     if not is_jira_configured_and_enabled(engagement):
@@ -1175,7 +1175,7 @@ def jira_get_issue(jira_project, issue_key):
 @app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
-def add_comment(obj, note, force_push=False):
+def add_comment(obj, note, force_push=False, **kwargs):
     if not is_jira_configured_and_enabled(obj):
         return False
 

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -86,7 +86,7 @@ def my_test_task(new_finding, *args, **kwargs):
 @app.task
 @dojo_model_from_id(model=Notes, parameter=1)
 @dojo_model_from_id
-def test_valentijn_task(new_finding, note):
+def test_valentijn_task(new_finding, note, **kwargs):
     logger.debug('test_valentijn:')
     logger.debug(new_finding)
     logger.debug(note)

--- a/dojo/tools/tool_issue_updater.py
+++ b/dojo/tools/tool_issue_updater.py
@@ -30,7 +30,7 @@ def tool_issue_updater(finding, *args, **kwargs):
 
 @dojo_async_task
 @app.task
-def update_findings_from_source_issues():
+def update_findings_from_source_issues(**kwargs):
     from dojo.tools.sonarqube_api.updater_from_source import \
         SonarQubeApiUpdaterFromSource
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1244,7 +1244,7 @@ def handle_uploaded_selenium(f, cred):
 @dojo_async_task
 @app.task
 @dojo_model_from_id
-def add_external_issue(find, external_issue_provider):
+def add_external_issue(find, external_issue_provider, **kwargs):
     eng = Engagement.objects.get(test=find.test)
     prod = Product.objects.get(engagement=eng)
     logger.debug('adding external issue with provider: ' + external_issue_provider)
@@ -1257,7 +1257,7 @@ def add_external_issue(find, external_issue_provider):
 @dojo_async_task
 @app.task
 @dojo_model_from_id
-def update_external_issue(find, old_status, external_issue_provider):
+def update_external_issue(find, old_status, external_issue_provider, **kwargs):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
     eng = Engagement.objects.get(test=find.test)
 
@@ -1269,7 +1269,7 @@ def update_external_issue(find, old_status, external_issue_provider):
 @dojo_async_task
 @app.task
 @dojo_model_from_id
-def close_external_issue(find, note, external_issue_provider):
+def close_external_issue(find, note, external_issue_provider, **kwargs):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
     eng = Engagement.objects.get(test=find.test)
 
@@ -1281,7 +1281,7 @@ def close_external_issue(find, note, external_issue_provider):
 @dojo_async_task
 @app.task
 @dojo_model_from_id
-def reopen_external_issue(find, note, external_issue_provider):
+def reopen_external_issue(find, note, external_issue_provider, **kwargs):
     prod = Product.objects.get(engagement=Engagement.objects.get(test=find.test))
     eng = Engagement.objects.get(test=find.test)
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -92,6 +92,9 @@ def do_false_positive_history(new_finding, *args, **kwargs):
         new_finding.false_p = True
         new_finding.active = False
         new_finding.verified = True
+        # Remove the async user kwarg because save() really does not like it
+        # Would rather not add anything to Finding.save()
+        kwargs.pop('async_user')
         super(Finding, new_finding).save(*args, **kwargs)
 
 


### PR DESCRIPTION
Add `user` kwarg to finding group assignment helper method to all for the `group_by` flag to work during async imports. The requirement for a kwarg is because the `get_current_user()` crum function does not return anything when the context is async 