### PR TITLE
Implement object copy to parent objects

### DIFF
--- a/dojo/engagement/urls.py
+++ b/dojo/engagement/urls.py
@@ -18,6 +18,8 @@ urlpatterns = [
         name='edit_engagement'),
     url(r'^engagement/(?P<eid>\d+)/delete$', views.delete_engagement,
         name='delete_engagement'),
+    url(r'^engagement/(?P<eid>\d+)/copy$', views.copy_engagement,
+        name='copy_engagement'),
     url(r'^engagement/(?P<eid>\d+)/add_tests$', views.add_tests,
         name='add_tests'),
     url(r'^engagement/(?P<eid>\d+)/import_scan_results$',

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -36,7 +36,7 @@ from dojo.models import Finding, Product, Engagement, Test, \
 from dojo.tools.factory import get_scan_types_sorted
 from dojo.utils import add_error_message_to_response, add_success_message_to_response, get_page_items, add_breadcrumb, handle_uploaded_threat, \
     FileIterWrapper, get_cal_event, Product_Tab, is_scan_file_too_large, async_delete, \
-    get_system_setting, get_setting, redirect_to_return_url_or_else, get_return_url
+    get_system_setting, get_setting, redirect_to_return_url_or_else, get_return_url, calculate_grade
 from dojo.notifications.helper import create_notification
 from dojo.finding.views import find_available_notetypes
 from functools import reduce
@@ -330,6 +330,47 @@ def delete_engagement(request, eid):
         'engagement': engagement,
         'form': form,
         'rels': rels,
+    })
+
+
+@user_is_authorized(Engagement, Permissions.Engagement_Edit, 'eid')
+def copy_engagement(request, eid):
+    engagement = get_object_or_404(Engagement, id=eid)
+    product = engagement.product
+    form = DoneForm()
+
+    if request.method == 'POST':
+        form = DoneForm(request.POST)
+        if form.is_valid():
+            engagement_copy = engagement.copy()
+            calculate_grade(product)
+            messages.add_message(
+                request,
+                messages.SUCCESS,
+                'Engagement Copied successfully.',
+                extra_tags='alert-success')
+            create_notification(event='other',
+                                title='Copying of %s' % engagement.name,
+                                description='The engagement "%s" was copied by %s' % (engagement.name, request.user),
+                                product=product,
+                                url=request.build_absolute_uri(reverse('view_engagement', args=(engagement_copy.id, ))),
+                                recipients=[engagement.lead],
+                                icon="exclamation-triangle")
+            return redirect_to_return_url_or_else(request, reverse("view_engagements", args=(product.id, )))
+        else:
+            messages.add_message(
+                request,
+                messages.ERROR,
+                'Unable to copy engagement, please try again.',
+                extra_tags='alert-danger')
+
+    product_tab = Product_Tab(product, title="Copy Engagement", tab="engagements")
+    return render(request, 'dojo/copy_object.html', {
+        'source': engagement,
+        'source_label': 'Engagement',
+        'destination_label': 'Engagement',
+        'product_tab': product_tab,
+        'form': form,
     })
 
 

--- a/dojo/finding/urls.py
+++ b/dojo/finding/urls.py
@@ -65,6 +65,8 @@ urlpatterns = [
         views.clear_finding_review, name='clear_finding_review'),
     url(r'^finding/(?P<fid>\d+)/delete$',
         views.delete_finding, name='delete_finding'),
+    url(r'^finding/(?P<fid>\d+)/copy$',
+        views.copy_finding, name='copy_finding'),
     url(r'^finding/(?P<fid>\d+)/apply_cwe$',
         views.apply_template_cwe, name='apply_template_cwe'),
     url(r'^finding/(?P<fid>\d+)/mktemplate$', views.mktemplate,

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -856,6 +856,18 @@ class DeleteTestForm(forms.ModelForm):
         fields = ['id']
 
 
+class CopyTestForm(forms.Form):
+    engagement = forms.ModelChoiceField(
+        required=True,
+        queryset=Engagement.objects.none(),
+        error_messages={'required': '*'})
+
+    def __init__(self, *args, **kwargs):
+        authorized_lists = kwargs.pop('engagements', None)
+        super(CopyTestForm, self).__init__(*args, **kwargs)
+        self.fields['engagement'].queryset = authorized_lists
+
+
 class AddFindingForm(forms.ModelForm):
     title = forms.CharField(max_length=1000)
     date = forms.DateField(required=True,
@@ -2020,6 +2032,18 @@ class DeleteFindingForm(forms.ModelForm):
     class Meta:
         model = Finding
         fields = ['id']
+
+
+class CopyFindingForm(forms.Form):
+    test = forms.ModelChoiceField(
+        required=True,
+        queryset=Test.objects.none(),
+        error_messages={'required': '*'})
+
+    def __init__(self, *args, **kwargs):
+        authorized_lists = kwargs.pop('tests', None)
+        super(CopyFindingForm, self).__init__(*args, **kwargs)
+        self.fields['test'].queryset = authorized_lists
 
 
 class FindingFormID(forms.ModelForm):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2256,7 +2256,7 @@ class Finding(models.Model):
         copy.found_by.set(old_found_by)
         # Assign any tags
         copy.tags.set(old_tags)
-        
+
         return copy
 
     def get_absolute_url(self):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import Group
 from django.db.models.expressions import Case, When
 from django.urls import reverse
 from django.core.validators import RegexValidator, validate_ipv46_address
+from django.core.files.base import ContentFile
 from django.core.exceptions import ValidationError
 from django.db import models, connection
 from django.db.models import Q, Count
@@ -558,6 +559,13 @@ class NoteHistory(models.Model):
                                 default=get_current_datetime)
     current_editor = models.ForeignKey(Dojo_User, editable=False, null=True, on_delete=models.CASCADE)
 
+    def copy(self):
+        copy = self
+        copy.pk = None
+        copy.id = None
+        copy.save()
+        return copy
+
 
 class Notes(models.Model):
     note_type = models.ForeignKey(Note_Type, related_name='note_type', null=True, blank=True, on_delete=models.CASCADE)
@@ -579,15 +587,47 @@ class Notes(models.Model):
     def __str__(self):
         return self.entry
 
+    def copy(self):
+        copy = self
+        # Save the necessary ManyToMany relationships
+        old_history = self.history.all()
+        # Wipe the IDs of the new object
+        copy.pk = None
+        copy.id = None
+        # Save the object before setting any ManyToMany relationships
+        copy.save()
+        # Copy the history
+        for history in old_history:
+            copy.history.add(history.copy())
+
+        return copy
+
 
 class FileUpload(models.Model):
     title = models.CharField(max_length=100, unique=True)
     file = models.FileField(upload_to=UniqueUploadNameProvider('uploaded_files'))
 
+    def copy(self):
+        copy = self
+        # Wipe the IDs of the new object
+        copy.pk = None
+        copy.id = None
+        # Add unique modifier to file name
+        copy.title = '{} - clone-{}'.format(self.title, str(uuid4())[:8])
+        # Create new unique file name
+        current_url = self.file.url
+        _, current_full_filename = current_url.rsplit('/', 1)
+        _, extension = current_full_filename.split('.', 1)
+        new_file = ContentFile(self.file.read(), name='{}.{}'.format(uuid4(), extension))
+        copy.file = new_file
+        copy.save()
+
+        return copy
+
 
 class Product_Type(models.Model):
     """Product types represent the top level model, these can be business unit divisions, different offices or locations, development teams, or any other logical way of distinguishing “types” of products.
-
+`
        Examples:
          * IAM Team
          * Internal / 3rd Party
@@ -1178,6 +1218,36 @@ class Engagement(models.Model):
                                         self.target_start.strftime(
                                             "%b %d, %Y"))
 
+    def copy(self):
+        copy = self
+        # Save the necessary ManyToMany relationships
+        old_notes = self.notes.all()
+        old_files = self.files.all()
+        old_tags = self.tags.all()
+        old_risk_acceptances = self.risk_acceptance.all()
+        old_tests = Test.objects.filter(engagement=self)
+        # Wipe the IDs of the new object
+        copy.pk = None
+        copy.id = None
+        # Save the object before setting any ManyToMany relationships
+        copy.save()
+        # Copy the notes
+        for notes in old_notes:
+            copy.notes.add(notes.copy())
+        # Copy the files
+        for files in old_files:
+            copy.files.add(files.copy())
+        # Copy the tests
+        for test in old_tests:
+            test.copy(engagement=copy)
+        # Copy the risk_acceptances
+        for risk_acceptance in old_risk_acceptances:
+            copy.risk_acceptance.add(risk_acceptance.copy(engagement=copy))
+        # Assign any tags
+        copy.tags.set(old_tags)
+
+        return copy
+
     def get_breadcrumbs(self):
         bc = self.product.get_breadcrumbs()
         bc += [{'title': str(self),
@@ -1254,6 +1324,18 @@ class Endpoint_Status(models.Model):
         for field in self._meta.get_fields():
             field_values.append(str(getattr(self, field.name, '')))
         return ' '.join(field_values)
+
+    def copy(self, finding=None):
+        copy = self
+        current_endpoint = self.endpoint
+        copy.pk = None
+        copy.id = None
+        if finding:
+            copy.finding = finding
+        copy.endpoint = current_endpoint
+        copy.save()
+
+        return copy
 
     class Meta:
         indexes = [
@@ -1629,6 +1711,34 @@ class Test(models.Model):
         bc += [{'title': str(self),
                 'url': reverse('view_test', args=(self.id,))}]
         return bc
+
+    def copy(self, engagement=None):
+        copy = self
+        # Save the necessary ManyToMany relationships
+        old_notes = self.notes.all()
+        old_files = self.files.all()
+        old_tags = self.tags.all()
+        old_findings = Finding.objects.filter(test=self)
+        # Wipe the IDs of the new object
+        copy.pk = None
+        copy.id = None
+        if engagement:
+            copy.engagement = engagement
+        # Save the object before setting any ManyToMany relationships
+        copy.save()
+        # Copy the notes
+        for notes in old_notes:
+            copy.notes.add(notes.copy())
+        # Copy the files
+        for files in old_files:
+            copy.files.add(files.copy())
+        # Copy the Findings
+        for finding in old_findings:
+            finding.copy(test=copy)
+        # Assign any tags
+        copy.tags.set(old_tags)
+
+        return copy
 
     # only used by bulk risk acceptance api
     @property
@@ -2111,6 +2221,43 @@ class Finding(models.Model):
         self.unsaved_tags = None
         self.unsaved_files = None
         self.unsaved_vulnerability_ids = None
+
+    def copy(self, test=None):
+        copy = self
+        # Save the necessary ManyToMany relationships
+        old_notes =  self.notes.all()
+        old_files =  self.files.all()
+        old_endpoint_status =  self.endpoint_status.all()
+        old_endpoints =  self.endpoints.all()
+        old_reviewers =  self.reviewers.all()
+        old_found_by =  self.found_by.all()
+        old_tags = self.tags.all()
+        # Wipe the IDs of the new object
+        copy.pk = None
+        copy.id = None
+        if test:
+            copy.test = test
+        # Save the object before setting any ManyToMany relationships
+        copy.save()
+        # Copy the notes
+        for notes in old_notes:
+            copy.notes.add(notes.copy())
+        # Copy the files
+        for files in old_files:
+            copy.files.add(files.copy())
+        # Copy the endpoint_status
+        for endpoint_status in old_endpoint_status:
+            copy.endpoint_status.add(endpoint_status.copy(finding=copy))
+        # Assign any endpoints
+        copy.endpoints.set(old_endpoints)
+        # Assign any reviewers
+        copy.reviewers.set(old_reviewers)
+        # Assign any found_by
+        copy.found_by.set(old_found_by)
+        # Assign any tags
+        copy.tags.set(old_tags)
+        
+        return copy
 
     def get_absolute_url(self):
         from django.urls import reverse
@@ -2989,6 +3136,25 @@ class Risk_Acceptance(models.Model):
             return engs[0]
 
         return None
+
+    def copy(self, engagement=None):
+        copy = self
+        # Save the necessary ManyToMany relationships
+        old_notes =  self.notes.all()
+        old_accepted_findings_hash_codes = [finding.hash_code for finding in self.accepted_findings.all()]
+        # Wipe the IDs of the new object
+        copy.pk = None
+        copy.id = None
+        # Save the object before setting any ManyToMany relationships
+        copy.save()
+        # Copy the notes
+        for notes in old_notes:
+            copy.notes.add(notes.copy())
+        # Assign any accepted findings
+        if engagement:
+            new_accepted_findings = Finding.objects.filter(test__engagement=engagement, hash_code__in=old_accepted_findings_hash_codes, risk_accepted=True).distinct()
+            copy.accepted_findings.set(new_accepted_findings)
+        return copy
 
 
 class FileAccessToken(models.Model):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2225,12 +2225,12 @@ class Finding(models.Model):
     def copy(self, test=None):
         copy = self
         # Save the necessary ManyToMany relationships
-        old_notes =  self.notes.all()
-        old_files =  self.files.all()
-        old_endpoint_status =  self.endpoint_status.all()
-        old_endpoints =  self.endpoints.all()
-        old_reviewers =  self.reviewers.all()
-        old_found_by =  self.found_by.all()
+        old_notes = self.notes.all()
+        old_files = self.files.all()
+        old_endpoint_status = self.endpoint_status.all()
+        old_endpoints = self.endpoints.all()
+        old_reviewers = self.reviewers.all()
+        old_found_by = self.found_by.all()
         old_tags = self.tags.all()
         # Wipe the IDs of the new object
         copy.pk = None
@@ -3140,7 +3140,7 @@ class Risk_Acceptance(models.Model):
     def copy(self, engagement=None):
         copy = self
         # Save the necessary ManyToMany relationships
-        old_notes =  self.notes.all()
+        old_notes = self.notes.all()
         old_accepted_findings_hash_codes = [finding.hash_code for finding in self.accepted_findings.all()]
         # Wipe the IDs of the new object
         copy.pk = None

--- a/dojo/templates/dojo/copy_object.html
+++ b/dojo/templates/dojo/copy_object.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% load static %}
+{% block add_css %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{% static "chosen-bootstrap/chosen.bootstrap.min.css" %}"/>
+{% endblock add_css %}
+{% block content %}
+    {{ block.super }}
+    <h3> Copy {{ source }} to a new {{ destination_label }}</h3>
+    <div class="alert alert-info" role="alert">
+        Please select the {{ destination_label }} you would like to copy this {{ source_label }} to
+    </div>
+
+    <form class="form-horizontal" method="post" enctype="multipart/form-data">
+        {% csrf_token %}
+        {% include "dojo/form_fields.html" with form=form %}
+        <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-10">
+                <input class="btn btn-primary" name="copy" type="submit" value="Copy"/>
+            </div>
+        </div>
+    </form>
+{% endblock content %}

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -248,6 +248,11 @@
                                           <i class="fa fa-pencil-square-o"></i> Edit
                                           </a>
                                        </li>
+                                       <li>
+                                          <a class="" href="{% url 'copy_finding' finding.id %}?return_url={{ request.get_full_path|urlencode }}"/>
+                                          <i class="fa fa-copy"></i> Copy
+                                          </a>
+                                        </li>
                                        {% endif %}
                                        {% if finding|has_object_permission:"Finding_Edit" %}
                                           <li class="divider"></li>

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -77,6 +77,11 @@
                                </a>
                             </li>
                             <li>
+                              <a class="" href="{% url 'copy_engagement' eng.id %}">
+                                <i class="fa fa-copy"></i> Copy
+                              </a>
+                           </li>
+                            <li>
                               </a>
                               {% if status == "open" or status == "paused" %}
                               <a class="" href="{% url 'close_engagement' eng.id %}">

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -268,6 +268,10 @@
                                                                     <a class="" href="{% url 'edit_test' test.id %}">
                                                                     <i class="fa fa-pencil-square-o"></i> Edit</a>
                                                                 </li>
+                                                                <li>
+                                                                    <a class="" href="{% url 'copy_test' test.id %}">
+                                                                    <i class="fa fa-copy"></i> Copy</a>
+                                                                </li>
                                                             {% endif %}
                                                             {% if test|has_object_permission:"Finding_Add" %}
                                                                 <li class="divider"></li>

--- a/dojo/test/urls.py
+++ b/dojo/test/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
         name='edit_test'),
     url(r'^test/(?P<tid>\d+)/delete$', views.delete_test,
         name='delete_test'),
+     url(r'^test/(?P<tid>\d+)/copy$', views.copy_test,
+        name='copy_test'),
     url(r'^test/(?P<tid>\d+)/add_findings$', views.add_findings,
         name='add_findings'),
     url(r'^test/(?P<tid>\d+)/add_findings/(?P<fid>\d+)$',

--- a/dojo/test/urls.py
+++ b/dojo/test/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
         name='edit_test'),
     url(r'^test/(?P<tid>\d+)/delete$', views.delete_test,
         name='delete_test'),
-     url(r'^test/(?P<tid>\d+)/copy$', views.copy_test,
+    url(r'^test/(?P<tid>\d+)/copy$', views.copy_test,
         name='copy_test'),
     url(r'^test/(?P<tid>\d+)/add_findings$', views.add_findings,
         name='add_findings'),

--- a/unittests/test_copy_model.py
+++ b/unittests/test_copy_model.py
@@ -1,0 +1,323 @@
+from .dojo_test_case import DojoTestCase
+from dojo.models import Endpoint, Endpoint_Status, Finding, Test, Engagement, Product, User
+
+
+class TestCopyFindingModel(DojoTestCase):
+
+    def test_duplicate_finding_same_test(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_finding', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        finding = Finding.objects.create(test=test, reporter=user)
+        # Do the counting
+        current_finding_count = Finding.objects.filter(test=test).count()
+        # Do the copy
+        finding_copy = finding.copy(test=test)
+        # Make sure the copy was made without error
+        self.assertEqual(current_finding_count + 1, Finding.objects.filter(test=test).count())
+        # Are the findings the same
+        self.assertEqual(finding.hash_code, finding_copy.hash_code)
+
+    def test_duplicate_finding_different_test(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_finding', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test1 = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test1')
+        test2 = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test2')
+        finding = Finding.objects.create(test=test1, reporter=user)
+        # Do the counting
+        engagement_finding_count = Finding.objects.filter(test__engagement=engagement).count()
+        # Do the copy
+        finding_copy = finding.copy(test=test2)
+        # Make sure the copy was made without error
+        self.assertEqual(Finding.objects.filter(test=test1).count(), Finding.objects.filter(test=test2).count())
+        # Are the findings the same
+        self.assertEqual(finding.hash_code, finding_copy.hash_code)
+        # Does the engagement have more findings
+        self.assertEqual(engagement_finding_count + 1, Finding.objects.filter(test__engagement=engagement).count())
+
+    def test_duplicate_finding_with_tags(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_finding', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        finding = Finding.objects.create(test=test, reporter=user)
+        finding.unsaved_tags = ['test_tag']
+        finding.save()
+        # Do the counting
+        current_finding_count = Finding.objects.filter(test=test).count()
+        # Do the copy
+        finding_copy = finding.copy(test=test)
+        # Make sure the copy was made without error
+        self.assertEqual(current_finding_count + 1, Finding.objects.filter(test=test).count())
+        # Do the tags match
+        self.assertEqual(finding.tags, finding_copy.tags)
+
+    def test_duplicate_finding_with_notes(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_finding', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        finding = Finding.objects.create(test=test, reporter=user)
+        finding.unsaved_notes = ['test_note']
+        finding.save()
+        # Do the counting
+        current_finding_count = Finding.objects.filter(test=test).count()
+        # Do the copy
+        finding_copy = finding.copy(test=test)
+        # Make sure the copy was made without error
+        self.assertEqual(current_finding_count + 1, Finding.objects.filter(test=test).count())
+        # Do the notes match
+        self.assertEqual(finding.notes, finding_copy.notes)
+
+    def test_duplicate_finding_with_tags_and_notes(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_finding', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        finding = Finding.objects.create(test=test, reporter=user)
+        finding.unsaved_tags = ['test_tag']
+        finding.unsaved_notes = ['test_note']
+        finding.save()
+        # Do the counting
+        current_finding_count = Finding.objects.filter(test=test).count()
+        # Do the copy
+        finding_copy = finding.copy(test=test)
+        # Make sure the copy was made without error
+        self.assertEqual(current_finding_count + 1, Finding.objects.filter(test=test).count())
+        # Do the tags match
+        self.assertEqual(finding.notes, finding_copy.notes)
+        # Do the notes match
+        self.assertEqual(finding.notes, finding_copy.notes)
+
+    def test_duplicate_finding_with_endpoints(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_finding', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        endpoint = Endpoint.from_uri('0.0.0.0')
+        endpoint.save()
+        finding = Finding.objects.create(test=test, reporter=user)
+        endpoint_status = Endpoint_Status.objects.create(finding=finding, endpoint=endpoint)
+        finding.endpoints.add(endpoint)
+        finding.endpoint_status.add(endpoint_status)
+        # Do the counting
+        current_finding_count = Finding.objects.filter(test=test).count()
+        current_endpoint_finding_count = endpoint.findings_count()
+        current_endpoint_count = Endpoint.objects.all().count()
+        current_endpoint_status_count = Endpoint_Status.objects.filter(endpoint=endpoint).count()
+        # Do the copy
+        finding_copy = finding.copy(test=test)
+        # Make sure the copy was made without error
+        self.assertEqual(current_finding_count + 1, Finding.objects.filter(test=test).count())
+        # Make sure the number of endpoints stayed the same
+        self.assertEqual(current_endpoint_count, Endpoint.objects.all().count())
+        # Make sure the number of findings on the endpoint grew
+        self.assertEqual(current_endpoint_finding_count + 1, endpoint.findings_count())
+        # Make sure the number of endpoint status objects grew
+        self.assertEqual(current_endpoint_status_count + 1, Endpoint_Status.objects.filter(endpoint=endpoint).count())
+        # Make sure the endpoint status objects point at different findings
+        self.assertNotEqual(endpoint_status, finding_copy.endpoint_status.all().first())
+
+
+class TestCopyTestModel(DojoTestCase):
+
+    def test_duplicate_test_same_enagagement(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        # Do the counting
+        current_test_count = Test.objects.filter(engagement=engagement).count()
+        current_test_finding_count = Finding.objects.filter(test=test).count()
+        current_engagement_finding_count = Finding.objects.filter(test__engagement=engagement).count()
+        # Do the copy
+        test_copy = test.copy(engagement=engagement)
+        # Make sure the copy was made without error
+        self.assertEqual(current_test_count + 1, Test.objects.filter(engagement=engagement).count())
+        # Do the tests have the same number of findings
+        self.assertEqual(current_test_finding_count, Finding.objects.filter(test=test_copy).count())
+        # Make sure the engagement has more findings
+        self.assertEqual(current_engagement_finding_count + 1, Finding.objects.filter(test__engagement=engagement).count())
+
+    def test_duplicate_tests_different_engagements(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement1 = self.create_engagement('eng1', product)
+        engagement2 = self.create_engagement('eng2', product)
+        test = self.create_test(engagement=engagement1, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        # Do the counting
+        product_finding_count = Finding.objects.filter(test__engagement__product=product).count()
+        # Do the copy
+        test_copy = test.copy(engagement=engagement2)
+        # Make sure the copy was made without error
+        self.assertEqual(Test.objects.filter(engagement=engagement1).count(), Test.objects.filter(engagement=engagement2).count())
+        # Do the enagements have the same number of findings
+        self.assertEqual(Finding.objects.filter(test__engagement=engagement1).count(), Finding.objects.filter(test__engagement=engagement2).count())
+        # Are the tests equal
+        self.assertEqual(test, test_copy)
+        # Does the product thave more findings
+        self.assertEqual(product_finding_count + 1, Finding.objects.filter(test__engagement__product=product).count())
+
+    def test_duplicate_test_with_tags(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        test.unsaved_tags = ['test_tag']
+        test.save()
+        # Do the counting
+        current_test_count = Test.objects.filter(engagement=engagement).count()
+        # Do the copy
+        test_copy = test.copy(engagement=engagement)
+        # Make sure the copy was made without error
+        self.assertEqual(current_test_count + 1, Test.objects.filter(engagement=engagement).count())
+        # Do the tags match
+        self.assertEqual(test.tags, test_copy.tags)
+
+    def test_duplicate_test_with_notes(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        test.unsaved_notes = ['test_note']
+        test.save()
+        # Do the counting
+        current_test_count = Test.objects.filter(engagement=engagement).count()
+        # Do the copy
+        test_copy = test.copy(engagement=engagement)
+        # Make sure the copy was made without error
+        self.assertEqual(current_test_count + 1, Test.objects.filter(engagement=engagement).count())
+        # Do the notes match
+        self.assertEqual(test.notes, test_copy.notes)
+
+    def test_duplicate_test_with_tags_and_notes(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        test.unsaved_tags = ['test_tag']
+        test.unsaved_notes = ['test_note']
+        test.save()
+        # Do the counting
+        current_test_count = Test.objects.filter(engagement=engagement).count()
+        # Do the copy
+        test_copy = test.copy(engagement=engagement)
+        # Make sure the copy was made without error
+        self.assertEqual(current_test_count + 1, Test.objects.filter(engagement=engagement).count())
+        # Do the notes match
+        self.assertEqual(test.notes, test_copy.notes)
+        # Do the tags match
+        self.assertEqual(test.tags, test_copy.tags)
+
+
+class TestCopyEngagementModel(DojoTestCase):
+
+    def test_duplicate_engagement(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        # Do the counting
+        current_product_count = Product.objects.filter(prod_type=product_type).count()
+        current_engagement_finding_count = Finding.objects.filter(test__engagement=engagement).count()
+        current_engagement_product_finding_count = Finding.objects.filter(test__engagement__product=product).count()
+        # Do the copy
+        engagement_copy = engagement.copy()
+        # Make sure the copy was made without error
+        self.assertEqual(current_product_count + 1, Engagement.objects.filter(product=product).count())
+        # Do the tests have the same number of findings
+        self.assertEqual(current_engagement_finding_count, Finding.objects.filter(test__engagement=engagement_copy).count())
+        # Make sure the product has more findings
+        self.assertEqual(current_engagement_product_finding_count + 1, Finding.objects.filter(test__engagement__product=product).count())
+
+    def test_duplicate_engagement_with_tags(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        engagement.unsaved_tags = ['test_tag']
+        engagement.save()
+        # Do the counting
+        current_engagement_count = Engagement.objects.filter(product=product).count()
+        # Do the copy
+        engagement_copy = engagement.copy()
+        # Make sure the copy was made without error
+        self.assertEqual(current_engagement_count + 1, Engagement.objects.filter(product=product).count())
+        # Do the tags match
+        self.assertEqual(engagement.tags, engagement_copy.tags)
+
+    def test_duplicate_engagement_with_notes(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        engagement.unsaved_notes = ['test_note']
+        engagement.save()
+        # Do the counting
+        current_engagement_count = Engagement.objects.filter(product=product).count()
+        # Do the copy
+        engagement_copy = engagement.copy()
+        # Make sure the copy was made without error
+        self.assertEqual(current_engagement_count + 1, Engagement.objects.filter(product=product).count())
+        # Do the notes match
+        self.assertEqual(engagement.notes, engagement_copy.notes)
+
+    def test_duplicate_engagement_with_tags_and_notes(self):
+        # Set the scene
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type('prod_type')
+        product = self.create_product('test_deuplicate_test', prod_type=product_type)
+        engagement = self.create_engagement('eng', product)
+        test = self.create_test(engagement=engagement, scan_type='NPM Audit Scan', title='test')
+        _ = Finding.objects.create(test=test, reporter=user)
+        engagement.unsaved_tags = ['test_tag']
+        engagement.unsaved_notes = ['test_note']
+        engagement.save()
+        # Do the counting
+        current_engagement_count = Engagement.objects.filter(product=product).count()
+        # Do the copy
+        engagement_copy = engagement.copy()
+        # Make sure the copy was made without error
+        self.assertEqual(current_engagement_count + 1, Engagement.objects.filter(product=product).count())
+        # Do the notes match
+        self.assertEqual(engagement.notes, engagement_copy.notes)
+        # Do the tags match
+        self.assertEqual(engagement.tags, engagement_copy.tags)


### PR DESCRIPTION
Users with edit permissions can copy an object from one parent to another.  For example, findings can be copied between tests, tests between engagements, and then engagements can be copied to the same product, but not to another product. 