### PR TITLE
Fix shebang on shell scripts

### DIFF
--- a/dc-build.sh
+++ b/dc-build.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 bash ./docker/docker-compose-check.sh
 if [[ $? -eq 1 ]]; then exit 1; fi

--- a/dc-down.sh
+++ b/dc-down.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 bash ./docker/docker-compose-check.sh
 if [[ $? -eq 1 ]]; then exit 1; fi

--- a/dc-stop.sh
+++ b/dc-stop.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 bash ./docker/docker-compose-check.sh
 if [[ $? -eq 1 ]]; then exit 1; fi

--- a/dc-unittest.sh
+++ b/dc-unittest.sh
@@ -1,4 +1,4 @@
-#/bin/env bash
+#!/bin/env bash
 
 unset PROFILE
 unset TEST_CASE

--- a/dc-up-d.sh
+++ b/dc-up-d.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 unset PROFILE
 

--- a/dc-up.sh
+++ b/dc-up.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 unset PROFILE
 

--- a/docker/docker-compose-check.sh
+++ b/docker/docker-compose-check.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 main=`docker-compose  version  --short | cut -d '.' -f 1`
 minor=`docker-compose  version  --short | cut -d '.' -f 2`


### PR DESCRIPTION
The first line of many shell scripts are missing the "!" character,
which make them not to be taken as proper shebangs.