### PR TITLE
API-Swagger(drf-yasg): fix docExpansion

### DIFF
--- a/docs/content/en/integrations/api-v2-docs.md
+++ b/docs/content/en/integrations/api-v2-docs.md
@@ -20,7 +20,7 @@ The documentation is generated using [Django Rest Framework
 Yet Another Swagger Generator](https://github.com/axnsan12/drf-yasg/), and is
 interactive. On the top of API v2 docs is a link that generates an OpenAPI v2 spec.
 
-As a preparation to move to OpenAPIv3, we have added an compatible spec and documentation at [`/api/v2/oa3/swagger-ui/`](https://demo.defectdojo.org/api/v2/oa3/swagger-ui/?docExpansion=none)
+As a preparation to move to OpenAPIv3, we have added an compatible spec and documentation at [`/api/v2/oa3/swagger-ui/`](https://demo.defectdojo.org/api/v2/oa3/swagger-ui/)
 
 To interact with the documentation, a valid Authorization header value
 is needed. Visit the `/api/v2/key/` view to generate your

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -712,6 +712,9 @@ SPECTACULAR_SETTINGS = {
     'POSTPROCESSING_HOOKS': ['dojo.api_v2.prefetch.schema.prefetch_postprocessing_hook'],
     # show file selection dialogue, see https://github.com/tfranzel/drf-spectacular/issues/455
     "COMPONENT_SPLIT_REQUEST": True,
+    "SWAGGER_UI_SETTINGS": {
+        "docExpansion": "none"
+    }
 }
 
 # ------------------------------------------------------------------------------

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -173,7 +173,7 @@
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="{% url 'swagger-ui_oa3' %}?docExpansion=none" target="_blank">
+                                        <a href="{% url 'swagger-ui_oa3' %}" target="_blank">
                                             <i class="fa fa-book fa-fw" title="OpenAPI v3 Docs"></i>
                                             {% trans "API v2 OpenAPI3 Docs" %}
                                         </a>


### PR DESCRIPTION
Even if there was `?docExpansion=none` in the URL, the list was still expanded. Now, it is fixed.