### PR TITLE
Ignore patch (0.0.X) release for renovate bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,5 +12,8 @@
     "commitMessageExtra": "from {{currentVersion}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
     "commitMessageSuffix": "({{packageFile}})",
     "labels": ["dependencies"]
-  }]
+  }],
+  "patch": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
Renovate bot generate too much PR every time upstream projects update (ex: https://github.com/DefectDojo/django-DefectDojo/pull/6952 )

This PR limit to minor version (0.X.X)

Ref:
* https://docs.renovatebot.com/configuration-options/#patch
* https://github.com/renovatebot/config-help/issues/477