### PR TITLE
Oauth: enable keycloak to use auto redirect

### DIFF
--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -82,6 +82,7 @@ def login_view(request):
         settings.AZUREAD_TENANT_OAUTH2_ENABLED,
         settings.GITLAB_OAUTH2_ENABLED,
         settings.AUTH0_OAUTH2_ENABLED,
+        settings.KEYCLOAK_OAUTH2_ENABLED,
         settings.SAML2_ENABLED
     ]) == 1 and not ('force_login_form' in request.GET):
         if settings.GOOGLE_OAUTH_ENABLED:
@@ -92,6 +93,8 @@ def login_view(request):
             social_auth = 'azuread-tenant-oauth2'
         elif settings.GITLAB_OAUTH2_ENABLED:
             social_auth = 'gitlab'
+        elif settings.KEYCLOAK_OAUTH2_ENABLED:
+            social_auth = 'keycloak'
         elif settings.AUTH0_OAUTH2_ENABLED:
             social_auth = 'auth0'
         else:


### PR DESCRIPTION
Actual keycloak implementation in DD doesn't support ["Login speed-up"](https://defectdojo.github.io/django-DefectDojo/integrations/social-authentication/#login-speed-up). So even if the admin of DD set  `SOCIAL_LOGIN_AUTO_REDIRECT: True` and `SHOW_LOGIN_FORM: False`, the user of DD will not be redirected automatically to IDP.

This PR solve this issue.

Note: Implementation of https://github.com/DefectDojo/django-DefectDojo/pull/5726#issuecomment-1023323371