### PR TITLE
Show file selection dialogue in OpenAPI3 Swagger

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -686,7 +686,9 @@ SPECTACULAR_SETTINGS = {
     # OTHER SETTINGS
     # the following set to False could help some client generators
     # 'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': False,
-    'POSTPROCESSING_HOOKS': ['dojo.api_v2.prefetch.schema.prefetch_postprocessing_hook']
+    'POSTPROCESSING_HOOKS': ['dojo.api_v2.prefetch.schema.prefetch_postprocessing_hook'],
+    # show file selection dialogue, see https://github.com/tfranzel/drf-spectacular/issues/455
+    "COMPONENT_SPLIT_REQUEST": True,
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
fixes #5891 

Swagger for OpenAPI3 now looks like this:

![2022-03-30 06_07_27-Defect Dojo API v2](https://user-images.githubusercontent.com/2698502/160749648-8dbc622b-8091-41b5-baf9-c1b92e75d549.png)