### PR TITLE
Allow empty report files (in API v2 and UI)

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1288,7 +1288,7 @@ class ImportScanSerializer(serializers.Serializer):
     endpoint_to_add = serializers.PrimaryKeyRelatedField(queryset=Endpoint.objects.all(),
                                                          required=False,
                                                          default=None)
-    file = serializers.FileField(required=False)
+    file = serializers.FileField(allow_empty_file=True, required=False)
 
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)
@@ -1427,7 +1427,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
     endpoint_to_add = serializers.PrimaryKeyRelatedField(queryset=Endpoint.objects.all(),
                                                           default=None,
                                                           required=False)
-    file = serializers.FileField(required=False)
+    file = serializers.FileField(allow_empty_file=True, required=False)
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)
     engagement_name = serializers.CharField(required=False)

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -401,8 +401,9 @@ class ImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Add tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt, .sarif"}),
+        attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"}),
         label="Choose report file",
+        allow_empty_file=True,
         required=False)
 
     close_old_findings = forms.BooleanField(help_text="Select if old findings no longer present in the report get closed as mitigated when importing. "

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -472,8 +472,9 @@ class ReImportScanForm(forms.Form):
     tags = TagField(required=False, help_text="Modify existing tags that help describe this scan.  "
                     "Choose from the list or add new tags. Press Enter key to add.")
     file = forms.FileField(widget=forms.widgets.FileInput(
-        attrs={"accept": ".xml, .csv, .nessus, .json, .html, .js, .zip, .xlsx, .txt, .sarif"}),
+        attrs={"accept": ".xml, .csv, .nessus, .json, .jsonl, .html, .js, .zip, .xlsx, .txt, .sarif"}),
         label="Choose report file",
+        allow_empty_file=True,
         required=False)
     close_old_findings = forms.BooleanField(help_text="Select if old findings no longer present in the report get closed as mitigated when importing.",
                                             required=False, initial=True)

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -87,6 +87,8 @@ class ImportReimportMixin(object):
         self.aws_prowler_file_name_plus_one = self.scans_path + 'aws_prowler/many_vuln_plus_one.json'
         self.scan_type_aws_prowler = 'AWS Prowler Scan'
 
+        self.nuclei_empty = self.scans_path + 'nuclei/empty.jsonl'
+
     # import zap scan, testing:
     # - import
     # - active/verifed = True
@@ -1316,6 +1318,22 @@ class ImportReimportMixin(object):
         # inversely, we should see no findings with verified=False
         findings = self.get_test_findings_api(test_id, verified=False)
         self.assert_finding_count_json(0, findings)
+
+    def test_import_nuclei_emptyc(self):
+        """This test do a basic import of Nuclei report with no vulnerability
+
+        This test is useful because Nuclei use jsonl for his format so it can generate empty files.
+        It tests the condition limit of loading an empty file.
+        """
+
+        import0 = self.import_scan_with_params(self.nuclei_empty, scan_type="Nuclei Scan")
+
+        test_id = import0['test']
+
+        reimport0 = self.reimport_scan_with_params(test_id, self.nuclei_empty, scan_type="Nuclei Scan")
+
+        test_id2 = reimport0['test']
+        self.assertEqual(test_id, test_id2)
 
 
 class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):

--- a/unittests/tools/test_nuclei_parser.py
+++ b/unittests/tools/test_nuclei_parser.py
@@ -5,6 +5,12 @@ from dojo.models import Test
 
 class TestNucleiParser(DojoTestCase):
 
+    def test_parse_no_empty(self):
+        testfile = open("unittests/scans/nuclei/empty.jsonl")
+        parser = NucleiParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(0, len(findings))
+
     def test_parse_no_findings(self):
         testfile = open("unittests/scans/nuclei/no_findings.json")
         parser = NucleiParser()


### PR DESCRIPTION
Some security tools generate reports as empty file.

For example, Nuclei report format is JSON lines. So an empty report is a possible.

This modification let's the API v2 accept empty files.