### PR TITLE
Performance optimization: Don't read product in Product_Tab

### DIFF
--- a/dojo/benchmark/views.py
+++ b/dojo/benchmark/views.py
@@ -119,7 +119,7 @@ def benchmark_view(request, pid, type, cat=None):
 
     benchmark_summary_form = Benchmark_Product_SummaryForm(instance=benchmark_product_summary)
 
-    product_tab = Product_Tab(pid, title="Benchmarks", tab="benchmarks")
+    product_tab = Product_Tab(product, title="Benchmarks", tab="benchmarks")
 
     return render(request, 'dojo/benchmark.html',
                   {'benchmarks': benchmarks,
@@ -154,7 +154,7 @@ def delete(request, pid, type):
                                      extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('product'))
 
-    product_tab = Product_Tab(pid, title="Delete Benchmarks", tab="benchmarks")
+    product_tab = Product_Tab(product, title="Delete Benchmarks", tab="benchmarks")
     return render(request, 'dojo/delete_benchmark.html',
                   {'product': product,
                    'form': form,

--- a/dojo/cred/views.py
+++ b/dojo/cred/views.py
@@ -45,7 +45,7 @@ def all_cred_product(request, pid):
     prod = get_object_or_404(Product, id=pid)
     creds = Cred_Mapping.objects.filter(product=prod).order_by('cred_id__name')
 
-    product_tab = Product_Tab(prod.id, title="Credentials", tab="settings")
+    product_tab = Product_Tab(prod, title="Credentials", tab="settings")
     return render(request, 'dojo/view_cred_prod.html', {'product_tab': product_tab, 'creds': creds, 'prod': prod})
 
 
@@ -368,7 +368,7 @@ def edit_cred_product(request, pid, ttid):
     else:
         tform = CredMappingFormProd(instance=cred)
 
-    product_tab = Product_Tab(prod.id, title="Edit Product Credential", tab="settings")
+    product_tab = Product_Tab(prod, title="Edit Product Credential", tab="settings")
     return render(request, 'dojo/edit_cred_all.html', {
         'tform': tform,
         'product_tab': product_tab,
@@ -435,7 +435,7 @@ def new_cred_product(request, pid):
     else:
         tform = CredMappingFormProd()
 
-    product_tab = Product_Tab(pid, title="Add Credential Configuration", tab="settings")
+    product_tab = Product_Tab(prod, title="Add Credential Configuration", tab="settings")
 
     return render(request, 'dojo/new_cred_product.html', {
         'tform': tform,
@@ -662,19 +662,19 @@ def delete_cred_controller(request, destination_url, id, ttid):
     add_breadcrumb(title="Delete Credential", top_level=False, request=request)
     product_tab = None
     if id:
-        pid = None
+        product = None
         if destination_url == "all_cred_product":
-            pid = id
+            product = get_object_or_404(Product, id)
         elif destination_url == "view_engagement":
             engagement = get_object_or_404(Engagement, id=id)
-            pid = engagement.product.id
+            product = engagement.product
         elif destination_url == "view_test":
             test = get_object_or_404(Test, id=id)
-            pid = test.engagement.product.id
+            product = test.engagement.product
         elif destination_url == "view_finding":
             finding = get_object_or_404(Finding, id=id)
-            pid = finding.test.engagement.product.id
-        product_tab = Product_Tab(pid, title="Delete Credential Mapping", tab="settings")
+            product = finding.test.engagement.product
+        product_tab = Product_Tab(product, title="Delete Credential Mapping", tab="settings")
     return render(request, 'dojo/delete_cred_all.html', {
         'tform': tform,
         'product_tab': product_tab

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -67,7 +67,7 @@ def process_endpoints_view(request, host_view=False, vulnerable=False):
         if len(p) == 1:
             product = get_object_or_404(Product, id=p[0])
             user_has_permission_or_403(request.user, product, Permissions.Product_View)
-            product_tab = Product_Tab(product.id, view_name, tab="endpoints")
+            product_tab = Product_Tab(product, view_name, tab="endpoints")
 
     return render(
         request, 'dojo/endpoints.html', {
@@ -147,7 +147,7 @@ def process_endpoint_view(request, eid, host_view=False):
     if active_findings.count() != 0:
         vulnerable = True
 
-    product_tab = Product_Tab(endpoint.product.id, "Host" if host_view else "Endpoint", tab="endpoints")
+    product_tab = Product_Tab(endpoint.product, "Host" if host_view else "Endpoint", tab="endpoints")
     return render(request,
                   "dojo/view_endpoint.html",
                   {"endpoint": endpoint,
@@ -190,7 +190,7 @@ def edit_endpoint(request, eid):
         add_breadcrumb(parent=endpoint, title="Edit", top_level=False, request=request)
         form = EditEndpointForm(instance=endpoint)
 
-    product_tab = Product_Tab(endpoint.product.id, "Endpoint", tab="endpoints")
+    product_tab = Product_Tab(endpoint.product, "Endpoint", tab="endpoints")
 
     return render(request,
                   "dojo/edit_endpoint.html",
@@ -228,7 +228,7 @@ def delete_endpoint(request, eid):
     collector.collect([endpoint])
     rels = collector.nested()
 
-    product_tab = Product_Tab(endpoint.product.id, "Delete Endpoint", tab="endpoints")
+    product_tab = Product_Tab(endpoint.product, "Delete Endpoint", tab="endpoints")
 
     return render(request, 'dojo/delete_endpoint.html',
                   {'endpoint': endpoint,
@@ -258,7 +258,7 @@ def add_endpoint(request, pid):
                                  extra_tags='alert-success')
             return HttpResponseRedirect(reverse('endpoint') + "?product=" + pid)
 
-    product_tab = Product_Tab(product.id, "Add Endpoint", tab="endpoints")
+    product_tab = Product_Tab(product, "Add Endpoint", tab="endpoints")
 
     return render(request, template, {
         'product_tab': product_tab,
@@ -309,7 +309,7 @@ def add_meta_data(request, eid):
         form = DojoMetaDataForm()
 
     add_breadcrumb(parent=endpoint, title="Add Metadata", top_level=False, request=request)
-    product_tab = Product_Tab(endpoint.product.id, "Add Metadata", tab="endpoints")
+    product_tab = Product_Tab(endpoint.product, "Add Metadata", tab="endpoints")
     return render(request,
                   'dojo/add_endpoint_meta_data.html',
                   {'form': form,
@@ -343,7 +343,7 @@ def edit_meta_data(request, eid):
                              extra_tags='alert-success')
         return HttpResponseRedirect(reverse('view_endpoint', args=(eid,)))
 
-    product_tab = Product_Tab(endpoint.product.id, "Edit Metadata", tab="endpoints")
+    product_tab = Product_Tab(endpoint.product, "Edit Metadata", tab="endpoints")
     return render(request,
                   'dojo/edit_endpoint_meta_data.html',
                   {'endpoint': endpoint,
@@ -506,7 +506,7 @@ def import_endpoint_meta(request, pid):
             return HttpResponseRedirect(reverse('endpoint') + "?product=" + pid)
 
     add_breadcrumb(title="Endpoint Meta Importer", top_level=False, request=request)
-    product_tab = Product_Tab(product.id, title="Endpoint Meta Importer", tab="endpoints")
+    product_tab = Product_Tab(product, title="Endpoint Meta Importer", tab="endpoints")
     return render(request, 'dojo/endpoint_meta_importer.html', {
         'product_tab': product_tab,
         'form': form,

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -265,7 +265,7 @@ def edit_engagement(request, eid):
     else:
         title = 'Edit Interactive Engagement'
 
-    product_tab = Product_Tab(engagement.product.id, title=title, tab="engagements")
+    product_tab = Product_Tab(engagement.product, title=title, tab="engagements")
     product_tab.setEngagement(engagement)
     return render(request, 'dojo/new_eng.html', {
         'product_tab': product_tab,
@@ -309,7 +309,7 @@ def delete_engagement(request, eid):
     collector.collect([engagement])
     rels = collector.nested()
 
-    product_tab = Product_Tab(product.id, title="Delete Engagement", tab="engagements")
+    product_tab = Product_Tab(product, title="Delete Engagement", tab="engagements")
     product_tab.setEngagement(engagement)
     return render(request, 'dojo/delete_engagement.html', {
         'product_tab': product_tab,
@@ -395,7 +395,7 @@ def view_engagement(request, eid):
     title = ""
     if eng.engagement_type == "CI/CD":
         title = " CI/CD"
-    product_tab = Product_Tab(prod.id, title="View" + title + " Engagement", tab="engagements")
+    product_tab = Product_Tab(prod, title="View" + title + " Engagement", tab="engagements")
     product_tab.setEngagement(eng)
     return render(
         request, 'dojo/view_eng.html', {
@@ -506,7 +506,7 @@ def add_tests(request, eid):
         form.initial['lead'] = request.user
     add_breadcrumb(
         parent=eng, title="Add Tests", top_level=False, request=request)
-    product_tab = Product_Tab(eng.product.id, title="Add Tests", tab="engagements")
+    product_tab = Product_Tab(eng.product, title="Add Tests", tab="engagements")
     product_tab.setEngagement(eng)
     return render(request, 'dojo/add_tests.html', {
         'product_tab': product_tab,
@@ -649,13 +649,11 @@ def import_scan_results(request, eid=None, pid=None):
     custom_breadcrumb = None
     title = "Import Scan Results"
     if engagement:
-        prod_id = engagement.product.id
-        product_tab = Product_Tab(prod_id, title=title, tab="engagements")
+        product_tab = Product_Tab(engagement.product, title=title, tab="engagements")
         product_tab.setEngagement(engagement)
     else:
-        prod_id = pid
         custom_breadcrumb = {"", ""}
-        product_tab = Product_Tab(prod_id, title=title, tab="findings")
+        product_tab = Product_Tab(product, title=title, tab="findings")
 
     if jira_helper.get_jira_project(engagement_or_product):
         jform = JIRAImportScanForm(push_all=push_all_jira_issues, prefix='jiraform')
@@ -757,7 +755,7 @@ def complete_checklist(request, eid):
         findings = Finding.objects.filter(test__in=tests).all()
         form = CheckForm(instance=checklist, findings=findings)
 
-    product_tab = Product_Tab(eng.product.id, title="Checklist", tab="engagements")
+    product_tab = Product_Tab(eng.product, title="Checklist", tab="engagements")
     product_tab.setEngagement(eng)
     return render(request, 'dojo/checklist.html', {
         'form': form,
@@ -827,7 +825,7 @@ def add_risk_acceptance(request, eid, fid=None):
     form.fields['accepted_findings'].queryset = finding_choices
     if fid:
         form.fields['accepted_findings'].initial = {fid}
-    product_tab = Product_Tab(eng.product.id, title="Risk Acceptance", tab="engagements")
+    product_tab = Product_Tab(eng.product, title="Risk Acceptance", tab="engagements")
     product_tab.setEngagement(eng)
 
     return render(request, 'dojo/add_risk_acceptance.html', {
@@ -984,7 +982,7 @@ def view_edit_risk_acceptance(request, eid, raid, edit_mode=False):
     add_findings_form.fields[
         "accepted_findings"].queryset = add_fpage.object_list
 
-    product_tab = Product_Tab(eng.product.id, title="Risk Acceptance", tab="engagements")
+    product_tab = Product_Tab(eng.product, title="Risk Acceptance", tab="engagements")
     product_tab.setEngagement(eng)
     return render(
         request, 'dojo/view_risk_acceptance.html', {
@@ -1095,7 +1093,7 @@ def upload_threatmodel(request, eid):
                 reverse('view_engagement', args=(eid, )))
     else:
         form = UploadThreatForm()
-    product_tab = Product_Tab(eng.product.id, title="Upload Threat Model", tab="engagements")
+    product_tab = Product_Tab(eng.product, title="Upload Threat Model", tab="engagements")
     return render(request, 'dojo/up_threat.html', {
         'form': form,
         'product_tab': product_tab,

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -133,7 +133,7 @@ def findings(request, pid=None, eid=None, view=None, filter_name=None, order_by=
         product = get_object_or_404(Product, id=pid)
         user_has_permission_or_403(request.user, product, Permissions.Product_View)
         show_product_column = False
-        product_tab = Product_Tab(pid, title="Findings", tab="findings")
+        product_tab = Product_Tab(product, title="Findings", tab="findings")
         jira_project = jira_helper.get_jira_project(product)
         github_config = GITHUB_PKey.objects.filter(product=pid).first()
 
@@ -141,7 +141,7 @@ def findings(request, pid=None, eid=None, view=None, filter_name=None, order_by=
         engagement = get_object_or_404(Engagement, id=eid)
         user_has_permission_or_403(request.user, engagement, Permissions.Engagement_View)
         show_product_column = False
-        product_tab = Product_Tab(engagement.product_id, title=engagement.name, tab="engagements")
+        product_tab = Product_Tab(engagement.product, title=engagement.name, tab="engagements")
         jira_project = jira_helper.get_jira_project(engagement)
         github_config = GITHUB_PKey.objects.filter(product__engagement=eid).first()
     else:
@@ -366,7 +366,7 @@ def view_finding(request, fid):
     for similar_finding in similar_findings:
         similar_finding.related_actions = calculate_possible_related_actions_for_similar_finding(request, finding, similar_finding)
 
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="View Finding", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="View Finding", tab="findings")
 
     can_be_pushed_to_jira, can_be_pushed_to_jira_error, error_code = jira_helper.can_be_pushed_to_jira(finding)
 
@@ -471,7 +471,7 @@ def close_finding(request, fid):
     else:
         form = CloseFindingForm(missing_note_types=missing_note_types)
 
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Close", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Close", tab="findings")
 
     return render(request, 'dojo/close_finding.html', {
         'finding': finding,
@@ -553,7 +553,7 @@ def defect_finding_review(request, fid):
     else:
         form = DefectFindingForm()
 
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Jira Status Review", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Jira Status Review", tab="findings")
 
     return render(request, 'dojo/defect_finding_review.html', {
         'finding': finding,
@@ -855,7 +855,7 @@ def edit_finding(request, fid):
             if GITHUB_PKey.objects.filter(product=finding.test.engagement.product).exclude(git_conf_id=None):
                 gform = GITHUBFindingForm(enabled=github_enabled, prefix='githubform')
 
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Edit Finding", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Edit Finding", tab="findings")
 
     return render(request, 'dojo/edit_finding.html', {
         'product_tab': product_tab,
@@ -958,7 +958,7 @@ def request_finding_review(request, fid):
     else:
         form = ReviewFindingForm(finding=finding)
 
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Review Finding", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Review Finding", tab="findings")
 
     return render(request, 'dojo/review_finding.html', {
         'finding': finding,
@@ -1013,7 +1013,7 @@ def clear_finding_review(request, fid):
     else:
         form = ClearFindingReviewForm(instance=finding)
 
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Clear Finding Review", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Clear Finding Review", tab="findings")
 
     return render(request, 'dojo/clear_finding_review.html', {
         'finding': finding,
@@ -1090,7 +1090,7 @@ def find_template_to_apply(request, fid):
 
     # just query all templates as this weird ordering above otherwise breaks Django ORM
     title_words = get_words_for_field(Finding_Template, 'title')
-    product_tab = Product_Tab(test.engagement.product.id, title="Apply Template to Finding", tab="findings")
+    product_tab = Product_Tab(test.engagement.product, title="Apply Template to Finding", tab="findings")
     return render(
         request, 'dojo/templates.html', {
             'templates': paged_templates,
@@ -1114,7 +1114,7 @@ def choose_finding_template_options(request, tid, fid):
     data['vulnerability_ids'] = '\n'.join(finding.vulnerability_ids)
 
     form = ApplyFindingTemplateForm(data=data, template=template)
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Finding Template Options", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Finding Template Options", tab="findings")
     return render(request, 'dojo/apply_finding_template.html', {
         'finding': finding,
         'product_tab': product_tab,
@@ -1157,7 +1157,7 @@ def apply_template_to_finding(request, fid, tid):
                 'There appears to be errors on the form, please correct below.',
                 extra_tags='alert-danger')
             # form_error = True
-            product_tab = Product_Tab(finding.test.engagement.product.id, title="Apply Finding Template", tab="findings")
+            product_tab = Product_Tab(finding.test.engagement.product, title="Apply Finding Template", tab="findings")
             return render(request, 'dojo/apply_finding_template.html', {
                 'finding': finding,
                 'product_tab': product_tab,
@@ -1249,7 +1249,7 @@ def promote_to_finding(request, fid):
     push_all_jira_issues = jira_helper.is_push_all_issues(finding)
     jform = None
     use_jira = jira_helper.get_jira_project(finding) is not None
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Promote Finding", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Promote Finding", tab="findings")
 
     if request.method == 'POST':
         form = PromoteFindingForm(request.POST, product=test.engagement.product)
@@ -1741,7 +1741,7 @@ def merge_finding_product(request, pid):
                                      'Unable to merge findings. Required fields were not selected.',
                                      extra_tags='alert-danger')
 
-    product_tab = Product_Tab(finding.test.engagement.product.id, title="Merge Findings", tab="findings")
+    product_tab = Product_Tab(finding.test.engagement.product, title="Merge Findings", tab="findings")
     custom_breadcrumb = {"Open Findings": reverse('product_open_findings', args=(finding.test.engagement.product.id, )) + '?test__engagement__product=' + str(finding.test.engagement.product.id)}
 
     return render(request, 'dojo/merge_findings.html', {

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -59,7 +59,7 @@ def delete_finding_group(request, fgid):
     collector = NestedObjects(using=DEFAULT_DB_ALIAS)
     collector.collect([finding_group])
     rels = collector.nested()
-    product_tab = Product_Tab(finding_group.test.engagement.product.id, title="Product", tab="settings")
+    product_tab = Product_Tab(finding_group.test.engagement.product, title="Product", tab="settings")
 
     return render(request, 'dojo/delete_finding_group.html',
                   {'finding_group': finding_group,

--- a/dojo/google_sheet/views.py
+++ b/dojo/google_sheet/views.py
@@ -225,7 +225,7 @@ def export_to_sheet(request, tid):
             errors = sync['errors']
             sheet_title = sync['sheet_title']
             if len(errors) > 0:
-                product_tab = Product_Tab(test.engagement.product.id, title="Syncing Errors", tab="engagements")
+                product_tab = Product_Tab(test.engagement.product, title="Syncing Errors", tab="engagements")
                 product_tab.setEngagement(test.engagement)
                 spreadsheet_url = 'https://docs.google.com/spreadsheets/d/' + spreadsheetId
                 return render(

--- a/dojo/object/views.py
+++ b/dojo/object/views.py
@@ -30,7 +30,7 @@ def new_object(request, pid):
             return HttpResponseRedirect(reverse('view_objects', args=(pid,)))
     else:
         tform = ObjectSettingsForm()
-        product_tab = Product_Tab(pid, title="Add Tracked Files to a Product", tab="settings")
+        product_tab = Product_Tab(prod, title="Add Tracked Files to a Product", tab="settings")
 
         return render(request, 'dojo/new_object.html',
                       {'tform': tform,
@@ -43,7 +43,7 @@ def view_objects(request, pid):
     product = get_object_or_404(Product, id=pid)
     object_queryset = Objects_Product.objects.filter(product=pid).order_by('path', 'folder', 'artifact')
 
-    product_tab = Product_Tab(pid, title="Tracked Product Files, Paths and Artifacts", tab="settings")
+    product_tab = Product_Tab(product, title="Tracked Product Files, Paths and Artifacts", tab="settings")
     return render(request,
                   'dojo/view_objects.html',
                   {
@@ -73,7 +73,7 @@ def edit_object(request, pid, ttid):
     else:
         tform = ObjectSettingsForm(instance=object)
 
-    product_tab = Product_Tab(pid, title="Edit Tracked Files", tab="settings")
+    product_tab = Product_Tab(product, title="Edit Tracked Files", tab="settings")
     return render(request,
                   'dojo/edit_object.html',
                   {
@@ -100,7 +100,7 @@ def delete_object(request, pid, ttid):
     else:
         tform = DeleteObjectsSettingsForm(instance=object)
 
-    product_tab = Product_Tab(pid, title="Delete Product Tool Configuration", tab="settings")
+    product_tab = Product_Tab(product, title="Delete Product Tool Configuration", tab="settings")
     return render(request,
                   'dojo/delete_object.html',
                   {

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -182,7 +182,7 @@ def view_product(request, pid):
 
     total = critical + high + medium + low + info
 
-    product_tab = Product_Tab(pid, title="Product", tab="overview")
+    product_tab = Product_Tab(prod, title="Product", tab="overview")
     return render(request, 'dojo/view_product_details.html', {
         'prod': prod,
         'product_tab': product_tab,
@@ -211,7 +211,7 @@ def view_product(request, pid):
 @user_is_authorized(Product, Permissions.Component_View, 'pid')
 def view_product_components(request, pid):
     prod = get_object_or_404(Product, id=pid)
-    product_tab = Product_Tab(pid, title="Product", tab="components")
+    product_tab = Product_Tab(prod, title="Product", tab="components")
     separator = ', '
 
     # Get components ordered by component_name and concat component versions to the same row
@@ -590,7 +590,7 @@ def view_product_metrics(request, pid):
             test_data[t.test_type.name] += t.verified_finding_count
         else:
             test_data[t.test_type.name] = t.verified_finding_count
-    product_tab = Product_Tab(pid, title="Product", tab="metrics")
+    product_tab = Product_Tab(prod, title="Product", tab="metrics")
 
     return render(request,
                   'dojo/product_metrics.html',
@@ -652,7 +652,7 @@ def view_engagements(request, pid):
 
     title = "All Engagements"
 
-    product_tab = Product_Tab(pid, title=title, tab="engagements")
+    product_tab = Product_Tab(prod, title=title, tab="engagements")
     return render(request,
                   'dojo/view_engagements.html',
                   {'prod': prod,
@@ -862,7 +862,7 @@ def edit_product(request, pid):
         else:
             gform = None
 
-    product_tab = Product_Tab(pid, title="Edit Product", tab="settings")
+    product_tab = Product_Tab(product, title="Edit Product", tab="settings")
     return render(request,
                   'dojo/edit_product.html',
                   {'form': form,
@@ -907,7 +907,7 @@ def delete_product(request, pid):
     collector.collect([product])
     rels = collector.nested()
 
-    product_tab = Product_Tab(pid, title="Product", tab="settings")
+    product_tab = Product_Tab(product, title="Product", tab="settings")
 
     logger.debug('delete_product: GET RENDER')
 
@@ -1004,7 +1004,7 @@ def new_eng_for_app(request, pid, cicd=False):
     else:
         title = 'New Interactive Engagement'
 
-    product_tab = Product_Tab(pid, title=title, tab="engagements")
+    product_tab = Product_Tab(product, title=title, tab="engagements")
     return render(request, 'dojo/new_eng.html',
                   {'form': form,
                    'title': title,
@@ -1029,7 +1029,7 @@ def new_tech_for_prod(request, pid):
             return HttpResponseRedirect(reverse('view_product', args=(pid,)))
 
     form = AppAnalysisForm(initial={'user': request.user})
-    product_tab = Product_Tab(pid, title="Add Technology", tab="settings")
+    product_tab = Product_Tab(get_object_or_404(Product, id=pid), title="Add Technology", tab="settings")
     return render(request, 'dojo/new_tech.html',
                   {'form': form,
                    'product_tab': product_tab,
@@ -1053,7 +1053,7 @@ def edit_technology(request, tid):
                                  extra_tags='alert-success')
             return HttpResponseRedirect(reverse('view_product', args=(technology.product.id,)))
 
-    product_tab = Product_Tab(technology.product.id, title="Edit Technology", tab="settings")
+    product_tab = Product_Tab(technology.product, title="Edit Technology", tab="settings")
     return render(request, 'dojo/edit_technology.html',
                   {'form': form,
                    'product_tab': product_tab,
@@ -1074,7 +1074,7 @@ def delete_technology(request, tid):
                             extra_tags='alert-success')
         return HttpResponseRedirect(reverse('view_product', args=(technology.product.id,)))
 
-    product_tab = Product_Tab(technology.product.id, title="Delete Technology", tab="settings")
+    product_tab = Product_Tab(technology.product, title="Delete Technology", tab="settings")
     return render(request, 'dojo/delete_technology.html', {
         'technology': technology,
         'form': form,
@@ -1106,7 +1106,7 @@ def add_meta_data(request, pid):
     else:
         form = DojoMetaDataForm()
 
-    product_tab = Product_Tab(pid, title="Add Metadata", tab="settings")
+    product_tab = Product_Tab(prod, title="Add Metadata", tab="settings")
 
     return render(request,
                   'dojo/add_product_meta_data.html',
@@ -1139,7 +1139,7 @@ def edit_meta_data(request, pid):
                              extra_tags='alert-success')
         return HttpResponseRedirect(reverse('view_product', args=(pid,)))
 
-    product_tab = Product_Tab(pid, title="Edit Metadata", tab="settings")
+    product_tab = Product_Tab(prod, title="Edit Metadata", tab="settings")
     return render(request,
                   'dojo/edit_product_meta_data.html',
                   {'product': prod,
@@ -1289,7 +1289,7 @@ def ad_hoc_finding(request, pid):
         else:
             gform = None
 
-    product_tab = Product_Tab(pid, title="Add Finding", tab="engagements")
+    product_tab = Product_Tab(prod, title="Add Finding", tab="engagements")
     product_tab.setEngagement(eng)
     return render(request, 'dojo/ad_hoc_findings.html',
                   {'form': form,
@@ -1308,7 +1308,7 @@ def engagement_presets(request, pid):
     prod = get_object_or_404(Product, id=pid)
     presets = Engagement_Presets.objects.filter(product=prod).all()
 
-    product_tab = Product_Tab(prod.id, title="Engagement Presets", tab="settings")
+    product_tab = Product_Tab(prod, title="Engagement Presets", tab="settings")
 
     return render(request, 'dojo/view_presets.html',
                   {'product_tab': product_tab,
@@ -1321,7 +1321,7 @@ def edit_engagement_presets(request, pid, eid):
     prod = get_object_or_404(Product, id=pid)
     preset = get_object_or_404(Engagement_Presets, id=eid)
 
-    product_tab = Product_Tab(prod.id, title="Edit Engagement Preset", tab="settings")
+    product_tab = Product_Tab(prod, title="Edit Engagement Preset", tab="settings")
 
     if request.method == 'POST':
         tform = EngagementPresetsForm(request.POST, instance=preset)
@@ -1361,7 +1361,7 @@ def add_engagement_presets(request, pid):
     else:
         tform = EngagementPresetsForm()
 
-    product_tab = Product_Tab(pid, title="New Engagement Preset", tab="settings")
+    product_tab = Product_Tab(prod, title="New Engagement Preset", tab="settings")
     return render(request, 'dojo/new_params.html', {'tform': tform, 'pid': pid, 'product_tab': product_tab})
 
 
@@ -1386,7 +1386,7 @@ def delete_engagement_presets(request, pid, eid):
     collector.collect([preset])
     rels = collector.nested()
 
-    product_tab = Product_Tab(pid, title="Delete Engagement Preset", tab="settings")
+    product_tab = Product_Tab(prod, title="Delete Engagement Preset", tab="settings")
     return render(request, 'dojo/delete_presets.html',
                   {'product': product,
                    'form': form,
@@ -1446,7 +1446,7 @@ def add_product_member(request, pid):
                                     'Product members added successfully.',
                                     extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('view_product', args=(pid, )))
-    product_tab = Product_Tab(pid, title="Add Product Member", tab="settings")
+    product_tab = Product_Tab(product, title="Add Product Member", tab="settings")
     return render(request, 'dojo/new_product_member.html', {
         'product': product,
         'form': memberform,
@@ -1476,7 +1476,7 @@ def edit_product_member(request, memberid):
                     return HttpResponseRedirect(reverse('view_user', args=(member.user.id, )))
                 else:
                     return HttpResponseRedirect(reverse('view_product', args=(member.product.id, )))
-    product_tab = Product_Tab(member.product.id, title="Edit Product Member", tab="settings")
+    product_tab = Product_Tab(member.product, title="Edit Product Member", tab="settings")
     return render(request, 'dojo/edit_product_member.html', {
         'memberid': memberid,
         'form': memberform,
@@ -1504,7 +1504,7 @@ def delete_product_member(request, memberid):
                 return HttpResponseRedirect(reverse('product'))
             else:
                 return HttpResponseRedirect(reverse('view_product', args=(member.product.id, )))
-    product_tab = Product_Tab(member.product.id, title="Delete Product Member", tab="settings")
+    product_tab = Product_Tab(member.product, title="Delete Product Member", tab="settings")
     return render(request, 'dojo/delete_product_member.html', {
         'memberid': memberid,
         'form': memberform,
@@ -1547,7 +1547,7 @@ def add_api_scan_configuration(request, pid):
     else:
         form = Product_API_Scan_ConfigurationForm()
 
-    product_tab = Product_Tab(pid, title="Add API Scan Configuration", tab="settings")
+    product_tab = Product_Tab(product, title="Add API Scan Configuration", tab="settings")
 
     return render(request,
                   'dojo/add_product_api_scan_configuration.html',
@@ -1562,7 +1562,7 @@ def view_api_scan_configurations(request, pid):
 
     product_api_scan_configurations = Product_API_Scan_Configuration.objects.filter(product=pid)
 
-    product_tab = Product_Tab(pid, title="API Scan Configurations", tab="settings")
+    product_tab = Product_Tab(get_object_or_404(Product, id=pid), title="API Scan Configurations", tab="settings")
     return render(request,
                   'dojo/view_product_api_scan_configurations.html',
                   {
@@ -1608,7 +1608,7 @@ def edit_api_scan_configuration(request, pid, pascid):
     else:
         form = Product_API_Scan_ConfigurationForm(instance=product_api_scan_configuration)
 
-    product_tab = Product_Tab(pid, title="Edit API Scan Configuration", tab="settings")
+    product_tab = Product_Tab(get_object_or_404(Product, id=pid), title="Edit API Scan Configuration", tab="settings")
     return render(request,
                   'dojo/edit_product_api_scan_configuration.html',
                   {
@@ -1636,7 +1636,7 @@ def delete_api_scan_configuration(request, pid, pascid):
     else:
         form = DeleteProduct_API_Scan_ConfigurationForm(instance=product_api_scan_configuration)
 
-    product_tab = Product_Tab(pid, title="Delete Tool Configuration", tab="settings")
+    product_tab = Product_Tab(get_object_or_404(Product, id=pid), title="Delete Tool Configuration", tab="settings")
     return render(request,
                   'dojo/delete_product_api_scan_configuration.html',
                   {
@@ -1670,7 +1670,7 @@ def edit_product_group(request, groupid):
                 else:
                     return HttpResponseRedirect(reverse('view_product', args=(group.product.id, )))
 
-    product_tab = Product_Tab(group.product.id, title="Edit Product Group", tab="settings")
+    product_tab = Product_Tab(group.product, title="Edit Product Group", tab="settings")
     return render(request, 'dojo/edit_product_group.html', {
         'groupid': groupid,
         'form': groupform,
@@ -1698,7 +1698,7 @@ def delete_product_group(request, groupid):
             #  page
             return HttpResponseRedirect(reverse('view_product', args=(group.product.id, )))
 
-    product_tab = Product_Tab(group.product.id, title="Delete Product Group", tab="settings")
+    product_tab = Product_Tab(group.product, title="Delete Product Group", tab="settings")
     return render(request, 'dojo/delete_product_group.html', {
         'groupid': groupid,
         'form': groupform,
@@ -1734,7 +1734,7 @@ def add_product_group(request, pid):
                                          'Product groups added successfully.',
                                          extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('view_product', args=(pid, )))
-    product_tab = Product_Tab(pid, title="Edit Product Group", tab="settings")
+    product_tab = Product_Tab(product, title="Edit Product Group", tab="settings")
     return render(request, 'dojo/new_product_group.html', {
         'product': product,
         'form': group_form,

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -334,7 +334,7 @@ def product_endpoint_report(request, pid):
         else:
             raise Http404()
 
-    product_tab = Product_Tab(product.id, "Product Endpoint Report", tab="endpoints")
+    product_tab = Product_Tab(product, "Product Endpoint Report", tab="endpoints")
     return render(request,
                   'dojo/request_endpoint_report.html',
                   {"endpoints": paged_endpoints,
@@ -648,18 +648,18 @@ def generate_report(request, obj, host_view=False):
 
     product_tab = None
     if engagement:
-        product_tab = Product_Tab(engagement.product.id, title="Engagement Report", tab="engagements")
+        product_tab = Product_Tab(engagement.product, title="Engagement Report", tab="engagements")
         product_tab.setEngagement(engagement)
     elif test:
-        product_tab = Product_Tab(test.engagement.product.id, title="Test Report", tab="engagements")
+        product_tab = Product_Tab(test.engagement.product, title="Test Report", tab="engagements")
         product_tab.setEngagement(test.engagement)
     elif product:
-        product_tab = Product_Tab(product.id, title="Product Report", tab="findings")
+        product_tab = Product_Tab(product, title="Product Report", tab="findings")
     elif endpoints:
         if host_view:
-            product_tab = Product_Tab(endpoint.product.id, title="Endpoint Host Report", tab="endpoints")
+            product_tab = Product_Tab(endpoint.product, title="Endpoint Host Report", tab="endpoints")
         else:
-            product_tab = Product_Tab(endpoint.product.id, title="Endpoint Report", tab="endpoints")
+            product_tab = Product_Tab(endpoint.product, title="Endpoint Report", tab="endpoints")
 
     return render(request, 'dojo/request_report.html',
                   {'product_type': product_type,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -119,7 +119,7 @@ def view_test(request, tid):
     paged_stub_findings = get_page_items(request, stub_findings, 25)
     show_re_upload = any(test.test_type.name in code for code in get_choices_sorted())
 
-    product_tab = Product_Tab(prod.id, title="Test", tab="engagements")
+    product_tab = Product_Tab(prod, title="Test", tab="engagements")
     product_tab.setEngagement(test.engagement)
     jira_project = jira_helper.get_jira_project(test)
 
@@ -252,7 +252,7 @@ def edit_test(request, tid):
     form.initial['target_end'] = test.target_end.date()
     form.initial['description'] = test.description
 
-    product_tab = Product_Tab(test.engagement.product.id, title="Edit Test", tab="engagements")
+    product_tab = Product_Tab(test.engagement.product, title="Edit Test", tab="engagements")
     product_tab.setEngagement(test.engagement)
     return render(request, 'dojo/edit_test.html',
                   {'test': test,
@@ -290,7 +290,7 @@ def delete_test(request, tid):
     collector.collect([test])
     rels = collector.nested()
 
-    product_tab = Product_Tab(test.engagement.product.id, title="Delete Test", tab="engagements")
+    product_tab = Product_Tab(test.engagement.product, title="Delete Test", tab="engagements")
     product_tab.setEngagement(test.engagement)
     return render(request, 'dojo/delete_test.html',
                   {'test': test,
@@ -456,7 +456,7 @@ def add_findings(request, tid):
         if use_jira:
             jform = JIRAFindingForm(push_all=jira_helper.is_push_all_issues(test), prefix='jiraform', jira_project=jira_helper.get_jira_project(test), finding_form=form)
 
-    product_tab = Product_Tab(test.engagement.product.id, title="Add Finding", tab="engagements")
+    product_tab = Product_Tab(test.engagement.product, title="Add Finding", tab="engagements")
     product_tab.setEngagement(test.engagement)
     return render(request, 'dojo/add_findings.html',
                   {'form': form,
@@ -561,7 +561,7 @@ def add_temp_finding(request, tid, fid):
     # logger.debug('jform errors: %s', jform.errors)
     # logger.debug('jform errors: %s', vars(jform))
 
-    product_tab = Product_Tab(test.engagement.product.id, title="Add Finding", tab="engagements")
+    product_tab = Product_Tab(test.engagement.product, title="Add Finding", tab="engagements")
     product_tab.setEngagement(test.engagement)
     return render(request, 'dojo/add_findings.html',
                   {'form': form,
@@ -679,7 +679,7 @@ def re_import_scan_results(request, tid):
 
             return HttpResponseRedirect(reverse('view_test', args=(test.id,)))
 
-    product_tab = Product_Tab(engagement.product.id, title="Re-upload a %s" % scan_type, tab="engagements")
+    product_tab = Product_Tab(engagement.product, title="Re-upload a %s" % scan_type, tab="engagements")
     product_tab.setEngagement(engagement)
     form.fields['endpoints'].queryset = Endpoint.objects.filter(product__id=product_tab.product.id)
     form.initial['api_scan_configuration'] = test.api_scan_configuration

--- a/dojo/tool_product/views.py
+++ b/dojo/tool_product/views.py
@@ -34,7 +34,7 @@ def new_tool_product(request, pid):
                 reverse('all_tool_product', args=(pid, )))
     else:
         tform = ToolProductSettingsForm()
-    product_tab = Product_Tab(pid, title="Tool Configurations", tab="settings")
+    product_tab = Product_Tab(prod, title="Tool Configurations", tab="settings")
     return render(request, 'dojo/new_tool_product.html', {
         'tform': tform,
         'product_tab': product_tab,
@@ -46,7 +46,7 @@ def new_tool_product(request, pid):
 def all_tool_product(request, pid):
     prod = get_object_or_404(Product, id=pid)
     tools = Tool_Product_Settings.objects.filter(product=prod).order_by('name')
-    product_tab = Product_Tab(prod.id, title="Tool Configurations", tab="settings")
+    product_tab = Product_Tab(prod, title="Tool Configurations", tab="settings")
     return render(request, 'dojo/view_tool_product_all.html', {
         'prod': prod,
         'tools': tools,
@@ -74,7 +74,7 @@ def edit_tool_product(request, pid, ttid):
     else:
         tform = ToolProductSettingsForm(instance=tool_product)
 
-    product_tab = Product_Tab(pid, title="Edit Product Tool Configuration", tab="settings")
+    product_tab = Product_Tab(product, title="Edit Product Tool Configuration", tab="settings")
     return render(request, 'dojo/edit_tool_product.html', {
         'tform': tform,
         'product_tab': product_tab
@@ -101,7 +101,7 @@ def delete_tool_product(request, pid, ttid):
     else:
         tform = ToolProductSettingsForm(instance=tool_product)
 
-    product_tab = Product_Tab(pid, title="Delete Product Tool Configuration", tab="settings")
+    product_tab = Product_Tab(product, title="Delete Product Tool Configuration", tab="settings")
 
     return render(request, 'dojo/delete_tool_product.html', {
         'tform': tform,

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1493,8 +1493,8 @@ def get_celery_worker_status():
 
 # Used to display the counts and enabled tabs in the product view
 class Product_Tab():
-    def __init__(self, product_id, title=None, tab=None):
-        self.product = Product.objects.get(id=product_id)
+    def __init__(self, product, title=None, tab=None):
+        self.product = product
         self.title = title
         self.tab = tab
         self.engagement_count = Engagement.objects.filter(

--- a/dojo/views.py
+++ b/dojo/views.py
@@ -76,7 +76,7 @@ def action_history(request, cid, oid):
 
     product_tab = None
     if product_id:
-        product_tab = Product_Tab(product_id, title="History", tab=active_tab)
+        product_tab = Product_Tab(get_object_or_404(Product, id=product_id), title="History", tab=active_tab)
         if active_tab == "engagements":
             if str(ct) == "engagement":
                 product_tab.setEngagement(object_value)


### PR DESCRIPTION
We have a lot of duplicated SQL statements at the moment. This PR removes some of them. The `Product_Tab` received the id of a product until now and read the product. But the majority of views has already read the product before. Now the product is given to the `Product_Tab` and removes one duplicate SQL statement.