### PR TITLE
add extraEnv to helm chart

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -134,6 +134,9 @@ spec:
             secretKeyRef:
               name: {{ $fullName }}
               key: DD_SECRET_KEY
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.celery.beat.resources | nindent 10 }}
       {{- with .Values.celery.beat.nodeSelector }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -129,6 +129,9 @@ spec:
             secretKeyRef:
               name: {{ $fullName }}
               key: DD_SECRET_KEY
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.celery.worker.resources | nindent 10 }}
       {{- with .Values.celery.worker.nodeSelector }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -201,6 +201,9 @@ spec:
           value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
         - name: DD_CSRF_COOKIE_SECURE
           value: {{- if or .Values.django.ingress.activateTLS .Values.django.nginx.tls.enabled }} "True" {{- else }} "False" {{- end }}
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
         {{- if .Values.django.uwsgi.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -75,6 +75,9 @@ spec:
               name: {{ .Values.mysql.auth.existingSecret }}
               key: {{ .Values.mysql.auth.secretKey }}
               {{- end }}
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.initializer.resources | nindent 10 }}
       restartPolicy: Never

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -410,3 +410,12 @@ redis:
 # extraSecrets:
 #   DD_SOCIAL_AUTH_AUTH0_SECRET: 'xxx'
 extraConfigs: {}
+
+# To add (or override) extra variables which need to be pulled from another configMap, you can
+# use extraEnv. For example:
+# extraEnv:
+# - name: DD_DATABASE_HOST
+#   valueFrom:
+#     configMapKeyRef:
+#       name: my-other-postgres-configmap
+#       key: cluster_endpoint


### PR DESCRIPTION
This adds an value to the helm chart's `values.yaml` file which can be used to inject extra environment variables into the containers. 

It's different from the existing `extraConfigs` value because this is injected into the container definition, not into the configmap. That matters because you can't dynamically pull values from one configmap into another configmap - so if your parameters are stored elsewhere we need this mechanism to add these values to the containers.

An example (very similar to what I'm currently using with this changeset) is in the docs in the values file (below). We have the built-in postgres container disabled but have another template creating our postgres cluster, which then stores its host name in a configmap, and this allows us to inject that host into the containers.

```
# To add (or override) extra variables which need to be pulled from another configMap, you can
# use extraEnv. For example:
# extraEnv:
# - name: DD_DATABASE_HOST
#   valueFrom:
#     configMapKeyRef:
#       name: my-other-postgres-configmap
#       key: cluster_endpoint
```