### PR TITLE
Helm Chart: Create PVC as part of the Chart

### DIFF
--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -110,3 +110,14 @@ Create chart name and version as used by the chart label.
 {{ .Values.host }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  Creates the persistentVolumeName
+*/}}
+{{- define "django.pvc_name" -}}
+{{- if .Values.django.mediaPersistentVolume.persistentVolumeClaim.create -}}
+{{- printf "%s-django-media" .Release.Name -}}
+{{- else -}}
+{{ .Values.django.mediaPersistentVolume.persistentVolumeClaim.name }}
+{{- end -}}
+{{- end -}}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -71,7 +71,7 @@ spec:
       - name: {{ .Values.django.mediaPersistentVolume.name }}
         {{- if eq .Values.django.mediaPersistentVolume.type "pvc"  }}
         persistentVolumeClaim:
-          claimName: {{ .Values.django.mediaPersistentVolume.persistentVolumeClaim }}
+          claimName: {{ include "django.pvc_name" $ }}
         {{ else }}
         emptyDir: {}
         {{- end }}

--- a/helm/defectdojo/templates/media-pvc.yaml
+++ b/helm/defectdojo/templates/media-pvc.yaml
@@ -1,6 +1,6 @@
-{{- $fullName := include "defectdojo.fullname" $ -}}
+{{- $fullName := include "django.pvc_name" $ -}}
 {{ with .Values.django.mediaPersistentVolume }}
-{{- if and .enabled (eq .type "pvc")   }}
+{{- if and .enabled (eq .type "pvc") .persistentVolumeClaim.create   }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/helm/defectdojo/templates/media-pvc.yaml
+++ b/helm/defectdojo/templates/media-pvc.yaml
@@ -1,0 +1,24 @@
+{{- $fullName := include "defectdojo.fullname" $ -}}
+{{ with .Values.django.mediaPersistentVolume }}
+{{- if and .enabled (eq .type "pvc")   }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    defectdojo.org/component: django
+    app.kubernetes.io/name: {{ include "defectdojo.name" $ }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    helm.sh/chart: {{ include "defectdojo.chart" $ }}
+  name: {{ $fullName }}-media
+spec:
+  accessModes: 
+  {{- toYaml .persistentVolumeClaim.accessModes |nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .persistentVolumeClaim.size }}
+  {{- if .persistentVolumeClaim.storageClassName }}
+  storageClassName: {{ .persistentVolumeClaim.storageClassName }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -251,8 +251,8 @@ django:
     type: emptyDir
     # in case if pvc specified, should point to the already existing pvc
     persistentVolumeClaim:
-      # set to false if an external pvc is to be provided. Also set django.mediaPersistentVolume.persistentVolumeClaim.name
-      create: true 
+      # set to true if django.mediaPersistentVolume.type is set to pvc
+      create: false 
       name:
       size: 10Gi
       accessModes:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -256,7 +256,7 @@ django:
       name:
       size: 5Gi
       accessModes:
-      - ReadWriteMany # check KUBERNETES.md doc first for option to choose
+      - ReadWriteMany  # check KUBERNETES.md doc first for option to choose
       storageClassName:
 
 initializer:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -256,7 +256,7 @@ django:
       name:
       size: 5Gi
       accessModes:
-      - ReadWriteMany
+      - ReadWriteMany # check KUBERNETES.md doc first for option to choose
       storageClassName:
 
 initializer:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -251,6 +251,9 @@ django:
     type: emptyDir
     # in case if pvc specified, should point to the already existing pvc
     persistentVolumeClaim:
+      # set to false if an external pvc is to be provided. Also set django.mediaPersistentVolume.persistentVolumeClaim.name
+      create: true 
+      name:
       size: 10Gi
       accessModes:
       - ReadWriteOnce

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -251,12 +251,12 @@ django:
     type: emptyDir
     # in case if pvc specified, should point to the already existing pvc
     persistentVolumeClaim:
-      # set to true if django.mediaPersistentVolume.type is set to pvc
+      # set to true to create a new pvc and if django.mediaPersistentVolume.type is set to pvc
       create: false
       name:
-      size: 10Gi
+      size: 5Gi
       accessModes:
-      - ReadWriteOnce
+      - ReadWriteMany
       storageClassName:
 
 initializer:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -252,7 +252,7 @@ django:
     # in case if pvc specified, should point to the already existing pvc
     persistentVolumeClaim:
       # set to true if django.mediaPersistentVolume.type is set to pvc
-      create: false 
+      create: false
       name:
       size: 10Gi
       accessModes:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -250,8 +250,11 @@ django:
     # could be emptyDir (not for production) or pvc
     type: emptyDir
     # in case if pvc specified, should point to the already existing pvc
-    persistentVolumeClaim: media
-
+    persistentVolumeClaim:
+      size: 10Gi
+      accessModes:
+      - ReadWriteOnce
+      storageClassName:
 
 initializer:
   run: true

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -268,11 +268,13 @@ mediaPersistentVolume:
   name: media
   # could be emptyDir (not for production) or pvc
   type: pvc
-  # in case if pvc specified, should point to already existing pvc
-  persistentVolumeClaim: media
+  # if pvc is specified, django.mediaPersistentVolume.create should be set to true so that the chart creates the persistent volume claim. Else, the user has to externally create the pvc and pass it via django.mediaPersistentVolume.persistentVolumeClaim.name. 
+  persistentVolumeClaim:
+    create: true 
+    name:
 ```
 
-In the example above, we want that media content to be preserved to `pvc` named `media` as `persistentVolumeClaim` k8s resource.
+In the example above, we want the media content to be preserved to `pvc` as `persistentVolumeClaim` k8s resource and what we are basically doing is enabling the pvc to be created conditionally if the user wants to create it using the chart (in this case the pvc name 'defectdojo-media' will be inherited from template file used to deploy the pvc). By default the volume type is emptyDir which does not require a pvc. But when the type is set to pvc then we need a kubernetes Persistent Volume Claim and this is where the django.mediaPersistentVolume.persistentVolumeClaim.name comes into play.
 
 NOTE: PersistrentVolume needs to be prepared in front before helm installation/update is triggered.
 

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -268,7 +268,7 @@ mediaPersistentVolume:
   name: media
   # could be emptyDir (not for production) or pvc
   type: pvc
-  # if pvc is specified, django.mediaPersistentVolume.create should be set to true so that the chart creates the persistent volume claim. Else, the user has to externally create the pvc and pass it via django.mediaPersistentVolume.persistentVolumeClaim.name. 
+  # there are two options to create pvc 1) when you want the chart to create pvc for you, set django.mediaPersistentVolume.persistentVolumeClaim.create to true and do not specify anything for django.mediaPersistentVolume.PersistentVolumeClaim.name  2) when you want to create pvc outside the chart, pass the pvc name via django.mediaPersistentVolume.PersistentVolumeClaim.name and ensure django.mediaPersistentVolume.PersistentVolumeClaim.create is set to false
   persistentVolumeClaim:
     create: true 
     name:

--- a/readme-docs/KUBERNETES.md
+++ b/readme-docs/KUBERNETES.md
@@ -272,9 +272,15 @@ mediaPersistentVolume:
   persistentVolumeClaim:
     create: true 
     name:
+    size: 5Gi
+    accessModes:
+    - ReadWriteMany
+    storageClassName:
 ```
 
 In the example above, we want the media content to be preserved to `pvc` as `persistentVolumeClaim` k8s resource and what we are basically doing is enabling the pvc to be created conditionally if the user wants to create it using the chart (in this case the pvc name 'defectdojo-media' will be inherited from template file used to deploy the pvc). By default the volume type is emptyDir which does not require a pvc. But when the type is set to pvc then we need a kubernetes Persistent Volume Claim and this is where the django.mediaPersistentVolume.persistentVolumeClaim.name comes into play.
+
+The accessMode is set to ReadWriteMany by default to accommodate using more than one replica. Ensure storage support ReadWriteMany before setting this option, otherwise set accessMode to ReadWriteOnce.
 
 NOTE: PersistrentVolume needs to be prepared in front before helm installation/update is triggered.
 


### PR DESCRIPTION
Managing a persistent volume claim outside the Chart seems to be stressful. The Chart should be self-sufficient hence, the reason for creating this PR.