### PR TITLE
Setting the date of Bugcrowd findings to the 'submitted_at' value

### DIFF
--- a/dojo/tools/bugcrowd/parser.py
+++ b/dojo/tools/bugcrowd/parser.py
@@ -2,6 +2,7 @@ import csv
 import hashlib
 import io
 
+from dateutil import parser
 from dojo.models import Endpoint, Finding
 
 
@@ -58,6 +59,9 @@ class BugCrowdParser(object):
             finding.steps_to_reproduce = pre_description.get('steps_to_reproduce', None)
             finding.references = References
             finding.severity = self.convert_severity(row.get('priority', 0))
+
+            if row.get('submitted_at'):
+                finding.date = parser.parse(row.get('submitted_at'))
 
             if url:
                 finding.unsaved_endpoints = list()

--- a/unittests/tools/test_bugcrowd_parser.py
+++ b/unittests/tools/test_bugcrowd_parser.py
@@ -1,6 +1,7 @@
 from ..dojo_test_case import DojoTestCase
 from dojo.tools.bugcrowd.parser import BugCrowdParser
 from dojo.models import Test
+from datetime import datetime, timezone
 
 
 class TestBugCrowdParser(DojoTestCase):
@@ -22,6 +23,7 @@ class TestBugCrowdParser(DojoTestCase):
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()
         self.assertEqual(1, len(findings))
+        self.assertEqual(findings[0].date, datetime(2020, 3, 1, 6, 15, 6, tzinfo=timezone.utc))
 
     def test_parse_file_with_multiple_vuln_has_multiple_finding(self):
         testfile = open("unittests/scans/bugcrowd/BugCrowd-many.csv")


### PR DESCRIPTION
When you import findings from Bugcrowd it just sets the current date. Instead it should get the date from submitted_at in the imported CSV.