### PR TITLE
Make version optional for cyclonedx

### DIFF
--- a/dojo/tools/cyclonedx/parser.py
+++ b/dojo/tools/cyclonedx/parser.py
@@ -415,6 +415,8 @@ class CycloneDXParser(object):
         if reference not in components:
             LOGGER.warning(f"reference:{reference} not found in the BOM")
             return (None, None)
+        if "version" not in components[reference]:
+            return (components[reference]["name"], None)
         return (components[reference]["name"], components[reference]["version"])
 
     def fix_severity(self, severity):


### PR DESCRIPTION
version is optional for a CycloneDX components, but DefectDojo throws an error if version isn't present.
https://cyclonedx.org/docs/1.4/json/#components_items_version
