### PR TITLE
Changed blue panel CSS, plus a few minor design fixes

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -326,6 +326,21 @@ form.metric_form p label {
     border-top: 0px solid #ddd;
 }
 
+.panel-blue .panel-heading,
+.panel-blue {
+    color: #f5f5f5;
+    background-color: #546474!important;
+    border-color: #546474!important;
+}
+
+.panel-blue a {
+    color: #546474;
+}
+
+.panel-blue a:hover {
+    color: #38434d;
+}
+
 .nowrap {
     white-space: nowrap;
 }
@@ -584,7 +599,7 @@ form ul#id_accepted_findings input {
 }
 
 .pagination {
-    margin: 10px 0 15px;
+    margin: 10px;
 }
 
 .pagination>.active>a, .pagination>.active>a:focus, .pagination>.active>a:hover, .pagination>.active>span, .pagination>.active>span:focus, .pagination>.active>span:hover
@@ -735,6 +750,11 @@ body #header form#api_selector .input a#explore {
 .controls ul {
     list-style-type: none;
     margin: 0
+}
+
+div.dataTables_wrapper
+div.dataTables_filter {
+    margin: 10px!important;
 }
 
 .navbar li.search-form {
@@ -1215,6 +1235,10 @@ div.custom-search-form {
 
 .panel-footer small{
 	color: #246c91;
+}
+
+div.dt-buttons {
+    margin: 10px!important;
 }
 
 table#product_types .btn-success{

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -15,7 +15,7 @@
         <div class="row status">
             {% block active_engagements %}
                 <div class="col-lg-3 col-md-6">
-                    <div class="panel secondary-color">
+                    <div class="panel panel-blue">
                         <div class="panel-heading">
                             <div class="row">
                                 <div class="col-xs-3">


### PR DESCRIPTION
Previously, the blue panel on Dojo Dashboard used the "secondary-color" CSS class, created "panel-blue" specific CSS class. Also added a few minor design fixes to add spacing between buttons on forms, as well as the search bar on forms (such as the "View Products" page).

<img width="1427" alt="Screen Shot 2022-04-04 at 6 17 15 PM" src="https://user-images.githubusercontent.com/76979297/161647782-217e3e2a-fdc4-4e91-9dde-2a232cd5f708.png">


<img width="1427" alt="Screen Shot 2022-04-04 at 6 16 51 PM" src="https://user-images.githubusercontent.com/76979297/161647752-bad2228a-7bf7-4fbb-800b-df653644930c.png">

