### PR TITLE
[FIX] Date erased when Finding created from Template

### DIFF
--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -505,7 +505,7 @@ def add_temp_finding(request, tid, fid):
             new_finding.reporter = request.user
             new_finding.numerical_severity = Finding.get_numerical_severity(
                 new_finding.severity)
-            new_finding.date = datetime.today()
+            new_finding.date = form.cleaned_data['date'] or datetime.today()
             finding_helper.update_finding_status(new_finding, request.user)
 
             new_finding.save(dedupe_option=False, false_history=False)


### PR DESCRIPTION
When creating a Finding from a Template, the date given to the finding is not taken into account. Instead, date provided is erased by the date of the day.
This fix allows to create a Finding, from a Template, with a given date or date of the day.