### PR TITLE
APIv2: Add support for configuration_permissions

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -411,7 +411,7 @@ class UserSerializer(serializers.ModelSerializer):
 
         # This will create only Permissions from category "configuration_permissions". There are no other Permissions.
         if new_configuration_permissions:
-            instance.user_permissions.set(new_configuration_permissions)
+            user.user_permissions.set(new_configuration_permissions)
 
         user.save()
         return user

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from rest_framework import serializers
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.models import Permission
 from django.utils import timezone
 from django.db.utils import IntegrityError
 import six
@@ -41,6 +42,7 @@ from dojo.importers.reimporter.reimporter import DojoDefaultReImporter as ReImpo
 from dojo.authorization.authorization import user_has_permission
 from dojo.authorization.roles_permissions import Permissions
 from dojo.finding.helper import save_vulnerability_ids, save_vulnerability_ids_template
+from dojo.user.utils import get_configuration_permissions_codenames
 
 
 logger = logging.getLogger(__name__)
@@ -350,24 +352,67 @@ class UserSerializer(serializers.ModelSerializer):
     last_login = serializers.DateTimeField(read_only=True)
     password = serializers.CharField(write_only=True, style={'input_type': 'password'}, required=False,
                                      validators=[validate_password])
+    configuration_permissions = serializers.PrimaryKeyRelatedField(
+         allow_null=True,
+         queryset=Permission.objects.filter(codename__in=get_configuration_permissions_codenames()),
+         many=True,
+         required=False,
+         source='user_permissions')
 
     class Meta:
         model = Dojo_User
         if settings.FEATURE_CONFIGURATION_AUTHORIZATION:
-            fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_superuser', 'password')
+            fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_superuser', 'password', 'configuration_permissions')
         else:
-            fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_staff', 'is_superuser', 'password')
+            fields = ('id', 'username', 'first_name', 'last_name', 'email', 'last_login', 'is_active', 'is_staff', 'is_superuser', 'password', 'configuration_permissions')
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+
+        # This will show only "configuration_permissions" even if user has also other permissions
+        all_permissions = set(ret['configuration_permissions'])
+        allowed_configuration_permissions = set(self.fields['configuration_permissions'].child_relation.queryset.values_list('id', flat=True))
+        ret['configuration_permissions'] = list(all_permissions.intersection(allowed_configuration_permissions))
+
+        return ret
+
+    def update(self, instance, validated_data):
+        new_configuration_permissions = None
+        if 'user_permissions' in validated_data:  # This field was renamed from "configuration_permissions" in the meantime
+            new_configuration_permissions = set(validated_data.pop('user_permissions'))
+
+        instance = super().update(instance, validated_data)
+
+        # This will update only Permissions from category "configuration_permissions". Others will be untouched
+        if new_configuration_permissions:
+            allowed_configuration_permissions = set(self.fields['configuration_permissions'].child_relation.queryset.all())
+            non_configuration_permissions = set(instance.user_permissions.all()) - allowed_configuration_permissions
+            new_permissions = non_configuration_permissions.union(new_configuration_permissions)
+            instance.user_permissions.set(new_permissions)
+
+        return instance
 
     def create(self, validated_data):
         if 'password' in validated_data:
             password = validated_data.pop('password')
         else:
             password = None
+
+        new_configuration_permissions = None
+        if 'user_permissions' in validated_data:  # This field was renamed from "configuration_permissions" in the meantime
+            new_configuration_permissions = set(validated_data.pop('user_permissions'))
+
         user = Dojo_User.objects.create(**validated_data)
+
         if password:
             user.set_password(password)
         else:
             user.set_unusable_password()
+
+        # This will create only Permissions from category "configuration_permissions". There are no other Permissions.
+        if new_configuration_permissions:
+            instance.user_permissions.set(new_configuration_permissions)
+
         user.save()
         return user
 
@@ -409,9 +454,55 @@ class RoleSerializer(serializers.ModelSerializer):
 
 class DojoGroupSerializer(serializers.ModelSerializer):
 
+    configuration_permissions = serializers.PrimaryKeyRelatedField(
+         allow_null=True,
+         queryset=Permission.objects.filter(codename__in=get_configuration_permissions_codenames()),
+         many=True,
+         required=False,
+         source='auth_group.permissions')
+
     class Meta:
         model = Dojo_Group
         exclude = ['auth_group']
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+
+        # This will show only "configuration_permissions" even if user has also other permissions
+        all_permissions = set(ret['configuration_permissions'])
+        allowed_configuration_permissions = set(self.fields['configuration_permissions'].child_relation.queryset.values_list('id', flat=True))
+        ret['configuration_permissions'] = list(all_permissions.intersection(allowed_configuration_permissions))
+
+        return ret
+
+    def create(self, validated_data):
+        new_configuration_permissions = None
+        if 'auth_group' in validated_data and 'permissions' in validated_data['auth_group']:  # This field was renamed from "configuration_permissions" in the meantime
+            new_configuration_permissions = set(validated_data.pop('auth_group')['permissions'])
+
+        instance = super().create(validated_data)
+
+        # This will update only Permissions from category "configuration_permissions". There are no other Permissions.
+        if new_configuration_permissions:
+            instance.auth_group.permissions.set(new_configuration_permissions)
+
+        return instance
+
+    def update(self, instance, validated_data):
+        new_configuration_permissions = None
+        if 'auth_group' in validated_data and 'permissions' in validated_data['auth_group']:  # This field was renamed from "configuration_permissions" in the meantime
+            new_configuration_permissions = set(validated_data.pop('auth_group')['permissions'])
+
+        instance = super().update(instance, validated_data)
+
+        # This will update only Permissions from category "configuration_permissions". Others will be untouched
+        if new_configuration_permissions:
+            allowed_configuration_permissions = set(self.fields['configuration_permissions'].child_relation.queryset.all())
+            non_configuration_permissions = set(instance.auth_group.permissions.all()) - allowed_configuration_permissions
+            new_permissions = non_configuration_permissions.union(new_configuration_permissions)
+            instance.auth_group.permissions.set(new_permissions)
+
+        return instance
 
 
 class DojoGroupMemberSerializer(serializers.ModelSerializer):
@@ -1952,3 +2043,9 @@ class DeletePreviewSerializer(serializers.Serializer):
     model = serializers.CharField(read_only=True)
     id = serializers.IntegerField(read_only=True, allow_null=True)
     name = serializers.CharField(read_only=True)
+
+
+class ConfigurationPermissionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Permission
+        exclude = ['content_type']

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -4,6 +4,7 @@ from crum import get_current_user
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
+from django.contrib.auth.models import Permission
 from django.core.exceptions import ValidationError
 from django.utils.decorators import method_decorator
 from drf_yasg.inspectors.base import NotHandled
@@ -60,6 +61,7 @@ from dojo.jira_link.queries import get_authorized_jira_projects, get_authorized_
 from dojo.tool_product.queries import get_authorized_tool_product_settings
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
 from dojo.authorization.roles_permissions import Permissions
+from dojo.user.utils import get_configuration_permissions_codenames
 
 logger = logging.getLogger(__name__)
 
@@ -2542,3 +2544,14 @@ class NetworkLocationsViewset(mixins.ListModelMixin,
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('id', 'location')
     permission_classes = (IsAuthenticated, DjangoModelPermissions)
+
+
+# Authorization: superuser
+class ConfigurationPermissionViewSet(mixins.RetrieveModelMixin,
+                                     mixins.ListModelMixin,
+                                     viewsets.GenericViewSet):
+    serializer_class = serializers.ConfigurationPermissionSerializer
+    queryset = Permission.objects.filter(codename__in=get_configuration_permissions_codenames())
+    filter_backends = (DjangoFilterBackend,)
+    filter_fields = ('id', 'name', 'codename')
+    permission_classes = (permissions.IsSuperUser, DjangoModelPermissions)

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -101,7 +101,7 @@
       "is_staff": false,
       "last_login": null,
       "groups": [],
-      "user_permissions": [],
+      "user_permissions": [218, 220, 26, 28],
       "password": "pbkdf2_sha256$36000$pe8Ff8HrBPac$Lb3ee6/R9z/aL9nM+D2AXWTpIt9Pa9kcLueXxYNy1ZY=",
       "email": "",
       "date_joined": "2018-04-13T07:59:51.527Z"
@@ -2352,6 +2352,78 @@
       "product": 1,
       "user": 2,
       "product_type_added": ["slack"]
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 217,
+    "fields": {
+      "name": "Can add finding_ template",
+      "content_type": 55,
+      "codename": "add_finding_template"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 218,
+    "fields": {
+      "name": "Can change finding_ template",
+      "content_type": 55,
+      "codename": "change_finding_template"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 219,
+    "fields": {
+      "name": "Can delete finding_ template",
+      "content_type": 55,
+      "codename": "delete_finding_template"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 220,
+    "fields": {
+      "name": "Can view finding_ template",
+      "content_type": 55,
+      "codename": "view_finding_template"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 25,
+    "fields": {
+      "name": "Can add log entry",
+      "content_type": 7,
+      "codename": "add_logentry"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 26,
+    "fields": {
+      "name": "Can change log entry",
+      "content_type": 7,
+      "codename": "change_logentry"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 27,
+    "fields": {
+      "name": "Can delete log entry",
+      "content_type": 7,
+      "codename": "delete_logentry"
+    }
+  },
+  {
+    "model": "auth.permission",
+    "pk": 28,
+    "fields": {
+      "name": "Can view log entry",
+      "content_type": 7,
+      "codename": "view_logentry"
     }
   }
 ]

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -46,6 +46,7 @@ from dojo.product_type.queries import get_authorized_product_types
 from dojo.product.queries import get_authorized_products
 from dojo.finding.queries import get_authorized_findings
 from dojo.user.queries import get_authorized_users_for_product_and_product_type, get_authorized_users
+from dojo.user.utils import get_configuration_permissions_fields
 from dojo.group.queries import get_authorized_groups, get_group_member_roles
 
 logger = logging.getLogger(__name__)
@@ -3194,62 +3195,7 @@ class ConfigurationPermissionsForm(forms.Form):
         self.group = kwargs.pop('group', None)
         super(ConfigurationPermissionsForm, self).__init__(*args, **kwargs)
 
-        if get_system_setting('enable_github'):
-            github_permissions = [
-                Permission_Helper(name='github conf', app='dojo', view=True, add=True, delete=True),
-            ]
-        else:
-            github_permissions = []
-
-        if get_system_setting('enable_google_sheets'):
-            google_sheet_permissions = [
-                Permission_Helper(name='google sheet', app='dojo', change=True),
-            ]
-        else:
-            google_sheet_permissions = []
-
-        if get_system_setting('enable_jira'):
-            jira_permissions = [
-                Permission_Helper(name='jira instance', app='dojo', view=True, add=True, change=True, delete=True),
-            ]
-        else:
-            jira_permissions = []
-
-        if get_system_setting('enable_questionnaires'):
-            questionnaire_permissions = [
-                Permission_Helper(name='engagement survey', app='dojo', view=True, add=True, change=True, delete=True),
-                Permission_Helper(name='question', app='dojo', view=True, add=True, change=True),
-            ]
-        else:
-            questionnaire_permissions = []
-
-        if get_system_setting('enable_rules_framework'):
-            rules_permissions = [
-                Permission_Helper(name='rule', app='auth', view=True, add=True, change=True, delete=True),
-            ]
-        else:
-            rules_permissions = []
-
-        self.permission_fields = [
-            Permission_Helper(name='cred user', app='dojo', view=True, add=True, change=True, delete=True),
-            Permission_Helper(name='development environment', app='dojo', add=True, change=True, delete=True),
-            Permission_Helper(name='finding template', app='dojo', view=True, add=True, change=True, delete=True)] + \
-            github_permissions + \
-            google_sheet_permissions + [
-            Permission_Helper(name='group', app='auth', view=True, add=True)] + \
-            jira_permissions + [
-            Permission_Helper(name='language type', app='dojo', view=True, add=True, change=True, delete=True),
-            Permission_Helper(name='bannerconf', app='dojo', change=True),
-            Permission_Helper(name='note type', app='dojo', view=True, add=True, change=True, delete=True),
-            Permission_Helper(name='product type', app='dojo', add=True)] + \
-            questionnaire_permissions + [
-            Permission_Helper(name='regulation', app='dojo', add=True, change=True, delete=True)] + \
-            rules_permissions + [
-            Permission_Helper(name='test type', app='dojo', add=True, change=True),
-            Permission_Helper(name='tool configuration', app='dojo', view=True, add=True, change=True, delete=True),
-            Permission_Helper(name='tool type', app='dojo', view=True, add=True, change=True, delete=True),
-            Permission_Helper(name='user', app='auth', view=True, add=True, change=True, delete=True),
-        ]
+        self.permission_fields = get_configuration_permissions_fields()
 
         for permission_field in self.permission_fields:
             for codename in permission_field.codenames():
@@ -3285,63 +3231,3 @@ class ConfigurationPermissionsForm(forms.Form):
                 self.group.auth_group.permissions.remove(self.permissions[codename])
             else:
                 raise Exception('Neither user or group are set')
-
-
-class Permission_Helper:
-    def __init__(self, *args, **kwargs):
-        self.name = kwargs.pop('name')
-        self.app = kwargs.pop('app')
-        self.view = kwargs.pop('view', False)
-        self.add = kwargs.pop('add', False)
-        self.change = kwargs.pop('change', False)
-        self.delete = kwargs.pop('delete', False)
-
-    def display_name(self):
-        if self.name == 'bannerconf':
-            return 'Login Banner'
-        elif self.name == 'cred user':
-            return 'Credentials'
-        elif self.name == 'github conf':
-            return 'GitHub Configurations'
-        elif self.name == 'engagement survey':
-            return 'Questionnaires'
-        elif self.name == 'permission':
-            return 'Configuration Permissions'
-        else:
-            return self.name.title() + 's'
-
-    def view_codename(self):
-        if self.view:
-            return f'view_{self.name.replace(" ", "_")}'
-        else:
-            return None
-
-    def add_codename(self):
-        if self.add:
-            return f'add_{self.name.replace(" ", "_")}'
-        else:
-            return None
-
-    def change_codename(self):
-        if self.change:
-            return f'change_{self.name.replace(" ", "_")}'
-        else:
-            return None
-
-    def delete_codename(self):
-        if self.delete:
-            return f'delete_{self.name.replace(" ", "_")}'
-        else:
-            return None
-
-    def codenames(self):
-        codenames = []
-        if self.view:
-            codenames.append(self.view_codename())
-        if self.add:
-            codenames.append(self.add_codename())
-        if self.change:
-            codenames.append(self.change_codename())
-        if self.delete:
-            codenames.append(self.delete_codename())
-        return codenames

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -21,7 +21,8 @@ from dojo.api_v2.views import EndPointViewSet, EngagementViewSet, \
     DojoGroupViewSet, ProductGroupViewSet, ProductTypeGroupViewSet, RoleViewSet, GlobalRoleViewSet, \
     DojoGroupMemberViewSet, ImportLanguagesView, LanguageTypeViewSet, LanguageViewSet, \
     NotificationsViewSet, EngagementPresetsViewset, NetworkLocationsViewset, UserContactInfoViewSet, \
-    ProductAPIScanConfigurationViewSet, UserProfileView, EndpointMetaImporterView
+    ProductAPIScanConfigurationViewSet, UserProfileView, EndpointMetaImporterView, \
+    ConfigurationPermissionViewSet
 
 from dojo.utils import get_system_setting
 from dojo.development_environment.urls import urlpatterns as dev_env_urls
@@ -67,6 +68,7 @@ admin.autodiscover()
 # v2 api written in django-rest-framework
 v2_api = DefaultRouter()
 v2_api.register(r'technologies', AppAnalysisViewSet)
+v2_api.register(r'configuration_permissions', ConfigurationPermissionViewSet)
 v2_api.register(r'endpoints', EndPointViewSet)
 v2_api.register(r'endpoint_meta_import', EndpointMetaImporterView, basename='endpointmetaimport')
 v2_api.register(r'endpoint_status', EndpointStatusViewSet)

--- a/dojo/user/utils.py
+++ b/dojo/user/utils.py
@@ -1,0 +1,132 @@
+from dojo.utils import get_system_setting
+
+
+class Permission_Helper:
+    def __init__(self, *args, **kwargs):
+        self.name = kwargs.pop('name')
+        self.app = kwargs.pop('app')
+        self.view = kwargs.pop('view', False)
+        self.add = kwargs.pop('add', False)
+        self.change = kwargs.pop('change', False)
+        self.delete = kwargs.pop('delete', False)
+
+    def display_name(self):
+        if self.name == 'bannerconf':
+            return 'Login Banner'
+        elif self.name == 'cred user':
+            return 'Credentials'
+        elif self.name == 'github conf':
+            return 'GitHub Configurations'
+        elif self.name == 'engagement survey':
+            return 'Questionnaires'
+        elif self.name == 'permission':
+            return 'Configuration Permissions'
+        else:
+            return self.name.title() + 's'
+
+    def view_codename(self):
+        if self.view:
+            return f'view_{self.name.replace(" ", "_")}'
+        else:
+            return None
+
+    def add_codename(self):
+        if self.add:
+            return f'add_{self.name.replace(" ", "_")}'
+        else:
+            return None
+
+    def change_codename(self):
+        if self.change:
+            return f'change_{self.name.replace(" ", "_")}'
+        else:
+            return None
+
+    def delete_codename(self):
+        if self.delete:
+            return f'delete_{self.name.replace(" ", "_")}'
+        else:
+            return None
+
+    def codenames(self):
+        codenames = []
+        if self.view:
+            codenames.append(self.view_codename())
+        if self.add:
+            codenames.append(self.add_codename())
+        if self.change:
+            codenames.append(self.change_codename())
+        if self.delete:
+            codenames.append(self.delete_codename())
+        return codenames
+
+
+def get_configuration_permissions_fields():
+
+    if get_system_setting('enable_github'):
+        github_permissions = [
+            Permission_Helper(name='github conf', app='dojo', view=True, add=True, delete=True),
+        ]
+    else:
+        github_permissions = []
+
+    if get_system_setting('enable_google_sheets'):
+        google_sheet_permissions = [
+            Permission_Helper(name='google sheet', app='dojo', change=True),
+        ]
+    else:
+        google_sheet_permissions = []
+
+    if get_system_setting('enable_jira'):
+        jira_permissions = [
+            Permission_Helper(name='jira instance', app='dojo', view=True, add=True, change=True, delete=True),
+        ]
+    else:
+        jira_permissions = []
+
+    if get_system_setting('enable_questionnaires'):
+        questionnaire_permissions = [
+            Permission_Helper(name='engagement survey', app='dojo', view=True, add=True, change=True, delete=True),
+            Permission_Helper(name='question', app='dojo', view=True, add=True, change=True),
+        ]
+    else:
+        questionnaire_permissions = []
+
+    if get_system_setting('enable_rules_framework'):
+        rules_permissions = [
+            Permission_Helper(name='rule', app='auth', view=True, add=True, change=True, delete=True),
+        ]
+    else:
+        rules_permissions = []
+
+    permission_fields = [
+        Permission_Helper(name='cred user', app='dojo', view=True, add=True, change=True, delete=True),
+        Permission_Helper(name='development environment', app='dojo', add=True, change=True, delete=True),
+        Permission_Helper(name='finding template', app='dojo', view=True, add=True, change=True, delete=True)] + \
+        github_permissions + \
+        google_sheet_permissions + [
+        Permission_Helper(name='group', app='auth', view=True, add=True)] + \
+        jira_permissions + [
+        Permission_Helper(name='language type', app='dojo', view=True, add=True, change=True, delete=True),
+        Permission_Helper(name='bannerconf', app='dojo', change=True),
+        Permission_Helper(name='note type', app='dojo', view=True, add=True, change=True, delete=True),
+        Permission_Helper(name='product type', app='dojo', add=True)] + \
+        questionnaire_permissions + [
+        Permission_Helper(name='regulation', app='dojo', add=True, change=True, delete=True)] + \
+        rules_permissions + [
+        Permission_Helper(name='test type', app='dojo', add=True, change=True),
+        Permission_Helper(name='tool configuration', app='dojo', view=True, add=True, change=True, delete=True),
+        Permission_Helper(name='tool type', app='dojo', view=True, add=True, change=True, delete=True),
+        Permission_Helper(name='user', app='auth', view=True, add=True, change=True, delete=True),
+    ]
+
+    return permission_fields
+
+
+def get_configuration_permissions_codenames():
+    codenames = []
+
+    for permission_field in get_configuration_permissions_fields():
+        codenames.extend(permission_field.codenames())
+
+    return codenames

--- a/unittests/test_apiv2_methods.py
+++ b/unittests/test_apiv2_methods.py
@@ -16,7 +16,7 @@ class ApiEndpointMethods(DojoTestCase):
     def test_is_defined(self):
 
         for reg, _, _ in sorted(self.registry):
-            if reg in ['import-scan', 'reimport-scan', 'notes', 'system_settings', 'roles', 'import-languages', 'endpoint_meta_import', 'test_types']:
+            if reg in ['import-scan', 'reimport-scan', 'notes', 'system_settings', 'roles', 'import-languages', 'endpoint_meta_import', 'test_types', 'configuration_permissions']:
                 continue
 
             for method in ['get', 'post']:

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1491,7 +1491,7 @@ class UsersTest(BaseClass.RESTEndpointTest):
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
         self.deleted_objects = 17
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
-
+# TODO
 
 class UserContactInfoTest(BaseClass.RESTEndpointTest):
     fixtures = ['dojo_testdata.json']
@@ -2203,7 +2203,7 @@ class DojoGroupsTest(BaseClass.RESTEndpointTest):
         self.permission_delete = Permissions.Group_Delete
         self.deleted_objects = 4
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
-
+# TODO
     def test_list_object_not_authorized(self):
         self.setUp_not_authorized()
 

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -21,10 +21,12 @@ from dojo.api_v2.views import DevelopmentEnvironmentViewSet, EndPointViewSet, En
     DojoGroupViewSet, RoleViewSet, ProductTypeMemberViewSet, ProductMemberViewSet, \
     ProductTypeGroupViewSet, ProductGroupViewSet, GlobalRoleViewSet, \
     DojoGroupMemberViewSet, LanguageTypeViewSet, LanguageViewSet, ImportLanguagesView, \
-    NotificationsViewSet, UserContactInfoViewSet, ProductAPIScanConfigurationViewSet
+    NotificationsViewSet, UserContactInfoViewSet, ProductAPIScanConfigurationViewSet, \
+    ConfigurationPermissionViewSet
 from json import dumps
 from enum import Enum
 from django.urls import reverse
+from django.contrib.auth.models import Permission
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
@@ -1486,12 +1488,36 @@ class UsersTest(BaseClass.RESTEndpointTest):
             "last_name": "user",
             "email": "example@email.com",
             "is_active": True,
+            "configuration_permissions": [217, 218]
         }
-        self.update_fields = {"first_name": "test changed"}
+        self.update_fields = {"first_name": "test changed", "configuration_permissions": [219, 220]}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
         self.deleted_objects = 17
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
-# TODO
+
+    def test_create_user_with_non_configuration_permissions(self):
+        payload = self.payload.copy()
+        payload['configuration_permissions'] = [25, 26]  # these permissions exist but user can not assign them becaause they are not "configuration_permissions"
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('object does not exist', response.data['message'])
+
+    def test_update_user_with_non_configuration_permissions(self):
+        payload = {}
+        payload['configuration_permissions'] = [25, 26]  # these permissions exist but user can not assign them becaause they are not "configuration_permissions"
+        response = self.client.patch(self.url + '3/', payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('object does not exist', response.data['message'])
+
+    def test_update_user_other_permissions_will_not_leak_and_stay_untouched(self):
+        payload = {}
+        payload['configuration_permissions'] = [217, 218, 219]
+        response = self.client.patch(self.url + '6/', payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['configuration_permissions'], payload['configuration_permissions'])
+        user_permissions = User.objects.get(username='user5').user_permissions.all().values_list('id', flat=True)
+        self.assertEqual(set(user_permissions), set(payload['configuration_permissions'] + [26, 28]))
+
 
 class UserContactInfoTest(BaseClass.RESTEndpointTest):
     fixtures = ['dojo_testdata.json']
@@ -2195,15 +2221,16 @@ class DojoGroupsTest(BaseClass.RESTEndpointTest):
         self.payload = {
             "name": "Test Group",
             "description": "Test",
+            "configuration_permissions": [217, 218],
         }
-        self.update_fields = {'description': "changed"}
+        self.update_fields = {'description': "changed", "configuration_permissions": [219, 220]}
         self.test_type = TestType.OBJECT_PERMISSIONS
         self.permission_check_class = Dojo_Group
         self.permission_update = Permissions.Group_Edit
         self.permission_delete = Permissions.Group_Delete
         self.deleted_objects = 4
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
-# TODO
+
     def test_list_object_not_authorized(self):
         self.setUp_not_authorized()
 
@@ -2223,6 +2250,31 @@ class DojoGroupsTest(BaseClass.RESTEndpointTest):
 
         response = self.client.post(self.url, self.payload)
         self.assertEqual(403, response.status_code, response.content[:1000])
+
+    def test_create_group_with_non_configuration_permissions(self):
+        payload = self.payload.copy()
+        payload['configuration_permissions'] = [25, 26]  # these permissions exist but user can not assign them becaause they are not "configuration_permissions"
+        response = self.client.post(self.url, payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('object does not exist', response.data['message'])
+
+    def test_update_group_with_non_configuration_permissions(self):
+        payload = {}
+        payload['configuration_permissions'] = [25, 26]  # these permissions exist but user can not assign them becaause they are not "configuration_permissions"
+        response = self.client.patch(self.url + '2/', payload)
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('object does not exist', response.data['message'])
+
+    def test_update_group_other_permissions_will_not_leak_and_stay_untouched(self):
+        Dojo_Group.objects.get(name='Group 1 Testdata').auth_group.permissions.set([218, 220, 26, 28])  # I was trying to set this in 'dojo_testdata.json' but it hasn't sucessful
+        payload = {}
+        payload['configuration_permissions'] = [217, 218, 219]
+        response = self.client.patch(self.url + '1/', payload)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['configuration_permissions'], payload['configuration_permissions'])
+        permissions = Dojo_Group.objects.get(name='Group 1 Testdata').auth_group.permissions.all().values_list('id', flat=True)
+        self.assertEqual(set(permissions), set(payload['configuration_permissions'] + [26, 28]))
+        Dojo_Group.objects.get(name='Group 1 Testdata').auth_group.permissions.clear()
 
 
 class DojoGroupsUsersTest(BaseClass.MemberEndpointTest):
@@ -2541,4 +2593,16 @@ class TestTypeTest(BaseClass.AuthenticatedViewTest):
         self.update_fields = {'name': 'Test_2'}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
         self.deleted_objects = 1
+        BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
+
+
+class ConfigurationPermissionTest(BaseClass.RESTEndpointTest):
+    fixtures = ['dojo_testdata.json']
+
+    def __init__(self, *args, **kwargs):
+        self.endpoint_model = Permission
+        self.endpoint_path = 'configuration_permissions'
+        self.viewname = 'permission'
+        self.viewset = ConfigurationPermissionViewSet
+        self.test_type = TestType.STANDARD
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)


### PR DESCRIPTION
# Intro 
There are 2 new API endpoints:
- `GET configuration_permissions/`
- `GET configuration_permissions/{id}/`

For listing (+showing) `Permission`s which are part of [`configuration_permissions`](https://defectdojo.github.io/django-DefectDojo/usage/permissions/#configuration-permissions)

These permissions can be assigned through endpoints `POST/PATCH/PUT users/` and `POST/PATCH/PUT dojo_groups/` to users and groups by specifying the list of `Permission ID`s in the field `configuration_permissions` in the original query.
This action will not touch any other permissions.

# Example of request/response bodies
`GET /configuration_permissions/{id}/`
```json
{
  "id": 0,
  "name": "string",
  "codename": "string"
}
```
`GET /users/{id}/`
```json
{
  "id": 0,
  "username": "NX-Esa5Ai_CyZzxj9MF2I0x@-ZOYX6yY41gck@SeJjelxt@b6H1jApB15Tcf_Wu9jCb@-EJqJp4ZyIn1Re+kF",
  "first_name": "string",
  "last_name": "string",
  "email": "user@example.com",
  "last_login": "2022-06-18T02:13:28.620Z",
  "is_active": true,
  "is_superuser": true,
  "configuration_permissions": [
    0
  ]
}
```
`GET /dojo_groups/{id}/`
```json
{
  "id": 0,
  "configuration_permissions": [
    0
  ],
  "name": "string",
  "description": "string",
  "social_provider": "AzureAD",
  "users": [
    0
  ],
  "prefetch": { ... }
}
```