### PR TITLE
Design fixes to footer, tags input, and filters snippet

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -688,6 +688,7 @@ input#simple_search {
 }
 
 .dojo-modals-wrapper {
+    display: none;
     flex-direction: column;
     position: fixed;
     z-index: 1;

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -687,6 +687,18 @@ input#simple_search {
     width: 100%;
 }
 
+.dojo-modals-wrapper {
+    flex-direction: column;
+    position: fixed;
+    z-index: 1;
+    padding-top: 100px;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+}
+
 .footer {
     background-color: #F8F8F8;
     border-top: 1px solid #dcdcdc;
@@ -1020,16 +1032,28 @@ div.custom-search-form {
     #page-wrapper {
         margin: 75px 0 0 0;
     }
+
+    #footer-wrapper {
+        margin: 75px 0 0 0;
+    }
 }
 
 @media (min-width: 359px) {
     #page-wrapper {
         margin: 100px 0 0 0;
     }
+
+    #footer-wrapper {
+        margin: 100px 0 0 0;
+    }
 }
 
 @media (min-width: 600px) {
     #page-wrapper {
+        margin: 50px 0 0 0;
+    }
+
+    #footer-wrapper {
         margin: 50px 0 0 0;
     }
 }
@@ -1041,6 +1065,11 @@ div.custom-search-form {
 
     #page-wrapper {
         margin: 0 0 0 175px;
+    }
+
+    #footer-wrapper {
+        margin: 0 0 0 175px;
+        border-left: 1px solid #e7e7e7;
     }
 
     li#minimize-menu-li {
@@ -1085,6 +1114,11 @@ div.custom-search-form {
 
     body.min #page-wrapper {
         margin: 0 0 0 50px;
+        border-left: 1px solid #e7e7e7;
+    }
+
+    body.min #footer-wrapper {
+        margin: 0 0 0 50px;
     }
 
     body.min div.navbar-default.sidebar {
@@ -1128,6 +1162,31 @@ div.custom-search-form {
     margin-bottom: 10px;
     vertical-align: middle;
     margin-right: 25px;
+}
+
+.dojo-filter-set.form-inline .filter-form-group {
+    display: flex;
+    flex-wrap: wrap;
+    flex-basis: auto;
+    flex-grow: 4;
+    align-content: stretch;
+    margin-bottom: 10px;
+    vertical-align: middle;
+    margin-right: 25px;
+}
+
+.dojo-filter-set.form-inline .filter-form-input {
+    margin-right: 25px;
+    margin-bottom: 10px;
+}
+
+.dojo-filter-set.form-inline .filter-form-control {
+    width: auto!important;
+    vertical-align: middle;
+}
+
+.dojo-filter-set.form-inline .form-control {
+    height: auto!important;
 }
 
 .report-filter-set {

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1009,7 +1009,7 @@
             {% block modals %}
             {% endblock %}
             </div>
-            <!-- /dojo-modals-wrapper -->
+            <!-- /.dojo-modals-wrapper -->
 
             <!-- #footer-wrapper -->
             <div id="footer-wrapper">

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -1003,6 +1003,16 @@
                 <!-- /.container-fluid -->
             </div>
             <!-- /#page-wrapper -->
+
+            <!-- .dojo-modals-wrapper -->
+            <div id="dojo-modals-wrapper" class="dojo-modals-wrapper">
+            {% block modals %}
+            {% endblock %}
+            </div>
+            <!-- /dojo-modals-wrapper -->
+
+            <!-- #footer-wrapper -->
+            <div id="footer-wrapper">
             {% block footer %}
                 <footer class="footer">
                     <div class="container">
@@ -1035,6 +1045,8 @@
                     <p id="disable_count" class="hidden">{{ 'DISABLE_ALERT_COUNTER'|setting_enabled }}</p>
                 </footer>
             {% endblock %}
+            </div>
+            <!-- /#footer-wrapper -->
         </div>
 
         <!-- /#wrapper -->

--- a/dojo/templates/dojo/ad_hoc_findings.html
+++ b/dojo/templates/dojo/ad_hoc_findings.html
@@ -66,13 +66,12 @@
         $ = django.jQuery;
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids') {
+                if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
                         element: elem,

--- a/dojo/templates/dojo/add_findings.html
+++ b/dojo/templates/dojo/add_findings.html
@@ -112,29 +112,28 @@
             {% endif %}
         });
 
-            $("textarea").each(function (index, elem) {
+        $("textarea").each(function (index, elem) {
+            if (elem.hasAttribute("required")) {
+                elem.removeAttribute("required");
+                elem.id = "req"
+            }
 
-                if (elem.hasAttribute("required")) {
-                    elem.removeAttribute("required");
-                    elem.id = "req"
-                }
-
-                if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids') {
-                    var mde = new EasyMDE({
-                        spellChecker: false,
-                        element: elem,
-                        autofocus: false,
-                        forceSync: true,
-                        toolbar: ["bold", "italic", "heading", "|",
-                            "quote", "unordered-list", "ordered-list", "|",
-                            "link", "image", "|",
-                            "table", "horizontal-rule", "code", "|",
-                            "guide"
-                        ]
-                    });
-                    mde.render();
-                }
-            });
+            if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
+                var mde = new EasyMDE({
+                    spellChecker: false,
+                    element: elem,
+                    autofocus: false,
+                    forceSync: true,
+                    toolbar: ["bold", "italic", "heading", "|",
+                        "quote", "unordered-list", "ordered-list", "|",
+                        "link", "image", "|",
+                        "table", "horizontal-rule", "code", "|",
+                        "guide"
+                    ]
+                });
+                mde.render();
+            }
+        });
 
         $("#add_finding").submit(function () {
             var isFormValid = true;

--- a/dojo/templates/dojo/add_group.html
+++ b/dojo/templates/dojo/add_group.html
@@ -2,60 +2,62 @@
 {% load display_tags %}
 {% load static %}
 {% block add_css %}
-
-<link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
+    <link rel="stylesheet" href="{% static "easymde/dist/easymde.min.css" %}">
 {% endblock %}
 {% block add_styles %}
-.editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
-width: 70% !important;
-}
-.chosen-container.chosen-container-multi {
-width: 70% !important;
-}
+    .editor-toolbar, .editor-statusbar, .editor-preview-side, .CodeMirror {
+        width: 70% !important;
+    }
+  
+    .chosen-container.chosen-container-multi {
+        width: 70% !important;
+    }
 {% endblock %}
-{% block content %}
 
+{% block content %}
 <form class="form-horizontal" method="post">{% csrf_token %}
-  <fieldset>
-    <legend>Default Information</legend>
-    {% include "dojo/form_fields.html" with form=form %}
-  </fieldset>
-  <fieldset>
-    <legend>Global Role</legend>
-    {% include "dojo/form_fields.html" with form=global_role_form %}
-  </fieldset>
-<div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <input class="btn btn-primary" type="submit" name="add_group" value="Submit"/>
+    <fieldset>
+	    <legend>Default Information</legend>
+	    {% include "dojo/form_fields.html" with form=form %}
+    </fieldset>
+    <fieldset>
+	    <legend>Global Role</legend>
+	    {% include "dojo/form_fields.html" with form=global_role_form %}
+    </fieldset>
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+            <input class="btn btn-primary" type="submit" name="add_group" value="Submit"/>
+        </div>
     </div>
-  </div>
 </form>
 {% endblock %}
+
 {% block postscript %}
 <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
 <script type="application/javascript">
-  $(function () {
-    $("textarea").each(function (index, elem) {
+    $(function () {
+        $("textarea").each(function (index, elem) {
+            if (elem.hasAttribute("required")) {
+                elem.removeAttribute("required");
+                elem.id = "req"
+            }
 
-      if (elem.hasAttribute("required")) {
-        elem.removeAttribute("required");
-        elem.id = "req"
-      }
-
-      var mde = new EasyMDE({
-        spellChecker: false,
-        element: elem,
-        autofocus: false,
-        forceSync: true,
-        toolbar: ["bold", "italic", "heading", "|",
-          "quote", "unordered-list", "ordered-list", "|",
-          "link", "image", "|",
-          "table", "horizontal-rule", "code", "|",
-          "guide"
-        ]
-      });
-      mde.render();
+            if(!$(elem).hasClass('select2-search__field')) {
+                var mde = new EasyMDE({
+                    spellChecker: false,
+                    element: elem,
+                    autofocus: false,
+                    forceSync: true,
+                    toolbar: ["bold", "italic", "heading", "|",
+                        "quote", "unordered-list", "ordered-list", "|",
+                        "link", "image", "|",
+                        "table", "horizontal-rule", "code", "|",
+                        "guide"
+                    ]
+                });
+                mde.render();
+            }
+        });
     });
-  });
 </script>
 {% endblock %}

--- a/dojo/templates/dojo/add_template.html
+++ b/dojo/templates/dojo/add_template.html
@@ -66,13 +66,12 @@
 
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                if (elem.name != 'vulnerability_ids') {
+                if (elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
                         element: elem,
@@ -88,6 +87,7 @@
                     mde.render();
                 }
             });
+
             // add req id to input field which enables input length check
             $("input").each(function (index, elem) {
 

--- a/dojo/templates/dojo/apply_finding_template.html
+++ b/dojo/templates/dojo/apply_finding_template.html
@@ -45,13 +45,12 @@
 
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                if (elem.name != 'vulnerability_ids') {
+                if (elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
                         element: elem,

--- a/dojo/templates/dojo/edit_finding.html
+++ b/dojo/templates/dojo/edit_finding.html
@@ -164,13 +164,12 @@
             });
 
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids') {
+                if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
                         element: elem,

--- a/dojo/templates/dojo/edit_presets.html
+++ b/dojo/templates/dojo/edit_presets.html
@@ -31,25 +31,26 @@
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-                mde.render();
+                if(!$(elem).hasClass('select2-search__field')) {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
 
         });

--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -45,27 +45,27 @@
     <script type="application/javascript">
         $(function () {
           $("textarea").each(function (index, elem) {
-
               if (elem.hasAttribute("required")) {
                   elem.removeAttribute("required");
                   elem.id = "req"
               }
-
-              var mde = new EasyMDE({
-                  spellChecker: false,
-                  element: elem,
-                  autofocus: false,
-                  forceSync: true,
-                  toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-              });
-              mde.render();
+              
+              if(!$(elem).hasClass('select2-search__field')) {
+                var mde = new EasyMDE({
+                    spellChecker: false,
+                    element: elem,
+                    autofocus: false,
+                    forceSync: true,
+                    toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                });
+                mde.render();
+                }
             });
-
         });
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/edit_product_type.html
+++ b/dojo/templates/dojo/edit_product_type.html
@@ -36,20 +36,22 @@
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
-
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-            mde.render();
+                
+                if(!$(elem).hasClass('select2-search__field')) {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
         });
     </script>

--- a/dojo/templates/dojo/filter_snippet.html
+++ b/dojo/templates/dojo/filter_snippet.html
@@ -15,15 +15,17 @@
         {% for field in form.hidden_fields %}
             {{ field }}
         {% endfor %}
-        {% for field in form.visible_fields %}
-            <div class="form-group">
-                {{ field.errors }}
-                <label for="{{ field.auto_id }}" style="display: block;">{{ field.label }}</label>
-                {% with placeholder="placeholder:"|add:field.label %}
-                    {{ field|addcss:"class:form-control input-sm"|addcss:placeholder }}
-                {% endwith %}
-            </div>
-        {% endfor %}
+        <div class="filter-form-group">
+            {% for field in form.visible_fields %}
+                <div class="filter-form-input">
+                    {{ field.errors }}
+                    <label for="{{ field.auto_id }}" style="display: block;">{{ field.label }}</label>
+                    {% with placeholder="placeholder:"|add:field.label %}
+                        {{ field|addcss:"class: form-control filter-form-control"|addcss:placeholder }}
+                    {% endwith %}
+                </div>
+            {% endfor %}
+        </div>        
         {% if submit == 'report' %}
             {% query_string_as_hidden %}
             <div class="inline-block" style="vertical-align: text-top">

--- a/dojo/templates/dojo/new_eng.html
+++ b/dojo/templates/dojo/new_eng.html
@@ -65,25 +65,26 @@
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-                mde.render();
+                if(!$(elem).hasClass('select2-search__field')) {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
         });
     </script>

--- a/dojo/templates/dojo/new_params.html
+++ b/dojo/templates/dojo/new_params.html
@@ -31,27 +31,27 @@
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
-
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-                mde.render();
+                
+                if(!$(elem).hasClass('select2-search__field')) {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
-
         });
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -42,25 +42,26 @@
     <script type="application/javascript">
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-                mde.render();
+                if(!$(elem).hasClass('select2-search__field')) {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
         });
     </script>

--- a/dojo/templates/dojo/new_product_type.html
+++ b/dojo/templates/dojo/new_product_type.html
@@ -35,20 +35,22 @@
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
-
-                var mde = new EasyMDE({
-                    spellChecker: false,
-                    element: elem,
-                    autofocus: false,
-                    forceSync: true,
-                    toolbar: ["bold", "italic", "heading", "|",
-                        "quote", "unordered-list", "ordered-list", "|",
-                        "link", "image", "|",
-                        "table", "horizontal-rule", "code", "|",
-                        "guide"
-                    ]
-                });
-            mde.render();
+                
+                if(!$(elem).hasClass('select2-search__field')) {
+                    var mde = new EasyMDE({
+                        spellChecker: false,
+                        element: elem,
+                        autofocus: false,
+                        forceSync: true,
+                        toolbar: ["bold", "italic", "heading", "|",
+                            "quote", "unordered-list", "ordered-list", "|",
+                            "link", "image", "|",
+                            "table", "horizontal-rule", "code", "|",
+                            "guide"
+                        ]
+                    });
+                    mde.render();
+                }
             });
         });
     </script>

--- a/dojo/templates/dojo/promote_to_finding.html
+++ b/dojo/templates/dojo/promote_to_finding.html
@@ -49,13 +49,12 @@
 
         $(function () {
             $("textarea").each(function (index, elem) {
-
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");
                     elem.id = "req"
                 }
 
-                if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids') {
+                if (elem.name != 'endpoints_to_add' && elem.name != 'vulnerability_ids' && !$(elem).hasClass('select2-search__field')) {
                     var mde = new EasyMDE({
                         spellChecker: false,
                         element: elem,


### PR DESCRIPTION
### Footer Changes
Changes to the footer have been made to prevent it from covering the side navbar. On certain pages, the side navbar and the footer conflict with one another.

_Before this change:_ 
<img width="1920" alt="Screen Shot 2022-08-23 at 12 15 08 AM" src="https://user-images.githubusercontent.com/76979297/186075586-fa929165-62fb-4081-964c-f3eb26105084.png">

_With this change:_
<img width="1919" alt="Screen Shot 2022-08-23 at 12 16 58 AM" src="https://user-images.githubusercontent.com/76979297/186075789-7ab6b719-6643-40a5-9cd2-f4eb6a4a230a.png">


### Tags Input Changes
Previously, the input for tags was being rendered as an EasyMDE editor, this is not necessary, nor is it visually pleasing. Propagated this change to all occurrences of `textarea` elements being replaced by EasyMDEs.

_Before this change:_
<img width="1399" alt="Screen Shot 2022-08-23 at 12 21 43 AM" src="https://user-images.githubusercontent.com/76979297/186076531-bee11963-cfca-4d2d-bfd4-b11c06724b1d.png">

_With this change:_
<img width="1469" alt="Screen Shot 2022-08-23 at 12 18 03 AM" src="https://user-images.githubusercontent.com/76979297/186076006-a63db862-7b2c-434b-a18f-27ee7fe4d7a4.png">


### Filter Snippet Changes
The current rendering of filter inputs is poorly styled (inconsistent input box sizes, poor spacing, etc). Added a few new styles to better display these inputs.

_Before this change:_
<img width="1814" alt="Screen Shot 2022-08-23 at 12 27 24 AM" src="https://user-images.githubusercontent.com/76979297/186077260-0d2e9340-1444-444d-a6cc-78392105717a.png">

_With this change:_
<img width="1810" alt="Screen Shot 2022-08-23 at 12 26 58 AM" src="https://user-images.githubusercontent.com/76979297/186077256-97438f87-1a2e-4330-9d95-44f9334d8961.png">

