### PR TITLE
Add severity for Veracode SCA hashcode calculation

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1206,7 +1206,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Blackduck Hub Scan': ['title', 'vulnerability_ids', 'component_name', 'component_version'],
     'BlackDuck API': ['unique_id_from_tool'],
     'docker-bench-security Scan': ['unique_id_from_tool'],
-    'Veracode SourceClear Scan': ['title', 'vulnerability_ids', 'component_name', 'component_version'],
+    'Veracode SourceClear Scan': ['title', 'vulnerability_ids', 'component_name', 'component_version', 'severity'],
     'Twistlock Image Scan': ['title', 'severity', 'component_name', 'component_version'],
     'NeuVector (REST)': ['title', 'severity', 'component_name', 'component_version'],
     'NeuVector (compliance)': ['title', 'vuln_id_from_tool', 'description'],


### PR DESCRIPTION
On re-import, or if de-dup is enabled, it closes all other findings for a given component name/version that don't have a CVE (Veracode premium data). This takes the severity into account, so it doesn't end up closing a critical finding as a duplicate of a Low severity finding.