### PR TITLE
[FIX] Edit Finding's mitigated time (EDITABLE_MITIGATED_DATA)

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -417,7 +417,7 @@ def close_finding(request, fid):
             now = timezone.now()
             new_note = form.save(commit=False)
             new_note.author = request.user
-            new_note.date = now
+            new_note.date = form.cleaned_data["mitigated"] or now
             new_note.save()
             finding.notes.add(new_note)
 
@@ -430,7 +430,7 @@ def close_finding(request, fid):
             if len(missing_note_types) == 0:
                 finding.active = False
                 now = timezone.now()
-                finding.mitigated = now
+                finding.mitigated = form.cleaned_data["mitigated"] or now
                 finding.mitigated_by = request.user
                 finding.is_mitigated = True
                 finding.last_reviewed = finding.mitigated
@@ -438,7 +438,7 @@ def close_finding(request, fid):
                 endpoint_status = finding.endpoint_status.all()
                 for status in endpoint_status:
                     status.mitigated_by = request.user
-                    status.mitigated_time = timezone.now()
+                    status.mitigated_time = form.cleaned_data["mitigated"] or now
                     status.mitigated = True
                     status.last_modified = timezone.now()
                     status.save()

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1121,15 +1121,15 @@ class FindingForm(forms.ModelForm):
                                widget=forms.widgets.Textarea(attrs={'rows': '3', 'cols': '400'}))
     references = forms.CharField(widget=forms.Textarea, required=False)
 
-    mitigated = SplitDateTimeField(required=False, help_text='Date and time when the flaw has been fixed')
-    mitigated_by = forms.ModelChoiceField(required=True, queryset=User.objects.all(), initial=get_current_user)
+    #mitigated = SplitDateTimeField(required=False, help_text='Date and time when the flaw has been fixed')
+    #mitigated_by = forms.ModelChoiceField(required=True, queryset=User.objects.all(), initial=get_current_user)
 
     publish_date = forms.DateField(widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}), required=False)
 
     # the onyl reliable way without hacking internal fields to get predicatble ordering is to make it explicit
     field_order = ('title', 'group', 'date', 'sla_start_date', 'cwe', 'cve', 'severity', 'cvssv3', 'cvssv3_score', 'description', 'mitigation', 'impact',
                    'request', 'response', 'steps_to_reproduce', 'severity_justification', 'endpoints', 'endpoints_to_add', 'references',
-                   'active', 'mitigated', 'mitigated_by', 'verified', 'false_p', 'duplicate',
+                   'active', 'verified', 'false_p', 'duplicate',
                    'out_of_scope', 'risk_accept', 'under_defect_review')
 
     def __init__(self, *args, **kwargs):
@@ -1137,8 +1137,8 @@ class FindingForm(forms.ModelForm):
         if 'req_resp' in kwargs:
             req_resp = kwargs.pop('req_resp')
 
-        self.can_edit_mitigated_data = kwargs.pop('can_edit_mitigated_data') if 'can_edit_mitigated_data' in kwargs \
-            else False
+        #self.can_edit_mitigated_data = kwargs.pop('can_edit_mitigated_data') if 'can_edit_mitigated_data' in kwargs \
+        #    else False
 
         super(FindingForm, self).__init__(*args, **kwargs)
 
@@ -1167,13 +1167,13 @@ class FindingForm(forms.ModelForm):
 
         self.fields['sla_start_date'].disabled = True
 
-        if self.can_edit_mitigated_data:
-            if hasattr(self, 'instance'):
-                self.fields['mitigated'].initial = self.instance.mitigated
-                self.fields['mitigated_by'].initial = self.instance.mitigated_by
-        else:
-            del self.fields['mitigated']
-            del self.fields['mitigated_by']
+        #if self.can_edit_mitigated_data:
+        #    if hasattr(self, 'instance'):
+        #        self.fields['mitigated'].initial = self.instance.mitigated
+        #        self.fields['mitigated_by'].initial = self.instance.mitigated_by
+        #else:
+        #    del self.fields['mitigated']
+        #    del self.fields['mitigated_by']
 
         if not settings.FEATURE_FINDING_GROUPS or not hasattr(self.instance, 'test'):
             del self.fields['group']
@@ -1208,13 +1208,13 @@ class FindingForm(forms.ModelForm):
     def _post_clean(self):
         super(FindingForm, self)._post_clean()
 
-        if self.can_edit_mitigated_data:
-            opts = self.instance._meta
-            try:
-                opts.get_field('mitigated').save_form_data(self.instance, self.cleaned_data.get('mitigated'))
-                opts.get_field('mitigated_by').save_form_data(self.instance, self.cleaned_data.get('mitigated_by'))
-            except forms.ValidationError as e:
-                self._update_errors(e)
+        #if self.can_edit_mitigated_data:
+        #    opts = self.instance._meta
+        #    try:
+        #        opts.get_field('mitigated').save_form_data(self.instance, self.cleaned_data.get('mitigated'))
+        #        opts.get_field('mitigated_by').save_form_data(self.instance, self.cleaned_data.get('mitigated_by'))
+        #    except forms.ValidationError as e:
+        #        self._update_errors(e)
 
     class Meta:
         model = Finding
@@ -1511,6 +1511,9 @@ class CloseFindingForm(forms.ModelForm):
                                      'required, please use the text area '
                                      'below to provide documentation.')})
 
+    mitigated = forms.DateField(required=False, widget=forms.TextInput(attrs={'class': 'datepicker', 'autocomplete': 'off'}))
+    mitigated_by = forms.ModelChoiceField(required=True, queryset=User.objects.all(), initial=get_current_user)
+    
     def __init__(self, *args, **kwargs):
         queryset = kwargs.pop('missing_note_types')
         super(CloseFindingForm, self).__init__(*args, **kwargs)
@@ -1518,10 +1521,17 @@ class CloseFindingForm(forms.ModelForm):
             self.fields['note_type'].widget = forms.HiddenInput()
         else:
             self.fields['note_type'] = forms.ModelChoiceField(queryset=queryset, label='Note Type', required=True)
+        
+        self.can_edit_mitigated_data = kwargs.pop('can_edit_mitigated_data') if 'can_edit_mitigated_data' in kwargs \
+            else False
+
+        if self.can_edit_mitigated_data:
+            self.fields['mitigated'].initial = self.instance.mitigated
+            self.fields['mitigated_by'].initial = self.instance.mitigated_by
 
     class Meta:
         model = Notes
-        fields = ['note_type', 'entry']
+        fields = ['note_type', 'entry', 'mitigated', 'mitigated_by']
 
 
 class DefectFindingForm(forms.ModelForm):


### PR DESCRIPTION
When using "EDITABLE_MITIGATED_DATA = True", several issues are present within the application:
    - Closing a finding with a mitigation date in the past close the finding badly: the "active" parameter is not set to false and thus, Finding does not appear at all in the "Closed Finding" tab...
    - Closing a finding with a mitigation date in the past close the finding badly: The assets linked to the finding are not affected and remain vulnerable, even if Finding is closed.
    - The form is added within the "Edit Finding" form, whereas there is a dedicated "Close Finding Form". Not very logical.
    - Calendar Box used is not the standard DefectDojo one.

The Fix contains:
    - Close date is added within the "Close Finding" formulary and removed from "Edit Finding", which is much more logical.
    - Calendar is set to the default one used in the whole app.
    - Closing a finding with a date in the past sets also "active" to "False" and closes the linked asset. Nothing touched here, as we are now using functions of the "Close Finding" form !