### PR TITLE
Adding Closed Notes to Jira

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -448,6 +448,7 @@ def close_finding(request, fid):
 
                 # only push to JIRA if there is an issue, to prevent a new one from being created
                 if jira_helper.is_push_all_issues(finding) and finding.has_jira_issue:
+                    jira_helper.add_comment(finding, new_note, force_push=True)
                     finding.save(push_to_jira=True)
                 else:
                     finding.save()


### PR DESCRIPTION
current condition : All notes that we sent through the finding detail are sent to jira. But, the closed notes we sent when we close the finding is not sent to jira even if that notes are saved to the finding notes in the finding detail page.
proposed changes : sent the close finding notes to jira also