### PR TITLE
helm: defectdojo-deployment: support defaultMode parameter for django.extraVolumes

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -66,6 +66,7 @@ spec:
           type: {{ .pathType | default "Directory" }}
           path: {{ .hostPath }}
           {{- end }}
+          defaultMode: {{ .defaultMode | default 644 }}
       {{- end }}
       {{- if .Values.django.mediaPersistentVolume.enabled }}
       - name: {{ .Values.django.mediaPersistentVolume.name }}


### PR DESCRIPTION
.Values.django.extraVolumes is useful to pass aritrary files from K8s to
DefectDojo containers. However, it does not have customizable
"defaultMode" parameter. This makes file permissions having default
value which in some cases (i.e. private key) can be considered as
insecure.

This commit adds .Values.django.extraVolumes.defaultMode parameter with
default mode set to 0644 (this should be suitable for most needs).