### PR TITLE
APIv2: remove configuration_url from ToolConfigurationSerializer

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -61,6 +61,10 @@ godojo installations
 
 If you have installed DefectDojo on "iron" and wish to upgrade the installation, please see the [instructions in the repo](https://github.com/DefectDojo/godojo/blob/master/docs-and-scripts/upgrading.md).
 
+## Upgrading to DefectDojo Version 2.9.x.
+
+**Breaking change for APIv2:** From API endpoint `/api/v2/tool_configurations/` was removed `configuration_url` because of redundancy.
+
 ## Upgrading to DefectDojo Version 2.8.x.
 
 **Breaking change for Docker Compose:** Starting DefectDojo with Docker Compose now supports 2 databases (MySQL and PostgreSQL) and 2 celery brokers (RabbitMQ and Redis). To make this possible, docker-compose needs to be started with the parameters `--profile` and `--env-file`. You can get more information in [Setup via Docker Compose - Profiles](https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/DOCKER.md#setup-via-docker-compose---profiles). The profile `mysql-rabbitmq` provides the same configuration as in previous releases. With this the prerequisites have changed as well: Docker requires at least version 19.03.0 and Docker Compose 1.28.0.

--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -63,7 +63,7 @@ If you have installed DefectDojo on "iron" and wish to upgrade the installation,
 
 ## Upgrading to DefectDojo Version 2.9.x.
 
-**Breaking change for APIv2:** From API endpoint `/api/v2/tool_configurations/` was removed `configuration_url` because of redundancy.
+**Breaking change for APIv2:** `configuration_url` was removed from API endpoint `/api/v2/tool_configurations/` due to redundancy.
 
 ## Upgrading to DefectDojo Version 2.8.x.
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -691,8 +691,6 @@ class RegulationSerializer(serializers.ModelSerializer):
 
 
 class ToolConfigurationSerializer(serializers.ModelSerializer):
-    configuration_url = serializers.CharField(source='url')
-
     class Meta:
         model = Tool_Configuration
         fields = '__all__'

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1326,7 +1326,7 @@ class ToolConfigurationsTest(BaseClass.RESTEndpointTest):
         self.endpoint_path = 'tool_configurations'
         self.viewset = ToolConfigurationsViewSet
         self.payload = {
-            "configuration_url": "http://www.example.com",
+            "url": "http://www.example.com",
             "name": "Tool Configuration",
             "description": "",
             "authentication_type": "API",


### PR DESCRIPTION
remove obsolete field

https://owasp.slack.com/archives/C2P5BA8MN/p1647430817715979