### PR TITLE
Improvements for the default finding group JIRA template

### DIFF
--- a/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
@@ -14,12 +14,21 @@ h2. Group
 || Severity || CVE || CWE || Component || Version || Title || Status ||{% for finding in finding_group.findings.all %}
 | {{finding.severity}} | {% if finding.cve %}[{{finding.cve}}|{{finding.cve|vulnerability_url}}]{% else %}None{% endif %} | [{{finding.cwe}}|{{finding.cwe|cwe_url}}] | {{finding.component_name|jiraencode_component}} | {{finding.component_version}} | [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}] | {{ finding.status }} |{% endfor %}
 
+*Severity:* {{ finding_group.severity }}
+
+{% if finding_group.sla_deadline %} *Due Date:* {{ finding_group.sla_deadline }} {% endif %}
+
+{% if finding_group.test.engagement.branch_tag %}
 *Branch/Tag:* {{ finding_group.test.engagement.branch_tag }}
+{% endif %}
 
+{% if finding_group.test.engagement.build_id %}
 *BuildID:* {{ finding_group.test.engagement.build_id }}
+{% endif %}
 
+{% if finding_group.test.engagement.commit_hash %}
 *Commit hash:* {{ finding_group.test.engagement.commit_hash }}
-
+{% endif %}
 
 {% for finding in finding_group.findings.all %}
 {% url 'view_finding' finding.id as finding_url %}
@@ -29,8 +38,10 @@ h1. Findings
 h3. [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]
 *Defect Dojo link:* {{ finding_url|full_url }} ({{ finding.id }})
 *Severity:* {{ finding.severity }}
-{% if finding.cwe > 0 %}*CWE:* [CWE-{{ finding.cwe }}|{{ finding.cwe|cwe_url }}]{% else %}*CWE:* Unknown{% endif %}
+{% if finding.sla_deadline %} *Due Date:* {{ finding.sla_deadline }} {% endif %}
+{% if finding.cwe > 0 %} *CWE:* [CWE-{{ finding.cwe }}|{{ finding.cwe|cwe_url }}] {% endif %}
 {% if finding.cve %}*CVE:* [{{ finding.cve }}|{{ finding.cve|vulnerability_url }}]{% else %}*CVE:* Unknown{% endif %}
+{% if finding.cvssv3_score %} *CVSSv3 Score:* {{ finding.cvssv3_score }} {% endif %}
 
 {% if finding.endpoints.all %}
 *Systems/Endpoints*:
@@ -38,31 +49,42 @@ h3. [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]
 * {{ endpoint }}{% endfor %}
 {%endif%}
 
-{% if finding.component_name %}
-Vulnerable Component: {{finding.component_name }} - {{ finding.component_version }}
-
-{% endif %}
 {% if finding.sast_source_object %}
-Source Object: {{ finding.sast_source_object }}
-Source File: {{ finding.sast_source_file_path }}
-Source Line: {{ finding.sast_source_line }}
-Sink Object: {{ finding.sast_sink_object }}
+*Source Object*: {{ finding.sast_source_object }}
+*Source File*: {{ finding.sast_source_file_path }}
+*Source Line*: {{ finding.sast_source_line }}
+*Sink Object*: {{ finding.sast_sink_object }}
+{% elif finding.static_finding %}
+{% if finding.file_path %}
+*Source File*: {{ finding.file_path }}
+{% endif %}
+{% if finding.line %}
+*Source Line*: {{ finding.line }}
+{% endif %}
 {% endif %}
 
 *Description*:
 {{ finding.description }}
 
+{% if finding.mitigation %}
 *Mitigation*:
 {{ finding.mitigation }}
+{% endif %}
 
+{% if finding.impact %}
 *Impact*:
 {{ finding.impact }}
+{% endif %}
 
+{% if finding.steps_to_reproduce %}
 *Steps to reproduce*:
 {{ finding.steps_to_reproduce }}
+{% endif %}
 
+{% if finding.references %}
 *References*:
 {{ finding.references }}
+{% endif %}
 
 *Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]
 {% endfor %}

--- a/dojo/templates/issue-trackers/jira_limited/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_limited/jira-finding-group-description.tpl
@@ -13,8 +13,14 @@ Findings:
 {% for finding in finding_group.findings.all %}
 - [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]{% endfor %}
 
+{% if finding_group.test.engagement.branch_tag %}
 *Branch/Tag:* {{ finding_group.test.engagement.branch_tag }}
+{% endif %}
 
+{% if finding_group.test.engagement.build_id %}
 *BuildID:* {{ finding_group.test.engagement.build_id }}
+{% endif %}
 
+{% if finding_group.test.engagement.commit_hash %}
 *Commit hash:* {{ finding_group.test.engagement.commit_hash }}
+{% endif %}


### PR DESCRIPTION
- Add group severity and due-date
- Avoid writing out "None" when we don't have branch Id, git tag, etc.
- Write out individual finding CVSS score.
- Write out SAST source line/path