### PR TITLE
Fix url creation for github for file location

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2797,7 +2797,13 @@ class Finding(models.Model):
             return None
         if self.test.engagement.source_code_management_uri is None:
             return escape(self.file_path)
-        link = self.test.engagement.source_code_management_uri + '/' + self.file_path
+        if "https://github.com/" in self.test.engagement.source_code_management_uri:
+            if self.test.engagement.commit_hash is not None:
+                link = self.test.engagement.source_code_management_uri + '/blob/' + self.test.engagement.commit_hash + '/' + self.file_path
+            elif self.test.engagement.branch_tag is not None:
+                link = self.test.engagement.source_code_management_uri + '/blob/' + self.test.engagement.branch_tag + '/' + self.file_path
+        else:
+            link = self.test.engagement.source_code_management_uri + '/' + self.file_path
         if self.line:
             link = link + '#L' + str(self.line)
         return create_bleached_link(link, self.file_path)


### PR DESCRIPTION
The URL inside the file location (in Finding view) generated from Repo URL (in Engagement configuration) is only based on `source_code_management_uri` but scanning results come front different commit hash or branches that are provided by CI/CD platform. I added (only for GitHub) a way to generate the right URL for GitHub repositories gathering hash commit or branch from engagement config.