### PR TITLE
dojo: tool: introduce NeuVector compliance scans import support

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1203,6 +1203,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Veracode SourceClear Scan': ['title', 'vulnerability_ids', 'component_name', 'component_version'],
     'Twistlock Image Scan': ['title', 'severity', 'component_name', 'component_version'],
     'NeuVector (REST)': ['title', 'severity', 'component_name', 'component_version'],
+    'NeuVector (compliance)': ['title', 'vuln_id_from_tool', 'description'],
 }
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
@@ -1366,6 +1367,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'docker-bench-security Scan': DEDUPE_ALGO_HASH_CODE,
     'Twistlock Image Scan': DEDUPE_ALGO_HASH_CODE,
     'NeuVector (REST)': DEDUPE_ALGO_HASH_CODE,
+    'NeuVector (compliance)': DEDUPE_ALGO_HASH_CODE,
 }
 
 DUPE_DELETE_MAX_PER_RUN = env('DD_DUPE_DELETE_MAX_PER_RUN')

--- a/dojo/tools/neuvector_compliance/parser.py
+++ b/dojo/tools/neuvector_compliance/parser.py
@@ -1,0 +1,147 @@
+import hashlib
+import json
+
+from dojo.models import Finding
+
+
+NEUVECTOR_SCAN_NAME = 'NeuVector (compliance)'
+
+
+def parse(json_output, test):
+    tree = parse_json(json_output)
+    items = []
+    if tree:
+        items = [data for data in get_items(tree, test)]
+    return items
+
+
+def parse_json(json_output):
+    try:
+        data = json_output.read()
+        try:
+            tree = json.loads(str(data, 'utf-8'))
+        except:
+            tree = json.loads(data)
+    except:
+        raise Exception("Invalid format")
+
+    return tree
+
+
+def get_items(tree, test):
+    items = {}
+
+    # if 'report' is in the tree, it means that we received an export from
+    # endpoints like /v1/scan/workload/{id}. otherwize, it is an export from
+    # /v1/host/{id}/compliance or similar. thus, we need to support items in a
+    # bit different leafs.
+    testsTree = None
+    if 'report' in tree:
+        testsTree = tree.get('report').get('checks', [])
+    else:
+        testsTree = tree.get('items', [])
+
+    for node in testsTree:
+        item = get_item(node, test)
+        unique_key = node.get('type') + node.get('category') + node.get('test_number') + node.get('description')
+        unique_key = hashlib.md5(unique_key.encode('utf-8')).hexdigest()
+        items[unique_key] = item
+    return list(items.values())
+
+
+def get_item(node, test):
+    if 'test_number' not in node:
+        return None
+    if 'category' not in node:
+        return None
+    if 'description' not in node:
+        return None
+    if 'level' not in node:
+        return None
+
+    test_number = node.get('test_number')
+    test_description = node.get('description').rstrip()
+
+    title = test_number + ' - ' + test_description
+
+    test_severity = node.get('level')
+    severity = convert_severity(test_severity)
+
+    mitigation = node.get('remediation', '').rstrip()
+
+    category = node.get('category')
+
+    vuln_id_from_tool = category + '_' + test_number
+
+    test_profile = node.get('profile', 'profile unknown')
+
+    full_description = '{} ({}), {}:\n'.format(test_number, category, test_profile)
+    full_description += '{}\n'.format(test_description)
+    full_description += 'Audit: {}\n'.format(test_severity)
+    if 'evidence' in node:
+        full_description += 'Evidence:\n{}\n'.format(node.get('evidence'))
+    if 'location' in node:
+        full_description += 'Location:\n{}\n'.format(node.get('location'))
+    full_description += 'Mitigation:\n{}\n'.format(mitigation)
+
+    tags = node.get('tags', [])
+    if len(tags) > 0:
+        full_description += 'Tags:\n'
+        for t in tags:
+            full_description += '{}\n'.format(str(t).rstrip())
+
+    messages = node.get('message', [])
+    if len(messages) > 0:
+        full_description += 'Messages:\n'
+        for m in messages:
+            full_description += '{}\n'.format(str(m).rstrip())
+
+    finding = Finding(title=title,
+                      test=test,
+                      description=full_description,
+                      severity=severity,
+                      mitigation=mitigation,
+                      vuln_id_from_tool=vuln_id_from_tool,
+                      static_finding=True,
+                      dynamic_finding=False)
+
+    return finding
+
+
+# see neuvector/share/clus_apis.go
+def convert_severity(severity):
+    if severity.lower() == 'high':
+        return "High"
+    elif severity.lower() == 'warn':
+        return "Medium"
+    elif severity.lower() == 'info':
+        return "Low"
+    elif severity.lower() == 'pass':
+        return "Info"
+    elif severity.lower() == 'note':
+        return "Info"
+    elif severity.lower() == 'error':
+        return "Info"
+    else:
+        return severity.title()
+
+
+class NeuVectorComplianceParser(object):
+
+    def get_scan_types(self):
+        return [NEUVECTOR_SCAN_NAME]
+
+    def get_label_for_scan_types(self, scan_type):
+        return NEUVECTOR_SCAN_NAME
+
+    def get_description_for_scan_types(self, scan_type):
+        return "Imports compliance scans returned by REST API."
+
+    def get_findings(self, filename, test):
+        if filename is None:
+            return list()
+
+        if filename.name.lower().endswith('.json'):
+            return parse(filename, test)
+        else:
+            raise Exception('Unknown File Format')

--- a/unittests/scans/neuvector_compliance/many_vulns.json
+++ b/unittests/scans/neuvector_compliance/many_vulns.json
@@ -1,0 +1,104 @@
+{
+    "run_timestamp": 1663583567,
+    "run_at": "2022-09-19T10:32:47Z",
+    "kubernetes_cis_version": "1.6.0",
+    "docker_cis_version": "1.2.0",
+    "items": [
+        {
+            "test_number": "D.1.1.1",
+            "category": "docker",
+            "type": "host",
+            "profile": "Level 1",
+            "scored": true,
+            "automated": true,
+            "description": "Ensure a separate partition for containers has been created",
+            "remediation": "For new installations, you should create a separate partition for the /var/lib/docker mount point. For systems that have already been installed, you should use the Logical Volume Manager (LVM) within Linux to create a new partition.",
+            "tags": [],
+            "level": "PASS",
+            "message": []
+        },
+        {
+            "test_number": "D.1.1.11",
+            "category": "docker",
+            "type": "host",
+            "profile": "Level 1",
+            "scored": true,
+            "automated": true,
+            "description": "Ensure auditing is configured for Dockerfiles and directories - /etc/docker/daemon.json",
+            "remediation": "Install auditd. Add -w /etc/docker/daemon.json -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
+            "tags": [
+                "GDPR",
+                "HIPAA",
+                "NIST"
+            ],
+            "level": "WARN",
+            "message": []
+        },
+        {
+            "test_number": "D.1.2.2",
+            "category": "docker",
+            "type": "host",
+            "profile": "Level 1",
+            "scored": true,
+            "automated": false,
+            "description": "Ensure that the version of Docker is up to date - Using 20.10.11, verify is it up to date as deemed necessary",
+            "remediation": "You should monitor versions of Docker releases and make sure your software is updated as required.",
+            "tags": [],
+            "level": "PASS",
+            "message": [
+                "Using 20.10.11, verify is it up to date as deemed necessary"
+            ]
+        },
+        {
+            "test_number": "D.2.10",
+            "category": "docker",
+            "type": "host",
+            "profile": "Level 2",
+            "scored": true,
+            "automated": false,
+            "description": "Ensure the default cgroup usage has been confirmed",
+            "remediation": "",
+            "tags": [],
+            "level": "PASS",
+            "message": []
+        },
+        {
+            "test_number": "K.4.1.3",
+            "category": "kubernetes",
+            "type": "worker",
+            "profile": "Level 1",
+            "scored": true,
+            "automated": false,
+            "description": "Ensure that the proxy kubeconfig file permissions are set to 644 or more restrictive",
+            "remediation": "Run the below command (based on the file location on your system) on the each worker node. For example, chmod 644 \u003cproxy kubeconfig file",
+            "tags": [
+                "GDPR",
+                "HIPAA",
+                "NIST",
+                "PCI"
+            ],
+            "level": "PASS",
+            "message": []
+        },
+        {
+            "test_number": "K.4.1.8",
+            "category": "kubernetes",
+            "type": "worker",
+            "profile": "Level 1",
+            "scored": true,
+            "automated": true,
+            "description": "Ensure that the client certificate authorities file ownership is set to root:root - client-ca-file: /etc/kubernetes/ssl/kube-ca.pem",
+            "remediation": "Run the following command to modify the ownership of the --client-ca-file. chown root:root \u003cfilename\u003e",
+            "tags": [
+                "GDPR",
+                "HIPAA",
+                "NIST",
+                "PCI"
+            ],
+            "level": "PASS",
+            "message": [
+                "client-ca-file: /etc/kubernetes/ssl/kube-ca.pem"
+            ]
+        }
+    ]
+}

--- a/unittests/scans/neuvector_compliance/no_vuln.json
+++ b/unittests/scans/neuvector_compliance/no_vuln.json
@@ -1,0 +1,7 @@
+{
+    "run_timestamp": 1663583567,
+    "run_at": "2022-09-19T10:32:47Z",
+    "kubernetes_cis_version": "1.6.0",
+    "docker_cis_version": "1.2.0",
+    "items": []
+}

--- a/unittests/scans/neuvector_compliance/one_vuln.json
+++ b/unittests/scans/neuvector_compliance/one_vuln.json
@@ -1,0 +1,25 @@
+{
+    "run_timestamp": 1663583567,
+    "run_at": "2022-09-19T10:32:47Z",
+    "kubernetes_cis_version": "1.6.0",
+    "docker_cis_version": "1.2.0",
+    "items": [
+        {
+            "test_number": "D.1.1.11",
+            "category": "docker",
+            "type": "host",
+            "profile": "Level 1",
+            "scored": true,
+            "automated": true,
+            "description": "Ensure auditing is configured for Dockerfiles and directories - /etc/docker/daemon.json",
+            "remediation": "Install auditd. Add -w /etc/docker/daemon.json -k docker to the /etc/audit/rules.d/audit.rules file. Then restart the audit daemon using command service auditd restart.",
+            "tags": [
+                "GDPR",
+                "HIPAA",
+                "NIST"
+            ],
+            "level": "WARN",
+            "message": []
+        }
+    ]
+}

--- a/unittests/tools/test_neuvector_compliance_parser.py
+++ b/unittests/tools/test_neuvector_compliance_parser.py
@@ -1,0 +1,28 @@
+from os import path
+from ..dojo_test_case import DojoTestCase
+from dojo.models import Test
+from dojo.tools.neuvector_compliance.parser import NeuVectorComplianceParser
+
+
+class TestNeuVectorComplianceParser(DojoTestCase):
+    def test_parse_file_with_no_vuln(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/neuvector_compliance/no_vuln.json"))
+        parser = NeuVectorComplianceParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(0, len(findings))
+
+    def test_parse_file_with_one_vuln(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/neuvector_compliance/one_vuln.json"))
+        parser = NeuVectorComplianceParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(findings))
+        self.assertEqual("docker_D.1.1.11", findings[0].vuln_id_from_tool)
+
+    def test_parse_file_with_many_vulns(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/neuvector_compliance/many_vulns.json"))
+        parser = NeuVectorComplianceParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(6, len(findings))


### PR DESCRIPTION
This commit makes DefectDojo to support compliance scans performed by NeuVector. Such scan results can only be fetched via REST API using endpoints like /v1/scan/workload/{id} and /v1/host/{id}/compliance. The latter one returns the results in a slightly different format. Both of them are supported.