### PR TITLE
Add engagement end-date to API

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1498,6 +1498,7 @@ class ImportScanSerializer(serializers.Serializer):
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)
     engagement_name = serializers.CharField(required=False)
+    engagement_end_date = serializers.DateField(required=False)
     source_code_management_uri = serializers.URLField(max_length=600, required=False, help_text="Resource link to source code")
     engagement = serializers.PrimaryKeyRelatedField(
         queryset=Engagement.objects.all(), required=False)
@@ -1566,9 +1567,10 @@ class ImportScanSerializer(serializers.Serializer):
         group_by = data.get('group_by', None)
         create_finding_groups_for_all_findings = data.get('create_finding_groups_for_all_findings', True)
 
+        engagement_end_date = data.get('engagement_end_date', None)
         _, test_title, scan_type, engagement_id, engagement_name, product_name, product_type_name, auto_create_context, deduplication_on_engagement, do_not_reactivate = get_import_meta_data_from_dict(data)
         engagement = get_or_create_engagement(engagement_id, engagement_name, product_name, product_type_name, auto_create_context,
-                                              deduplication_on_engagement, source_code_management_uri=source_code_management_uri)
+                                              deduplication_on_engagement, source_code_management_uri=source_code_management_uri, target_end=engagement_end_date)
 
         # have to make the scan_date_time timezone aware otherwise uploads via the API would fail (but unit tests for api upload would pass...)
         scan_date_time = timezone.make_aware(datetime.combine(scan_date, datetime.min.time())) if scan_date else None
@@ -1644,6 +1646,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)
     engagement_name = serializers.CharField(required=False)
+    engagement_end_date = serializers.DateField(required=False)
     source_code_management_uri = serializers.URLField(max_length=600, required=False, help_text="Resource link to source code")
     test = serializers.PrimaryKeyRelatedField(required=False,
         queryset=Test.objects.all())
@@ -1709,6 +1712,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         scan = data.get('file', None)
         endpoints_to_add = [endpoint_to_add] if endpoint_to_add else None
         source_code_management_uri = data.get('source_code_management_uri', None)
+        engagement_end_date = data.get('engagement_end_date', None)
 
         group_by = data.get('group_by', None)
         create_finding_groups_for_all_findings = data.get('create_finding_groups_for_all_findings', True)
@@ -1735,8 +1739,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                                                 commit_hash=commit_hash, push_to_jira=push_to_jira,
                                                 close_old_findings=close_old_findings,
                                                 group_by=group_by, api_scan_configuration=api_scan_configuration,
-                                                service=service, do_not_reactivate=do_not_reactivate,
-                                                create_finding_groups_for_all_findings=create_finding_groups_for_all_findings)
+                                                service=service, do_not_reactivate=do_not_reactivate)
 
                 if test_import:
                     statistics_delta = test_import.statistics
@@ -1744,7 +1747,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 # perform Import to create test
                 logger.debug('reimport for non-existing test, using import to create new test')
                 engagement = get_or_create_engagement(None, engagement_name, product_name, product_type_name, auto_create_context,
-                                                      deduplication_on_engagement, source_code_management_uri=source_code_management_uri)
+                                                      deduplication_on_engagement, source_code_management_uri=source_code_management_uri, target_end=engagement_end_date)
                 importer = Importer()
                 test, finding_count, closed_finding_count, _ = importer.import_scan(scan, scan_type, engagement, lead, environment,
                                                                                                 active=active, verified=verified, tags=tags,

--- a/dojo/importers/reimporter/utils.py
+++ b/dojo/importers/reimporter/utils.py
@@ -197,7 +197,7 @@ def get_or_create_product(product_name=None, product_type_name=None, auto_create
 
 
 def get_or_create_engagement(engagement_id=None, engagement_name=None, product_name=None, product_type_name=None, auto_create_context=None,
-                             deduplication_on_engagement=False, source_code_management_uri=None):
+                             deduplication_on_engagement=False, source_code_management_uri=None, target_end=None):
     # try to find the engagement (and product)
     product = get_target_product_if_exists(product_name, product_type_name)
     engagement = get_target_engagement_if_exists(engagement_id, engagement_name, product)
@@ -213,8 +213,14 @@ def get_or_create_engagement(engagement_id=None, engagement_name=None, product_n
         if not product:
             raise ValueError('no product, unable to create engagement')
 
+        target_start = timezone.now().date()
+        if isinstance(target_end, type(None)):
+            target_end = (timezone.now() + timedelta(days=365)).date()
+        if target_start > target_end:
+            target_end = (timezone.now() + timedelta(days=365)).date()
+
         engagement = Engagement.objects.create(engagement_type="CI/CD", name=engagement_name, product=product, lead=get_current_user(),
-                                               target_start=timezone.now().date(), target_end=(timezone.now() + timedelta(days=365)).date(),
+                                               target_start=target_start, target_end=target_end,
                                                deduplication_on_engagement=deduplication_on_engagement,
                                                source_code_management_uri=source_code_management_uri)
 


### PR DESCRIPTION
Added the possibility to add an end_date for engagements, s.t. not a year is fix. If no end_date is provided defaults to old value of delta 365. Also added check whether start_date > engagement_date.
Closes #7156 