### PR TITLE
Set connection charset

### DIFF
--- a/docker/environments/mysql-rabbitmq.env
+++ b/docker/environments/mysql-rabbitmq.env
@@ -1,4 +1,4 @@
-DD_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/defectdojo
+DD_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/defectdojo?charset=utf8mb4
 DD_DATABASE_ENGINE=django.db.backends.mysql
 DD_DATABASE_HOST=mysql
 DD_DATABASE_PORT=3306
@@ -8,6 +8,6 @@ DD_DATABASE_USER=defectdojo
 DD_DATABASE_PASSWORD=defectdojo
 
 DD_TEST_DATABASE_NAME=test_defectdojo
-DD_TEST_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo
+DD_TEST_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo?charset=utf8mb4
 
 DD_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672//

--- a/docker/environments/mysql-redis.env
+++ b/docker/environments/mysql-redis.env
@@ -1,4 +1,4 @@
-DD_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/defectdojo
+DD_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/defectdojo?charset=utf8mb4
 DD_DATABASE_ENGINE=django.db.backends.mysql
 DD_DATABASE_HOST=mysql
 DD_DATABASE_PORT=3306
@@ -8,6 +8,6 @@ DD_DATABASE_USER=defectdojo
 DD_DATABASE_PASSWORD=defectdojo
 
 DD_TEST_DATABASE_NAME=test_defectdojo
-DD_TEST_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo
+DD_TEST_DATABASE_URL=mysql://defectdojo:defectdojo@mysql:3306/test_defectdojo?charset=utf8mb4
 
 DD_CELERY_BROKER_URL=redis://redis:6379/0


### PR DESCRIPTION
In the `docker-compose` file, the MySQL character set is explicitly [set to `utf8mb4`](https://github.com/DefectDojo/django-DefectDojo/blob/master/docker-compose.yml#L142). However, the applications connection string does not include the character set. This PR fixes this.

When importing scan results containing UTF-8 characters, the import used to fail when trying to insert certain characters. After the change in this PR was applied, the problem is gone. 