### PR TITLE
Fix helm chart using external databases

### DIFF
--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.16.1"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.45
+version: 1.6.46
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -320,9 +320,8 @@ mysql:
     service:
       ports:
         mysql: 3306
-  # To use an external mySQL instance, set enabled to false and uncomment
-  # the line below / add external address:
-  # mysqlServer: "127.0.0.1"
+  # To use an external mySQL instance, set enabled to false and set this value to the external address
+  mysqlServer: "127.0.0.1"
 
 postgresql:
   enabled: true
@@ -366,9 +365,8 @@ postgresql:
     chmod:
       enabled: false
 
-  # To use an external PostgreSQL instance, set enabled to false and uncomment
-  # the line below:
-  # postgresServer: "127.0.0.1"
+  # To use an external PostgreSQL instance, set enabled to false and set a value here
+  postgresServer: "127.0.0.1"
 
 postgresqlha:
   enabled: false
@@ -476,9 +474,8 @@ redis:
     existingSecretPasswordKey: redis-password
     password: ""
   architecture: standalone
-  # To use an external Redis instance, set enabled to false and uncomment
-  # the line below:
-  # redisServer: myrediscluster
+  # To use an external Redis instance, set enabled to false and set the following to the external host
+  redisServer: localhost
 
 # To add extra variables not predefined by helm config it is possible to define in extraConfigs block, e.g. below:
 # NOTE  Do not store any kind of sensitive information inside of it


### PR DESCRIPTION
The helm chart does not currently allow external databases without modification of the ```values.yaml``` file by hand. This makes deploying the helm chart from the repository impossible if you want to use an external database.

Helm does not allow setting the values if they are not defaulted in values.yaml. Having the values defaulted will not affect the chart because they are each in templated ```if``` blocks.

It's possible this failure was introduced with Helm 3 specifically not allowing the use of ```.Values``` that aren't in the ```values.yaml```.

This is something I noticed while setting it up, so I made a PR. I didn't think it should be against dev, because it would be nice to get this in without waiting for an application release. If you need be to rebase or make a fresh branch I can.