### PR TITLE
Read only authorized users in filters and calendar

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -32,7 +32,7 @@ from dojo.forms import CheckForm, \
 from dojo.models import Finding, Product, Engagement, Test, \
     Check_List, Test_Import, Notes, \
     Risk_Acceptance, Development_Environment, Endpoint, \
-    Cred_Mapping, Dojo_User, System_Settings, Note_Type, Product_API_Scan_Configuration
+    Cred_Mapping, System_Settings, Note_Type, Product_API_Scan_Configuration
 from dojo.tools.factory import get_scan_types_sorted
 from dojo.utils import add_error_message_to_response, add_success_message_to_response, get_page_items, add_breadcrumb, handle_uploaded_threat, \
     FileIterWrapper, get_cal_event, Product_Tab, is_scan_file_too_large, \

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -50,6 +50,7 @@ from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.roles_permissions import Permissions
 from dojo.product.queries import get_authorized_products
 from dojo.engagement.queries import get_authorized_engagements
+from dojo.user.queries import get_authorized_users
 from dojo.authorization.authorization_decorators import user_is_authorized
 from dojo.importers.importer.importer import DojoDefaultImporter as Importer
 import dojo.notifications.helper as notifications_helper
@@ -83,7 +84,7 @@ def engagement_calendar(request):
             'caltype': 'engagements',
             'leads': request.GET.getlist('lead', ''),
             'engagements': engagements,
-            'users': Dojo_User.objects.all()
+            'users': get_authorized_users(Permissions.Engagement_View)
         })
 
 

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1153,6 +1153,18 @@ div.custom-search-form {
     background-color: #f9f9f9;
 }
 
+#the-filters-open {
+    background-color: #f9f9f9;
+}
+
+#the-filters-paused {
+    background-color: #f9f9f9;
+}
+
+#the-filters-closed {
+    background-color: #f9f9f9;
+}
+
 .panel-default {
     border: 1px solid #dddedf;
 }

--- a/dojo/templates/dojo/action_history.html
+++ b/dojo/templates/dojo/action_history.html
@@ -9,7 +9,7 @@
                     <h3>
                         {{ obj }} History
                         <div class="dropdown pull-right">
-                            <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
+                            <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters" aria-label="Filter"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
                         </div>
                     </h3>
                 </div>

--- a/dojo/templates/dojo/action_history.html
+++ b/dojo/templates/dojo/action_history.html
@@ -8,7 +8,13 @@
                 <div class="panel-heading tight">
                     <h3>
                         {{ obj }} History
+                        <div class="dropdown pull-right">
+                            <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
+                        </div>
                     </h3>
+                </div>
+                <div id="the-filters" class="is-filters panel-body collapse {% if log_entry_filter.form.has_changed %}in{% endif %}">
+                    {% include "dojo/filter_snippet.html" with form=log_entry_filter.form %}
                 </div>
             </div>
             {% if history %}

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -6,6 +6,7 @@
         <div class="panel-heading">
             <h4> {% if status == "open" %}Active{% elif status == "paused" %}Paused {% else %}Closed{% endif %} Engagements ({{ count }})
                 <div class="dropdown pull-right">
+                    <button id="show-filters-{{status}}" data-toggle="collapse" data-target="#the-filters-{{status}}" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
                     <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1" aria-label="Add Engagement"
                     data-toggle="dropdown" aria-expanded="true">
                 <span class="fa fa-bars"></span>

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -6,7 +6,7 @@
         <div class="panel-heading">
             <h4> {% if status == "open" %}Active{% elif status == "paused" %}Paused {% else %}Closed{% endif %} Engagements ({{ count }})
                 <div class="dropdown pull-right">
-                    <button id="show-filters-{{status}}" data-toggle="collapse" data-target="#the-filters-{{status}}" class="btn btn-primary toggle-filters"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
+                    <button id="show-filters-{{status}}" data-toggle="collapse" data-target="#the-filters-{{status}}" class="btn btn-primary toggle-filters" aria-label="Filter"> <i class="fa fa-filter"></i> <i class="caret"></i> </button>
                     <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1" aria-label="Add Engagement"
                     data-toggle="dropdown" aria-expanded="true">
                 <span class="fa fa-bars"></span>

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -27,7 +27,7 @@ from dojo.forms import NoteForm, TestForm, \
     ReImportScanForm, JIRAFindingForm, JIRAImportScanForm, \
     FindingBulkUpdateForm
 from dojo.models import IMPORT_UNTOUCHED_FINDING, Finding, Finding_Group, Test, Note_Type, BurpRawRequestResponse, Endpoint, Stub_Finding, \
-    Finding_Template, Cred_Mapping, Dojo_User, System_Settings, Test_Import, Product_API_Scan_Configuration, Test_Import_Finding_Action
+    Finding_Template, Cred_Mapping, System_Settings, Test_Import, Product_API_Scan_Configuration, Test_Import_Finding_Action
 
 from dojo.tools.factory import get_choices_sorted, get_scan_types_sorted
 from dojo.utils import add_error_message_to_response, add_field_errors_to_response, add_success_message_to_response, get_page_items, get_page_items_and_count, add_breadcrumb, get_cal_event, process_notifications, get_system_setting, \

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -43,6 +43,7 @@ from dojo.authorization.authorization_decorators import user_is_authorized
 from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.roles_permissions import Permissions
 from dojo.test.queries import get_authorized_tests
+from dojo.user.queries import get_authorized_users
 from dojo.importers.reimporter.reimporter import DojoDefaultReImporter as ReImporter
 
 
@@ -322,7 +323,7 @@ def test_calendar(request):
         'caltype': 'tests',
         'leads': request.GET.getlist('lead', ''),
         'tests': tests,
-        'users': Dojo_User.objects.all()})
+        'users': get_authorized_users(Permissions.Test_View)})
 
 
 @user_is_authorized(Test, Permissions.Test_View, 'tid')

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -60,7 +60,7 @@ def get_authorized_users(permission, user=None):
     if user is None:
         return Dojo_User.objects.none()
 
-    users = Dojo_User.objects.order_by('first_name', 'last_name', 'username')
+    users = Dojo_User.objects.all().order_by('first_name', 'last_name', 'username')
 
     if user.is_superuser or user_has_global_permission(user, permission):
         return users

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -54,7 +54,7 @@ def get_authorized_users(permission, user=None):
     if user is None:
         return Dojo_User.objects.none()
 
-    users = Dojo_User.objects.filter(is_active=True).order_by('first_name', 'last_name', 'username')
+    users = Dojo_User.objects.order_by('first_name', 'last_name', 'username')
 
     if user.is_superuser or user_has_global_permission(user, permission):
         return users

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -11,11 +11,13 @@ from dojo.request_cache import cache_for_request
 def get_authorized_users_for_product_type(users, product_type, permission):
     roles = get_roles_for_permission(permission)
     product_type_members = Product_Type_Member.objects \
-        .filter(product_type=product_type, role__in=roles)
+        .filter(product_type=product_type, role__in=roles) \
+        .select_related('user')
     product_type_groups = Product_Type_Group.objects \
         .filter(product_type=product_type, role__in=roles)
-    group_members = Dojo_Group_Member.objects. \
-        filter(group__in=[ptg.group for ptg in product_type_groups])
+    group_members = Dojo_Group_Member.objects \
+        .filter(group__in=[ptg.group for ptg in product_type_groups]) \
+        .select_related('user')
     return users.filter(Q(id__in=[ptm.user.id for ptm in product_type_members]) |
         Q(id__in=[gm.user.id for gm in group_members]) |
         Q(global_role__role__in=roles) |
@@ -28,16 +30,20 @@ def get_authorized_users_for_product_and_product_type(users, product, permission
 
     roles = get_roles_for_permission(permission)
     product_members = Product_Member.objects \
-        .filter(product=product, role__in=roles)
+        .filter(product=product, role__in=roles) \
+        .select_related('user')
     product_type_members = Product_Type_Member.objects \
-        .filter(product_type=product.prod_type, role__in=roles)
+        .filter(product_type=product.prod_type, role__in=roles) \
+        .select_related('user')
     product_groups = Product_Group.objects \
         .filter(product=product, role__in=roles)
     product_type_groups = Product_Type_Group.objects \
         .filter(product_type=product.prod_type, role__in=roles)
-    group_members = Dojo_Group_Member.objects.filter(
-        Q(group__in=[pg.group for pg in product_groups]) |
-        Q(group__in=[ptg.group for ptg in product_type_groups]))
+    group_members = Dojo_Group_Member.objects \
+        .filter(
+            Q(group__in=[pg.group for pg in product_groups]) |
+            Q(group__in=[ptg.group for ptg in product_type_groups])) \
+        .select_related('user')
     return users.filter(Q(id__in=[pm.user.id for pm in product_members]) |
         Q(id__in=[ptm.user.id for ptm in product_type_members]) |
         Q(id__in=[gm.user.id for gm in group_members]) |
@@ -64,16 +70,20 @@ def get_authorized_users(permission, user=None):
 
     roles = get_roles_for_permission(permission)
     product_members = Product_Member.objects \
-        .filter(product_id__in=authorized_products, role__in=roles)
+        .filter(product_id__in=authorized_products, role__in=roles) \
+        .select_related('user')
     product_type_members = Product_Type_Member.objects \
-        .filter(product_type_id__in=authorized_product_types, role__in=roles)
+        .filter(product_type_id__in=authorized_product_types, role__in=roles) \
+        .select_related('user')
     product_groups = Product_Group.objects \
         .filter(product_id__in=authorized_products, role__in=roles)
     product_type_groups = Product_Type_Group.objects \
         .filter(product_type_id__in=authorized_product_types, role__in=roles)
-    group_members = Dojo_Group_Member.objects.filter(
-        Q(group__in=[pg.group for pg in product_groups]) |
-        Q(group__in=[ptg.group for ptg in product_type_groups]))
+    group_members = Dojo_Group_Member.objects \
+        .filter(
+            Q(group__in=[pg.group for pg in product_groups]) |
+            Q(group__in=[ptg.group for ptg in product_type_groups])) \
+        .select_related('user')
     return users.filter(Q(id__in=[pm.user.id for pm in product_members]) |
         Q(id__in=[ptm.user.id for ptm in product_type_members]) |
         Q(id__in=[gm.user.id for gm in group_members]) |

--- a/dojo/user/queries.py
+++ b/dojo/user/queries.py
@@ -1,7 +1,11 @@
+from crum import get_current_user
 from django.db.models import Q
 from dojo.models import Dojo_Group_Member, Product_Member, Product_Type_Member, \
     Product_Group, Product_Type_Group, Dojo_User
-from dojo.authorization.authorization import get_roles_for_permission
+from dojo.authorization.authorization import get_roles_for_permission, user_has_global_permission
+from dojo.product.queries import get_authorized_products
+from dojo.product_type.queries import get_authorized_product_types
+from dojo.request_cache import cache_for_request
 
 
 def get_authorized_users_for_product_type(users, product_type, permission):
@@ -31,6 +35,42 @@ def get_authorized_users_for_product_and_product_type(users, product, permission
         .filter(product=product, role__in=roles)
     product_type_groups = Product_Type_Group.objects \
         .filter(product_type=product.prod_type, role__in=roles)
+    group_members = Dojo_Group_Member.objects.filter(
+        Q(group__in=[pg.group for pg in product_groups]) |
+        Q(group__in=[ptg.group for ptg in product_type_groups]))
+    return users.filter(Q(id__in=[pm.user.id for pm in product_members]) |
+        Q(id__in=[ptm.user.id for ptm in product_type_members]) |
+        Q(id__in=[gm.user.id for gm in group_members]) |
+        Q(global_role__role__in=roles) |
+        Q(is_superuser=True))
+
+
+# Cached because it is a complex SQL query and it is called 3 times for the engagement lists in products
+@cache_for_request
+def get_authorized_users(permission, user=None):
+    if user is None:
+        user = get_current_user()
+
+    if user is None:
+        return Dojo_User.objects.none()
+
+    users = Dojo_User.objects.filter(is_active=True).order_by('first_name', 'last_name', 'username')
+
+    if user.is_superuser or user_has_global_permission(user, permission):
+        return users
+
+    authorized_products = get_authorized_products(permission).values('id')
+    authorized_product_types = get_authorized_product_types(permission).values('id')
+
+    roles = get_roles_for_permission(permission)
+    product_members = Product_Member.objects \
+        .filter(product_id__in=authorized_products, role__in=roles)
+    product_type_members = Product_Type_Member.objects \
+        .filter(product_type_id__in=authorized_product_types, role__in=roles)
+    product_groups = Product_Group.objects \
+        .filter(product_id__in=authorized_products, role__in=roles)
+    product_type_groups = Product_Type_Group.objects \
+        .filter(product_type_id__in=authorized_product_types, role__in=roles)
     group_members = Dojo_Group_Member.objects.filter(
         Q(group__in=[pg.group for pg in product_groups]) |
         Q(group__in=[ptg.group for ptg in product_type_groups]))

--- a/dojo/views.py
+++ b/dojo/views.py
@@ -85,8 +85,8 @@ def action_history(request, cid, oid):
 
     history = LogEntry.objects.filter(content_type=ct,
                                       object_pk=obj.id).order_by('-timestamp')
-    history = LogEntryFilter(request.GET, queryset=history)
-    paged_history = get_page_items(request, history.qs, 25)
+    log_entry_filter = LogEntryFilter(request.GET, queryset=history)
+    paged_history = get_page_items(request, log_entry_filter.qs, 25)
 
     if not get_system_setting('enable_auditlog'):
         messages.add_message(
@@ -99,6 +99,7 @@ def action_history(request, cid, oid):
                   {"history": paged_history,
                    'product_tab': product_tab,
                    "filtered": history,
+                   "log_entry_filter": log_entry_filter,
                    "obj": obj,
                    "test": test,
                    "object_value": object_value,

--- a/unittests/test_user_queries.py
+++ b/unittests/test_user_queries.py
@@ -1,0 +1,83 @@
+from unittest.mock import patch
+from .dojo_test_case import DojoTestCase
+from dojo.authorization.roles_permissions import Permissions
+from dojo.models import Dojo_User, Global_Role, Role, Product_Type, Product, Product_Type_Member, Product_Member
+from dojo.user.queries import get_authorized_users
+
+
+class TestUserQueries(DojoTestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.product_type_1 = Product_Type(name='product_type_1')
+        self.product_type_1.save()
+        self.product_1 = Product(name='product_1', prod_type=self.product_type_1)
+        self.product_1.save()
+        self.product_type_2 = Product_Type(name='product_type_2')
+        self.product_type_2.save()
+        self.product_2 = Product(name='product_2', prod_type=self.product_type_2)
+        self.product_2.save()
+
+        self.admin_user = Dojo_User(username='admin_user', is_superuser=True)
+        self.admin_user.save()
+
+        self.global_permission_user = Dojo_User(username='global_permission_user')
+        self.global_permission_user.save()
+        Global_Role(user=self.global_permission_user, role=Role.objects.get(name='Reader')).save()
+
+        self.regular_user = Dojo_User(username='regular_user')
+        self.regular_user.save()
+        Product_Member(user=self.regular_user, product=self.product_1, role=Role.objects.get(name='Owner')).save()
+        Product_Type_Member(user=self.regular_user, product_type=self.product_type_2, role=Role.objects.get(name='Writer')).save()
+
+        self.product_user = Dojo_User(username='product_user')
+        self.product_user.save()
+        Product_Member(user=self.product_user, product=self.product_1, role=Role.objects.get(name='Reader')).save()
+
+        self.product_type_user = Dojo_User(username='product_type_user')
+        self.product_type_user.save()
+        Product_Member(user=self.product_type_user, product=self.product_2, role=Role.objects.get(name='Maintainer')).save()
+
+        self.invisible_user = Dojo_User(username='invisible_user')
+        self.invisible_user.save()
+
+    def tearDown(self):
+        super().tearDown()
+        self.product_type_1.delete()
+        self.product_type_2.delete()
+        self.admin_user.delete()
+        self.global_permission_user.delete()
+        self.regular_user.delete()
+        self.product_user.delete()
+        self.product_type_user.delete()
+        self.invisible_user.delete()
+
+    @patch('dojo.user.queries.get_current_user')
+    def test_user_none(self, mock_current_user):
+        mock_current_user.return_value = None
+
+        self.assertQuerysetEqual(Dojo_User.objects.none(), get_authorized_users(Permissions.Product_View))
+
+    @patch('dojo.user.queries.get_current_user')
+    def test_user_admin(self, mock_current_user):
+        mock_current_user.return_value = self.admin_user
+
+        users = Dojo_User.objects.all().order_by('first_name', 'last_name', 'username')
+        self.assertQuerysetEqual(users, get_authorized_users(Permissions.Product_View))
+
+    @patch('dojo.user.queries.get_current_user')
+    def test_user_global_permission(self, mock_current_user):
+        mock_current_user.return_value = self.global_permission_user
+
+        users = Dojo_User.objects.all().order_by('first_name', 'last_name', 'username')
+        self.assertQuerysetEqual(users, get_authorized_users(Permissions.Product_View))
+
+    @patch('dojo.user.queries.get_current_user')
+    @patch('dojo.product.queries.get_current_user')
+    def test_user_regular(self, mock_current_user_1, mock_current_user_2):
+        mock_current_user_1.return_value = self.regular_user
+        mock_current_user_2.return_value = self.regular_user
+
+        users = Dojo_User.objects.exclude(username='invisible_user').order_by('first_name', 'last_name', 'username')
+        self.assertQuerysetEqual(users, get_authorized_users(Permissions.Product_View))


### PR DESCRIPTION
Until now some filters and the calendar view listed all DefectDojo users. This might not be desired, e.g. if an instance has external users that should not be visible for everyone.

With this PR a user can only see the users that are authorized for the same products and product types as themselve, including users with global roles and administrators.