### PR TITLE
Fix get slack id at 1st notification and disclaimer in slack notifications

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -333,7 +333,7 @@ def get_slack_user_id(user_email):
     if user:
         if 'error' in user:
             logger.error("Slack is complaining. See error message below.")
-            logger.error(users)
+            logger.error(user)
             raise RuntimeError('Error getting user list from Slack: ' + res.text)
         else:
             if "email" in user["user"]["profile"]:

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -327,25 +327,23 @@ def get_slack_user_id(user_email):
         url='https://slack.com/api/users.lookupByEmail',
         data={'token': get_system_setting('slack_token'), 'email': user_email})
 
-    users = json.loads(res.text)
+    user = json.loads(res.text)
 
     slack_user_is_found = False
-    if users:
-        if 'error' in users:
+    if user:
+        if 'error' in user:
             logger.error("Slack is complaining. See error message below.")
             logger.error(users)
             raise RuntimeError('Error getting user list from Slack: ' + res.text)
         else:
-            for member in users["members"]:
-                if "email" in member["profile"]:
-                    if user_email == member["profile"]["email"]:
-                        if "id" in member:
-                            user_id = member["id"]
-                            logger.debug("Slack user ID is {}".format(user_id))
-                            slack_user_is_found = True
-                            break
-                    else:
-                        logger.warning("A user with email {} could not be found in this Slack workspace.".format(user_email))
+            if "email" in user["user"]["profile"]:
+                if user_email == user["user"]["profile"]["email"]:
+                    if "id" in user["user"]:
+                        user_id = user["user"]["id"]
+                        logger.debug("Slack user ID is {}".format(user_id))
+                        slack_user_is_found = True
+                else:
+                    logger.warning("A user with email {} could not be found in this Slack workspace.".format(user_email))
 
             if not slack_user_is_found:
                 logger.warning("The Slack user was not found.")

--- a/dojo/templates/notifications/other.tpl
+++ b/dojo/templates/notifications/other.tpl
@@ -46,8 +46,8 @@
     {% if url is not None %}
         More information on this event can be found here: {{ url|full_url }}
     {% endif %}
-    {% if system_settings.disclaimer is not None %}
-        
+    {% if system_settings.disclaimer|length %}
+
         Disclaimer:
         {{ system_settings.disclaimer }}
     {% endif %}


### PR DESCRIPTION
- Fix non working get_slack_user_id function
- Switch on system_settings.disclaimer length as the var cannot be null