### PR TITLE
Update bitnami refs in GHA and requirements

### DIFF
--- a/.github/workflows/release-2-tag-docker-push.yml
+++ b/.github/workflows/release-2-tag-docker-push.yml
@@ -36,7 +36,7 @@ jobs:
           version: v3.4.0
       - name: Configure Helm repos
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
           helm dependency list ./helm/defectdojo
           helm dependency update ./helm/defectdojo
       - name: Package Helm chart

--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -34,7 +34,7 @@ jobs:
           version: v3.4.0
       - name: Configure HELM repos
         run: |-
-             helm repo add bitnami https://charts.bitnami.com/bitnami
+             helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
       - name: Package Helm chart

--- a/helm/defectdojo/requirements.lock
+++ b/helm/defectdojo/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: mysql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
   version: 8.8.12
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
   version: 10.13.4
 - name: rabbitmq
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
   version: 8.24.2
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
   version: 15.5.4
-digest: sha256:703b13af68b77d817409b3bb4f3c6427cd96b6000b46b21c15125d21fa47a8ac
-generated: "2021-11-15T12:49:03.596417+01:00"
+digest: sha256:4179e10d903938116d617bd616f0bbfecb261cd237b80c81cbf3a30bfa0e57bd
+generated: "2022-06-07T13:10:26.03593-05:00"

--- a/helm/defectdojo/requirements.lock
+++ b/helm/defectdojo/requirements.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: mysql
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
+  repository: https://charts.bitnami.com/bitnami
   version: 8.8.12
 - name: postgresql
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
+  repository: https://charts.bitnami.com/bitnami
   version: 10.13.4
 - name: rabbitmq
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
+  repository: https://charts.bitnami.com/bitnami
   version: 8.24.2
 - name: redis
-  repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/
+  repository: https://charts.bitnami.com/bitnami
   version: 15.5.4
-digest: sha256:4179e10d903938116d617bd616f0bbfecb261cd237b80c81cbf3a30bfa0e57bd
-generated: "2022-06-07T13:10:26.03593-05:00"
+digest: sha256:703b13af68b77d817409b3bb4f3c6427cd96b6000b46b21c15125d21fa47a8ac
+generated: "2021-11-15T12:49:03.596417+01:00"

--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
   - name: mysql
     version: 8.8.12
-    repository: "@bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
     condition: mysql.enabled
   - name: postgresql
     version: 10.13.4
-    repository: "@bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
     condition: postgresql.enabled
   - name: rabbitmq
     version: 8.24.2
-    repository: "@bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
     condition: rabbitmq.enabled
   - name: redis
     version: 15.5.4
-    repository: "@bitnami"
+    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
     condition: redis.enabled

--- a/helm/defectdojo/requirements.yaml
+++ b/helm/defectdojo/requirements.yaml
@@ -1,17 +1,17 @@
 dependencies:
   - name: mysql
     version: 8.8.12
-    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
+    repository: "@bitnami"
     condition: mysql.enabled
   - name: postgresql
     version: 10.13.4
-    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
+    repository: "@bitnami"
     condition: postgresql.enabled
   - name: rabbitmq
     version: 8.24.2
-    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
+    repository: "@bitnami"
     condition: rabbitmq.enabled
   - name: redis
     version: 15.5.4
-    repository: "https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami/"
+    repository: "@bitnami"
     condition: redis.enabled


### PR DESCRIPTION
When doing the release, updating index.yml in the [helm-charts](https://github.com/DefectDojo/django-DefectDojo/blob/helm-charts/index.yaml) branch fails due to some uncommitted changes. Here are the [logs of the failed release action](https://github.com/DefectDojo/django-DefectDojo/runs/6779678651?check_suite_focus=true)

Since the release cannot be accomplished without pushing the helm chart, I reverted the ongoing release for now until this gets sorted

I am unsure if this will actually fix the problem though. Still doing testing.  @dsever @alles-klar @StefanFl 