### PR TITLE
Add fixes to bugcrowd parser and endpoint uri util

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1513,14 +1513,30 @@ class Endpoint(models.Model):
                 query_parts.append(u"=".join([k, v]))
         query_string = u"&".join(query_parts)
 
+        protocol = url.scheme if url.scheme != '' else None
+        userinfo = ':'.join(url.userinfo) if url.userinfo not in [(), ('',)] else None
+        host = url.host if url.host != '' else None
+        port = url.port
+        path = '/'.join(url.path)[:500] if url.path not in [None, (), ('',)] else None
+        query = query_string[:1000] if query_string is not None and query_string != '' else None
+        fragment = url.fragment[:500] if url.fragment is not None and url.fragment != '' else None
+
+        # Attempt to fix urls that look like subdomain.domain.com:7273
+        # The protocol would be sub.domain.com
+        # The path would be 7273
+        # I am nervous to tamper with the path to extract the port, so leaving it as is
+        if protocol and len(protocol) > 20 and not host:
+            host = protocol
+            protocol = None
+
         return Endpoint(
-            protocol=url.scheme if url.scheme != '' else None,
-            userinfo=':'.join(url.userinfo) if url.userinfo not in [(), ('',)] else None,
-            host=url.host if url.host != '' else None,
-            port=url.port,
-            path='/'.join(url.path)[:500] if url.path not in [None, (), ('',)] else None,
-            query=query_string[:1000] if query_string is not None and query_string != '' else None,
-            fragment=url.fragment[:500] if url.fragment is not None and url.fragment != '' else None
+            protocol=protocol,
+            userinfo=userinfo,
+            host=host,
+            port=port,
+            path=path,
+            query=query,
+            fragment=fragment,
         )
 
     def get_absolute_url(self):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1521,14 +1521,6 @@ class Endpoint(models.Model):
         query = query_string[:1000] if query_string is not None and query_string != '' else None
         fragment = url.fragment[:500] if url.fragment is not None and url.fragment != '' else None
 
-        # Attempt to fix urls that look like subdomain.domain.com:7273
-        # The protocol would be sub.domain.com
-        # The path would be 7273
-        # I am nervous to tamper with the path to extract the port, so leaving it as is
-        if protocol and len(protocol) > 20 and not host:
-            host = protocol
-            protocol = None
-
         return Endpoint(
             protocol=protocol,
             userinfo=userinfo,

--- a/dojo/tools/bugcrowd/parser.py
+++ b/dojo/tools/bugcrowd/parser.py
@@ -163,8 +163,8 @@ class BugCrowdParser(object):
 
     def get_endpoint(self, url):
         stripped_url = url.strip()
-        if '://' in stripped_url:  # is the host full uri? 
-            endpoint = Endpoint.from_uri(stripped_url) 
-        else: 
-            endpoint = Endpoint.from_uri('//' + stripped_url) 
+        if '://' in stripped_url:  # is the host full uri?
+            endpoint = Endpoint.from_uri(stripped_url)
+        else:
+            endpoint = Endpoint.from_uri('//' + stripped_url)
         return endpoint

--- a/dojo/tools/bugcrowd/parser.py
+++ b/dojo/tools/bugcrowd/parser.py
@@ -57,9 +57,7 @@ class BugCrowdParser(object):
             finding.impact = pre_description.get('impact', '') + '\n' + row.get('vrt_lineage', '')
             finding.steps_to_reproduce = pre_description.get('steps_to_reproduce', None)
             finding.references = References
-            priority = row.get('priority', 0)
-            priority = priority if priority != '' else 0
-            finding.severity = self.convert_severity(int(priority))
+            finding.severity = self.convert_severity(row.get('priority', 0))
 
             if url:
                 finding.unsaved_endpoints = list()
@@ -144,6 +142,11 @@ class BugCrowdParser(object):
         return ret
 
     def convert_severity(self, sev_num):
+        # Attempt to convert to an int
+        try:
+            sev_num = int(sev_num)
+        except ValueError:
+            sev_num = 0
         severity = 'Info'
         if sev_num == 1:
             severity = 'Critical'
@@ -153,6 +156,9 @@ class BugCrowdParser(object):
             severity = 'Medium'
         elif sev_num == 4:
             severity = 'Low'
+        else:
+            # If the arg is an unexpected value, leave it as "Info"
+            pass
         return severity
 
     def get_endpoint(self, url):

--- a/dojo/tools/bugcrowd/parser.py
+++ b/dojo/tools/bugcrowd/parser.py
@@ -57,7 +57,9 @@ class BugCrowdParser(object):
             finding.impact = pre_description.get('impact', '') + '\n' + row.get('vrt_lineage', '')
             finding.steps_to_reproduce = pre_description.get('steps_to_reproduce', None)
             finding.references = References
-            finding.severity = self.convert_severity(int(row.get('priority', 0)))
+            priority = row.get('priority', 0)
+            priority = priority if priority != '' else 0
+            finding.severity = self.convert_severity(int(priority))
 
             if url:
                 finding.unsaved_endpoints = list()
@@ -121,17 +123,18 @@ class BugCrowdParser(object):
         ret['description'] = ''
         for item in split_des:
             lines = [line.strip() for line in ''.join(item.split('#')).splitlines() if line != '']
-            first = lines[0].strip()
-            if first == 'Impact':
-                ret['impact'] = item
-            elif first == 'Steps to reproduce':
-                ret['steps_to_reproduce'] = item
-            elif first == 'How to fix' or first == 'Fix':
-                ret['mitigation'] = item
-            elif first == 'PoC code':
-                ret['poc'] = item
-            else:
-                ret['description'] += ret['description'] + item
+            if lines:
+                first = lines[0].strip()
+                if first == 'Impact':
+                    ret['impact'] = item
+                elif first == 'Steps to reproduce':
+                    ret['steps_to_reproduce'] = item
+                elif first == 'How to fix' or first == 'Fix':
+                    ret['mitigation'] = item
+                elif first == 'PoC code':
+                    ret['poc'] = item
+                else:
+                    ret['description'] += ret['description'] + item
 
         ret = self.description_parse(ret)
 
@@ -153,4 +156,5 @@ class BugCrowdParser(object):
         return severity
 
     def get_endpoint(self, url):
-        return Endpoint.from_uri(url)
+        endpoint = Endpoint.from_uri(url.strip())
+        return endpoint

--- a/dojo/tools/bugcrowd/parser.py
+++ b/dojo/tools/bugcrowd/parser.py
@@ -162,5 +162,9 @@ class BugCrowdParser(object):
         return severity
 
     def get_endpoint(self, url):
-        endpoint = Endpoint.from_uri(url.strip())
+        stripped_url = url.strip()
+        if '://' in stripped_url:  # is the host full uri? 
+            endpoint = Endpoint.from_uri(stripped_url) 
+        else: 
+            endpoint = Endpoint.from_uri('//' + stripped_url) 
         return endpoint


### PR DESCRIPTION
I found that the bug crowd parser had a couple pitfalls where information that was expected to be in the scan report was not actually there. Additionally, I found a strange endpoint deciphering bug where if given a uri like `subdomain.domain.com:1234` the `Endpoint.from_uri()` function will attempt to create an endpoint with the protocol being `subdomain.domain.com` and the path would be `1234`. Im nervous to attempt to modify the path because it is sort of the catch all for uri attributes. Hopefully what I have implemented will suffice for now.