### PR TITLE
Make requests of a peer review available to those with read access

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -985,7 +985,7 @@ def risk_unaccept(request, fid):
     return redirect_to_return_url_or_else(request, reverse('view_finding', args=(finding.id, )))
 
 
-@user_is_authorized(Finding, Permissions.Finding_Edit, 'fid')
+@user_is_authorized(Finding, Permissions.Finding_View, 'fid')
 def request_finding_review(request, fid):
     finding = get_object_or_404(Finding, id=fid)
     user = get_object_or_404(Dojo_User, id=request.user.id)


### PR DESCRIPTION
When users have read only access, It makes sense for them to be able to request another user to review a finding