### PR TITLE
Fix appscreener parser

### DIFF
--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -47,7 +47,7 @@ class SolarAppscreenerParser(object):
             if finding.line:
                 if not finding.line.isdigit():
                     finding.line = finding.line.split("-")[0]
-              finding.line = int(finding.line)
+                finding.line = int(finding.line)
 
             finding.sast_source_line = finding.line
 

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -46,7 +46,10 @@ class SolarAppscreenerParser(object):
 
             if not finding.line.isdigit():
                 finding.line = finding.line.split("-")[0]
-
+                
+            if finding.line == '':
+                finding.line = 0
+                
             finding.line = int(finding.line)
 
             finding.sast_source_line = finding.line

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -47,7 +47,11 @@ class SolarAppscreenerParser(object):
             if finding.line:
                 if not finding.line.isdigit():
                     finding.line = finding.line.split("-")[0]
-                finding.line = int(finding.line)
+                
+                if finding.line:
+                    finding.line = int(finding.line)
+                else:
+                    finding.line = 0
 
             finding.sast_source_line = finding.line
 

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -44,8 +44,10 @@ class SolarAppscreenerParser(object):
             finding.sast_source_file_path = row.get('File')
             finding.line = row.get('Line')
 
-            if finding.line and not finding.line.isdigit():
-                finding.line = int(finding.line.split("-")[0])
+            if finding.line:
+              if not finding.line.isdigit():
+                finding.line = finding.line.split("-")[0]
+              finding.line = int(finding.line)
 
             finding.sast_source_line = finding.line
 

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -37,20 +37,15 @@ class SolarAppscreenerParser(object):
             finding = Finding(test=test)
             finding.title = row.get('Vulnerability', '')
             finding.description = row.get('Description', '')
-            finding.mitigation = row.get('Recommendations', '')
-            finding.references = row.get('Links', '')
+            finding.mitigation = row.get('Recommendations')
+            finding.references = row.get('Links')
             finding.severity = row.get('Severity Level', 'Info')
-            finding.file_path = row.get('File', '')
-            finding.sast_source_file_path = row.get('File', '')
-            finding.line = row.get('Line', '')
+            finding.file_path = row.get('File')
+            finding.sast_source_file_path = row.get('File')
+            finding.line = row.get('Line')
 
-            if not finding.line.isdigit():
-                finding.line = finding.line.split("-")[0]
-                
-            if finding.line == '':
-                finding.line = 0
-                
-            finding.line = int(finding.line)
+            if finding.line and not finding.line.isdigit():
+                finding.line = int(finding.line.split("-")[0])
 
             finding.sast_source_line = finding.line
 

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -47,7 +47,7 @@ class SolarAppscreenerParser(object):
             if finding.line:
                 if not finding.line.isdigit():
                     finding.line = finding.line.split("-")[0]
-                
+
                 if finding.line:
                     finding.line = int(finding.line)
                 else:

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -45,8 +45,8 @@ class SolarAppscreenerParser(object):
             finding.line = row.get('Line')
 
             if finding.line:
-              if not finding.line.isdigit():
-                finding.line = finding.line.split("-")[0]
+                if not finding.line.isdigit():
+                    finding.line = finding.line.split("-")[0]
               finding.line = int(finding.line)
 
             finding.sast_source_line = finding.line


### PR DESCRIPTION
Error, when trying to parse appscreener report. 

[05/Nov/2022 01:41:15] ERROR [dojo.engagement.views:683] invalid literal for int() with base 10: '' Traceback (most recent call last):
  File "/app/./dojo/engagement/views.py", line 668, in import_scan_results
    test, finding_count, closed_finding_count, _ = importer.import_scan(scan, scan_type, engagement, user, environment, active=active, verified=verified, tags=tags,
  File "/app/./dojo/importers/importer/importer.py", line 298, in import_scan
    parsed_findings = parser.get_findings(scan, test)
  File "/app/./dojo/tools/solar_appscreener/parser.py", line 50, in get_findings
    finding.line = int(finding.line)
ValueError: invalid literal for int() with base 10: ''

Because first line transfer to string after split. This fix should resolve it. I checked - all ok.