### PR TITLE
SonarQube API Importer: Add sonarcloud global org id, code clean up

### DIFF
--- a/docs/content/en/integrations/parsers.md
+++ b/docs/content/en/integrations/parsers.md
@@ -1120,9 +1120,12 @@ Follow these steps to setup the SonarQube API import:
     Configuration / Tool Configuration. Note the url must be in the
     format of `https://<sonarqube_host>/api`. Select the tool
     type to be SonarQube. By default the tool will import vulnerabilities issues
-    and security hotspots only,
-    but additional filters can be setup using the Extras field separated by
-    commas (e.g. BUG,VULNERABILITY,CODE_SMELL)
+    and security hotspots only, but additional filters can be setup using the 
+    Extras field separated by commas (e.g. BUG,VULNERABILITY,CODE_SMELL). When using
+    SonarCloud, you must also specify the Organization ID in the Extras field as follows
+    `OrgID=sonarcloud-organzation-ID`. If also specifying issue type filters, please 
+    seperate the items in the Extras field by a vertical bar as follows
+    `BUG,VULNERABILITY,CODE_SMEL|OrgID=sonarcloud-organzation-ID`
 2.  In the Product settings add an API Scan Configuration. *Service key 1* must
     be the SonarQube project key, which can be found by navigating to a specific project and
     selecting the value from the url
@@ -1131,8 +1134,8 @@ Follow these steps to setup the SonarQube API import:
     use the name of the Product as the project key in SonarQube. If you would like to
     import findings from multiple projects, you can specify multiple keys as
     separated API Scan Configuration in the Product settings.
-3.  If using SonarCloud, you will need to supply your organization ID in the
-    the *Service key 2* input field. The functionality is the same after this step.
+3.  If using SonarCloud, the orginization ID can be used from step 1, but it 
+    can be ovverirdden by supplying a different orginization ID in the *Service key 2* input field.
 4.  Once all of the settings are made, the SonarQube API Import will be
     able to import all vulnerability information from the SonarQube
     instance. 

--- a/dojo/tools/sonarqube_api/api_client.py
+++ b/dojo/tools/sonarqube_api/api_client.py
@@ -8,7 +8,7 @@ class SonarQubeAPI:
 
     def __init__(self, tool_config=None):
 
-        self.rules_cache = dict()
+        self.rules_cache = {}
 
         tool_type, _ = Tool_Type.objects.get_or_create(name='SonarQube')
 
@@ -25,7 +25,33 @@ class SonarQubeAPI:
                     'More than one Tool Configuration for SonarQube exists. \n'
                     'Please specify at Product configuration which one should be used.'
                 )
-        self.extras = tool_config.extras
+
+        supported_issue_types = ["BUG", "VULNERABILITY", "CODE_SMELL"]
+        self.org_id = None
+        self.extras = None
+        # Parse the extras field to extract issue types and org id
+        # This case is when org id and  types are both supplied seperated by a vertical bar
+        if tool_config.extras and '|' in tool_config.extras:
+            split_extras = tool_config.extras.split('|')
+            # Iterate through the options as it is unknow which entry came first
+            for entry in split_extras:
+                if 'OrgID' in entry:
+                    self.org_id = entry.replace('OrgID=', '')
+                else:
+                    self.extras = entry
+        # The types must not be supplied, so assume it is only org id
+        elif tool_config.extras and 'OrgID' in tool_config.extras:
+            self.org_id = tool_config.extras.replace('OrgID=', '')
+        # Does not appear the org id is present, set the whole field as the types
+        else:
+            self.extras = tool_config.extras
+
+        # Validate the extras field to ensure only supported types are imported
+        split_issue_types = self.extras.split(',')
+        all_clean = all(entry in supported_issue_types for entry in split_issue_types)
+        if not all_clean:
+            raise Exception(f"Deteced unsupported issue type! Supported types are {', '.join(supported_issue_types)}")
+
         self.session = requests.Session()
         self.default_headers = {
             'User-Agent': 'DefectDojo'
@@ -36,7 +62,7 @@ class SonarQubeAPI:
         elif tool_config.authentication_type == "API":
             self.session.auth = (tool_config.api_key, '')
         else:
-            raise Exception('SonarQube Authentication type {} not supported'.format(tool_config.authentication_type))
+            raise Exception(f'SonarQube Authentication type {tool_config.authentication_type} not supported')
 
     def find_project(self, project_name, organization=None, branch=None):
         """
@@ -54,30 +80,26 @@ class SonarQubeAPI:
 
         if organization:
             parameters['organization'] = organization
+        elif self.org_id:
+            parameters['organization'] = self.org_id
 
         response = self.session.get(
-            url='{}/components/search'.format(self.sonar_api_url),
+            url=f'{self.sonar_api_url}/components/search',
             params=parameters,
             headers=self.default_headers,
         )
 
-        if response.ok:
-            for component in response.json().get('components', []):
-                if component['name'] == project_name:
-                    return component
-            raise Exception(
-                'Expected Project "{}", but it returned {}. \n'
-                'Project Name is case sensitive and must match the DefectDojo Product Name. \n'
-                'Alternatively it can also be specified the Project Key at Product configuration.'.format(
-                    project_name,
-                    [x.get('name') for x in response.json().get('components')]
-                )
-            )
+        if not response.ok:
+            raise Exception(f'Unable to find the project {project_name} due to {response.status_code} - {response.content.decode("utf-8")}')
 
-        else:
-            raise Exception("Unable to find the project {} due to {} - {}".format(
-                project_name, response.status_code, response.content.decode("utf-8")
-            ))
+        for component in response.json().get('components', []):
+            if component['name'] == project_name:
+                return component
+        raise Exception(f"""
+                'Expected Project "{project_name}", but it returned {[x.get('name') for x in response.json().get('components')]}. \n'
+                'Project Name is case sensitive and must match the DefectDojo Product Name. \n'
+                'Alternatively it can also be specified the Project Key at Product configuration.
+                """)
 
     def get_project(self, project_key, organization=None, branch=None):
         """
@@ -86,8 +108,6 @@ class SonarQubeAPI:
         :param project_key:
         :return:
         """
-        print('\n\n\t\tproject_key ::', project_key, type(project_key))
-        print('\n\n\t\torganization ::', organization, type(organization))
         parameters = {
             'component': project_key,
         }
@@ -97,19 +117,18 @@ class SonarQubeAPI:
 
         if organization:
             parameters['organization'] = organization
+        elif self.org_id:
+            parameters['organization'] = self.org_id
 
         response = self.session.get(
-            url='{}/components/show'.format(self.sonar_api_url),
+            url=f'{self.sonar_api_url}/components/show',
             params=parameters,
-            headers=self.default_headers,
-        )
+            headers=self.default_headers)
 
-        if response.ok:
-            return response.json().get('component')
-        else:
-            raise Exception("Unable to find the project {} due to {} - {}".format(
-                project_key, response.status_code, response.content.decode("utf-8")
-            ))
+        if not response.ok:
+            raise Exception(f'Unable to find the project {project_key} due to {response.status_code} - {response.content.decode("utf-8")}')
+
+        return response.json().get('component')
 
     def find_issues(self, component_key, types='VULNERABILITY', organization=None, branch=None):
         """
@@ -127,7 +146,7 @@ class SonarQubeAPI:
 
         page = 1
         max_page = 100
-        issues = list()
+        issues = []
 
         while page <= max_page:
             request_filter = {
@@ -141,26 +160,24 @@ class SonarQubeAPI:
 
             if organization:
                 request_filter['organization'] = organization
+            elif self.org_id:
+                request_filter['organization'] = self.org_id
 
             response = self.session.get(
-                url='{}/issues/search'.format(self.sonar_api_url),
+                url=f'{self.sonar_api_url}/issues/search',
                 params=request_filter,
                 headers=self.default_headers,
             )
 
-            if response.ok:
-                issues_page = response.json().get('issues')
-                if not issues_page:
-                    break
-                issues.extend(issues_page)
-                page += 1
+            if not response.ok:
+                raise Exception(f'Unable to find the issues for component {component_key} due to {response.status_code} - {response.content.decode("utf-8")}')
 
-            else:
-                raise Exception(
-                    "Unable to find the issues for component {} due to {} - {}".format(
-                        component_key, response.status_code, response.content.decode("utf-8")
-                    )
-                )
+
+            issues_page = response.json().get('issues')
+            if not issues_page:
+                break
+            issues.extend(issues_page)
+            page += 1
 
         return issues
 
@@ -172,7 +189,7 @@ class SonarQubeAPI:
         """
         page = 1
         max_page = 100
-        hotspots = list()
+        hotspots = []
 
         while page <= max_page:
             request_filter = {
@@ -185,26 +202,23 @@ class SonarQubeAPI:
 
             if organization:
                 request_filter['organization'] = organization
+            elif self.org_id:
+                request_filter['organization'] = self.org_id
 
             response = self.session.get(
-                url='{}/hotspots/search'.format(self.sonar_api_url),
+                url=f'{self.sonar_api_url}/hotspots/search',
                 params=request_filter,
                 headers=self.default_headers,
             )
 
-            if response.ok:
-                hotspots_page = response.json().get('hotspots')
-                if not hotspots_page:
-                    break
-                hotspots.extend(hotspots_page)
-                page += 1
+            if not response.ok:
+                raise Exception(f"Unable to find the hotspots for project {project_key} due to {response.status_code} - {response.content}")
 
-            else:
-                raise Exception(
-                    "Unable to find the hotspots for project {} due to {} - {}".format(
-                        project_key, response.status_code, response.content
-                    )
-                )
+            hotspots_page = response.json().get('hotspots')
+            if not hotspots_page:
+                break
+            hotspots.extend(hotspots_page)
+            page += 1
 
         return hotspots
 
@@ -221,30 +235,21 @@ class SonarQubeAPI:
             'issues': issue_key,
             'types': 'BUG,VULNERABILITY,CODE_SMELL'
         }
+
         response = self.session.get(
-            url='{}/issues/search'.format(self.sonar_api_url),
+            url=f'{self.sonar_api_url}/issues/search',
             params=request_filter,
             headers=self.default_headers,
         )
 
-        if response.ok:
-            issues = response.json().get('issues', [])
-            if issues:
-                for issue in response.json().get('issues', []):
-                    if issue['key'] == issue_key:
-                        return issue
-                raise Exception(
-                    'Expected Issue "{}", but it returned {}.'.format(
-                        issue_key,
-                        [x.get('key') for x in response.json().get('issues')]
-                    )
-                )
-        else:
-            raise Exception(
-                "Unable to get issue {} due to {} - {}".format(
-                    issue_key, response.status_code, response.content.decode("utf-8")
-                )
-            )
+        if not response.ok:
+            raise Exception(f'Unable to get issue {issue_key} due to {response.status_code} - {response.content.decode("utf-8")}')
+
+        issues = response.json().get('issues', [])
+        for issue in issues:
+            if issue['key'] == issue_key:
+                return issue
+        raise Exception(f"""Expected Issue "{issue_key}", but it returned {[x.get('key') for x in response.json().get('issues')]}.""")
 
     def get_rule(self, rule_id):
         """
@@ -255,17 +260,15 @@ class SonarQubeAPI:
         rule = self.rules_cache.get(rule_id)
         if not rule:
             response = self.session.get(
-                url='{}/rules/show'.format(self.sonar_api_url),
+                url=f'{self.sonar_api_url}/rules/show',
                 params={'key': rule_id},
                 headers=self.default_headers,
             )
-            if response.ok:
-                rule = response.json()['rule']
-                self.rules_cache.update({rule_id: rule})
-            else:
-                raise Exception("Unable to get the rule {} due to {} - {}".format(
-                    rule_id, response.status_code, response.content.decode("utf-8")
-                ))
+            if not response.ok:
+                raise Exception(f'Unable to get the rule {rule_id} due to {response.status_code} - {response.content.decode("utf-8")}')
+
+            rule = response.json()['rule']
+            self.rules_cache.update({rule_id: rule})
         return rule
 
     def get_hotspot_rule(self, rule_id):
@@ -277,17 +280,15 @@ class SonarQubeAPI:
         rule = self.rules_cache.get(rule_id)
         if not rule:
             response = self.session.get(
-                url='{}/hotspots/show'.format(self.sonar_api_url),
+                url=f'{self.sonar_api_url}/hotspots/show',
                 params={'hotspot': rule_id},
                 headers=self.default_headers,
             )
-            if response.ok:
-                rule = response.json()['rule']
-                self.rules_cache.update({rule_id: rule})
-            else:
-                raise Exception("Unable to get the hotspot rule {} due to {} - {}".format(
-                    rule_id, response.status_code, response.content
-                ))
+            if not response.ok:
+                raise Exception(f"Unable to get the hotspot rule {rule_id} due to {response.status_code} - {response.content}")
+
+            rule = response.json()['rule']
+            self.rules_cache.update({rule_id: rule})
         return rule
 
     def transition_issue(self, issue_key, transition):
@@ -318,19 +319,16 @@ class SonarQubeAPI:
         :return:
         """
         response = self.session.post(
-            url='{}/issues/do_transition'.format(self.sonar_api_url),
+            url=f'{self.sonar_api_url}/issues/do_transition',
             data={
                 'issue': issue_key,
                 'transition': transition
             },
             headers=self.default_headers,
         )
+
         if not response.ok:
-            raise Exception(
-                "Unable to transition {} the issue {} due to {} - {}".format(
-                    transition, issue_key, response.status_code, response.content.decode("utf-8")
-                )
-            )
+            raise Exception(f'Unable to transition {transition} the issue {issue_key} due to {response.status_code} - {response.content.decode("utf-8")}')
 
     def add_comment(self, issue_key, text):
         """
@@ -341,7 +339,7 @@ class SonarQubeAPI:
         :return:
         """
         response = self.session.post(
-            url='{}/issues/add_comment'.format(self.sonar_api_url),
+            url=f'{self.sonar_api_url}/issues/add_comment',
             data={
                 'issue': issue_key,
                 'text': text
@@ -349,32 +347,30 @@ class SonarQubeAPI:
             headers=self.default_headers,
         )
         if not response.ok:
-            raise Exception(
-                "Unable to add a comment into issue {} due to {} - {}".format(
-                    issue_key, response.status_code, response.content.decode("utf-8")
-                )
-            )
+            raise Exception(f'Unable to add a comment into issue {issue_key} due to {response.status_code} - {response.content.decode("utf-8")}')
 
     def test_connection(self):
         """
         Returns number of components (projects) or raise error.
         """
+        parameters = {
+            'qualifiers': 'TRK'
+        }
+
+        if self.org_id is not None:
+            parameters['organization'] = self.org_id
+
         response = self.session.get(
-            url='{}/components/search'.format(self.sonar_api_url),
-            params={
-                'qualifiers': 'TRK'
-            },
+            url=f'{self.sonar_api_url}/components/search',
+            params=parameters,
             headers=self.default_headers,
         )
 
-        if response.ok:
-            num_projects = response.json()['paging']['total']
-            return f'You have access to {num_projects} projects'
+        if not response.ok:
+            raise Exception(f'Unable to connect and search in SonarQube due to {response.status_code} - {response.content.decode("utf-8")}')
 
-        else:
-            raise Exception("Unable to connect and search in SonarQube due to {} - {}".format(
-                response.status_code, response.content.decode("utf-8")
-            ))
+        num_projects = response.json()['paging']['total']
+        return f'You have access to {num_projects} projects'
 
     def test_product_connection(self, api_scan_configuration):
         organization = api_scan_configuration.service_key_2 or None

--- a/dojo/tools/sonarqube_api/api_client.py
+++ b/dojo/tools/sonarqube_api/api_client.py
@@ -47,10 +47,11 @@ class SonarQubeAPI:
             self.extras = tool_config.extras
 
         # Validate the extras field to ensure only supported types are imported
-        split_issue_types = self.extras.split(',')
-        all_clean = all(entry in supported_issue_types for entry in split_issue_types)
-        if not all_clean:
-            raise Exception(f"Deteced unsupported issue type! Supported types are {', '.join(supported_issue_types)}")
+        if self.extras:
+            split_issue_types = self.extras.split(',')
+            all_clean = all(entry in supported_issue_types for entry in split_issue_types)
+            if not all_clean:
+                raise Exception(f"Deteced unsupported issue type! Supported types are {', '.join(supported_issue_types)}")
 
         self.session = requests.Session()
         self.default_headers = {

--- a/dojo/tools/sonarqube_api/api_client.py
+++ b/dojo/tools/sonarqube_api/api_client.py
@@ -172,7 +172,6 @@ class SonarQubeAPI:
             if not response.ok:
                 raise Exception(f'Unable to find the issues for component {component_key} due to {response.status_code} - {response.content.decode("utf-8")}')
 
-
             issues_page = response.json().get('issues')
             if not issues_page:
                 break

--- a/dojo/tools/sonarqube_api/importer.py
+++ b/dojo/tools/sonarqube_api/importer.py
@@ -77,7 +77,7 @@ class SonarQubeApiImporter(object):
 
     def import_issues(self, test):
 
-        items = list()
+        items = []
 
         try:
             client, config = self.prepare_client(test)
@@ -90,7 +90,7 @@ class SonarQubeApiImporter(object):
                 component = client.find_project(test.engagement.product.name, organization=organization, branch=test.branch_tag)
             # Get the resource from SonarQube
             issues = client.find_issues(component['key'], organization=organization, branch=test.branch_tag)
-            logging.info('Found {} issues for component {}'.format(len(issues), component["key"]))
+            logging.info(f'Found {len(issues)} issues for component {component["key"]}')
 
             for issue in issues:
                 status = issue['status']
@@ -99,7 +99,7 @@ class SonarQubeApiImporter(object):
                 if self.is_closed(status) or from_hotspot:
                     continue
 
-                type = issue['type']
+                issue_type = issue['type']
                 if len(issue['message']) > 511:
                     title = issue['message'][0:507] + "..."
                 else:
@@ -123,7 +123,7 @@ class SonarQubeApiImporter(object):
                     key=issue['key'],
                     defaults={
                         'status': status,
-                        'type': type,
+                        'type': issue_type,
                     }
                 )
 
@@ -168,7 +168,7 @@ class SonarQubeApiImporter(object):
 
     def import_hotspots(self, test):
         try:
-            items = list()
+            items = []
             client, config = self.prepare_client(test)
             # Get the value in the service key 2 box
             organization = config.service_key_2 if (config and config.service_key_2) else None
@@ -179,7 +179,7 @@ class SonarQubeApiImporter(object):
                 component = client.find_project(test.engagement.product.name, organization=organization, branch=test.branch_tag)
 
             hotspots = client.find_hotspots(component['key'], organization=organization, branch=test.branch_tag)
-            logging.info('Found {} hotspots for project {}'.format(len(hotspots), component["key"]))
+            logging.info(f'Found {len(hotspots)} hotspots for project {component["key"]}')
 
             for hotspot in hotspots:
                 status = hotspot['status']
@@ -187,7 +187,7 @@ class SonarQubeApiImporter(object):
                 if self.is_reviewed(status):
                     continue
 
-                type = 'SECURITY_HOTSPOT'
+                issue_type = 'SECURITY_HOTSPOT'
                 severity = 'Info'
                 title = textwrap.shorten(text=hotspot.get('message', ''), width=500)
                 component_key = hotspot.get('component')
@@ -203,7 +203,7 @@ class SonarQubeApiImporter(object):
                     key=hotspot['key'],
                     defaults={
                         'status': status,
-                        'type': type
+                        'type': issue_type
                     }
                 )
 
@@ -292,7 +292,7 @@ class SonarQubeApiImporter(object):
         details = etree.fromstring(vuln_details, parser)
 
         rule_references = ""
-        if details:
+        if details is not None:
             for a in details.iter("a"):
-                rule_references += "[{}]({})\n".format(a.text, a.get('href'))
+                rule_references += f"[{a.text}]({a.get('href')})\n"
         return rule_references


### PR DESCRIPTION
When SonarCloud integration was initially implemented, each API scan config needed to have an org ID in the service key2 slot. In most cases, this is the same org ID. This PR makes the ORG ID set at the Tool Configuration level with the option to override the global value at the API Scan Config level

Also did some code cleanup and docs