### PR TITLE
Fix groups handling when non native auth is used

### DIFF
--- a/dojo/group/utils.py
+++ b/dojo/group/utils.py
@@ -26,11 +26,19 @@ def group_post_save_handler(sender, **kwargs):
     created = kwargs.pop('created')
     group = kwargs.pop('instance')
     if created:
+        # will also be called when "auth_group" is created by underlying
+        # authentication method (see the slot below). at this moment
+        # "auth_group" is not ready yet on database level, but is already set
+        # as a class member.
+        if group.auth_group is not None:
+            return
+
         # Create authentication group
         auth_group = Group(name=get_auth_group_name(group))
         auth_group.save()
         group.auth_group = auth_group
         group.save()
+
         user = get_current_user()
         if user and not(settings.AZUREAD_TENANT_OAUTH2_GET_GROUPS):
             # Add the current user as the owner of the group
@@ -40,7 +48,28 @@ def group_post_save_handler(sender, **kwargs):
             member.role = Role.objects.get(is_owner=True)
             member.save()
             # Add user to authentication group as well
-            auth_group.user_set.add(user)
+            group.auth_group.user_set.add(user)
+    else:
+        # rename auth_group if necessary
+        if group.auth_group:
+            group.auth_group.name = group.name
+            group.auth_group.save()
+
+
+# will be called when underlying authentication model creates a group or it is
+# created manually in the slot above
+@receiver(post_save, sender=Group)
+def auth_group_post_save_handler(sender, **kwargs):
+    created = kwargs.pop('created')
+    group = kwargs.pop('instance')
+    if created:
+        # at this moment we may have the corresponding Dojo_Group instance if
+        # auth_group was created in the slot above. otherwize, there is no
+        # Dojo_Group yet and we need to create one.
+        try:
+            Dojo_Group.objects.get(name=group.name)
+        except:
+            Dojo_Group.objects.create(name=group.name, auth_group=group)
 
 
 @receiver(post_delete, sender=Dojo_Group)
@@ -49,6 +78,20 @@ def group_post_delete_handler(sender, **kwargs):
     # Authorization group doesn't get deleted automatically
     if group.auth_group:
         group.auth_group.delete()
+
+
+@receiver(post_delete, sender=Group)
+def auth_group_post_delete_handler(sender, **kwargs):
+    group = kwargs.pop('instance')
+    # DefectDojo group doesn't get deleted automatically when underlying group
+    # is deleted. we need to avoid post_delete recursion.
+    try:
+        dgroup = Dojo_Group.objects.get(name=group.name)
+        dgroup.auth_group = None
+        dgroup.save()
+        dgroup.delete()
+    except:
+        pass
 
 
 @receiver(post_save, sender=Dojo_Group_Member)

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -27,7 +27,7 @@ import calendar as tcalendar
 from dojo.github import add_external_issue_github, update_external_issue_github, close_external_issue_github, reopen_external_issue_github
 from dojo.models import Finding, Engagement, Finding_Group, Finding_Template, Product, \
     Dojo_User, Test, User, System_Settings, Notifications, Endpoint, Benchmark_Type, \
-    Language_Type, Languages, Rule, Dojo_Group_Member, NOTIFICATION_CHOICES
+    Language_Type, Languages, Rule, Dojo_Group_Member, Dojo_Group, NOTIFICATION_CHOICES
 from asteval import Interpreter
 from dojo.notifications.helper import create_notification
 import logging
@@ -1736,6 +1736,63 @@ def user_post_save(sender, instance, created, **kwargs):
     if instance.is_superuser and not instance.is_staff:
         instance.is_staff = True
         instance.save()
+
+
+# called when underlying authentication backend alters a User, we handle only
+# the case when user is NOT created. the purpose of this slot is to update Dojo
+# native user group membership from membership managed by underlying
+# authentication backend.
+@receiver(post_save, sender=User)
+def user_post_save_auth_backend(sender, instance, created, **kwargs):
+    if not created:
+        # do not do anything if the user does not belong to any groups
+        backend_groups = instance.groups.all()
+        if backend_groups.count() == 0:
+            return
+        # refreshing user's group membership: keeping only those Dojo groups
+        # which correspond to internal groups. as Dojo_Group and Group are
+        # different classes we can't easily compare lists. thus, the code below
+        # is quite ugly.
+        dojo_user = Dojo_User.objects.get(username=instance.username)
+        existing_membership = Dojo_Group_Member.objects.filter(user=dojo_user)
+        for em in existing_membership:
+            delete_membership = True
+            for bg in backend_groups:
+                if em.group.name == bg.name:
+                    delete_membership = False
+                    break
+            if delete_membership:
+                em.delete()
+
+        updated_membership = Dojo_Group_Member.objects.filter(user=dojo_user)
+
+        # need this to set default role
+        system_settings = System_Settings.objects.get()
+        for bg in backend_groups:
+            add_membership = True
+            for um in updated_membership:
+                if um.group.name == bg.name:
+                    add_membership = False
+                    break
+
+            if not add_membership:
+                continue
+
+            # if Dojo group that corresponds to backend authentication group
+            # does not exist yet, it is an issue, but we have to escape from it
+            # in a safe way, so we just do not add user to the group without
+            # throwing 500 error.
+            try:
+                dojo_group = Dojo_Group.objects.get(name=bg.name)
+                gm = None
+                if system_settings.default_group_role:
+                    gm = Dojo_Group_Member(group=dojo_group, user=dojo_user,
+                                           role=system_settings.default_group_role)
+                else:
+                    gm = Dojo_Group_Member(group=dojo_group, user=dojo_user)
+                gm.save()
+            except:
+                pass
 
 
 @receiver(post_save, sender=Engagement)


### PR DESCRIPTION
These commits is the attempt to resolve groups handling when underlying authentication backend manages them ahead of DefectDojo.
Such case can appear when LDAP authentication is used with AUTH_LDAP_MIRROR_GROUPS set to True.
