### PR TITLE
Fix CSV and Excel export for findings

### DIFF
--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -821,7 +821,8 @@ def get_excludes():
     return ['SEVERITIES', 'age', 'github_issue', 'jira_issue', 'objects', 'risk_acceptance',
     'test__engagement__product__authorized_group', 'test__engagement__product__member',
     'test__engagement__product__prod_type__authorized_group', 'test__engagement__product__prod_type__member',
-    'unsaved_endpoints']
+    'unsaved_endpoints', 'unsaved_vulnerability_ids', 'unsaved_files', 'unsaved_request', 'unsaved_response',
+    'unsaved_tags', 'vulnerability_ids', 'cve']
 
 
 def get_foreign_keys():
@@ -851,6 +852,7 @@ def csv_export(request):
             fields.append('product_id')
             fields.append('product')
             fields.append('endpoints')
+            fields.append('vulnerability_ids')
 
             writer.writerow(fields)
 
@@ -883,6 +885,18 @@ def csv_export(request):
             if endpoint_value.endswith('; '):
                 endpoint_value = endpoint_value[:-2]
             fields.append(endpoint_value)
+
+            vulnerability_ids_value = ''
+            num_vulnerability_ids = 0
+            for vulnerability_id in finding.vulnerability_ids:
+                num_vulnerability_ids += 1
+                if num_vulnerability_ids > 5:
+                    vulnerability_ids_value += '...'
+                    break
+                vulnerability_ids_value += f'{str(vulnerability_id)}; '
+            if vulnerability_ids_value.endswith('; '):
+                vulnerability_ids_value = vulnerability_ids_value[:-2]
+            fields.append(vulnerability_ids_value)
 
             writer.writerow(fields)
 
@@ -925,6 +939,9 @@ def excel_export(request):
             col_num += 1
             cell = worksheet.cell(row=row_num, column=col_num, value='endpoints')
             cell.font = font_bold
+            col_num += 1
+            cell = worksheet.cell(row=row_num, column=col_num, value='vulnerability_ids')
+            cell.font = font_bold
 
             row_num = 2
         if row_num > 1:
@@ -960,6 +977,19 @@ def excel_export(request):
             if endpoint_value.endswith('; \n'):
                 endpoint_value = endpoint_value[:-3]
             worksheet.cell(row=row_num, column=col_num, value=endpoint_value)
+            col_num += 1
+
+            vulnerability_ids_value = ''
+            num_vulnerability_ids = 0
+            for vulnerability_id in finding.vulnerability_ids:
+                num_vulnerability_ids += 1
+                if num_vulnerability_ids > 5:
+                    vulnerability_ids_value += '...'
+                    break
+                vulnerability_ids_value += f'{str(vulnerability_id)}; \n'
+            if vulnerability_ids_value.endswith('; \n'):
+                vulnerability_ids_value = vulnerability_ids_value[:-3]
+            worksheet.cell(row=row_num, column=col_num, value=vulnerability_ids_value)
 
         row_num += 1
 

--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -80,6 +80,8 @@ class FindingTest(BaseTestCase):
         driver.find_element(By.ID, "downloadMenu").click()
         driver.find_element(By.ID, "csv_export").click()
 
+        time.sleep(5)
+
         self.check_file(f'{self.export_path}/findings.csv')
 
     def test_excel_export(self):
@@ -88,6 +90,8 @@ class FindingTest(BaseTestCase):
 
         driver.find_element(By.ID, "downloadMenu").click()
         driver.find_element(By.ID, "excel_export").click()
+
+        time.sleep(5)
 
         self.check_file(f'{self.export_path}/findings.xlsx')
 
@@ -519,9 +523,8 @@ def add_finding_tests_to_suite(suite, jira=False, github=False, block_execution=
     suite.addTest(FindingTest('test_list_findings_all'))
     suite.addTest(FindingTest('test_list_findings_open'))
     suite.addTest(FindingTest('test_quick_report'))
-    # Export tests are not stable and therefore disabled
-    # suite.addTest(FindingTest('test_csv_export'))
-    # suite.addTest(FindingTest('test_excel_export'))
+    suite.addTest(FindingTest('test_csv_export'))
+    suite.addTest(FindingTest('test_excel_export'))
     suite.addTest(FindingTest('test_list_components'))
     suite.addTest(FindingTest('test_edit_finding'))
     suite.addTest(FindingTest('test_add_note_to_finding'))


### PR DESCRIPTION
The Excel export for findings wasn't working anymore after the introduction of the vulnerability ids. With this PR the Excel export works again and both CSV and Excel export contain the vulnerability ids now.

Additionally the integration tests are waiting 5 seconds now for the generation of the file.