### PR TITLE
Fix entrypoint when running in Kubernetes

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/*.py)
-NUM_FILES=$(echo "$FILES" | wc -l)
+if [ -d /app/docker/extra_settings ]; then
+    FILES=$(ls /app/docker/extra_settings/*.py)
+    NUM_FILES=$(echo "$FILES" | wc -l)
+else
+    NUM_FILES=0
+fi
+
 if [ "$NUM_FILES" -gt "0" ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
     echo "============================================================"


### PR DESCRIPTION
Adds a check to see if `/app/docker/extra_settings` exists before trying to enumerate settings files from it.