### PR TITLE
Wrong var in include_executive_summary block for product_type

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -2306,7 +2306,7 @@ def report_generate(request, obj, options):
                         if eng.test_set.all():
                             for t in eng.test_set.all():
                                 test_type_name = t.test_type.name
-                                if test.environment:
+                                if t.environment:
                                     test_environment_name = t.environment.name
                                 test_target_start = t.target_start
                                 if t.target_end:


### PR DESCRIPTION
After enabling `"include_executive_summary": true` in Api_V2 (`product_types` -> `/product_types/{id}/generate_report/`) we started getting 500 errors by api requests. 
In logs:
```
uwsgi_1 | File "./dojo/api_v2/views.py", line 1618, in report_generate
uwsgi_1 | if test.environment:
uwsgi_1 | AttributeError: 'NoneType' object has no attribute 'environment'
```
Rename test var to t solved the problem.