### PR TITLE
Fix format strings used in exceptions

### DIFF
--- a/dojo/api_v2/permissions.py
+++ b/dojo/api_v2/permissions.py
@@ -497,10 +497,10 @@ def check_auto_create_permission(user, product, product_name, engagement, engage
 
     if product and product_name and engagement_name:
         if not user_has_permission(user, product, Permissions.Engagement_Add):
-            raise PermissionDenied("No permission to create engagements in product '%s'", product_name)
+            raise PermissionDenied("No permission to create engagements in product '%s'" % product_name)
 
         if not user_has_permission(user, product, Permissions.Import_Scan_Result):
-            raise PermissionDenied("No permission to import scans into product '%s'", product_name)
+            raise PermissionDenied("No permission to import scans into product '%s'" % product_name)
 
         # all good
         return True
@@ -511,12 +511,12 @@ def check_auto_create_permission(user, product, product_name, engagement, engage
 
         if not product_type:
             if not user_has_global_permission(user, Permissions.Product_Type_Add):
-                raise PermissionDenied("No permission to create product_type '%s'", product_type_name)
+                raise PermissionDenied("No permission to create product_type '%s'" % product_type_name)
             # new product type can be created with current user as owner, so all objects in it can be created as well
             return True
         else:
             if not user_has_permission(user, product_type, Permissions.Product_Type_Add_Product):
-                raise PermissionDenied("No permission to create products in product_type '%s'", product_type)
+                raise PermissionDenied("No permission to create products in product_type '%s'" % product_type)
 
         # product can be created, so objects in it can be created as well
         return True

--- a/dojo/endpoint/utils.py
+++ b/dojo/endpoint/utils.py
@@ -323,7 +323,7 @@ def endpoint_meta_import(file, product, create_endpoints, create_tags, create_me
             return HttpResponseRedirect(reverse('import_endpoint_meta', args=(product.id, )))
         elif origin == 'API':
             from rest_framework.serializers import ValidationError
-            raise ValidationError('The column "hostname" must be present to map host to Endpoint.',)
+            raise ValidationError('The column "hostname" must be present to map host to Endpoint.')
 
     keys = [key for key in reader.fieldnames if key != 'hostname']
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3393,7 +3393,7 @@ class JIRA_Issue(models.Model):
         elif type(obj) == Engagement:
             self.engagement = obj
         else:
-            raise ValueError('unknown objec type whiel creating JIRA_Issue: %s', to_str_typed(obj))
+            raise ValueError('unknown objec type whiel creating JIRA_Issue: %s' % to_str_typed(obj))
 
     def __str__(self):
         text = ""

--- a/dojo/tools/checkmarx_osa/parser.py
+++ b/dojo/tools/checkmarx_osa/parser.py
@@ -32,9 +32,9 @@ class CheckmarxOsaParser(object):
             library = libraries_dict[item['libraryId']]
             self.check_mandatory(library, mandatory_library_fields)
             if 'name' not in item['state']:
-                raise ValueError("Invalid format: missing mandatory field %s", 'state.name')
+                raise ValueError("Invalid format: missing mandatory field state.name")
             if 'name' not in item['severity']:
-                raise ValueError("Invalid format: missing mandatory field %s", 'severity.name')
+                raise ValueError("Invalid format: missing mandatory field severity.name")
 
             # Possible status as per checkmarx 9.2: TO_VERIFY, NOT_EXPLOITABLE, CONFIRMED, URGENT, PROPOSED_NOT_EXPLOITABLE
             status = item['state']['name']
@@ -96,4 +96,4 @@ class CheckmarxOsaParser(object):
     def check_mandatory(self, item, mandatory_vulnerability_fields):
         for field in mandatory_vulnerability_fields:
             if field not in item:
-                raise ValueError("Invalid format: missing mandatory field %s", field)
+                raise ValueError("Invalid format: missing mandatory field %s" % field)


### PR DESCRIPTION
First of all, thanks for this project!

Unlike logging functions, Exceptions do not have this "lazy string formatting" that makes `log("message %s", value)` work and be formatted only when the message is to be printed somewhere. Exceptions are always evaluated when raised.

I have found a couple of lines with that wrong pattern `raise ExceptionName("message %s", value)` instead of `raise ExceptionName("message %s" % value)`, and this PR fixes them.

This leads to message bodies such as:
```json
{
  "detail": "No permission to create product_type '%s'"
}
```

Hope this helps!

Pierre