### PR TITLE
Veracode parser does not set the CVSS score for SCA

### DIFF
--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -220,7 +220,9 @@ class VeracodeParser(object):
         finding.unique_id_from_tool = xml_node.attrib['cve_id']
 
         # Report values
-        finding.severity = cls.__cvss_to_severity(float(xml_node.attrib['cvss_score']))
+        cvss_score = float(xml_node.attrib['cvss_score'])
+        finding.cvssv3_score = cvss_score
+        finding.severity = cls.__cvss_to_severity(cvss_score)
         finding.unsaved_vulnerability_ids = [xml_node.attrib['cve_id']]
         finding.cwe = cls._get_cwe(xml_node.attrib['cwe_id'])
         finding.title = "Vulnerable component: {0}:{1}".format(library, version)

--- a/unittests/tools/test_veracode_parser.py
+++ b/unittests/tools/test_veracode_parser.py
@@ -95,6 +95,7 @@ class TestVeracodeScannerParser(SimpleTestCase):
         self.assertEqual("commons-httpclient", finding.component_name)
         self.assertEqual("3.1", finding.component_version)
         self.assertEqual("CVE-2012-6153", finding.unique_id_from_tool)
+        self.assertEqual(4.3, finding.cvssv3_score)
 
     def test_parse_file_with_mitigated_finding(self):
         testfile = open("unittests/scans/veracode/mitigated_finding.xml")


### PR DESCRIPTION
Veracode parser does not set the CVSS score for SCA