### PR TITLE
Bugfixing when the Checkov report has no findings

### DIFF
--- a/dojo/tools/checkov/parser.py
+++ b/dojo/tools/checkov/parser.py
@@ -19,7 +19,9 @@ class CheckovParser(object):
         if json_output:
             deserialized = self.parse_json(json_output)
             for tree in deserialized:
-                check_type = tree['check_type']
+                check_type = ''
+                if 'check_type' in tree:
+                    check_type = tree['check_type']
                 findings += self.get_items(tree, test, check_type)
 
         return findings

--- a/dojo/tools/checkov/parser.py
+++ b/dojo/tools/checkov/parser.py
@@ -19,9 +19,7 @@ class CheckovParser(object):
         if json_output:
             deserialized = self.parse_json(json_output)
             for tree in deserialized:
-                check_type = ''
-                if 'check_type' in tree:
-                    check_type = tree['check_type']
+                check_type = tree.get('check_type', '')
                 findings += self.get_items(tree, test, check_type)
 
         return findings


### PR DESCRIPTION
# Current error log:
[29/Mar/2022 11:55:54] ERROR [dojo.api_v2.exception_handler:26] 'check_type'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/app/./dojo/api_v2/views.py", line 1957, in perform_create
    serializer.save(push_to_jira=push_to_jira)
  File "/app/./dojo/api_v2/serializers.py", line 1246, in save
    test, finding_count, closed_finding_count = importer.import_scan(scan, scan_type, engagement, lead, environment,
  File "/app/./dojo/importers/importer/importer.py", line 349, in import_scan
    parsed_findings = parser.get_findings(scan, test)
  File "/app/./dojo/tools/checkov/parser.py", line 22, in get_findings
    check_type = tree['check_type']
KeyError: 'check_type'
[29/Mar/2022 11:55:54] ERROR [django.request:224] Internal Server Error: /api/v2/import-scan/
ERROR:django.request:Internal Server Error: /api/v2/import-scan/
[pid: 1|app: 0|req: 2020/4117] 10.6.33.147 () {44 vars in 738 bytes} [Tue Mar 29 11:55:54 2022] POST /api/v2/import-scan/ => generated 59 bytes in 54 msecs (HTTP/1.1 500) 7 headers in 212 bytes (1 switches on core 1)