### PR TITLE
copy python files from extra_settings

### DIFF
--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -12,9 +12,9 @@ done
 echo
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls -I README.md /app/docker/extra_settings)
+FILES=$(ls /app/docker/extra_settings/*.py)
 NUM_FILES=$(echo "$FILES" | wc -l)
-if [ "$NUM_FILES" -gt "1" ]; then
+if [ "$NUM_FILES" -gt "0" ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
     echo "============================================================"
     echo "     Overriding DefectDojo's local_settings.py with multiple"

--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -3,14 +3,6 @@ umask 0002
 
 id
 
-echo -n "Waiting for database to be reachable "
-until echo "select 1;" | python3 manage.py dbshell > /dev/null
-do
-  echo -n "."
-  sleep 1
-done
-echo
-
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls /app/docker/extra_settings/*.py)
 NUM_FILES=$(echo "$FILES" | wc -l)
@@ -22,6 +14,14 @@ if [ "$NUM_FILES" -gt "0" ]; then
     echo "============================================================"
     cp /app/docker/extra_settings/* /app/dojo/settings/
 fi
+
+echo -n "Waiting for database to be reachable "
+until echo "select 1;" | python3 manage.py dbshell > /dev/null
+do
+  echo -n "."
+  sleep 1
+done
+echo
 
 # do the check with Django stack
 python3 manage.py check

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -12,9 +12,9 @@ done
 echo
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls -I README.md /app/docker/extra_settings)
+FILES=$(ls /app/docker/extra_settings/*.py)
 NUM_FILES=$(echo "$FILES" | wc -l)
-if [ "$NUM_FILES" -gt "1" ]; then
+if [ "$NUM_FILES" -gt "0" ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
     echo "============================================================"
     echo "     Overriding DefectDojo's local_settings.py with multiple"
@@ -37,4 +37,3 @@ exec celery --app=dojo \
   --pool="${DD_CELERY_WORKER_POOL_TYPE}" \
   --concurrency=${DD_CELERY_WORKER_CONCURRENCY:-1} \
   ${EXTRA_PARAMS}
-

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -3,14 +3,6 @@ umask 0002
 
 id
 
-echo -n "Waiting for database to be reachable "
-until echo "select 1;" | python3 manage.py dbshell > /dev/null
-do
-  echo -n "."
-  sleep 1
-done
-echo
-
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls /app/docker/extra_settings/*.py)
 NUM_FILES=$(echo "$FILES" | wc -l)
@@ -22,6 +14,14 @@ if [ "$NUM_FILES" -gt "0" ]; then
     echo "============================================================"
     cp /app/docker/extra_settings/* /app/dojo/settings/
 fi
+
+echo -n "Waiting for database to be reachable "
+until echo "select 1;" | python3 manage.py dbshell > /dev/null
+do
+  echo -n "."
+  sleep 1
+done
+echo
 
 if [ "${DD_CELERY_WORKER_POOL_TYPE}" = "prefork" ]; then
   EXTRA_PARAMS="--autoscale=${DD_CELERY_WORKER_AUTOSCALE_MAX},${DD_CELERY_WORKER_AUTOSCALE_MIN}

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -14,9 +14,9 @@ initialize_data()
 }
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls -I README.md /app/docker/extra_settings)
+FILES=$(ls /app/docker/extra_settings/*.py)
 NUM_FILES=$(echo "$FILES" | wc -l)
-if [ "$NUM_FILES" -gt "1" ]; then
+if [ "$NUM_FILES" -gt "0" ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
     echo "============================================================"
     echo "     Overriding DefectDojo's local_settings.py with multiple"

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls -I README.md /app/docker/extra_settings)
+FILES=$(ls /app/docker/extra_settings/*.py)
 NUM_FILES=$(echo "$FILES" | wc -l)
-if [ "$NUM_FILES" -gt "1" ]; then
+if [ "$NUM_FILES" -gt "0" ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
     echo "============================================================"
     echo "     Overriding DefectDojo's local_settings.py with multiple"
@@ -27,4 +27,3 @@ exec uwsgi \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
   --http 0.0.0.0:8081 --http-to ${DD_UWSGI_ENDPOINT}
   # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a serivce.
-


### PR DESCRIPTION
The new approach to copy files from `/app/docker/extra_settings` will fail in **kubernetes** when overwriting the folder through a volume mount. README.md will no longer be there and as such the number of files will be 1, instead of 2 as expected by the if conditions. I propose this be moved to enumerate and copy all *.py files found in the folder.

Additionally, this PR also deals with celery beat and worker, for which the local_settings.py file is being copied only after executing `python3 manage.py dbshell`, causing late-defined variables to not be counted on. In my use case this causes the DB password to not be passed