### PR TITLE
[Helm] Fix flawed logic in deployment env vars

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -103,24 +103,24 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
-            key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
+              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
+              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-            name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
-            key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+              name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
-              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
+                name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
+                key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
               {{- else if eq .Values.database "postgresqlha" }}
-              name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
-              key: postgresql-postgres-password
+                name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
+                key: postgresql-postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
-              key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
+                name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
+                key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -103,34 +103,24 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            {{- if .Values.rabbitmq.enabled }}
-              name: defectdojo-{{ .Values.celery.broker }}-specific
-              key: {{ .Values.celery.broker }}-password
-            {{- else }}
-              name: {{ .Values.rabbitmq.existingPasswordSecret }}
-              key: {{ .Values.rabbitmq.secretPasswordKey }}  
-            {{- end }}            
+              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
+              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-            {{- if .Values.redis.enabled }}
-              name: defectdojo-{{ .Values.celery.broker }}-specific
-              key: {{ .Values.celery.broker }}-password
-            {{- else }}
-              name: {{ .Values.redis.auth.existingSecret }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
-            {{- end }}  
+              name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.auth.existingSecret }}
-              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+              name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
+              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
               {{- else if eq .Values.database "postgresqlha" }}
-              name: {{ .Values.postgresqlha.postgresql.existingSecret }}
+              name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
               key: postgresql-postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.auth.existingSecret }}
-              key: {{ .Values.mysql.auth.secretKey }}
+              name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
+              key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -103,11 +103,11 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
-              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
+            name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
+            key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-              name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+            name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
+            key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -98,24 +98,24 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific"}}
-            key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
+              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific"}}
+              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-            name: {{ .Values.redis.auth.existingSecret| default "defectdojo-redis-specific" }}
-            key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+              name: {{ .Values.redis.auth.existingSecret| default "defectdojo-redis-specific" }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
-              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
+                name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
+                key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
               {{- else if eq .Values.database "postgresqlha" }}
-              name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
-              key: postgresql-postgres-password
+                name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
+                key: postgresql-postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
-              key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
+                name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
+                key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -98,11 +98,11 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific"}}
-              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
+            name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific"}}
+            key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-              name: {{ .Values.redis.auth.existingSecret| default "defectdojo-redis-specific" }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+            name: {{ .Values.redis.auth.existingSecret| default "defectdojo-redis-specific" }}
+            key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -98,34 +98,24 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            {{- if .Values.rabbitmq.enabled}}
-              name: defectdojo-{{ .Values.celery.broker }}-specific
-              key: {{ .Values.celery.broker }}-password
-            {{- else }}
-              name: {{ .Values.rabbitmq.existingPasswordSecret }}
-              key: {{ .Values.rabbitmq.secretPasswordKey }}  
-            {{- end }}            
+              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific"}}
+              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-            {{- if .Values.redis.enabled }}
-              name: defectdojo-{{ .Values.celery.broker }}-specific
-              key: {{ .Values.celery.broker }}-password
-            {{- else }}
-              name: {{ .Values.redis.auth.existingSecret }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
-            {{- end }}  
+              name: {{ .Values.redis.auth.existingSecret| default "defectdojo-redis-specific" }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.auth.existingSecret }}
-              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+              name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
+              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
               {{- else if eq .Values.database "postgresqlha" }}
-              name: {{ .Values.postgresqlha.postgresql.existingSecret }}
+              name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
               key: postgresql-postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.auth.existingSecret }}
-              key: {{ .Values.mysql.auth.secretKey }}
+              name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
+              key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -157,11 +157,11 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
-            key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
+              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
+              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-            name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
-            key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+              name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         {{- if .Values.django.uwsgi.enable_debug }}
         - name: DD_DEBUG
@@ -171,14 +171,14 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
-              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
+                name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
+                key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
               {{- else if eq .Values.database "postgresqlha" }}
-              name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
-              key: postgresql-postgres-password
+                name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
+                key: postgresql-postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
-              key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
+                name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
+                key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -157,21 +157,11 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-            {{- if .Values.rabbitmq.enabled }}
-              name: defectdojo-{{ .Values.celery.broker }}-specific
-              key: {{ .Values.celery.broker }}-password
-            {{- else }}
-              name: {{ .Values.rabbitmq.existingPasswordSecret }}
-              key: {{ .Values.rabbitmq.secretPasswordKey }}  
-            {{- end }}            
+              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
+              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-            {{- if .Values.redis.enabled }}
-              name: defectdojo-{{ .Values.celery.broker }}-specific
-              key: {{ .Values.celery.broker }}-password
-            {{- else }}
-              name: {{ .Values.redis.auth.existingSecret }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey }}
-            {{- end }}  
+              name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
+              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         {{- if .Values.django.uwsgi.enable_debug }}
         - name: DD_DEBUG
@@ -181,14 +171,14 @@ spec:
           valueFrom:
             secretKeyRef:
               {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.auth.existingSecret }}
-              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+              name: {{ .Values.postgresql.auth.existingSecret | default "defectdojo-postgresql-specific" }}
+              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey | default "postgresql-password" }}
               {{- else if eq .Values.database "postgresqlha" }}
-              name: {{ .Values.postgresqlha.postgresql.existingSecret }}
+              name: {{ .Values.postgresqlha.postgresql.existingSecret | default "defectdojo-postgresql-ha-specific" }}
               key: postgresql-postgres-password
               {{- else if eq .Values.database "mysql" }}
-              name: {{ .Values.mysql.auth.existingSecret }}
-              key: {{ .Values.mysql.auth.secretKey }}
+              name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
+              key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -157,11 +157,11 @@ spec:
           valueFrom:
             secretKeyRef:
             {{- if eq .Values.celery.broker "rabbitmq" }}
-              name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
-              key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
+            name: {{ .Values.rabbitmq.auth.existingPasswordSecret | default "defectdojo-rabbitmq-specific" }}
+            key: {{ .Values.rabbitmq.auth.secretPasswordKey | default "rabbitmq-password" }}  
             {{- else if eq .Values.celery.broker "redis" }}
-              name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
-              key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
+            name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
+            key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
         {{- if .Values.django.uwsgi.enable_debug }}
         - name: DD_DEBUG


### PR DESCRIPTION
PR #6149 only fixed the keys for redis but not for rabbitmq. This PR fixes this problem and additionally removed unnecessary ifs, which was already discussed in #6054.