### PR TITLE
[FIX] Wrong Endpoint 'Date Discovered'

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -553,6 +553,6 @@ def add_endpoints(new_finding, form):
     for endpoint in new_finding.endpoints.all():
         eps, created = Endpoint_Status.objects.get_or_create(
             finding=new_finding,
-            endpoint=endpoint)
+            endpoint=endpoint, defaults={'date': form.cleaned_data['date'] or now})
         endpoint.endpoint_status.add(eps)
         new_finding.endpoint_status.add(eps)


### PR DESCRIPTION
When creating a new Finding in the past for an Endpoint (new or already existing one), the 'Date Discovered' of this Endpoint (for the corresponding Finding) is always set to the today's date as defaulted in models.py files.
This date should be fixed to the same value than the Finding's date, because the 'Date Discovered' is linked between the Endpoint and the Finding