### PR TITLE
Fixing link generation code

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2815,14 +2815,16 @@ class Finding(models.Model):
             return escape(self.file_path)
         link = self.test.engagement.source_code_management_uri
         if "https://github.com/" in self.test.engagement.source_code_management_uri:
-            if self.test.commit_hash is not None:
+            if self.test.commit_hash:
                 link += '/blob/' + self.test.commit_hash + '/' + self.file_path
-            elif self.test.engagement.commit_hash is not None:
+            elif self.test.engagement.commit_hash:
                 link += '/blob/' + self.test.engagement.commit_hash + '/' + self.file_path
-            elif self.test.branch_tag is not None:
+            elif self.test.branch_tag:
                 link += '/blob/' + self.test.branch_tag + '/' + self.file_path
-            elif self.test.engagement.branch_tag is not None:
+            elif self.test.engagement.branch_tag:
                 link += '/blob/' + self.test.engagement.branch_tag + '/' + self.file_path
+            else:
+                link += '/' + self.file_path
         else:
             link += '/' + self.file_path
         if self.line:


### PR DESCRIPTION
I noticed for SAST, it doesn't generate a correct link back to GitHub when the repo is configured in the engagement, because the if statement for branch/commit hash etc only checks if the value is not None. Instead it should check for not empty.