### PR TITLE
HELM: Fix probes when SOCIAL_LOGIN_AUTO_REDIRECT is True

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -204,7 +204,7 @@ spec:
         {{- if .Values.django.uwsgi.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /login?next=/
+            path: /login?force_login_form&next=/
             port: http
             httpHeaders:
             - name: Host

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -64,7 +64,7 @@ http {
     # Used by Kuebernetes readiness checks
     location = /uwsgi_health {
       limit_except GET { deny all; }
-      rewrite /.+ /login?next=/ break;
+      rewrite /.+ /login?force_login_form&next=/ break;
       include /run/defectdojo/uwsgi_pass;
       include /etc/nginx/wsgi_params;
       access_log off;

--- a/nginx/nginx_TLS.conf
+++ b/nginx/nginx_TLS.conf
@@ -128,7 +128,7 @@ http {
     }
     location = /uwsgi_health {
       limit_except GET { deny all; }
-      rewrite /.+ /login?next=/ break;
+      rewrite /.+ /login?force_login_form&next=/ break;
       include /run/defectdojo/uwsgi_pass;
       include /etc/nginx/wsgi_params;
       access_log off;


### PR DESCRIPTION
If `SOCIAL_LOGIN_AUTO_REDIRECT=True`, `/login?next=/` is redirected to `SOCIAL_LOGIN` handler. If it fails (for example because IdP is down) also `SOCIAL_LOGIN` mechanism fails and the container is marked as not ready or not live. This needs to be avoided because the health of DD is independent of the health of IdPs. `force_login_form` will forbid redirection.