### PR TITLE
Fix: in reimporter, do not reactivate mitigated findings if they have the same date

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -140,7 +140,7 @@ class DojoDefaultReImporter(object):
                             logger.debug('%i: closing: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                             finding.mitigated = item.mitigated
                             finding.is_mitigated = True
-                            finding.mitigated_by = None
+                            finding.mitigated_by = item.mitigated_by
                             finding.active = False
                             finding.verified = verified
                     if not finding.component_name or not finding.component_version:

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -88,10 +88,12 @@ class DojoDefaultReImporter(object):
                         logger.debug("finding mitigated time: " + str(finding.mitigated.timestamp()))
                         if item.mitigated.timestamp() == finding.mitigated.timestamp():
                             logger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")
+                            unchanged_items.append(finding)
+                            unchanged_count += 1
                             continue
                         if item.mitigated.timestamp() != finding.mitigated.timestamp():
-                            logger.debug("New imported finding and already existing finding have different dates")
-
+                            logger.debug("New imported finding and already existing finding are both mitigated but have different dates")
+                            # TODO: implement proper date-aware reimporting mechanism
                     if not item.mitigated:
                         logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                         finding.mitigated = None

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -82,7 +82,7 @@ class DojoDefaultReImporter(object):
                 finding = findings[0]
                 if finding.false_p or finding.out_of_scope or finding.risk_accepted:
                     logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
-                elif finding.mitigated and finding.is_mitigated:
+                elif finding.is_mitigated:
                     if item.mitigated:
                         logger.debug("item mitigated time: " + str(item.mitigated.timestamp()))
                         logger.debug("finding mitigated time: " + str(finding.mitigated.timestamp()))

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -40,7 +40,7 @@ class DojoDefaultReImporter(object):
         unchanged_count = 0
         unchanged_items = []
 
-        logger.debug('starting reimport of %i items.', len(items) if items else 0)
+        deduplicationLogger.debug('starting reimport of %i items.', len(items) if items else 0)
         from dojo.importers.reimporter.utils import (
             match_new_finding_to_existing_finding,
             update_endpoint_status,
@@ -83,7 +83,13 @@ class DojoDefaultReImporter(object):
                 if finding.false_p or finding.out_of_scope or finding.risk_accepted:
                     logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
                 elif finding.mitigated or finding.is_mitigated:
-                    logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
+                    deduplicationLogger.debug("item mitigated time: "+str(item.mitigated.timestamp()))
+                    deduplicationLogger.debug("finding mitigated time: "+str(finding.mitigated.timestamp()))
+                    if item.mitigated:
+                        if item.mitigated.timestamp() == finding.mitigated.timestamp():
+                            deduplicationLogger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")
+                            continue
+                    deduplicationLogger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                     finding.mitigated = None
                     finding.is_mitigated = False
                     finding.mitigated_by = None
@@ -111,7 +117,7 @@ class DojoDefaultReImporter(object):
                         # If there is only one chunk, then do not bother with async
                         if len(chunk_list) < 2:
                             reactivate_endpoint_status(endpoint_statuses, sync=True)
-                        logger.debug('IMPORT_SCAN: Split endpoints into ' + str(len(chunk_list)) + ' chunks of ' + str(chunk_list[0]))
+                        deduplicationLogger.debug('IMPORT_SCAN: Split endpoints into ' + str(len(chunk_list)) + ' chunks of ' + str(chunk_list[0]))
                         # First kick off all the workers
                         for endpoint_status_list in chunk_list:
                             reactivate_endpoint_status(endpoint_status_list, sync=False)
@@ -123,7 +129,7 @@ class DojoDefaultReImporter(object):
                     reactivated_count += 1
                 else:
                     # existing findings may be from before we had component_name/version fields
-                    logger.debug('%i: updating existing finding: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
+                    deduplicationLogger.debug('%i: updating existing finding: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                     if not finding.component_name or not finding.component_version:
                         finding.component_name = finding.component_name if finding.component_name else component_name
                         finding.component_version = finding.component_version if finding.component_version else component_version
@@ -133,7 +139,7 @@ class DojoDefaultReImporter(object):
                     unchanged_items.append(finding)
                     unchanged_count += 1
                 if finding.dynamic_finding:
-                    logger.debug("Re-import found an existing dynamic finding for this new finding. Checking the status of endpoints")
+                    deduplicationLogger.debug("Re-import found an existing dynamic finding for this new finding. Checking the status of endpoints")
                     update_endpoint_status(finding, item, user)
             else:
                 # no existing finding found

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -83,8 +83,8 @@ class DojoDefaultReImporter(object):
                 if finding.false_p or finding.out_of_scope or finding.risk_accepted:
                     logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
                 elif finding.mitigated or finding.is_mitigated:
-                    logger.debug("item mitigated time: "+str(item.mitigated.timestamp()))
-                    logger.debug("finding mitigated time: "+str(finding.mitigated.timestamp()))
+                    logger.debug("item mitigated time: " + str(item.mitigated.timestamp()))
+                    logger.debug("finding mitigated time: " + str(finding.mitigated.timestamp()))
                     if item.mitigated:
                         if item.mitigated.timestamp() == finding.mitigated.timestamp():
                             logger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -40,7 +40,7 @@ class DojoDefaultReImporter(object):
         unchanged_count = 0
         unchanged_items = []
 
-        deduplicationLogger.debug('starting reimport of %i items.', len(items) if items else 0)
+        logger.debug('starting reimport of %i items.', len(items) if items else 0)
         from dojo.importers.reimporter.utils import (
             match_new_finding_to_existing_finding,
             update_endpoint_status,
@@ -83,13 +83,13 @@ class DojoDefaultReImporter(object):
                 if finding.false_p or finding.out_of_scope or finding.risk_accepted:
                     logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
                 elif finding.mitigated or finding.is_mitigated:
-                    deduplicationLogger.debug("item mitigated time: "+str(item.mitigated.timestamp()))
-                    deduplicationLogger.debug("finding mitigated time: "+str(finding.mitigated.timestamp()))
+                    logger.debug("item mitigated time: "+str(item.mitigated.timestamp()))
+                    logger.debug("finding mitigated time: "+str(finding.mitigated.timestamp()))
                     if item.mitigated:
                         if item.mitigated.timestamp() == finding.mitigated.timestamp():
-                            deduplicationLogger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")
+                            logger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")
                             continue
-                    deduplicationLogger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
+                    logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                     finding.mitigated = None
                     finding.is_mitigated = False
                     finding.mitigated_by = None
@@ -117,7 +117,7 @@ class DojoDefaultReImporter(object):
                         # If there is only one chunk, then do not bother with async
                         if len(chunk_list) < 2:
                             reactivate_endpoint_status(endpoint_statuses, sync=True)
-                        deduplicationLogger.debug('IMPORT_SCAN: Split endpoints into ' + str(len(chunk_list)) + ' chunks of ' + str(chunk_list[0]))
+                        logger.debug('IMPORT_SCAN: Split endpoints into ' + str(len(chunk_list)) + ' chunks of ' + str(chunk_list[0]))
                         # First kick off all the workers
                         for endpoint_status_list in chunk_list:
                             reactivate_endpoint_status(endpoint_status_list, sync=False)
@@ -129,7 +129,7 @@ class DojoDefaultReImporter(object):
                     reactivated_count += 1
                 else:
                     # existing findings may be from before we had component_name/version fields
-                    deduplicationLogger.debug('%i: updating existing finding: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
+                    logger.debug('%i: updating existing finding: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                     if not finding.component_name or not finding.component_version:
                         finding.component_name = finding.component_name if finding.component_name else component_name
                         finding.component_version = finding.component_version if finding.component_version else component_version
@@ -139,7 +139,7 @@ class DojoDefaultReImporter(object):
                     unchanged_items.append(finding)
                     unchanged_count += 1
                 if finding.dynamic_finding:
-                    deduplicationLogger.debug("Re-import found an existing dynamic finding for this new finding. Checking the status of endpoints")
+                    logger.debug("Re-import found an existing dynamic finding for this new finding. Checking the status of endpoints")
                     update_endpoint_status(finding, item, user)
             else:
                 # no existing finding found

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -88,12 +88,11 @@ class DojoDefaultReImporter(object):
                         logger.debug("finding mitigated time: " + str(finding.mitigated.timestamp()))
                         if item.mitigated.timestamp() == finding.mitigated.timestamp():
                             logger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")
-                            unchanged_items.append(finding)
-                            unchanged_count += 1
                             continue
                         if item.mitigated.timestamp() != finding.mitigated.timestamp():
-                            logger.debug("New imported finding and already existing finding are both mitigated but have different dates")
-                            # TODO: implement proper date-aware reimporting mechanism
+                            logger.debug("New imported finding and already existing finding are both mitigated but have different dates, not taking action")
+                            # TODO: implement proper date-aware reimporting mechanism, if an imported finding is closed more recently than the defectdojo finding, then there might be details in the scanner that should be added
+                            continue
                     if not item.mitigated:
                         logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                         finding.mitigated = None
@@ -134,11 +133,13 @@ class DojoDefaultReImporter(object):
                     reactivated_items.append(finding)
                     reactivated_count += 1
                 else:
+                    # if finding associated to new item is none of risk accepted, mitigated, false positive or out of scope
                     # existing findings may be from before we had component_name/version fields
                     logger.debug('%i: updating existing finding: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                     if not (finding.mitigated and finding.is_mitigated):
-                        logger.debug('Item matches a finding that is currently open.')
+                        logger.debug('Reimported item matches a finding that is currently open.')
                         if item.mitigated:
+                            # TODO: Implement a date comparison for opened defectdojo findings before closing them by reimporting, as they could be force closed by the scanner but a DD user forces it open ?
                             logger.debug('%i: closing: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                             finding.mitigated = item.mitigated
                             finding.is_mitigated = True

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -92,7 +92,6 @@ class DojoDefaultReImporter(object):
                         if item.mitigated.timestamp() != finding.mitigated.timestamp():
                             logger.debug("New imported finding and already existing finding have different dates")
 
-
                     if not item.mitigated:
                         logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                         finding.mitigated = None

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -76,6 +76,7 @@ class ImportReimportMixin(object):
         self.veracode_same_hash_code_different_unique_id = self.scans_path + 'veracode/many_findings_same_hash_code_different_unique_id.xml'
         self.veracode_same_unique_id_different_hash_code = self.scans_path + 'veracode/many_findings_same_unique_id_different_hash_code.xml'
         self.veracode_different_hash_code_different_unique_id = self.scans_path + 'veracode/many_findings_different_hash_code_different_unique_id.xml'
+        self.veracode_mitigated_findings = self.scans_path + 'veracode/mitigated_finding.xml'
         self.scan_type_veracode = 'Veracode Scan'
 
         self.clair_few_findings = self.scans_path + 'clair/few_vuln.json'
@@ -368,6 +369,44 @@ class ImportReimportMixin(object):
         self.assertEqual(notes_count_before, self.db_notes_count())
 
         return test_id
+
+    # import veracode and then reimport veracode again
+    # - reimport, findings stay the same, stay active
+    # - active = True, verified = True
+    # - existing findings with verified is true should stay verified
+    def test_import_veracode_reimport_veracode_active_verified_mitigated(self):
+        logger.debug('reimporting exact same original veracode mitigated xml report again')
+
+        import_veracode_many_findings = self.import_scan_with_params(self.veracode_mitigated_findings, scan_type=self.scan_type_veracode, verified=True)
+
+        test_id = import_veracode_many_findings['test']
+
+        notes_count_before = self.db_notes_count()
+
+        # reimport exact same report
+        # not specifying the untouched because untouched won't be flagged, even though we will have 0 reactivated...
+        with assertTestImportModelsCreated(self, reimports=1, affected_findings=0, created=0, closed=0, reactivated=0):
+            reimport_veracode_mitigated_findings = self.reimport_scan_with_params(test_id, self.veracode_mitigated_findings, scan_type=self.scan_type_veracode)
+
+        test_id = reimport_veracode_mitigated_findings['test']
+        self.assertEqual(test_id, test_id)
+
+        findings = self.get_test_findings_api(test_id)
+        self.log_finding_summary_json_api(findings)
+
+        # reimported count must match count in veracode report
+        # we set verified=False in this reimport but DD keeps true as per the previous import (reimport doesn't "unverify" findings)
+        findings = self.get_test_findings_api(test_id, verified=True)
+        self.assert_finding_count_json(1, findings)
+
+        # inversely, we should see no findings with verified=False
+        findings = self.get_test_findings_api(test_id, verified=False)
+        self.assert_finding_count_json(0, findings)
+
+        # reimporting the exact same scan shouldn't create any notes
+        self.assertEqual(notes_count_before, self.db_notes_count())
+        mitigated_findings = self.get_test_findings_api(test_id, is_mitigated=True)
+        self.assert_finding_count_json(1, mitigated_findings)
 
     # import 0 and then reimport 0 again
     # - reimport, findings stay the same, stay active


### PR DESCRIPTION
This is clearly a bug, reimporting the same report over and over would reactivate the previously closed findings. (notice that the code before my change reactivates findings by default, even if the reimport adds a mitigated finding, it opens the existing finding and makes it active for no reason)
This can be improved by doing other date comparisons, so that triage done directly in the scanners can be reflected during reimport.