### PR TITLE
Replace user id with full_name

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -937,13 +937,15 @@ def request_finding_review(request, fid):
             finding.save()
             reviewers = ""
             for suser in form.cleaned_data['reviewers']:
-                reviewers += str(suser) + ", "
+                full_user = Dojo_User.generate_full_name(Dojo_User.objects.get(id=suser))
+                logger.debug("Asking %s for review", full_user)
+                reviewers += str(full_user) + ", "
             reviewers = reviewers[:-2]
 
             create_notification(event='review_requested',
                                 title='Finding review requested',
                                 finding=finding,
-                                description='User %s has requested that users %s review the finding "%s" for accuracy:\n\n%s' % (user, reviewers, finding.title, new_note),
+                                description='User %s has requested that user(s) %s review the finding "%s" for accuracy:\n\n%s' % (user, reviewers, finding.title, new_note),
                                 icon='check',
                                 url=reverse("view_finding", args=(finding.id,)))
 


### PR DESCRIPTION
Replaces user id with a full user name inside of the notification  message.

Previously 
```
User name surname (user) has requested that users 43 review the
```
Now
```
User name surname (user) has requested that user(s) user surname (user) review the...
```
