### PR TITLE
Improve notifications on Exceptions 

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -95,7 +95,6 @@ def create_notification(event=None, **kwargs):
                 logger.debug('Product is not specified, making it silent')
                 users = users.filter(is_superuser=True)
 
-
             for user in users:
                 logger.debug("Authorized user for the product %s", user)
                 # send notifications to user after merging possible multiple notifications records (i.e. personal global + personal product)

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -20,7 +20,7 @@ def create_notification(event=None, **kwargs):
 
     if 'recipients' in kwargs:
         # mimic existing code so that when recipients is specified, no other system or personal notifications are sent.
-        logger.debug('creating notifications for recipients')
+        logger.debug('creating notifications for recipients: %s', kwargs['recipients'])
         for recipient_notifications in Notifications.objects.filter(user__username__in=kwargs['recipients'], user__is_active=True, product=None):
             # kwargs.update({'user': recipient_notifications.user})
             process_notifications(event, recipient_notifications, **kwargs)
@@ -32,19 +32,29 @@ def create_notification(event=None, **kwargs):
         product_type = None
         if 'product_type' in kwargs:
             product_type = kwargs.get('product_type')
+            logger.debug("Defined product type %s", product_type)
 
         product = None
         if 'product' in kwargs:
             product = kwargs.get('product')
+            logger.debug("Defined product  %s", product)
+
         elif 'engagement' in kwargs:
             product = kwargs['engagement'].product
+            logger.debug("Defined product of engagement %s", product)
+
         elif 'test' in kwargs:
             product = kwargs['test'].engagement.product
+            logger.debug("Defined product of test %s", product)
+
         elif 'finding' in kwargs:
             product = kwargs['finding'].test.engagement.product
+            logger.debug("Defined product of finding %s", product)
+
         elif 'obj' in kwargs:
             from dojo.utils import get_product
             product = get_product(kwargs['obj'])
+            logger.debug("Defined product of obj %s", product)
 
         # System notifications
         try:
@@ -73,16 +83,26 @@ def create_notification(event=None, **kwargs):
                 .filter((Q(applicable_notifications_count__gt=0) | Q(is_superuser=True)))
 
             # only send to authorized users or admin/superusers
+            logger.debug('Filtering users for the product %s', product)
+
             if product:
                 users = get_authorized_users_for_product_and_product_type(users, product, Permissions.Product_View)
+
             elif product_type:
                 users = get_authorized_users_for_product_type(users, product_type, Permissions.Product_Type_View)
+            else:
+                # nor product_type nor product defined, we should not make noise and send only notifications to admins
+                logger.debug('Product is not specified, making it silent')
+                users = users.filter(is_superuser=True)
+
 
             for user in users:
+                logger.debug("Authorized user for the product %s", user)
                 # send notifications to user after merging possible multiple notifications records (i.e. personal global + personal product)
                 # kwargs.update({'user': user})
                 applicable_notifications = user.applicable_notifications
                 if user.is_superuser:
+                    logger.debug("User %s is superuser", user)
                     # admin users get all system notifications
                     applicable_notifications.append(system_notifications)
 

--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -155,75 +155,87 @@ class SonarQubeApiImporter(object):
                 title='SonarQube API import issue',
                 description=e,
                 icon='exclamation-triangle',
-                source='SonarQube API'
+                source='SonarQube API',
+                obj=test.engagement.product
             )
 
         return items
 
     def import_hotspots(self, test):
+        try:
+            items = list()
+            client, config = self.prepare_client(test)
 
-        items = list()
-        client, config = self.prepare_client(test)
+            if config and config.service_key_1:  # https://github.com/DefectDojo/django-DefectDojo/pull/4676 cases no. 5 and 8
+                component = client.get_project(config.service_key_1)
+            else:  # https://github.com/DefectDojo/django-DefectDojo/pull/4676 cases no. 2, 4 and 7
+                component = client.find_project(test.engagement.product.name)
 
-        if config and config.service_key_1:  # https://github.com/DefectDojo/django-DefectDojo/pull/4676 cases no. 5 and 8
-            component = client.get_project(config.service_key_1)
-        else:  # https://github.com/DefectDojo/django-DefectDojo/pull/4676 cases no. 2, 4 and 7
-            component = client.find_project(test.engagement.product.name)
+            hotspots = client.find_hotspots(component['key'])
+            logging.info('Found {} hotspots for project {}'.format(len(hotspots), component["key"]))
 
-        hotspots = client.find_hotspots(component['key'])
-        logging.info('Found {} hotspots for project {}'.format(len(hotspots), component["key"]))
+            for hotspot in hotspots:
+                status = hotspot['status']
 
-        for hotspot in hotspots:
-            status = hotspot['status']
+                if self.is_reviewed(status):
+                    continue
 
-            if self.is_reviewed(status):
-                continue
+                type = 'SECURITY_HOTSPOT'
+                severity = 'Info'
+                title = textwrap.shorten(text=hotspot['message'], width=500)
+                component_key = hotspot['component']
+                line = hotspot.get('line')
+                rule_id = hotspot['key']
+                rule = client.get_hotspot_rule(rule_id)
+                scanner_confidence = self.convert_scanner_confidence(hotspot['vulnerabilityProbability'])
+                description = self.clean_rule_description_html(rule['vulnerabilityDescription'])
+                cwe = self.clean_cwe(rule['fixRecommendations'])
+                references = self.get_references(rule['riskDescription']) + self.get_references(rule['fixRecommendations'])
 
-            type = 'SECURITY_HOTSPOT'
-            severity = 'Info'
-            title = textwrap.shorten(text=hotspot['message'], width=500)
-            component_key = hotspot['component']
-            line = hotspot.get('line')
-            rule_id = hotspot['key']
-            rule = client.get_hotspot_rule(rule_id)
-            scanner_confidence = self.convert_scanner_confidence(hotspot['vulnerabilityProbability'])
-            description = self.clean_rule_description_html(rule['vulnerabilityDescription'])
-            cwe = self.clean_cwe(rule['fixRecommendations'])
-            references = self.get_references(rule['riskDescription']) + self.get_references(rule['fixRecommendations'])
+                sonarqube_issue, _ = Sonarqube_Issue.objects.update_or_create(
+                    key=hotspot['key'],
+                    defaults={
+                        'status': status,
+                        'type': type
+                    }
+                )
 
-            sonarqube_issue, _ = Sonarqube_Issue.objects.update_or_create(
-                key=hotspot['key'],
-                defaults={
-                    'status': status,
-                    'type': type
-                }
+                # Only assign the SonarQube_issue to the first finding related to the issue
+                if Finding.objects.filter(sonarqube_issue=sonarqube_issue).exists():
+                    sonarqube_issue = None
+
+                find = Finding(
+                    title=title,
+                    cwe=cwe,
+                    description=description,
+                    test=test,
+                    severity=severity,
+                    references=references,
+                    file_path=component_key,
+                    line=line,
+                    active=True,
+                    verified=self.is_confirmed(status),
+                    false_p=False,
+                    duplicate=False,
+                    out_of_scope=False,
+                    static_finding=True,
+                    scanner_confidence=scanner_confidence,
+                    sonarqube_issue=sonarqube_issue,
+                )
+                items.append(find)
+
+            return items
+
+        except Exception as e:
+            logger.exception(e)
+            create_notification(
+                event='other',
+                title='SonarQube API import issue',
+                description=e,
+                icon='exclamation-triangle',
+                source='SonarQube API',
+                obj=test.engagement.product
             )
-
-            # Only assign the SonarQube_issue to the first finding related to the issue
-            if Finding.objects.filter(sonarqube_issue=sonarqube_issue).exists():
-                sonarqube_issue = None
-
-            find = Finding(
-                title=title,
-                cwe=cwe,
-                description=description,
-                test=test,
-                severity=severity,
-                references=references,
-                file_path=component_key,
-                line=line,
-                active=True,
-                verified=self.is_confirmed(status),
-                false_p=False,
-                duplicate=False,
-                out_of_scope=False,
-                static_finding=True,
-                scanner_confidence=scanner_confidence,
-                sonarqube_issue=sonarqube_issue,
-            )
-            items.append(find)
-
-        return items
 
     @staticmethod
     def clean_rule_description_html(raw_html):


### PR DESCRIPTION
In current implementation in case of Exceptions, e.g SonarQube availability, all users will receive information about it, even those who are not entitled for particular product. 

This PR just detects if product is not defined, and then sends notifications only to admins. 
And enhances sonarqubeAPI parser to distribute product as part of Exception (obj). 

