### PR TITLE
Write out the file path and line for static findings

### DIFF
--- a/dojo/templates/issue-trackers/jira_full/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-description.tpl
@@ -58,6 +58,9 @@
 *Source File*: {{ finding.sast_source_file_path }}
 *Source Line*: {{ finding.sast_source_line }}
 *Sink Object*: {{ finding.sast_sink_object }}
+{% elif finding.static_finding %}
+*Source File*: {{ finding.file_path }}
+*Source Line*: {{ finding.line }}
 {% endif %}
 
 *Description*:


### PR DESCRIPTION
For SAST parsers such as Sarif and Semgrep, it doesn't write out the file path and line number to JIRA in the default template. Tested manually.