### PR TITLE
Fix CycloneDX severity parsing

### DIFF
--- a/unittests/scans/cyclonedx/spec1_lowfirst.xml
+++ b/unittests/scans/cyclonedx/spec1_lowfirst.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2"
+     xmlns:v="http://cyclonedx.org/schema/ext/vulnerability/1.0"
+     serialNumber="urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79"
+     version="1">
+  <components>
+    <component type="library" bom-ref="pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.9">
+      <group>com.fasterxml.jackson.core</group>
+      <name>jackson-databind</name>
+      <version>2.9.9</version>
+      <purl>pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.9</purl>
+    </component>
+  </components>
+  <v:vulnerabilities>
+    <v:vulnerability ref="pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.9">
+      <v:id>CVE-2018-7489</v:id>
+      <v:source name="NVD">
+        <v:url>https://nvd.nist.gov/vuln/detail/CVE-2018-7489</v:url>
+      </v:source>
+      <v:ratings>
+        <v:rating>
+          <v:severity>Low</v:severity>
+          <v:method>OWASP Risk</v:method>
+          <v:vector>OWASP/K9:M1:O0:Z2/D1:X1:W1:L3/C2:I1:A1:T1/F1:R1:S2:P3/50</v:vector>
+        </v:rating>
+        <v:rating>
+          <v:score>
+            <v:base>9.8</v:base>
+            <v:impact>5.9</v:impact>
+            <v:exploitability>3.0</v:exploitability>
+          </v:score>
+          <v:severity>Critical</v:severity>
+          <v:method>CVSSv3</v:method>
+          <v:vector>AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H</v:vector>
+        </v:rating>
+      </v:ratings>
+      <v:cwes>
+        <v:cwe>184</v:cwe>
+        <v:cwe>502</v:cwe>
+      </v:cwes>
+      <v:description>FasterXML jackson-databind before 2.7.9.3, 2.8.x before 2.8.11.1 and 2.9.x before 2.9.5 allows unauthenticated remote code execution because of an incomplete fix for the CVE-2017-7525 deserialization flaw. This is exploitable by sending maliciously crafted JSON input to the readValue method of the ObjectMapper, bypassing a blacklist that is ineffective if the c3p0 libraries are available in the classpath.</v:description>
+      <v:recommendations>
+        <v:recommendation>Upgrade</v:recommendation>
+      </v:recommendations>
+      <v:advisories>
+        <v:advisory>https://github.com/FasterXML/jackson-databind/issues/1931</v:advisory>
+        <v:advisory>http://www.securityfocus.com/bid/103203</v:advisory>
+        <v:advisory>http://www.securitytracker.com/id/1040693</v:advisory>
+        <v:advisory>http://www.securitytracker.com/id/1041890</v:advisory>
+      </v:advisories>
+    </v:vulnerability>
+  </v:vulnerabilities>
+</bom>

--- a/unittests/tools/test_cyclonedx_parser.py
+++ b/unittests/tools/test_cyclonedx_parser.py
@@ -50,6 +50,27 @@ class TestParser(DojoTestCase):
                 self.assertEqual("CVE-2018-7489", finding.vuln_id_from_tool)
                 self.assertEqual("Upgrade\n", finding.mitigation)
 
+    def test_spec1_report_low_first(self):
+        """Test a report from the spec itself"""
+        with open("unittests/scans/cyclonedx/spec1_lowfirst.xml") as file:
+            parser = CycloneDXParser()
+            findings = list(parser.get_findings(file, Test()))
+            for finding in findings:
+                self.assertIn(finding.severity, Finding.SEVERITIES)
+            self.assertEqual(1, len(findings))
+            with self.subTest(i=0):
+                finding = findings[0]
+                vulnerability_ids = finding.unsaved_vulnerability_ids
+                self.assertEqual(1, len(vulnerability_ids))
+                self.assertEqual('CVE-2018-7489', vulnerability_ids[0])
+                self.assertEqual("Critical", finding.severity)
+                self.assertIn(finding.cwe, [184, 502])  # there is 2 CWE in the report
+                self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", finding.cvssv3)
+                self.assertEqual("jackson-databind", finding.component_name)
+                self.assertEqual("2.9.9", finding.component_version)
+                self.assertEqual("CVE-2018-7489", finding.vuln_id_from_tool)
+                self.assertEqual("Upgrade\n", finding.mitigation)
+
     def test_cyclonedx_bom_report(self):
         with open("unittests/scans/cyclonedx/cyclonedx_bom.xml") as file:
             parser = CycloneDXParser()


### PR DESCRIPTION
There are a few problems with the CycloneDX severity parsing:

- For the legacy parsing it takes the first severity found, but also the first CVSSv3 score, which may be in a later severity, so they don't align.
- For XML/JSON it takes the severity directly from the CVSSv3 score, instead of using the Severity field if it exists in the Rating.
