### PR TITLE
Update importing.md

### DIFF
--- a/docs/content/en/integrations/importing.md
+++ b/docs/content/en/integrations/importing.md
@@ -1,6 +1,6 @@
 ---
 title: "Importing"
-description: "DefectDojo has the ability to import scan reports from a large number of security tools."
+description: "How DefectDojo imports and reimports security tool reports"
 draft: false
 weight: 1
 ---


### PR DESCRIPTION
**suggestion**
On the Integrations pages, both Importing and Supported Reports has the same subtitle "DefectDojo has the ability to import scan reports from a large number of security tools."
I've made a suggestion to change this to make the Importing link more specific to the contents.