### PR TITLE
Send message only to reviewers

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -936,15 +936,18 @@ def request_finding_review(request, fid):
             finding.reviewers.set(users)
             finding.save()
             reviewers = ""
+            reviewers_short = []
             for suser in form.cleaned_data['reviewers']:
                 full_user = Dojo_User.generate_full_name(Dojo_User.objects.get(id=suser))
                 logger.debug("Asking %s for review", full_user)
                 reviewers += str(full_user) + ", "
+                reviewers_short.append(Dojo_User.objects.get(id=suser).username)
             reviewers = reviewers[:-2]
 
             create_notification(event='review_requested',
                                 title='Finding review requested',
                                 finding=finding,
+                                recipients=reviewers_short,
                                 description='User %s has requested that user(s) %s review the finding "%s" for accuracy:\n\n%s' % (user, reviewers, finding.title, new_note),
                                 icon='check',
                                 url=reverse("view_finding", args=(finding.id,)))

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -26,7 +26,9 @@ def create_notification(event=None, **kwargs):
         logger.debug('creating notifications for recipients: %s', kwargs['recipients'])
         for recipient_notifications in Notifications.objects.filter(user__username__in=kwargs['recipients'], user__is_active=True, product=None):
             # kwargs.update({'user': recipient_notifications.user})
+            logger.debug('Sent notification to %s', recipient_notifications)
             process_notifications(event, recipient_notifications, **kwargs)
+
     else:
         logger.debug('creating system notifications for event: %s', event)
         # send system notifications to all admin users

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -26,7 +26,7 @@ def create_notification(event=None, **kwargs):
         logger.debug('creating notifications for recipients: %s', kwargs['recipients'])
         for recipient_notifications in Notifications.objects.filter(user__username__in=kwargs['recipients'], user__is_active=True, product=None):
             # kwargs.update({'user': recipient_notifications.user})
-            logger.debug('Sent notification to %s', recipient_notifications)
+            logger.debug('Sent notification to %s', recipient_notifications.user)
             process_notifications(event, recipient_notifications, **kwargs)
 
     else:


### PR DESCRIPTION
When product member is asking for review, all product members are receiving a message. This PR adapts code, so only user that are asked for review will receive the message. Reason is to eliminate noise generated by alerts. 