### PR TITLE
Update the Cobalt API parser's API client

### DIFF
--- a/dojo/tools/cobalt_api/api_client.py
+++ b/dojo/tools/cobalt_api/api_client.py
@@ -33,7 +33,7 @@ class CobaltAPI:
     def get_assets(self):
         """Returns all org assets"""
         response = self.session.get(
-            url='{}/assets'.format(self.cobalt_api_url),
+            url='{}/assets?limit=1000'.format(self.cobalt_api_url),
             headers=self.get_headers(),
         )
 
@@ -51,7 +51,7 @@ class CobaltAPI:
         :return:
         """
         response = self.session.get(
-            url='{}/findings?asset={}'.format(self.cobalt_api_url, asset_id),
+            url='{}/findings?limit=1000&asset={}'.format(self.cobalt_api_url, asset_id),
             headers=self.get_headers(),
         )
 


### PR DESCRIPTION
Update the Cobalt.io API parser's `CobaltAPI` client to fetch the maximum allowed number of findings and assets.

This fixes a bug in the parser due to changes to the Cobalt.io API that resulted in users not being able to
1. import findings from all of their assets, and
2. import all findings from any given asset.