### PR TITLE
Add a link back to the vulnerability in the references for Acunetix360

### DIFF
--- a/dojo/tools/acunetix360/parser.py
+++ b/dojo/tools/acunetix360/parser.py
@@ -38,8 +38,10 @@ class Acunetix360Parser(object):
             if sev not in ['Info', 'Low', 'Medium', 'High', 'Critical']:
                 sev = 'Info'
             mitigation = text_maker.handle(item.get("RemedialProcedure", ""))
-            references = "https://online.acunetix360.com/issues/detail/" + item["LookupId"] + "\n"
-            references += text_maker.handle(item.get("RemedyReferences", ""))
+            references = text_maker.handle(item.get("RemedyReferences", ""))
+            if "LookupId" in item:
+                lookupId = item["LookupId"]
+                references = f"https://online.acunetix360.com/issues/detail/{lookupId}\n" + references
             url = item["Url"]
             impact = text_maker.handle(item.get("Impact", ""))
             dupe_key = title

--- a/dojo/tools/acunetix360/parser.py
+++ b/dojo/tools/acunetix360/parser.py
@@ -38,7 +38,8 @@ class Acunetix360Parser(object):
             if sev not in ['Info', 'Low', 'Medium', 'High', 'Critical']:
                 sev = 'Info'
             mitigation = text_maker.handle(item.get("RemedialProcedure", ""))
-            references = text_maker.handle(item.get("RemedyReferences", ""))
+            references = "https://online.acunetix360.com/issues/detail/" + item["LookupId"] + "\n"
+            references += text_maker.handle(item.get("RemedyReferences", ""))
             url = item["Url"]
             impact = text_maker.handle(item.get("Impact", ""))
             dupe_key = title

--- a/unittests/tools/test_acunetix360_parser.py
+++ b/unittests/tools/test_acunetix360_parser.py
@@ -25,6 +25,7 @@ class TestAcunetix360Parser(DojoTestCase):
             endpoint = finding.unsaved_endpoints[0]
             self.assertEqual(str(endpoint), "http://php.testsparker.com/auth/login.php")
             self.assertEqual(finding.date, datetime(2021, 6, 16, 12, 30))
+            self.assertTrue("https://online.acunetix360.com/issues/detail/735f4503-e9eb-4b4c-4306-ad49020a4c4b" in finding.references)
 
     def test_parse_file_with_one_finding_false_positive(self):
         testfile = open("unittests/scans/acunetix360/acunetix360_one_finding_false_positive.json")


### PR DESCRIPTION
It's useful in DefectDojo to be able to click on a link in the report to go back to the dashboard in Acunetix for the finding.