### PR TITLE
Vulnerability Id: Various small changes

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1057,7 +1057,7 @@ class FindingRelatedFieldsSerializer(serializers.Serializer):
         return JIRAIssueSerializer(read_only=True).to_representation(issue)
 
 
-class VulnerabilityReferenceSerializer(serializers.ModelSerializer):
+class VulnerabilityIdSerializer(serializers.ModelSerializer):
     class Meta:
         model = Vulnerability_Id
         fields = ['vulnerability_id']
@@ -1077,7 +1077,7 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
     jira_change = serializers.SerializerMethodField(read_only=True)
     display_status = serializers.SerializerMethodField()
     finding_groups = FindingGroupSerializer(source='finding_group_set', many=True, read_only=True)
-    vulnerability_ids = VulnerabilityReferenceSerializer(source='vulnerability_id_set', many=True, required=False)
+    vulnerability_ids = VulnerabilityIdSerializer(source='vulnerability_id_set', many=True, required=False)
 
     class Meta:
         model = Finding
@@ -1206,7 +1206,7 @@ class FindingCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
         default=None)
     tags = TagListSerializerField(required=False)
     push_to_jira = serializers.BooleanField(default=False)
-    vulnerability_ids = VulnerabilityReferenceSerializer(source='vulnerability_id_set', many=True, required=False)
+    vulnerability_ids = VulnerabilityIdSerializer(source='vulnerability_id_set', many=True, required=False)
 
     class Meta:
         model = Finding
@@ -1275,7 +1275,7 @@ class FindingCreateSerializer(TaggitSerializer, serializers.ModelSerializer):
         return data
 
 
-class VulnerabilityReferenceTemplateSerializer(serializers.ModelSerializer):
+class VulnerabilityIdTemplateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Vulnerability_Id_Template
         fields = ['vulnerability_id']
@@ -1283,7 +1283,7 @@ class VulnerabilityReferenceTemplateSerializer(serializers.ModelSerializer):
 
 class FindingTemplateSerializer(TaggitSerializer, serializers.ModelSerializer):
     tags = TagListSerializerField(required=False)
-    vulnerability_ids = VulnerabilityReferenceTemplateSerializer(source='vulnerability_id_template_set', many=True, required=False)
+    vulnerability_ids = VulnerabilityIdTemplateSerializer(source='vulnerability_id_template_set', many=True, required=False)
 
     class Meta:
         model = Finding_Template

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -894,6 +894,8 @@ def csv_export(request):
                     vulnerability_ids_value += '...'
                     break
                 vulnerability_ids_value += f'{str(vulnerability_id)}; '
+            if finding.cve and vulnerability_ids_value.find(finding.cve) < 0:
+                vulnerability_ids_value += finding.cve
             if vulnerability_ids_value.endswith('; '):
                 vulnerability_ids_value = vulnerability_ids_value[:-2]
             fields.append(vulnerability_ids_value)
@@ -987,6 +989,8 @@ def excel_export(request):
                     vulnerability_ids_value += '...'
                     break
                 vulnerability_ids_value += f'{str(vulnerability_id)}; \n'
+            if finding.cve and vulnerability_ids_value.find(finding.cve) < 0:
+                vulnerability_ids_value += finding.cve
             if vulnerability_ids_value.endswith('; \n'):
                 vulnerability_ids_value = vulnerability_ids_value[:-3]
             worksheet.cell(row=row_num, column=col_num, value=vulnerability_ids_value)

--- a/unittests/test_deduplication_logic.py
+++ b/unittests/test_deduplication_logic.py
@@ -586,7 +586,7 @@ class TestDuplicationLogic(DojoTestCase):
         # create identical copy, change some fields
         finding_new, finding_124 = self.copy_and_reset_finding(id=124)
         finding_new.title = 'another title'
-        finding_new.cve = 'CVE-2020-12345'
+        finding_new.unsaved_vulnerability_ids = ['CVE-2020-12345']
         finding_new.cwe = '456'
         finding_new.description = 'useless finding'
         finding_new.save()
@@ -598,7 +598,7 @@ class TestDuplicationLogic(DojoTestCase):
         # create identical copy, change some fields
         finding_new, finding_124 = self.copy_and_reset_finding(id=124)
         finding_new.title = 'another title'
-        finding_new.cve = 'CVE-2020-12345'
+        finding_new.unsaved_vulnerability_ids = ['CVE-2020-12345']
         finding_new.cwe = '456'
         finding_new.description = 'useless finding'
         finding_new.unique_id_from_tool = '9999'
@@ -740,7 +740,7 @@ class TestDuplicationLogic(DojoTestCase):
         # create identical copy, change some fields
         finding_new, finding_224 = self.copy_and_reset_finding(id=224)
         finding_new.title = 'another title'
-        finding_new.cve = 'CVE-2020-12345'
+        finding_new.unsaved_vulnerability_ids = ['CVE-2020-12345']
         finding_new.cwe = '456'
         finding_new.description = 'useless finding'
         finding_new.save()
@@ -752,7 +752,7 @@ class TestDuplicationLogic(DojoTestCase):
         # create identical copy, change some fields
         finding_new, finding_224 = self.copy_and_reset_finding(id=224)
         finding_new.title = 'another title'
-        finding_new.cve = 'CVE-2020-12345'
+        finding_new.unsaved_vulnerability_ids = ['CVE-2020-12345']
         finding_new.cwe = '456'
         finding_new.description = 'useless finding'
         finding_new.unique_id_from_tool = '9999'
@@ -1165,7 +1165,7 @@ class TestDuplicationLogic(DojoTestCase):
         hash_code_at_creation = finding_new.hash_code
 
         finding_new.title = 'new_title'
-        finding_new.cve = 999
+        finding_new.unsaved_vulnerability_ids = [999]
 
         # both title and cve affect hash_code for ZAP scans, but not here because hash_code was already calculated
         finding_new.save()
@@ -1191,14 +1191,14 @@ class TestDuplicationLogic(DojoTestCase):
         # expect: not marked as duplicate with dedupe_option-False
         finding_new, finding_24 = self.copy_and_reset_finding(id=24)
         finding_new.title = 'new_title'
-        finding_new.cve = 999
+        finding_new.unsaved_vulnerability_ids = [999]
         finding_new.save(dedupe_option=True)
         self.assert_finding(finding_new, not_pk=24, duplicate=False, not_hash_code=None)
 
         # now when we change the title and cve back the same as finding_24, it should be marked as duplicate
         # howwever defect dojo does NOT recalculate the hash_code, so it will not mark this finding as duplicate. feature or BUG?
         finding_new.title = finding_24.title
-        finding_new.cve = finding_24.cve
+        finding_new.unsaved_vulnerability_ids = finding_24.unsaved_vulnerability_ids
         finding_new.save(dedupe_option=True)
         self.assert_finding(finding_new, not_pk=24, duplicate=False, not_hash_code=None)
 

--- a/unittests/test_finding_helper.py
+++ b/unittests/test_finding_helper.py
@@ -193,7 +193,7 @@ class TestUpdateFindingStatusSignal(DojoTestCase):
             )
 
 
-class TestSaveVulnerabilityReferences(DojoTestCase):
+class TestSaveVulnerabilityIds(DojoTestCase):
 
     @patch('dojo.finding.helper.Vulnerability_Id.objects.filter')
     @patch('dojo.finding.helper.Vulnerability_Id.objects.get_or_create')
@@ -274,7 +274,7 @@ class TestSaveVulnerabilityReferences(DojoTestCase):
         mock_delete.assert_not_called()
 
 
-class TestSaveVulnerabilityReferencesTemplate(DojoTestCase):
+class TestSaveVulnerabilityIdsTemplate(DojoTestCase):
 
     @patch('dojo.finding.helper.Vulnerability_Id_Template.objects.filter')
     @patch('dojo.finding.helper.Vulnerability_Id_Template.objects.get_or_create')


### PR DESCRIPTION
`dojo/api_v2/serializers.py`: Renaming of 2 classes

`dojo/reports/views.py`: Fix for CVS und Excel export to include content of CVE field in Vulnerability Ids for older findings

`unittests/test_deduplication_logic.py`: Change from CVE to Vulnerability Ids

`unittests/test_finding_helper.py`: Renaming of 2 classes