### PR TITLE
Add Postgres NULL char validation/removal in Endpoint cleaning

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1281,7 +1281,7 @@ class Endpoint(models.Model):
 
     def clean(self):
         errors = []
-        null_char_list = ["0x00", "%00", "\x00"]
+        null_char_list = ["0x00", "\x00"]
         db_type = connection.vendor
         if self.protocol or self.protocol == '':
             if not re.match(r'^[A-Za-z][A-Za-z0-9\.\-\+]+$', self.protocol):  # https://tools.ietf.org/html/rfc3986#section-3.1
@@ -1319,9 +1319,9 @@ class Endpoint(models.Model):
             if any([null_char in self.path for null_char in null_char_list]):
                 old_value = self.path
                 if 'postgres' in db_type:
-                    action_string = 'Postgres does not accept NULL character. Attempting to remove...'
+                    action_string = 'Postgres does not accept NULL character. Attempting to replace with %00...'
                     for remove_str in null_char_list:
-                        self.path = self.path.replace(remove_str, '')
+                        self.path = self.path.replace(remove_str, '%00')
                     errors.append(ValidationError('Path "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
             if self.path == '':
                 self.path = None
@@ -1332,9 +1332,9 @@ class Endpoint(models.Model):
             if any([null_char in self.query for null_char in null_char_list]):
                 old_value = self.query
                 if 'postgres' in db_type:
-                    action_string = 'Postgres does not accept NULL character. Attempting to remove...'
+                    action_string = 'Postgres does not accept NULL character. Attempting to replace with %00...'
                     for remove_str in null_char_list:
-                        self.query = self.query.replace(remove_str, '')
+                        self.query = self.query.replace(remove_str, '%00')
                     errors.append(ValidationError('Query "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
             if self.query == '':
                 self.query = None
@@ -1345,9 +1345,9 @@ class Endpoint(models.Model):
             if any([null_char in self.fragment for null_char in null_char_list]):
                 old_value = self.fragment
                 if 'postgres' in db_type:
-                    action_string = 'Postgres does not accept NULL character. Attempting to remove...'
+                    action_string = 'Postgres does not accept NULL character. Attempting to replace with %00...'
                     for remove_str in null_char_list:
-                        self.fragment = self.fragment.replace(remove_str, '')
+                        self.fragment = self.fragment.replace(remove_str, '%00')
                     errors.append(ValidationError('Fragment "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
             if self.fragment == '':
                 self.fragment = None

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1318,13 +1318,11 @@ class Endpoint(models.Model):
                 self.path = self.path[1:]
             if any([null_char in self.path for null_char in null_char_list]):
                 old_value = self.path
-                if 'mysql' in db_type:
-                    action_string = 'No action taken as MySQL allows for storing the NULL character'
                 if 'postgres' in db_type:
                     action_string = 'Postgres does not accept NULL character. Attempting to remove...'
                     for remove_str in null_char_list:
                         self.path = self.path.replace(remove_str, '')
-                errors.append(ValidationError('Path "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
+                    errors.append(ValidationError('Path "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
             if self.path == '':
                 self.path = None
 
@@ -1333,13 +1331,11 @@ class Endpoint(models.Model):
                 self.query = self.query[1:]
             if any([null_char in self.query for null_char in null_char_list]):
                 old_value = self.query
-                if 'mysql' in db_type:
-                    action_string = 'No action taken as MySQL allows for storing the NULL character'
                 if 'postgres' in db_type:
                     action_string = 'Postgres does not accept NULL character. Attempting to remove...'
                     for remove_str in null_char_list:
                         self.query = self.query.replace(remove_str, '')
-                errors.append(ValidationError('Query "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
+                    errors.append(ValidationError('Query "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
             if self.query == '':
                 self.query = None
 
@@ -1348,13 +1344,11 @@ class Endpoint(models.Model):
                 self.fragment = self.fragment[1:]
             if any([null_char in self.fragment for null_char in null_char_list]):
                 old_value = self.fragment
-                if 'mysql' in db_type:
-                    action_string = 'No action taken as MySQL allows for storing the NULL character'
                 if 'postgres' in db_type:
                     action_string = 'Postgres does not accept NULL character. Attempting to remove...'
                     for remove_str in null_char_list:
                         self.fragment = self.fragment.replace(remove_str, '')
-                errors.append(ValidationError('Fragment "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
+                    errors.append(ValidationError('Fragment "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
             if self.fragment == '':
                 self.fragment = None
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1357,7 +1357,7 @@ class Endpoint(models.Model):
                 errors.append(ValidationError('Fragment "{}" has invalid format - It contains the NULL character. The following action was taken: {}'.format(old_value, action_string)))
             if self.fragment == '':
                 self.fragment = None
-        
+
         if errors:
             raise ValidationError(errors)
 


### PR DESCRIPTION
When first importing a scan file that contained a NULL char to my sandbox env (running MySQL) I did not experience any issues. After attempting to import to production (running Postgres) I was greeted with the following 

<img width="519" alt="Screen Shot 2022-02-10 at 5 29 11 PM" src="https://user-images.githubusercontent.com/46459665/153514944-86f36a48-0598-4501-89f6-0f83ab29fcd3.png">

<img width="624" alt="Screen Shot 2022-02-10 at 5 29 35 PM" src="https://user-images.githubusercontent.com/46459665/153514960-f9496d9c-f70a-4437-bc9c-89c0e8eee6aa.png">

This error is totally dependent on the DB connected to dojo, so a universal fix is sorta out the window. Ideally, removing information from an endpoint is not acceptable, but I figured there was no way to import a scan with a NULL char to a Postgres backend anyways, so might as well remove the offending bits of the URL. 

<img width="423" alt="Screen Shot 2022-02-10 at 5 30 56 PM" src="https://user-images.githubusercontent.com/46459665/153515112-7ae028ff-a6dc-4bdf-8c42-49356a7d6f7c.png">
 
 I added some validation errors to make the log reader aware of what is going on

`uwsgi_1         | [10/Feb/2022 23:29:53] WARNING [dojo.importers.utils:133] DefectDojo is storing broken endpoint because cleaning wasn't successful: ['Query "count=50&query=http://test.com/n?\x00.php&" has invalid format - It contains the NULL character. The following action was taken: Postgres does not accept NULL character. Attempting to remove...']`

For those that run MySQL, they will see a similar error message like the one below and the endpoint (and NULL chars) will be preserved 

`uwsgi_1         | [10/Feb/2022 23:29:53] WARNING [dojo.importers.utils:133] DefectDojo is storing broken endpoint because cleaning wasn't successful: ['Query "count=50&query=http://test.com/n?\x00.php&" has invalid format - It contains the NULL character. The following action was taken: No action taken as MySQL allows for storing the NULL character']`