### PR TITLE
changed type to regular django type to also pick up creation events

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -26,7 +26,7 @@ from django.db.models.query import QuerySet
 import calendar as tcalendar
 from dojo.github import add_external_issue_github, update_external_issue_github, close_external_issue_github, reopen_external_issue_github
 from dojo.models import Finding, Engagement, Finding_Group, Finding_Template, Product, \
-    Dojo_User, Test, User, System_Settings, Notifications, Endpoint, Benchmark_Type, \
+    Test, User, System_Settings, Notifications, Endpoint, Benchmark_Type, \
     Language_Type, Languages, Rule, Dojo_Group_Member, NOTIFICATION_CHOICES
 from asteval import Interpreter
 from dojo.notifications.helper import create_notification

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1665,7 +1665,7 @@ def get_site_url():
         return "settings.SITE_URL"
 
 
-@receiver(post_save, sender=Dojo_User)
+@receiver(post_save, sender=User)
 def user_post_save(sender, instance, created, **kwargs):
     # For new users we create a Notifications object so the default 'alert' notifications work and
     # assign them to a default group if specified in the system settings.

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -26,7 +26,7 @@ from django.db.models.query import QuerySet
 import calendar as tcalendar
 from dojo.github import add_external_issue_github, update_external_issue_github, close_external_issue_github, reopen_external_issue_github
 from dojo.models import Finding, Engagement, Finding_Group, Finding_Template, Product, \
-    Test, User, System_Settings, Notifications, Endpoint, Benchmark_Type, \
+    Test, User, Dojo_User, System_Settings, Notifications, Endpoint, Benchmark_Type, \
     Language_Type, Languages, Rule, Dojo_Group_Member, NOTIFICATION_CHOICES
 from asteval import Interpreter
 from dojo.notifications.helper import create_notification
@@ -1666,6 +1666,7 @@ def get_site_url():
 
 
 @receiver(post_save, sender=User)
+@receiver(post_save, sender=Dojo_User)
 def user_post_save(sender, instance, created, **kwargs):
     # For new users we create a Notifications object so the default 'alert' notifications work and
     # assign them to a default group if specified in the system settings.

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1492,7 +1492,7 @@ class UsersTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {"first_name": "test changed", "configuration_permissions": [219, 220]}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
-        self.deleted_objects = 17
+        self.deleted_objects = 18
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_create_user_with_non_configuration_permissions(self):


### PR DESCRIPTION
changed the type of user_post_save to generic Django user so all users created (ldap, oauth, ui) will trigger this function. This should fix https://github.com/DefectDojo/django-DefectDojo/issues/6626

Created a new pull request based of the DEV branch, see the old pull request for previous comments: https://github.com/DefectDojo/django-DefectDojo/pull/6725 