### PR TITLE
Ignore warning from django-auditlog

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1379,3 +1379,7 @@ ASYNC_FINDING_IMPORT = env("DD_ASYNC_FINDING_IMPORT")
 ASYNC_FINDING_IMPORT_CHUNK_SIZE = env("DD_ASYNC_FINDING_IMPORT_CHUNK_SIZE")
 # Feature toggle for new authorization for configurations
 FEATURE_CONFIGURATION_AUTHORIZATION = env("DD_FEATURE_CONFIGURATION_AUTHORIZATION")
+
+# django-auditlog imports django-jsonfield-backport raises a warning that can be ignored,
+# see https://github.com/laymonage/django-jsonfield-backport
+SILENCED_SYSTEM_CHECKS = ["django_jsonfield_backport.W001"]


### PR DESCRIPTION
**django-auditlog** started to produce the warning `auditlog.LogEntry.additional_data: (django_jsonfield_backport.W001) You are using Django 3.1 or newer, which already has a built-in JSONField.` with its release 1.0.0. That happens because they are importing **django-jsonfield-backport** now. According to https://github.com/laymonage/django-jsonfield-backport/blob/master/README.rst:

> This package is fully compatible with the JSONField from Django 3.1. That means you just need to change your imports and edit your migrations when you finally upgrade to Django 3.1. If you leave them as they are, this package will use the built-in JSONField and system warnings will be raised.

That is why we can ignore the warning.