### PR TITLE
Align severity mapping between SARIF/semgrep

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -265,7 +265,7 @@ def get_severity(result, rule):
     elif 'warning' == severity:
         return 'Medium'
     elif 'error' == severity:
-        return 'Critical'
+        return 'High'
     else:
         return 'Medium'
 

--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -67,7 +67,7 @@ class SemgrepParser(object):
 
     def convert_severity(self, val):
         if "WARNING" == val.upper():
-            return "Low"
+            return "Medium"
         elif "ERROR" == val.upper():
             return "High"
         elif "INFO" == val.upper():

--- a/unittests/tools/test_sarif_parser.py
+++ b/unittests/tools/test_sarif_parser.py
@@ -35,7 +35,7 @@ class TestSarifParser(DojoTestCase):
         item = findings[0]
         self.assertEqual("collections/list.h", item.file_path)
         self.assertEqual(15, item.line)
-        self.assertEqual("Critical", item.severity)
+        self.assertEqual("High", item.severity)
         description = """**Result message:** Variable "ptr" was used without being initialized. It was declared [here](0).
 **Snippet:**
 ```add_core(ptr, offset, val);
@@ -136,7 +136,7 @@ class TestSarifParser(DojoTestCase):
             "CVE-2019-11358 - jQuery before 3.4.0, as used in Drupal, Backdrop CMS, and other products, mishandles jQuery.extend(true, {}, ...) because of [...]",
             item.title,
         )
-        self.assertEqual("Critical", item.severity)
+        self.assertEqual("High", item.severity)
         self.assertEqual(1, len(item.unsaved_vulnerability_ids))
         self.assertEqual("CVE-2019-11358", item.unsaved_vulnerability_ids[0])
         for finding in findings:
@@ -192,7 +192,7 @@ class TestSarifParser(DojoTestCase):
             "XML injection with user data from `filename in parser_helper.py:167` is used for parsing XML at `parser_helper.py:23`.",
             item.title,
         )
-        self.assertEqual("Critical", item.severity)
+        self.assertEqual("High", item.severity)
         self.assertIsNone(item.unsaved_vulnerability_ids)
         for finding in findings:
             self.common_checks(finding)
@@ -235,7 +235,7 @@ class TestSarifParser(DojoTestCase):
         with self.subTest(i=0):
             finding = findings[0]
             self.assertEqual("CIS-DI-0010", finding.vuln_id_from_tool)
-            self.assertEqual("Critical", finding.severity)
+            self.assertEqual("High", finding.severity)
             description = """**Result message:** Suspicious ENV key found : DD_ADMIN_PASSWORD, Suspicious ENV key found : DD_CELERY_BROKER_PASSWORD, Suspicious ENV key found : DD_DATABASE_PASSWORD
 **Rule short description:** Do not store credential in ENVIRONMENT vars/files"""
             self.assertEqual(description, finding.description)
@@ -338,7 +338,7 @@ class TestSarifParser(DojoTestCase):
                 "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).",
                 finding.title,
             )
-            self.assertEqual("Critical", finding.severity)
+            self.assertEqual("High", finding.severity)
             description = """**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
 **Snippet:**
 ```      is.setstate(std::ios::failbit);```
@@ -374,7 +374,7 @@ class TestSarifParser(DojoTestCase):
                 "buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).",
                 finding.title,
             )
-            self.assertEqual("Critical", finding.severity)
+            self.assertEqual("High", finding.severity)
             description = """**Result message:** buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).
 **Snippet:**
 ```      if (sscanf(argv[i], "%[^=]=%s", name, val) == 2) {```
@@ -401,7 +401,7 @@ class TestSarifParser(DojoTestCase):
                 "random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).",
                 finding.title,
             )
-            self.assertEqual("Critical", finding.severity)
+            self.assertEqual("High", finding.severity)
             description = """**Result message:** random/setstate:This function is not sufficiently random for security-related functions such as key and nonce creation (CWE-327).
 **Snippet:**
 ```      is.setstate(std::ios::failbit);```
@@ -434,7 +434,7 @@ class TestSarifParser(DojoTestCase):
         with self.subTest(i=52):
             finding = findings[52]
             self.assertEqual("buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).", finding.title)
-            self.assertEqual("Critical", finding.severity)
+            self.assertEqual("High", finding.severity)
             description = """**Result message:** buffer/sscanf:The scanf() family's %s operation, without a limit specification, permits buffer overflows (CWE-120, CWE-20).
 **Snippet:**
 ```      if (sscanf(argv[i], "%[^=]=%s", name, val) == 2) {```
@@ -470,7 +470,7 @@ class TestSarifParser(DojoTestCase):
         item = findings[7]
         self.assertEqual("good/mod_user.py", item.file_path)
         self.assertEqual(33, item.line)
-        self.assertEqual("Critical", item.severity)
+        self.assertEqual("High", item.severity)
         description = """**Result message:** Keyword argument 'request' is not a supported parameter name of [function create](1).
 **Snippet:**
 ```

--- a/unittests/tools/test_semgrep_parser.py
+++ b/unittests/tools/test_semgrep_parser.py
@@ -19,7 +19,7 @@ class TestSemgrepParser(DojoTestCase):
         testfile.close()
         self.assertEqual(1, len(findings))
         finding = findings[0]
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Medium", finding.severity)
         self.assertEqual("src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02194.java", finding.file_path)
         self.assertEqual(64, finding.line)
         self.assertEqual(696, finding.cwe)
@@ -35,7 +35,7 @@ class TestSemgrepParser(DojoTestCase):
         testfile.close()
         self.assertEqual(3, len(findings))
         finding = findings[0]
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Medium", finding.severity)
         self.assertEqual("src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02194.java", finding.file_path)
         self.assertEqual(64, finding.line)
         self.assertEqual(696, finding.cwe)
@@ -56,7 +56,7 @@ class TestSemgrepParser(DojoTestCase):
         testfile.close()
         self.assertEqual(1, len(findings))
         finding = findings[0]
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Medium", finding.severity)
         self.assertEqual("src/main/java/org/owasp/benchmark/testcode/BenchmarkTest01150.java", finding.file_path)
         self.assertEqual(66, finding.line)
         self.assertEqual("java.lang.security.audit.cbc-padding-oracle.cbc-padding-oracle", finding.vuln_id_from_tool)
@@ -77,12 +77,12 @@ class TestSemgrepParser(DojoTestCase):
         self.assertIsNone(finding.mitigation)
         self.assertEqual("python.lang.correctness.tempfile.flush.tempfile-without-flush", finding.vuln_id_from_tool)
         finding = findings[2]
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Medium", finding.severity)
         self.assertEqual("utils.py", finding.file_path)
         self.assertEqual(503, finding.line)
         self.assertEqual("python.lang.maintainability.useless-ifelse.useless-if-conditional", finding.vuln_id_from_tool)
         finding = findings[4]
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Medium", finding.severity)
         self.assertEqual("tools/sslyze/parser_xml.py", finding.file_path)
         self.assertEqual(124, finding.line)
         self.assertEqual(327, finding.cwe)


### PR DESCRIPTION
Align severity mapping between SARIF and semgrep as proposed here:

https://github.com/DefectDojo/django-DefectDojo/issues/6289

- Change SARIF "error" to "High" from "Critical"
- Change Semgrep "warning" to "Medium" from "Low"

With this change both SARIF and Semgrep are consistent with how they map warning and errors.