### PR TITLE
Update parser of DependencyTrack

### DIFF
--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -141,10 +141,7 @@ class DependencyTrackParser(object):
         title = "{component_name}:{version_description} affected by: {vuln_id} ({source})"\
             .format(vuln_id=vuln_id, source=source, version_description=version_description, component_name=component_name)
 
-        # The vulnId is not always a CVE (e.g. if the vulnerability is not from the NVD source)
-        # So here we set the cve for the DefectDojo finding to null unless the source of the
-        # Dependency Track vulnerability is NVD
-        vulnerability_id = vuln_id if source is not None and source.upper() == 'NVD' else None
+        vulnerability_id = vuln_id
 
         # Default CWE to CWE-1035 Using Components with Known Vulnerabilities if there is no CWE
         if 'cweId' in dependency_track_finding['vulnerability'] and dependency_track_finding['vulnerability']['cweId'] is not None:

--- a/unittests/tools/test_dependency_track_parser.py
+++ b/unittests/tools/test_dependency_track_parser.py
@@ -46,7 +46,7 @@ class TestDependencyTrackParser(DojoTestCase):
         self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
         self.assertEqual('533', findings[0].unsaved_vulnerability_ids[0]))
         self.assertEqual(1, len(findings[1].unsaved_vulnerability_ids))
-        self.assertEqual('48', findings[1].unsaved_vulnerability_ids[0]))
+        self.assertEqual('48', findings[1].unsaved_vulnerability_ids[0])
         self.assertEqual(1, len(findings[2].unsaved_vulnerability_ids))
         self.assertEqual('CVE-2016-2097', findings[2].unsaved_vulnerability_ids[0])
         self.assertEqual(1, len(findings[3].unsaved_vulnerability_ids))

--- a/unittests/tools/test_dependency_track_parser.py
+++ b/unittests/tools/test_dependency_track_parser.py
@@ -43,8 +43,10 @@ class TestDependencyTrackParser(DojoTestCase):
         testfile.close()
         self.assertEqual(4, len(findings))
 
-        self.assertIsNone(findings[0].unsaved_vulnerability_ids)
-        self.assertIsNone(findings[1].unsaved_vulnerability_ids)
+        self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
+        self.assertEqual('533', findings[0].unsaved_vulnerability_ids[0]))
+        self.assertEqual(1, len(findings[1].unsaved_vulnerability_ids))
+        self.assertEqual('48', findings[1].unsaved_vulnerability_ids[0]))
         self.assertEqual(1, len(findings[2].unsaved_vulnerability_ids))
         self.assertEqual('CVE-2016-2097', findings[2].unsaved_vulnerability_ids[0])
         self.assertEqual(1, len(findings[3].unsaved_vulnerability_ids))

--- a/unittests/tools/test_dependency_track_parser.py
+++ b/unittests/tools/test_dependency_track_parser.py
@@ -44,7 +44,7 @@ class TestDependencyTrackParser(DojoTestCase):
         self.assertEqual(4, len(findings))
 
         self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
-        self.assertEqual('533', findings[0].unsaved_vulnerability_ids[0]))
+        self.assertEqual('533', findings[0].unsaved_vulnerability_ids[0])
         self.assertEqual(1, len(findings[1].unsaved_vulnerability_ids))
         self.assertEqual('48', findings[1].unsaved_vulnerability_ids[0])
         self.assertEqual(1, len(findings[2].unsaved_vulnerability_ids))


### PR DESCRIPTION
As cve was replaced by vuln_id the filtering for cves from NVD is unnecessary