### PR TITLE
Copy only *.py files from extra_settings

### DIFF
--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -12,7 +12,7 @@ if [ "$NUM_FILES" -gt "0" ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/* /app/dojo/settings/
+    cp /app/docker/extra_settings/*.py /app/dojo/settings/
 fi
 
 echo -n "Waiting for database to be reachable "

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -12,7 +12,7 @@ if [ "$NUM_FILES" -gt "0" ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/* /app/dojo/settings/
+    cp /app/docker/extra_settings/*.py /app/dojo/settings/
 fi
 
 echo -n "Waiting for database to be reachable "

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -22,7 +22,7 @@ if [ "$NUM_FILES" -gt "0" ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/* /app/dojo/settings/
+    cp /app/docker/extra_settings/*.py /app/dojo/settings/
 fi
 
 umask 0002

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -9,7 +9,7 @@ if [ "$NUM_FILES" -gt "0" ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/* /app/dojo/settings/
+    cp /app/docker/extra_settings/*.py /app/dojo/settings/
 fi
 
 umask 0002


### PR DESCRIPTION
This is a follow-up to #5797 and #5839. Files will be copied from `docker/extra_settings` to `dojo\settings` if there a `*.py` files in the source directory. In that case currently all files are copied, including a `README.md`. This copied readme file appears then in the list of changed files to commit to git, which is unnecessary.

With this PR only `*.py` files are copied from `docker/extra_settings` to `dojo\settings`.