### PR TITLE
Bugcrowd API parser fixes

### DIFF
--- a/dojo/tools/bugcrowd_api/api_client.py
+++ b/dojo/tools/bugcrowd_api/api_client.py
@@ -44,7 +44,7 @@ class BugcrowdAPI:
             "filter[program]": program,
             "page[limit]": 100,
             "page[offset]": 0,
-            "include": "monetary_rewards,target",
+            "include": "monetary_rewards,target,program,external_issues",
             "sort": "submitted-desc",
         }
 

--- a/dojo/tools/bugcrowd_api/importer.py
+++ b/dojo/tools/bugcrowd_api/importer.py
@@ -31,7 +31,7 @@ class BugcrowdApiImporter(object):
             counter += 1
         logger.debug("{} Bugcrowd submissions pages fetched".format(counter))
 
-        return submissions
+        return submissions, config
 
     def prepare_client(self, test):
         product = test.engagement.product

--- a/dojo/tools/bugcrowd_api/parser.py
+++ b/dojo/tools/bugcrowd_api/parser.py
@@ -37,6 +37,7 @@ class BugcrowdApiParser(object):
         return "Bugcrowd API"
 
     def get_findings(self, file, test):
+        api_scan_config = None
         if file is None:
             data, api_scan_config = BugcrowdApiImporter().get_findings(test)
         else:
@@ -51,7 +52,7 @@ class BugcrowdApiParser(object):
                 links = "https://tracker.bugcrowd.com/{}{}".format(
                     str(config.service_key_1), entry["links"]["self"]
                 )
-            if api_scan_config:
+            if api_scan_config is not None:
                 links = "https://tracker.bugcrowd.com/{}{}".format(
                     str(api_scan_config.service_key_1), entry["links"]["self"]
                 )

--- a/dojo/tools/bugcrowd_api/parser.py
+++ b/dojo/tools/bugcrowd_api/parser.py
@@ -38,7 +38,7 @@ class BugcrowdApiParser(object):
 
     def get_findings(self, file, test):
         if file is None:
-            data = BugcrowdApiImporter().get_findings(test)
+            data, api_scan_config = BugcrowdApiImporter().get_findings(test)
         else:
             data = json.load(file)
         findings = []
@@ -46,11 +46,14 @@ class BugcrowdApiParser(object):
         for entry in data:
             if not self.include_finding(entry):
                 continue
-
             if test.api_scan_configuration:
                 config = test.api_scan_configuration
                 links = "https://tracker.bugcrowd.com/{}{}".format(
                     str(config.service_key_1), entry["links"]["self"]
+                )
+            if api_scan_config:
+                links = "https://tracker.bugcrowd.com/{}{}".format(
+                    str(api_scan_config.service_key_1), entry["links"]["self"]
                 )
             else:
                 links = None
@@ -98,9 +101,9 @@ class BugcrowdApiParser(object):
                     "",
                     "Bugcrowd details:",
                     f"- Severity: P{ bugcrowd_severity }",
-                    f"- Bug Url: { bug_url }",
+                    f"- Bug Url: [{bug_url}]({ bug_url })",
                     "",
-                    f"Bugcrowd link: {links}",
+                    f"Bugcrowd link: [{links}]({links})",
                 ]
             )
             mitigation = entry["attributes"]["remediation_advice"]
@@ -118,14 +121,13 @@ class BugcrowdApiParser(object):
                 active=self.is_active(bugcrowd_state),
                 verified=self.is_verified(bugcrowd_state),
                 false_p=self.is_false_p(bugcrowd_state),
-                duplicate=bugcrowd_duplicate,
                 out_of_scope=self.is_out_of_scope(bugcrowd_state),
                 risk_accepted=self.is_risk_accepted(bugcrowd_state),
                 is_mitigated=self.is_mitigated(bugcrowd_state),
                 static_finding=False,
                 dynamic_finding=True,
                 unique_id_from_tool=unique_id_from_tool,
-                references=links
+                references=links,
             )
             if bug_endpoint:
                 try:
@@ -211,6 +213,7 @@ class BugcrowdApiParser(object):
             or self.is_out_of_scope(bugcrowd_state)
             or self.is_risk_accepted(bugcrowd_state)
             or bugcrowd_state == "not_reproducible"
+            or bugcrowd_state == "informational"
         )
 
     def is_duplicate(self, bugcrowd_state):

--- a/unittests/scans/bugcrowd_api/bugcrowd_many.json
+++ b/unittests/scans/bugcrowd_api/bugcrowd_many.json
@@ -212,7 +212,7 @@
             "remediation_advice": "Do things properly2",
             "severity": 1,
             "source": "external_form",
-            "state": "informational",
+            "state": "unresolved",
             "submitted_at": "2000-01-02T19:22:10.916Z",
             "title": "you did something wrong",
             "vrt_id": "server_security_misconfiguration.clickjacking.non_sensitive_action",

--- a/unittests/scans/bugcrowd_api/bugcrowd_one.json
+++ b/unittests/scans/bugcrowd_api/bugcrowd_one.json
@@ -19,7 +19,7 @@
             "remediation_advice": "Properly do JWT",
             "severity": 5,
             "source": "external_form",
-            "state": "informational",
+            "state": "unresolved",
             "submitted_at": "2002-04-01T21:59:56.546Z",
             "title": "JWT Alg none",
             "vrt_id": "broken_authentication_and_session_management.authentication_bypass",

--- a/unittests/tools/test_bugcrowd_api_importer.py
+++ b/unittests/tools/test_bugcrowd_api_importer.py
@@ -127,7 +127,7 @@ class TestBugcrowdApiImporter(TestCase):
         mock_foo.return_value = self.findings
 
         bugrcrowd_api_importer = BugcrowdApiImporter()
-        my_findings = bugrcrowd_api_importer.get_findings(self.test_2)
+        my_findings, api_scan_config = bugrcrowd_api_importer.get_findings(self.test_2)
 
         mock_foo.assert_called_with("SERVICE_KEY_1", "SERVICE_KEY_2")
         self.assertListEqual(my_findings, self.findings)

--- a/unittests/tools/test_bugcrowd_api_parser.py
+++ b/unittests/tools/test_bugcrowd_api_parser.py
@@ -42,7 +42,10 @@ class TestBugcrowdApiParser(TestCase):
             self.assertEqual(
                 finding.unique_id_from_tool, "a4201d47-62e1-4287-9ff6-30807ae9d36a"
             )
-            self.assertTrue("https://tracker.bugcrowd.com/example/submissions/a4201d47-62e1-4287-9ff6-30807ae9d36a" in finding.references)
+            self.assertTrue(
+                "/submissions/a4201d47-62e1-4287-9ff6-30807ae9d36a"
+                in finding.references
+            )
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()
 
@@ -112,7 +115,9 @@ class TestBugcrowdApiParser(TestCase):
             )
 
     def test_parse_file_with_not_reproducible_finding(self):
-        with open("unittests/scans/bugcrowd_api/bugcrowd_not_reproducible.json") as testfile:
+        with open(
+            "unittests/scans/bugcrowd_api/bugcrowd_not_reproducible.json"
+        ) as testfile:
 
             #             description = """
             # Vulnerability Name: JWT alg none


### PR DESCRIPTION
I noticed that my implementation did a duplicate detection in the wrong way, since Bugcrowd itself marks submissions as duplicates, but they mean something else: another researcher made a submission about the same thing.
Since my API client is not returning the duplicate submissions, but only the "first come, first served" submission, there is no reason to use the duplicate field, and it was throwing a lot of issues.
So I ripped out the line `duplicate=bugcrowd_duplicate,`

I'm also fixing the links in the defectdojo findings in markdown, I had to propagate the api scan configuration object back to the parser so it can get the service key 1, which is the program name required in the url link.

I also have removed the "Informational" state from the active issues. It is considered to be a closed subject when Informational is used, so a lot of issues were shown active for no reason.

Lastly, I have added an inclusion of fields in the API call, to try to get the external Jira issues linked (but it's not implemented by the API yet apparently) and also getting the program, but it's not giving the name of it yet.