### PR TITLE
Updated API sample code to py3

### DIFF
--- a/docs/content/en/integrations/api-v2-docs.md
+++ b/docs/content/en/integrations/api-v2-docs.md
@@ -61,10 +61,9 @@ headers = {'content-type': 'application/json',
             'Authorization': 'Token c8572a5adf107a693aa6c72584da31f4d1f1dcff'}
 r = requests.get(url, headers=headers, verify=True) # set verify to False if ssl cert is self-signed
 
-for key, value in r.__dict__.iteritems():
-    print key
-    print value
-    print '------------------'
+for key, value in r.__dict__.items():
+  print(f"'{key}': '{value}'")
+  print('------------------')
 {{< /highlight >}}
 
 This code will return the list of all the users defined in DefectDojo.
@@ -101,10 +100,9 @@ headers = {'content-type': 'application/json',
             'Authorization': 'Token c8572a5adf107a693aa6c72584da31f4d1f1dcff'}
 r = requests.get(url, headers=headers, verify=True) # set verify to False if ssl cert is self-signed
 
-for key, value in r.__dict__.iteritems():
-    print key
-    print value
-    print '------------------'
+for key, value in r.__dict__.items():
+  print(f"'{key}': '{value}'")
+  print('------------------')
 {{< /highlight >}}
 
 The json object result is: :

--- a/dojo/templates/dojo/api_v2_key.html
+++ b/dojo/templates/dojo/api_v2_key.html
@@ -36,9 +36,8 @@ headers = {'content-type': 'application/json',
            'Authorization': 'Token {{ key.key }}'}
 r = requests.get(url, headers=headers, verify=True) # set verify to False if ssl cert is self-signed
 
-for key, value in r.__dict__.iteritems():
-  print key
-  print value
-  print '------------------'
+for key, value in r.__dict__.items():
+  print(f"'{key}': '{value}'")
+  print('------------------')
 	</pre>
 {% endblock %}


### PR DESCRIPTION
Updated the sample code for API key usage to Python3. 

I left it as close to the original as possible (i.e. accessing __dict__), a cleaner example would probably be to simply pretty-print the response? e.g. `print(json.dumps(r.json(), indent=4)` (without any error handling, assuming the API token and code works)