### PR TITLE
Endpoint Meta Importer - Import UTF-8-BOM files

### DIFF
--- a/dojo/endpoint/utils.py
+++ b/dojo/endpoint/utils.py
@@ -306,6 +306,8 @@ def save_endpoints_to_add(endpoint_list, product):
 
 def endpoint_meta_import(file, product, create_endpoints, create_tags, create_meta, origin='UI', request=None):
     content = file.read()
+    sig = content.decode('utf-8-sig')
+    content = sig.encode("utf-8")
     if type(content) is bytes:
         content = content.decode('utf-8')
     reader = csv.DictReader(io.StringIO(content))


### PR DESCRIPTION
I learned that windows attached something the byte order mark onto files that are generated on windows. The endpoint meta importer did not accept that file encoding.