### PR TITLE
Don't save vulnerability Ids on a re-import if they're already define…

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -233,7 +233,8 @@ class DojoDefaultReImporter(object):
                         file_upload.save()
                         finding.files.add(file_upload)
 
-                importer_utils.handle_vulnerability_ids(finding)
+                if finding.unsaved_vulnerability_ids:
+                    importer_utils.handle_vulnerability_ids(finding)
 
                 # existing findings may be from before we had component_name/version fields
                 finding.component_name = finding.component_name if finding.component_name else component_name


### PR DESCRIPTION
…d for the finding

I noticed on calling the API that it was returning multiple duplicate vulnerability Ids for a Finding, after calling re-import multiple times. This is because on each re-import it's saving a new VulnerabilityId for the same finding + CVE.