### PR TITLE
Display tags in several lists again

### DIFF
--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -109,7 +109,7 @@
                                 {% if not product_tab %}
                                   <td>
                                     <a href="{% url 'view_product' e.product.id %}">{{ e.product }}</a>
-                                    {% include "dojo/snippets/tags.html" with tags=e.product.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=e.product.tags.all %}
                                   </td>
                                 {% endif %}
                                 <td class="text-center">

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -65,7 +65,7 @@
                                 <td style="white-space: normal">
                                     <a class="eng_link" href="{%url 'view_engagement' e.id %}">{% if e.name %}{{ e.name }}{% endif %}</a>
                                     <div>
-                                        {% include "dojo/snippets/tags.html" with tags=e.tags.alll %}
+                                        {% include "dojo/snippets/tags.html" with tags=e.tags.all %}
                                     </div>
                                 </td>
                                 <td> {{ e.target_start }} - {{ e.target_end }}
@@ -81,7 +81,7 @@
                                         {{ e.product.name }}
                                     </a>
                                     {{ e.product|jira_project_tag }}
-                                    {% include "dojo/snippets/tags.html" with tags=e.product.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=e.product.tags.all %}
                                 </td>
                                 <td class="prod_name">
                                     <a href="{% url 'product_type_metrics' e.product.prod_type.id %}">

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -49,14 +49,14 @@
                                 <tr>
 
                                     <td class="prod_name"><a href="{% url 'view_product' p.id %}">{{ p.name }}</a>
-                                        {% include "dojo/snippets/tags.html" with tags=p.tags.alll %}
+                                        {% include "dojo/snippets/tags.html" with tags=p.tags.all %}
                                     </td>
                                     <td class="prod_name">
                                         <a href="{% url 'product_type_metrics' p.prod_type.id %}">{{ p.prod_type.name }}</a>
                                     </td>
                                     <td>
                                         <a class="eng_link" href="{% url 'view_engagement' e.id %}">{% if e.name %}{{ e.name }}{% endif %}</a>
-                                        {% include "dojo/snippets/tags.html" with tags=e.tags.alll %}
+                                        {% include "dojo/snippets/tags.html" with tags=e.tags.all %}
                                         <br>
                                     </td>
                                     {% if system_settings.enable_jira %}

--- a/dojo/templates/dojo/finding_related_row.html
+++ b/dojo/templates/dojo/finding_related_row.html
@@ -22,7 +22,7 @@
         <a title="{{ similar_finding.title }}" href="{% url 'view_finding' similar_finding.id %}">{{ similar_finding.title|truncatechars_html:80 }}</a>
         {% if similar_finding.tags %}
         <small>
-            {% include "dojo/snippets/tags.html" with tags=similar_finding.tags.alll %}
+            {% include "dojo/snippets/tags.html" with tags=similar_finding.tags.all %}
         </small>
         {% endif %}
         {% with similar_finding.notes.count as note_count %}

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -390,7 +390,7 @@
                                         ({{ finding.notes.count }})
                                     </a>
                                   {% endif %}
-                                  {% include "dojo/snippets/tags.html" with tags=finding.tags.alll %}
+                                  {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                 </td>
                                 <td class="nowrap">
                                   {% if finding.cwe > 0 %}

--- a/dojo/templates/dojo/report_findings.html
+++ b/dojo/templates/dojo/report_findings.html
@@ -42,7 +42,7 @@
                         <tr>
                             <td>
                                 <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title }}</a>
-                                {% include "dojo/snippets/tags.html" with tags=finding.tags.alll %}
+                                {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                             </td>
                             <td class="nowrap">{{ finding.date }}</td>
                             <td>{{ finding.severity }}</td>

--- a/dojo/templates/dojo/request_endpoint_report.html
+++ b/dojo/templates/dojo/request_endpoint_report.html
@@ -51,7 +51,7 @@
                             <tr>
                                 <td>
                                     <a href="{% url 'view_endpoint' e.id %}">{{ e|truncatechars_html:70 }}</a>
-                                    {% include "dojo/snippets/tags.html" with tags=e.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=e.tags.all %}
                                 </td>
                                 <td>
                                     <a href="{% url 'open_findings' %}?endpoints={{ e.id }}">{{ e.findings_count }}</a>

--- a/dojo/templates/dojo/request_report.html
+++ b/dojo/templates/dojo/request_report.html
@@ -78,7 +78,7 @@
                             <tr>
                                 <td>
                                     <a title="{{ finding.title }}" href="{% url 'view_finding' finding.id %}">{{ finding.title|truncatechars_html:50 }}</a>
-                                    {% include "dojo/snippets/tags.html" with tags=finding.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                 </td>
                                 <td class="nowrap">{{ finding.date }}</td>
                                 <td class="">{{ finding.status }}</td>

--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -117,7 +117,7 @@
                             <tr>
                                 <td>
                                     <a class="search-finding" href="{% url 'view_product' product.id %}">{{ product.name }}</a>
-                                    {% include "dojo/snippets/tags.html" with tags=product.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=product.tags.all %}
                                 </td>
                                 <td>{{ product.description|truncatechars_html:150|markdown_render }}</td>
                             </tr>
@@ -145,11 +145,11 @@
                             <tr>
                                 <td>
                                     <a class="search-finding" href="{% url 'view_engagement' engagement.id %}">{{ engagement.name }}</a>
-                                    {% include "dojo/snippets/tags.html" with tags=engagement.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=engagement.tags.all %}
                                 </td>
                                 <td>
                                     <a href="{% url 'view_product' engagement.product.id %}">{{ engagement.product.name }}</a>
-                                    {% include "dojo/snippets/tags.html" with tags=engagement.product.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=engagement.product.tags.all %}
                                 </td>
                                 <td>{{ engagement.target_start|date }} - {{ engagement.target_end|date }}</td>
                                 <td>{{ engagement.status }}</td>
@@ -179,7 +179,7 @@
                             <tr>
                                 <td>
                                     <a class="search-finding" href="{% url 'view_test' test.id %}">{{ test }}</a>
-                                    {% include "dojo/snippets/tags.html" with tags=test.tags.alll %}
+                                    {% include "dojo/snippets/tags.html" with tags=test.tags.all %}
                                 </td>
                                 <td>
                                     <a href="{% url 'view_product' test.engagement.product.id %}">{{ test.engagement.product.name }}</a>


### PR DESCRIPTION
A PR end of last year introduced a typo that let tags not to be displayed anymore in several list.