### PR TITLE
Metrics Style Fixes, Calendar Filters Fix

### DIFF
--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -6,13 +6,13 @@
     <form method="GET" id="calfilter" action="/calendar">
         <div class="container-fluid chosen-container side-by-side">
             <div class="row">
-                <div class="col-lg-6" style="width:200px;">
+                <div style="display: inline-block;">
                     <select data-placeholder="Calendar type" id="caltype" class="chosen-select">
                         <option value="engagements">Engagements</option>
                         <option value="tests">Tests</option>
                     </select>
                 </div>
-                <div class="col-lg-6" style="width:400px;">
+                <div style="display: inline-block;">
                     <select data-placeholder="All users" multiple id="lead" name="lead" class="chosen-select">
                         <option value="0">All users</option>
                         <option value="-1">Unassigned</option>
@@ -21,7 +21,7 @@
                         {% endfor %}
                     </select>
                 </div>
-                <div class="col-lg-6">
+                <div style="display: inline-block;">
                     <input class="btn btn-primary" type="submit" value="Apply" />
                 </div>
             </div>
@@ -34,9 +34,9 @@
 {% block postscript %}
     {{ block.super }}
     <script>
-          $(function () {
+        $(function () {
             $('#caltype').change(function() {
-                 $('#calfilter').attr('action', '/calendar/' + $(this).val());
+                $('#calfilter').attr('action', '/calendar/' + $(this).val());
             });
             if (caltype) {
                 $('#caltype').val('{{ caltype }}');
@@ -77,8 +77,6 @@
                     {% endif %}
                 ]
             });
-
-
         });
     </script>
 {% endblock %}

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -205,6 +205,7 @@
                     </div>
                 </div>
             {% endif %}
+
             <div class="row">
                 {% if opened_per_month %}
                     <div class="col-lg-6">
@@ -232,7 +233,6 @@
                         <!-- /.panel -->
                     </div>
                 {% endif %}
-
                 {% if accepted_per_month %}
                     <div class="col-lg-6">
                         <div class="panel panel-default">
@@ -248,7 +248,7 @@
                         <!-- /.panel -->
                     </div>
                 {% endif %}
-                {% if  not critical_prods %}
+                {% if not critical_prods %}
                     <div class="col-lg-12">
                         <div class="panel panel-default">
                             <div class="panel-heading">
@@ -631,9 +631,10 @@
                         </div>
                     </div>
                 {% endif %}
-    <br/>
-    <br/>
-    <br/>
+                </div>
+            </div>
+        </div>
+    </div>
 {% endblock %}
 {% block postscript %}
     {{ block.super }}

--- a/dojo/templates/dojo/pt_counts.html
+++ b/dojo/templates/dojo/pt_counts.html
@@ -229,7 +229,7 @@
         <br/>
         <div class="panel panel-default table-responsive">
             <div class="panel-heading">
-                <h4>}{% blocktrans %}{{ pt }} Open Findings{% endblocktrans %}</h4>
+                <h4>{% blocktrans %}{{ pt }} Open Findings{% endblocktrans %}</h4>
             </div>
             <table id="open_findings"
                    class="tablesorter-bootstrap table table-bordered table-condensed table-striped table-hover">


### PR DESCRIPTION
**Fixed footer starting at the top of the critical product metrics page, due to missing div**
_Before_
<img width="707" alt="Screen Shot 2022-10-25 at 11 54 39 PM" src="https://user-images.githubusercontent.com/76979297/197938115-8c1a3283-3d9c-4598-bd46-8d627a7bc3d0.png">

_After_ 
<img width="750" alt="Screen Shot 2022-10-25 at 11 54 03 PM" src="https://user-images.githubusercontent.com/76979297/197938034-ecbef1cb-c903-495f-b39d-76692b50b3fe.png">


**Removed accidental curly brace from the product type counts template (when filtering on R&D findings)**
_Before_
<img width="547" alt="Screen Shot 2022-10-25 at 11 56 42 PM" src="https://user-images.githubusercontent.com/76979297/197938423-710d86da-a0b6-4841-b10b-12d8b458de5b.png">

_After_
<img width="584" alt="Screen Shot 2022-10-25 at 11 57 01 PM" src="https://user-images.githubusercontent.com/76979297/197938490-1790c868-e2cd-416d-81ef-d2b6c1a13834.png">


**Fixed calendar filter buttons**
_Before_
<img width="784" alt="Screen Shot 2022-10-25 at 11 57 43 PM" src="https://user-images.githubusercontent.com/76979297/197938560-abb14597-4c53-45f4-9471-1be2e3a4a44b.png">

_After_
<img width="647" alt="Screen Shot 2022-10-25 at 11 57 24 PM" src="https://user-images.githubusercontent.com/76979297/197938532-7dce59dc-748d-4986-b4ce-3fcc9a1afd66.png">
