### PR TITLE
Deprecation notice for legacy authorization for configurations

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -5,6 +5,20 @@ draft: false
 weight: 5
 ---
 
+{{% alert title="Deprecation notice" color="warning" %}}
+Legacy authorization for changing configurations based on staff users will be
+removed with version 2.12.0 / 5. July 2022. If you have set
+`FEATURE_CONFIGURATION_AUTHORIZATION` to `False` in your local configuration,
+remove this local setting and start using the new authorization as described
+in [Configuration permissions]({{< ref "/usage/permissions#configuration-permissions" >}}).
+
+To support the transition, you can run a migration script with ``./manage.py migrate staff_users``. This script:
+
+* creates a group for all staff users,
+* sets all configuration permissions that staff users had and
+* sets the global Owner role, if `AUTHORIZATION_STAFF_OVERRIDE` is set to `True`.
+{{% /alert %}}
+
 Docker-compose
 --------------
 

--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -12,7 +12,7 @@ removed with version 2.12.0 / 5. July 2022. If you have set
 remove this local setting and start using the new authorization as described
 in [Configuration permissions]({{< ref "/usage/permissions#configuration-permissions" >}}).
 
-To support the transition, you can run a migration script with ``./manage.py migrate staff_users``. This script:
+To support the transition, you can run a migration script with ``./manage.py migrate_staff_users``. This script:
 
 * creates a group for all staff users,
 * sets all configuration permissions that staff users had and

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -4,6 +4,8 @@ from typing import Dict
 
 from dateutil.relativedelta import relativedelta
 
+from django.conf import settings
+from django.contrib import messages
 from django.urls import reverse
 from django.http import HttpResponseRedirect, HttpResponse, HttpRequest
 from django.shortcuts import render
@@ -52,6 +54,13 @@ def dashboard(request: HttpRequest) -> HttpResponse:
             .filter(Q(engagement__isnull=True) | Q(engagement__in=engagements))
     else:
         unassigned_surveys = None
+
+    if request.user.is_superuser and not settings.FEATURE_CONFIGURATION_AUTHORIZATION:
+        message = '''Legacy authorization for changing configurations based on staff users will be
+                     removed with version 2.12.0 / 5. July 2022. If you have set
+                     `FEATURE_CONFIGURATION_AUTHORIZATION` to `False` in your local configuration,
+                     remove this local setting and start using the new authorization.'''
+        messages.add_message(request, messages.WARNING, message, extra_tags='alert-warning')
 
     add_breadcrumb(request=request, clear=True)
     return render(request, 'dojo/dashboard.html', {


### PR DESCRIPTION
The deprecation notice for the legacy authorization for configurations will be shown:

* on top of the upgrading page in the documentation
* on top of the dashboard in the UI for superusers when the legacy authorization is still active