### PR TITLE
Fix view tool product error

### DIFF
--- a/dojo/templates/dojo/view_tool_product_all.html
+++ b/dojo/templates/dojo/view_tool_product_all.html
@@ -43,9 +43,7 @@
                                   </td>
                                   <td>{{ tool.tool_configuration.tool_type.name }}</td>
                                   <td>
-                                      <div class="btn-group"><!--
-                                          <a class="btn btn-sm btn-primary"
-                                             href="{% url 'view_tool_product' tool.product.id tool.id  %}">View</a>-->
+                                      <div class="btn-group">
                                           <a class="btn btn-sm btn-warning"
                                              href="{% url 'edit_tool_product' tool.product.id tool.id  %}">Edit</a>
                                           <a class="btn btn-sm btn-danger delete-finding"


### PR DESCRIPTION
fixes https://github.com/DefectDojo/django-DefectDojo/issues/6111

`'view_tool_product' not found when I added a tool or clicked on view tools on product dashboard settings.`