### PR TITLE
Reintroduce missing method modify_permissions to fix OAuth2 login

### DIFF
--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -63,6 +63,10 @@ def social_uid(backend, details, response, *args, **kwargs):
             return {'uid': response.get('preferred_username')}
 
 
+def modify_permissions(backend, uid, user=None, social=None, *args, **kwargs):
+    pass
+
+
 def update_azure_groups(backend, uid, user=None, social=None, *args, **kwargs):
     if settings.AZUREAD_TENANT_OAUTH2_ENABLED and settings.AZUREAD_TENANT_OAUTH2_GET_GROUPS and isinstance(backend, AzureADTenantOAuth2):
         soc = user.social_auth.get()


### PR DESCRIPTION
fixes #6653 

Without this missing method OAuth2 login is not possible, which affects a lot of DefectDojo installations.