### PR TITLE
Hash_code calculation with Vulnerability Ids

### DIFF
--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -10,7 +10,7 @@ cd /app
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)
 unset DD_DATABASE_URL
 
-# Unset the celery broker URL so that we can force the other DD_CELERY_BROKER settings
+# Unset the celery broker URL so that we can force the other DD_CELERY_BROKER settings
 unset DD_CELERY_BROKER_URL
 
 python3 manage.py makemigrations dojo

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2183,7 +2183,7 @@ class Finding(models.Model):
                 vulnerability_id_str_list = list(
                     map(
                         lambda vulnerability_id: str(vulnerability_id),
-                        self.vulnerability_ids
+                        self.unsaved_vulnerability_ids
                     ))
                 # deduplicate (usually done upon saving finding) and sort endpoints
                 vulnerability_id_str = ''.join(sorted(list(dict.fromkeys(vulnerability_id_str_list))))

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2156,11 +2156,11 @@ class Finding(models.Model):
                 myEndpoints = self.get_endpoints()
                 fields_to_hash = fields_to_hash + myEndpoints
                 deduplicationLogger.debug(hashcodeField + ' : ' + myEndpoints)
-            elif hashcodeField == 'vulnerability_references':
-                # For vulnerability_references, need to compute the field
-                my_vulnerability_references = self.get_vulnerability_references()
-                fields_to_hash = fields_to_hash + my_vulnerability_references
-                deduplicationLogger.debug(hashcodeField + ' : ' + my_vulnerability_references)
+            elif hashcodeField == 'vulnerability_ids':
+                # For vulnerability_ids, need to compute the field
+                my_vulnerability_ids = self.get_vulnerability_ids()
+                fields_to_hash = fields_to_hash + my_vulnerability_ids
+                deduplicationLogger.debug(hashcodeField + ' : ' + my_vulnerability_ids)
             else:
                 # Generically use the finding attribute having the same name, converts to str in case it's integer
                 fields_to_hash = fields_to_hash + str(getattr(self, hashcodeField))
@@ -2173,34 +2173,34 @@ class Finding(models.Model):
         deduplicationLogger.debug("compute_hash_code_legacy - fields_to_hash = " + fields_to_hash)
         return self.hash_fields(fields_to_hash)
 
-    # Get vulnerability_references to use for hash_code computation
-    def get_vulnerability_references(self):
-        vulnerability_reference_str = ''
+    # Get vulnerability_ids to use for hash_code computation
+    def get_vulnerability_ids(self):
+        vulnerability_id_str = ''
         if self.id is None:
-            if self.unsaved_vulnerability_references:
-                deduplicationLogger.debug("get_vulnerability_references before the finding was saved")
-                # convert list of unsaved vulnerability_references to the list of their canonical representation
-                vulnerability_reference_str_list = list(
+            if self.unsaved_vulnerability_ids:
+                deduplicationLogger.debug("get_vulnerability_ids before the finding was saved")
+                # convert list of unsaved vulnerability_ids to the list of their canonical representation
+                vulnerability_id_str_list = list(
                     map(
-                        lambda vulnerability_reference: str(vulnerability_reference),
-                        self.vulnerability_references
+                        lambda vulnerability_id: str(vulnerability_id),
+                        self.vulnerability_ids
                     ))
                 # deduplicate (usually done upon saving finding) and sort endpoints
-                vulnerability_reference_str = ''.join(sorted(list(dict.fromkeys(vulnerability_reference_str_list))))
+                vulnerability_id_str = ''.join(sorted(list(dict.fromkeys(vulnerability_id_str_list))))
             else:
                 deduplicationLogger.debug("finding has no unsaved vulnerability references")
         else:
-            vulnerability_references = Vulnerability_Reference.objects.filter(finding=self)
-            deduplicationLogger.debug("get_vulnerability_references after the finding was saved. Vulnerability references count: " + str(vulnerability_references.count()))
-            # convert list of vulnerability_references to the list of their canonical representation
-            vulnerability_reference_str_list = list(
+            vulnerability_ids = Vulnerability_Id.objects.filter(finding=self)
+            deduplicationLogger.debug("get_vulnerability_ids after the finding was saved. Vulnerability references count: " + str(vulnerability_ids.count()))
+            # convert list of vulnerability_ids to the list of their canonical representation
+            vulnerability_id_str_list = list(
                 map(
-                    lambda vulnerability_reference: str(vulnerability_reference),
-                    vulnerability_references.all()
+                    lambda vulnerability_id: str(vulnerability_id),
+                    vulnerability_ids.all()
                 ))
-            # sort vulnerability_references strings
-            vulnerability_reference_str = ''.join(sorted(vulnerability_reference_str_list))
-        return vulnerability_reference_str
+            # sort vulnerability_ids strings
+            vulnerability_id_str = ''.join(sorted(vulnerability_id_str_list))
+        return vulnerability_id_str
 
     # Get endpoints to use for hash_code computation
     # (This sometimes reports "None")
@@ -2671,7 +2671,7 @@ class Vulnerability_Id(models.Model):
     vulnerability_id = models.TextField(max_length=50, blank=False, null=False)
 
     def __str__(self):
-        return self.vulnerability_reference
+        return self.vulnerability_id
 
 
 class Stub_Finding(models.Model):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2177,7 +2177,7 @@ class Finding(models.Model):
     def get_vulnerability_references(self):
         vulnerability_reference_str = ''
         if self.id is None:
-            if len(self.unsaved_vulnerability_references) > 0:
+            if self.unsaved_vulnerability_references:
                 deduplicationLogger.debug("get_vulnerability_references before the finding was saved")
                 # convert list of unsaved vulnerability_references to the list of their canonical representation
                 vulnerability_reference_str_list = list(
@@ -2190,12 +2190,13 @@ class Finding(models.Model):
             else:
                 deduplicationLogger.debug("finding has no unsaved vulnerability references")
         else:
-            deduplicationLogger.debug("get_vulnerability_references after the finding was saved. Vulnerability references count: " + str(self.vulnerability_references.count()))
+            vulnerability_references = Vulnerability_Reference.objects.filter(finding=self)
+            deduplicationLogger.debug("get_vulnerability_references after the finding was saved. Vulnerability references count: " + str(vulnerability_references.count()))
             # convert list of vulnerability_references to the list of their canonical representation
             vulnerability_reference_str_list = list(
                 map(
                     lambda vulnerability_reference: str(vulnerability_reference),
-                    self.vulnerability_references.all()
+                    vulnerability_references.all()
                 ))
             # sort vulnerability_references strings
             vulnerability_reference_str = ''.join(sorted(vulnerability_reference_str_list))
@@ -2668,6 +2669,9 @@ Finding.endpoints.through.__str__ = lambda \
 class Vulnerability_Id(models.Model):
     finding = models.ForeignKey(Finding, editable=False, on_delete=models.CASCADE)
     vulnerability_id = models.TextField(max_length=50, blank=False, null=False)
+
+    def __str__(self):
+        return self.vulnerability_reference
 
 
 class Stub_Finding(models.Model):

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1426,4 +1426,5 @@ VULNERABILITY_URLS = {
     'OSV': 'https://osv.dev/vulnerability/',
     'PYSEC': 'https://osv.dev/vulnerability/',
     'SNYK': 'https://snyk.io/vuln/',
+    'RUSTSEC': 'https://rustsec.org/advisories/',
 }

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1045,43 +1045,43 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # Including the severity in the hash_code keeps those findings not duplicate
     'Anchore Engine Scan': ['title', 'severity', 'component_name', 'component_version', 'file_path'],
     'Anchore Grype': ['title', 'severity', 'component_name', 'component_version'],
-    'Aqua Scan': ['severity', 'cve', 'component_name', 'component_version'],
+    'Aqua Scan': ['severity', 'vulnerability_references', 'component_name', 'component_version'],
     'Bandit Scan': ['file_path', 'line', 'vuln_id_from_tool'],
-    'CargoAudit Scan': ['cve', 'severity', 'component_name', 'component_version', 'vuln_id_from_tool'],
+    'CargoAudit Scan': ['vulnerability_references', 'severity', 'component_name', 'component_version', 'vuln_id_from_tool'],
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
-    'Checkmarx OSA': ['cve', 'component_name'],
+    'Checkmarx OSA': ['vulnerability_references', 'component_name'],
     'Cloudsploit Scan': ['title', 'description'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube API Import': ['title', 'file_path', 'line'],
-    'Dependency Check Scan': ['cve', 'cwe', 'file_path'],
+    'Dependency Check Scan': ['vulnerability_references', 'cwe', 'file_path'],
     'Dockle Scan': ['title', 'description', 'vuln_id_from_tool'],
-    'Dependency Track Finding Packaging Format (FPF) Export': ['component_name', 'component_version', 'cwe', 'cve'],
+    'Dependency Track Finding Packaging Format (FPF) Export': ['component_name', 'component_version', 'cwe', 'vulnerability_references'],
     'Mobsfscan Scan': ['title', 'severity', 'cwe'],
-    'Nessus Scan': ['title', 'severity', 'cve', 'cwe'],
-    'Nexpose Scan': ['title', 'severity', 'cve', 'cwe'],
+    'Nessus Scan': ['title', 'severity', 'vulnerability_references', 'cwe'],
+    'Nexpose Scan': ['title', 'severity', 'vulnerability_references', 'cwe'],
     # possible improvement: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
-    'NPM Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
+    'NPM Audit Scan': ['title', 'severity', 'file_path', 'vulnerability_references', 'cwe'],
     # possible improvement: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
-    'Yarn Audit Scan': ['title', 'severity', 'file_path', 'cve', 'cwe'],
-    # possible improvement: in the scanner put the library name into file_path, then dedup on cve + file_path + severity
+    'Yarn Audit Scan': ['title', 'severity', 'file_path', 'vulnerability_references', 'cwe'],
+    # possible improvement: in the scanner put the library name into file_path, then dedup on vulnerability_references + file_path + severity
     'Whitesource Scan': ['title', 'severity', 'description'],
     'ZAP Scan': ['title', 'cwe', 'severity'],
     'Qualys Scan': ['title', 'severity'],
     # 'Qualys Webapp Scan': ['title', 'unique_id_from_tool'],
-    'PHP Symfony Security Check': ['title', 'cve'],
-    'Clair Scan': ['title', 'cve', 'description', 'severity'],
+    'PHP Symfony Security Check': ['title', 'vulnerability_references'],
+    'Clair Scan': ['title', 'vulnerability_references', 'description', 'severity'],
     'Clair Klar Scan': ['title', 'description', 'severity'],
     # for backwards compatibility because someone decided to rename this scanner:
-    'Symfony Security Check': ['title', 'cve'],
-    'DSOP Scan': ['cve'],
+    'Symfony Security Check': ['title', 'vulnerability_references'],
+    'DSOP Scan': ['vulnerability_references'],
     'Acunetix Scan': ['title', 'description'],
     'Terrascan Scan': ['vuln_id_from_tool', 'title', 'severity', 'file_path', 'line', 'component_name'],
-    'Trivy Scan': ['title', 'severity', 'cve', 'cwe'],
+    'Trivy Scan': ['title', 'severity', 'vulnerability_references', 'cwe'],
     'TFSec Scan': ['severity', 'vuln_id_from_tool', 'file_path', 'line'],
     'Snyk Scan': ['vuln_id_from_tool', 'file_path', 'component_name', 'component_version'],
-    'GitLab Dependency Scanning Report': ['title', 'cve', 'file_path', 'component_name', 'component_version'],
+    'GitLab Dependency Scanning Report': ['title', 'vulnerability_references', 'file_path', 'component_name', 'component_version'],
     'SpotBugs Scan': ['cwe', 'severity', 'file_path', 'line'],
-    'JFrog Xray Unified Scan': ['cve', 'file_path', 'component_name', 'component_version'],
+    'JFrog Xray Unified Scan': ['vulnerability_references', 'file_path', 'component_name', 'component_version'],
     'Scout Suite Scan': ['file_path', 'vuln_id_from_tool'],  # for now we use file_path as there is no attribute for "service"
     'AWS Security Hub Scan': ['unique_id_from_tool'],
     'Meterian Scan': ['cwe', 'component_name', 'component_version', 'description', 'severity'],
@@ -1137,7 +1137,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
 # List of fields that are known to be usable in hash_code computation)
 # 'endpoints' is a pseudo field that uses the endpoints (for dynamic scanners)
 # 'unique_id_from_tool' is often not needed here as it can be used directly in the dedupe algorithm, but it's also possible to use it for hashing
-HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'cve', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
+HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'vulnerability_references', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
 
 # Adding fields to the hash_code calculation regardless of the previous settings
 HASH_CODE_FIELDS_ALWAYS = ['service']

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1045,43 +1045,43 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # Including the severity in the hash_code keeps those findings not duplicate
     'Anchore Engine Scan': ['title', 'severity', 'component_name', 'component_version', 'file_path'],
     'Anchore Grype': ['title', 'severity', 'component_name', 'component_version'],
-    'Aqua Scan': ['severity', 'vulnerability_references', 'component_name', 'component_version'],
+    'Aqua Scan': ['severity', 'vulnerability_ids', 'component_name', 'component_version'],
     'Bandit Scan': ['file_path', 'line', 'vuln_id_from_tool'],
-    'CargoAudit Scan': ['vulnerability_references', 'severity', 'component_name', 'component_version', 'vuln_id_from_tool'],
+    'CargoAudit Scan': ['vulnerability_ids', 'severity', 'component_name', 'component_version', 'vuln_id_from_tool'],
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
-    'Checkmarx OSA': ['vulnerability_references', 'component_name'],
+    'Checkmarx OSA': ['vulnerability_ids', 'component_name'],
     'Cloudsploit Scan': ['title', 'description'],
     'SonarQube Scan': ['cwe', 'severity', 'file_path'],
     'SonarQube API Import': ['title', 'file_path', 'line'],
-    'Dependency Check Scan': ['vulnerability_references', 'cwe', 'file_path'],
+    'Dependency Check Scan': ['vulnerability_ids', 'cwe', 'file_path'],
     'Dockle Scan': ['title', 'description', 'vuln_id_from_tool'],
-    'Dependency Track Finding Packaging Format (FPF) Export': ['component_name', 'component_version', 'cwe', 'vulnerability_references'],
+    'Dependency Track Finding Packaging Format (FPF) Export': ['component_name', 'component_version', 'cwe', 'vulnerability_ids'],
     'Mobsfscan Scan': ['title', 'severity', 'cwe'],
-    'Nessus Scan': ['title', 'severity', 'vulnerability_references', 'cwe'],
-    'Nexpose Scan': ['title', 'severity', 'vulnerability_references', 'cwe'],
+    'Nessus Scan': ['title', 'severity', 'vulnerability_ids', 'cwe'],
+    'Nexpose Scan': ['title', 'severity', 'vulnerability_ids', 'cwe'],
     # possible improvement: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
-    'NPM Audit Scan': ['title', 'severity', 'file_path', 'vulnerability_references', 'cwe'],
+    'NPM Audit Scan': ['title', 'severity', 'file_path', 'vulnerability_ids', 'cwe'],
     # possible improvement: in the scanner put the library name into file_path, then dedup on cwe + file_path + severity
-    'Yarn Audit Scan': ['title', 'severity', 'file_path', 'vulnerability_references', 'cwe'],
-    # possible improvement: in the scanner put the library name into file_path, then dedup on vulnerability_references + file_path + severity
+    'Yarn Audit Scan': ['title', 'severity', 'file_path', 'vulnerability_ids', 'cwe'],
+    # possible improvement: in the scanner put the library name into file_path, then dedup on vulnerability_ids + file_path + severity
     'Whitesource Scan': ['title', 'severity', 'description'],
     'ZAP Scan': ['title', 'cwe', 'severity'],
     'Qualys Scan': ['title', 'severity'],
     # 'Qualys Webapp Scan': ['title', 'unique_id_from_tool'],
-    'PHP Symfony Security Check': ['title', 'vulnerability_references'],
-    'Clair Scan': ['title', 'vulnerability_references', 'description', 'severity'],
+    'PHP Symfony Security Check': ['title', 'vulnerability_ids'],
+    'Clair Scan': ['title', 'vulnerability_ids', 'description', 'severity'],
     'Clair Klar Scan': ['title', 'description', 'severity'],
     # for backwards compatibility because someone decided to rename this scanner:
-    'Symfony Security Check': ['title', 'vulnerability_references'],
-    'DSOP Scan': ['vulnerability_references'],
+    'Symfony Security Check': ['title', 'vulnerability_ids'],
+    'DSOP Scan': ['vulnerability_ids'],
     'Acunetix Scan': ['title', 'description'],
     'Terrascan Scan': ['vuln_id_from_tool', 'title', 'severity', 'file_path', 'line', 'component_name'],
-    'Trivy Scan': ['title', 'severity', 'vulnerability_references', 'cwe'],
+    'Trivy Scan': ['title', 'severity', 'vulnerability_ids', 'cwe'],
     'TFSec Scan': ['severity', 'vuln_id_from_tool', 'file_path', 'line'],
     'Snyk Scan': ['vuln_id_from_tool', 'file_path', 'component_name', 'component_version'],
-    'GitLab Dependency Scanning Report': ['title', 'vulnerability_references', 'file_path', 'component_name', 'component_version'],
+    'GitLab Dependency Scanning Report': ['title', 'vulnerability_ids', 'file_path', 'component_name', 'component_version'],
     'SpotBugs Scan': ['cwe', 'severity', 'file_path', 'line'],
-    'JFrog Xray Unified Scan': ['vulnerability_references', 'file_path', 'component_name', 'component_version'],
+    'JFrog Xray Unified Scan': ['vulnerability_ids', 'file_path', 'component_name', 'component_version'],
     'Scout Suite Scan': ['file_path', 'vuln_id_from_tool'],  # for now we use file_path as there is no attribute for "service"
     'AWS Security Hub Scan': ['unique_id_from_tool'],
     'Meterian Scan': ['cwe', 'component_name', 'component_version', 'description', 'severity'],
@@ -1137,7 +1137,7 @@ HASHCODE_ALLOWS_NULL_CWE = {
 # List of fields that are known to be usable in hash_code computation)
 # 'endpoints' is a pseudo field that uses the endpoints (for dynamic scanners)
 # 'unique_id_from_tool' is often not needed here as it can be used directly in the dedupe algorithm, but it's also possible to use it for hashing
-HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'vulnerability_references', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
+HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'vulnerability_ids', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
 
 # Adding fields to the hash_code calculation regardless of the previous settings
 HASH_CODE_FIELDS_ALWAYS = ['service']

--- a/dojo/tools/aqua/parser.py
+++ b/dojo/tools/aqua/parser.py
@@ -42,7 +42,7 @@ class AquaParser(object):
 def get_item(resource, vuln, test):
     resource_name = resource.get('name', resource.get('path'))
     resource_version = resource.get('version', 'No version')
-    cve = vuln.get('name', 'No CVE')
+    vulnerability_reference = vuln.get('name', 'No CVE')
     fix_version = vuln.get('fix_version', 'None')
     description = vuln.get('description', 'No description.')
     cvssv3 = None
@@ -84,13 +84,12 @@ def get_item(resource, vuln, test):
         severity = severity_of(score)
         severity_justification += "\n{}".format(used_for_classification)
 
-    return Finding(
-        title=cve + " - " + resource_name + " (" + resource_version + ") ",
+    finding = Finding(
+        title=vulnerability_reference + " - " + resource_name + " (" + resource_version + ") ",
         test=test,
         severity=severity,
         severity_justification=severity_justification,
         cwe=0,
-        cve=cve,
         cvssv3=cvssv3,
         description=description.strip(),
         mitigation=fix_version,
@@ -98,10 +97,14 @@ def get_item(resource, vuln, test):
         component_name=resource.get('name'),
         component_version=resource.get('version'),
         impact=severity)
+    if vulnerability_reference != 'No CVE':
+        finding.unsaved_vulnerability_references = [vulnerability_reference]
+
+    return finding
 
 
 def get_item_v2(item, test):
-    cve = item['name']
+    vulnerability_reference = item['name']
     file_path = item['file']
     url = item.get('url')
     severity = severity_of(float(item['score']))
@@ -115,15 +118,17 @@ def get_item_v2(item, test):
     else:
         mitigation = 'No known mitigation'
 
-    return Finding(title=str(cve) + ': ' + str(file_path),
+    finding = Finding(title=str(vulnerability_reference) + ': ' + str(file_path),
                    description=description,
                    url=url,
                    cwe=0,
-                   cve=cve,
                    test=test,
                    severity=severity,
                    impact=severity,
                    mitigation=mitigation)
+    finding.unsaved_vulnerability_references = [vulnerability_reference]
+
+    return finding
 
 
 def aqua_severity_of(score):

--- a/dojo/tools/aqua/parser.py
+++ b/dojo/tools/aqua/parser.py
@@ -42,7 +42,7 @@ class AquaParser(object):
 def get_item(resource, vuln, test):
     resource_name = resource.get('name', resource.get('path'))
     resource_version = resource.get('version', 'No version')
-    vulnerability_reference = vuln.get('name', 'No CVE')
+    vulnerability_id = vuln.get('name', 'No CVE')
     fix_version = vuln.get('fix_version', 'None')
     description = vuln.get('description', 'No description.')
     cvssv3 = None
@@ -85,7 +85,7 @@ def get_item(resource, vuln, test):
         severity_justification += "\n{}".format(used_for_classification)
 
     finding = Finding(
-        title=vulnerability_reference + " - " + resource_name + " (" + resource_version + ") ",
+        title=vulnerability_id + " - " + resource_name + " (" + resource_version + ") ",
         test=test,
         severity=severity,
         severity_justification=severity_justification,
@@ -97,14 +97,14 @@ def get_item(resource, vuln, test):
         component_name=resource.get('name'),
         component_version=resource.get('version'),
         impact=severity)
-    if vulnerability_reference != 'No CVE':
-        finding.unsaved_vulnerability_references = [vulnerability_reference]
+    if vulnerability_id != 'No CVE':
+        finding.unsaved_vulnerability_ids = [vulnerability_id]
 
     return finding
 
 
 def get_item_v2(item, test):
-    vulnerability_reference = item['name']
+    vulnerability_id = item['name']
     file_path = item['file']
     url = item.get('url')
     severity = severity_of(float(item['score']))
@@ -118,7 +118,7 @@ def get_item_v2(item, test):
     else:
         mitigation = 'No known mitigation'
 
-    finding = Finding(title=str(vulnerability_reference) + ': ' + str(file_path),
+    finding = Finding(title=str(vulnerability_id) + ': ' + str(file_path),
                    description=description,
                    url=url,
                    cwe=0,
@@ -126,7 +126,7 @@ def get_item_v2(item, test):
                    severity=severity,
                    impact=severity,
                    mitigation=mitigation)
-    finding.unsaved_vulnerability_references = [vulnerability_reference]
+    finding.unsaved_vulnerability_ids = [vulnerability_id]
 
     return finding
 

--- a/dojo/tools/cargo_audit/parser.py
+++ b/dojo/tools/cargo_audit/parser.py
@@ -39,9 +39,9 @@ class CargoAuditParser(object):
                 date = advisory.get('date')
 
                 if len(advisory.get('aliases')) != 0:
-                    cve = advisory.get('aliases')[0]
+                    vulnerability_reference = advisory.get('aliases')[0]
                 else:
-                    cve = None
+                    vulnerability_reference = None
 
                 package_name = item.get('package').get('name')
                 package_version = item.get('package').get('version')
@@ -56,7 +56,7 @@ class CargoAuditParser(object):
                 except KeyError:
                     mitigation = "No information about patched version"
                 dupe_key = hashlib.sha256(
-                    (vuln_id + str(cve) + date + package_name + package_version).encode('utf-8')
+                    (vuln_id + str(vulnerability_reference) + date + package_name + package_version).encode('utf-8')
                 ).hexdigest()
 
                 if dupe_key in dupes:
@@ -67,7 +67,6 @@ class CargoAuditParser(object):
                         title=title,
                         test=test,
                         severity=severity,
-                        cve=cve,
                         tags=tags,
                         description=description,
                         component_name=package_name,
@@ -78,5 +77,7 @@ class CargoAuditParser(object):
                         references=references,
                         mitigation=mitigation
                     )
+                    if vulnerability_reference:
+                        finding.unsaved_vulnerability_references = [vulnerability_reference]
                     dupes[dupe_key] = finding
         return list(dupes.values())

--- a/dojo/tools/cargo_audit/parser.py
+++ b/dojo/tools/cargo_audit/parser.py
@@ -24,6 +24,7 @@ class CargoAuditParser(object):
             for item in data.get('vulnerabilities').get('list'):
                 advisory = item.get('advisory')
                 vuln_id = advisory.get('id')
+                vulnerability_ids = [advisory.get('id')]
                 if "categories" in advisory:
                     categories = f"**Categories:** {', '.join(advisory['categories'])}"
                 else:
@@ -38,10 +39,8 @@ class CargoAuditParser(object):
                 references = f"{advisory.get('url')}\n" + '\n'.join(advisory['references'])
                 date = advisory.get('date')
 
-                if len(advisory.get('aliases')) != 0:
-                    vulnerability_id = advisory.get('aliases')[0]
-                else:
-                    vulnerability_id = None
+                for alias in advisory.get('aliases', []):
+                    vulnerability_ids.append(alias)
 
                 package_name = item.get('package').get('name')
                 package_version = item.get('package').get('version')
@@ -56,7 +55,7 @@ class CargoAuditParser(object):
                 except KeyError:
                     mitigation = "No information about patched version"
                 dupe_key = hashlib.sha256(
-                    (vuln_id + str(vulnerability_id) + date + package_name + package_version).encode('utf-8')
+                    (vuln_id + date + package_name + package_version).encode('utf-8')
                 ).hexdigest()
 
                 if dupe_key in dupes:
@@ -77,7 +76,6 @@ class CargoAuditParser(object):
                         references=references,
                         mitigation=mitigation
                     )
-                    if vulnerability_id:
-                        finding.unsaved_vulnerability_ids = [vulnerability_id]
+                    finding.unsaved_vulnerability_ids = vulnerability_ids
                     dupes[dupe_key] = finding
         return list(dupes.values())

--- a/dojo/tools/cargo_audit/parser.py
+++ b/dojo/tools/cargo_audit/parser.py
@@ -39,9 +39,9 @@ class CargoAuditParser(object):
                 date = advisory.get('date')
 
                 if len(advisory.get('aliases')) != 0:
-                    vulnerability_reference = advisory.get('aliases')[0]
+                    vulnerability_id = advisory.get('aliases')[0]
                 else:
-                    vulnerability_reference = None
+                    vulnerability_id = None
 
                 package_name = item.get('package').get('name')
                 package_version = item.get('package').get('version')
@@ -56,7 +56,7 @@ class CargoAuditParser(object):
                 except KeyError:
                     mitigation = "No information about patched version"
                 dupe_key = hashlib.sha256(
-                    (vuln_id + str(vulnerability_reference) + date + package_name + package_version).encode('utf-8')
+                    (vuln_id + str(vulnerability_id) + date + package_name + package_version).encode('utf-8')
                 ).hexdigest()
 
                 if dupe_key in dupes:
@@ -77,7 +77,7 @@ class CargoAuditParser(object):
                         references=references,
                         mitigation=mitigation
                     )
-                    if vulnerability_reference:
-                        finding.unsaved_vulnerability_references = [vulnerability_reference]
+                    if vulnerability_id:
+                        finding.unsaved_vulnerability_ids = [vulnerability_id]
                     dupes[dupe_key] = finding
         return list(dupes.values())

--- a/dojo/tools/checkmarx_osa/parser.py
+++ b/dojo/tools/checkmarx_osa/parser.py
@@ -38,9 +38,9 @@ class CheckmarxOsaParser(object):
 
             # Possible status as per checkmarx 9.2: TO_VERIFY, NOT_EXPLOITABLE, CONFIRMED, URGENT, PROPOSED_NOT_EXPLOITABLE
             status = item['state']['name']
-            cve = item.get('cveName', 'NC')
+            vulnerability_reference = item.get('cveName', 'NC')
             finding_item = Finding(
-                title='{0} {1} | {2}'.format(library['name'], library['version'], cve),
+                title='{0} {1} | {2}'.format(library['name'], library['version'], vulnerability_reference),
                 severity=item['severity']['name'],
                 description=item.get('description', 'NC'),
                 unique_id_from_tool=item.get('id', None),
@@ -48,7 +48,6 @@ class CheckmarxOsaParser(object):
                 mitigation=item.get('recommendations', None),
                 component_name=library['name'],
                 component_version=library['version'],
-                cve=cve,
                 # 1035 is "Using Components with Known Vulnerabilities"
                 # Possible improvment: get the CWE from the CVE using some database?
                 # nvd.nist.gov has the info; see for eg https://nvd.nist.gov/vuln/detail/CVE-2020-25649 "Weakness Enumeration"
@@ -63,6 +62,8 @@ class CheckmarxOsaParser(object):
                 verified=status != 'TO_VERIFY' and status != 'NOT_EXPLOITABLE' and status != 'PROPOSED_NOT_EXPLOITABLE',
                 test=test
             )
+            if vulnerability_reference != 'NC':
+                finding_item.unsaved_vulnerability_references = [vulnerability_reference]
             items.append(finding_item)
         return items
 

--- a/dojo/tools/checkmarx_osa/parser.py
+++ b/dojo/tools/checkmarx_osa/parser.py
@@ -38,9 +38,9 @@ class CheckmarxOsaParser(object):
 
             # Possible status as per checkmarx 9.2: TO_VERIFY, NOT_EXPLOITABLE, CONFIRMED, URGENT, PROPOSED_NOT_EXPLOITABLE
             status = item['state']['name']
-            vulnerability_reference = item.get('cveName', 'NC')
+            vulnerability_id = item.get('cveName', 'NC')
             finding_item = Finding(
-                title='{0} {1} | {2}'.format(library['name'], library['version'], vulnerability_reference),
+                title='{0} {1} | {2}'.format(library['name'], library['version'], vulnerability_id),
                 severity=item['severity']['name'],
                 description=item.get('description', 'NC'),
                 unique_id_from_tool=item.get('id', None),
@@ -62,8 +62,8 @@ class CheckmarxOsaParser(object):
                 verified=status != 'TO_VERIFY' and status != 'NOT_EXPLOITABLE' and status != 'PROPOSED_NOT_EXPLOITABLE',
                 test=test
             )
-            if vulnerability_reference != 'NC':
-                finding_item.unsaved_vulnerability_references = [vulnerability_reference]
+            if vulnerability_id != 'NC':
+                finding_item.unsaved_vulnerability_ids = [vulnerability_id]
             items.append(finding_item)
         return items
 

--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -56,7 +56,6 @@ def get_item(item_node, test):
                       references=item_node['link'],
                       component_name=item_node['featurename'],
                       component_version=item_node['featureversion'],
-                      cve=item_node['vulnerability'],
                       false_p=False,
                       duplicate=False,
                       out_of_scope=False,
@@ -64,5 +63,8 @@ def get_item(item_node, test):
                       static_finding=True,
                       dynamic_finding=False,
                       impact="No impact provided")
+
+    if item_node['vulnerability']:
+        finding.unsaved_vulnerability_references = [item_node['vulnerability']]
 
     return finding

--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -65,6 +65,6 @@ def get_item(item_node, test):
                       impact="No impact provided")
 
     if item_node['vulnerability']:
-        finding.unsaved_vulnerability_references = [item_node['vulnerability']]
+        finding.unsaved_vulnerability_ids = [item_node['vulnerability']]
 
     return finding

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -137,11 +137,11 @@ class DependencyCheckParser(object):
         # I need the notes field since this is how the suppression is documented.
         notes = vulnerability.findtext(f'.//{namespace}notes')
 
-        vulnerability_reference = name[:28]
-        if vulnerability_reference and not vulnerability_reference.startswith('CVE'):
+        vulnerability_id = name[:28]
+        if vulnerability_id and not vulnerability_id.startswith('CVE'):
             # for vulnerability sources which have a CVE, it is the start of the 'name'.
             # for other sources, we have to set it to None
-            vulnerability_reference = None
+            vulnerability_id = None
 
         # Use CWE-1035 as fallback
         cwe = 1035  # Vulnerable Third Party Component
@@ -236,8 +236,8 @@ class DependencyCheckParser(object):
             component_version=component_version,
         )
 
-        if vulnerability_reference:
-            finding.unsaved_vulnerability_references = [vulnerability_reference]
+        if vulnerability_id:
+            finding.unsaved_vulnerability_ids = [vulnerability_id]
 
         return finding
 

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -23,7 +23,7 @@ class DependencyCheckParser(object):
 
     def add_finding(self, finding, dupes):
         key_str = '|'.join([
-            str(finding.cve),
+            str(finding.title),
             str(finding.cwe),
             str(finding.file_path).lower()
         ])
@@ -137,11 +137,11 @@ class DependencyCheckParser(object):
         # I need the notes field since this is how the suppression is documented.
         notes = vulnerability.findtext(f'.//{namespace}notes')
 
-        cve = name[:28]
-        if cve and not cve.startswith('CVE'):
+        vulnerability_reference = name[:28]
+        if vulnerability_reference and not vulnerability_reference.startswith('CVE'):
             # for vulnerability sources which have a CVE, it is the start of the 'name'.
             # for other sources, we have to set it to None
-            cve = None
+            vulnerability_reference = None
 
         # Use CWE-1035 as fallback
         cwe = 1035  # Vulnerable Third Party Component
@@ -219,12 +219,11 @@ class DependencyCheckParser(object):
             description += '\n**Filepath:** ' + str(dependency_filepath)
             active = True
 
-        return Finding(
+        finding = Finding(
             title=f'{component_name}:{component_version} | {name}',
             file_path=dependency_filename,
             test=test,
             cwe=cwe,
-            cve=cve,
             description=description,
             severity=severity,
             mitigation=mitigation,
@@ -236,6 +235,11 @@ class DependencyCheckParser(object):
             component_name=component_name,
             component_version=component_version,
         )
+
+        if vulnerability_reference:
+            finding.unsaved_vulnerability_references = [vulnerability_reference]
+
+        return finding
 
     def get_scan_types(self):
         return ["Dependency Check Scan"]

--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -144,7 +144,7 @@ class DependencyTrackParser(object):
         # The vulnId is not always a CVE (e.g. if the vulnerability is not from the NVD source)
         # So here we set the cve for the DefectDojo finding to null unless the source of the
         # Dependency Track vulnerability is NVD
-        vulnerability_reference = vuln_id if source is not None and source.upper() == 'NVD' else None
+        vulnerability_id = vuln_id if source is not None and source.upper() == 'NVD' else None
 
         # Default CWE to CWE-1035 Using Components with Known Vulnerabilities if there is no CWE
         if 'cweId' in dependency_track_finding['vulnerability'] and dependency_track_finding['vulnerability']['cweId'] is not None:
@@ -210,8 +210,8 @@ class DependencyTrackParser(object):
             static_finding=True,
             dynamic_finding=False)
 
-        if vulnerability_reference:
-            finding.unsaved_vulnerability_references = [vulnerability_reference]
+        if vulnerability_id:
+            finding.unsaved_vulnerability_ids = [vulnerability_id]
 
         return finding
 

--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -144,7 +144,7 @@ class DependencyTrackParser(object):
         # The vulnId is not always a CVE (e.g. if the vulnerability is not from the NVD source)
         # So here we set the cve for the DefectDojo finding to null unless the source of the
         # Dependency Track vulnerability is NVD
-        cve = vuln_id if source is not None and source.upper() == 'NVD' else None
+        vulnerability_reference = vuln_id if source is not None and source.upper() == 'NVD' else None
 
         # Default CWE to CWE-1035 Using Components with Known Vulnerabilities if there is no CWE
         if 'cweId' in dependency_track_finding['vulnerability'] and dependency_track_finding['vulnerability']['cweId'] is not None:
@@ -196,11 +196,10 @@ class DependencyTrackParser(object):
         is_false_positive = True if analysis is not None and analysis.get('state') == 'FALSE_POSITIVE' else False
 
         # Build and return Finding model
-        return Finding(
+        finding = Finding(
             title=title,
             test=test,
             cwe=cwe,
-            cve=cve,
             description=vulnerability_description,
             severity=vulnerability_severity,
             false_p=is_false_positive,
@@ -210,6 +209,11 @@ class DependencyTrackParser(object):
             vuln_id_from_tool=vuln_id_from_tool,
             static_finding=True,
             dynamic_finding=False)
+
+        if vulnerability_reference:
+            finding.unsaved_vulnerability_references = [vulnerability_reference]
+
+        return finding
 
     def get_scan_types(self):
         return ["Dependency Track Finding Packaging Format (FPF) Export"]

--- a/dojo/tools/dsop/parser.py
+++ b/dojo/tools/dsop/parser.py
@@ -43,16 +43,19 @@ class DsopParser:
                     severity = 'Info'
                 else:
                     severity = row[headers['severity']].title()
-                cve = row[headers['identifiers']]
                 references = row[headers['refs']]
                 description = row[headers['desc']]
                 impact = row[headers['rationale']]
                 date = row[headers['scanned_date']]
                 tags = "disa"
 
-                finding = Finding(title=title, date=date, cve=cve, severity=severity, description=description,
+                finding = Finding(title=title, date=date, severity=severity, description=description,
                             impact=impact, references=references, test=test, unique_id_from_tool=unique_id,
                             static_finding=True, dynamic_finding=False)
+
+                if row[headers['identifiers']]:
+                    finding.unsaved_vulnerability_references = [row[headers['identifiers']]]
+
                 finding.unsaved_tags = tags
                 items.append(finding)
 
@@ -84,11 +87,14 @@ class DsopParser:
                 else:
                     severity = 'Info'
                 unique_id = row[headers['id']]
-                cve = row[headers['ref']]
                 tags = "oval"
 
-                finding = Finding(title=title, cve=cve, severity=severity, unique_id_from_tool=unique_id,
+                finding = Finding(title=title, severity=severity, unique_id_from_tool=unique_id,
                         test=test, static_finding=True, dynamic_finding=False)
+
+                if row[headers['ref']]:
+                    finding.unsaved_vulnerability_references = [row[headers['ref']]]
+
                 finding.unsaved_tags = tags
                 items.append(finding)
 
@@ -104,14 +110,13 @@ class DsopParser:
             else:
                 if row[headers['severity']] is None:
                     continue
-                cve = row[headers['cve']]
                 description = row[headers['desc']]
                 mitigation = row[headers['status']]
                 url = row[headers['link']]
 
                 component_name = row[headers['packageName']]
                 component_version = row[headers['packageVersion']]
-                title = '{}: {} - {}'.format(cve, component_name, component_version)
+                title = '{}: {} - {}'.format(row[headers['cve']], component_name, component_version)
                 if row[headers['severity']] == 'important':
                     severity = 'High'
                 elif row[headers['severity']] == 'moderate':
@@ -121,10 +126,14 @@ class DsopParser:
                 severity_justification = row[headers['vecStr']]
                 tags = "twistlock"
 
-                finding = Finding(title=title, cve=cve, url=url, severity=severity, description=description,
+                finding = Finding(title=title, url=url, severity=severity, description=description,
                                         component_name=component_name, component_version=component_version,
                                         severity_justification=severity_justification, test=test,
                                         static_finding=True, dynamic_finding=False)
+
+                if row[headers['cve']]:
+                    finding.unsaved_vulnerability_references = [row[headers['cve']]]
+
                 finding.unsaved_tags = tags
                 items.append(finding)
 
@@ -140,20 +149,23 @@ class DsopParser:
             else:
                 if row[0] is None:
                     continue
-                cve = row[headers['cve']]
                 severity = row[headers['severity']]
                 component = row[headers['package']]
                 file_path = row[headers['package_path']]
                 mitigation = row[headers['fix']]
                 description = "Image affected: {}".format(row[headers['tag']])
-                title = '{}: {}'.format(cve, component)
+                title = '{}: {}'.format(row[headers['cve']], component)
                 tags = "anchore"
 
-                finding = Finding(title=title, cve=cve, severity=severity,
+                finding = Finding(title=title, severity=severity,
                                         mitigation=mitigation, component_name=component,
                                         description=description, test=test,
                                         static_finding=True, dynamic_finding=False,
                                         file_path=file_path)
+
+                if row[headers['cve']]:
+                    finding.unsaved_vulnerability_references = [row[headers['cve']]]
+
                 finding.unsaved_tags = tags
                 items.append(finding)
 

--- a/dojo/tools/dsop/parser.py
+++ b/dojo/tools/dsop/parser.py
@@ -54,7 +54,7 @@ class DsopParser:
                             static_finding=True, dynamic_finding=False)
 
                 if row[headers['identifiers']]:
-                    finding.unsaved_vulnerability_references = [row[headers['identifiers']]]
+                    finding.unsaved_vulnerability_ids = [row[headers['identifiers']]]
 
                 finding.unsaved_tags = tags
                 items.append(finding)
@@ -93,7 +93,7 @@ class DsopParser:
                         test=test, static_finding=True, dynamic_finding=False)
 
                 if row[headers['ref']]:
-                    finding.unsaved_vulnerability_references = [row[headers['ref']]]
+                    finding.unsaved_vulnerability_ids = [row[headers['ref']]]
 
                 finding.unsaved_tags = tags
                 items.append(finding)
@@ -132,7 +132,7 @@ class DsopParser:
                                         static_finding=True, dynamic_finding=False)
 
                 if row[headers['cve']]:
-                    finding.unsaved_vulnerability_references = [row[headers['cve']]]
+                    finding.unsaved_vulnerability_ids = [row[headers['cve']]]
 
                 finding.unsaved_tags = tags
                 items.append(finding)
@@ -164,7 +164,7 @@ class DsopParser:
                                         file_path=file_path)
 
                 if row[headers['cve']]:
-                    finding.unsaved_vulnerability_references = [row[headers['cve']]]
+                    finding.unsaved_vulnerability_ids = [row[headers['cve']]]
 
                 finding.unsaved_tags = tags
                 items.append(finding)

--- a/dojo/tools/gitlab_dep_scan/parser.py
+++ b/dojo/tools/gitlab_dep_scan/parser.py
@@ -100,14 +100,14 @@ def get_item(vuln, test):
         mitigation = vuln['solution']
 
     cwe = None
-    cve = None
+    vulnerability_reference = None
     references = ''
     if 'identifiers' in vuln:
         for identifier in vuln['identifiers']:
             if identifier['type'].lower() == 'cwe':
                 cwe = identifier['value']
             elif identifier['type'].lower() == 'cve':
-                cve = identifier['value']
+                vulnerability_reference = identifier['value']
             else:
                 references += 'Identifier type: {}\n'.format(identifier['type'])
                 references += 'Name: {}\n'.format(identifier['name'])
@@ -116,7 +116,7 @@ def get_item(vuln, test):
                     references += 'URL: {}\n'.format(identifier['url'])
                 references += '\n'
 
-    finding = Finding(title=cve + ": " + title if cve else title,
+    finding = Finding(title=vulnerability_reference + ": " + title if vulnerability_reference else title,
                       test=test,
                       description=description,
                       severity=severity,
@@ -128,8 +128,10 @@ def get_item(vuln, test):
                       component_name=component_name,
                       component_version=component_version,
                       cwe=cwe,
-                      cve=cve,
                       static_finding=True,
                       dynamic_finding=False)
+
+    if vulnerability_reference:
+        finding.unsaved_vulnerability_references = [vulnerability_reference]
 
     return finding

--- a/dojo/tools/gitlab_dep_scan/parser.py
+++ b/dojo/tools/gitlab_dep_scan/parser.py
@@ -100,14 +100,14 @@ def get_item(vuln, test):
         mitigation = vuln['solution']
 
     cwe = None
-    vulnerability_reference = None
+    vulnerability_id = None
     references = ''
     if 'identifiers' in vuln:
         for identifier in vuln['identifiers']:
             if identifier['type'].lower() == 'cwe':
                 cwe = identifier['value']
             elif identifier['type'].lower() == 'cve':
-                vulnerability_reference = identifier['value']
+                vulnerability_id = identifier['value']
             else:
                 references += 'Identifier type: {}\n'.format(identifier['type'])
                 references += 'Name: {}\n'.format(identifier['name'])
@@ -116,7 +116,7 @@ def get_item(vuln, test):
                     references += 'URL: {}\n'.format(identifier['url'])
                 references += '\n'
 
-    finding = Finding(title=vulnerability_reference + ": " + title if vulnerability_reference else title,
+    finding = Finding(title=vulnerability_id + ": " + title if vulnerability_id else title,
                       test=test,
                       description=description,
                       severity=severity,
@@ -131,7 +131,7 @@ def get_item(vuln, test):
                       static_finding=True,
                       dynamic_finding=False)
 
-    if vulnerability_reference:
-        finding.unsaved_vulnerability_references = [vulnerability_reference]
+    if vulnerability_id:
+        finding.unsaved_vulnerability_ids = [vulnerability_id]
 
     return finding

--- a/dojo/tools/jfrog_xray_unified/parser.py
+++ b/dojo/tools/jfrog_xray_unified/parser.py
@@ -59,7 +59,7 @@ def get_item(vulnerability, test):
 
     cveIndex = highestCvssV3Index
 
-    cve = None
+    vulnerability_reference = None
     cvss_v3 = "No CVSS v3 score."  # for justification field
     cvssv3 = None  # for actual cvssv3 field
     cvss_v2 = "No CVSS v2 score."
@@ -70,7 +70,7 @@ def get_item(vulnerability, test):
     if len(cves) > 0:
         worstCve = cves[cveIndex]
         if 'cve' in cves[cveIndex]:
-            cve = worstCve['cve']
+            vulnerability_reference = worstCve['cve']
         if 'cvss_v3_vector' in worstCve:
             cvss_v3 = worstCve['cvss_v3_vector']
             cvssv3 = cvss_v3
@@ -105,7 +105,6 @@ def get_item(vulnerability, test):
     # create the finding object
     finding = Finding(
         title=title,
-        cve=cve,
         test=test,
         severity=severity,
         description=(vulnerability['description'] + "\n\n" + extra_desc).strip(),
@@ -122,5 +121,8 @@ def get_item(vulnerability, test):
         date=scan_time,
         unique_id_from_tool=vulnerability['issue_id'],
         tags=tags)
+
+    if vulnerability_reference:
+        finding.unsaved_vulnerability_references = [vulnerability_reference]
 
     return finding

--- a/dojo/tools/jfrog_xray_unified/parser.py
+++ b/dojo/tools/jfrog_xray_unified/parser.py
@@ -59,7 +59,7 @@ def get_item(vulnerability, test):
 
     cveIndex = highestCvssV3Index
 
-    vulnerability_reference = None
+    vulnerability_id = None
     cvss_v3 = "No CVSS v3 score."  # for justification field
     cvssv3 = None  # for actual cvssv3 field
     cvss_v2 = "No CVSS v2 score."
@@ -70,7 +70,7 @@ def get_item(vulnerability, test):
     if len(cves) > 0:
         worstCve = cves[cveIndex]
         if 'cve' in cves[cveIndex]:
-            vulnerability_reference = worstCve['cve']
+            vulnerability_id = worstCve['cve']
         if 'cvss_v3_vector' in worstCve:
             cvss_v3 = worstCve['cvss_v3_vector']
             cvssv3 = cvss_v3
@@ -122,7 +122,7 @@ def get_item(vulnerability, test):
         unique_id_from_tool=vulnerability['issue_id'],
         tags=tags)
 
-    if vulnerability_reference:
-        finding.unsaved_vulnerability_references = [vulnerability_reference]
+    if vulnerability_id:
+        finding.unsaved_vulnerability_ids = [vulnerability_id]
 
     return finding

--- a/dojo/tools/nessus/parser.py
+++ b/dojo/tools/nessus/parser.py
@@ -74,12 +74,6 @@ class NessusCSVParser(object):
             dupe_key = severity + title + row.get('Host', 'No host') + str(row.get('Port', 'No port')) + row.get('Synopsis', 'No synopsis')
 
             detected_cve = self._format_cve(str(row.get('CVE')))
-            cve = None
-            if detected_cve:
-                # FIXME support more than one CVE in Nessus CSV parser
-                cve = detected_cve[0]
-                if len(detected_cve) > 1:
-                    LOGGER.debug("more than one CVE for a finding. NOT supported by Nessus CSV parser")
 
             if dupe_key in dupes:
                 find = dupes[dupe_key]
@@ -90,12 +84,13 @@ class NessusCSVParser(object):
                     description = description + str(row.get('Plugin Output'))
                 find = Finding(title=title,
                                 test=test,
-                                cve=cve,
                                 description=description,
                                 severity=severity,
                                 mitigation=mitigation,
                                 impact=impact,
                                 references=references)
+                if detected_cve:
+                    find.unsaved_vulnerability_references = detected_cve
 
                 # manage CVSS vector (only v3.x for now)
                 if 'CVSS V3 Vector' in row and '' != row.get('CVSS V3 Vector'):
@@ -191,9 +186,9 @@ class NessusXMLParser(object):
                     for xref in item.iter("xref"):
                         references += xref.text + "\n"
 
-                    cve = None
+                    vulnerability_reference = None
                     if item.findtext("cve"):
-                        cve = item.find("cve").text
+                        vulnerability_reference = item.find("cve").text
                     cwe = None
                     if item.findtext("cwe"):
                         cwe = item.find("cwe").text
@@ -212,10 +207,13 @@ class NessusXMLParser(object):
                                        mitigation=mitigation,
                                        impact=impact,
                                        references=references,
-                                       cwe=cwe,
-                                       cve=cve)
+                                       cwe=cwe)
+                        find.unsaved_vulnerability_references = list()
                         find.unsaved_endpoints = list()
                         dupes[dupe_key] = find
+
+                    if vulnerability_reference:
+                        find.unsaved_vulnerability_references.append(vulnerability_reference)
 
                     if fqdn and '://' in fqdn:
                         endpoint = Endpoint.from_uri(fqdn)

--- a/dojo/tools/nessus/parser.py
+++ b/dojo/tools/nessus/parser.py
@@ -90,7 +90,7 @@ class NessusCSVParser(object):
                                 impact=impact,
                                 references=references)
                 if detected_cve:
-                    find.unsaved_vulnerability_references = detected_cve
+                    find.unsaved_vulnerability_ids = detected_cve
 
                 # manage CVSS vector (only v3.x for now)
                 if 'CVSS V3 Vector' in row and '' != row.get('CVSS V3 Vector'):
@@ -186,9 +186,9 @@ class NessusXMLParser(object):
                     for xref in item.iter("xref"):
                         references += xref.text + "\n"
 
-                    vulnerability_reference = None
+                    vulnerability_id = None
                     if item.findtext("cve"):
-                        vulnerability_reference = item.find("cve").text
+                        vulnerability_id = item.find("cve").text
                     cwe = None
                     if item.findtext("cwe"):
                         cwe = item.find("cwe").text
@@ -208,12 +208,12 @@ class NessusXMLParser(object):
                                        impact=impact,
                                        references=references,
                                        cwe=cwe)
-                        find.unsaved_vulnerability_references = list()
+                        find.unsaved_vulnerability_ids = list()
                         find.unsaved_endpoints = list()
                         dupes[dupe_key] = find
 
-                    if vulnerability_reference:
-                        find.unsaved_vulnerability_references.append(vulnerability_reference)
+                    if vulnerability_id:
+                        find.unsaved_vulnerability_ids.append(vulnerability_id)
 
                     if fqdn and '://' in fqdn:
                         endpoint = Endpoint.from_uri(fqdn)

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -307,7 +307,7 @@ class NexposeParser(object):
             find.references = refs
             # update CVE
             if "CVE" in vuln.get('refs', {}):
-                find.cve = vuln['refs']['CVE']
+                find.unsaved_vulnerability_references = [vuln['refs']['CVE']]
             find.unsaved_endpoints = list()
             dupes[dupe_key] = find
         return find

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -307,7 +307,7 @@ class NexposeParser(object):
             find.references = refs
             # update CVE
             if "CVE" in vuln.get('refs', {}):
-                find.unsaved_vulnerability_references = [vuln['refs']['CVE']]
+                find.unsaved_vulnerability_ids = [vuln['refs']['CVE']]
             find.unsaved_endpoints = list()
             dupes[dupe_key] = find
         return find

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -119,8 +119,8 @@ def get_item(item_node, test):
                       dynamic_finding=False)
 
     if len(item_node['cves']) > 0:
-        dojo_finding.unsaved_vulnerability_references = list()
-        for vulnerability_reference in item_node['cves']:
-            dojo_finding.unsaved_vulnerability_references.append(vulnerability_reference)
+        dojo_finding.unsaved_vulnerability_ids = list()
+        for vulnerability_id in item_node['cves']:
+            dojo_finding.unsaved_vulnerability_ids.append(vulnerability_id)
 
     return dojo_finding

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -106,7 +106,6 @@ def get_item(item_node, test):
                       str(item_node['cwe']) + "\n Access: " +
                       str(item_node['access']),
                       cwe=cwe,
-                      cve=item_node['cves'][0] if (len(item_node['cves']) > 0) else None,
                       mitigation=item_node['recommendation'],
                       references=item_node['url'],
                       component_name=item_node['module_name'],
@@ -118,5 +117,10 @@ def get_item(item_node, test):
                       impact="No impact provided",
                       static_finding=True,
                       dynamic_finding=False)
+
+    if len(item_node['cves']) > 0:
+        dojo_finding.unsaved_vulnerability_references = list()
+        for vulnerability_reference in item_node['cves']:
+            dojo_finding.unsaved_vulnerability_references.append(vulnerability_reference)
 
     return dojo_finding

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -58,7 +58,6 @@ def get_item(dependency_name, dependency_version, advisory, test):
                       description=advisory['title'],
                       # TODO Decide if the default '1035: vulnerable 3rd party component' is OK to use?
                       cwe=1035,
-                      cve=advisory['cve'],
                       mitigation='upgrade',
                       references=advisory['link'],
                       false_p=False,
@@ -70,5 +69,8 @@ def get_item(dependency_name, dependency_version, advisory, test):
                       dynamic_finding=False,
                       component_name=dependency_name,
                       component_version=dependency_version)
+
+    if advisory['cve']:
+        finding.unsaved_vulnerability_references = [advisory['cve']]
 
     return finding

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -71,6 +71,6 @@ def get_item(dependency_name, dependency_version, advisory, test):
                       component_version=dependency_version)
 
     if advisory['cve']:
-        finding.unsaved_vulnerability_references = [advisory['cve']]
+        finding.unsaved_vulnerability_ids = [advisory['cve']]
 
     return finding

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -119,7 +119,7 @@ class TrivyParser:
                 )
 
                 if vuln_id:
-                    finding.unsaved_vulnerability_references = [vuln_id]
+                    finding.unsaved_vulnerability_ids = [vuln_id]
 
                 items.append(finding)
         return items

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -102,22 +102,24 @@ class TrivyParser:
                     nvd = cvss.get('nvd', None)
                     if nvd is not None:
                         cvssv3 = nvd.get('V3Vector', None)
-                items.append(
-                    Finding(
-                        test=test,
-                        title=title,
-                        cve=vuln_id,
-                        cwe=cwe,
-                        severity=severity,
-                        references=references,
-                        description=description,
-                        mitigation=mitigation,
-                        component_name=package_name,
-                        component_version=package_version,
-                        cvssv3=cvssv3,
-                        static_finding=True,
-                        dynamic_finding=False,
-                        tags=[type],
-                    )
+                finding = Finding(
+                    test=test,
+                    title=title,
+                    cwe=cwe,
+                    severity=severity,
+                    references=references,
+                    description=description,
+                    mitigation=mitigation,
+                    component_name=package_name,
+                    component_version=package_version,
+                    cvssv3=cvssv3,
+                    static_finding=True,
+                    dynamic_finding=False,
+                    tags=[type],
                 )
+
+                if vuln_id:
+                    finding.unsaved_vulnerability_references = [vuln_id]
+
+                items.append(finding)
         return items

--- a/dojo/tools/yarn_audit/parser.py
+++ b/dojo/tools/yarn_audit/parser.py
@@ -70,7 +70,6 @@ def get_item(item_node, test):
                       str(item_node['cwe']) + "\n Access: " +
                       str(item_node['access']),
                       cwe=cwe,
-                      cve=item_node['cves'][0] if (len(item_node['cves']) > 0) else None,
                       mitigation=item_node['recommendation'],
                       references=item_node['url'],
                       component_name=item_node['module_name'],
@@ -82,5 +81,10 @@ def get_item(item_node, test):
                       impact="No impact provided",
                       static_finding=True,
                       dynamic_finding=False)
+
+    if len(item_node['cves']) > 0:
+        dojo_finding.unsaved_vulnerability_references = list()
+        for vulnerability_reference in item_node['cves']:
+            dojo_finding.unsaved_vulnerability_references.append(vulnerability_reference)
 
     return dojo_finding

--- a/dojo/tools/yarn_audit/parser.py
+++ b/dojo/tools/yarn_audit/parser.py
@@ -83,8 +83,8 @@ def get_item(item_node, test):
                       dynamic_finding=False)
 
     if len(item_node['cves']) > 0:
-        dojo_finding.unsaved_vulnerability_references = list()
-        for vulnerability_reference in item_node['cves']:
-            dojo_finding.unsaved_vulnerability_references.append(vulnerability_reference)
+        dojo_finding.unsaved_vulnerability_ids = list()
+        for vulnerability_id in item_node['cves']:
+            dojo_finding.unsaved_vulnerability_ids.append(vulnerability_id)
 
     return dojo_finding

--- a/unittests/tools/test_aqua_parser.py
+++ b/unittests/tools/test_aqua_parser.py
@@ -26,8 +26,8 @@ class TestAquaParser(DojoTestCase):
         self.assertEqual('\nhttps://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-14697', finding.references)
         self.assertEqual('musl', finding.component_name)
         self.assertEqual('1.1.20-r4', finding.component_version)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual('CVE-2019-14697', finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual('CVE-2019-14697', finding.unsaved_vulnerability_ids[0])
 
     def test_aqua_parser_has_many_findings(self):
         testfile = open("unittests/scans/aqua/many_vulns.json")
@@ -46,8 +46,8 @@ class TestAquaParser(DojoTestCase):
             self.assertEqual('Medium', finding.severity)
             self.assertEqual('CURL before 7.68.0 lacks proper input validation, which allows users to create a `FILE:` URL that can make the client access a remote file using SMB (Windows-only issue).', finding.description)
             self.assertEqual('Upgrade to curl 7.68.0', finding.mitigation)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-            self.assertEqual('CVE-2019-15601', finding.unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual('CVE-2019-15601', finding.unsaved_vulnerability_ids[0])
 
     def test_aqua_parser_v2_has_many_findings(self):
         with open("unittests/scans/aqua/many_v2.json") as testfile:

--- a/unittests/tools/test_aqua_parser.py
+++ b/unittests/tools/test_aqua_parser.py
@@ -17,6 +17,17 @@ class TestAquaParser(DojoTestCase):
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(1, len(findings))
+        finding = findings[0]
+        self.assertEqual('CVE-2019-14697 - musl (1.1.20-r4) ', finding.title)
+        self.assertEqual('High', finding.severity)
+        self.assertEqual('CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', finding.cvssv3)
+        self.assertEqual('musl libc through 1.1.23 has an x87 floating-point stack adjustment imbalance, related to the math/i386/ directory. In some cases, use of this library could introduce out-of-bounds writes that are not present in an application\'s source code.', finding.description)
+        self.assertEqual('1.1.20-r5', finding.mitigation)
+        self.assertEqual('\nhttps://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2019-14697', finding.references)
+        self.assertEqual('musl', finding.component_name)
+        self.assertEqual('1.1.20-r4', finding.component_version)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual('CVE-2019-14697', finding.unsaved_vulnerability_references[0])
 
     def test_aqua_parser_has_many_findings(self):
         testfile = open("unittests/scans/aqua/many_vulns.json")
@@ -30,6 +41,13 @@ class TestAquaParser(DojoTestCase):
             parser = AquaParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
+            finding = findings[0]
+            self.assertEqual('CVE-2019-15601: curl', finding.title)
+            self.assertEqual('Medium', finding.severity)
+            self.assertEqual('CURL before 7.68.0 lacks proper input validation, which allows users to create a `FILE:` URL that can make the client access a remote file using SMB (Windows-only issue).', finding.description)
+            self.assertEqual('Upgrade to curl 7.68.0', finding.mitigation)
+            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+            self.assertEqual('CVE-2019-15601', finding.unsaved_vulnerability_references[0])
 
     def test_aqua_parser_v2_has_many_findings(self):
         with open("unittests/scans/aqua/many_v2.json") as testfile:

--- a/unittests/tools/test_cargo_audit_parser.py
+++ b/unittests/tools/test_cargo_audit_parser.py
@@ -21,7 +21,6 @@ class TestCargoAuditParser(DojoTestCase):
             finding = findings[0]
             self.assertEqual("[arc-swap 0.4.7] Dangling reference in `access::Map` with Constant", finding.title)
             self.assertEqual("High", finding.severity)
-            self.assertEqual("CVE-2020-35711", finding.cve)
             self.assertIsNotNone(finding.description)
             self.assertEqual(["dangling reference"], finding.tags)
             self.assertEqual("arc-swap", finding.component_name)
@@ -29,12 +28,13 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2020-0091", finding.vuln_id_from_tool)
             self.assertEqual("2020-12-10", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+            self.assertEqual("CVE-2020-35711", finding.unsaved_vulnerability_references[0])
 
         with self.subTest(i=1):
             finding = findings[1]
             self.assertEqual("[hyper 0.13.9] Multiple Transfer-Encoding headers misinterprets request payload", finding.title)
             self.assertEqual("High", finding.severity)
-            self.assertEqual("CVE-2021-21299", finding.cve)
             self.assertIsNotNone(finding.description)
             self.assertEqual(["http", "request-smuggling"], finding.tags)
             self.assertEqual("hyper", finding.component_name)
@@ -42,12 +42,13 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0020", finding.vuln_id_from_tool)
             self.assertEqual("2021-02-05", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+            self.assertEqual("CVE-2021-21299", finding.unsaved_vulnerability_references[0])
 
         with self.subTest(i=2):
             finding = findings[2]
             self.assertEqual("[smallvec 0.6.13] Buffer overflow in SmallVec::insert_many", finding.title)
             self.assertEqual("High", finding.severity)
-            self.assertEqual("CVE-2021-25900", finding.cve)
             self.assertIsNotNone(finding.description)
             self.assertEqual(["buffer-overflow", "heap-overflow", "unsound"], finding.tags)
             self.assertEqual("smallvec", finding.component_name)
@@ -55,12 +56,13 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0003", finding.vuln_id_from_tool)
             self.assertEqual("2021-01-08", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_references[0])
 
         with self.subTest(i=3):
             finding = findings[3]
             self.assertEqual("[smallvec 1.5.0] Buffer overflow in SmallVec::insert_many", finding.title)
             self.assertEqual("High", finding.severity)
-            self.assertEqual("CVE-2021-25900", finding.cve)
             self.assertIsNotNone(finding.description)
             self.assertEqual(["buffer-overflow", "heap-overflow", "unsound"], finding.tags)
             self.assertEqual("smallvec", finding.component_name)
@@ -68,3 +70,5 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0003", finding.vuln_id_from_tool)
             self.assertEqual("2021-01-08", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
+            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_references[0])

--- a/unittests/tools/test_cargo_audit_parser.py
+++ b/unittests/tools/test_cargo_audit_parser.py
@@ -28,8 +28,8 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2020-0091", finding.vuln_id_from_tool)
             self.assertEqual("2020-12-10", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-            self.assertEqual("CVE-2020-35711", finding.unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("CVE-2020-35711", finding.unsaved_vulnerability_ids[0])
 
         with self.subTest(i=1):
             finding = findings[1]
@@ -42,8 +42,8 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0020", finding.vuln_id_from_tool)
             self.assertEqual("2021-02-05", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-            self.assertEqual("CVE-2021-21299", finding.unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("CVE-2021-21299", finding.unsaved_vulnerability_ids[0])
 
         with self.subTest(i=2):
             finding = findings[2]
@@ -56,8 +56,8 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0003", finding.vuln_id_from_tool)
             self.assertEqual("2021-01-08", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_ids[0])
 
         with self.subTest(i=3):
             finding = findings[3]
@@ -70,5 +70,5 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0003", finding.vuln_id_from_tool)
             self.assertEqual("2021-01-08", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_ids[0])

--- a/unittests/tools/test_cargo_audit_parser.py
+++ b/unittests/tools/test_cargo_audit_parser.py
@@ -28,8 +28,9 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2020-0091", finding.vuln_id_from_tool)
             self.assertEqual("2020-12-10", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
-            self.assertEqual("CVE-2020-35711", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("RUSTSEC-2020-0091", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual("CVE-2020-35711", finding.unsaved_vulnerability_ids[1])
 
         with self.subTest(i=1):
             finding = findings[1]
@@ -42,8 +43,9 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0020", finding.vuln_id_from_tool)
             self.assertEqual("2021-02-05", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
-            self.assertEqual("CVE-2021-21299", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("RUSTSEC-2021-0020", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual("CVE-2021-21299", finding.unsaved_vulnerability_ids[1])
 
         with self.subTest(i=2):
             finding = findings[2]
@@ -56,8 +58,9 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0003", finding.vuln_id_from_tool)
             self.assertEqual("2021-01-08", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
-            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("RUSTSEC-2021-0003", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_ids[1])
 
         with self.subTest(i=3):
             finding = findings[3]
@@ -70,5 +73,6 @@ class TestCargoAuditParser(DojoTestCase):
             self.assertEqual("RUSTSEC-2021-0003", finding.vuln_id_from_tool)
             self.assertEqual("2021-01-08", finding.publish_date)
             self.assertEqual(1, finding.nb_occurences)
-            self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
-            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
+            self.assertEqual("RUSTSEC-2021-0003", finding.unsaved_vulnerability_ids[0])
+            self.assertEqual("CVE-2021-25900", finding.unsaved_vulnerability_ids[1])

--- a/unittests/tools/test_checkmarx_osa_parser.py
+++ b/unittests/tools/test_checkmarx_osa_parser.py
@@ -84,8 +84,8 @@ class TestCheckmarxOsaParser(DojoTestCase):
         self.assertEqual("A flaw was found in FasterXML Jackson Databind before 2.6.7.4, 2.7.0 through 2.9.10.6, and 2.10.0 through 2.10.5, where it did not have entity expansion secured properly. This flaw makes it vulnerable to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.", item.description)
         self.assertEqual(int, type(item.scanner_confidence))
         self.assertEqual(1, item.scanner_confidence)
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-25649", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-25649", item.unsaved_vulnerability_ids[0])
 
     # ----------------------------------------------------------------------------
     # single finding false positive

--- a/unittests/tools/test_checkmarx_osa_parser.py
+++ b/unittests/tools/test_checkmarx_osa_parser.py
@@ -56,8 +56,6 @@ class TestCheckmarxOsaParser(DojoTestCase):
         self.assertEqual("com.fasterxml.jackson.core:jackson-databind 2.10.2 | CVE-2020-25649", item.title)
         self.assertEqual(int, type(item.cwe))
         self.assertEqual(1035, item.cwe)
-        self.assertEqual(str, type(item.cve))
-        self.assertEqual("CVE-2020-25649", item.cve)
         self.assertEqual(float, type(item.cvssv3_score))
         self.assertEqual(7.5, item.cvssv3_score)
         self.assertEqual(datetime, type(item.publish_date))
@@ -86,6 +84,8 @@ class TestCheckmarxOsaParser(DojoTestCase):
         self.assertEqual("A flaw was found in FasterXML Jackson Databind before 2.6.7.4, 2.7.0 through 2.9.10.6, and 2.10.0 through 2.10.5, where it did not have entity expansion secured properly. This flaw makes it vulnerable to XML external entity (XXE) attacks. The highest threat from this vulnerability is data integrity.", item.description)
         self.assertEqual(int, type(item.scanner_confidence))
         self.assertEqual(1, item.scanner_confidence)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-25649", item.unsaved_vulnerability_references[0])
 
     # ----------------------------------------------------------------------------
     # single finding false positive

--- a/unittests/tools/test_clair_parser.py
+++ b/unittests/tools/test_clair_parser.py
@@ -20,5 +20,6 @@ class TestClairParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839", finding.references)
-        self.assertEqual("CVE-2018-20839", finding.cve)
         self.assertEqual("CVE-2018-20839 - (systemd, 237-3ubuntu10.29)", finding.title)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2018-20839", finding.unsaved_vulnerability_references[0])

--- a/unittests/tools/test_clair_parser.py
+++ b/unittests/tools/test_clair_parser.py
@@ -21,5 +21,5 @@ class TestClairParser(DojoTestCase):
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("http://people.ubuntu.com/~ubuntu-security/cve/CVE-2018-20839", finding.references)
         self.assertEqual("CVE-2018-20839 - (systemd, 237-3ubuntu10.29)", finding.title)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2018-20839", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2018-20839", finding.unsaved_vulnerability_ids[0])

--- a/unittests/tools/test_dependency_check_parser.py
+++ b/unittests/tools/test_dependency_check_parser.py
@@ -731,6 +731,8 @@ class TestDependencyCheckParser(DojoTestCase):
             self.assertEqual(
                 items[0].date, datetime(2016, 11, 5, 14, 52, 15, 748000, tzinfo=tzoffset(None, -14400))
             )  # 2016-11-05T14:52:15.748-0400
+            self.assertEqual(1, len(items[0].unsaved_vulnerability_references))
+            self.assertEqual('CVE-0000-0001', items[0].unsaved_vulnerability_references[0])
 
         with self.subTest(i=1):
             self.assertEqual(items[1].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
@@ -751,6 +753,8 @@ class TestDependencyCheckParser(DojoTestCase):
                 "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
             )
             self.assertEqual(items[1].tags, "related")
+            self.assertEqual(1, len(items[1].unsaved_vulnerability_references))
+            self.assertEqual('CVE-0000-0001', items[1].unsaved_vulnerability_references[0])
 
         with self.subTest(i=2):
             self.assertEqual(items[2].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
@@ -770,6 +774,8 @@ class TestDependencyCheckParser(DojoTestCase):
                 items[2].mitigation,
                 "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
             )
+            self.assertEqual(1, len(items[2].unsaved_vulnerability_references))
+            self.assertEqual('CVE-0000-0001', items[2].unsaved_vulnerability_references[0])
 
         with self.subTest(i=3):
             # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities, relateddependencies without filename (pre v6.0.0)
@@ -789,6 +795,7 @@ class TestDependencyCheckParser(DojoTestCase):
                 "**Source:** NPM",
                 items[3].description,
             )
+            self.assertIsNone(items[3].unsaved_vulnerability_references)
 
         with self.subTest(i=4):
             self.assertEqual(
@@ -810,6 +817,8 @@ class TestDependencyCheckParser(DojoTestCase):
             self.assertEqual(
                 items[4].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description"
             )
+            self.assertEqual(1, len(items[4].unsaved_vulnerability_references))
+            self.assertEqual('CVE-2020-7608', items[4].unsaved_vulnerability_references[0])
 
         with self.subTest(i=5):
             self.assertEqual(
@@ -832,6 +841,7 @@ class TestDependencyCheckParser(DojoTestCase):
             self.assertEqual(
                 items[5].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description"
             )
+            self.assertIsNone(items[5].unsaved_vulnerability_references)
 
         with self.subTest(i=6):
             # identifier -> cpe java
@@ -844,6 +854,8 @@ class TestDependencyCheckParser(DojoTestCase):
                 items[6].mitigation,
                 "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
             )
+            self.assertEqual(1, len(items[6].unsaved_vulnerability_references))
+            self.assertEqual('CVE-0000-0001', items[6].unsaved_vulnerability_references[0])
 
         with self.subTest(i=7):
             # identifier -> maven java

--- a/unittests/tools/test_dependency_check_parser.py
+++ b/unittests/tools/test_dependency_check_parser.py
@@ -731,8 +731,8 @@ class TestDependencyCheckParser(DojoTestCase):
             self.assertEqual(
                 items[0].date, datetime(2016, 11, 5, 14, 52, 15, 748000, tzinfo=tzoffset(None, -14400))
             )  # 2016-11-05T14:52:15.748-0400
-            self.assertEqual(1, len(items[0].unsaved_vulnerability_references))
-            self.assertEqual('CVE-0000-0001', items[0].unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(items[0].unsaved_vulnerability_ids))
+            self.assertEqual('CVE-0000-0001', items[0].unsaved_vulnerability_ids[0])
 
         with self.subTest(i=1):
             self.assertEqual(items[1].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
@@ -753,8 +753,8 @@ class TestDependencyCheckParser(DojoTestCase):
                 "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
             )
             self.assertEqual(items[1].tags, "related")
-            self.assertEqual(1, len(items[1].unsaved_vulnerability_references))
-            self.assertEqual('CVE-0000-0001', items[1].unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(items[1].unsaved_vulnerability_ids))
+            self.assertEqual('CVE-0000-0001', items[1].unsaved_vulnerability_ids[0])
 
         with self.subTest(i=2):
             self.assertEqual(items[2].title, "org.dom4j:dom4j:2.1.1.redhat-00001 | CVE-0000-0001")
@@ -774,8 +774,8 @@ class TestDependencyCheckParser(DojoTestCase):
                 items[2].mitigation,
                 "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
             )
-            self.assertEqual(1, len(items[2].unsaved_vulnerability_references))
-            self.assertEqual('CVE-0000-0001', items[2].unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(items[2].unsaved_vulnerability_ids))
+            self.assertEqual('CVE-0000-0001', items[2].unsaved_vulnerability_ids[0])
 
         with self.subTest(i=3):
             # identifier -> package url javascript, no vulnerabilitids, 3 vulnerabilities, relateddependencies without filename (pre v6.0.0)
@@ -795,7 +795,7 @@ class TestDependencyCheckParser(DojoTestCase):
                 "**Source:** NPM",
                 items[3].description,
             )
-            self.assertIsNone(items[3].unsaved_vulnerability_references)
+            self.assertIsNone(items[3].unsaved_vulnerability_ids)
 
         with self.subTest(i=4):
             self.assertEqual(
@@ -817,8 +817,8 @@ class TestDependencyCheckParser(DojoTestCase):
             self.assertEqual(
                 items[4].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description"
             )
-            self.assertEqual(1, len(items[4].unsaved_vulnerability_references))
-            self.assertEqual('CVE-2020-7608', items[4].unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(items[4].unsaved_vulnerability_ids))
+            self.assertEqual('CVE-2020-7608', items[4].unsaved_vulnerability_ids[0])
 
         with self.subTest(i=5):
             self.assertEqual(
@@ -841,7 +841,7 @@ class TestDependencyCheckParser(DojoTestCase):
             self.assertEqual(
                 items[5].mitigation, "Update yargs-parser:5.0.0 to at least the version recommended in the description"
             )
-            self.assertIsNone(items[5].unsaved_vulnerability_references)
+            self.assertIsNone(items[5].unsaved_vulnerability_ids)
 
         with self.subTest(i=6):
             # identifier -> cpe java
@@ -854,8 +854,8 @@ class TestDependencyCheckParser(DojoTestCase):
                 items[6].mitigation,
                 "Update org.dom4j:dom4j:2.1.1.redhat-00001 to at least the version recommended in the description",
             )
-            self.assertEqual(1, len(items[6].unsaved_vulnerability_references))
-            self.assertEqual('CVE-0000-0001', items[6].unsaved_vulnerability_references[0])
+            self.assertEqual(1, len(items[6].unsaved_vulnerability_ids))
+            self.assertEqual('CVE-0000-0001', items[6].unsaved_vulnerability_ids[0])
 
         with self.subTest(i=7):
             # identifier -> maven java

--- a/unittests/tools/test_dependency_track_parser.py
+++ b/unittests/tools/test_dependency_track_parser.py
@@ -43,12 +43,12 @@ class TestDependencyTrackParser(DojoTestCase):
         testfile.close()
         self.assertEqual(4, len(findings))
 
-        self.assertIsNone(findings[0].unsaved_vulnerability_references)
-        self.assertIsNone(findings[1].unsaved_vulnerability_references)
-        self.assertEqual(1, len(findings[2].unsaved_vulnerability_references))
-        self.assertEqual('CVE-2016-2097', findings[2].unsaved_vulnerability_references[0])
-        self.assertEqual(1, len(findings[3].unsaved_vulnerability_references))
-        self.assertEqual('CVE-2016-2097', findings[3].unsaved_vulnerability_references[0])
+        self.assertIsNone(findings[0].unsaved_vulnerability_ids)
+        self.assertIsNone(findings[1].unsaved_vulnerability_ids)
+        self.assertEqual(1, len(findings[2].unsaved_vulnerability_ids))
+        self.assertEqual('CVE-2016-2097', findings[2].unsaved_vulnerability_ids[0])
+        self.assertEqual(1, len(findings[3].unsaved_vulnerability_ids))
+        self.assertEqual('CVE-2016-2097', findings[3].unsaved_vulnerability_ids[0])
 
     def test_dependency_track_parser_has_one_finding(self):
         testfile = open(

--- a/unittests/tools/test_dependency_track_parser.py
+++ b/unittests/tools/test_dependency_track_parser.py
@@ -43,6 +43,13 @@ class TestDependencyTrackParser(DojoTestCase):
         testfile.close()
         self.assertEqual(4, len(findings))
 
+        self.assertIsNone(findings[0].unsaved_vulnerability_references)
+        self.assertIsNone(findings[1].unsaved_vulnerability_references)
+        self.assertEqual(1, len(findings[2].unsaved_vulnerability_references))
+        self.assertEqual('CVE-2016-2097', findings[2].unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(findings[3].unsaved_vulnerability_references))
+        self.assertEqual('CVE-2016-2097', findings[3].unsaved_vulnerability_references[0])
+
     def test_dependency_track_parser_has_one_finding(self):
         testfile = open(
             get_unit_tests_path() + "/scans/dependency_track_samples/one_finding.json"

--- a/unittests/tools/test_dsop_parser.py
+++ b/unittests/tools/test_dsop_parser.py
@@ -20,4 +20,3 @@ class TestDsopParser(DojoTestCase):
         self.assertEqual("Low", finding.severity)
         self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
         self.assertEqual("CVE-2019-15587", finding.unsaved_vulnerability_ids[0])
-

--- a/unittests/tools/test_dsop_parser.py
+++ b/unittests/tools/test_dsop_parser.py
@@ -18,6 +18,6 @@ class TestDsopParser(DojoTestCase):
         self.assertEquals(len(findings), 4)
         finding = findings[0]
         self.assertEqual("Low", finding.severity)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2019-15587", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2019-15587", finding.unsaved_vulnerability_ids[0])
 

--- a/unittests/tools/test_dsop_parser.py
+++ b/unittests/tools/test_dsop_parser.py
@@ -17,5 +17,7 @@ class TestDsopParser(DojoTestCase):
         findings = parser.get_findings(testfile, Test())
         self.assertEquals(len(findings), 4)
         finding = findings[0]
-        self.assertEqual("CVE-2019-15587", finding.cve)
         self.assertEqual("Low", finding.severity)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2019-15587", finding.unsaved_vulnerability_references[0])
+

--- a/unittests/tools/test_gitlab_dep_scan_parser.py
+++ b/unittests/tools/test_gitlab_dep_scan_parser.py
@@ -42,3 +42,6 @@ class TestGitlabDepScanParser(DojoTestCase):
         parser = GitlabDepScanParser()
         findings = parser.get_findings(testfile, Test())
         self.assertTrue(len(findings) > 2)
+
+        self.assertEqual(1, len(findings[0].unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-29652", findings[0].unsaved_vulnerability_references[0])

--- a/unittests/tools/test_gitlab_dep_scan_parser.py
+++ b/unittests/tools/test_gitlab_dep_scan_parser.py
@@ -43,5 +43,5 @@ class TestGitlabDepScanParser(DojoTestCase):
         findings = parser.get_findings(testfile, Test())
         self.assertTrue(len(findings) > 2)
 
-        self.assertEqual(1, len(findings[0].unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-29652", findings[0].unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-29652", findings[0].unsaved_vulnerability_ids[0])

--- a/unittests/tools/test_jfrog_xray_unified_parser.py
+++ b/unittests/tools/test_jfrog_xray_unified_parser.py
@@ -23,7 +23,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         self.assertEquals("XRAY-139239 - This affects the package", item.title[:38])
         self.assertEquals(" memory.", item.title[-8:])
-        self.assertEquals("CVE-2020-28493", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-28493", item.unsaved_vulnerability_references[0])
         self.assertEquals("Medium", item.severity)
         self.assertEquals("This affects the package", item.description[:24])
         self.assertEquals(" memory.", item.description[-8:])
@@ -59,105 +60,123 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # blank cvss2
         item = [i for i in findings if i.title[:11] == "XRAY-106730"][-1]
-        self.assertEquals("CVE-2018-10754", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2018-10754", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.severity_justification)
         self.assertGreater(len(item.severity_justification), 0)
 
         # blank cvss3
         item = [i for i in findings if i.title[:11] == "XRAY-100538"][-1]
-        self.assertEquals("CVE-2015-2716", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2015-2716", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.severity_justification)
         self.assertGreater(len(item.severity_justification), 0)
 
         # 0 references
         item = [i for i in findings if i.title[:11] == "XRAY-100015"][-1]
-        self.assertEquals("CVE-2020-13790", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-13790", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.references)
         self.assertEquals(len(item.references), 0)
 
         # 1 reference
         item = [i for i in findings if i.title[:11] == "XRAY-101489"][-1]
-        self.assertEquals("CVE-2020-14040", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-14040", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.references)
         self.assertGreater(len(item.references), 0)
 
         # many references
         item = [i for i in findings if i.title[:11] == "XRAY-100092"][-1]
-        self.assertEquals("CVE-2020-12723", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-12723", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.references)
         self.assertGreater(len(item.references), 50)
 
         # multiple cvss scores - all have cvss3
         item = [i for i in findings if i.title[:10] == "XRAY-96518"][-1]
-        self.assertEquals("CVE-2016-10745", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2016-10745", item.unsaved_vulnerability_references[0])
         self.assertEquals("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N", item.cvssv3)
 
         # multiiple cvss scores, some cvss2 missing
         item = [i for i in findings if i.title[:11] == "XRAY-128854"][-1]
-        self.assertEquals("CVE-2019-17006", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2019-17006", item.unsaved_vulnerability_references[0])
         self.assertEquals("CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H", item.cvssv3)
 
         # multiiple cvss scores, some cvss3 missing
         item = [i for i in findings if i.title[:11] == "XRAY-135206"][-1]
-        self.assertEquals("CVE-2019-17006", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2019-17006", item.unsaved_vulnerability_references[0])
         self.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", item.cvssv3)
 
         # 0 fixed verisons
         item = [i for i in findings if i.title[:11] == "XRAY-100015"][-1]
-        self.assertEquals("CVE-2020-13790", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-13790", item.unsaved_vulnerability_references[0])
         self.assertIsNone(item.mitigation)
 
         # 1 fixed version
         item = [i for i in findings if i.title[:11] == "XRAY-100646"][-1]
-        self.assertEquals("CVE-2020-14062", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-14062", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.mitigation)
         self.assertGreater(len(item.mitigation), 0)
 
         # multiple fixed versions
         item = [i for i in findings if i.title[:11] == "XRAY-127258"][-1]
-        self.assertEquals("CVE-2020-27216", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-27216", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.mitigation)
         self.assertGreater(len(item.mitigation), 50)
 
         # fixed versions with weird characters
         item = [i for i in findings if i.title[:11] == "XRAY-128876"][-1]
-        self.assertEquals("CVE-2020-8623", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-8623", item.unsaved_vulnerability_references[0])
         self.assertIsNotNone(item.mitigation)
         self.assertGreater(len(item.mitigation), 0)
 
         # severity unknown
         item = [i for i in findings if i.title[:11] == "XRAY-119297"][-1]
-        self.assertEquals("CVE-2020-12403", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-12403", item.unsaved_vulnerability_references[0])
         self.assertEquals("Info", item.severity)
         self.assertEquals("Info", item.impact)
 
         # severity low
         item = [i for i in findings if i.title[:11] == "XRAY-100046"][-1]
-        self.assertEquals("CVE-2020-13871", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-13871", item.unsaved_vulnerability_references[0])
         self.assertEquals("Low", item.severity)
         self.assertEquals("Low", item.impact)
 
         # severity medium
         item = [i for i in findings if i.title[:11] == "XRAY-100757"][-1]
-        self.assertEquals("CVE-2020-14155", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-14155", item.unsaved_vulnerability_references[0])
         self.assertEquals("Medium", item.severity)
         self.assertEquals("Medium", item.impact)
 
         # severity high
         item = [i for i in findings if i.title[:11] == "XRAY-109517"][-1]
-        self.assertEquals("CVE-2019-5827", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2019-5827", item.unsaved_vulnerability_references[0])
         self.assertEquals("High", item.severity)
         self.assertEquals("High", item.impact)
 
         # external severity in details
         item = [i for i in findings if i.title[:11] == "XRAY-111224"][-1]
-        self.assertEquals("CVE-2015-8385", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2015-8385", item.unsaved_vulnerability_references[0])
         self.assertEquals("Red Hat Severity: Important", item.description[-27:])
 
         # **various packages**
         # alpine
         item = [i for i in findings if i.title[:11] == "XRAY-100301"][-1]
-        self.assertEquals("CVE-2020-13871", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-13871", item.unsaved_vulnerability_references[0])
         self.assertEquals("XRAY-100301 - SQLite 3.32.2 has a use", item.title[:37])
         self.assertEquals(" is too late.", item.title[-13:])
         self.assertEquals("Medium", item.severity)
@@ -179,7 +198,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # debian
         item = [i for i in findings if i.title[:11] == "XRAY-137237"][-1]
-        self.assertEquals("CVE-2020-1971", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-1971", item.unsaved_vulnerability_references[0])
         self.assertEquals("XRAY-137237 - The X.509 GeneralName", item.title[:35])
         self.assertEquals("(Affected 1.0.2-1.0.2w).", item.title[-24:])
         self.assertEquals("High", item.severity)
@@ -201,7 +221,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # go
         item = [i for i in findings if i.title[:10] == "XRAY-86054"][-1]
-        self.assertEquals("CVE-2014-0047", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2014-0047", item.unsaved_vulnerability_references[0])
         self.assertEquals("XRAY-86054 - Docker before 1.5 allows", item.title[:37])
         self.assertEquals("/tmp usage.", item.title[-11:])
         self.assertEquals("Medium", item.severity)
@@ -224,7 +245,7 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # maven
         item = [i for i in findings if i.title[:11] == "XRAY-126663"][-1]
-        self.assertIsNone(item.cve)  # has cvss score but no cve??
+        self.assertIsNone(item.unsaved_vulnerability_references)  # has cvss score but no cve??
         self.assertEquals("XRAY-126663 - FasterXML jackson", item.title[:31])
         self.assertEquals("Expansion Remote Issue", item.title[-22:])
         self.assertEquals("High", item.severity)
@@ -246,7 +267,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # npm
         item = [i for i in findings if i.title[:10] == "XRAY-97245"][-1]
-        self.assertEquals("CVE-2020-11023", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-11023", item.unsaved_vulnerability_references[0])
         self.assertEquals("XRAY-97245 - In jQuery versions great", item.title[:37])
         self.assertEquals("patched in jQuery 3.5.0.", item.title[-24:])
         self.assertEquals("Medium", item.severity)
@@ -269,7 +291,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # pypi
         item = [i for i in findings if i.title[:10] == "XRAY-97724"][-1]
-        self.assertEquals("CVE-2018-20225", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2018-20225", item.unsaved_vulnerability_references[0])
         self.assertEquals("XRAY-97724 - An issue was discovered", item.title[:36])
         self.assertEquals("an arbitrary version number).", item.title[-29:])
         self.assertEquals("Medium", item.severity)
@@ -292,7 +315,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # rpm
         item = [i for i in findings if i.title[:11] == "XRAY-106044"][-1]
-        self.assertEquals("CVE-2019-19645", item.cve)
+        self.assertEqual(1, len(item.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2019-19645", item.unsaved_vulnerability_references[0])
         self.assertEquals("XRAY-106044 - CVE-2019-19645 sqlite: infinite", item.title[:45])
         self.assertEquals("TABLE statements", item.title[-16:])
         self.assertEquals("Medium", item.severity)

--- a/unittests/tools/test_jfrog_xray_unified_parser.py
+++ b/unittests/tools/test_jfrog_xray_unified_parser.py
@@ -23,8 +23,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         self.assertEquals("XRAY-139239 - This affects the package", item.title[:38])
         self.assertEquals(" memory.", item.title[-8:])
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-28493", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-28493", item.unsaved_vulnerability_ids[0])
         self.assertEquals("Medium", item.severity)
         self.assertEquals("This affects the package", item.description[:24])
         self.assertEquals(" memory.", item.description[-8:])
@@ -60,123 +60,123 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # blank cvss2
         item = [i for i in findings if i.title[:11] == "XRAY-106730"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2018-10754", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2018-10754", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.severity_justification)
         self.assertGreater(len(item.severity_justification), 0)
 
         # blank cvss3
         item = [i for i in findings if i.title[:11] == "XRAY-100538"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2015-2716", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2015-2716", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.severity_justification)
         self.assertGreater(len(item.severity_justification), 0)
 
         # 0 references
         item = [i for i in findings if i.title[:11] == "XRAY-100015"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-13790", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-13790", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.references)
         self.assertEquals(len(item.references), 0)
 
         # 1 reference
         item = [i for i in findings if i.title[:11] == "XRAY-101489"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-14040", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-14040", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.references)
         self.assertGreater(len(item.references), 0)
 
         # many references
         item = [i for i in findings if i.title[:11] == "XRAY-100092"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-12723", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-12723", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.references)
         self.assertGreater(len(item.references), 50)
 
         # multiple cvss scores - all have cvss3
         item = [i for i in findings if i.title[:10] == "XRAY-96518"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2016-10745", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2016-10745", item.unsaved_vulnerability_ids[0])
         self.assertEquals("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N", item.cvssv3)
 
         # multiiple cvss scores, some cvss2 missing
         item = [i for i in findings if i.title[:11] == "XRAY-128854"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2019-17006", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2019-17006", item.unsaved_vulnerability_ids[0])
         self.assertEquals("CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H", item.cvssv3)
 
         # multiiple cvss scores, some cvss3 missing
         item = [i for i in findings if i.title[:11] == "XRAY-135206"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2019-17006", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2019-17006", item.unsaved_vulnerability_ids[0])
         self.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", item.cvssv3)
 
         # 0 fixed verisons
         item = [i for i in findings if i.title[:11] == "XRAY-100015"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-13790", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-13790", item.unsaved_vulnerability_ids[0])
         self.assertIsNone(item.mitigation)
 
         # 1 fixed version
         item = [i for i in findings if i.title[:11] == "XRAY-100646"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-14062", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-14062", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.mitigation)
         self.assertGreater(len(item.mitigation), 0)
 
         # multiple fixed versions
         item = [i for i in findings if i.title[:11] == "XRAY-127258"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-27216", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-27216", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.mitigation)
         self.assertGreater(len(item.mitigation), 50)
 
         # fixed versions with weird characters
         item = [i for i in findings if i.title[:11] == "XRAY-128876"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-8623", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-8623", item.unsaved_vulnerability_ids[0])
         self.assertIsNotNone(item.mitigation)
         self.assertGreater(len(item.mitigation), 0)
 
         # severity unknown
         item = [i for i in findings if i.title[:11] == "XRAY-119297"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-12403", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-12403", item.unsaved_vulnerability_ids[0])
         self.assertEquals("Info", item.severity)
         self.assertEquals("Info", item.impact)
 
         # severity low
         item = [i for i in findings if i.title[:11] == "XRAY-100046"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-13871", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-13871", item.unsaved_vulnerability_ids[0])
         self.assertEquals("Low", item.severity)
         self.assertEquals("Low", item.impact)
 
         # severity medium
         item = [i for i in findings if i.title[:11] == "XRAY-100757"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-14155", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-14155", item.unsaved_vulnerability_ids[0])
         self.assertEquals("Medium", item.severity)
         self.assertEquals("Medium", item.impact)
 
         # severity high
         item = [i for i in findings if i.title[:11] == "XRAY-109517"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2019-5827", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2019-5827", item.unsaved_vulnerability_ids[0])
         self.assertEquals("High", item.severity)
         self.assertEquals("High", item.impact)
 
         # external severity in details
         item = [i for i in findings if i.title[:11] == "XRAY-111224"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2015-8385", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2015-8385", item.unsaved_vulnerability_ids[0])
         self.assertEquals("Red Hat Severity: Important", item.description[-27:])
 
         # **various packages**
         # alpine
         item = [i for i in findings if i.title[:11] == "XRAY-100301"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-13871", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-13871", item.unsaved_vulnerability_ids[0])
         self.assertEquals("XRAY-100301 - SQLite 3.32.2 has a use", item.title[:37])
         self.assertEquals(" is too late.", item.title[-13:])
         self.assertEquals("Medium", item.severity)
@@ -198,8 +198,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # debian
         item = [i for i in findings if i.title[:11] == "XRAY-137237"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-1971", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-1971", item.unsaved_vulnerability_ids[0])
         self.assertEquals("XRAY-137237 - The X.509 GeneralName", item.title[:35])
         self.assertEquals("(Affected 1.0.2-1.0.2w).", item.title[-24:])
         self.assertEquals("High", item.severity)
@@ -221,8 +221,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # go
         item = [i for i in findings if i.title[:10] == "XRAY-86054"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2014-0047", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2014-0047", item.unsaved_vulnerability_ids[0])
         self.assertEquals("XRAY-86054 - Docker before 1.5 allows", item.title[:37])
         self.assertEquals("/tmp usage.", item.title[-11:])
         self.assertEquals("Medium", item.severity)
@@ -245,7 +245,7 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # maven
         item = [i for i in findings if i.title[:11] == "XRAY-126663"][-1]
-        self.assertIsNone(item.unsaved_vulnerability_references)  # has cvss score but no cve??
+        self.assertIsNone(item.unsaved_vulnerability_ids)  # has cvss score but no cve??
         self.assertEquals("XRAY-126663 - FasterXML jackson", item.title[:31])
         self.assertEquals("Expansion Remote Issue", item.title[-22:])
         self.assertEquals("High", item.severity)
@@ -267,8 +267,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # npm
         item = [i for i in findings if i.title[:10] == "XRAY-97245"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-11023", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-11023", item.unsaved_vulnerability_ids[0])
         self.assertEquals("XRAY-97245 - In jQuery versions great", item.title[:37])
         self.assertEquals("patched in jQuery 3.5.0.", item.title[-24:])
         self.assertEquals("Medium", item.severity)
@@ -291,8 +291,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # pypi
         item = [i for i in findings if i.title[:10] == "XRAY-97724"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2018-20225", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2018-20225", item.unsaved_vulnerability_ids[0])
         self.assertEquals("XRAY-97724 - An issue was discovered", item.title[:36])
         self.assertEquals("an arbitrary version number).", item.title[-29:])
         self.assertEquals("Medium", item.severity)
@@ -315,8 +315,8 @@ class TestJFrogXrayUnifiedParser(DojoTestCase):
 
         # rpm
         item = [i for i in findings if i.title[:11] == "XRAY-106044"][-1]
-        self.assertEqual(1, len(item.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2019-19645", item.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(item.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2019-19645", item.unsaved_vulnerability_ids[0])
         self.assertEquals("XRAY-106044 - CVE-2019-19645 sqlite: infinite", item.title[:45])
         self.assertEquals("TABLE statements", item.title[-16:])
         self.assertEquals("Medium", item.severity)

--- a/unittests/tools/test_nessus_parser.py
+++ b/unittests/tools/test_nessus_parser.py
@@ -22,7 +22,6 @@ class TestNessusParser(DojoTestCase):
         finding = findings[5]
         self.assertEqual("Info", finding.severity)
         self.assertIsNone(finding.cwe)
-        print(finding.unsaved_endpoints)
         endpoint = finding.unsaved_endpoints[0]
         self.assertEqual("https", endpoint.protocol)
         endpoint = finding.unsaved_endpoints[1]
@@ -44,17 +43,19 @@ class TestNessusParser(DojoTestCase):
             self.assertEqual(0, finding.cwe)
         # check some data
         finding = findings[0]
-        self.assertEqual("CVE-2004-2761", finding.cve)
         self.assertEqual(1, len(finding.unsaved_endpoints))
         self.assertEqual("10.1.1.1", finding.unsaved_endpoints[0].host)
         self.assertEqual("AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N/E:P/RL:O/RC:C", finding.cvssv3)
         # TODO work on component attributes for Nessus CSV parser
         self.assertIsNotNone(finding.component_name)
         self.assertEqual("md5", finding.component_name)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_references[0])
         # this vuln have 'CVE-2013-2566,CVE-2015-2808' as CVE
-        # current implementation return the first
         finding = findings[3]
-        self.assertEqual("CVE-2013-2566", finding.cve)
+        self.assertEqual(2, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2013-2566", finding.unsaved_vulnerability_references[0])
+        self.assertEqual("CVE-2015-2808", finding.unsaved_vulnerability_references[1])
 
     def test_parse_some_findings_csv2(self):
         """Test that use default columns of Nessus Pro 8.13.1 (#257)"""
@@ -75,7 +76,8 @@ class TestNessusParser(DojoTestCase):
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("SSL Certificate Signed Using Weak Hashing Algorithm (Known CA)", finding.title)
         self.assertEqual("Info", finding.severity)
-        self.assertEqual("CVE-2004-2761", finding.cve)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_references[0])
 
     def test_parse_some_findings_csv2_all(self):
         """Test that use a report with all columns of Nessus Pro 8.13.1 (#257)"""
@@ -96,7 +98,8 @@ class TestNessusParser(DojoTestCase):
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("SSL Certificate Signed Using Weak Hashing Algorithm (Known CA)", finding.title)
         self.assertEqual("Info", finding.severity)
-        self.assertEqual("CVE-2004-2761", finding.cve)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_references[0])
 
     def test_parse_some_findings_csv_bytes(self):
         """This tests is designed to test the parser with different read modes"""
@@ -128,17 +131,24 @@ class TestNessusParser(DojoTestCase):
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()
         self.assertEqual(32, len(findings))
+
         finding = findings[0]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Info", finding.severity)
-        self.assertIsNone(finding.cve)
+        self.assertFalse(finding.unsaved_vulnerability_references)
         self.assertEqual("Nessus Scan Information", finding.title)
+
         finding = findings[25]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Nessus SYN scanner", finding.title)
         self.assertEqual("Info", finding.severity)
-        self.assertIsNone(finding.cve)
+        self.assertFalse(finding.unsaved_vulnerability_references)
         endpoint = finding.unsaved_endpoints[26]
         self.assertEqual("http", endpoint.protocol)
         endpoint = finding.unsaved_endpoints[37]
         self.assertEqual("tcp", endpoint.protocol)
+
+        finding = findings[9]
+        self.assertEqual(7, len(finding.unsaved_vulnerability_references))
+        for vulnerability_reference in finding.unsaved_vulnerability_references:
+            self.assertEqual('CVE-2005-1794', vulnerability_reference)

--- a/unittests/tools/test_nessus_parser.py
+++ b/unittests/tools/test_nessus_parser.py
@@ -49,13 +49,13 @@ class TestNessusParser(DojoTestCase):
         # TODO work on component attributes for Nessus CSV parser
         self.assertIsNotNone(finding.component_name)
         self.assertEqual("md5", finding.component_name)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_ids[0])
         # this vuln have 'CVE-2013-2566,CVE-2015-2808' as CVE
         finding = findings[3]
-        self.assertEqual(2, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2013-2566", finding.unsaved_vulnerability_references[0])
-        self.assertEqual("CVE-2015-2808", finding.unsaved_vulnerability_references[1])
+        self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2013-2566", finding.unsaved_vulnerability_ids[0])
+        self.assertEqual("CVE-2015-2808", finding.unsaved_vulnerability_ids[1])
 
     def test_parse_some_findings_csv2(self):
         """Test that use default columns of Nessus Pro 8.13.1 (#257)"""
@@ -76,8 +76,8 @@ class TestNessusParser(DojoTestCase):
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("SSL Certificate Signed Using Weak Hashing Algorithm (Known CA)", finding.title)
         self.assertEqual("Info", finding.severity)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_ids[0])
 
     def test_parse_some_findings_csv2_all(self):
         """Test that use a report with all columns of Nessus Pro 8.13.1 (#257)"""
@@ -98,8 +98,8 @@ class TestNessusParser(DojoTestCase):
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("SSL Certificate Signed Using Weak Hashing Algorithm (Known CA)", finding.title)
         self.assertEqual("Info", finding.severity)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2004-2761", finding.unsaved_vulnerability_ids[0])
 
     def test_parse_some_findings_csv_bytes(self):
         """This tests is designed to test the parser with different read modes"""
@@ -135,20 +135,20 @@ class TestNessusParser(DojoTestCase):
         finding = findings[0]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Info", finding.severity)
-        self.assertFalse(finding.unsaved_vulnerability_references)
+        self.assertFalse(finding.unsaved_vulnerability_ids)
         self.assertEqual("Nessus Scan Information", finding.title)
 
         finding = findings[25]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Nessus SYN scanner", finding.title)
         self.assertEqual("Info", finding.severity)
-        self.assertFalse(finding.unsaved_vulnerability_references)
+        self.assertFalse(finding.unsaved_vulnerability_ids)
         endpoint = finding.unsaved_endpoints[26]
         self.assertEqual("http", endpoint.protocol)
         endpoint = finding.unsaved_endpoints[37]
         self.assertEqual("tcp", endpoint.protocol)
 
         finding = findings[9]
-        self.assertEqual(7, len(finding.unsaved_vulnerability_references))
-        for vulnerability_reference in finding.unsaved_vulnerability_references:
-            self.assertEqual('CVE-2005-1794', vulnerability_reference)
+        self.assertEqual(7, len(finding.unsaved_vulnerability_ids))
+        for vulnerability_id in finding.unsaved_vulnerability_ids:
+            self.assertEqual('CVE-2005-1794', vulnerability_id)

--- a/unittests/tools/test_nexpose_parser.py
+++ b/unittests/tools/test_nexpose_parser.py
@@ -44,15 +44,15 @@ class TestNexposeParser(DojoTestCase):
         self.assertIn("https://www.securityfocus.com/bid/10183", finding.references)  # BID: 10183
         self.assertIn("https://www.kb.cert.org/vuls/id/415294.html", finding.references)  # CERT-VN: 415294
         self.assertIn("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2004-0230", finding.references)  # CVE: CVE-2004-0230
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2004-0230", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2004-0230", finding.unsaved_vulnerability_ids[0])
 
         # vuln 2
         finding = findings[2]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("TCP timestamp response", finding.title)
         self.assertEqual(5, len(finding.unsaved_endpoints))
-        self.assertIsNone(finding.unsaved_vulnerability_references)
+        self.assertIsNone(finding.unsaved_vulnerability_ids)
 
         # vuln 2 - endpoint
         endpoint = finding.unsaved_endpoints[0]
@@ -147,21 +147,21 @@ class TestNexposeParser(DojoTestCase):
         self.assertEqual("High", finding.severity)
         self.assertEqual("ICMP redirection enabled", finding.title)
         self.assertEqual(4, len(finding.unsaved_endpoints))
-        self.assertIsNone(finding.unsaved_vulnerability_references)
+        self.assertIsNone(finding.unsaved_vulnerability_ids)
 
         # vuln 1
         finding = findings[1]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("No password for Grub", finding.title)
         self.assertEqual(4, len(finding.unsaved_endpoints))
-        self.assertIsNone(finding.unsaved_vulnerability_references)
+        self.assertIsNone(finding.unsaved_vulnerability_ids)
 
         # vuln 2
         finding = findings[2]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("User home directory mode unsafe", finding.title)
         self.assertEqual(16, len(finding.unsaved_endpoints))
-        self.assertIsNone(finding.unsaved_vulnerability_references)
+        self.assertIsNone(finding.unsaved_vulnerability_ids)
 
     def test_nexpose_parser_dns(self):
         testfile = open("unittests/scans/nexpose/dns.xml")

--- a/unittests/tools/test_nexpose_parser.py
+++ b/unittests/tools/test_nexpose_parser.py
@@ -40,18 +40,19 @@ class TestNexposeParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("TCP Sequence Number Approximation Vulnerability", finding.title)
-        self.assertEqual("CVE-2004-0230", finding.cve)
         self.assertEqual(3, len(finding.unsaved_endpoints))
         self.assertIn("https://www.securityfocus.com/bid/10183", finding.references)  # BID: 10183
         self.assertIn("https://www.kb.cert.org/vuls/id/415294.html", finding.references)  # CERT-VN: 415294
         self.assertIn("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2004-0230", finding.references)  # CVE: CVE-2004-0230
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2004-0230", finding.unsaved_vulnerability_references[0])
 
         # vuln 2
         finding = findings[2]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("TCP timestamp response", finding.title)
-        self.assertIsNone(finding.cve)
         self.assertEqual(5, len(finding.unsaved_endpoints))
+        self.assertIsNone(finding.unsaved_vulnerability_references)
 
         # vuln 2 - endpoint
         endpoint = finding.unsaved_endpoints[0]
@@ -145,22 +146,22 @@ class TestNexposeParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("High", finding.severity)
         self.assertEqual("ICMP redirection enabled", finding.title)
-        self.assertIsNone(finding.cve)
         self.assertEqual(4, len(finding.unsaved_endpoints))
+        self.assertIsNone(finding.unsaved_vulnerability_references)
 
         # vuln 1
         finding = findings[1]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual("No password for Grub", finding.title)
-        self.assertIsNone(finding.cve)
         self.assertEqual(4, len(finding.unsaved_endpoints))
+        self.assertIsNone(finding.unsaved_vulnerability_references)
 
         # vuln 2
         finding = findings[2]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("User home directory mode unsafe", finding.title)
-        self.assertIsNone(finding.cve)
         self.assertEqual(16, len(finding.unsaved_endpoints))
+        self.assertIsNone(finding.unsaved_vulnerability_references)
 
     def test_nexpose_parser_dns(self):
         testfile = open("unittests/scans/nexpose/dns.xml")

--- a/unittests/tools/test_npm_audit_parser.py
+++ b/unittests/tools/test_npm_audit_parser.py
@@ -30,10 +30,12 @@ class TestNpmAuditParser(DojoTestCase):
         self.assertEqual(5, len(findings))
 
         for find in findings:
-            if find.cve == "CVE-2017-16138":
-                self.assertEqual(find.file_path, "censored_by_npm_audit>send>mime")
-            elif find.cve == "CVE-2017-16119":
-                self.assertEqual(find.file_path, "express>fresh")
+            if find.file_path == "censored_by_npm_audit>send>mime":
+                self.assertEqual(1, len(find.unsaved_vulnerability_references))
+                self.assertEqual("CVE-2017-16138", find.unsaved_vulnerability_references[0])
+            if find.file_path == "express>fresh":
+                self.assertEqual(1, len(find.unsaved_vulnerability_references))
+                self.assertEqual("CVE-2017-16119", find.unsaved_vulnerability_references[0])
 
         # TODO ordering seems to be different in ci compared to local, so disable for now
         # self.assertEqual('mime', findings[4].component_name)

--- a/unittests/tools/test_npm_audit_parser.py
+++ b/unittests/tools/test_npm_audit_parser.py
@@ -31,11 +31,11 @@ class TestNpmAuditParser(DojoTestCase):
 
         for find in findings:
             if find.file_path == "censored_by_npm_audit>send>mime":
-                self.assertEqual(1, len(find.unsaved_vulnerability_references))
-                self.assertEqual("CVE-2017-16138", find.unsaved_vulnerability_references[0])
+                self.assertEqual(1, len(find.unsaved_vulnerability_ids))
+                self.assertEqual("CVE-2017-16138", find.unsaved_vulnerability_ids[0])
             if find.file_path == "express>fresh":
-                self.assertEqual(1, len(find.unsaved_vulnerability_references))
-                self.assertEqual("CVE-2017-16119", find.unsaved_vulnerability_references[0])
+                self.assertEqual(1, len(find.unsaved_vulnerability_ids))
+                self.assertEqual("CVE-2017-16119", find.unsaved_vulnerability_ids[0])
 
         # TODO ordering seems to be different in ci compared to local, so disable for now
         # self.assertEqual('mime', findings[4].component_name)

--- a/unittests/tools/test_php_symfony_security_check_parser.py
+++ b/unittests/tools/test_php_symfony_security_check_parser.py
@@ -37,3 +37,5 @@ class TestPhpSymfonySecurityCheckerParser(DojoTestCase):
         self.assertEqual(8, len(items))
         self.assertEqual("symfony/cache", items[0].component_name)
         self.assertEqual("3.4.16", items[0].component_version)
+        self.assertEqual(1, len(items[0].unsaved_vulnerability_references))
+        self.assertEqual("CVE-2019-10912", items[0].unsaved_vulnerability_references[0])

--- a/unittests/tools/test_php_symfony_security_check_parser.py
+++ b/unittests/tools/test_php_symfony_security_check_parser.py
@@ -37,5 +37,5 @@ class TestPhpSymfonySecurityCheckerParser(DojoTestCase):
         self.assertEqual(8, len(items))
         self.assertEqual("symfony/cache", items[0].component_name)
         self.assertEqual("3.4.16", items[0].component_version)
-        self.assertEqual(1, len(items[0].unsaved_vulnerability_references))
-        self.assertEqual("CVE-2019-10912", items[0].unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(items[0].unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2019-10912", items[0].unsaved_vulnerability_ids[0])

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -24,8 +24,8 @@ class TestTrivyParser(DojoTestCase):
         self.assertEqual(len(findings), 93)
         finding = findings[0]
         self.assertEqual("Low", finding.severity)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2011-3374", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2011-3374", finding.unsaved_vulnerability_ids[0])
         self.assertEqual(347, finding.cwe)
         self.assertEqual("apt", finding.component_name)
         self.assertEqual("1.8.2.2", finding.component_version)
@@ -46,8 +46,8 @@ class TestTrivyParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual('CVE-2020-15999 freetype 2.9.1-r2', finding.title)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-15999", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-15999", finding.unsaved_vulnerability_ids[0])
         self.assertEqual(787, finding.cwe)
         self.assertEqual("freetype", finding.component_name)
         self.assertEqual("2.9.1-r2", finding.component_version)
@@ -61,8 +61,8 @@ class TestTrivyParser(DojoTestCase):
         finding = findings[1]
         self.assertEqual("High", finding.severity)
         self.assertEqual('CVE-2020-28196 krb5-libs 1.15.5-r0', finding.title)
-        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
-        self.assertEqual("CVE-2020-28196", finding.unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2020-28196", finding.unsaved_vulnerability_ids[0])
         self.assertEqual(674, finding.cwe)
         self.assertEqual("krb5-libs", finding.component_name)
         self.assertEqual("1.15.5-r0", finding.component_version)

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -24,7 +24,8 @@ class TestTrivyParser(DojoTestCase):
         self.assertEqual(len(findings), 93)
         finding = findings[0]
         self.assertEqual("Low", finding.severity)
-        self.assertEqual("CVE-2011-3374", finding.cve)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2011-3374", finding.unsaved_vulnerability_references[0])
         self.assertEqual(347, finding.cwe)
         self.assertEqual("apt", finding.component_name)
         self.assertEqual("1.8.2.2", finding.component_version)
@@ -45,7 +46,8 @@ class TestTrivyParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual('CVE-2020-15999 freetype 2.9.1-r2', finding.title)
-        self.assertEqual("CVE-2020-15999", finding.cve)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-15999", finding.unsaved_vulnerability_references[0])
         self.assertEqual(787, finding.cwe)
         self.assertEqual("freetype", finding.component_name)
         self.assertEqual("2.9.1-r2", finding.component_version)
@@ -59,7 +61,8 @@ class TestTrivyParser(DojoTestCase):
         finding = findings[1]
         self.assertEqual("High", finding.severity)
         self.assertEqual('CVE-2020-28196 krb5-libs 1.15.5-r0', finding.title)
-        self.assertEqual("CVE-2020-28196", finding.cve)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_references))
+        self.assertEqual("CVE-2020-28196", finding.unsaved_vulnerability_references[0])
         self.assertEqual(674, finding.cwe)
         self.assertEqual("krb5-libs", finding.component_name)
         self.assertEqual("1.15.5-r0", finding.component_version)

--- a/unittests/tools/test_yarn_audit_parser.py
+++ b/unittests/tools/test_yarn_audit_parser.py
@@ -46,14 +46,14 @@ class TestYarnAuditParser(DojoTestCase):
         testfile.close()
         self.assertEqual(3, len(findings))
         self.assertEqual(findings[0].cwe, 1333)
-        self.assertEqual(1, len(findings[0].unsaved_vulnerability_references))
-        self.assertEqual("CVE-2021-3803", findings[0].unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2021-3803", findings[0].unsaved_vulnerability_ids[0])
         self.assertEqual(findings[1].cwe, 173)
-        self.assertEqual(1, len(findings[1].unsaved_vulnerability_references))
-        self.assertEqual("CVE-2022-0235", findings[1].unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(findings[1].unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2022-0235", findings[1].unsaved_vulnerability_ids[0])
         self.assertEqual(findings[2].cwe, 1035)
-        self.assertEqual(1, len(findings[2].unsaved_vulnerability_references))
-        self.assertEqual("CVE-2021-3807", findings[2].unsaved_vulnerability_references[0])
+        self.assertEqual(1, len(findings[2].unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2021-3807", findings[2].unsaved_vulnerability_ids[0])
 
     def test_yarn_audit_parser_with_multiple_cwes_per_finding_list(self):
         # cwes formatted as proper list: "cwe": ["CWE-918","CWE-1333"],

--- a/unittests/tools/test_yarn_audit_parser.py
+++ b/unittests/tools/test_yarn_audit_parser.py
@@ -46,8 +46,14 @@ class TestYarnAuditParser(DojoTestCase):
         testfile.close()
         self.assertEqual(3, len(findings))
         self.assertEqual(findings[0].cwe, 1333)
+        self.assertEqual(1, len(findings[0].unsaved_vulnerability_references))
+        self.assertEqual("CVE-2021-3803", findings[0].unsaved_vulnerability_references[0])
         self.assertEqual(findings[1].cwe, 173)
+        self.assertEqual(1, len(findings[1].unsaved_vulnerability_references))
+        self.assertEqual("CVE-2022-0235", findings[1].unsaved_vulnerability_references[0])
         self.assertEqual(findings[2].cwe, 1035)
+        self.assertEqual(1, len(findings[2].unsaved_vulnerability_references))
+        self.assertEqual("CVE-2021-3807", findings[2].unsaved_vulnerability_references[0])
 
     def test_yarn_audit_parser_with_multiple_cwes_per_finding_list(self):
         # cwes formatted as proper list: "cwe": ["CWE-918","CWE-1333"],


### PR DESCRIPTION
With this PR the calculation of hash_codes gets changed from `cve` to `vulnerability_ids`.