### PR TITLE
Remove CWE from Dependency Track Hash Code Field

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1077,7 +1077,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'SonarQube API Import': ['title', 'file_path', 'line'],
     'Dependency Check Scan': ['vulnerability_ids', 'cwe', 'file_path'],
     'Dockle Scan': ['title', 'description', 'vuln_id_from_tool'],
-    'Dependency Track Finding Packaging Format (FPF) Export': ['component_name', 'component_version', 'cwe', 'vulnerability_ids'],
+    'Dependency Track Finding Packaging Format (FPF) Export': ['component_name', 'component_version', 'vulnerability_ids'],
     'Mobsfscan Scan': ['title', 'severity', 'cwe'],
     'Nessus Scan': ['title', 'severity', 'vulnerability_ids', 'cwe'],
     'Nexpose Scan': ['title', 'severity', 'vulnerability_ids', 'cwe'],


### PR DESCRIPTION
Dependency Track upgraded the export of results format in order to follow the relevant updated FPF format, so now multiple CWEs are included into to the vulnerabilities export. For information visit their release log https://docs.dependencytrack.org/changelog/ version 4.5.0 . 

In order to not change their API and relevant integrations (such as DefectDojo) they created a work around. So, in case there are multiple CWEs in a single finding they would always use the first one in the list (under the same JSON objects "cweId"and "cweName"), while the total count of CWEs and relevant information will be available in a new array. For more information https://github.com/DependencyTrack/dependency-track/issues/1467#issuecomment-1128161152. 

Close old findings and deduplication features breaks since findings with multiple CWEs may include a different CWE than the one used in order to calculate the original hash (due to the new CWE holding the first place in the array).

Based on the above I would propose to change the "HASHCODE_FIELDS_PER_SCANNER" for "Dependency Track Finding Packaging Format (FPF) Export" in order to not include CWE by default.