### PR TITLE
Enlarge RAM Request

### DIFF
--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -189,7 +189,7 @@ django:
     resources:
       requests:
         cpu: 100m
-        memory: 128Mi
+        memory: 256Mi
       limits:
         cpu: 2000m
         memory: 512Mi


### PR DESCRIPTION
Hi,

on all my defectdojo instances, the uwsgi DefectDojo container operates with ~250MB. Therefore, I recommend to set the request higher to not get into resource conflicts. 

Kind regards
Timo