### PR TITLE
[HELM] Network policies

### DIFF
--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -140,7 +140,7 @@ jobs:
           minikube version: 'v1.24.0'
           kubernetes version: ${{ matrix.k8s }}
           driver: docker
-          start args: '--addons=ingress'
+          start args: '--addons=ingress --cni calico'
 
       - name: Status of minikube
         run: |-
@@ -194,6 +194,7 @@ jobs:
 
       - name: Check Application
         run: |-
+             echo 'Running from fork'
              to_complete () {
                kubectl wait --for=$1 $2 --timeout=500s --selector=$3 2>/tmp/test || true
                if [[ -s /tmp/test ]]; then

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -194,7 +194,6 @@ jobs:
 
       - name: Check Application
         run: |-
-             echo 'Running from fork'
              to_complete () {
                kubectl wait --for=$1 $2 --timeout=500s --selector=$3 2>/tmp/test || true
                if [[ -s /tmp/test ]]; then

--- a/helm/defectdojo/templates/network-policy.yaml
+++ b/helm/defectdojo/templates/network-policy.yaml
@@ -1,0 +1,22 @@
+{{- if eq (.Values.networkPolicy.enabled | toString) "true"  }}
+{{- $fullName := include "defectdojo.fullname" . -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-networkpolicy
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+  {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{ end }}
+{{ end }}

--- a/helm/defectdojo/templates/network-policy.yaml
+++ b/helm/defectdojo/templates/network-policy.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ $fullName }}-networkpolicy
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "defectdojo.chart" . }}
+    app.kubernetes.io/name: {{ include "defectdojo.name" . }}
 spec:
   podSelector:
     matchLabels:
@@ -26,6 +29,9 @@ metadata:
   name: {{ $fullName }}-networkpolicy-django
   labels:
     app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "defectdojo.chart" . }}
+    app.kubernetes.io/name: {{ include "defectdojo.name" . }}
 spec:
   podSelector:
     matchLabels:

--- a/helm/defectdojo/templates/network-policy.yaml
+++ b/helm/defectdojo/templates/network-policy.yaml
@@ -39,10 +39,10 @@ spec:
   ingress:
     - from: []
       ports:
-        {{- if .if .Values.django.nginx.tls.enabled }}
+        {{- if .Values.django.nginx.tls.enabled }}
         - port: 8443
         {{- else }}
-        - port: 8443
+        - port: 8080
         {{- end  }}
           protocol: TCP
 {{ end }}

--- a/helm/defectdojo/templates/network-policy.yaml
+++ b/helm/defectdojo/templates/network-policy.yaml
@@ -15,8 +15,26 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
+    - from: []
+      ports:
+        - port: 8080
   {{- if .Values.networkPolicy.egress }}
   egress:
   {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
   {{ end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $fullName }}-networkpolicy-django
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      defectdojo.org/component: django
+  ingress:
+    - from: []
+      ports:
+        - port: 8080
 {{ end }}

--- a/helm/defectdojo/templates/network-policy.yaml
+++ b/helm/defectdojo/templates/network-policy.yaml
@@ -39,6 +39,10 @@ spec:
   ingress:
     - from: []
       ports:
-        - port: 8080
+        {{- if .if .Values.django.nginx.tls.enabled }}
+        - port: 8443
+        {{- else }}
+        - port: 8443
+        {{- end  }}
           protocol: TCP
 {{ end }}

--- a/helm/defectdojo/templates/network-policy.yaml
+++ b/helm/defectdojo/templates/network-policy.yaml
@@ -15,9 +15,6 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
-    - from: []
-      ports:
-        - port: 8080
   {{- if .Values.networkPolicy.egress }}
   egress:
   {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
@@ -37,4 +34,5 @@ spec:
     - from: []
       ports:
         - port: 8080
+          protocol: TCP
 {{ end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -16,6 +16,10 @@ createPostgresqlSecret: false
 # - enabled, enables tracking configuration changes based on SHA256
 # trackConfig: disabled
 
+# When set to true, enables a Network Policy for the for the defectDojo.
+# networkPolicy: false
+
+
 # Configuration value to select database type
 # Option to use "postgresql" or "mysql" database type, by default "mysql" is chosen
 # Set the "enable" field to true of the database type you select (if you want to use internal database) and false of the one you don't select

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -16,9 +16,18 @@ createPostgresqlSecret: false
 # - enabled, enables tracking configuration changes based on SHA256
 # trackConfig: disabled
 
-# When set to true, enables a Network Policy for the for the defectDojo.
-# networkPolicy: false
-
+# Enables network policy for server pods
+# check https://kubernetes.io/docs/concepts/services-networking/network-policies/
+networkPolicy:
+  enabled: false
+  egress: []
+  # egress:
+  # - to:
+  #   - ipBlock:
+  #       cidr: 10.0.0.0/24
+  #   ports:
+  #   - protocol: TCP
+  #     port: 443
 
 # Configuration value to select database type
 # Option to use "postgresql" or "mysql" database type, by default "mysql" is chosen

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -16,8 +16,8 @@ createPostgresqlSecret: false
 # - enabled, enables tracking configuration changes based on SHA256
 # trackConfig: disabled
 
-# Enables network policy for server pods
-# check https://kubernetes.io/docs/concepts/services-networking/network-policies/
+# Enables application network policy
+# For more info follow https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy:
   enabled: false
   egress: []


### PR DESCRIPTION
This brings light network policies option, that blocks k8s defaults to have open communication between all pods within the cluster. When the option is enabled, communication is allowed only within the DD application components within the same namespace, and from an ingressController toward Django pods from the outside of a namespace. 

Default: disabled 
