### PR TITLE
fix(helm): redis auth variables changed path

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -115,8 +115,8 @@ spec:
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}
-              name: {{ .Values.redis.existingSecret }}
-              key: {{ .Values.redis.secretKey }}
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
             {{- end }}  
             {{- end }}
         - name: DD_DATABASE_PASSWORD

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -110,8 +110,8 @@ spec:
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}
-              name: {{ .Values.redis.existingSecret }}
-              key: {{ .Values.redis.secretKey }}
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
             {{- end }}  
             {{- end }}
         - name: DD_DATABASE_PASSWORD

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -169,8 +169,8 @@ spec:
               name: defectdojo-{{ .Values.celery.broker }}-specific
               key: {{ .Values.celery.broker }}-password
             {{- else }}
-              name: {{ .Values.redis.existingSecret }}
-              key: {{ .Values.redis.secretKey }}
+              name: {{ .Values.redis.auth.existingSecret }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
             {{- end }}  
             {{- end }}
         {{- if .Values.django.uwsgi.enable_debug }}


### PR DESCRIPTION
fix(helm): update redis keys [@alles-klar](https://github.com/alles-klar) ([#5886](https://github.com/DefectDojo/django-DefectDojo/pull/5886))
changed the values.yaml keys for redis auth, but did not change those keys in the deployments.
This PR shall fix this