### PR TITLE
Fixed system notifications

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -63,7 +63,7 @@ def create_notification(event=None, **kwargs):
 
         # System notifications
         try:
-            system_notifications = Notifications.objects.get(user=None)
+            system_notifications = Notifications.objects.get(user=None, template=False)
         except Exception:
             system_notifications = Notifications()
 


### PR DESCRIPTION
Before this fix django tried to get one row from database for system notifications settings, but there are two rows when user_id=None - system and template notifications settings. As a result there was used Notifications() instance with default settings `(alert, alert)` and system notifications settings was ignored.
