### PR TITLE
Allow HTML img tag resizing

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -36,16 +36,21 @@ markdown_tags = [
     "img",
     "a",
     "sub", "sup",
+    "center",
 ]
 
 markdown_attrs = {
     "*": ["id"],
-    "img": ["src", "alt", "title"],
+    "img": ["src", "alt", "title", "width", "height", "style"],
     "a": ["href", "alt", "target", "title"],
     "span": ["class"],  # used for code highlighting
     "pre": ["class"],  # used for code highlighting
     "div": ["class"],  # used for code highlighting
 }
+
+markdown_styles = [
+    "background-color"
+]
 
 finding_related_action_classes_dict = {
     'reset_finding_duplicate_status': 'fa fa-eraser',
@@ -75,8 +80,9 @@ def markdown_render(value):
                                                       'markdown.extensions.codehilite',
                                                       'markdown.extensions.fenced_code',
                                                       'markdown.extensions.toc',
-                                                      'markdown.extensions.tables'])
-        return mark_safe(bleach.clean(markdown_text, markdown_tags, markdown_attrs))
+                                                      'markdown.extensions.tables',
+                                                      'markdown.extensions.attr_list'])
+        return mark_safe(bleach.clean(markdown_text, markdown_tags, markdown_attrs, markdown_styles))
 
 
 @register.filter(name='url_shortner')

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -505,7 +505,7 @@ def add_temp_finding(request, tid, fid):
             new_finding.reporter = request.user
             new_finding.numerical_severity = Finding.get_numerical_severity(
                 new_finding.severity)
-            new_finding.date = datetime.today()
+            new_finding.date = form.cleaned_data['date'] or datetime.today()
             finding_helper.update_finding_status(new_finding, request.user)
 
             new_finding.save(dedupe_option=False, false_history=False)


### PR DESCRIPTION
By default, it is possible to add some <img /> HTML tag. However, width, height and style attribute are not allowed.
This commits add possibility to add these attributes. Style can only be used in addition with background-color tag (in case of white PNG).