### PR TITLE
Remove host from links for custom reports

### DIFF
--- a/dojo/templates/dojo/custom_html_report.html
+++ b/dojo/templates/dojo/custom_html_report.html
@@ -4,7 +4,7 @@
 <html lang="en">
     <meta charset="UTF-8">
     <title>{{ report_name }}</title>
-    <link href="{{ host }}{% static "bootswatch/readable/bootstrap.min.css" %}" rel="stylesheet">
+    <link href="{% static "bootswatch/readable/bootstrap.min.css" %}" rel="stylesheet">
     <style type="text/css">
         @import url(https://fonts.googleapis.com/css?family=Roboto+Slab:400,700);
 

--- a/dojo/templates/report_base.html
+++ b/dojo/templates/report_base.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <title>{{ report_name }}</title>
-    <link href="{{ host }}{% static "bootswatch/readable/bootstrap.min.css" %}" rel="stylesheet">
+    <link href="{% static "bootswatch/readable/bootstrap.min.css" %}" rel="stylesheet">
 
     <!-- Custom Fonts -->
     <link href="{% static "font-awesome/css/font-awesome.min.css" %}" rel="stylesheet" type="text/css">


### PR DESCRIPTION
fixes  #5917

This PR removes `{{ host }}` from the links for `bootstrap.min.js` in 2 templates and make them similar to all other links for JavaScript files.