### PR TITLE
Add middleware to alert users of missing trailing slash

### DIFF
--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -128,3 +128,26 @@ class System_Settings_Manager(models.Manager):
             return self.get_from_db(*args, **kwargs)
 
         return from_cache
+
+
+class APITrailingSlashMiddleware:
+    """
+    Middleware that will send a more informative error response to POST requests
+    made without the trailing slash. When this middleware is not active, POST requests
+    without the trailing slash will return a 301 status code, with no explanation as to why
+    """
+
+    def __init__(self, get_response):
+
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        path = request.path_info.lstrip('/')
+        if 'api/v2/' in path and path[-1] == '/' and response.status_code == 400:
+            response.data = {'message': 'Please add a trailing slash to your request.'}
+            # you need to change private attribute `_is_render` 
+            # to call render second time
+            response._is_rendered = False
+            response.render()
+        return response

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -144,9 +144,9 @@ class APITrailingSlashMiddleware:
     def __call__(self, request):
         response = self.get_response(request)
         path = request.path_info.lstrip('/')
-        if 'api/v2/' in path and path[-1] == '/' and response.status_code == 400:
+        if request.method == 'POST' and 'api/v2/' in path and path[-1] != '/' and response.status_code == 400:
             response.data = {'message': 'Please add a trailing slash to your request.'}
-            # you need to change private attribute `_is_render` 
+            # you need to change private attribute `_is_render`
             # to call render second time
             response._is_rendered = False
             response.render()

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -816,6 +816,7 @@ INSTALLED_APPS = (
 # ------------------------------------------------------------------------------
 DJANGO_MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
+    'dojo.middleware.APITrailingSlashMiddleware',
     'dojo.middleware.DojoSytemSettingsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
As the title says, the API does not respond very well to POST requests that do not have a trailing slash. Simply redirecting whatever data in the payload would not be a good idea either, so I took the "update the response" in transit route