### PR TITLE
fix(helm): fix postgresql svc name

### DIFF
--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -38,7 +38,11 @@ Create chart name and version as used by the chart label.
 {{- define "postgresql.hostname" -}}
 {{- if eq .Values.database "postgresql" -}}
 {{- if .Values.postgresql.enabled -}}
+{{- if eq .Values.postgresql.architecture "replication" -}}
+{{- printf "%s-%s-%s" .Release.Name "postgresql" .Values.postgresql.primary.name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- else -}}
 {{- printf "%s" .Values.postgresql.postgresServer -}}
 {{- end -}}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -328,6 +328,7 @@ postgresql:
       replicationPasswordKey: postgresql-replication-password
   architecture: standalone
   primary:
+    name: primary
     persistence:
       enabled: true
     service:


### PR DESCRIPTION
## What

Fix PostgreSQL service name in the Helm chart

## Background

When `postgresql.architecture` is `replication`, 2 services with suffixes are created
- `${release-name}-postgresql-primary`
- `${release-name}-postgresql-read`

*Those suffixes are also customizable via `primary.name` and `readReplicas.name`, but the default values are `-primay` and `-read`.

However, the current chart always tries to use `${release-name}-postgresql` regardless of `postgresql.architecture`