### PR TITLE
Fix errors with risk acceptance filter

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2,7 +2,7 @@ import collections
 from drf_spectacular.types import OpenApiTypes
 
 from drf_spectacular.utils import extend_schema_field
-from dojo.finding.helper import ACCEPTED_FINDINGS_QUERY, CLOSED_FINDINGS_QUERY, FALSE_POSITIVE_FINDINGS_QUERY, INACTIVE_FINDINGS_QUERY, OPEN_FINDINGS_QUERY, OUT_OF_SCOPE_FINDINGS_QUERY, VERIFIED_FINDINGS_QUERY, UNDER_REVIEW_QUERY
+from dojo.finding.helper import ACCEPTED_FINDINGS_QUERY, NOT_ACCEPTED_FINDINGS_QUERY, WAS_ACCEPTED_FINDINGS_QUERY, CLOSED_FINDINGS_QUERY, FALSE_POSITIVE_FINDINGS_QUERY, INACTIVE_FINDINGS_QUERY, OPEN_FINDINGS_QUERY, OUT_OF_SCOPE_FINDINGS_QUERY, VERIFIED_FINDINGS_QUERY, UNDER_REVIEW_QUERY
 import logging
 from datetime import timedelta, datetime
 from django import forms
@@ -500,15 +500,12 @@ class ReportRiskAcceptanceFilter(ChoiceFilter):
 
     def accepted(self, qs, name):
         # return qs.filter(risk_acceptance__isnull=False)
-        from dojo.finding.views import ACCEPTED_FINDINGS_QUERY
         return qs.filter(ACCEPTED_FINDINGS_QUERY)
 
     def not_accepted(self, qs, name):
-        from dojo.finding.views import NOT_ACCEPTED_FINDINGS_QUERY
         return qs.filter(NOT_ACCEPTED_FINDINGS_QUERY)
 
     def was_accepted(self, qs, name):
-        from dojo.finding.views import WAS_ACCEPTED_FINDINGS_QUERY
         return qs.filter(WAS_ACCEPTED_FINDINGS_QUERY)
 
     options = {

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -577,7 +577,7 @@ def add_endpoints(new_finding, form):
     for endpoint in new_finding.endpoints.all():
         eps, created = Endpoint_Status.objects.get_or_create(
             finding=new_finding,
-            endpoint=endpoint, defaults={'date': form.cleaned_data['date'] or now})
+            endpoint=endpoint, defaults={'date': form.cleaned_data['date'] or timezone.now()})
         endpoint.endpoint_status.add(eps)
         new_finding.endpoint_status.add(eps)
 


### PR DESCRIPTION
When filtering with risk acceptance you get a 500 error:

http://localhost:8080/product/3/finding/open?test_import_finding_action__test_import=&title=&component_name=&component_version=&date=&last_reviewed=&last_status_update=&mitigated=&test__engagement__version=&test__version=&status=&active=unknown&verified=unknown&duplicate=&is_mitigated=&out_of_scope=unknown&false_p=unknown&risk_accepted=unknown&has_component=unknown&has_notes=unknown&file_path=&unique_id_from_tool=&vuln_id_from_tool=&service=&param=&payload=&risk_acceptance=1&has_jira_issue=unknown&jira_creation=&jira_change=&jira_issue__jira_key=&has_finding_group=unknown&has_jira_group_issue=unknown&tags=&test__tags=&test__engagement__tags=&test__engagement__product__tags=&tag=&not_tags=&not_test__tags=&not_test__engagement__tags=&not_test__engagement__product__tags=&not_tag=&vulnerability_id=&planned_remediation_date=&endpoints__host=&o=

ImportError: cannot import name 'ACCEPTED_FINDINGS_QUERY' from 'dojo.finding.views' (/app/./dojo/finding/views.py)

Actually intellij also flagged these errors, and I also fixed an issue it found with timezone.now()