### PR TITLE
Fix bug that caused scan imports to fail

### DIFF
--- a/dojo/tools/edgescan/api_client.py
+++ b/dojo/tools/edgescan/api_client.py
@@ -46,7 +46,7 @@ class EdgescanAPI(object):
 
     def get_findings(self, asset_id):
         url = f"{self.url}/api/v1/vulnerabilities/export.json?c[asset_id]={asset_id}&c[status]=open"
-        if 'date' in self.options:
+        if self.options and 'date' in self.options:
             url += f"&c[date_opened_after]={self.options['date']}"
 
         response = requests.get(
@@ -67,7 +67,7 @@ class EdgescanAPI(object):
         return headers
 
     def get_proxies(self):
-        if "proxy" not in self.options:
-            return None
+        if self.options and "proxy" in self.options:
+            return {"https": self.options["proxy"]}
 
-        return {"https": self.options["proxy"]}
+        return None


### PR DESCRIPTION
# Context

If no options were provided to the API scan configuration for edgescan then the scan import would fail when searching for a key in the options object, since no object was available. 

# Changes

Check if options object is available first before checking for keys.