### PR TITLE
Update the Cobalt API parser's severity mapping

### DIFF
--- a/dojo/tools/cobalt_api/parser.py
+++ b/dojo/tools/cobalt_api/parser.py
@@ -139,12 +139,16 @@ class CobaltApiParser(object):
 
     def convert_severity(self, cobalt_severity):
         """Convert severity value"""
-        if cobalt_severity == "low":
+        if cobalt_severity == "informational":
+            return "Info"
+        elif cobalt_severity == "low":
             return "Low"
         elif cobalt_severity == "medium":
             return "Medium"
         elif cobalt_severity == "high":
             return "High"
+        elif cobalt_severity == "critical":
+            return "Critical"
         else:
             return "Info"
 

--- a/unittests/scans/cobalt_api/cobalt_api_one_vul_invalid.json
+++ b/unittests/scans/cobalt_api/cobalt_api_one_vul_invalid.json
@@ -10,7 +10,7 @@
         "labels": [],
         "impact": 1,
         "likelihood": 1,
-        "severity": "low",
+        "severity": "critical",
         "affected_targets": [
           "https://example.com"
         ],

--- a/unittests/scans/cobalt_api/cobalt_api_one_vul_out_of_scope.json
+++ b/unittests/scans/cobalt_api/cobalt_api_one_vul_out_of_scope.json
@@ -10,7 +10,7 @@
         "labels": [],
         "impact": 1,
         "likelihood": 1,
-        "severity": "low",
+        "severity": "informational",
         "affected_targets": [
           "https://example.com"
         ],

--- a/unittests/tools/test_cobalt_api_parser.py
+++ b/unittests/tools/test_cobalt_api_parser.py
@@ -94,7 +94,7 @@ class TestCobaltApiParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("SQL Injection", finding.title)
         self.assertEqual("2021-01-01", finding.date)
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Critical", finding.severity)
         self.assertIn("A SQL injection attack...", finding.description)
         self.assertEqual("Ensure this...", finding.mitigation)
         self.assertEqual("Do this than that...", finding.steps_to_reproduce)
@@ -178,7 +178,7 @@ class TestCobaltApiParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("SQL Injection", finding.title)
         self.assertEqual("2021-01-01", finding.date)
-        self.assertEqual("Low", finding.severity)
+        self.assertEqual("Info", finding.severity)
         self.assertIn("A SQL injection attack...", finding.description)
         self.assertEqual("Ensure this...", finding.mitigation)
         self.assertEqual("Do this than that...", finding.steps_to_reproduce)


### PR DESCRIPTION
Update the Cobalt API parser in accordance with newly introduced severity levels over at Cobalt.io. In particular, this makes explicit that findings with the Cobalt.io severity "informational" should be mapped to "Info" and adds that findings with the Cobalt.io severity "critical" should be mapped to "Critical".

I adjusted the existing test suite for the parser so that one of existing cases now has an "informational" severity and a "critical" severity. Every possible severity (including `null`) is now tested at least once.

<details>
<summary><a href="https://docs.cobalt.io/v1/#findings">See the Cobalt.io API (v1) docs for more details</a></summary> 

<img width="960" alt="Screenshot 2022-11-08 at 12 15 26" src="https://user-images.githubusercontent.com/3742559/200550377-fa7f07f0-5d41-4a8d-950e-42b4255a2439.png">

</details>