### PR TITLE
Create a notification if the template does not exist

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -5,6 +5,7 @@ import io
 import json
 import requests
 from django.conf import settings
+from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import timezone
 from jira import JIRA
@@ -719,6 +720,10 @@ def add_jira_issue(obj, *args, **kwargs):
 
         logger.info('Created the following jira issue for %d:%s', obj.id, to_str_typed(obj))
         return True
+    except TemplateDoesNotExist as e:
+        logger.exception(e)
+        log_jira_alert(str(e), obj)
+        return False
     except JIRAError as e:
         logger.exception(e)
         logger.error("jira_meta for project: %s and url: %s meta: %s", jira_project.project_key, jira_project.jira_instance.url, json.dumps(meta, indent=4))  # this is None safe


### PR DESCRIPTION
If the template does not exist in the configured template directory then no alert is raised when you push to JIRA.