### PR TITLE
fix(helm): update redis keys

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -65,6 +65,8 @@ If you have installed DefectDojo on "iron" and wish to upgrade the installation,
 
 **Breaking change for Docker Compose:** Starting DefectDojo with Docker Compose now supports 2 databases (MySQL and PostgreSQL) and 2 celery brokers (RabbitMQ and Redis). To make this possible, docker-compose needs to be started with the parameters `--profile` and `--env-file`. You can get more information in [Setup via Docker Compose - Profiles](https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/DOCKER.md#setup-via-docker-compose---profiles). The profile `mysql-rabbitmq` provides the same configuration as in previous releases. With this the prerequisites have changed as well: Docker requires at least version 19.03.0 and Docker Compose 1.28.0.
 
+**Breaking change for Helm Chart:** In one of the last releases we upgraded the redis dependency in our helm chart without renaming keys in our helm chart. We fixed this bug with this release, but you may want to check if all redis values are correct ([Pull Request](https://github.com/DefectDojo/django-DefectDojo/pull/5886)).
+
 The flexible permissions for the configuration of DefectDojo are now active by default. With this, the flag **Staff** for users is not relevant and not visible anymore. The old behaviour can still be activated by setting the parameter `FEATURE_CONFIGURATION_AUTHORIZATION` to `False`. If you haven't done so with the previous release, you can still run a migration script with `./manage.py migrate staff_users`. This script:
 
 * creates a group for all staff users,

--- a/helm/defectdojo/templates/secret-redis.yaml
+++ b/helm/defectdojo/templates/secret-redis.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.redis.existingSecret }}
+  name: {{ .Values.redis.auth.existingSecret }}
   labels:
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -14,9 +14,9 @@ metadata:
     helm.sh/hook-delete-policy: "before-hook-creation"
 type: Opaque
 data:
-{{- if .Values.redis.password }}
-  {{ .Values.redis.secretKey }}: {{ .Values.redis.password | b64enc | quote }}
+{{- if .Values.redis.auth.password }}
+  {{ .Values.redis.auth.existingSecretPasswordKey }}: {{ .Values.redis.auth.password | b64enc | quote }}
 {{- else }}
-  {{ .Values.redis.secretKey }}: {{ randAlphaNum 10 | b64enc | quote }}
+  {{ .Values.redis.auth.existingSecretPasswordKey }}: {{ randAlphaNum 10 | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -383,6 +383,7 @@ rabbitmq:
     fsGroup: 1001
     runAsUser: 1001
 
+# For more advance options check the bitnami chart documentation: https://github.com/bitnami/charts/tree/master/bitnami/redis
 redis:
   enabled: false
   transportEncryption:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -381,11 +381,11 @@ redis:
   transportEncryption:
     enabled: false
     params: ''
-  existingSecret: defectdojo-redis-specific
-  secretKey: redis-password
-  password: ""
-  cluster:
-    slaveCount: 1
+  auth:
+    existingSecret: defectdojo-redis-specific
+    existingSecretPasswordKey: redis-password
+    password: ""
+  architecture: standalone
   # To use an external Redis instance, set enabled to false and uncomment
   # the line below:
   # redisServer: myrediscluster


### PR DESCRIPTION
 In on of the last updates, bitnami has change the name of some keys. We need to update them too.

[Bitnami Redis Chart](https://github.com/bitnami/charts/tree/master/bitnami/redis)

---

On behalf of DB Systel GmbH