### PR TITLE
Trivy image scan: Vulnerability location

### DIFF
--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -126,6 +126,7 @@ class TrivyParser:
                     vuln_id = vuln.get('VulnerabilityID', '0')
                     package_name = vuln['PkgName']
                     severity = TRIVY_SEVERITIES[vuln['Severity']]
+                    file_path = vuln['PkgPath']
                 except KeyError as exc:
                     logger.warning('skip vulnerability due %r', exc)
                     continue
@@ -160,6 +161,7 @@ class TrivyParser:
                     title=title,
                     cwe=cwe,
                     severity=severity,
+                    file_path=file_path,
                     references=references,
                     description=description,
                     mitigation=mitigation,

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -126,7 +126,7 @@ class TrivyParser:
                     vuln_id = vuln.get('VulnerabilityID', '0')
                     package_name = vuln['PkgName']
                     severity = TRIVY_SEVERITIES[vuln['Severity']]
-                    file_path = vuln['PkgPath']
+                    file_path = vuln.get('PkgPath')
                 except KeyError as exc:
                     logger.warning('skip vulnerability due %r', exc)
                     continue


### PR DESCRIPTION
The image scanning results don't show the location of vulnerable components.
The trivy scan report contains the component path information, "PkgPath" is the file path.
The structure of finding, including "file_path" field, which can also correspond to the path of the image scanning vulnerability file.