### PR TITLE
Adjust description of Generic Parser

### DIFF
--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -16,7 +16,7 @@ class GenericParser(object):
         return scan_type  # no custom label for now
 
     def get_description_for_scan_types(self, scan_type):
-        return "Import Generic findings in CSV format."
+        return "Import Generic findings in CSV or JSON format."
 
     def get_findings(self, filename, test, active=None, verified=None):
         if filename.name.lower().endswith(".csv"):


### PR DESCRIPTION
The description of the generic parser only mentions that a cvs file can be provided but json files are possible too, therefore this should be mentioned in the description, s.t. it will be shown in the overview when importing a scan result.