### PR TITLE
Don't show 'all alerts' and 'clear all alerts' when no notification found

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -764,10 +764,16 @@
                                                htmlEscape(elem.fields.source) + '</span></div></li><li class="divider"></li>');
                   $("#" + dropdown_alert).text(display_title);
                 });
-                $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "alerts" %}"><strong>See All Alerts </strong>' +
-                                             '<i class="fa fa-angle-right"></i></a></li>');
-                $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "delete_alerts" %}"><strong>Clear All Alerts </strong>' +
-                                           '<i class="fa fa-angle-right"></i></a></li>');
+
+                if (data.length > 0) {
+                    $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "alerts" %}"><strong>{% trans "See All Alerts" %}</strong>' +
+                                                 '<i class="fa fa-angle-right"></i></a></li>');
+                    $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "delete_alerts" %}"><strong>{% trans "Clear All Alerts" %} </strong>' +
+                                               '<i class="fa fa-angle-right"></i></a></li>');
+                }
+                else {
+                    $('.dropdown-alerts').append('<li class="text-center"><h3 style="padding: 15px;">{% trans "No alerts found" %}</h2></li>');
+                }
             });
             update_alertcount()
         }

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1,7 +1,6 @@
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
-{% load i18n %}
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">
@@ -767,13 +766,13 @@
                 });
 
                 if (data.length > 0) {
-                    $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "alerts" %}"><strong>{% trans "See All Alerts" %}</strong>' +
+                    $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "alerts" %}"><strong>See All Alerts</strong>' +
                                                  '<i class="fa fa-angle-right"></i></a></li>');
-                    $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "delete_alerts" %}"><strong>{% trans "Clear All Alerts" %} </strong>' +
+                    $('.dropdown-alerts').append('<li><a class="text-center" href="{% url "delete_alerts" %}"><strong>Clear All Alerts</strong>' +
                                                '<i class="fa fa-angle-right"></i></a></li>');
                 }
                 else {
-                    $('.dropdown-alerts').append('<li class="text-center"><h3 style="padding: 15px;">{% trans "No alerts found" %}</h2></li>');
+                    $('.dropdown-alerts').append('<li class="text-center"><h3 style="padding: 15px;">No alerts found</h2></li>');
                 }
             });
             update_alertcount()

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -772,7 +772,7 @@
                                                '<i class="fa fa-angle-right"></i></a></li>');
                 }
                 else {
-                    $('.dropdown-alerts').append('<li class="text-center"><h3 style="padding: 15px;">No alerts found</h2></li>');
+                    $('.dropdown-alerts').append('<li class="text-center"><strong>No alerts found</strong></li>');
                 }
             });
             update_alertcount()

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1,6 +1,7 @@
 {% load navigation_tags %}
 {% load display_tags %}
 {% load authorization_tags %}
+{% load i18n %}
 {% load static %}
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
It's strange that in the absence of alerts, we suggest looking at all the alerts or clearing them. 

I suggest showing a big message instead

Before:
<img width="515" alt="Снимок экрана 2022-02-12 в 12 31 57" src="https://user-images.githubusercontent.com/1519243/153698178-65b9263e-468b-4c1e-a714-f7ac25f8543d.png">

After:
<img width="515" alt="Снимок экрана 2022-02-12 в 12 31 57" src="https://user-images.githubusercontent.com/1519243/153698321-864bd7ef-18fd-4dd6-b44c-f81480b8fb32.png">

