### PR TITLE
Set the finding date for Acunetix360 from FirstSeenDate

### DIFF
--- a/dojo/tools/acunetix360/parser.py
+++ b/dojo/tools/acunetix360/parser.py
@@ -1,7 +1,7 @@
 import json
-import datetime
 import html2text
 
+from dateutil import parser
 from dojo.models import Finding, Endpoint
 
 
@@ -19,7 +19,7 @@ class Acunetix360Parser(object):
     def get_findings(self, filename, test):
         data = json.load(filename)
         dupes = dict()
-        scan_date = datetime.datetime.strptime(data["Generated"], "%d/%m/%Y %H:%M %p").date()
+        scan_date = parser.parse(data["Generated"])
         text_maker = html2text.HTML2Text()
         text_maker.body_width = 0
 
@@ -64,6 +64,10 @@ class Acunetix360Parser(object):
 
             finding.unsaved_req_resp = [{"req": request, "resp": response}]
             finding.unsaved_endpoints = [Endpoint.from_uri(url)]
+
+            if item.get("FirstSeenDate"):
+                parseddate = parser.parse(item["FirstSeenDate"])
+                finding.date = parseddate
 
             if dupe_key in dupes:
                 find = dupes[dupe_key]

--- a/unittests/tools/test_acunetix360_parser.py
+++ b/unittests/tools/test_acunetix360_parser.py
@@ -1,6 +1,7 @@
 from ..dojo_test_case import DojoTestCase
 from dojo.models import Test
 from dojo.tools.acunetix360.parser import Acunetix360Parser
+from datetime import datetime
 
 
 class TestAcunetix360Parser(DojoTestCase):
@@ -23,6 +24,7 @@ class TestAcunetix360Parser(DojoTestCase):
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
             self.assertEqual(str(endpoint), "http://php.testsparker.com/auth/login.php")
+            self.assertEqual(finding.date, datetime(2021, 6, 16, 12, 30))
 
     def test_parse_file_with_multiple_finding(self):
         testfile = open("unittests/scans/acunetix360/acunetix360_many_findings.json")


### PR DESCRIPTION
On an import from Acunetix360 the finding date is set to the import date rather than from FirstSeenDate in the report