### PR TITLE
Fix flaw in logic in edit_finding

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -743,10 +743,10 @@ def edit_finding(request, fid):
         if finding.active:
             if (form['active'].value() is False or form['false_p'].value()) and form['duplicate'].value() is False:
                 note_type_activation = Note_Type.objects.filter(is_active=True).count()
-                closing_disabled = 0
+                closing_disabled = 1
                 if note_type_activation:
-                    closing_disabled = len(get_missing_mandatory_notetypes(finding))
-                if closing_disabled != 0:
+                    closing_disabled = 0
+                if closing_disabled:
                     error_inactive = ValidationError('Can not set a finding as inactive without adding all mandatory notes',
                                                      code='inactive_without_mandatory_notes')
                     error_false_p = ValidationError('Can not set a finding as false positive without adding all mandatory notes',


### PR DESCRIPTION
If I understand it correctly the closing should be disabled if a special note is missing. So if note_type exists the closing should be NOT disabled. Therefore it makes more sense to have closing_disable = 1 and set it to 0.
Alternative: It has to be `if closing_disabled == 0` because it was initialed with it.