### PR TITLE
Adjusted Rusty Hog deduplication to be less flaky

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1197,7 +1197,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'CycloneDX Scan': ['vuln_id_from_tool', 'component_name', 'component_version'],
     'SSLyze Scan (JSON)': ['title', 'description'],
     'Harbor Vulnerability Scan': ['title'],
-    'Rusty Hog Scan': ['title', 'description'],
+    'Rusty Hog Scan': ['file_path', 'payload'],
     'StackHawk HawkScan': ['vuln_id_from_tool', 'component_name', 'component_version'],
     'Hydra Scan': ['title', 'description'],
     'DrHeader JSON Importer': ['title', 'description'],

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1253,12 +1253,13 @@ HASHCODE_ALLOWS_NULL_CWE = {
     'Veracode SourceClear Scan': True,
     'Twistlock Image Scan': True,
     'Wpscan': True,
+    'Rusty Hog Scan': True,
 }
 
 # List of fields that are known to be usable in hash_code computation)
 # 'endpoints' is a pseudo field that uses the endpoints (for dynamic scanners)
 # 'unique_id_from_tool' is often not needed here as it can be used directly in the dedupe algorithm, but it's also possible to use it for hashing
-HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'vulnerability_ids', 'line', 'file_path', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
+HASHCODE_ALLOWED_FIELDS = ['title', 'cwe', 'vulnerability_ids', 'line', 'file_path', 'payload', 'component_name', 'component_version', 'description', 'endpoints', 'unique_id_from_tool', 'severity', 'vuln_id_from_tool']
 
 # Adding fields to the hash_code calculation regardless of the previous settings
 HASH_CODE_FIELDS_ALWAYS = ['service']

--- a/dojo/tools/rusty_hog/parser.py
+++ b/dojo/tools/rusty_hog/parser.py
@@ -63,13 +63,15 @@ class RustyhogParser(object):
     def __getitem(self, vulnerabilities, scanner):
         findings = []
         line = ""
+        found_secret_string = ""
         cwe = 200
         for vulnerability in vulnerabilities:
             if scanner == "Rusty Hog":
                 break
             elif scanner == "Choctaw Hog":
                 """Choctaw Hog"""
-                description = "**This string was found:** {}".format(vulnerability.get('stringsFound'))
+                found_secret_string = vulnerability.get('stringsFound')
+                description = "**This string was found:** {}".format(found_secret_string)
                 if vulnerability.get('commit') is not None:
                     description += "\n**Commit message:** {}".format(vulnerability.get('commit'))
                 if vulnerability.get('commitHash') is not None:
@@ -86,7 +88,8 @@ class RustyhogParser(object):
                                     vulnerability.get('new_line_num'))
             elif scanner == "Duroc Hog":
                 """Duroc Hog"""
-                description = "**This string was found:** {}".format(vulnerability.get('stringsFound'))
+                found_secret_string = vulnerability.get('stringsFound')
+                description = "**This string was found:** {}".format(found_secret_string)
                 if vulnerability.get('path') is not None:
                     description += "\n**Path of Issue:** {}".format(vulnerability.get('path'))
                 if vulnerability.get('linenum') is not None:
@@ -95,7 +98,8 @@ class RustyhogParser(object):
                     description += "\n**Diff:** {}".format(vulnerability.get('diff'))
             elif scanner == "Gottingen Hog":
                 """Gottingen Hog"""
-                description = "**This string was found:** {}".format(vulnerability.get('stringsFound'))
+                found_secret_string = vulnerability.get('stringsFound')
+                description = "**This string was found:** {}".format(found_secret_string)
                 if vulnerability.get('issue_id') is not None:
                     description += "\n**JIRA Issue ID:** {}".format(vulnerability.get('issue_id'))
                 if vulnerability.get('location') is not None:
@@ -103,7 +107,8 @@ class RustyhogParser(object):
                 if vulnerability.get('url') is not None:
                     description += "\n**JIRA url:** {}".format(vulnerability.get('url'))
             elif scanner == "Essex Hog":
-                description = "**This string was found:** {}".format(vulnerability.get('stringsFound'))
+                found_secret_string = vulnerability.get('stringsFound')
+                description = "**This string was found:** {}".format(found_secret_string)
                 if vulnerability.get('page_id') is not None:
                     description += "\n**Confluence URL:** {}".format(vulnerability.get('url'))
                     description += "\n**Confluence Page ID:** {}".format(vulnerability.get('page_id'))
@@ -138,7 +143,8 @@ class RustyhogParser(object):
                 description=description,
                 file_path=file_path,
                 static_finding=True,
-                dynamic_finding=False
+                dynamic_finding=False,
+                payload=found_secret_string
             )
             finding.description = finding.description.strip()
             if scanner == "Choctaw Hog":


### PR DESCRIPTION
Currently the same finding (e.g. a secret string in line 3) will not be deduplicated in case its line shifts (e.g. new lines included in between), but instead be found as a new finding, thought the core issue was not resolved.

This change adjusts the hashcode calculation to include the file path + actual occurrence of the secret string.