### PR TITLE
[FIX] Reassign an engagement to another product

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -221,6 +221,7 @@ def edit_engagement(request, eid):
         if form.is_valid():
             # first save engagement details
             new_status = form.cleaned_data.get('status')
+            engagement.product = form.cleaned_data.get('product')
             engagement = form.save(commit=False)
             if (new_status == "Cancelled" or new_status == "Completed"):
                 engagement.active = False


### PR DESCRIPTION
On the Engagement Edit page, it is possible to change the product. However, this has no effect on real engagement's product assignment. Adding the line to fix the issue.

https://github.com/DefectDojo/django-DefectDojo/issues/6588