### PR TITLE
Format of reviewer form 

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1555,8 +1555,8 @@ class ClearFindingReviewForm(forms.ModelForm):
 
 
 class ReviewFindingForm(forms.Form):
-    reviewers = forms.ModelMultipleChoiceField(queryset=Dojo_User.objects.filter(is_active=True),
-                                               help_text="Select all users who can review Finding.")
+
+    reviewers = forms.MultipleChoiceField(help_text="Select all users who can review Finding.")
     entry = forms.CharField(
         required=True, max_length=2400,
         help_text='Please provide a message for reviewers.',
@@ -1571,9 +1571,18 @@ class ReviewFindingForm(forms.Form):
             finding = kwargs.pop('finding')
 
         super(ReviewFindingForm, self).__init__(*args, **kwargs)
+        self.fields['reviewers'].choices = self._get_choices(Dojo_User.objects.filter(is_active=True))
 
         if finding is not None:
-            self.fields['reviewers'].queryset = get_authorized_users_for_product_and_product_type(None, finding.test.engagement.product, Permissions.Finding_Edit)
+            queryset = get_authorized_users_for_product_and_product_type(None, finding.test.engagement.product, Permissions.Finding_Edit)
+            self.fields['reviewers'].choices = self._get_choices(queryset)
+
+    @staticmethod
+    def _get_choices(queryset):
+        l_choices = []
+        for item in queryset:
+            l_choices.append((item.pk, Dojo_User.generate_full_name(item)))
+        return l_choices
 
     class Meta:
         fields = ['reviewers', 'entry']

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1581,7 +1581,7 @@ class ReviewFindingForm(forms.Form):
     def _get_choices(queryset):
         l_choices = []
         for item in queryset:
-            l_choices.append((item.pk, Dojo_User.generate_full_name(item)))
+            l_choices.append((item.pk, item.get_full_name()))
         return l_choices
 
     class Meta:

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -1,4 +1,3 @@
-from django.contrib.auth import get_user_model
 from django.db.models import Q
 from dojo.models import Dojo_Group_Member, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group, Dojo_User

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.db.models import Q
 from dojo.models import Dojo_Group_Member, Product_Member, Product_Type_Member, \
-    Product_Group, Product_Type_Group
+    Product_Group, Product_Type_Group, Dojo_User
 from dojo.authorization.authorization import get_roles_for_permission
 
 
@@ -21,8 +21,7 @@ def get_authorized_users_for_product_type(users, product_type, permission):
 
 def get_authorized_users_for_product_and_product_type(users, product, permission):
     if users is None:
-        User = get_user_model()
-        users = User.objects.filter(is_active=True)
+        users = Dojo_User.objects.filter(is_active=True)
 
     roles = get_roles_for_permission(permission)
     product_members = Product_Member.objects \

--- a/tests/product_test.py
+++ b/tests/product_test.py
@@ -163,7 +163,7 @@ class ProductTest(BaseTestCase):
         # engagement target start and target end already have defaults
         # we can safely skip
         # Testing Lead: This can be the logged in user
-        Select(driver.find_element(By.ID, "id_lead")).select_by_visible_text('admin')
+        Select(driver.find_element(By.ID, "id_lead")).select_by_visible_text('Admin User (admin)')
         # engagement status
         Select(driver.find_element(By.ID, "id_status")).select_by_visible_text("In Progress")
         # "Click" the Done button to Add the engagement

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -74,7 +74,7 @@ class TestUnitTest(BaseTestCase):
         # engagement target start and target end already have defaults
         # we can safely skip
         # Testing Lead: This can be the logged in user
-        Select(driver.find_element(By.ID, "id_lead")).select_by_visible_text('admin')
+        Select(driver.find_element(By.ID, "id_lead")).select_by_visible_text('Admin User (admin)')
         # engagement status
         Select(driver.find_element(By.ID, "id_status")).select_by_visible_text("In Progress")
         # "Click" the 'Add Test' button to Add Test to engagement


### PR DESCRIPTION
When usernames are anonymized  it is very hard to find the right user for peer review. So it is adapted to use `generate_full_name()`

Before:
![image](https://user-images.githubusercontent.com/7211879/153572282-47e91ff7-dd23-403f-9a48-694b77a840d4.png)


After:
![Screenshot from 2022-02-09 15-29-38](https://user-images.githubusercontent.com/7211879/153222388-5aca3fac-78ce-466e-9027-8cc5873ae4e7.png)
