### PR TITLE
Add possibility for arbitrary files to get copied to extra settings

### DIFF
--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -4,7 +4,7 @@ umask 0002
 id
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/*.py 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
@@ -12,7 +12,8 @@ if [ "$NUM_FILES" -gt 0 ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/*.py /app/dojo/settings/
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+    rm -f /app/dojo/settings/README.md
 fi
 
 echo -n "Waiting for database to be reachable "

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -4,7 +4,7 @@ umask 0002
 id
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/*.py 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
@@ -12,7 +12,8 @@ if [ "$NUM_FILES" -gt 0 ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/*.py /app/dojo/settings/
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+    rm -f /app/dojo/settings/README.md
 fi
 
 echo -n "Waiting for database to be reachable "

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -14,7 +14,7 @@ initialize_data()
 }
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/*.py 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
@@ -22,7 +22,8 @@ if [ "$NUM_FILES" -gt 0 ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/*.py /app/dojo/settings/
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+    rm -f /app/dojo/settings/README.md
 fi
 
 umask 0002

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/*.py 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo $FILES | tr -s '[:blank:]' ', ')
@@ -9,7 +9,8 @@ if [ "$NUM_FILES" -gt 0 ]; then
     echo "     Overriding DefectDojo's local_settings.py with multiple"
     echo "     Files: $COMMA_LIST"
     echo "============================================================"
-    cp /app/docker/extra_settings/*.py /app/dojo/settings/
+    cp /app/docker/extra_settings/* /app/dojo/settings/
+    rm -f /app/dojo/settings/README.md
 fi
 
 umask 0002


### PR DESCRIPTION
On one of my dev servers, I am unable to use remote SAML metadata files and instead use XML files. This was restricted to just python files with #5884 as the motive was to remove the possibility of the `README.md` file. I think this approach gives the best of both worlds 