### PR TITLE
fix(auditjs-parser): error when npm package has scope

### DIFF
--- a/dojo/tools/auditjs/parser.py
+++ b/dojo/tools/auditjs/parser.py
@@ -42,8 +42,11 @@ class AuditJSParser(object):
         for dependency in data:
             # reading package name in format pkg:npm/PACKAGE_NAME@PACKAGE_VERSION
             if "coordinates" in dependency:
-                file_path = dependency["coordinates"]
-                component_name, component_version = file_path.split('/')[1].split('@')
+                file_path = dependency["coordinates"]       
+                file_path_splitted = file_path.split("/")
+                pacakge_full_name = f'{file_path_splitted[1]}/{file_path_splitted[2]}' if len(file_path_splitted) == 3 else file_path_splitted[1]
+
+                component_name, component_version = pacakge_full_name.split('@')
 
             # Check if there are any vulnerabilities
             if dependency['vulnerabilities']:

--- a/dojo/tools/auditjs/parser.py
+++ b/dojo/tools/auditjs/parser.py
@@ -41,8 +41,9 @@ class AuditJSParser(object):
 
         for dependency in data:
             # reading package name in format pkg:npm/PACKAGE_NAME@PACKAGE_VERSION
+            # or pkg:npm/PACKAGE_SCOPE/PACKAGE_NAME@PACKAGE_VERSION
             if "coordinates" in dependency:
-                file_path = dependency["coordinates"]       
+                file_path = dependency["coordinates"]
                 file_path_splitted = file_path.split("/")
                 pacakge_full_name = f'{file_path_splitted[1]}/{file_path_splitted[2]}' if len(file_path_splitted) == 3 else file_path_splitted[1]
 

--- a/unittests/scans/auditjs/auditjs_with_package_namespace.json
+++ b/unittests/scans/auditjs/auditjs_with_package_namespace.json
@@ -1,0 +1,65 @@
+[
+  {
+    "coordinates": "pkg:npm/loose-envify@1.4.0",
+    "description": "Fast (and loose) selective `process.env` replacer using js-tokens instead of an AST",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/loose-envify@1.4.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": []
+  },
+  {
+    "coordinates": "pkg:npm/js-tokens@4.0.0",
+    "description": "Tiny JavaScript tokenizer.",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/js-tokens@4.0.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": []
+  },
+  {
+    "coordinates": "pkg:npm/react-dom@18.2.0",
+    "description": "React package for working with the DOM.",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/react-dom@18.2.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": []
+  },
+  {
+    "coordinates": "pkg:npm/scheduler@0.23.0",
+    "description": "Cooperative scheduler for the browser environment.",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/scheduler@0.23.0?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": []
+  },
+  {
+    "coordinates": "pkg:npm/next@12.2.2",
+    "description": "The React Framework",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/next@12.2.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": [
+      
+    ]
+  },
+  {
+    "coordinates": "pkg:npm/%40next/env@12.2.2",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/%40next/env@12.2.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": [
+        {
+          "id": "da5a3b11-c75b-48e7-9c28-1123f0a492bf",
+          "title": "Unverified Certificate",
+          "description": "> When using SSL to connect to a MySQL server, the SSL procedure implemented does not actually check if the remote server has a trusted certificate or not.\n> \n> -- [github.com](https://github.com/mysqljs/mysql/issues/816)",
+          "cvssScore": 9.6,
+          "cvssVector": "CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+          "reference": "https://ossindex.sonatype.org/vulnerability/da5a3b11-c75b-48e7-9c28-1123f0a492bf?component-type=npm&component-name=mysql&utm_source=auditjs&utm_medium=integration&utm_content=4.0.25"
+        }
+      ]
+  },
+  {
+    "coordinates": "pkg:npm/%40swc/helpers@0.4.2",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/%40swc/helpers@0.4.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": [
+      
+    ]
+  },
+  {
+    "coordinates": "pkg:npm/%40next/swc-linux-x64-gnu@12.2.2",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/%40next/swc-linux-x64-gnu@12.2.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": []
+  },
+  {
+    "coordinates": "pkg:npm/%40next/swc-linux-x64-musl@12.2.2",
+    "reference": "https://ossindex.sonatype.org/component/pkg:npm/%40next/swc-linux-x64-musl@12.2.2?utm_source=auditjs&utm_medium=integration&utm_content=4.0.37",
+    "vulnerabilities": []
+  }
+]

--- a/unittests/tools/test_auditjs_parser.py
+++ b/unittests/tools/test_auditjs_parser.py
@@ -68,3 +68,15 @@ class TestAuditJSParser(DojoTestCase):
             self.assertTrue(
                 "Invalid JSON format. Are you sure you used --json option ?" in str(context.exception)
             )
+
+    def test_auditjs_parser_with_package_name_has_namespace(self):
+        testfile = open("unittests/scans/auditjs/auditjs_with_package_namespace.json")
+        parser = AuditJSParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+
+        self.assertEqual(1, len(findings))
+        self.assertEqual("%40next/env", findings[0].component_name)
+
+# ./dc-unittest.sh --profile mysql-rabbitmq --test-case unittests.tools.test_usditjs_parser.TestAuditJSParser
+# python manage.py test unittests.tools.test_auditjs_parser.TestAuditJSParser --keepdb

--- a/unittests/tools/test_auditjs_parser.py
+++ b/unittests/tools/test_auditjs_parser.py
@@ -77,6 +77,3 @@ class TestAuditJSParser(DojoTestCase):
 
         self.assertEqual(1, len(findings))
         self.assertEqual("%40next/env", findings[0].component_name)
-
-# ./dc-unittest.sh --profile mysql-rabbitmq --test-case unittests.tools.test_usditjs_parser.TestAuditJSParser
-# python manage.py test unittests.tools.test_auditjs_parser.TestAuditJSParser --keepdb


### PR DESCRIPTION
## 📝 Description

based on this issue https://github.com/DefectDojo/django-DefectDojo/issues/6154, the AuditJS parser will throw an error when the package name has a scope or looks like this `@lerna/cli`. It will show an error like the image below. Generated file by auditjs can see [here](https://mikqi.gitlab.io/-/auditjs-poc/-/jobs/2755337092/artifacts/auditjs_report.json)

![image](https://user-images.githubusercontent.com/4416419/180689177-f786f3ae-3b93-43c0-97f4-821df16a158a.png)

## 📝 Additional information

This PR is to fix manipulate package name in auditjs parser.
