### PR TITLE
Add support for ZAP "XML with requests and responses" format

### DIFF
--- a/docs/content/en/integrations/parsers.md
+++ b/docs/content/en/integrations/parsers.md
@@ -1283,4 +1283,4 @@ Import Yarn Audit scan report in JSON format. Use something like `yarn audit --j
 
 ### Zed Attack Proxy
 
-ZAP XML report format.
+ZAP XML report format (with or without requests and responses).

--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -55,9 +55,6 @@ class ZapParser(object):
                         # Assemble the request from header and body
                         request = instance.findtext('requestheader') + instance.findtext('requestbody')
                         response = instance.findtext('responseheader') + instance.findtext('responsebody')
-                        # Turn escaped into unescaped nlbr, accounting for different types of newlines
-                        request = request.replace("\\r\\n", "\\n").replace("\\n", "\n")
-                        response = response.replace("\\r\\n", "\\n").replace("\\n", "\n")
                     else:
                         # The report is in the regular XML format, without requests and responses.
                         # Use the default settings for constructing the request and response fields.

--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -49,12 +49,26 @@ class ZapParser(object):
                 finding.unsaved_req_resp = []
                 for instance in item.findall("instances/instance"):
                     endpoint = Endpoint.from_uri(instance.findtext("uri"))
-                    request = f"{instance.findtext('method')} {endpoint.query}#{endpoint.fragment}"
+                    # If the requestheader key is set, the report is in the "XML with requests and responses"
+                    # format - load requests and responses and add them to the database
+                    if instance.findtext('requestheader') is not None:
+                        # Assemble the request from header and body
+                        request = instance.findtext('requestheader') + instance.findtext('requestbody')
+                        response = instance.findtext('responseheader') + instance.findtext('responsebody')
+                        # Turn escaped into unescaped nlbr, accounting for different types of newlines
+                        request = request.replace("\\r\\n", "\\n").replace("\\n", "\n")
+                        response = response.replace("\\r\\n", "\\n").replace("\\n", "\n")
+                    else:
+                        # The report is in the regular XML format, without requests and responses.
+                        # Use the default settings for constructing the request and response fields.
+                        request = f"{instance.findtext('method')} {endpoint.query}#{endpoint.fragment}"
+                        response = f"{instance.findtext('evidence')}"
+
                     # we remove query and fragment because with some configuration
                     # the tool generate them on-the-go and it produces a lot of fake endpoints
                     endpoint.query = None
                     endpoint.fragment = None
                     finding.unsaved_endpoints.append(endpoint)
-                    finding.unsaved_req_resp.append({"req": request, "resp": f"{instance.findtext('evidence')}"})
+                    finding.unsaved_req_resp.append({"req": request, "resp": response})
                 items.append(finding)
         return items

--- a/unittests/scans/zap/zap-xml-plus-format.xml
+++ b/unittests/scans/zap/zap-xml-plus-format.xml
@@ -1,43 +1,60 @@
 <?xml version="1.0"?>
-<OWASPZAPReport version="2.11.1" generated="Do., 25 Aug. 2022 10:16:56">
-		<site name="http://redacted.com" host="redacted.com" port="80" ssl="false">
+<OWASPZAPReport version="2.11.1" generated="Fr., 30 Sep. 2022 08:40:35">
+		<site name="http://localhost:8080" host="localhost" port="8080" ssl="false">
 			<alerts>
-				
 					<alertitem>
-						<pluginid>10104</pluginid>
-						<alertRef>10104</alertRef>
-						<alert>User Agent Fuzzer</alert>
-						<name>User Agent Fuzzer</name>
-						<riskcode>0</riskcode>
+						<pluginid>90028</pluginid>
+						<alertRef>90028</alertRef>
+						<alert>Insecure HTTP Method - PUT</alert>
+						<name>Insecure HTTP Method - PUT</name>
+						<riskcode>2</riskcode>
 						<confidence>2</confidence>
-						<riskdesc>Informational (Medium)</riskdesc>
+						<riskdesc>Medium (Medium)</riskdesc>
 						<confidencedesc>Medium</confidencedesc>
-						<desc>&lt;p&gt;Check for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). Compares the response statuscode and the hashcode of the response body with the original response.&lt;/p&gt;</desc>
+						<desc>This method was originally intended for file managemant operations. It is now most commonly used in REST services, PUT is most-often utilized for **update** capabilities, PUT-ing to a known resource URI with the request body containing the newly-updated representation of the original resource..</desc>
 						<instances>
 							
 								<instance>
-									<uri>http://redacted.com</uri>
-									<method>GET</method>
-									<param>Header User-Agent</param>
-									<attack>Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)</attack>
-									<evidence></evidence>
-									<requestheader>GET http://redacted.com HTTP/1.1\r\nHost: redacted.com\r\nContent-Length: 0\r\n\r\n</requestheader>
-									<requestbody></requestbody>
-									<responseheader>HTTP/1.1 200 OK\r\nDate: Thu, 25 Aug 2022 08:15:19 GMT\r\nServer: Apache/2.4.29 (Ubuntu)\r\n\r\n</responseheader>
-									<responsebody>Hello World</responsebody>
+									<uri>http://localhost:8080/bodgeit/js/qndto7n63d</uri>
+									<method>PUT</method>
+									<param></param>
+									<attack></attack>
+									<evidence>response code 403 for potentially insecure HTTP METHOD</evidence>
+									<requestheader>PUT http://localhost:8080/bodgeit/js/qndto7n63d HTTP/1.1
+Host: localhost:8080
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:105.0) Gecko/20100101 Firefox/105.0
+Accept: */*
+Accept-Language: de,en-US;q=0.7,en;q=0.3
+Connection: keep-alive
+Referer: https://localhost:8080/bodgeit/
+Cookie: JSESSIONID=9E75E26E50F681208096FFAA0B566901
+Sec-Fetch-Dest: script
+Sec-Fetch-Mode: no-cors
+Sec-Fetch-Site: same-origin
+Content-Length: 35
+
+</requestheader>
+									<requestbody>&quot;J0O0glajHdR0Mgp&quot;:&quot;UToh9IpCY5zh3CB&quot;</requestbody>
+									<responseheader>HTTP/1.1 403 Forbidden
+Server: Apache-Coyote/1.1
+Content-Type: text/html;charset=utf-8
+Content-Language: en
+Content-Length: 1004
+Date: Fri, 30 Sep 2022 06:40:15 GMT
+
+</responseheader>
+									<responsebody>&lt;!DOCTYPE html&gt;&lt;html&gt;&lt;head&gt;&lt;title&gt;Apache Tomcat/8.0.37 - Error report&lt;/title&gt;&lt;style type=&quot;text/css&quot;&gt;H1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} H2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} H3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} B {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} P {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;}A {color : black;}A.name {color : black;}.line {height: 1px; background-color: #525D76; border: none;}&lt;/style&gt; &lt;/head&gt;&lt;body&gt;&lt;h1&gt;HTTP Status 403 - &lt;/h1&gt;&lt;div class=&quot;line&quot;&gt;&lt;/div&gt;&lt;p&gt;&lt;b&gt;type&lt;/b&gt; Status report&lt;/p&gt;&lt;p&gt;&lt;b&gt;message&lt;/b&gt; &lt;u&gt;&lt;/u&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;description&lt;/b&gt; &lt;u&gt;Access to the specified resource has been forbidden.&lt;/u&gt;&lt;/p&gt;&lt;hr class=&quot;line&quot;&gt;&lt;h3&gt;Apache Tomcat/8.0.37&lt;/h3&gt;&lt;/body&gt;&lt;/html&gt;</responsebody>
 								</instance>
-							
 						</instances>
 						<count>1</count>
-						<solution></solution>
-						<otherinfo></otherinfo>
-						<reference>&lt;p&gt;https://owasp.org/wstg&lt;/p&gt;</reference>
-						<cweid>0</cweid>
-						<wascid>0</wascid>
-						<sourceid>907</sourceid>
+						<solution>TBA</solution>
+						<otherinfo>See the discussion on stackexchange: https://security.stackexchange.com/questions/21413/how-to-exploit-http-methods, for understanding REST operations see http://www.restapitutorial.com/lessons/httpmethods.html</otherinfo>
+						<reference>http://projects.webappsec.org/Fingerprinting
+</reference>
+						<cweid>200</cweid>
+						<wascid>45</wascid>
+						<sourceid>2303</sourceid>
 					</alertitem>
-				
 			</alerts>
 		</site>
-	
 </OWASPZAPReport>

--- a/unittests/scans/zap/zap-xml-plus-format.xml
+++ b/unittests/scans/zap/zap-xml-plus-format.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<OWASPZAPReport version="2.11.1" generated="Do., 25 Aug. 2022 10:16:56">
+		<site name="http://redacted.com" host="redacted.com" port="80" ssl="false">
+			<alerts>
+				
+					<alertitem>
+						<pluginid>10104</pluginid>
+						<alertRef>10104</alertRef>
+						<alert>User Agent Fuzzer</alert>
+						<name>User Agent Fuzzer</name>
+						<riskcode>0</riskcode>
+						<confidence>2</confidence>
+						<riskdesc>Informational (Medium)</riskdesc>
+						<confidencedesc>Medium</confidencedesc>
+						<desc>&lt;p&gt;Check for differences in response based on fuzzed User Agent (eg. mobile sites, access as a Search Engine Crawler). Compares the response statuscode and the hashcode of the response body with the original response.&lt;/p&gt;</desc>
+						<instances>
+							
+								<instance>
+									<uri>http://redacted.com</uri>
+									<method>GET</method>
+									<param>Header User-Agent</param>
+									<attack>Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)</attack>
+									<evidence></evidence>
+									<requestheader>GET http://redacted.com HTTP/1.1\r\nHost: redacted.com\r\nContent-Length: 0\r\n\r\n</requestheader>
+									<requestbody></requestbody>
+									<responseheader>HTTP/1.1 200 OK\r\nDate: Thu, 25 Aug 2022 08:15:19 GMT\r\nServer: Apache/2.4.29 (Ubuntu)\r\n\r\n</responseheader>
+									<responsebody>Hello World</responsebody>
+								</instance>
+							
+						</instances>
+						<count>1</count>
+						<solution></solution>
+						<otherinfo></otherinfo>
+						<reference>&lt;p&gt;https://owasp.org/wstg&lt;/p&gt;</reference>
+						<cweid>0</cweid>
+						<wascid>0</wascid>
+						<sourceid>907</sourceid>
+					</alertitem>
+				
+			</alerts>
+		</site>
+	
+</OWASPZAPReport>

--- a/unittests/tools/test_zap_parser.py
+++ b/unittests/tools/test_zap_parser.py
@@ -196,7 +196,6 @@ class TestZapParser(DojoTestCase):
             self.assertEqual("assets", endpoint.path)
 
     def test_parse_xml_plus_format(self):
-        """Generated with OWASP Juicy shop"""
         testfile = open("unittests/scans/zap/zap-xml-plus-format.xml")
         parser = ZapParser()
         findings = parser.get_findings(testfile, Test())
@@ -212,17 +211,17 @@ class TestZapParser(DojoTestCase):
 
         with self.subTest(i=0):
             finding = findings[0]
-            self.assertEqual("User Agent Fuzzer", finding.title)
-            self.assertEqual("Info", finding.severity)
-            self.assertEqual("10104", finding.vuln_id_from_tool)
+            self.assertEqual("Insecure HTTP Method - PUT", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual("90028", finding.vuln_id_from_tool)
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
             self.assertEqual("http", endpoint.protocol)
-            self.assertEqual("redacted.com", endpoint.host)
-            self.assertEqual(80, endpoint.port)
+            self.assertEqual("localhost", endpoint.host)
+            self.assertEqual(8080, endpoint.port)
             # Check request and response pair
             request_pair = finding.unsaved_req_resp[0]
             request = request_pair["req"]
             response = request_pair["resp"]
-            self.assertEqual("HTTP/1.1 200 OK\nDate: Thu, 25 Aug 2022 08:15:19 GMT\nServer: Apache/2.4.29 (Ubuntu)\n\nHello World", response)
-            self.assertEqual("GET http://redacted.com HTTP/1.1\nHost: redacted.com\nContent-Length: 0\n\n", request)
+            self.assertEqual('HTTP/1.1 403 Forbidden\nServer: Apache-Coyote/1.1\nContent-Type: text/html;charset=utf-8\nContent-Language: en\nContent-Length: 1004\nDate: Fri, 30 Sep 2022 06:40:15 GMT\n\n<!DOCTYPE html><html><head><title>Apache Tomcat/8.0.37 - Error report</title><style type="text/css">H1 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:22px;} H2 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:16px;} H3 {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;font-size:14px;} BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;} B {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#525D76;} P {font-family:Tahoma,Arial,sans-serif;background:white;color:black;font-size:12px;}A {color : black;}A.name {color : black;}.line {height: 1px; background-color: #525D76; border: none;}</style> </head><body><h1>HTTP Status 403 - </h1><div class="line"></div><p><b>type</b> Status report</p><p><b>message</b> <u></u></p><p><b>description</b> <u>Access to the specified resource has been forbidden.</u></p><hr class="line"><h3>Apache Tomcat/8.0.37</h3></body></html>', response)
+            self.assertEqual('PUT http://localhost:8080/bodgeit/js/qndto7n63d HTTP/1.1\nHost: localhost:8080\nUser-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:105.0) Gecko/20100101 Firefox/105.0\nAccept: */*\nAccept-Language: de,en-US;q=0.7,en;q=0.3\nConnection: keep-alive\nReferer: https://localhost:8080/bodgeit/\nCookie: JSESSIONID=9E75E26E50F681208096FFAA0B566901\nSec-Fetch-Dest: script\nSec-Fetch-Mode: no-cors\nSec-Fetch-Site: same-origin\nContent-Length: 35\n\n"J0O0glajHdR0Mgp":"UToh9IpCY5zh3CB"', request)


### PR DESCRIPTION
I have [added a new XML report format to ZAP](https://github.com/zaproxy/zap-extensions/pull/3983) that includes full request and response headers and bodies. This makes ZAP findings a lot more useful, as they now show the entire req/response pair, making it easier to understand what exactly ZAP did and why it believes the response to be a problem. This PR adds support for the new format to DefectDojo.

Here's an example of what the result looks like in DefectDojo, with my patch applied:
![Results in DefectDojo](https://user-images.githubusercontent.com/1688580/197137396-b79f4bb7-4358-4ac8-9bfc-f6f3fd3f04c8.png)

As you can see, there is a small inconsistency in how the data is displayed: The response does not have an empty line between HTTP headers and body. This is due to the fact that [the model removes blank lines](https://github.com/malexmave/django-DefectDojo/blob/feature/zap-request-response/dojo/models.py#L2777-L2778). As changing this would potentially break things in other places, I chose not to change this behavior as part of this pull request, even though it means that there are some cosmetic problems with the output - but I'd be happy to make that small change if you believe that it should be made, of course.

As this is my first PR to this project, I'm not sure if anything else is required - let me know if I forgot anything :).