### PR TITLE
Fix bug with alert title link for JIRA creation

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -456,7 +456,7 @@ def log_jira_alert(error, obj):
         event='jira_update',
         title='Error pushing to JIRA ' + '(' + truncate_with_dots(prod_name(obj), 25) + ')',
         description=to_str_typed(obj) + ', ' + error,
-        url=obj.get_absolute_url,
+        url=obj.get_absolute_url(),
         icon='bullseye',
         source='Push to JIRA',
         obj=obj)


### PR DESCRIPTION
If there is an error in pushing a finding to JIRA, the alert will be created with an invalid link (404). For example:

http://localhost:8080/finding/%3Cbound%20method%20Finding.get_absolute_url%20of%20%3CFinding:%20javascript.browser.security.insecure-document-method.insecure-document-method%3E%3E

This is because of a typo in calling get_absolute_url on the finding rather than get_absolute_url()