### PR TITLE
Fix 500 error on adding finding to group name

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1877,7 +1877,7 @@ def finding_bulk_update_all(request, pid=None):
 
                 if form.cleaned_data['finding_group_add']:
                     logger.debug('finding_group_add checked!')
-                    fgid = form.cleaned_data['add_to_finding_group']
+                    fgid = form.cleaned_data['add_to_finding_group_id']
                     finding_group = Finding_Group.objects.get(id=fgid)
                     finding_group, added, skipped = finding_helper.add_to_finding_group(finding_group, finds)
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1333,7 +1333,7 @@ class FindingBulkUpdateForm(forms.ModelForm):
     finding_group_create = forms.BooleanField(required=False)
     finding_group_create_name = forms.CharField(required=False)
     finding_group_add = forms.BooleanField(required=False)
-    add_to_finding_group = forms.BooleanField(required=False)
+    add_to_finding_group_id = forms.CharField(required=False)
     finding_group_remove = forms.BooleanField(required=False)
     finding_group_by = forms.BooleanField(required=False)
     finding_group_by_option = forms.CharField(required=False)

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -588,7 +588,7 @@
                                 <label style="font-size: 80%; font-weight: normal;">
                                     <input id="id_bulk_finding_group_add" name="finding_group_add" class="finding_group_option" type="checkbox" disabled/> <span>Add to...</span>
                                 </label>
-                                <select id="id_add_to_finding_group" name="add_to_finding_group" style="font-size: 80%">
+                                <select id="id_add_to_finding_group_id" name="add_to_finding_group_id" style="font-size: 80%">
                                     <option value="">Choose...</option>
                                     {% for group in finding_groups %}
                                         <option value="{{ group.id }}">{{ group.name|truncatechars_html:40 }}</option>


### PR DESCRIPTION
When you try to add a finding to a group by group name, you get a 500 error. This is because the form uses a boolean instead of a charfield. The form name is a bit confusing, so I renamed it to make it clearer that it's an id.