### PR TITLE
Parse Veracode library_id for SCA to get the maven component name

### DIFF
--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -72,6 +72,11 @@ class VeracodeParser(object):
         for component in root.findall('x:software_composition_analysis/x:vulnerable_components'
                                              '/x:component', namespaces=XML_NAMESPACE):
             _library = component.attrib['library']
+            if 'library_id' in component.attrib and component.attrib['library_id'].startswith("maven:"):
+                # Set the library name from the maven component if it's available to align with CycloneDX + Veracode SCA
+                split_library_id = component.attrib['library_id'].split(":")
+                if len(split_library_id) > 2:
+                    _library = split_library_id[2]
             _vendor = component.attrib['vendor']
             _version = component.attrib['version']
 

--- a/unittests/scans/veracode/veracode_maven.xml
+++ b/unittests/scans/veracode/veracode_maven.xml
@@ -1,0 +1,46 @@
+<?xml version='1.0' encoding='UTF-8'?>
+
+<detailedreport xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://www.veracode.com/schema/reports/export/1.0" xsi:schemaLocation="https://www.veracode.com/schema/reports/export/1.0 https://analysiscenter.veracode.com/resource/detailedreport.xsd" report_format_version="1.5" account_id="48767" app_name="data-services" app_id="402332" analysis_id="2335367" static_analysis_unit_id="2351115" sandbox_id="537358" first_build_submitted_date="2018-02-17 00:39:35 UTC" version="2018-05-25-18:00:29" build_id="2348782" submitter="Bob Cratchet" platform="Not Specified" assurance_level="5" business_criticality="5" generation_date="2018-06-25 16:19:28 UTC" veracode_level="VL3" total_flaws="26" flaws_not_mitigated="19" teams="" life_cycle_stage="Not Specified" planned_deployment_date="" last_update_time="2018-05-26 00:06:22 UTC" is_latest_build="false" policy_name="Veracode Recommended Very High" policy_version="1" policy_compliance_status="Did Not Pass" policy_rules_status="Did Not Pass" grace_period_expired="true" scan_overdue="false" business_owner="" business_unit="Not Specified" tags="" legacy_scan_engine="false">
+	<static-analysis rating="B" score="94" submitted_date="2018-05-26 00:03:25 UTC" published_date="2018-05-26 00:06:16 UTC" version="2018-05-25-18:00:29" mitigated_rating="B" mitigated_score="94" next_scan_due="2018-08-26 00:06:16 UTC" analysis_size_bytes="8486358" engine_version="123190">
+		<modules>
+			<module name="bogus-services-1.1.15-SNAPSHOT.war" compiler="JAVAC_6" os="Java J2SE 6" architecture="JVM" loc="6517" score="94" numflawssev0="0" numflawssev1="0" numflawssev2="0" numflawssev3="14" numflawssev4="0" numflawssev5="0" />
+			<module name="bogus-services-client-web-1.1.15-SNAPSHOT.war" compiler="JAVAC_6" os="Java J2SE 6" architecture="JVM" loc="4817" score="96" numflawssev0="0" numflawssev1="0" numflawssev2="3" numflawssev3="9" numflawssev4="0" numflawssev5="0" />
+		</modules>
+	</static-analysis>
+	<severity level="5" />
+	<severity level="4" />
+	<severity level="3" />
+				<severity level="1" />
+					<severity level="0" />
+					<flaw-status new="0" reopen="0" open="19" cannot-reproduce="0" fixed="0" total="26" not_mitigated="19" sev-1-change="0" sev-2-change="0" sev-3-change="0" sev-4-change="0" sev-5-change="0" />
+					<customfields>
+					<customfield name="Jira Project" value="" />
+					<customfield name="Custom 2" value="" />
+					<customfield name="Custom 3" value="" />
+					<customfield name="Custom 4" value="" />
+					<customfield name="Custom 5" value="" />
+					<customfield name="Custom 6" value="" />
+					<customfield name="Custom 7" value="" />
+					<customfield name="Custom 8" value="" />
+					<customfield name="Custom 9" value="" />
+					<customfield name="Custom 10" value="" />
+				</customfields>
+				<software_composition_analysis third_party_components="29" violate_policy="false" components_violated_policy="0">
+					<vulnerable_components>
+                    <component component_id="47c2f2ee-a72b-41b4-9558-2656c6b6879f" file_name="commons-jxpath-1.3.jar" sha1="c22d7d0f0f40eb7059a23cfa61773a416768b137" vulnerabilities="1" max_cvss_score="9.8" version="1.3" library="Commons JXPath" library_id="maven&#x3a;commons-jxpath&#x3a;commons-jxpath&#x3a;1.3&#x3a;" vendor="commons-jxpath" description="A Java-based implementation of XPath 1.0 that, in addition to XML processing, can inspect&#x2f;modify Java object graphs &#x28;the library&#x27;s explicit purpose&#x29; and even mixed Java&#x2f;XML structures." added_date="2021-10-11 11&#x3a;35&#x3a;55 UTC" component_affects_policy_compliance="false">
+					<file_paths>
+					<file_path value="bogus-services-1.1.15-SNAPSHOT.war#zip:WEB-INF/lib/commons-jxpath-1.3.jar" />
+					</file_paths>
+				<licenses>
+					<license name="Apache License 2.0" spdx_id="Apache-2.0" license_url="https://spdx.org/licenses/Apache-2.0.html" risk_rating="2" />
+					</licenses>
+				<vulnerabilities>
+                <vulnerability cve_id="CVE-2022-41852" cvss_score="9.8" severity="5" cwe_id="" first_found_date="2022-10-12 19&#x3a;55&#x3a;29 UTC" cve_summary="commons-jxpath is vulnerable to remote code execution. The vulnerability exists in &#x60;selectSingleNode&#x60; function in &#x60;JXPathContext.java&#x60; where the attacker can use the xpath expression to load any java class from the classpath which will lead to a code execution.&#xa;&#xa;" severity_desc="Very High" mitigation="false" vulnerability_affects_policy_compliance="false">
+                  <mitigations/>
+               </vulnerability>
+                 </vulnerabilities>
+					<violated_policy_rules />
+				</component>
+				</vulnerable_components>
+			</software_composition_analysis>
+			</detailedreport>

--- a/unittests/tools/test_veracode_parser.py
+++ b/unittests/tools/test_veracode_parser.py
@@ -155,3 +155,17 @@ class TestVeracodeScannerParser(DojoTestCase):
         self.assertEqual("commons-httpclient", finding.component_name)
         self.assertEqual("3.1", finding.component_version)
         self.assertEqual(4.3, finding.cvssv3_score)
+
+    def test_maven_component_name(self):
+        testfile = open("unittests/scans/veracode/veracode_maven.xml")
+        parser = VeracodeParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+
+        finding = findings[0]
+        self.assertEqual("Critical", finding.severity)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2022-41852", finding.unsaved_vulnerability_ids[0])
+        self.assertEqual("commons-jxpath", finding.component_name)
+        self.assertEqual("1.3", finding.component_version)
+        self.assertEqual(9.8, finding.cvssv3_score)


### PR DESCRIPTION
Veracode supplies the maven component name in the library_id attribute. We should use this to align with Veracode SourceClear + CycloneDX etc if it's available. Otherwise we can't group findings by component name correctly.