### PR TITLE
Fix: url of the finding

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -461,7 +461,7 @@ def close_finding(request, fid):
                                     title='Closing of %s' % finding.title,
                                     finding=finding,
                                     description='The finding "%s" was closed by %s' % (finding.title, request.user),
-                                    url=request.build_absolute_uri(reverse('view_test', args=(finding.test.id, ))),
+                                    url=reverse('view_finding', args=(finding.id, )),
                                     )
                 return HttpResponseRedirect(
                     reverse('view_test', args=(finding.test.id, )))

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -133,6 +133,7 @@ def create_notification_message(event, user, notification_type, *args, **kwargs)
     notification_message = None
     try:
         notification_message = render_to_string(template, kwargs)
+        logger.debug("Rendering from the template %s", template)
     except TemplateDoesNotExist:
         logger.debug('template not found or not implemented yet: %s', template)
     except Exception as e:


### PR DESCRIPTION
In previous implementation when closing finding message was like:
```
The finding "Make Sure That Hashing Data Is Safe Here." was closed by admin
More information on this event can be found here: http://localhost:8080http://localhost:8080/test/3
```
So url was repeating twice and there was link to test id, not to a particular finding, this improvement adapts it like:

```
More information on this event can be found here: http://localhost:8080/finding/200
```