### PR TITLE
Fix out of SLA time

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -254,7 +254,7 @@ def finding_sla(finding):
     title = ""
     severity = finding.severity
     find_sla = finding.sla_days_remaining()
-    sla_age = get_system_setting('sla_' + severity.lower())
+    sla_age = getattr(finding.get_sla_periods(), severity.lower(), None)
     if finding.mitigated:
         status = "blue"
         status_text = 'Remediated within SLA for ' + severity.lower() + ' findings (' + str(sla_age) + ' days since ' + finding.get_sla_start_date().strftime("%b %d, %Y") + ')'


### PR DESCRIPTION
In the findings page you see "None" for the SLA time:

<img width="547" alt="Screenshot 2022-10-24 at 07 53 36" src="https://user-images.githubusercontent.com/472162/197466785-6251462c-539b-423a-a6fb-74ccf35ffbe7.png">
