### PR TITLE
Expose prod_type on ApiFindingFilter

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1070,6 +1070,7 @@ class ApiFindingFilter(DojoFilter):
     test__test_type = NumberInFilter(field_name='test__test_type', lookup_expr='in', label='Test Type')
     test__engagement = NumberInFilter(field_name='test__engagement', lookup_expr='in')
     test__engagement__product = NumberInFilter(field_name='test__engagement__product', lookup_expr='in')
+    test__engagement__product__prod_type = NumberInFilter(field_name='test__engagement__product__prod_type', lookup_expr='in')
     finding_group = NumberInFilter(field_name='finding_group', lookup_expr='in')
 
     # ReportRiskAcceptanceFilter


### PR DESCRIPTION
This PR exposes the `test__engagement__product__prod_type ` on the `ApiFindingFilter`.
Previously it was already exposed on the `FindingFilter` and is used in the UI, e.g. here: `/finding/open?test__engagement__product__prod_type=<id>`.

Fixes #6589.