### PR TITLE
Hotfix 0150 - skip broken endpoint_statuses + command for removal of broken endpoints

### DIFF
--- a/dojo/db_migrations/0150_dedupe_endpoint_status.py
+++ b/dojo/db_migrations/0150_dedupe_endpoint_status.py
@@ -1,5 +1,5 @@
 from django.db import migrations
-from django.db.models import Count
+from django.db.models import Count, Q
 import logging
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,8 @@ class Migration(migrations.Migration):
         Endpoint = apps.get_model('dojo', 'endpoint')
         Finding = apps.get_model('dojo', 'finding')
 
-        to_process = Endpoint_Status.objects.values('finding', 'endpoint').annotate(cnt=Count('id')).filter(cnt__gt=1)
+        to_process = Endpoint_Status.objects.exclude(Q(endpoint=None) | Q(finding=None))\
+            .values('finding', 'endpoint').annotate(cnt=Count('id')).filter(cnt__gt=1)
         if to_process.count() == 0:
             logger.info('There is nothing to process')
         else:

--- a/dojo/endpoint/utils.py
+++ b/dojo/endpoint/utils.py
@@ -361,3 +361,16 @@ def endpoint_meta_import(file, product, create_endpoints, create_tags, create_me
                 # if tags are not supposed to be added, this value remain unchanged
                 endpoint.tags = existing_tags
             endpoint.save()
+
+
+def remove_broken_endpoint_statuses(apps):
+    Finding = apps.get_model('dojo', 'Finding')
+    Endpoint = apps.get_model('dojo', 'Endpoint')
+    Endpoint_Status = apps.get_model('dojo', 'endpoint_status')
+    broken_eps = Endpoint_Status.objects.filter(Q(endpoint=None) | Q(finding=None))
+    if broken_eps.count() == 0:
+        logger.info('There is no broken endpoint_status')
+    else:
+        logger.warning('We identified %s broken endpoint_statuses', broken_eps.count())
+        deleted = broken_eps.delete()
+        logger.warning('We removed: %s', deleted)

--- a/dojo/management/commands/fix_broken_endpoint_status.py
+++ b/dojo/management/commands/fix_broken_endpoint_status.py
@@ -1,0 +1,15 @@
+from django.core.management.base import BaseCommand
+from django.apps import apps
+from dojo.endpoint.utils import remove_broken_endpoint_statuses
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+
+    help = 'Usage: manage.py remove_broken_endpoint_statuses.py'
+
+    def handle(self, *args, **options):
+        remove_broken_endpoint_statuses(apps=apps)

--- a/unittests/test_endpoint_model.py
+++ b/unittests/test_endpoint_model.py
@@ -1,8 +1,12 @@
+import datetime
 from .dojo_test_case import DojoTestCase
 
 from dojo.endpoint.utils import endpoint_get_or_create
-from dojo.models import Endpoint
+from dojo.models import Product_Type, Product, Engagement, Test, Finding, Endpoint, Endpoint_Status
 from django.core.exceptions import ValidationError
+from django.apps import apps
+from django.utils import timezone
+from dojo.endpoint.utils import remove_broken_endpoint_statuses
 
 
 class TestEndpointModel(DojoTestCase):
@@ -149,3 +153,95 @@ class TestEndpointModel(DojoTestCase):
             port=8443
         )
         self.assertTrue(created7)
+
+
+# TODO: These tests can be skipped in the future (when Endpoint_Status.{finding,endpoint}(null=False,blank=False))
+# @skip("Outdated - this class was testing clean-up broken entries in old version of model; new version of model doesn't to store broken entries")
+class TestEndpointStatusBrokenModel(DojoTestCase):
+
+    def test_endpoint_status_broken(self):
+
+        self.prod_type = Product_Type.objects.create()
+        self.product = Product.objects.create(prod_type=self.prod_type)
+        self.engagement = Engagement.objects.create(
+            product=self.product,
+            target_start=datetime.datetime(2020, 1, 1, tzinfo=timezone.utc),
+            target_end=datetime.datetime(2022, 1, 1, tzinfo=timezone.utc)
+        )
+        self.test = Test.objects.create(
+            engagement=self.engagement,
+            target_start=datetime.datetime(2020, 1, 1, tzinfo=timezone.utc),
+            target_end=datetime.datetime(2022, 1, 1, tzinfo=timezone.utc),
+            test_type_id=1
+        )
+        from django.contrib.auth import get_user_model
+        user = get_user_model().objects.create().pk
+        self.finding = Finding.objects.create(test=self.test, reporter_id=user).pk
+        self.endpoint = Endpoint.objects.create(protocol='http', host='foo.bar.eps').pk
+        self.another_finding = Finding.objects.create(test=self.test, reporter_id=user).pk
+        self.another_endpoint = Endpoint.objects.create(protocol='http', host='bar.foo.eps').pk
+        self.endpoint_status = {
+            'standard': Endpoint_Status.objects.create(
+                date=datetime.datetime(2021, 3, 1, tzinfo=timezone.utc),
+                last_modified=datetime.datetime(2021, 4, 1, tzinfo=timezone.utc),
+                mitigated=False,
+                finding_id=self.finding,
+                endpoint_id=self.endpoint
+            ).pk,
+            'removed_endpoint': Endpoint_Status.objects.create(
+                date=datetime.datetime(2021, 2, 1, tzinfo=timezone.utc),
+                last_modified=datetime.datetime(2021, 5, 1, tzinfo=timezone.utc),
+                mitigated=True,
+                finding_id=self.another_finding,
+                endpoint_id=None
+            ).pk,
+            'removed_finding': Endpoint_Status.objects.create(
+                date=datetime.datetime(2021, 2, 1, tzinfo=timezone.utc),
+                last_modified=datetime.datetime(2021, 5, 1, tzinfo=timezone.utc),
+                mitigated=True,
+                finding_id=None,
+                endpoint_id=self.another_endpoint
+            ).pk,
+        }
+
+        Finding.objects.get(id=self.finding).endpoint_status.add(
+            Endpoint_Status.objects.get(id=self.endpoint_status['standard'])
+        )
+        Finding.objects.get(id=self.another_finding).endpoint_status.add(
+            Endpoint_Status.objects.get(id=self.endpoint_status['removed_endpoint'])
+        )
+
+        Endpoint.objects.get(id=self.endpoint).endpoint_status.add(
+            Endpoint_Status.objects.get(id=self.endpoint_status['standard'])
+        )
+        Endpoint.objects.get(id=self.another_endpoint).endpoint_status.add(
+            Endpoint_Status.objects.get(id=self.endpoint_status['removed_finding'])
+        )
+
+        remove_broken_endpoint_statuses(apps)
+
+        with self.subTest('Stadnard eps for finding'):
+            f = Finding.objects.filter(id=self.finding)
+            self.assertEqual(f.count(), 1)
+            f = f.first()
+            self.assertEqual(f.endpoint_status.count(), 1)
+            self.assertEqual(f.endpoint_status.first().pk, self.endpoint_status['standard'])
+
+        with self.subTest('Broken eps for finding'):
+            f = Finding.objects.filter(id=self.another_finding)
+            self.assertEqual(f.count(), 1)
+            f = f.first()
+            self.assertEqual(f.endpoint_status.count(), 0)
+
+        with self.subTest('Stadnard eps for endpoint'):
+            e = Endpoint.objects.filter(id=self.endpoint)
+            self.assertEqual(e.count(), 1)
+            e = e.first()
+            self.assertEqual(e.endpoint_status.count(), 1)
+            self.assertEqual(e.endpoint_status.first().pk, self.endpoint_status['standard'])
+
+        with self.subTest('Broken eps for endpoint'):
+            e = Endpoint.objects.filter(id=self.another_endpoint)
+            self.assertEqual(e.count(), 1)
+            e = e.first()
+            self.assertEqual(e.endpoint_status.count(), 0)


### PR DESCRIPTION
Original migration was failing in case the finding or the endpoint of endpoint_status was removed. Removal sets one of the values to null so it changes the related entry to broken (endpoint_status with an empty endpoint or finding doesn't make sense).

This PR:
 - fix original migration - it skips broken endpoint_statuses
 - unittests checking correctness of migrations
 - add command `manage.py remove_broken_endpoint_statuses.py`

https://owasp.slack.com/archives/C2P5BA8MN/p1649278993631269?thread_ts=1649254658.509179&cid=C2P5BA8MN