### PR TITLE
Fixed bug with the horusec parser's date parser.

### DIFF
--- a/dojo/tools/horusec/parser.py
+++ b/dojo/tools/horusec/parser.py
@@ -27,7 +27,7 @@ class HorusecParser(object):
 
     def get_findings(self, filename, test):
         data = json.load(filename)
-        report_date = datetime.strptime(data.get("createdAt")[0:9], "%Y-%m-%d")
+        report_date = datetime.strptime(data.get("createdAt")[0:10], "%Y-%m-%d")
         return [self._get_finding(node, report_date) for node in data.get("analysisVulnerabilities")]
 
     def get_tests(self, scan_type, scan):

--- a/unittests/tools/test_horusec_parser.py
+++ b/unittests/tools/test_horusec_parser.py
@@ -14,6 +14,14 @@ class TestHorusecParser(DojoTestCase):
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(267, len(findings))
 
+    def test_get_findings_date(self):
+        """"""
+        with open(path.join(path.dirname(__file__), "../scans/horusec/issue_6258.json")) as testfile:
+            parser = HorusecParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(14, len(findings))
+            self.assertEqual('2022-05-06', findings[0].date.strftime("%Y-%m-%d"))
+
     def test_get_tests(self):
         """Version 2.6.3 with big project in Python"""
         with open(path.join(path.dirname(__file__), "../scans/horusec/version_2.6.3.json")) as testfile:

--- a/unittests/tools/test_horusec_parser.py
+++ b/unittests/tools/test_horusec_parser.py
@@ -13,14 +13,7 @@ class TestHorusecParser(DojoTestCase):
             parser = HorusecParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(267, len(findings))
-
-    def test_get_findings_date(self):
-        """"""
-        with open(path.join(path.dirname(__file__), "../scans/horusec/issue_6258.json")) as testfile:
-            parser = HorusecParser()
-            findings = parser.get_findings(testfile, Test())
-            self.assertEqual(14, len(findings))
-            self.assertEqual('2022-05-06', findings[0].date.strftime("%Y-%m-%d"))
+            self.assertEqual('2021-10-19', findings[0].date.strftime("%Y-%m-%d"))
 
     def test_get_tests(self):
         """Version 2.6.3 with big project in Python"""


### PR DESCRIPTION
`2022-02-02` is 10 characters long, but it only took the first 9.