### PR TITLE
Doc: Update local_settings.py description

### DIFF
--- a/docs/content/en/getting_started/configuration.md
+++ b/docs/content/en/getting_started/configuration.md
@@ -28,7 +28,7 @@ An example can be found in [`template_env`](https://github.com/DefectDojo/django
 `local_settings.py` can contain more complex customizations such as adding MIDDLEWARE or INSTALLED_APP entries.
 This file is processed *after* settings.dist.py is processed, so you can modify settings delivered by Defect Dojo out of the box.
  The file must be located in the `dojo/settings` directory. Environment variables in this file must have no `DD_` prefix.
-If file is missing feel free to create it. Do not edit directly `settings.dist.py`.
+If the file is missing feel free to create it. Do not edit `settings.dist.py` directly.
 
 An example can be found in [`dojo/settings/template-local_settings`](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/settings/template-local_settings).
 

--- a/docs/content/en/getting_started/configuration.md
+++ b/docs/content/en/getting_started/configuration.md
@@ -28,6 +28,7 @@ An example can be found in [`template_env`](https://github.com/DefectDojo/django
 `local_settings.py` can contain more complex customizations such as adding MIDDLEWARE or INSTALLED_APP entries.
 This file is processed *after* settings.dist.py is processed, so you can modify settings delivered by Defect Dojo out of the box.
  The file must be located in the `dojo/settings` directory. Environment variables in this file must have no `DD_` prefix.
+If file is missing feel free to create it. Do not edit directly `settings.dist.py`.
 
 An example can be found in [`dojo/settings/template-local_settings`](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/settings/template-local_settings).
 


### PR DESCRIPTION
To avoid situations like https://owasp.slack.com/archives/C2P5BA8MN/p1661972243567139?thread_ts=1661970538.645869&cid=C2P5BA8MN
> In the documentation it says it's in the dojo/settings directory but it doesn't have any local_settings.py file. 