### PR TITLE
Add Due-Date to JIRA description and don't write out None values

### DIFF
--- a/dojo/templates/issue-trackers/jira_full/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-description.tpl
@@ -9,6 +9,11 @@
 *Defect Dojo link:* {{ finding_url|full_url }} ({{ finding.id }})
 
 *Severity:* {{ finding.severity }}
+
+{% if finding.sla_deadline %}
+*Due Date:* {{ finding.sla_deadline }}
+{% endif %}
+
 {% if finding.cwe > 0 %}
 *CWE:* [CWE-{{ finding.cwe }}|{{ finding.cwe|cwe_url }}]
 {% else %}
@@ -23,11 +28,17 @@
 
 *Product/Engagement/Test:* [{{ finding.test.engagement.product.name }}|{{ product_url|full_url }}] / [{{ finding.test.engagement.name }}|{{ engagement_url|full_url }}] / [{{ finding.test }}|{{ test_url|full_url }}]
 
+{% if finding.test.engagement.branch_tag %}
 *Branch/Tag:* {{ finding.test.engagement.branch_tag }}
+{% endif %}
 
+{% if finding.test.engagement.build_id %}
 *BuildID:* {{ finding.test.engagement.build_id }}
+{% endif %}
 
+{% if finding.test.engagement.commit_hash %}
 *Commit hash:* {{ finding.test.engagement.commit_hash }}
+{% endif %}
 
 {% if finding.endpoints.all %}
 *Systems/Endpoints*:
@@ -38,11 +49,10 @@
 {% endcomment %}
 {%endif%}
 
-
 {% if finding.component_name %}
 *Vulnerable Component*: {{finding.component_name }} - {{ finding.component_version }}
-
 {% endif %}
+
 {% if finding.sast_source_object %}
 *Source Object*: {{ finding.sast_source_object }}
 *Source File*: {{ finding.sast_source_file_path }}
@@ -53,16 +63,24 @@
 *Description*:
 {{ finding.description }}
 
+{% if finding.mitigation %}
 *Mitigation*:
 {{ finding.mitigation }}
+{% endif %}
 
+{% if finding.impact %}
 *Impact*:
 {{ finding.impact }}
+{% endif %}
 
+{% if finding.steps_to_reproduce %}
 *Steps to reproduce*:
 {{ finding.steps_to_reproduce }}
+{% endif %}
 
+{% if finding.references %}
 *References*:
 {{ finding.references }}
+{% endif %}
 
 *Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]


### PR DESCRIPTION
This PR adds a Due-Date to the JIRA description that looks like:

Due Date: July 22, 2022

In addition, it cleans up the JIRA description not to write out fields that are commonly "None".