### PR TITLE
Fix accepted by name

### DIFF
--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -414,7 +414,7 @@
                                                     </ul>
                                                 </td>
                                                 <td><a href="{% url 'view_risk_acceptance' eng.id risk_acceptance.id %}">{{ risk_acceptance.created|date }}</a></td>
-                                                <td>{{ risk_acceptance.accepted_by.get_full_name }}</td>
+                                                <td>{{ risk_acceptance.accepted_by }}</td>
                                                 <td><a href="{% url 'view_risk_acceptance' eng.id risk_acceptance.id %}">{{ risk_acceptance.name }}</a></td>
                                                 <td>
                                                     {{ risk_acceptance.get_decision_display|default_if_none:"" }}

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -93,7 +93,7 @@
                     </tr>
                     <tr>
                         <td>{{ risk_acceptance.created|date }}</td>
-                        <td>{{ risk_acceptance.accepted_by.get_full_name }}</td>
+                        <td>{{ risk_acceptance.accepted_by }}</td>
                         <td>{{ risk_acceptance.name }}</td>
                         <td>{{ risk_acceptance.get_decision_display|default_if_none:"" }}</td>
                         <!-- <td>{{ risk_acceptance.decision_details|default_if_none:""| truncatechars_html:100 }}</td> -->


### PR DESCRIPTION
Removed get_full_name from accepted_by in two templates, as accepted_by doesn't get set to a user, it's free text entry. Prior to this fix, "Accepted By" value was blank on these two pages.