### PR TITLE
Remove enforcement of unnecessary notes

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -430,7 +430,7 @@ def close_finding(request, fid):
                 'Note Saved.',
                 extra_tags='alert-success')
 
-            if len(missing_note_types) == 0:
+            if len(missing_note_types) <= 1:
                 finding.active = False
                 now = timezone.now()
                 finding.mitigated = form.cleaned_data.get("mitigated") or now

--- a/dojo/templates/dojo/close_finding.html
+++ b/dojo/templates/dojo/close_finding.html
@@ -4,9 +4,9 @@
     {{ block.super }}
     <h3> Close a Finding</h3>
     <h4>{{ finding.title }}</h4>
-    {% if note_types|length == 0 %}
+    {% if note_types|length <= 1 %}
       <p>Please provide a reason why this finding is being closed.</p>
-    {% elif note_types|length > 0 %}
+    {% elif note_types|length > 1 %}
       <p>Please add atleast one note from the following note type(s):</p>
       {% for note_type in note_types %}
         {{ note_type.name}}<br>
@@ -17,9 +17,9 @@
         {% include "dojo/form_fields.html" with form=form %}
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
-              {% if note_types|length == 0 %}
+              {% if note_types|length <= 1 %}
                 <input class="btn btn-primary" name='submit' type="submit" value="Close Finding" aria-label="Close Finding"/>
-              {% elif note_types|length > 0 %}
+              {% elif note_types|length > 1 %}
                 <input class="btn btn-primary" name='submit' type="submit" value="Add Note" aria-label="Add Note"/>
               {% endif %}
             </div>


### PR DESCRIPTION
When note_types activated it should be checked if up to one note_type is missing. When including this note no note_types would be missing and therefore all mandatory notes are included and an additional note is not necessary.
resolve #7160 