### PR TITLE
support csi volumes and passing secrets via them

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -50,6 +50,11 @@ spec:
           {{- else if (eq .type "hostPath") }}
           type: {{ .pathType | default "Directory" }}
           path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
           {{- end }}
       {{- end }}
       containers:
@@ -99,6 +104,7 @@ spec:
             name: {{ $fullName }}-extrasecrets
             optional: true
         env:
+        {{- if not .Values.externalBrokerPassword }}
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -119,6 +125,8 @@ spec:
               key: {{ .Values.redis.auth.existingSecretPasswordKey }}
             {{- end }}  
             {{- end }}
+        {{- end }}
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -132,6 +140,7 @@ spec:
               name: {{ .Values.mysql.auth.existingSecret }}
               key: {{ .Values.mysql.auth.secretKey }}
               {{- end }}
+        {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -48,6 +48,11 @@ spec:
           {{- else if (eq .type "hostPath") }}
           type: {{ .pathType | default "Directory" }}
           path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
           {{- end }}
       {{- end }}
       containers:
@@ -94,6 +99,7 @@ spec:
             name: {{ $fullName }}-extrasecrets
             optional: true
         env:
+        {{- if not .Values.externalBrokerPassword }}
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -114,6 +120,8 @@ spec:
               key: {{ .Values.redis.auth.existingSecretPasswordKey }}
             {{- end }}  
             {{- end }}
+        {{- end }}
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -127,6 +135,7 @@ spec:
               name: {{ .Values.mysql.auth.existingSecret }}
               key: {{ .Values.mysql.auth.secretKey }}
               {{- end }}
+        {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -65,6 +65,11 @@ spec:
           {{- else if (eq .type "hostPath") }}
           type: {{ .pathType | default "Directory" }}
           path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
           {{- end }}
       {{- end }}
       {{- if .Values.django.mediaPersistentVolume.enabled }}
@@ -153,6 +158,7 @@ spec:
             name: {{ $fullName }}-extrasecrets
             optional: true
         env:
+        {{- if not .Values.externalBrokerPassword }}
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -173,10 +179,12 @@ spec:
               key: {{ .Values.redis.auth.existingSecretPasswordKey }}
             {{- end }}  
             {{- end }}
+        {{- end }}
         {{- if .Values.django.uwsgi.enable_debug }}
         - name: DD_DEBUG
           value: 'True'
         {{- end }}
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -190,6 +198,7 @@ spec:
               name: {{ .Values.mysql.auth.existingSecret }}
               key: {{ .Values.mysql.auth.secretKey }}
               {{- end }}
+        {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -68,7 +68,9 @@ spec:
             name: {{ $fullName }}
         - secretRef:
             name: {{ $fullName }}
+        {{- if or (not .Values.externalDatabasePassword) .Values.extraEnv }}
         env:
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -82,8 +84,19 @@ spec:
               name: {{ .Values.mysql.auth.existingSecret }}
               key: {{ .Values.mysql.auth.secretKey }}
               {{- end }}
+        {{- end }}
         {{- if .Values.extraEnv }}
         {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.initializer.extraVolumes }}
+        volumeMounts:
+        {{- range .Values.initializer.extraVolumes }}
+        - name: userconfig-{{ .name }}
+          readOnly: true
+          mountPath: {{ .path }}
+          subPath: {{ .subPath }}
+        {{- end }}
         {{- end }}
         resources:
           {{- toYaml .Values.initializer.resources | nindent 10 }}
@@ -100,5 +113,26 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.initializer.extraVolumes }}
+      volumes:
+      {{- range .Values.initializer.extraVolumes }}
+      - name: userconfig-{{ .name }}
+        {{ .type }}:
+          {{- if (eq .type "configMap") }}
+          name: {{ .name }}
+          {{- else if (eq .type "secret") }}
+          secretName: {{ .name }}
+          {{- else if (eq .type "hostPath") }}
+          type: {{ .pathType | default "Directory" }}
+          path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
+          {{- end }}
+      {{- end }}
+      {{- end }}
+
   backoffLimit: 1
 {{- end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -20,6 +20,10 @@ createPostgresqlHaPgpoolSecret: false
 # - enabled, enables tracking configuration changes based on SHA256
 # trackConfig: disabled
 
+externalDatabasePassword: false
+# externalRedisPassword: false
+externalBrokerPassword: false
+
 # Enables application network policy
 # For more info follow https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy:
@@ -163,7 +167,7 @@ celery:
   #
   # Each object supports the following keys:
   #
-  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath". Case sensitive.
+  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath", "csi". Case sensitive.
   #    Even is supported we are highly recommending to avoid hostPath for security reasons (usually blocked by PSP)
   # - `name` - Name of the configMap or secret to be mounted. This also controls
   #    the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
@@ -183,7 +187,8 @@ django:
     ingressClassName: ""
     activateTLS: true
     secretName: defectdojo-tls
-    annotations: {}
+    annotations:
+      {}
       # Restricts the type of ingress controller that can interact with our chart (nginx, traefik, ...)
       # kubernetes.io/ingress.class: nginx
       # Depending on the size and complexity of your scans, you might want to increase the default ingress timeouts if you see repeated 504 Gateway Timeouts
@@ -222,10 +227,10 @@ django:
     app_settings:
       processes: 2
       threads: 2
-    enable_debug: false  # this also requires DD_DEBUG to be set to True
+    enable_debug: false # this also requires DD_DEBUG to be set to True
     certificates:
-    # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
-    # to create configMap `kubectl create  cm defectdojo-ca-certs --from-file=ca.crt`
+      # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
+      # to create configMap `kubectl create  cm defectdojo-ca-certs --from-file=ca.crt`
       enabled: false
       configName: defectdojo-ca-certs
       certMountPath: /certs/
@@ -254,7 +259,7 @@ django:
   #
   # Each object supports the following keys:
   #
-  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath". Case sensitive.
+  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath", "csi". Case sensitive.
   #    Even is supported we are highly recommending to avoid hostPath for security reasons (usually blocked by PSP)
   # - `name` - Name of the configMap or secret to be mounted. This also controls
   #    the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
@@ -278,12 +283,9 @@ django:
     # in case if pvc specified, should point to the already existing pvc
     persistentVolumeClaim: media
 
-
 initializer:
   run: true
-  jobAnnotations: {
-    helm.sh/hook: "post-install,post-upgrade"
-  }
+  jobAnnotations: { helm.sh/hook: "post-install,post-upgrade" }
   annotations: {}
   keepSeconds: 60
   affinity: {}
@@ -459,7 +461,7 @@ redis:
   enabled: false
   transportEncryption:
     enabled: false
-    params: ''
+    params: ""
   auth:
     existingSecret: defectdojo-redis-specific
     existingSecretPasswordKey: redis-password
@@ -481,7 +483,6 @@ redis:
 # extraSecrets:
 #   DD_SOCIAL_AUTH_AUTH0_SECRET: 'xxx'
 extraConfigs: {}
-
 # To add (or override) extra variables which need to be pulled from another configMap, you can
 # use extraEnv. For example:
 # extraEnv:


### PR DESCRIPTION
This PR:
- Adds support for csi volumes, extending currently supported types
- Add `.Values.externalDatabasePassword` and `.Values.externalBrokerPassword` to remove mandatory usage of secrets from the chart

By adding the two values, it becomes possible to pass DD_DATABASE_PASSWORD and DD_CELERY_BROKER_PASSWORD via csi volumes and external secret systems (e.g. vault).

Closes https://github.com/DefectDojo/django-DefectDojo/issues/5535