### PR TITLE
tools: NeuVector: introducing NeuVector (REST) scan type

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1199,6 +1199,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'docker-bench-security Scan': ['unique_id_from_tool'],
     'Veracode SourceClear Scan': ['title', 'vulnerability_ids', 'component_name', 'component_version'],
     'Twistlock Image Scan': ['title', 'severity', 'component_name', 'component_version'],
+    'NeuVector (REST)': ['title', 'severity', 'component_name', 'component_version'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
@@ -1355,6 +1356,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'BlackDuck API': DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     'docker-bench-security Scan': DEDUPE_ALGO_HASH_CODE,
     'Twistlock Image Scan': DEDUPE_ALGO_HASH_CODE,
+    'NeuVector (REST)': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')

--- a/dojo/tools/neuvector/parser.py
+++ b/dojo/tools/neuvector/parser.py
@@ -1,0 +1,117 @@
+import json
+import logging
+
+from dojo.models import Finding
+
+logger = logging.getLogger(__name__)
+
+NEUVECTOR_SCAN_NAME = 'NeuVector (REST)'
+NEUVECTOR_IMAGE_SCAN_ENGAGEMENT_NAME = 'NV image scan'
+NEUVECTOR_CONTAINER_SCAN_ENGAGEMENT_NAME = 'NV container scan'
+
+
+class NeuVectorJsonParser(object):
+    def parse(self, json_output, test):
+        tree = self.parse_json(json_output)
+        items = []
+        if tree:
+            items = [data for data in self.get_items(tree, test)]
+        return items
+
+    def parse_json(self, json_output):
+        try:
+            data = json_output.read()
+            try:
+                tree = json.loads(str(data, 'utf-8'))
+            except:
+                tree = json.loads(data)
+        except:
+            raise Exception("Invalid format")
+
+        return tree
+
+    def get_items(self, tree, test):
+        items = {}
+        if 'report' in tree:
+            vulnerabilityTree = tree.get('report').get('vulnerabilities', [])
+            for node in vulnerabilityTree:
+                item = get_item(node, test)
+                package_name = node.get('package_name')
+                if len(package_name) > 64:
+                    package_name = package_name[-64:]
+                unique_key = node.get('name') + str(package_name + str(
+                    node.get('package_version')) + str(node.get('severity')))
+                items[unique_key] = item
+        return list(items.values())
+
+
+def get_item(vulnerability, test):
+    severity = convert_severity(vulnerability.get('severity')) if 'severity' in vulnerability else "Info"
+    vector = vulnerability.get('vectors_v3') if 'vectors_v3' in vulnerability else "CVSSv3 vector not provided. "
+    fixed_version = vulnerability.get('fixed_version') if 'fixed_version' in vulnerability else "There seems to be no fix yet. Please check description field."
+    score_v3 = vulnerability.get('score_v3') if 'score_v3' in vulnerability else "No CVSSv3 score yet."
+    package_name = vulnerability.get('package_name')
+    if len(package_name) > 64:
+        package_name = package_name[-64:]
+    description = vulnerability.get('description') if 'description' in vulnerability else ""
+    link = vulnerability.get('link') if 'link' in vulnerability else ""
+
+    # create the finding object
+    finding = Finding(
+        title=vulnerability.get('name') + ": " + package_name + " - " + vulnerability.get('package_version'),
+        test=test,
+        severity=severity,
+        description=description + "<p> Vulnerable Package: " +
+        package_name + "</p><p> Current Version: " + str(
+            vulnerability['package_version']) + "</p>",
+        mitigation=fixed_version.title(),
+        references=link,
+        component_name=package_name,
+        component_version=vulnerability.get('package_version'),
+        false_p=False,
+        duplicate=False,
+        out_of_scope=False,
+        mitigated=None,
+        severity_justification="{} (CVSS v3 base score: {})\n".format(vector, score_v3),
+        impact=severity)
+    finding.unsaved_vulnerability_ids = [vulnerability.get('name')]
+    finding.description = finding.description.strip()
+
+    return finding
+
+
+# see neuvector/share/types.go
+def convert_severity(severity):
+    if severity.lower() == 'critical':
+        return "Critical"
+    elif severity.lower() == 'high':
+        return "High"
+    elif severity.lower() == 'medium':
+        return "Medium"
+    elif severity.lower() == 'low':
+        return "Low"
+    elif severity == '':
+        return "Info"
+    else:
+        return severity.title()
+
+
+class NeuVectorParser(object):
+
+    def get_scan_types(self):
+        return [NEUVECTOR_SCAN_NAME]
+
+    def get_label_for_scan_types(self, scan_type):
+        return NEUVECTOR_SCAN_NAME
+
+    def get_description_for_scan_types(self, scan_type):
+        return "JSON output of /v1/scan/{entity}/{id} endpoint."
+
+    def get_findings(self, filename, test):
+        if filename is None:
+            return list()
+
+        if filename.name.lower().endswith('.json'):
+            return NeuVectorJsonParser().parse(filename, test)
+        else:
+            raise Exception('Unknown File Format')

--- a/unittests/scans/neuvector/many_vulns.json
+++ b/unittests/scans/neuvector/many_vulns.json
@@ -1,0 +1,110 @@
+{
+    "report": {
+        "vulnerabilities": [
+            {
+            "name": "CVE-2015-8356",
+            "score": 7.2,
+            "severity": "High",
+            "vectors": "",
+            "description": "The setup_env function in group.c in sshd in OpenSSH allows local users to gain privileges.",
+            "package_name": "openssh",
+            "package_version": "7.2_p2-r0",
+            "fixed_version": "1:7.2p2-3",
+            "link": "https://security-tracker.debian.org/tracker/CVE-2015-8356",
+            "score_v3": 7.3,
+            "vectors_v3": "",
+            "published_timestamp": 1516561260,
+            "last_modified_timestamp": 1516561253,
+            "cpes": [
+                ""
+            ],
+            "cves": [
+                ""
+            ],
+            "feed_rating": "",
+            "in_base_image": true,
+            "tags": [
+                ""
+            ]
+        },{
+            "name": "CVE-2017-18342",
+            "score": 7.5,
+            "severity": "High",
+            "vectors": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+            "description": "STATEMENT: PyYAML in channels for Red Hat MRG Messaging 2 should no longer be used, as a newer version is now available in Red Hat Enterprise Linux. Newer packages should be consumed from Red Hat Enterprise Linux channels. This issue affects the versions of the PyYAML package as shipped with Red Hat Satellite 5. However, this flaw is not known to be exploitable under any supported scenario in Satellite 5. A future update may address this issue. The PyYAML libary that is provided in the Red Hat OpenStack repositories is vulnerable. However, there are no instances where this library is used in a way which exposes the vulnerability. Any updates will be through the RHEL channels.",
+            "package_name": "PyYAML",
+            "package_version": "3.10-11.el7",
+            "link": "https://access.redhat.com/security/cve/CVE-2017-18342",
+            "score_v3": 9.8,
+            "vectors_v3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "published_timestamp": 1638748800,
+            "last_modified_timestamp": 1638748800,
+            "feed_rating": "Moderate"
+        }
+        ],
+        "modules": [
+            {
+            "name": "scanner",
+            "version": "1.011",
+            "source": "github",
+            "cves": [
+                {
+                "name": "",
+                "status": ""
+            }
+            ],
+            "cpes": [
+                ""
+            ]
+        }
+        ],
+        "checks": [
+            {
+            "catalog": "docker",
+            "type": "",
+            "level": "INFO",
+            "test_number": "1",
+            "profile": "Level 1",
+            "scored": true,
+            "automated": true,
+            "description": "General Configuration",
+            "message": [
+                "Host Configuration"
+            ],
+            "remediation": "",
+            "group": "nv.calico"
+        }
+        ],
+        "secrets": [
+            {
+            "type": "",
+            "evidence": "",
+            "path": "",
+            "suggestion": ""
+        }
+        ],
+        "setid_perms": [
+            {
+            "type": "",
+            "evidence": "",
+            "path": ""
+        }
+        ],
+        "envs": [
+            [
+            "PATH=/usr/local/sbin",
+            "GOSU_VERSION=1.12",
+            "REDIS_VERSION=6.0.2"
+        ]
+        ],
+        "labels": {
+            "key": [
+                ""
+            ],
+            "value": ""
+        },
+        "cmds": [
+            ""
+        ]
+    }
+}

--- a/unittests/scans/neuvector/no_vuln.json
+++ b/unittests/scans/neuvector/no_vuln.json
@@ -1,0 +1,70 @@
+{
+  "report": {
+    "vulnerabilities": [
+    ],
+    "modules": [
+      {
+        "name": "scanner",
+        "version": "1.011",
+        "source": "github",
+        "cves": [
+          {
+            "name": "",
+            "status": ""
+          }
+        ],
+        "cpes": [
+          ""
+        ]
+      }
+    ],
+    "checks": [
+      {
+        "catalog": "docker",
+        "type": "",
+        "level": "INFO",
+        "test_number": "1",
+        "profile": "Level 1",
+        "scored": true,
+        "automated": true,
+        "description": "General Configuration",
+        "message": [
+          "Host Configuration"
+        ],
+        "remediation": "",
+        "group": "nv.calico"
+      }
+    ],
+    "secrets": [
+      {
+        "type": "",
+        "evidence": "",
+        "path": "",
+        "suggestion": ""
+      }
+    ],
+    "setid_perms": [
+      {
+        "type": "",
+        "evidence": "",
+        "path": ""
+      }
+    ],
+    "envs": [
+      [
+        "PATH=/usr/local/sbin",
+        "GOSU_VERSION=1.12",
+        "REDIS_VERSION=6.0.2"
+      ]
+    ],
+    "labels": {
+      "key": [
+        ""
+      ],
+      "value": ""
+    },
+    "cmds": [
+      ""
+    ]
+  }
+}

--- a/unittests/scans/neuvector/one_vuln.json
+++ b/unittests/scans/neuvector/one_vuln.json
@@ -1,0 +1,96 @@
+{
+  "report": {
+    "vulnerabilities": [
+      {
+        "name": "CVE-2015-8356",
+        "score": 7.2,
+        "severity": "High",
+        "vectors": "",
+        "description": "The setup_env function in group.c in sshd in OpenSSH allows local users to gain privileges.",
+        "package_name": "openssh",
+        "package_version": "7.2_p2-r0",
+        "fixed_version": "1:7.2p2-3",
+        "link": "https://security-tracker.debian.org/tracker/CVE-2015-8356",
+        "score_v3": 7.3,
+        "vectors_v3": "",
+        "published_timestamp": 1516561260,
+        "last_modified_timestamp": 1516561253,
+        "cpes": [
+          ""
+        ],
+        "cves": [
+          ""
+        ],
+        "feed_rating": "",
+        "in_base_image": true,
+        "tags": [
+          ""
+        ]
+      }
+    ],
+    "modules": [
+      {
+        "name": "scanner",
+        "version": "1.011",
+        "source": "github",
+        "cves": [
+          {
+            "name": "",
+            "status": ""
+          }
+        ],
+        "cpes": [
+          ""
+        ]
+      }
+    ],
+    "checks": [
+      {
+        "catalog": "docker",
+        "type": "",
+        "level": "INFO",
+        "test_number": "1",
+        "profile": "Level 1",
+        "scored": true,
+        "automated": true,
+        "description": "General Configuration",
+        "message": [
+          "Host Configuration"
+        ],
+        "remediation": "",
+        "group": "nv.calico"
+      }
+    ],
+    "secrets": [
+      {
+        "type": "",
+        "evidence": "",
+        "path": "",
+        "suggestion": ""
+      }
+    ],
+    "setid_perms": [
+      {
+        "type": "",
+        "evidence": "",
+        "path": ""
+      }
+    ],
+    "envs": [
+      [
+        "PATH=/usr/local/sbin",
+        "GOSU_VERSION=1.12",
+        "REDIS_VERSION=6.0.2"
+      ]
+    ],
+    "labels": {
+      "key": [
+        ""
+      ],
+      "value": ""
+    },
+    "cmds": [
+      ""
+    ]
+  }
+}

--- a/unittests/tools/test_neuvector_parser.py
+++ b/unittests/tools/test_neuvector_parser.py
@@ -1,0 +1,29 @@
+from os import path
+from ..dojo_test_case import DojoTestCase
+from dojo.models import Test
+from dojo.tools.neuvector.parser import NeuVectorParser
+
+
+class TestNeuVectorParser(DojoTestCase):
+    def test_parse_file_with_no_vuln(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/neuvector/no_vuln.json"))
+        parser = NeuVectorParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(0, len(findings))
+
+    def test_parse_file_with_one_vuln(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/neuvector/one_vuln.json"))
+        parser = NeuVectorParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(findings))
+        self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2015-8356", findings[0].unsaved_vulnerability_ids[0])
+
+    def test_parse_file_with_many_vulns(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/neuvector/many_vulns.json"))
+        parser = NeuVectorParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(2, len(findings))


### PR DESCRIPTION
This commit adds the support of NeuVector
(https://github.com/neuvector/neuvector) tool for importing scan results. Scan results can be exported via REST API in JSON format (that is why the tool is named 'NeuVector (REST)'). There is no GUI for that at the moment.

Scan results are just a list of issues found in packages installed in a container or an image. Very similar to Twistlock.

NeuVector also provides compliance scan results. This is not supported by the introduced tool.