### PR TITLE
Update the text that slack notification shows

### DIFF
--- a/dojo/templates/notifications/test_added.tpl
+++ b/dojo/templates/notifications/test_added.tpl
@@ -41,7 +41,7 @@
 {% elif type == 'alert' %}
     New test added for engagement {{ engagement.product }}: {{ test.test_type }}.
 {% elif type == 'slack' %}
-    New test added for engagement {{engagement.name }} in product {{ engagement.produc}}.
+    New test added for engagement {{engagement.name }} in product {{ engagement.product}}.
     Title: {{test.title}}
     Type: {{ test.test_type }}
     You can find details here: {{ url|full_url }}

--- a/dojo/templates/notifications/test_added.tpl
+++ b/dojo/templates/notifications/test_added.tpl
@@ -41,7 +41,7 @@
 {% elif type == 'alert' %}
     New test added for engagement {{ engagement.product }}: {{ test.test_type }}.
 {% elif type == 'slack' %}
-    New test added for engagement {{ engagement.product }}.
+    New test added for engagement {{engagement.name }} in product {{ engagement.produc}}.
     Title: {{test.title}}
     Type: {{ test.test_type }}
     You can find details here: {{ url|full_url }}


### PR DESCRIPTION
Currently, when a test is added and slack notification is enable is showed: "New test added for engagement {engament.product}" 
I suggest adding the engament name to this phrase: " New test added for engagement {{engagement.name }} in product {{ engagement.produc}}"