### PR TITLE
Option to extend ingress network policy

### DIFF
--- a/helm/defectdojo/templates/network-policy.yaml
+++ b/helm/defectdojo/templates/network-policy.yaml
@@ -18,6 +18,9 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.networkPolicy.ingressExtend }}
+        {{- toYaml .Values.networkPolicy.ingressExtend | nindent 8 }}
+        {{ end }}
   {{- if .Values.networkPolicy.egress }}
   egress:
   {{- toYaml .Values.networkPolicy.egress | nindent 4 }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -20,7 +20,8 @@ createPostgresqlSecret: false
 # For more info follow https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy:
   enabled: false
-  ingressExtend: [] # if additional label need to be allowed (e.g. prometheus scraper)
+  # if additional labels need to be allowed (e.g. prometheus scraper)
+  ingressExtend: []
   # ingressExtend:
   #  - podSelector:
   #      matchLabels:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -20,6 +20,11 @@ createPostgresqlSecret: false
 # For more info follow https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy:
   enabled: false
+  ingressExtend: [] # if additional label need to be allowed (e.g. prometheus scraper)
+  # ingressExtend:
+  #  - podSelector:
+  #      matchLabels:
+  #      app.kubernetes.io/instance: defectdojo-prometheus
   egress: []
   # egress:
   # - to:


### PR DESCRIPTION
When additional monitoring service is in use (e.g. prometheus) it would be nice for the user to specify and let system to scrape statistics.