### PR TITLE
Parse CWE/CVSS3 from Nuclei classification

### DIFF
--- a/dojo/tools/nuclei/parser.py
+++ b/dojo/tools/nuclei/parser.py
@@ -54,6 +54,19 @@ class NucleiParser(object):
                     finding.references = info.get('reference')
                 finding.unsaved_endpoints.append(endpoint)
 
+                classification = info.get('classification')
+                if classification:
+                    if 'cve-id' in classification and classification['cve-id']:
+                        cve_ids = classification['cve-id']
+                        finding.unsaved_vulnerability_ids = list(map(lambda x: x.upper(), cve_ids))
+                    if 'cwe-id' in classification and classification['cwe-id'] and len(classification['cwe-id']) > 0:
+                        cwe = classification['cwe-id'][0]
+                        finding.cwe = int(cwe[4:])
+                    if 'cvss-metrics' in classification and classification['cvss-metrics']:
+                        finding.cvssv3 = classification['cvss-metrics']
+                    if 'cvss-score' in classification and classification['cvss-score']:
+                        finding.cvssv3_score = classification['cvss-score']
+
                 dupe_key = hashlib.sha256(
                     (template_id + type).encode('utf-8')
                 ).hexdigest()

--- a/unittests/tools/test_nuclei_parser.py
+++ b/unittests/tools/test_nuclei_parser.py
@@ -151,6 +151,12 @@ class TestNucleiParser(DojoTestCase):
             self.assertEqual("nuclei-example.com", finding.unsaved_endpoints[0].host)
             self.assertEqual(22, finding.unsaved_endpoints[0].port)
             self.assertEqual("CVE-2018-15473", finding.vuln_id_from_tool)
+            vulnerability_ids = finding.unsaved_vulnerability_ids
+            self.assertEqual(1, len(vulnerability_ids))
+            self.assertIn('CVE-2018-15473', vulnerability_ids)
+            self.assertEqual(362, finding.cwe)
+            self.assertEqual("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N", finding.cvssv3)
+            self.assertEqual(5.3, finding.cvssv3_score)
 
         with self.subTest(i=1):
             finding = findings[1]


### PR DESCRIPTION
The Nuclei parser is not parsing the classification dictionary, and so is missing CWE/CVSS3 score etc.