### PR TITLE
Add the ability to specify the Epic name and priority in JIRA

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2791,6 +2791,8 @@ class JIRAEngagementForm(forms.Form):
                 self.fields['push_to_jira'].help_text = 'Checking this will update the existing EPIC in JIRA.'
 
     push_to_jira = forms.BooleanField(required=False, label="Create EPIC", help_text="Checking this will create an EPIC in JIRA for this engagement.")
+    epic_name = forms.CharField(max_length=200, required=False, help_text="EPIC name in JIRA. If not specified, it defaults to the engagement name")
+    epic_priority = forms.CharField(max_length=200, required=False, help_text="EPIC priority. If not specified, the JIRA default priority will be used")
 
 
 class GoogleSheetFieldsForm(forms.Form):


### PR DESCRIPTION
When creating a JIRA Epic, it uses the engagement name as the epic name (and JIRA summary), as well as the default priority specified in JIRA for epics. 

This task is to add the ability to configure the Epic Name and Priority in DefectDojo. It will fall back to the existing defaults if not specified.