### PR TITLE
Enable filtering Findings on steps_to_reproduce

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1105,7 +1105,7 @@ class ApiFindingFilter(DojoFilter):
     references = CharFilter(lookup_expr='icontains')
     severity = CharFilter(method=custom_filter, field_name='severity')
     severity_justification = CharFilter(lookup_expr='icontains')
-    step_to_reproduce = CharFilter(lookup_expr='icontains')
+    steps_to_reproduce = CharFilter(lookup_expr='icontains')
     unique_id_from_tool = CharFilter(lookup_expr='icontains')
     title = CharFilter(lookup_expr='icontains')
     # DateRangeFilter

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1050,6 +1050,37 @@ class FindingsTest(BaseClass.RESTEndpointTest):
         assert not result_json["duplicate"]
         assert result_json["duplicate_finding"] is None
 
+    def test_filter_steps_to_reproduce(self):
+        # Confirm initial data
+        result = self.client.get(self.url + '?steps_to_reproduce=lorem')
+        self.assertEqual(result.status_code, status.HTTP_200_OK, "Could not filter on steps_to_reproduce")
+        result_json = result.json()
+        assert result_json["count"] == 0
+
+        # Set steps to reproduce
+        result = self.client.patch(self.url + "2/", data={"steps_to_reproduce": "Lorem ipsum dolor sit amet"})
+        self.assertEqual(result.status_code, status.HTTP_200_OK, "Could not patch finding with steps to reproduce")
+        assert result.json()["steps_to_reproduce"] == "Lorem ipsum dolor sit amet"
+        result = self.client.patch(self.url + "3/", data={"steps_to_reproduce": "Ut enim ad minim veniam"})
+        self.assertEqual(result.status_code, status.HTTP_200_OK, "Could not patch finding with steps to reproduce")
+        assert result.json()["steps_to_reproduce"] == "Ut enim ad minim veniam"
+
+        # Test
+        result = self.client.get(self.url + "?steps_to_reproduce=lorem")
+        self.assertEqual(result.status_code, status.HTTP_200_OK, "Could not filter on steps_to_reproduce")
+        result_json = result.json()
+        assert result_json["count"] == 1
+        assert result_json["results"][0]["id"] == 2
+        assert result_json["results"][0]["steps_to_reproduce"] == "Lorem ipsum dolor sit amet"
+
+        # Set steps to reproduce
+        result = self.client.patch(self.url + "2/", data={"steps_to_reproduce": ""})
+        self.assertEqual(result.status_code, status.HTTP_200_OK, "Could not patch finding with steps to reproduce")
+        assert result.json()["steps_to_reproduce"] == ""
+        result = self.client.patch(self.url + "3/", data={"steps_to_reproduce": ""})
+        self.assertEqual(result.status_code, status.HTTP_200_OK, "Could not patch finding with steps to reproduce")
+        assert result.json()["steps_to_reproduce"] == ""
+
 
 class FindingMetadataTest(BaseClass.RESTEndpointTest):
     fixtures = ['dojo_testdata.json']


### PR DESCRIPTION
# Issue
It is not possible to filter `Findings` on `steps_to_reproduce`.

There appears to be a typo in the filter expression in filters.py at [`step_to_reproduce = CharFilter(lookup_expr='icontains')`](https://github.com/DefectDojo/django-DefectDojo/blob/e6a88af6109c8d9fdeee9dddc87a319d74292e88/dojo/filters.py#L1108)

# Solution
1. Fix typo replacing `step_to_reproduce` with `steps_to_reproduce`.
2. Add tests

I could take or leave the tests, there are no other examples of api filters being tested, but it didn't feel right to make a change without a test.

No other occurrences of `step_to_reproduce` exist in the repository.

# Examples
### Original
both `step_to_reproduce` and `steps_to_reproduce`
![image](https://user-images.githubusercontent.com/19413468/195201702-8354e4cd-06ec-444f-988c-12a315aa1c77.png)

### With Fix
![image](https://user-images.githubusercontent.com/19413468/195201837-8059cc99-4397-4468-bc23-560afaf19218.png)
