### PR TITLE
StackHawk HawkScan Parser Config Tweak

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1263,6 +1263,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'SSLyze Scan (JSON)': DEDUPE_ALGO_HASH_CODE,
     'Harbor Vulnerability Scan': DEDUPE_ALGO_HASH_CODE,
     'Rusty Hog Scan': DEDUPE_ALGO_HASH_CODE,
+    'StackHawk HawkScan': DEDUPE_ALGO_HASH_CODE,
     'Hydra Scan': DEDUPE_ALGO_HASH_CODE,
     'DrHeader JSON Importer': DEDUPE_ALGO_HASH_CODE,
 }


### PR DESCRIPTION
We noticed that we are missing `DEDUPLICATION_ALGORITHM_PER_PARSER` configuration for the `StackHawk HawkScan` parser to correctly use specific fields for de-duping, as configured in our `HASHCODE_FIELDS_PER_SCANNER`.