### PR TITLE
Support jira 9

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -631,29 +631,30 @@ def add_jira_issue_for_finding(finding, *args, **kwargs):
 def add_jira_issue_for_finding_group(finding_group, *args, **kwargs):
     return add_jira_issue(finding_group, *args, **kwargs)
 
+
 def prepare_jira_issue_fields(
         project_key,
         issuetype_name,
         summary,
         description,
-        component_name   = None,
-        custom_fields    = None,
-        labels           = None,
-        environment      = None,
-        priority_name    = None,
-        epic_name_field  = None,
-        duedate          = None,
+        component_name = None,
+        custom_fields = None,
+        labels = None,
+        environment = None,
+        priority_name = None,
+        epic_name_field = None,
+        duedate = None,
         issuetype_fields = []):
 
     fields = {
-            'project':      { 'key': project_key },
-            'issuetype':    { 'name': issuetype_name },
-            'summary':      summary,
-            'description':  description,
+            'project': {'key': project_key},
+            'issuetype': {'name': issuetype_name},
+            'summary': summary,
+            'description': description,
     }
 
     if component_name:
-        fields['components'] = [{ 'name': component_name }]
+        fields['components'] = [{'name': component_name}]
 
     if custom_fields:
         fields.update(custom_fields)
@@ -709,22 +710,19 @@ def add_jira_issue(obj, *args, **kwargs):
         if System_Settings.objects.get().enable_finding_sla:
             duedate = obj.sla_deadline()
 
-        issuetype_fields = []
-        meta = get_jira_meta(jira, jira_project)
-        issuetype_fields = meta['projects'][0]['issuetypes'][0]['fields'].keys()
-
+        issuetype_fields = get_issuetype_fields(jira, jira_project.project_key, jira_instance.default_issue_type)
         fields = prepare_jira_issue_fields(
-                project_key      = jira_project.project_key,
-                issuetype_name   = jira_instance.default_issue_type,
-                summary          = jira_summary(obj),
-                description      = jira_description(obj),
-                component_name   = jira_project.component,
-                custom_fields    = jira_project.custom_fields,
-                labels           = labels,
-                environment      = jira_environment(obj),
-                priority_name    = jira_priority(obj),
-                epic_name_field  = get_epic_name_field_name(jira_instance),
-                duedate          = duedate,
+                project_key = jira_project.project_key,
+                issuetype_name = jira_instance.default_issue_type,
+                summary = jira_summary(obj),
+                description = jira_description(obj),
+                component_name = jira_project.component,
+                custom_fields = jira_project.custom_fields,
+                labels = labels,
+                environment = jira_environment(obj),
+                priority_name = jira_priority(obj),
+                epic_name_field = get_epic_name_field_name(jira_instance),
+                duedate = duedate,
                 issuetype_fields = issuetype_fields)
 
 
@@ -830,19 +828,16 @@ def update_jira_issue(obj, *args, **kwargs):
         if labels:
             labels = list(dict.fromkeys(labels)) # de-dup
 
-        issuetype_fields = []
-        meta = get_jira_meta(jira, jira_project)
-        issuetype_fields = meta['projects'][0]['issuetypes'][0]['fields'].keys()
-
+        issuetype_fields = get_issuetype_fields(jira, jira_project.project_key, jira_instance.default_issue_type)
         fields = prepare_jira_issue_fields(
-                project_key      = jira_project.project_key,
-                issuetype_name   = jira_instance.default_issue_type,
-                summary          = jira_summary(obj),
-                description      = jira_description(obj),
-                component_name   = jira_project.component if not issue.fields.components else None,
-                labels           = labels,
-                environment      = jira_environment(obj),
-                priority_name    = jira_priority(obj),
+                project_key = jira_project.project_key,
+                issuetype_name = jira_instance.default_issue_type,
+                summary = jira_summary(obj),
+                description = jira_description(obj),
+                component_name = jira_project.component if not issue.fields.components else None,
+                labels = labels,
+                environment = jira_environment(obj),
+                priority_name = jira_priority(obj),
                 issuetype_fields = issuetype_fields)
 
         logger.debug('sending fields to JIRA: %s', fields)
@@ -891,6 +886,7 @@ def update_jira_issue(obj, *args, **kwargs):
         logger.error("jira_meta for project: %s and url: %s meta: %s", jira_project.project_key, jira_project.jira_instance.url, json.dumps(meta, indent=4))  # this is None safe
         log_jira_alert(e.text, obj)
         return False
+
 
 def get_jira_issue_from_jira(find):
     logger.debug('getting jira issue from JIRA for %d:%s', find.id, find)
@@ -978,67 +974,72 @@ def push_status_to_jira(obj, jira_instance, jira, issue, save=False):
         obj.jira_issue.save()
 
 
-# gets the metadata for the default issue type in this jira project
-def get_jira_meta(jira, jira_project):
-    meta = None
+# gets the metadata for the provided issue type in the provided jira project
+def get_issuetype_fields(
+        jira,
+        project_key,
+        issuetype_name):
+
+    issuetype_fields = None
     try:
-        meta = jira.createmeta(projectKeys=jira_project.project_key, issuetypeNames=jira_project.jira_instance.default_issue_type, expand="projects.issuetypes.fields")
+        if jira._version < (9, 0, 0):
+            try:
+                meta = jira.createmeta(
+                        projectKeys=project_key,
+                        issuetypeNames=issuetype_name,
+                        expand="projects.issuetypes.fields")
+            except JIRAError as e:
+                raise JIRAError(f"Jira API call 'createmeta' failed with status: {e.status_code} and message: {e.text}")
+
+            project = None
+            try:
+                project = meta['projects'][0]
+            except Exception as e:
+                raise JIRAError(f"Project misconfigured or no permissions in Jira ?")
+
+            try:
+                issuetype_fields = project['issuetypes'][0]['fields'].keys()
+            except Exception as e:
+                raise JIRAError(f"Misconfigured default issue type ?")
+
+        else:
+            try:
+                issuetypes = jira.createmeta_issuetypes(project_key)
+            except JIRAError as e:
+                raise JIRAError(f"Jira API call 'createmeta/issuetypes' failed with status: {e.status_code} and message: {e.text}. Project misconfigured or no permissions in Jira ?")
+
+            issuetype_id = None
+            for it in issuetypes['values']:
+                if it['name'] == issuetype_name:
+                    issuetype_id = it['id']
+                    break
+
+            if not issuetype_id:
+                raise JIRAError(f"Issue type ID can not be matched. Misconfigured default issue type ?")
+
+            try:
+                issuetype_fields = jira.createmeta_fieldtypes(project_key, issuetype_id)
+            except JIRAError as e:
+                raise JIRAError(f"Jira API call 'createmeta/fieldtypes' failed with status: {e.status_code} and message: {e.text}. Misconfigured project or default issue type ?")
+
+            try:
+                issuetype_fields = [f['fieldId'] for f in issuetype_fields['values']]
+            except Exception as e:
+                raise JIRAError(f"Misconfigured default issue type ?")
+
     except JIRAError as e:
-        message = "Invalid JIRA Project Config, can't retrieve or create metadata. status: %d, message: %s" % (e.status_code, e.text)
+        message = f"Failed retrieving field metadata from Jira version: {jira._version}, project: {project_key}, issue type: {issuetype_name}. {e.text}"
         logger.warn(message)
-
         add_error_message_to_response(message)
 
-        raise e
+        raise JIRAError(status_code = e.status_code, text = message)
 
-    meta_data_error = False
-    if len(meta['projects']) == 0:
-        # non-existent project, or no permissions
-        # [09/Nov/2020 21:04:22] DEBUG [dojo.jira_link.helper:595] get_jira_meta: {
-        #     "expand": "projects",
-        #     "projects": []
-        # }
-        meta_data_error = True
-        message = 'unable to retrieve metadata from JIRA %s for project %s. Invalid project key or no permissions to this project?' % (jira_project.jira_instance, jira_project.project_key)
-
-    elif len(meta['projects'][0]['issuetypes']) == 0:
-        # default issue type doesn't exist in project
-        # [09/Nov/2020 21:09:03] DEBUG [dojo.jira_link.helper:595] get_jira_meta: {
-        #     "expand": "projects",
-        #     "projects": [
-        #         {
-        #             "expand": "issuetypes",
-        #             "self": "https://jira-uat.com/rest/api/2/project/1212",
-        #             "id": "1212",
-        #             "key": "ISO",
-        #             "name": "ISO ISMS",
-        #             "avatarUrls": {
-        #                 "48x48": "https://jira-uat.com/secure/projectavatar?pid=14431&avatarId=17200",
-        #                 "24x24": "https://jira-uat.com/secure/projectavatar?size=small&pid=14431&avatarId=17200",
-        #                 "16x16": "https://jira-uat.com/secure/projectavatar?size=xsmall&pid=14431&avatarId=17200",
-        #                 "32x32": "https://jira-uat.com/secure/projectavatar?size=medium&pid=14431&avatarId=17200"
-        #             },
-        #             "issuetypes": []
-        #         }
-        #     ]
-        # }
-        meta_data_error = True
-        message = 'unable to retrieve metadata from JIRA %s for issuetype %s in project %s. Invalid default issue type configured in Defect Dojo?' % (jira_project.jira_instance, jira_project.jira_instance.default_issue_type, jira_project.project_key)
-
-    if meta_data_error:
-        logger.warn(message)
-        logger.warn("get_jira_meta: %s", json.dumps(meta, indent=4))  # this is None safe
-
-        add_error_message_to_response(message)
-
-        raise JIRAError(text=message)
-    else:
-        return meta
-
+    return issuetype_fields
 
 def is_jira_project_valid(jira_project):
     try:
-        meta = get_jira_meta(get_jira_connection(jira_project), jira_project)
+        jira = get_jira_connection(jira_project)
+        get_issuetype_fields(jira, jira_project.project_key, jira_project.jira_instance.default_issue_type)
         return True
     except JIRAError as e:
         logger.debug("invalid JIRA Project Config, can't retrieve metadata for '%s'", jira_project)


### PR DESCRIPTION
Fixes: https://github.com/DefectDojo/django-DefectDojo/issues/6963
Depends on: https://github.com/pycontribs/jira/pull/1527

If you don't have the update in the mentioned dependency than behaves as it used to - works until Jira 9 and breaks afterwards.
If you update the dependency than it will continue working after Jira 9.
With the updated dependency it will throw deprecation warnings on Jira versions [8.4 - 9).

Tested manually against Jira  7.13.8, 8.22.6 and 9.3.1.