### PR TITLE
Parse the report timestamp for CycloneDX json

### DIFF
--- a/dc-unittest.sh
+++ b/dc-unittest.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 
 unset PROFILE
 unset TEST_CASE

--- a/dojo/tools/cyclonedx/parser.py
+++ b/dojo/tools/cyclonedx/parser.py
@@ -294,6 +294,12 @@ class CycloneDXParser(object):
     def _get_findings_json(self, file, test):
         """Load a CycloneDX file in JSON format"""
         data = json.load(file)
+
+        # Parse timestamp to get the report date
+        report_date = None
+        if data.get("metadata") and data.get("metadata").get("timestamp"):
+            report_date = dateutil.parser.parse(data.get("metadata").get("timestamp"))
+
         # for each component we keep data
         components = {}
         for component in data.get("components", []):
@@ -348,6 +354,9 @@ class CycloneDXParser(object):
                     dynamic_finding=False,
                     vuln_id_from_tool=vulnerability.get("id"),
                 )
+
+                if report_date:
+                    finding.date = report_date
 
                 ratings = vulnerability.get("ratings", [])
                 for rating in ratings:

--- a/unittests/tools/test_cyclonedx_parser.py
+++ b/unittests/tools/test_cyclonedx_parser.py
@@ -238,50 +238,51 @@ class TestParser(DojoTestCase):
             self.assertEqual(7, len(findings))
             for finding in findings:
                 finding.clean()
-                if "CVE-2021-33203" == finding.vuln_id_from_tool:
+                if "c7129ff8-08bc-4afe-82ec-7d97b9491741" == finding.vuln_id_from_tool:
                     with self.subTest(i="CVE-2021-33203"):
                         self.assertIn(finding.severity, Finding.SEVERITIES)
-                        self.assertEqual("Django:2.0.1 | CVE-2021-33203", finding.title)
+                        self.assertEqual("Django:2.0 | c7129ff8-08bc-4afe-82ec-7d97b9491741", finding.title)
                         self.assertEqual("High", finding.severity)
                         self.assertEqual("Django", finding.component_name)
-                        self.assertEqual("2.0.1", finding.component_version)
+                        self.assertEqual("2.0", finding.component_version)
                         vulnerability_ids = finding.unsaved_vulnerability_ids
-                        self.assertEqual(1, len(vulnerability_ids))
-                        self.assertEqual('CVE-2021-33203', vulnerability_ids[0])
+                        self.assertEqual(2, len(vulnerability_ids))
+                        self.assertEqual('CVE-2021-33203', vulnerability_ids[1])
                         self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", finding.cvssv3)
                         self.assertIn(
                             "Django before 2.2.24, 3.x before 3.1.12, and 3.2.x before 3.2.4 has a potential directory traversal",
                             finding.description,
                         )
-                elif "CVE-2021-33203" == finding.vuln_id_from_tool:
-                    with self.subTest(i="CVE-2021-33203"):
-                        self.assertEqual("Django:2.0.1 | CVE-2018-7536", finding.title)
+                        self.assertEqual(datetime.date(2022, 1, 28), datetime.datetime.date(finding.date))
+                elif "c9b6a6a5-01a4-4d4c-b480-b9d6825dc4d0" == finding.vuln_id_from_tool:
+                    with self.subTest(i="CVE-2018-7536"):
+                        self.assertEqual("Django:2.0 | c9b6a6a5-01a4-4d4c-b480-b9d6825dc4d0", finding.title)
                         self.assertEqual("Medium", finding.severity)
                         self.assertEqual("Django", finding.component_name)
-                        self.assertEqual("2.0.1", finding.component_version)
+                        self.assertEqual("2.0", finding.component_version)
                         vulnerability_ids = finding.unsaved_vulnerability_ids
-                        self.assertEqual(1, len(vulnerability_ids))
-                        self.assertEqual('CVE-2018-7489', vulnerability_ids[0])
+                        self.assertEqual(2, len(vulnerability_ids))
+                        self.assertEqual('CVE-2018-7536', vulnerability_ids[1])
                         self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", finding.cvssv3)
                         self.assertIn(
                             "An issue was discovered in Django 2.0 before 2.0.3, 1.11 before 1.11.11, and 1.8 before 1.8.19.",
                             finding.description,
                         )
-                        self.assertEqual("CVE-2018-7536", finding.vuln_id_from_tool)
-                elif "CVE-2018-6188" == finding.vuln_id_from_tool:
+                        self.assertEqual(datetime.date(2022, 1, 28), datetime.datetime.date(finding.date))
+                elif "90cfba6a-ddc9-4708-b131-5d875e8c558d" == finding.vuln_id_from_tool:
                     with self.subTest(i="CVE-2018-6188"):
                         self.assertEqual("High", finding.severity)
                         self.assertEqual("Django", finding.component_name)
-                        self.assertEqual("2.0.1", finding.component_version)
+                        self.assertEqual("2.0", finding.component_version)
                         vulnerability_ids = finding.unsaved_vulnerability_ids
-                        self.assertEqual(1, len(vulnerability_ids))
-                        self.assertEqual('CVE-2018-6188', vulnerability_ids[0])
+                        self.assertEqual(2, len(vulnerability_ids))
+                        self.assertEqual('CVE-2018-6188', vulnerability_ids[1])
                         self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N", finding.cvssv3)
                         self.assertIn(
                             "django.contrib.auth.forms.AuthenticationForm in Django 2.0 before 2.0.2, and 1.11.8 and 1.11.9, allows remote attackers to obtain potentially sensitive information",
                             finding.description,
                         )
-                        self.assertEqual("CVE-2018-6188", finding.vuln_id_from_tool)
+                        self.assertEqual(datetime.date(2022, 1, 28), datetime.datetime.date(finding.date))
 
     def test_cyclonedx_json_cwe(self):
         """CycloneDX version 1.4 JSON format"""


### PR DESCRIPTION
For CycloneDX XML, it sets the finding date as the date of the report timestamp, however it doesn't do this for JSON. This PR is to make it consistent. In addition the PR fixes two issues:

1. The "jake.json" testcase for CycloneDX is not actually run, due to a previous change as to how vulnerability IDs are parsed.
2. The dc-unittest.sh fails on my machine (mac) due to a recent shebang change