### PR TITLE
Modify helm test workflow for master branch

### DIFF
--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -57,7 +57,7 @@ jobs:
       # run all checks but version increment always when something changed
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }} --check-version-increment=false
-        if: steps.list-changed.outputs.changed == 'true'
+        if: ${{ steps.list-changed.outputs.changed == 'true' && steps.ct-branch-target.outputs.ct-branch != 'master' }}
 
       # run version check only if not dev as in dev we have a `x.y.z-dev` version
       # x.y.z gets bumped automatically when doing a release


### PR DESCRIPTION
When doing the last release, I was really bothered that the helm test failed from merging dev into master (ptsd from last release) but had not failed from merging regular PRs into dev. I know the helm chart version is valid, because a new one was successfully created with the completion of the release, and that would not have happened if the release version was outdated. This tells me the issue is with the unit test itself. 

After looking at the workflow, I believe the issue to be that a new chart version is created **twice** in a row, but only when ran from against the master branch. In this check, a new version is created (before this past release, it was 1.6.35)

```
 # run all checks but version increment always when something changed
      - name: Run chart-testing (lint)
        run: ct lint --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }} --check-version-increment=false
        if: steps.list-changed.outputs.changed == 'true'
```

After the linting completes (and passes), the new version is 1.6.36. 

On the second check, it attempts to lint again from 1.6.35 and creates the new version (1.6.36)

```
# run version check only if not dev as in dev we have a `x.y.z-dev` version
      # x.y.z gets bumped automatically when doing a release
      - name: Run chart-testing (lint)
        run: ct lint --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }} --check-version-increment=true
        if: ${{ steps.list-changed.outputs.changed == 'true' && steps.ct-branch-target.outputs.ct-branch != 'dev' }}
```

Since the `check-version-increment` flag is set here,  it will see that the new version (1.6.36) was not incremented as the version in the last check was also 1.6.36, so the test fails.

Here is the failed test that led to this PR -> https://github.com/DefectDojo/django-DefectDojo/runs/7636675182?check_suite_focus=true
