### PR TITLE
Add native AWS SQS support to Django Docker image

### DIFF
--- a/Dockerfile.django
+++ b/Dockerfile.django
@@ -20,6 +20,8 @@ RUN \
     xmlsec1 \
     git \
     uuid-runtime \
+    # libcurl4-openssl-dev is required for installing pycurl python package
+    libcurl4-openssl-dev \
     && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
@@ -52,13 +54,16 @@ RUN \
     uuid-runtime \
     # only required for the dbshell (used by the initializer job)
     postgresql-client \
+    # libcurl4-openssl-dev is required for installing pycurl python package
+    libcurl4-openssl-dev \
     && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
   true
 COPY --from=build /tmp/wheels /tmp/wheels
 COPY requirements.txt ./
-RUN pip3 install \
+RUN export PYCURL_SSL_LIBRARY=openssl && \
+    pip3 install \
 	--no-cache-dir \
 	--no-index \
   --find-links=/tmp/wheels \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -20,6 +20,8 @@ RUN \
     xmlsec1 \
     git \
     uuid-runtime \
+    # libcurl4-openssl-dev is required for installing pycurl python package
+    libcurl4-openssl-dev \
     && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,3 +74,5 @@ djangosaml2==1.5.1
 drf-spectacular==0.23.1
 django-ratelimit==3.0.1
 argon2-cffi==21.3.0
+pycurl==7.45.1  # Required for Celery Broker AWS (SQS) support
+boto3==1.24.49  # Required for Celery Broker AWS (SQS) support


### PR DESCRIPTION
Extended Dockerfile.django and requirements.txt files to additionally install apt packages and python libraries required to support AWS SQS queue connections for Celery as described in Issue #6569. The extended setup has successfully been tested in the scenario described in the former mentioned issue.