### PR TITLE
Option not to create user automatically using SOCIAL_AUTH

### DIFF
--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -1,6 +1,7 @@
 import gitlab
 import re
 
+import social_core.pipeline.user
 from django.conf import settings
 from dojo.models import Product, Product_Member, Product_Type, System_Settings, Role
 from social_core.backends.azuread_tenant import AzureADTenantOAuth2
@@ -8,7 +9,7 @@ from social_core.backends.google import GoogleOAuth2
 from dojo.authorization.roles_permissions import Permissions, Roles
 from dojo.product.queries import get_authorized_products
 
-USER_FIELDS = ['username', 'email']
+
 
 
 def social_uid(backend, details, response, *args, **kwargs):
@@ -118,15 +119,5 @@ def update_product_access(backend, uid, user=None, social=None, *args, **kwargs)
 def create_user(strategy, details, backend, user=None, *args, **kwargs):
     if not settings.SOCIAL_AUTH_CREATE_USER:
         return
-    if user:
-        return {'is_new': False}
-
-    fields = {name: kwargs.get(name, details.get(name))
-        for name in backend.setting('USER_FIELDS', USER_FIELDS)}
-    if not fields:
-        return
-
-    return {
-        'is_new': True,
-        'user': strategy.create_user(**fields)
-    }
+    else:
+        return social_core.pipeline.user.create_user(strategy, details, backend, user, args, kwargs)

--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -10,8 +10,6 @@ from dojo.authorization.roles_permissions import Permissions, Roles
 from dojo.product.queries import get_authorized_products
 
 
-
-
 def social_uid(backend, details, response, *args, **kwargs):
     if settings.AZUREAD_TENANT_OAUTH2_ENABLED and isinstance(backend, AzureADTenantOAuth2):
         """Return user details from Azure AD account"""

--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -10,6 +10,7 @@ from dojo.product.queries import get_authorized_products
 
 USER_FIELDS = ['username', 'email']
 
+
 def social_uid(backend, details, response, *args, **kwargs):
     if settings.AZUREAD_TENANT_OAUTH2_ENABLED and isinstance(backend, AzureADTenantOAuth2):
         """Return user details from Azure AD account"""

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -81,6 +81,7 @@ env = environ.Env(
     DD_DATA_UPLOAD_MAX_MEMORY_SIZE=(int, 8388608),  # Max post size set to 8mb
     DD_FORGOT_PASSWORD=(bool, True),  # do we show link "I forgot my password" on login screen
     DD_SOCIAL_AUTH_SHOW_LOGIN_FORM=(bool, True),  # do we show user/pass input
+    DD_SOCIAL_AUTH_CREATE_USER=(bool, True),  # if True creates user at first login
     DD_SOCIAL_LOGIN_AUTO_REDIRECT=(bool, False),  # auto-redirect if there is only one social login method
     DD_SOCIAL_AUTH_TRAILING_SLASH=(bool, True),
     DD_SOCIAL_AUTH_AUTH0_OAUTH2_ENABLED=(bool, False),
@@ -426,7 +427,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_user',
     'social_core.pipeline.user.get_username',
     'social_core.pipeline.social_auth.associate_by_email',
-    'social_core.pipeline.user.create_user',
+    'dojo.pipeline.create_user',
     'dojo.pipeline.modify_permissions',
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.social_auth.load_extra_data',
@@ -439,6 +440,7 @@ FORGOT_PASSWORD = env('DD_FORGOT_PASSWORD')
 # Showing login form (form is not needed for external auth: OKTA, Google Auth, etc.)
 SHOW_LOGIN_FORM = env('DD_SOCIAL_AUTH_SHOW_LOGIN_FORM')
 SOCIAL_LOGIN_AUTO_REDIRECT = env('DD_SOCIAL_LOGIN_AUTO_REDIRECT')
+SOCIAL_AUTH_CREATE_USER = env('DD_SOCIAL_AUTH_CREATE_USER')
 
 SOCIAL_AUTH_STRATEGY = 'social_django.strategy.DjangoStrategy'
 SOCIAL_AUTH_STORAGE = 'social_django.models.DjangoStorage'


### PR DESCRIPTION
Adding (DD)_SOCIAL_AUTH_CREATE_USER option to:
True, user will be created automatically
False, user will not be created automatically 

Please test it, I have test it on my local instance, but double check would be useful.

