### PR TITLE
Fixing broken report generation when more than one item is selected

### DIFF
--- a/dojo/reports/widgets.py
+++ b/dojo/reports/widgets.py
@@ -402,7 +402,7 @@ def report_widget_factory(json_data=None, request=None, user=None, finding_notes
             d = QueryDict(mutable=True)
             for item in widget.get(list(widget.keys())[0]):
                 if item['name'] in d:
-                    d.getlist(item['name']).append(item['value'])
+                    d.appendlist(item['name'], item['value'])
                 else:
                     d[item['name']] = item['value']
             from dojo.endpoint.views import get_endpoint_ids
@@ -421,7 +421,7 @@ def report_widget_factory(json_data=None, request=None, user=None, finding_notes
             d = QueryDict(mutable=True)
             for item in widget.get(list(widget.keys())[0]):
                 if item['name'] in d:
-                    d.getlist(item['name']).append(item['value'])
+                    d.appendlist(item['name'], item['value'])
                 else:
                     d[item['name']] = item['value']
 


### PR DESCRIPTION
A fix for https://github.com/DefectDojo/django-DefectDojo/issues/6866

When multiple severities are selected, it only picks the first one. This is because it's appending to a list which doesn't modify the internal list.

Tested that the new report contains both high and critical severities when they are selected.