### PR TITLE
Fix deprecations of GHA (set-output and node12)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,7 +64,7 @@ jobs:
           
       # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact
-        uses:  actions/upload-artifact@v2
+        uses:  actions/upload-artifact@v3
         with:
           name: ${{ matrix.docker-image }}
           path: ${{ matrix.docker-image }}_img

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -101,7 +101,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
       - name: Upload image ${{ env.docker-image }} as artifact
-        uses:  actions/upload-artifact@v2
+        uses:  actions/upload-artifact@v3
         with:
           name: ${{ matrix.docker-image }}
           path: ${{ matrix.docker-image }}_img
@@ -176,11 +176,11 @@ jobs:
       - name: Set confings into Outputs
         id: set
         run: |-
-              echo ::set-output name=pgsql:: "${{ env.HELM_PG_DATABASE_SETTINGS }}"
-              echo ::set-output name=pgsqlha:: "${{ env.HELM_PGHA_DATABASE_SETTINGS }}"
-              echo ::set-output name=mysql:: "${{ env.HELM_MYSQL_DATABASE_SETTINGS }}"
-              echo ::set-output name=redis:: "${{ env.HELM_REDIS_BROKER_SETTINGS }}"
-              echo ::set-output name=rabbit:: "${{ env.HELM_RABBIT_BROKER_SETTINGS }}"
+              echo "pgsql=${{ env.HELM_PG_DATABASE_SETTINGS }}" >> $GITHUB_ENV
+              echo "pgsqlha=${{ env.HELM_PGHA_DATABASE_SETTINGS }}" >> $GITHUB_ENV
+              echo "mysql=${{ env.HELM_MYSQL_DATABASE_SETTINGS }}" >> $GITHUB_ENV
+              echo "redis=${{ env.HELM_REDIS_BROKER_SETTINGS }}" >> $GITHUB_ENV
+              echo "rabbit=${{ env.HELM_RABBIT_BROKER_SETTINGS }}" >> $GITHUB_ENV
 
       # - name: Create image pull Secrets
       #   run: |-
@@ -194,8 +194,8 @@ jobs:
                ./helm/defectdojo \
                --set django.ingress.enabled=true \
                --set imagePullPolicy=Never \
-               ${{ steps.set.outputs[matrix.databases] }} \
-               ${{ steps.set.outputs[matrix.brokers] }} \
+               ${{ env[matrix.databases] }} \
+               ${{ env[matrix.brokers] }} \
                --set createSecret=true \
                # --set imagePullSecrets=defectdojoregistrykey
 

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -76,10 +76,10 @@ jobs:
           commit_message: "Update versions in application files"
           branch: ${{ env.NEW_BRANCH }}
       - id: set-repo-org
-        run: echo ::set-output name=repoorg::${GITHUB_REPOSITORY%%/*}
+        run: echo "repoorg::${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV
       - name: Create Pull Request
         env:
-          REPO_ORG: ${{ steps.set-repo-org.outputs.repoorg }}
+          REPO_ORG: ${{ env.repoorg }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-1-create-pr.yml
+++ b/.github/workflows/release-1-create-pr.yml
@@ -19,29 +19,36 @@ jobs:
   create_pr:
     runs-on: ubuntu-latest
     steps:
+     
       - name: Checkout from_branch branch
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.from_branch }}
+     
       - name: Create release branch
         if: ${{ !startsWith(github.event.inputs.from_branch, 'release/') }}
         run: |
           echo "NEW_BRANCH=release/${{ github.event.inputs.release_number }}" >> $GITHUB_ENV
+     
       - name: Use existing release branch
         if: startsWith(github.event.inputs.from_branch, 'release/')
         run: |
           echo "NEW_BRANCH=${{ github.event.inputs.from_branch }}" >> $GITHUB_ENV
+     
       - name: Configure git
         run: |
           git config --global user.name "${{ env.GIT_USERNAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
+     
       - name: Push branch
         if: "!startsWith('${{ github.event.inputs.from_branch }}', 'release/')"
         run: git push origin HEAD:${NEW_BRANCH}
+     
       - name: Checkout release branch
         uses: actions/checkout@v3
         with:
           ref: ${{ env.NEW_BRANCH }}
+     
       - name: Update version numbers in key files
         run: |
           sed -ri "s/__version__ = '.*'/__version__ = '${{ github.event.inputs.release_number }}'/" dojo/__init__.py
@@ -77,6 +84,7 @@ jobs:
           branch: ${{ env.NEW_BRANCH }}
       - id: set-repo-org
         run: echo "repoorg::${GITHUB_REPOSITORY%%/*}" >> $GITHUB_ENV
+     
       - name: Create Pull Request
         env:
           REPO_ORG: ${{ env.repoorg }}

--- a/.github/workflows/release-2-tag-docker-push.yml
+++ b/.github/workflows/release-2-tag-docker-push.yml
@@ -52,29 +52,18 @@ jobs:
           echo "chart_version=$(ls build | cut -d '-' -f 2 | sed 's|\.tgz||')" >> $GITHUB_ENV
 
       - name: Create release ${{ github.event.inputs.release_number }}
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.event.inputs.release_number }}  # this does not create a tag
-          release_name: Release ${{ github.event.inputs.release_number }}
-          body: |
-            Run the release drafter to populate the release notes.
+          name: Release ${{ github.event.inputs.release_number }}
+          tag_name: ${{ github.event.inputs.release_number }}
+          body: Run the release drafter to populate the release notes.
           draft: true
           prerelease: false
-      
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+          files: ./build/defectdojo-${{ env.chart_version }}.tgz
+          token: ${{ secrets.GITHUB_TOKEN }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/defectdojo-${{ env.chart_version }}.tgz
-          asset_name: defectdojo-${{ env.chart_version }}.tgz
-          asset_content_type: application/tar+gzip
-      
+          GITHUB_REPOSITORY: DefectDojo/django-DefectDojo
+
       - name: Update Helm repository index
         id: update-helm-repository-index
         run: |

--- a/.github/workflows/release-2-tag-docker-push.yml
+++ b/.github/workflows/release-2-tag-docker-push.yml
@@ -21,30 +21,36 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: master
+
       - name: Configure git
         run: |
           git config --global user.name "${{ env.GIT_USERNAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
+
       - name: Create new tag ${{ github.event.inputs.release_number }}
         # at this point, the PR from the 1st workflow is merged into master.
         run: |
           git tag -a ${{ github.event.inputs.release_number }} -m "[bot] release ${{ github.event.inputs.release_number }}"
           git push origin ${{ github.event.inputs.release_number }}
+
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
           version: v3.4.0
+
       - name: Configure Helm repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependency list ./helm/defectdojo
           helm dependency update ./helm/defectdojo
+
       - name: Package Helm chart
         id: package-helm-chart
         run: |
           mkdir build
           helm package helm/defectdojo/ --destination ./build
-          echo "::set-output name=chart_version::$(ls build | cut -d '-' -f 2 | sed 's|\.tgz||')"
+          echo "chart_version=$(ls build | cut -d '-' -f 2 | sed 's|\.tgz||')" >> $GITHUB_ENV
+
       - name: Create release ${{ github.event.inputs.release_number }}
         id: create_release
         uses: actions/create-release@v1
@@ -57,6 +63,7 @@ jobs:
             Run the release drafter to populate the release notes.
           draft: true
           prerelease: false
+      
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -64,9 +71,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/defectdojo-${{ steps.package-helm-chart.outputs.chart_version }}.tgz
-          asset_name: defectdojo-${{ steps.package-helm-chart.outputs.chart_version }}.tgz
+          asset_path: ./build/defectdojo-${{ env.chart_version }}.tgz
+          asset_name: defectdojo-${{ env.chart_version }}.tgz
           asset_content_type: application/tar+gzip
+      
       - name: Update Helm repository index
         id: update-helm-repository-index
         run: |
@@ -106,7 +114,7 @@ jobs:
           ref: ${{ github.event.inputs.release_number }}
 
       - id: set-repo-org
-        run: echo ::set-output name=repoorg::${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]'
+        run: echo "repoorg=${GITHUB_REPOSITORY%%/*} | tr '[:upper:]' '[:lower:]'" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         id: buildx
@@ -127,7 +135,7 @@ jobs:
       - name: Build and push images
         uses: docker/build-push-action@v3
         env:
-          REPO_ORG: ${{ steps.set-repo-org.outputs.repoorg }}
+          REPO_ORG: ${{ env.repoorg }}
           docker-image: ${{ matrix.docker-image }}
         with:
           push: true

--- a/.github/workflows/release-3-master-into-dev.yml
+++ b/.github/workflows/release-3-master-into-dev.yml
@@ -19,23 +19,29 @@ jobs:
   create_pr_for_merge_back_into_dev:
     runs-on: ubuntu-latest
     steps:
+      
       - name: Checkout master
         uses: actions/checkout@v3
         with:
           ref: master
+      
       - name: Create merge back branch
         run: |
           echo "NEW_BRANCH=master-into-dev/${{ github.event.inputs.release_number_new }}-${{ github.event.inputs.release_number_dev }}" >> $GITHUB_ENV
+      
       - name: Configure git
         run: |
           git config --global user.name "${{ env.GIT_USERNAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
+      
       - name: Push new branch
         run: git push origin HEAD:${NEW_BRANCH}
+      
       - name: Checkout new branch
         uses: actions/checkout@v3
         with:
           ref: ${{ env.NEW_BRANCH }}
+      
       - name: Update version numbers in key files
         run: |
           sed -ri "s/__version__ = '.*'/__version__ = '${{ github.event.inputs.release_number_dev }}'/" dojo/__init__.py
@@ -43,11 +49,13 @@ jobs:
           sed -ri "s/\"version\": \".*\"/\"version\": \"${{ github.event.inputs.release_number_dev }}\"/" components/package.json
           CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml | head -1)
           sed -ri "0,/version/s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')-dev/" helm/defectdojo/Chart.yaml
+      
       - name: Check numbers
         run: |
           grep version dojo/__init__.py
           grep appVersion helm/defectdojo/Chart.yaml
           grep version components/package.json
+      
       - name: Push version changes
         uses: stefanzweifel/git-auto-commit-action@v4.15.4
         with:
@@ -57,10 +65,11 @@ jobs:
           commit_message: "Update versions in application files"
           branch: ${{ env.NEW_BRANCH }}
       - id: set-repo-org
-        run: echo ::set-output name=repoorg::${GITHUB_REPOSITORY%%/*}
+        run: echo "repoorg::${GITHUB_REPOSITORY%%/*}"  >> $GITHUB_ENV
+      
       - name: Create Pull Request
         env:
-          REPO_ORG: ${{ steps.set-repo-org.outputs.repoorg }}
+          REPO_ORG: ${{ env.repoorg }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -14,35 +14,42 @@ jobs:
   release-chart:
     runs-on: ubuntu-latest
     steps:
+      
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      
       - name: Get upload URL
         id: get-upload-url
         uses: pdamianik/release-tag-to-upload-url-action@v1.0.1
         with:
           tag: ${{ github.event.inputs.release_number }}
           token: ${{ github.token }}
+      
       - name: Configure git
         run: |
           git config --global user.name "${{ env.GIT_USERNAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
+      
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
           version: v3.4.0
+      
       - name: Configure HELM repos
         run: |-
              helm repo add bitnami https://charts.bitnami.com/bitnami
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
+      
       - name: Package Helm chart
         id: package-helm-chart
         run: |
           mkdir build
           helm package helm/defectdojo/ --destination ./build
-          echo "::set-output name=chart_version::$(ls build | cut -d '-' -f 2 | sed 's|\.tgz||')"
+          echo "chart_version=$(ls build | cut -d '-' -f 2 | sed 's|\.tgz||')" >> #GITHUB_ENV
+      
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
@@ -50,9 +57,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get-upload-url.outputs.uploadUrl }}
-          asset_path: ./build/defectdojo-${{ steps.package-helm-chart.outputs.chart_version }}.tgz
-          asset_name: defectdojo-${{ steps.package-helm-chart.outputs.chart_version }}.tgz
+          asset_path: ./build/defectdojo-${{ env.chart_version }}.tgz
+          asset_name: defectdojo-${{ env.chart_version }}.tgz
           asset_content_type: application/tar+gzip
+      
       - name: Update Helm repository index
         id: update-helm-repository-index
         run: |

--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -50,16 +50,18 @@ jobs:
           helm package helm/defectdojo/ --destination ./build
           echo "chart_version=$(ls build | cut -d '-' -f 2 | sed 's|\.tgz||')" >> #GITHUB_ENV
       
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release ${{ github.event.inputs.release_number }}
+        uses: softprops/action-gh-release@v1
         with:
-          upload_url: ${{ steps.get-upload-url.outputs.uploadUrl }}
-          asset_path: ./build/defectdojo-${{ env.chart_version }}.tgz
-          asset_name: defectdojo-${{ env.chart_version }}.tgz
-          asset_content_type: application/tar+gzip
+          name: Release ${{ github.event.inputs.release_number }}
+          tag_name: ${{ github.event.inputs.release_number }}
+          body: Run the release drafter to populate the release notes.
+          draft: true
+          prerelease: false
+          files: ./build/defectdojo-${{ env.chart_version }}.tgz
+          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_REPOSITORY: DefectDojo/django-DefectDojo
       
       - name: Update Helm repository index
         id: update-helm-repository-index

--- a/.github/workflows/submodule-update.yml
+++ b/.github/workflows/submodule-update.yml
@@ -18,21 +18,21 @@ jobs:
         id: branch-target
         run: |
           if [ ! -z ${GITHUB_BASE_REF} ]; then
-            echo ::set-output name=branch::${GITHUB_BASE_REF}
+            echo "branch=${GITHUB_BASE_REF}" >> $GITHUB_ENV
           else
-            echo ::set-output name=branch::${GITHUB_REF#refs/heads/}
+            echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
           fi
     
       - name: Checkout DefectDojo from dev 
         uses: actions/checkout@v3
-        if: steps.branch-target.outputs.branch == 'dev'
+        if: env.branch == 'dev'
         with:
           ref: dev
 
       - name: Create PR to Documentation repo on dev branch
         id: create_dev_pr
         uses: releasehub-com/github-action-create-pr-parent-submodule@v1
-        if: steps.branch-target.outputs.branch == 'dev'
+        if: env.branch == 'dev'
         with:
           github_token: ${{ secrets.DOCUMENTATION_TOKEN }}
           parent_repository: ${{ env.PARENT_REPOSITORY }}
@@ -42,14 +42,14 @@ jobs:
           
       - name: Checkout DefectDojo from master 
         uses: actions/checkout@v3
-        if: steps.branch-target.outputs.branch == 'master'
+        if: env.branch == 'master'
         with:
           ref: master
 
       - name: Create PR to Documentation repo on master branch
         id: create_master_pr
         uses: releasehub-com/github-action-create-pr-parent-submodule@v1
-        if: steps.branch-target.outputs.branch == 'master'
+        if: env.branch == 'master'
         with:
           github_token: ${{ secrets.DOCUMENTATION_TOKEN }}
           parent_repository: ${{ env.PARENT_REPOSITORY }}

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -41,34 +41,34 @@ jobs:
         id: ct-branch-target
         run: |
           if [ ! -z ${GITHUB_BASE_REF} ]; then
-            echo ::set-output name=ct-branch::${GITHUB_BASE_REF}
+            echo "ct-branch=${GITHUB_BASE_REF}" >> $GITHUB_ENV 
           else
-            echo ::set-output name=ct-branch::${GITHUB_REF#refs/heads/}
+            echo "ct-branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV 
           fi
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch}})
+          changed=$(ct list-changed --config ct.yaml --target-branch ${{ env.ct-branch}})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_ENV
           fi
 
       # run all checks but version increment always when something changed
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }} --check-version-increment=false
-        if: ${{ steps.list-changed.outputs.changed == 'true' && steps.ct-branch-target.outputs.ct-branch == 'dev' }}
+        run: ct lint --config ct.yaml --target-branch ${{ env.ct-branch }} --check-version-increment=false
+        if: env.changed == 'true'
 
       # run version check only if not dev as in dev we have a `x.y.z-dev` version
       # x.y.z gets bumped automatically when doing a release
       - name: Run chart-testing (lint)
-        run: ct lint --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }} --check-version-increment=true
-        if: ${{ steps.list-changed.outputs.changed == 'true' && steps.ct-branch-target.outputs.ct-branch != 'dev' }}
+        run: ct lint --config ct.yaml --target-branch ${{ env.ct-branch }} --check-version-increment=true
+        if: ${{ env.changed == 'true' && env.ct-branch != 'dev' }}  
 
       # - name: Create kind cluster
       #  uses: helm/kind-action@v1.1.0
-      #  if: steps.list-changed.outputs.changed == 'true'
+      #  if: env.changed == 'true'
 
       # - name: Run chart-testing (install)
-      #   run: ct install --config ct.yaml --target-branch ${{ steps.ct-branch-target.outputs.ct-branch }} --helm-extra-args '--set createSecret=true --set createRabbitMqSecret=true --set createPostgresqlSecret=true --set timeout=900'
-      #  if: steps.list-changed.outputs.changed == 'true'
+      #   run: ct install --config ct.yaml --target-branch ${{ env.ct-branch }} --helm-extra-args '--set createSecret=true --set createRabbitMqSecret=true --set createPostgresqlSecret=true --set timeout=900'
+      #  if: env.changed == 'true'


### PR DESCRIPTION
- GitHub has begun adding warnings to actions that are using the `set-output` directive in favor of a different format
  - https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ 
- GitHub is also deprecating the use of Node12 in favor of Node16, so some actions needed to be updated or replaced 
  - https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/