### PR TITLE
Add the ability to the UI to delete engagements from the engagement tab

### DIFF
--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% load display_tags %}
+{% load authorization_tags %}
 {% load dict_key %}
 
 {% block content %}
@@ -48,6 +49,7 @@
                     <table id="engagements"
                            class="tablesorter-bootstrap table table-condensed table-striped table-hover">
                         <tr>
+                            <th></th>
                             <th>{% dojo_sort request 'Engagement' 'name' 'asc' %}</th>
                             <th>{% dojo_sort request 'Period' 'target_start' 'asc' %}</th>
                             <th>Status</th>
@@ -62,6 +64,81 @@
 
                         {% for e in engagements %}
                             <tr>
+                                <td class="nowrap">
+                                    <div class="align-top">
+                                        <div class="dropdown">
+                                            <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
+                                            <ul class="dropdown-menu">
+                                                <li>
+                                                    <a class="" href="{% url 'view_engagement' e.id %}">
+                                                        <i class="fa fa-list-alt"></i> View
+                                                </li>
+                                                {% if e|has_object_permission:"Engagement_Edit" %}
+                                                <li>
+                                                    <a class="" href="{% url 'edit_engagement' e.id %}">
+                                                        <i class="fa fa-pencil-square-o"></i> Edit
+                                                    </a>
+                                                </li>
+                                                <li class="divider"></li>
+                                                {% endif %}
+                                                {% if e|has_object_permission:"Test_Add" %}
+                                                <li role="presentation">
+                                                    <a class="" href="{% url 'add_tests' e.id %}">
+                                                        <i class="fa fa-plus"></i> Add Tests
+                                                    </a>
+                                                </li>
+                                                {% endif %}
+                                                {% if e|has_object_permission:"Import_Scan_Result" %}
+                                                <li role="presentation">
+                                                    <a class="" href="{% url 'import_scan_results' e.id %}">
+                                                        <i class="fa fa-upload"></i> Import Scan Results
+                                                    </a>
+                                                </li>
+                                                {% endif %}
+                                                <li class="divider"></li>
+                                                <li role="presentation">
+                                                    <a href="{% url 'engagement_open_findings' e.id %}">
+                                                        <i class="fa fa-file-text-o"></i> View Active Findings
+                                                    </a>
+                                                </li>
+                                                <li role="presentation">
+                                                    <a href="{% url 'engagement_verified_findings' e.id %}">
+                                                        <i class="fa fa-file-text-o"></i> View Active and Verified Findings
+                                                    </a>
+                                                </li>
+                                                <li role="presentation">
+                                                    <a href="{% url 'engagement_closed_findings' e.id %}">
+                                                        <i class="fa fa-file-text-o"></i> View Mitigated Findings
+                                                    </a>
+                                                </li>
+                                                <li role="presentation">
+                                                    <a href="{% url 'engagement_accepted_findings' e.id %}">
+                                                        <i class="fa fa-file-text-o"></i> View Accepted Findings
+                                                    </a>
+                                                </li>
+                                                <li role="presentation">
+                                                    <a href="{% url 'engagement_all_findings' e.id %}">
+                                                        <i class="fa fa-file-text-o"></i> View All Findings
+                                                    </a>
+                                                </li>
+                                                <li class="divider"></li>
+                                                <li role="presentation">
+                                                    <a href="{% url 'engagement_report' e.id %}?title=&active=1&verified=1&false_p=2&duplicate=2">
+                                                        <i class="fa fa-file-text-o"></i> Engagement Report
+                                                    </a>
+                                                </li>
+                                                {% if e|has_object_permission:"Engagement_Delete" %}
+                                                <li class="divider"></li>
+                                                <li>
+                                                    <a class="text-danger" href="{% url 'delete_engagement' e.id %}">
+                                                        <i class="fa fa-trash-o"></i> Delete Engagement
+                                                    </a>
+                                                </li>
+                                                {% endif %}
+                                            </ul>
+                                            </li>
+                                            </ul>
+                                </td>
                                 <td style="white-space: normal">
                                     <a class="eng_link" href="{%url 'view_engagement' e.id %}">{% if e.name %}{{ e.name }}{% endif %}</a>
                                     <div>

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -68,7 +68,7 @@
                                     <div class="align-top">
                                         <div class="dropdown">
                                             <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
-                                            <ul class="dropdown-menu">
+                                            <ul class="dropdown-menu" style="position: unset!important;">
                                                 <li>
                                                     <a class="" href="{% url 'view_engagement' e.id %}">
                                                         <i class="fa fa-list-alt"></i> View

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -66,7 +66,7 @@
                             <tr>
                                 <td class="nowrap">
                                     <div class="align-top">
-                                        <div class="dropdown">
+                                        <div class="dropdown" style="position: fixed!important;">
                                             <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
                                             <ul class="dropdown-menu" style="position: unset!important;">
                                                 <li>

--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -66,9 +66,9 @@
                             <tr>
                                 <td class="nowrap">
                                     <div class="align-top">
-                                        <div class="dropdown" style="position: fixed!important;">
+                                        <div class="dropdown">
                                             <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
-                                            <ul class="dropdown-menu" style="position: unset!important;">
+                                            <ul class="dropdown-menu">
                                                 <li>
                                                     <a class="" href="{% url 'view_engagement' e.id %}">
                                                         <i class="fa fa-list-alt"></i> View
@@ -194,6 +194,29 @@
 {% endblock %}
 {% block postscript %}
     {{ block.super }}
+    <script>
+        $(function() {
+            $('.table-responsive').on('shown.bs.dropdown', function(e) {
+                var t = $(this),
+                m = $(e.target).find('.dropdown-menu'),
+                tb = t.offset().top + t.height(),
+                mb = m.offset().top + m.outerHeight(true),
+                d = 20; // Space for shadow + scrollbar.   
+            if (t[0].scrollWidth > t.innerWidth()) {
+                if (mb + d > tb) {
+                    t.css('padding-bottom', ((mb + d) - tb));
+                }
+            } else {
+                t.css('overflow', 'visible');
+            }
+            }).on('hidden.bs.dropdown', function() {
+                $(this).css({
+                    'padding-bottom': '',
+                    'overflow': ''
+                });
+            });
+        });
+    </script>
     <script>
         $(function () {
             var prodWords = [

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -50,9 +50,9 @@
                                 <tr>
                                     <td class="nowrap">
                                         <div class="align-top">
-                                            <div class="dropdown" style="position: fixed!important;">
+                                            <div class="dropdown">
                                                 <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
-                                                <ul class="dropdown-menu" style="position: unset!important;">
+                                                <ul class="dropdown-menu">
                                                     <li>
                                                         <a class="" href="{% url 'view_engagement' e.id %}">
                                                             <i class="fa fa-list-alt"></i> View
@@ -177,7 +177,29 @@
 {% endblock %}
 {% block postscript %}
     {{ block.super }}
-
+    <script>
+        $(function() {
+            $('.table-responsive').on('shown.bs.dropdown', function(e) {
+                var t = $(this),
+                m = $(e.target).find('.dropdown-menu'),
+                tb = t.offset().top + t.height(),
+                mb = m.offset().top + m.outerHeight(true),
+                d = 20; // Space for shadow + scrollbar.   
+            if (t[0].scrollWidth > t.innerWidth()) {
+                if (mb + d > tb) {
+                    t.css('padding-bottom', ((mb + d) - tb));
+                }
+            } else {
+                t.css('overflow', 'visible');
+            }
+            }).on('hidden.bs.dropdown', function() {
+                $(this).css({
+                    'padding-bottom': '',
+                    'overflow': ''
+                });
+            });
+        });
+    </script>
     <script>
         $(function () {
             var availableTags = [

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -52,7 +52,7 @@
                                         <div class="align-top">
                                             <div class="dropdown">
                                                 <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
-                                                <ul class="dropdown-menu">
+                                                <ul class="dropdown-menu" style="position: unset!important;">
                                                     <li>
                                                         <a class="" href="{% url 'view_engagement' e.id %}">
                                                             <i class="fa fa-list-alt"></i> View

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -29,6 +29,7 @@
                     <table id="engagements" class="tablesorter-bootstrap table table-condensed table-striped table-hover">
                         <thead>
                         <tr>
+                            <th></th>
                             <th>Product</th>
                             <th>Product Type</th>
                             <th>Engagement Name</th>
@@ -47,7 +48,81 @@
                         {% for p in products %}
                             {% for e in p.engagement_set.all %}
                                 <tr>
-
+                                    <td class="nowrap">
+                                        <div class="align-top">
+                                            <div class="dropdown">
+                                                <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
+                                                <ul class="dropdown-menu">
+                                                    <li>
+                                                        <a class="" href="{% url 'view_engagement' e.id %}">
+                                                            <i class="fa fa-list-alt"></i> View
+                                                    </li>
+                                                    {% if e|has_object_permission:"Engagement_Edit" %}
+                                                    <li>
+                                                        <a class="" href="{% url 'edit_engagement' e.id %}">
+                                                            <i class="fa fa-pencil-square-o"></i> Edit
+                                                        </a>
+                                                    </li>
+                                                    <li class="divider"></li>
+                                                    {% endif %}
+                                                    {% if e|has_object_permission:"Test_Add" %}
+                                                    <li role="presentation">
+                                                        <a class="" href="{% url 'add_tests' e.id %}">
+                                                            <i class="fa fa-plus"></i> Add Tests
+                                                        </a>
+                                                    </li>
+                                                    {% endif %}
+                                                    {% if e|has_object_permission:"Import_Scan_Result" %}
+                                                    <li role="presentation">
+                                                        <a class="" href="{% url 'import_scan_results' e.id %}">
+                                                            <i class="fa fa-upload"></i> Import Scan Results
+                                                        </a>
+                                                    </li>
+                                                    {% endif %}
+                                                    <li class="divider"></li>
+                                                    <li role="presentation">
+                                                        <a href="{% url 'engagement_open_findings' e.id %}">
+                                                            <i class="fa fa-file-text-o"></i> View Active Findings
+                                                        </a>
+                                                    </li>
+                                                    <li role="presentation">
+                                                        <a href="{% url 'engagement_verified_findings' e.id %}">
+                                                            <i class="fa fa-file-text-o"></i> View Active and Verified Findings
+                                                        </a>
+                                                    </li>
+                                                    <li role="presentation">
+                                                        <a href="{% url 'engagement_closed_findings' e.id %}">
+                                                            <i class="fa fa-file-text-o"></i> View Mitigated Findings
+                                                        </a>
+                                                    </li>
+                                                    <li role="presentation">
+                                                        <a href="{% url 'engagement_accepted_findings' e.id %}">
+                                                            <i class="fa fa-file-text-o"></i> View Accepted Findings
+                                                        </a>
+                                                    </li>
+                                                    <li role="presentation">
+                                                        <a href="{% url 'engagement_all_findings' e.id %}">
+                                                            <i class="fa fa-file-text-o"></i> View All Findings
+                                                        </a>
+                                                    </li>
+                                                    <li class="divider"></li>
+                                                    <li role="presentation">
+                                                        <a href="{% url 'engagement_report' e.id %}?title=&active=1&verified=1&false_p=2&duplicate=2">
+                                                            <i class="fa fa-file-text-o"></i> Engagement Report
+                                                        </a>
+                                                    </li>
+                                                    {% if e|has_object_permission:"Engagement_Delete" %}
+                                                    <li class="divider"></li>
+                                                    <li>
+                                                        <a class="text-danger" href="{% url 'delete_engagement' e.id %}">
+                                                            <i class="fa fa-trash-o"></i> Delete Engagement
+                                                        </a>
+                                                    </li>
+                                                    {% endif %}
+                                                </ul>
+                                                </li>
+                                                </ul>
+                                    </td>
                                     <td class="prod_name"><a href="{% url 'view_product' p.id %}">{{ p.name }}</a>
                                         {% include "dojo/snippets/tags.html" with tags=p.tags.all %}
                                     </td>

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -50,7 +50,7 @@
                                 <tr>
                                     <td class="nowrap">
                                         <div class="align-top">
-                                            <div class="dropdown">
+                                            <div class="dropdown" style="position: fixed!important;">
                                                 <a href="#" class="dropdown-toggle pull-left" data-toggle="dropdown">&nbsp;<i class="fa fa-ellipsis-v"></i>&nbsp;</a>
                                                 <ul class="dropdown-menu" style="position: unset!important;">
                                                     <li>


### PR DESCRIPTION
The products and findings tabs have three vertical dots that allow you to edit/delete/etc., however these are missing from the engagements tab. So if you go to "All Engagements" for example you can't delete an engagement.

This PR adds the three vertical dots for "All Engagements", "Active Engagements" and "Engagements by Product"