### PR TITLE
semgrep parser error fix > 'list' object has no attribute 'partition'

### DIFF
--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -36,9 +36,9 @@ class SemgrepParser(object):
             # manage CWE
             if 'cwe' in item["extra"]["metadata"]:
                 if isinstance(item["extra"]["metadata"].get("cwe"), list):
-                    finding.cwe = int(item["extra"]["metadata"].get("cwe")[0].partition(':')[0].partition('-')[2])
+                    finding.cwe = int(item["extra"]["metadata"].get("cwe")[0].split(':')[0].split('-')[1])
                 else:
-                    finding.cwe = int(item["extra"]["metadata"].get("cwe").partition(':')[0].partition('-')[2])
+                    finding.cwe = int(item["extra"]["metadata"].get("cwe").split(':')[0].split('-')[1])
 
             # manage references from metadata
             if 'references' in item["extra"]["metadata"]:


### PR DESCRIPTION
I noticed that this error happens _'list' object has no attribute 'partition'_ when I try to import semgrep results despite adding the flag --json, the issue happens when calling the function partition.

Next, the logged error:
```[15/Nov/2022 14:37:19] ERROR [dojo.api_v2.exception_handler:32] 'list' object has no attribute 'partition'
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/app/./dojo/api_v2/views.py", line 2145, in perform_create
    serializer.save(push_to_jira=push_to_jira)
  File "/app/./dojo/api_v2/serializers.py", line 1598, in save
    reimporter.reimport_scan(scan, scan_type, test, active=active, verified=verified,
  File "/app/./dojo/importers/reimporter/reimporter.py", line 311, in reimport_scan
    parsed_findings = parser.get_findings(scan, test)
  File "/app/./dojo/tools/semgrep/parser.py", line 38, in get_findings
    finding.cwe = int(item["extra"]["metadata"].get("cwe").partition(':')[0].partition('-')[2])
AttributeError: 'list' object has no attribute 'partition'
[15/Nov/2022 14:37:19] ERROR [django.request:224] Internal Server Error: /api/v2/reimport-scan/
```

This is how the semgrep output was created:
`docker run -v ${project_location}:/src --workdir /src returntocorp/semgrep:latest --config p/java --json > ${artifacts}/semgrep-classic-results.json
`