### PR TITLE
Make SLA calculation of a Finding Group use the most severe finding

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -243,7 +243,9 @@ def group_sla(group):
         return ""
 
     # if there is at least 1 finding, there will be date, severity etc to calculate sla
-    return finding_sla(group)
+    # Get the first finding with the highests severity
+    finding = group.findings.all().order_by('severity').first()
+    return finding_sla(finding)
 
 
 @register.filter(name='finding_sla')


### PR DESCRIPTION
When using finding groups within a test, the SLA calculation for groups passes the entire group to the SLA calculation for a single finding. There is an expected mismatch there. This PR takes the most severe finding I the group and passes that finding the SLA calculation function so that the group has the fastest approaching SLA.