### PR TITLE
(feat) Semgrep parser cwe list support

### DIFF
--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -35,7 +35,10 @@ class SemgrepParser(object):
 
             # manage CWE
             if 'cwe' in item["extra"]["metadata"]:
-                finding.cwe = int(item["extra"]["metadata"].get("cwe").partition(':')[0].partition('-')[2])
+                if isinstance(item["extra"]["metadata"].get("cwe"), list):
+                    finding.cwe = int(item["extra"]["metadata"].get("cwe")[0].partition(':')[0].partition('-')[2])
+                else:
+                    finding.cwe = int(item["extra"]["metadata"].get("cwe").partition(':')[0].partition('-')[2])
 
             # manage references from metadata
             if 'references' in item["extra"]["metadata"]:

--- a/unittests/scans/semgrep/cwe_list.json
+++ b/unittests/scans/semgrep/cwe_list.json
@@ -1,0 +1,86 @@
+{
+  "errors": [ ],
+  "results": [
+    {
+      "check_id": "javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage",
+      "end": {
+        "col": 22,
+        "line": 12,
+        "offset": 357
+      },
+      "extra": {
+        "fingerprint": "143cb0c62f3740d62180cbde3ffa976e",
+        "is_ignored": false,
+        "lines": "const app = express();",
+        "message": "A CSRF middleware was not detected in your express application. Ensure you are either using one  such as `csurf` or `csrf` (see rule references) and/or you are properly doing CSRF validation in your routes with a token or cookies.",
+        "metadata": {
+          "category": "security",
+          "cwe": [
+            "CWE-352: Cross-Site Request Forgery (CSRF)"
+          ],
+          "license": "Commons Clause License Condition v1.0[LGPL-2.1-only]",
+          "owasp": [
+            "A01:2021 - Broken Access Control",
+            "A05:2017 - Broken Access Control"
+          ],
+          "references": [
+            "https://www.npmjs.com/package/csurf",
+            "https://www.npmjs.com/package/csrf",
+            "https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html"
+          ],
+          "shortlink": "https://sg.run/BxzR",
+          "source": "https://semgrep.dev/r/javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage",
+          "technology": [
+            "javascript",
+            "typescript",
+            "express"
+          ]
+        },
+        "metavars": {
+          "$APP": {
+            "abstract_content": "app",
+            "end": {
+              "col": 10,
+              "line": 12,
+              "offset": 345
+            },
+            "start": {
+              "col": 7,
+              "line": 12,
+              "offset": 342
+            },
+            "unique_id": {
+              "sid": 9,
+              "type": "id"
+            }
+          },
+          "$EXPRESS": {
+            "abstract_content": "express",
+            "end": {
+              "col": 20,
+              "line": 12,
+              "offset": 355
+            },
+            "start": {
+              "col": 13,
+              "line": 12,
+              "offset": 348
+            },
+            "unique_id": {
+              "sid": 1,
+              "type": "id"
+            }
+          }
+        },
+        "severity": "INFO"
+      },
+      "path": "index.js",
+      "start": {
+        "col": 7,
+        "line": 12,
+        "offset": 342
+      }
+    }
+  ],
+  "version": "0.96.0"
+}

--- a/unittests/tools/test_semgrep_parser.py
+++ b/unittests/tools/test_semgrep_parser.py
@@ -93,3 +93,18 @@ class TestSemgrepParser(DojoTestCase):
         self.assertEqual(33, finding.line)
         self.assertEqual(1236, finding.cwe)
         self.assertEqual("python.lang.security.unquoted-csv-writer.unquoted-csv-writer", finding.vuln_id_from_tool)
+
+    def test_parse_cwe_list(self):
+        testfile = open("unittests/scans/semgrep/cwe_list.json")
+        parser = SemgrepParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(findings))
+        finding = findings[0]
+        self.assertEqual("Info", finding.severity)
+        self.assertEqual("index.js", finding.file_path)
+        self.assertEqual(12, finding.line)
+        self.assertEqual(352, finding.cwe)
+        self.assertEqual("javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage", finding.vuln_id_from_tool)
+        self.assertIn("const app = express();", finding.description)
+        self.assertIn("A CSRF middleware was not detected in your express application. Ensure you are either using one  such as `csurf` or `csrf` (see rule references) and/or you are properly doing CSRF validation in your routes with a token or cookies.", finding.description)


### PR DESCRIPTION
I faced a bug that in some cases Semgrep can init CWE field as a **list** type. 

And I got an error:
`File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/app/./dojo/api_v2/views.py", line 1971, in perform_create
    serializer.save(push_to_jira=push_to_jira)
  File "/app/./dojo/api_v2/serializers.py", line 1452, in save
    test, finding_count, closed_finding_count, test_import = importer.import_scan(scan, scan_type, engagement, lead, environment,
  File "/app/./dojo/importers/importer/importer.py", line 297, in import_scan
    parsed_findings = parser.get_findings(scan, test)
  File "/app/./dojo/tools/semgrep/parser.py", line 38, in get_findings
    finding.cwe = int(item["extra"]["metadata"].get("cwe").partition(':')[0].partition('-')[2])
AttributeError: 'list' object has no attribute 'partition'`

Here is a link to the Semgrep sources: https://github.com/returntocorp/semgrep/blob/develop/semgrep/semgrep/formatter/sarif.py#L132
