### PR TITLE
Only merge references if the reference is not None

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1651,7 +1651,7 @@ def merge_finding_product(request, pid):
                                 finding_descriptions = "{}\n**File Path:** {}\n".format(finding_descriptions, finding.file_path)
 
                         # If checked merge the Reference
-                        if form.cleaned_data['append_reference']:
+                        if form.cleaned_data['append_reference'] and finding.references is not None:
                             finding_references = "{}\n{}".format(finding_references, finding.references)
 
                         # if checked merge the endpoints


### PR DESCRIPTION
If you merge a number of findings with no references, the resulting merged finding has a ton of "None" lines in the references. This PR only merges the Reference value if it's not "None". Tested successfully locally.