### PR TITLE
Fix a bug that caused re-imports to drop service name of findings

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -68,7 +68,8 @@ class DojoDefaultReImporter(object):
             if not hasattr(item, 'test'):
                 item.test = test
 
-            item.service = service
+            if service:
+                item.service = service
 
             item.hash_code = item.compute_hash_code()
             deduplicationLogger.debug("item's hash_code: %s", item.hash_code)


### PR DESCRIPTION
If findings had a service name set, the re-importer would override it with an empty one, unless it is specified. This behaviour seems incorrect. 

This matches behaviour of the importer. 