### PR TITLE
Fix improper reactivation in reimporter, using is_mitigated

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -99,7 +99,7 @@ class DojoDefaultReImporter(object):
                         else:
                             # even if there is no mitigation time, skip it, because both the current finding and the reimported finding are is_mitigated
                             continue
-                    if not item.is_mitigated:
+                    else:
                         logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                         finding.mitigated = None
                         finding.is_mitigated = False

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -84,17 +84,22 @@ class DojoDefaultReImporter(object):
                 if finding.false_p or finding.out_of_scope or finding.risk_accepted:
                     logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
                 elif finding.is_mitigated:
-                    if item.mitigated:
-                        logger.debug("item mitigated time: " + str(item.mitigated.timestamp()))
-                        logger.debug("finding mitigated time: " + str(finding.mitigated.timestamp()))
-                        if item.mitigated.timestamp() == finding.mitigated.timestamp():
-                            logger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")
+                    # if the reimported item has a mitigation time, we can compare
+                    if item.is_mitigated:
+                        if item.mitigated:
+                            logger.debug("item mitigated time: " + str(item.mitigated.timestamp()))
+                            logger.debug("finding mitigated time: " + str(finding.mitigated.timestamp()))
+                            if item.mitigated.timestamp() == finding.mitigated.timestamp():
+                                logger.debug("New imported finding and already existing finding have the same mitigation date, will skip as they are the same.")
+                                continue
+                            if item.mitigated.timestamp() != finding.mitigated.timestamp():
+                                logger.debug("New imported finding and already existing finding are both mitigated but have different dates, not taking action")
+                                # TODO: implement proper date-aware reimporting mechanism, if an imported finding is closed more recently than the defectdojo finding, then there might be details in the scanner that should be added
+                                continue
+                        else:
+                            # even if there is no mitigation time, skip it, because both the current finding and the reimported finding are is_mitigated
                             continue
-                        if item.mitigated.timestamp() != finding.mitigated.timestamp():
-                            logger.debug("New imported finding and already existing finding are both mitigated but have different dates, not taking action")
-                            # TODO: implement proper date-aware reimporting mechanism, if an imported finding is closed more recently than the defectdojo finding, then there might be details in the scanner that should be added
-                            continue
-                    if not item.mitigated:
+                    if not item.is_mitigated:
                         logger.debug('%i: reactivating: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                         finding.mitigated = None
                         finding.is_mitigated = False
@@ -139,7 +144,8 @@ class DojoDefaultReImporter(object):
                     logger.debug('%i: updating existing finding: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                     if not (finding.mitigated and finding.is_mitigated):
                         logger.debug('Reimported item matches a finding that is currently open.')
-                        if item.mitigated:
+                        if item.is_mitigated:
+                            logger.debug('Reimported mitigated item matches a finding that is currently open, closing.')
                             # TODO: Implement a date comparison for opened defectdojo findings before closing them by reimporting, as they could be force closed by the scanner but a DD user forces it open ?
                             logger.debug('%i: closing: %i:%s:%s:%s', i, finding.id, finding, finding.component_name, finding.component_version)
                             finding.mitigated = item.mitigated


### PR DESCRIPTION
Due to incomplete fix in https://github.com/DefectDojo/django-DefectDojo/pull/6452
Explainer:
The initial fix was too narrow in its decision/conditions, only looking at items/findings that had a `mitigated` timestamp.
Instead, `is_mitigated` should be used, to simply check if the incoming item is already mitigated or not, and if the existing finding is mitigated or not. I have left the timestamp comparison IF it exists on the item.