### PR TITLE
Fix indentation in docker-compose.override.debug.yml

### DIFF
--- a/docker-compose.override.debug.yml
+++ b/docker-compose.override.debug.yml
@@ -1,43 +1,43 @@
 ---
-    version: '3.8'
-    services:
-      uwsgi:
-        entrypoint: ['/wait-for-it.sh', '${DD_DATABASE_HOST}:${DD_DATABASE_PORT}', '-t', '30', '--', '/entrypoint-uwsgi-dev.sh']
-        volumes:
-          - '.:/app:z'
-        environment:
-          DD_DEBUG: 'True'
-          DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
-          DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
-        ports:
-          - target: ${DD_DEBUG_PORT:-3000}
-            published: ${DD_DEBUG_PORT:-3000}
-            protocol: tcp
-            mode: host
-      celeryworker:
-        volumes:
-          - '.:/app:z'
-      celerybeat:
-        volumes:
-          - '.:/app:z'
-      initializer:
-        volumes:
-          - '.:/app:z'
-        environment:
-          DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
-          DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
-      nginx:
-        volumes:
-          - './dojo/static/dojo:/usr/share/nginx/html/static/dojo'
-      mysql:
-        ports:
-          - target: ${DD_DATABASE_PORT}
-            published: ${DD_DATABASE_PORT}
-            protocol: tcp
-            mode: host
-      postgres:
-        ports:
-          - target: ${DD_DATABASE_PORT}
-            published: ${DD_DATABASE_PORT}
-            protocol: tcp
-            mode: host
+version: '3.8'
+services:
+  uwsgi:
+    entrypoint: ['/wait-for-it.sh', '${DD_DATABASE_HOST}:${DD_DATABASE_PORT}', '-t', '30', '--', '/entrypoint-uwsgi-dev.sh']
+    volumes:
+      - '.:/app:z'
+    environment:
+      DD_DEBUG: 'True'
+      DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
+    ports:
+      - target: ${DD_DEBUG_PORT:-3000}
+        published: ${DD_DEBUG_PORT:-3000}
+        protocol: tcp
+        mode: host
+  celeryworker:
+    volumes:
+      - '.:/app:z'
+  celerybeat:
+    volumes:
+      - '.:/app:z'
+  initializer:
+    volumes:
+      - '.:/app:z'
+    environment:
+      DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
+      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
+  nginx:
+    volumes:
+      - './dojo/static/dojo:/usr/share/nginx/html/static/dojo'
+  mysql:
+    ports:
+      - target: ${DD_DATABASE_PORT}
+        published: ${DD_DATABASE_PORT}
+        protocol: tcp
+        mode: host
+  postgres:
+    ports:
+      - target: ${DD_DATABASE_PORT}
+        published: ${DD_DATABASE_PORT}
+        protocol: tcp
+        mode: host


### PR DESCRIPTION
For some reason, the structure in `docker-compose.override.debug.yml` was indented more then in other `docker-compose.override.*.yml` files