### PR TITLE
Fix helm unit test duplicate 'key' value in secretKeyRef

### DIFF
--- a/helm/defectdojo/templates/tests/unit-tests.yaml
+++ b/helm/defectdojo/templates/tests/unit-tests.yaml
@@ -50,9 +50,12 @@ spec:
               key: postgresql-postgres-password
               {{- else if eq .Values.database "mysql" }}
               name: {{ .Values.mysql.auth.existingSecret }}
+              {{- if .Values.mysql.auth.secretKey }}
               key: {{ .Values.mysql.auth.secretKey }}
+              {{- else }}
+              key: mysql-root-password
               {{- end }}
-              key: {{ if eq .Values.database "postgresql" }}{{ .Values.database }}-password{{ end }}{{ if eq .Values.database "postgresqlha" }}{{ .Values.database }}-password{{ end }}{{ if eq .Values.database "mysql" }}{{ .Values.database }}-root-password{{ end }}
+              {{- end }}
         - name: DD_DEBUG
           value: 'True'
         - name: DD_SECRET_KEY


### PR DESCRIPTION
This PR removes the duplicate `key` value in the `secretKeyRef` of the `DD_DATABASE_PASSWORD` environment variable. The change should keep the same behaviour as previously when it comes to default values but ensures that only a single `key` value exists.