### PR TITLE
Align formatting of cyclonedx title with that of the vex xml/json titles

### DIFF
--- a/dojo/tools/cyclonedx/parser.py
+++ b/dojo/tools/cyclonedx/parser.py
@@ -126,7 +126,7 @@ class CycloneDXParser(object):
         for adv in vulnerability.findall("v:advisories/v:advisory", namespaces=ns):
             references += f"{adv.text}\n"
         finding = Finding(
-            title=vuln_id,
+            title=f"{component_name}:{component_version} | {vuln_id}",
             description=description,
             severity=severity,
             references=references,

--- a/unittests/tools/test_cyclonedx_parser.py
+++ b/unittests/tools/test_cyclonedx_parser.py
@@ -49,6 +49,8 @@ class TestParser(DojoTestCase):
                 self.assertEqual("2.9.9", finding.component_version)
                 self.assertEqual("CVE-2018-7489", finding.vuln_id_from_tool)
                 self.assertEqual("Upgrade\n", finding.mitigation)
+                self.assertEqual(finding.component_name + ":" + finding.component_version + " | " + vulnerability_ids[0],
+                                 finding.title)
 
     def test_spec1_report_low_first(self):
         """Test a report from the spec itself"""


### PR DESCRIPTION
The current title of cyclonedx findings is just the CVE number, this PR aligns it with the titles for the vex xml/json findings, so e.g.:

log4j-core:2.13.2 | CVE-2021-44228