### PR TITLE
fix drheader deduplication #6280

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1106,6 +1106,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Rusty Hog Scan': ['title', 'description'],
     'StackHawk HawkScan': ['vuln_id_from_tool', 'component_name', 'component_version'],
     'Hydra Scan': ['title', 'description'],
+    'DrHeader JSON Importer': ['title', 'description'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
@@ -1238,6 +1239,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Harbor Vulnerability Scan': DEDUPE_ALGO_HASH_CODE,
     'Rusty Hog Scan': DEDUPE_ALGO_HASH_CODE,
     'Hydra Scan': DEDUPE_ALGO_HASH_CODE,
+    'DrHeader JSON Importer': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')


### PR DESCRIPTION
This fixes DrHeader deduplication. However, when you upload (no reupload) a new scan, the severity of existing findings is not  adapted yet. (See issue 6280). 