### PR TITLE
Add validation error when users attempt to send email without valid SMTP server

### DIFF
--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -590,7 +590,7 @@ class DojoPasswordResetForm(PasswordResetForm):
                 connection.open()
                 connection.close()
         except Exception:
-            raise ValidationError("SMTP server is not conifugred correctly...")
+            raise ValidationError("SMTP server is not configured correctly...")
 
 
 class DojoPasswordResetView(PasswordResetView):

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -588,6 +588,7 @@ class DojoPasswordResetForm(PasswordResetForm):
             connection = get_connection()
             if isinstance(connection, EmailBackend):
                 connection.open()
+                connection.close()
         except Exception:
             raise ValidationError("SMTP server is not conifugred correctly...")
 

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -8,8 +8,10 @@ from django.contrib.auth import logout
 from django.contrib.auth.decorators import user_passes_test, login_required
 from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.contrib.auth.views import LoginView, PasswordResetView
+from django.core.mail import get_connection
+from django.core.mail.backends.smtp import EmailBackend
 from django.core import serializers
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Q
 from django.db.models.deletion import RestrictedError
@@ -577,10 +579,17 @@ class DojoPasswordResetForm(PasswordResetForm):
         url = hyperlink.parse(settings.SITE_URL)
         context['site_name'] = url.host
         context['protocol'] = url.scheme
-        context['domain'] = settings.SITE_URL[len(url.scheme + '://'):]
+        context['domain'] = settings.SITE_URL[len(f'{url.scheme}://'):]
 
-        super().send_mail(subject_template_name, email_template_name,
-                          context, from_email, to_email, html_email_template_name)
+        super().send_mail(subject_template_name, email_template_name, context, from_email, to_email, html_email_template_name)
+
+    def clean(self):
+        try:
+            connection = get_connection()
+            if isinstance(connection, EmailBackend):
+                connection.open()
+        except Exception:
+            raise ValidationError("SMTP server is not conifugred correctly...")
 
 
 class DojoPasswordResetView(PasswordResetView):


### PR DESCRIPTION
When sending a 'forgot password' button, I was greeted with a 500 error. I was used to having mailhog there on dev servers..