### PR TITLE
Testing: Import and reimport Veracode test

### DIFF
--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -384,7 +384,7 @@ class ImportReimportMixin(object):
         notes_count_before = self.db_notes_count()
 
         # # reimport exact same report
-        with assertTestImportModelsCreated(self, reimports=1, untouched=4):
+        with assertTestImportModelsCreated(self, reimports=1, untouched=1):
             reimport_veracode_many_findings = self.reimport_scan_with_params(test_id, self.veracode_mitigated_findings, scan_type=self.scan_type_veracode)
 
         test_id = reimport_veracode_many_findings['test']
@@ -396,7 +396,7 @@ class ImportReimportMixin(object):
         # # reimported count must match count in sonar report
         # # we set verified=False in this reimport but DD keeps true as per the previous import (reimport doesn't "unverify" findings)
         findings = self.get_test_findings_api(test_id, verified=True)
-        self.assert_finding_count_json(4, findings)
+        self.assert_finding_count_json(1, findings)
 
         # inversely, we should see no findings with verified=False
         findings = self.get_test_findings_api(test_id, verified=False)

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -404,8 +404,8 @@ class ImportReimportMixin(object):
 
         # reimporting the exact same scan shouldn't create any notes
         self.assertEqual(notes_count_before, self.db_notes_count())
-        
-        # reimporting the same mitigated flaws should keep the same number of mitigated flaws, 
+
+        # reimporting the same mitigated flaws should keep the same number of mitigated flaws
         # since defectdojo is the only one that can override a mitigation coming from the scanner
         mitigated_findings = self.get_test_findings_api(test_id, is_mitigated=True)
         self.assert_finding_count_json(1, mitigated_findings)

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -76,6 +76,7 @@ class ImportReimportMixin(object):
         self.veracode_same_hash_code_different_unique_id = self.scans_path + 'veracode/many_findings_same_hash_code_different_unique_id.xml'
         self.veracode_same_unique_id_different_hash_code = self.scans_path + 'veracode/many_findings_same_unique_id_different_hash_code.xml'
         self.veracode_different_hash_code_different_unique_id = self.scans_path + 'veracode/many_findings_different_hash_code_different_unique_id.xml'
+        self.veracode_mitigated_findings = self.scans_path + 'veracode/mitigated_finding.xml'
         self.scan_type_veracode = 'Veracode Scan'
 
         self.clair_few_findings = self.scans_path + 'clair/few_vuln.json'
@@ -376,7 +377,7 @@ class ImportReimportMixin(object):
     def test_import_veracode_reimport_veracode_active_verified(self):
         logger.debug('reimporting exact same original veracode_many_findings xml report again')
 
-        import_veracode_many_findings = self.import_scan_with_params(self.veracode_many_findings, scan_type=self.scan_type_veracode, verified=True)
+        import_veracode_many_findings = self.import_scan_with_params(self.veracode_mitigated_findings, scan_type=self.scan_type_veracode, verified=True)
 
         test_id = import_veracode_many_findings['test']
 
@@ -384,7 +385,7 @@ class ImportReimportMixin(object):
 
         # # reimport exact same report
         with assertTestImportModelsCreated(self, reimports=1, untouched=4):
-            reimport_veracode_many_findings = self.reimport_scan_with_params(test_id, self.veracode_many_findings, scan_type=self.scan_type_veracode)
+            reimport_veracode_many_findings = self.reimport_scan_with_params(test_id, self.veracode_mitigated_findings, scan_type=self.scan_type_veracode)
 
         test_id = reimport_veracode_many_findings['test']
         self.assertEqual(test_id, test_id)

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -369,7 +369,7 @@ class ImportReimportMixin(object):
         self.assertEqual(notes_count_before, self.db_notes_count())
 
         return test_id
-    
+
     # import veracode and then reimport veracode again
     # - reimport, findings stay the same, stay active
     # - active = True, verified = True


### PR DESCRIPTION
Related to https://github.com/DefectDojo/django-DefectDojo/pull/6452
This test is to show that current reimporter fails to import the same veracode report twice without changes. It should fail for now, and work correctly once #6452 is merged