### PR TITLE
Logging enhancement 

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -14,8 +14,6 @@ if [ ${DD_DEBUG} == "True" ]; then
   DD_UWSGI_NUM_OF_THREADS=1
 fi
 
-echo $DD_UWSGI_LOGFORMAT
-
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -6,7 +6,7 @@ cd /app
 # Full list of uwsgi options: https://uwsgi-docs.readthedocs.io/en/latest/Options.html
 # --lazy-apps required for debugging --> https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html?highlight=lazy-apps#preforking-vs-lazy-apps-vs-lazy
 
-DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
+DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
 if [ ${DD_DEBUG} == "True" ]; then
   echo "Debug mode enabled, reducing # of processes and threads to 1"

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -6,12 +6,15 @@ cd /app
 # Full list of uwsgi options: https://uwsgi-docs.readthedocs.io/en/latest/Options.html
 # --lazy-apps required for debugging --> https://uwsgi-docs.readthedocs.io/en/latest/articles/TheArtOfGracefulReloading.html?highlight=lazy-apps#preforking-vs-lazy-apps-vs-lazy
 
+DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
 if [ ${DD_DEBUG} == "True" ]; then
   echo "Debug mode enabled, reducing # of processes and threads to 1"
   DD_UWSGI_NUM_OF_PROCESSES=1
   DD_UWSGI_NUM_OF_THREADS=1
 fi
+
+echo $DD_UWSGI_LOGFORMAT
 
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
@@ -25,4 +28,5 @@ exec uwsgi \
   --py-autoreload 1 \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
   --lazy-apps \
-  --touch-reload="/app/dojo/setting/settings.py"
+  --touch-reload="/app/dojo/setting/settings.py" \
+  --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}"

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -17,6 +17,8 @@ umask 0002
 # do the check with Django stack
 python3 manage.py check
 
+DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
+
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
   --protocol uwsgi \
@@ -25,5 +27,6 @@ exec uwsgi \
   --threads ${DD_UWSGI_NUM_OF_THREADS:-2} \
   --wsgi dojo.wsgi:application \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
-  --http 0.0.0.0:8081 --http-to ${DD_UWSGI_ENDPOINT}
-  # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a serivce.
+  --http 0.0.0.0:8081 --http-to ${DD_UWSGI_ENDPOINT} \
+  --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}"
+  # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -17,7 +17,7 @@ umask 0002
 # do the check with Django stack
 python3 manage.py check
 
-DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
+DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
 exec uwsgi \
   "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -127,7 +127,7 @@ def findings(request, pid=None, eid=None, view=None, filter_name=None, order_by=
     if view == "All":
         filter_name = "All"
     else:
-        print('Filtering!', view)
+        logger.debug('Filtering!: {}', view)
 
     if pid:
         product = get_object_or_404(Product, id=pid)

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -127,7 +127,7 @@ def findings(request, pid=None, eid=None, view=None, filter_name=None, order_by=
     if view == "All":
         filter_name = "All"
     else:
-        logger.debug('Filtering!: {}', view)
+        logger.debug('Filtering!: %s', view)
 
     if pid:
         product = get_object_or_404(Product, id=pid)

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -53,8 +53,12 @@ class LoginRequiredMiddleware:
 
         if request.user.is_authenticated:
             logger.debug("Authenticated user: %s", str(request.user))
-            # this populates dd_user log var, so can appear in the uwsgi logs
-            set_logvar('dd_user', str(request.user))
+            try:
+                # this populates dd_user log var, so can appear in the uwsgi logs
+                set_logvar('dd_user', str(request.user))
+            except:
+                # to avoid unittests to fail
+                pass
             path = request.path_info.lstrip('/')
             from dojo.models import Dojo_User
             if Dojo_User.force_password_reset(request.user) and path != 'change_password':

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -7,6 +7,12 @@ from threading import local
 from django.db import models
 from django.urls import reverse
 
+try:
+    from uwsgi import set_logvar
+except:
+    'This should be included by default is uwsgi is in use. but during the build it will fail anytime'
+    pass
+
 logger = logging.getLogger(__name__)
 
 EXEMPT_URLS = [compile(settings.LOGIN_URL.lstrip('/'))]
@@ -46,6 +52,8 @@ class LoginRequiredMiddleware:
                 return HttpResponseRedirect(fullURL)
 
         if request.user.is_authenticated:
+            logger.debug("Authenticated user: %s", str(request.user))
+            set_logvar('dd_user', str(request.user))
             path = request.path_info.lstrip('/')
             from dojo.models import Dojo_User
             if Dojo_User.force_password_reset(request.user) and path != 'change_password':

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -7,11 +7,6 @@ from threading import local
 from django.db import models
 from django.urls import reverse
 
-try:
-    from uwsgi import set_logvar
-except:
-    'This should be included by default if uwsgi is in use. But during the build it will fail anytime'
-    pass
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +49,9 @@ class LoginRequiredMiddleware:
         if request.user.is_authenticated:
             logger.debug("Authenticated user: %s", str(request.user))
             try:
+                uwsgi = __import__('uwsgi', globals(), locals(), ['set_logvar'], 0)
                 # this populates dd_user log var, so can appear in the uwsgi logs
-                set_logvar('dd_user', str(request.user))
+                uwsgi.set_logvar('dd_user', str(request.user))
             except:
                 # to avoid unittests to fail
                 pass

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 try:
     from uwsgi import set_logvar
 except:
-    'This should be included by default is uwsgi is in use. but during the build it will fail anytime'
+    'This should be included by default if uwsgi is in use. But during the build it will fail anytime'
     pass
 
 logger = logging.getLogger(__name__)
@@ -53,6 +53,7 @@ class LoginRequiredMiddleware:
 
         if request.user.is_authenticated:
             logger.debug("Authenticated user: %s", str(request.user))
+            # this populates dd_user log var, so can appear in the uwsgi logs
             set_logvar('dd_user', str(request.user))
             path = request.path_info.lstrip('/')
             from dojo.models import Dojo_User

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1305,7 +1305,7 @@ LOGGING = {
     'loggers': {
         'django.request': {
             'handlers': ['mail_admins', 'console'],
-            'level': % LOG_LEVEL,
+            'level': '%s' % LOG_LEVEL,
             'propagate': True,
         },
         'django.security': {
@@ -1337,13 +1337,13 @@ LOGGING = {
         'MARKDOWN': {
             # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': % LOG_LEVEL,
+            'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
         'titlecase': {
             # The titlecase library is too verbose in it's logging, reducing the verbosity in our logs.
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': % LOG_LEVEL,
+            'level': '%s' % LOG_LEVEL,
             'propagate': False,
         },
     }

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1306,7 +1306,7 @@ LOGGING = {
         'django.request': {
             'handlers': ['mail_admins', 'console'],
             'level': '%s' % LOG_LEVEL,
-            'propagate': True,
+            'propagate': False,
         },
         'django.security': {
             'handlers': [r'%s' % LOGGING_HANDLER],
@@ -1333,6 +1333,7 @@ LOGGING = {
         'saml2': {
             'handlers': [r'%s' % LOGGING_HANDLER],
             'level': '%s' % LOG_LEVEL,
+            'propagate': False,
         },
         'MARKDOWN': {
             # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1305,7 +1305,7 @@ LOGGING = {
     'loggers': {
         'django.request': {
             'handlers': ['mail_admins', 'console'],
-            'level': 'WARN',
+            'level': % LOG_LEVEL,
             'propagate': True,
         },
         'django.security': {
@@ -1337,13 +1337,13 @@ LOGGING = {
         'MARKDOWN': {
             # The markdown library is too verbose in it's logging, reducing the verbosity in our logs.
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': 'WARNING',
+            'level': % LOG_LEVEL,
             'propagate': False,
         },
         'titlecase': {
             # The titlecase library is too verbose in it's logging, reducing the verbosity in our logs.
             'handlers': [r'%s' % LOGGING_HANDLER],
-            'level': 'WARNING',
+            'level': % LOG_LEVEL,
             'propagate': False,
         },
     }

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -36,6 +36,7 @@ from django.http import HttpResponseRedirect
 import crum
 from dojo.celery import app
 from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
+from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
 
 
 logger = logging.getLogger(__name__)
@@ -2129,3 +2130,32 @@ def get_enabled_notifications_list():
 def is_finding_groups_enabled():
     """Returns true is feature is enabled otherwise false"""
     return get_system_setting("enable_finding_groups")
+
+
+@receiver(user_logged_in)
+def log_user_login(sender, request, user, **kwargs):
+    # to cover more complex cases:
+    # http://stackoverflow.com/questions/4581789/how-do-i-get-user-ip-address-in-django
+
+    logger.info('login user: {user} via ip: {ip}'.format(
+        user=user.username,
+        ip=request.META.get('REMOTE_ADDR')
+    ))
+
+
+@receiver(user_logged_out)
+def log_user_logout(sender, request, user, **kwargs):
+
+    logger.info('logout user: {user} via ip: {ip}'.format(
+        user=user.username,
+        ip=request.META.get('REMOTE_ADDR')
+    ))
+
+
+@receiver(user_login_failed)
+def log_user_login_failed(sender, credentials, request, **kwargs):
+
+    logger.warning('login failed for: {credentials} via ip: {ip}'.format(
+        credentials=credentials['username'],
+        ip=request.META['REMOTE_ADDR']
+    ))

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -61,7 +61,7 @@ http {
       return 200 "Born to be alive!\n";
       access_log off;
     }
-    # Used by Kuebernetes readiness checks
+    # Used by Kubernetes readiness checks
     location = /uwsgi_health {
       limit_except GET { deny all; }
       rewrite /.+ /login?force_login_form&next=/ break;


### PR DESCRIPTION
It adds options to define customized way of uwsgi logging, that can be changed without need to rebuild the images. 

For instance user can specify Apache format by defining (in compose or helm value):

`DD_UWSGI_LOGFORMAT: '"%(addr) - %(user) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"'`

To produce:
`"172.19.0.1 - - [18/Mar/2022:12:52:21 +0000] "GET /alerts/count HTTP/1.1" 200 183 "http://localhost:8080/system_settings" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.109 Safari/537.36 OPR/84.0.4316.31"`

The problem I still see that default is not populating (user) variable, I tried to do it manually in middleware with `set_logvar` but is not working as well (still empty). But it works fine if I define alternative logvar in the code like user1.
like 

``DD_UWSGI_LOGFORMAT: '"%(addr) - %(user1) [%(ltime)] "%(method) %(uri) %(proto)" %(status) %(size) "%(referer)" "%(uagent)"'``







