### PR TITLE
Add the merged findings as bulletpoints in the note

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1630,7 +1630,7 @@ def merge_finding_product(request, pid):
 
                 if finding_to_merge_into not in findings_to_merge:
                     for finding in findings_to_merge.exclude(pk=finding_to_merge_into.pk):
-                        notes_entry = "{} {} ({}),".format(notes_entry, finding.title, finding.id)
+                        notes_entry = "{}\n- {} ({}),".format(notes_entry, finding.title, finding.id)
                         if finding.static_finding:
                             static = finding.static_finding
 
@@ -1720,7 +1720,7 @@ def merge_finding_product(request, pid):
                         finding_action = "deleted"
                         findings_to_merge.delete()
 
-                    notes_entry = "Finding consists of merged findings from the following findings: {} which have been {}.".format(notes_entry[:-1], finding_action)
+                    notes_entry = "Finding consists of merged findings from the following findings which have been {}: {}".format(finding_action, notes_entry[:-1])
                     note = Notes(entry=notes_entry, author=request.user)
                     note.save()
                     finding_to_merge_into.notes.add(note)


### PR DESCRIPTION
When merging findings, it generates a note that bundles all the findings together like:

Finding consists of merged findings from the following findings: Calling Cipher.getInstance("AES") Will Return AES ECB Mode by Default. ECB Mode Is Known to Be Weak as It Results in the Same Ciphertext for [...] (4054), The App Uses the Encryption Mode CBC With PKCS5/PKCS7 Padding. This Configuration Is Vulnerable to Padding Oracle Attacks. (4010) which have been deleted.

It's hard to read this. Instead I propose to generate bulletpoints that looks like:

Finding consists of merged findings from the following findings which have been deleted:

- netty-codec:4.1.54.Final | CVE-2021-37137 (4097),
- CVE-2018-15756 org.springframework:spring-core 4.3.18.RELEASE (1281),
- Vulnerable Component: Xerces2-j:2.12.0 (4864)