### PR TITLE
Fix bug with creating two finding group JIRAs on group creation

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1969,8 +1969,6 @@ def finding_bulk_update_all(request, pid=None):
                             jira_helper.push_to_jira(group)
                             success_count += 1
 
-                        jira_helper.push_to_jira(group)
-
                 for error_message, error_count in error_counts.items():
                     add_error_message_to_response('%i finding groups could not be pushed to JIRA: %s' % (error_count, error_message))
 


### PR DESCRIPTION
When you create a finding group and select "Push to JIRA" it creates two JIRAs for the finding group.