### PR TITLE
Add sast/sca/dast tags to Veracode findings

### DIFF
--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -175,6 +175,8 @@ class VeracodeParser(object):
         _sast_source_obj = xml_node.attrib.get('functionprototype')
         finding.sast_source_object = _sast_source_obj if _sast_source_obj else None
 
+        finding.unsaved_tags = ["sast"]
+
         return finding
 
     @classmethod
@@ -185,6 +187,8 @@ class VeracodeParser(object):
 
         url_host = xml_node.attrib.get('url')
         finding.unsaved_endpoints = [Endpoint.from_uri(url_host)]
+
+        finding.unsaved_tags = ["dast"]
 
         return finding
 
@@ -245,5 +249,7 @@ class VeracodeParser(object):
                     cls.vc_severity_mapping.get(int(xml_node.attrib['severity']), 'Info'),
                     xml_node.attrib['cve_summary'])
         finding.description = _description
+
+        finding.unsaved_tags = ["sca"]
 
         return finding

--- a/unittests/tools/test_veracode_parser.py
+++ b/unittests/tools/test_veracode_parser.py
@@ -1,11 +1,11 @@
 import datetime
 
-from django.test import SimpleTestCase
+from ..dojo_test_case import DojoTestCase
 from dojo.tools.veracode.parser import VeracodeParser
 from dojo.models import Test
 
 
-class TestVeracodeScannerParser(SimpleTestCase):
+class TestVeracodeScannerParser(DojoTestCase):
 
     def test_parse_file_with_one_finding(self):
         testfile = open("unittests/scans/veracode/one_finding.xml")
@@ -51,10 +51,12 @@ class TestVeracodeScannerParser(SimpleTestCase):
         self.assertEqual("sourcefilepathMyApp.java", finding.file_path)
         self.assertEqual(2, finding.line)
         self.assertEqual("app-1234_issue-1", finding.unique_id_from_tool)
+        self.assertIn('sast', finding.unsaved_tags)
         finding = findings[1]
         self.assertEqual("Medium", finding.severity)
         self.assertEqual(456, finding.cwe)
         self.assertTrue(finding.dynamic_finding)
+        self.assertIn('dast', finding.unsaved_tags)
         finding = findings[2]
         self.assertEqual("High", finding.severity)
         self.assertIsNone(finding.cwe)
@@ -62,12 +64,14 @@ class TestVeracodeScannerParser(SimpleTestCase):
         self.assertEqual("CVE-1234-1234", finding.unsaved_vulnerability_ids[0])
         self.assertEqual("Vulnerable component: library:1234", finding.title)
         self.assertFalse(finding.is_mitigated)
+        self.assertIn('sca', finding.unsaved_tags)
         finding = findings[3]
         self.assertEqual("High", finding.severity)
         self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
         self.assertEqual("CVE-5678-5678", finding.unsaved_vulnerability_ids[0])
         self.assertEqual("Vulnerable component: library1:1234", finding.title)
         self.assertFalse(finding.is_mitigated)
+        self.assertIn('sca', finding.unsaved_tags)
 
     def test_parse_file_with_multiple_finding2(self):
         testfile = open("unittests/scans/veracode/veracode_scan.xml")
@@ -121,6 +125,7 @@ class TestVeracodeScannerParser(SimpleTestCase):
         self.assertEqual("Description", finding.description)
         self.assertFalse(finding.is_mitigated)
         self.assertEqual(datetime.datetime(2021, 9, 3, 10, 0, 0), finding.date)
+        self.assertIn('dast', finding.unsaved_tags)
         self.assertEqual(1, len(finding.unsaved_endpoints))
         endpoint = finding.unsaved_endpoints[0]
         self.assertEqual('https', endpoint.protocol)


### PR DESCRIPTION
When importing findings from Veracode, it's hard to tell whether findings are SCA/SAST/DAST, so adding a tag will make it easier to both see and search for issues matching a particular type.