### PR TITLE
Parse the location for Grype

### DIFF
--- a/dojo/tools/anchore_grype/parser.py
+++ b/dojo/tools/anchore_grype/parser.py
@@ -56,6 +56,9 @@ class AnchoreGrypeParser(object):
             artifact_name = artifact.get('name')
             artifact_version = artifact.get('version')
             artifact_purl = artifact.get('purl')
+            artifact_location = artifact.get('locations')
+            if artifact_location and len(artifact_location) > 0 and artifact_location[0].get('path'):
+                file_path = artifact_location[0].get('path')
 
             finding_title = f'{vuln_id} in {artifact_name}:{artifact_version}'
 
@@ -146,6 +149,7 @@ class AnchoreGrypeParser(object):
                             static_finding=True,
                             dynamic_finding=False,
                             nb_occurences=1,
+                            file_path=file_path,
                         )
                 dupes[dupe_key].unsaved_vulnerability_ids = vulnerability_ids
 

--- a/unittests/tools/test_anchore_grype_parser.py
+++ b/unittests/tools/test_anchore_grype_parser.py
@@ -31,6 +31,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
                 self.assertEqual("Medium", finding.severity)
                 self.assertEqual("libgnutls-openssl27", finding.component_name)
                 self.assertEqual("3.6.7-4+deb10u5", finding.component_version)
+                self.assertEqual("/var/lib/dpkg/status", finding.file_path)
                 found = True
                 break
         self.assertTrue(found)


### PR DESCRIPTION
When using grype to scan a filesystem, it doesn't parse the artifact path as the file-path for the finding. For example:

"locations": [
     {
      "path": "configuration/.m2/repository/log4j/log4j/1.2.12/log4j-1.2.12.jar"
     }
