### PR TITLE
Set finding to inactivate after creation of risk acceptance

### DIFF
--- a/dojo/risk_acceptance/api.py
+++ b/dojo/risk_acceptance/api.py
@@ -107,7 +107,7 @@ def _accept_risks(accepted_risks: List[AcceptedRisk], base_findings: QuerySet, o
                                                         decision_details=risk.justification,
                                                         accepted_by=risk.accepted_by[:200])
             acceptance.accepted_findings.set(findings)
-            findings.update(risk_accepted=True)
+            findings.update(risk_accepted=True, active=False)
             acceptance.save()
             accepted.append(acceptance)
 


### PR DESCRIPTION
Finding's don't get de-activated when the risk is accepted from the API.  See bug #6779
