### PR TITLE
Add Rubocop to parser documentation

### DIFF
--- a/docs/content/en/integrations/parsers.md
+++ b/docs/content/en/integrations/parsers.md
@@ -1037,6 +1037,10 @@ report as follows
 -   Removing both fields will allow retrieval of all findings in the
     Risk Recon instance.
 
+### Rubocop Scan
+
+Import Rubocop JSON scan report (with option -f json).
+
 ### Rusty Hog parser
 
 From: <https://github.com/newrelic/rusty-hog> Import the JSON output.


### PR DESCRIPTION
I noticed Rubocop has a parser, but it's not documented.

https://github.com/DefectDojo/django-DefectDojo/blob/dev/dojo/tools/rubocop/parser.py