### PR TITLE
Fix issues with Bugcrowd API parser not marking not_applicable/not_re…

### DIFF
--- a/dojo/tools/bugcrowd_api/parser.py
+++ b/dojo/tools/bugcrowd_api/parser.py
@@ -204,10 +204,12 @@ class BugcrowdApiParser(object):
             return "Info"
 
     def is_active(self, bugcrowd_state):
-        return (bugcrowd_state == "unresolved") or (
-            not self.is_mitigated(bugcrowd_state)
-            and not self.is_false_p(bugcrowd_state)
-            and not self.is_out_of_scope(bugcrowd_state)
+        return (bugcrowd_state == "unresolved") or not (
+            self.is_mitigated(bugcrowd_state)
+            or self.is_false_p(bugcrowd_state)
+            or self.is_out_of_scope(bugcrowd_state)
+            or self.is_risk_accepted(bugcrowd_state)
+            or bugcrowd_state == "not_reproducible"
         )
 
     def is_duplicate(self, bugcrowd_state):

--- a/unittests/scans/bugcrowd_api/bugcrowd_not_reproducible.json
+++ b/unittests/scans/bugcrowd_api/bugcrowd_not_reproducible.json
@@ -1,0 +1,195 @@
+[
+    {
+        "id": "a4201d47-62e1-4287-9ff6-30807ae9d36a",
+        "type": "submission",
+        "attributes": {
+            "bug_url": "https://example.com/",
+            "custom_fields": {},
+            "description": "Vulnerability Name: JWT alg none",
+            "duplicate": false,
+            "extra_info": null,
+            "http_request": null,
+            "last_transitioned_to_informational_at": "2002-04-01T21:59:56.546Z",
+            "last_transitioned_to_not_applicable_at": null,
+            "last_transitioned_to_not_reproducible_at": null,
+            "last_transitioned_to_out_of_scope_at": null,
+            "last_transitioned_to_resolved_at": null,
+            "last_transitioned_to_triaged_at": null,
+            "last_transitioned_to_unresolved_at": null,
+            "remediation_advice": "Properly do JWT",
+            "severity": 5,
+            "source": "external_form",
+            "state": "not_reproducible",
+            "submitted_at": "2002-04-01T21:59:56.546Z",
+            "title": "JWT Alg none",
+            "vrt_id": "broken_authentication_and_session_management.authentication_bypass",
+            "vrt_version": "1.10.1",
+            "vulnerability_references": ""
+        },
+        "relationships": {
+            "activities": {
+                "data": [
+                    {
+                        "id": "9b31ab18-0090-462c-a69d-75840e3aec7a",
+                        "type": "activity"
+                    },
+                    {
+                        "id": "1c332e75-b5bf-4eed-aa13-d1836a8be292",
+                        "type": "activity"
+                    },
+                    {
+                        "id": "5b9d763b-91e9-4f63-93ef-91ed891ae5d5",
+                        "type": "activity"
+                    },
+                    {
+                        "id": "91a81042-f43c-464f-a7a0-cff78ee28783",
+                        "type": "activity"
+                    },
+                    {
+                        "id": "5aa428b9-62f9-403b-a28c-e2cb5b01146d",
+                        "type": "activity"
+                    }
+                ],
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)",
+                        "meta": {
+                            "count": 5,
+                            "total_hits": 5
+                        }
+                    }
+                }
+            },
+            "assignee": {
+                "data": null,
+                "links": {
+                    "related": {
+                        "href": null
+                    }
+                }
+            },
+            "claim_ticket": {
+                "data": {
+                    "id": "d7ebbb6b-521b-4325-80af-e87161d1c1bc",
+                    "type": "claim_ticket"
+                },
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)"
+                    }
+                }
+            },
+            "comments": {
+                "data": [
+                    {
+                        "id": "f13040a4-2b21-4921-8f81-61b093da0542",
+                        "type": "comment"
+                    }
+                ],
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)",
+                        "meta": {
+                            "count": 1,
+                            "total_hits": 1
+                        }
+                    }
+                }
+            },
+            "duplicate_of": {
+                "data": null,
+                "links": {
+                    "related": {
+                        "href": null
+                    }
+                }
+            },
+            "duplicates": {
+                "data": [],
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)",
+                        "meta": {
+                            "count": 0,
+                            "total_hits": 0
+                        }
+                    }
+                }
+            },
+            "external_issues": {
+                "data": [],
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)",
+                        "meta": {
+                            "count": 1,
+                            "total_hits": 1
+                        }
+                    }
+                }
+            },
+            "file_attachments": {
+                "data": [
+                    {
+                        "id": "e5a0fd57-0cbb-4f0b-a44e-3401a859b8ba",
+                        "type": "file_attachment"
+                    }
+                ],
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)",
+                        "meta": {
+                            "count": 1,
+                            "total_hits": 1
+                        }
+                    }
+                }
+            },
+            "monetary_rewards": {
+                "data": [],
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)",
+                        "meta": {
+                            "count": 0,
+                            "total_hits": 0
+                        }
+                    }
+                }
+            },
+            "program": {
+                "data": {
+                    "id": "fd3d5a81-a84e-49fa-8487-796b96a7fce9",
+                    "type": "program"
+                },
+                "links": {
+                    "related": {
+                        "href": "/programs/fd3d5a81-a84e-49fa-8487-796b96a7fce9"
+                    }
+                }
+            },
+            "researcher": {
+                "data": {
+                    "id": "3660d761-7a3e-4351-a7d4-e2e21c3fda26",
+                    "type": "identity"
+                },
+                "links": {
+                    "related": {
+                        "href": "(NOT IMPLEMENTED YET)"
+                    }
+                }
+            },
+            "target": {
+                "data": null,
+                "links": {
+                    "related": {
+                        "href": null
+                    }
+                }
+            }
+        },
+        "links": {
+            "self": "/submissions/a4201d47-62e1-4287-9ff6-30807ae9d36a"
+        }
+    }
+]

--- a/unittests/tools/test_bugcrowd_api_parser.py
+++ b/unittests/tools/test_bugcrowd_api_parser.py
@@ -90,11 +90,12 @@ class TestBugcrowdApiParser(TestCase):
 
             self.assertEqual(finding_1.active, False)
             self.assertEqual(finding_2.active, True)
-            self.assertEqual(finding_3.active, True)
+            self.assertEqual(finding_3.active, False)
 
             self.assertEqual(finding_1.is_mitigated, True)
             self.assertEqual(finding_2.is_mitigated, False)
             self.assertEqual(finding_3.is_mitigated, False)
+            self.assertEqual(finding_3.risk_accepted, True)
 
             self.assertEqual(
                 finding_1.unique_id_from_tool, "3b0e6b2a-c21e-493e-bd19-de40f525016e"
@@ -105,3 +106,33 @@ class TestBugcrowdApiParser(TestCase):
             self.assertEqual(
                 finding_3.unique_id_from_tool, "335a7ba5-57ba-485a-b40e-2f9aa4e19786"
             )
+
+    def test_parse_file_with_not_reproducible_finding(self):
+        with open("unittests/scans/bugcrowd_api/bugcrowd_not_reproducible.json") as testfile:
+
+            #             description = """
+            # Vulnerability Name: JWT alg none
+
+            # Bugcrowd details:
+            # - Severity: P5
+            # - Bug Url: https://example.com/
+
+            # Bugcrowd link: /submissions/a4201d47-62e1-4287-9ff6-30807ae9d36a"""
+            parser = BugcrowdApiParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(1, len(findings))
+            finding = findings[0]
+            self.assertEqual(finding.title, "JWT Alg none")
+            self.assertEqual(
+                datetime.datetime.date(finding.date), datetime.date(2002, 4, 1)
+            )
+            self.assertEqual(str(finding.unsaved_endpoints[0]), "https://example.com")
+            self.assertEqual(finding.severity, "Info")
+            # self.assertEqual(finding.description, description)
+            self.assertEqual(finding.mitigation, "Properly do JWT")
+            self.assertEqual(finding.active, False)
+            self.assertEqual(
+                finding.unique_id_from_tool, "a4201d47-62e1-4287-9ff6-30807ae9d36a"
+            )
+            for endpoint in finding.unsaved_endpoints:
+                endpoint.clean()


### PR DESCRIPTION
…producible as inactive

There are some bugs with the Bugcrowd API parser:

- It doesn't mark not_applicable (risk accepted) findings as inactive.
- It doesn't mark not_reproducible findings as inactive