### PR TITLE
Fix for Kubernetes tests

### DIFF
--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -7,7 +7,6 @@ on:
       - dev
       - release/**
       - hotfix/**
-      - fix/bitnami
 
 env:
   DD_DOCKER_REPO: defectdojo

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -7,6 +7,7 @@ on:
       - dev
       - release/**
       - hotfix/**
+      - fix/bitnami
 
 env:
   DD_DOCKER_REPO: defectdojo
@@ -158,7 +159,7 @@ jobs:
 
       - name: Configure HELM repos
         run: |-
-             helm repo add bitnami https://charts.bitnami.com/bitnami
+             helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
 

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Configure Helm repos
         run: |-
-             helm repo add bitnami https://charts.bitnami.com/bitnami
+             helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
 


### PR DESCRIPTION
Bitnami has changed the index.yaml for pre-2022 charts, see https://github.com/bitnami/charts/issues/10539. The Kubernetes tests were not running anymore because of this.

This PR uses the pre-2022 index.yaml and fixes this problem. Nevertheless it shows DefectDojo's Kubernetes installation comes with old charts, that we should update from time to time.