### PR TITLE
Add BleachCSS for Login Banner

### DIFF
--- a/dojo/templatetags/get_banner.py
+++ b/dojo/templatetags/get_banner.py
@@ -1,5 +1,6 @@
 from django.utils.safestring import mark_safe
 import bleach
+from bleach.css_sanitizer import CSSSanitizer
 from django import template
 from dojo.models import BannerConf
 
@@ -10,15 +11,16 @@ register = template.Library()
 def get_banner_conf(attribute):
     try:
         banner_config = BannerConf.objects.get()
-
         value = getattr(banner_config, attribute, None)
         if value:
-
             if attribute == 'banner_message':
                 # only admin can edit login banner, so we allow html, but still bleach it
                 allowed_attributes = bleach.ALLOWED_ATTRIBUTES
                 allowed_attributes['a'] = allowed_attributes['a'] + ['style', 'target']
-                return mark_safe(bleach.clean(value, attributes=allowed_attributes, styles=['color', 'font-weight']))
+                return mark_safe(bleach.clean(
+                    value,
+                    attributes=allowed_attributes,
+                    css_sanitizer=CSSSanitizer(allowed_css_properties=['color', 'font-weight'])))
             else:
                 return value
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # requirements.txt for DefectDojo using Python 3.x
 asteval==0.9.27
 bleach==5.0.1
+bleach[css]
 celery==5.2.7
 coverage==6.4.3
 defusedxml==0.7.1


### PR DESCRIPTION
On the release of Bleach 5.0.0, the CSS module was separated into a different package. When upgrading to the Bleach 5.0 in dojo, I had overlooked that the login banner sanitizes CSS and not just HTML. This is the fix