### PR TITLE
Rev k8 supported versions

### DIFF
--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -128,13 +128,13 @@ jobs:
             k8s: 'v1.22.0'
           - databases: pgsql
             brokers: rabbit
-            k8s: 'v1.24.0'
+            k8s: 'v1.23.9'
           - databases: mysql
             brokers: redis
-            k8s: 'v1.24.0'
+            k8s: 'v1.23.9'
           - databases: pgsqlha
             brokers: rabbit
-            k8s: 'v1.24.0'
+            k8s: 'v1.23.9'
 
     steps:
 #      - name: Login to DockerHub

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -122,19 +122,19 @@ jobs:
           # are tested (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions)
           - databases: pgsql
             brokers: redis
-            k8s: 'v1.18.16'
+            k8s: 'v1.22.0'
           - databases: mysql
             brokers: rabbit
-            k8s: 'v1.18.16'
+            k8s: 'v1.22.0'
           - databases: pgsql
             brokers: rabbit
-            k8s: 'v1.22.0'
+            k8s: 'v1.24.0'
           - databases: mysql
             brokers: redis
-            k8s: 'v1.22.0'
+            k8s: 'v1.24.0'
           - databases: pgsqlha
             brokers: rabbit
-            k8s: 'v1.22.0'
+            k8s: 'v1.24.0'
 
     steps:
 #      - name: Login to DockerHub


### PR DESCRIPTION
Per the [Amazon EKS Kubernetes release calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar) version 1.18.x of Kubernetess has been dropped off. 

Since we have been testing againt 1.22.x as the latests version, I have made that our oldest supported version, and bumped the latest to 1.23.9

Ii would rather go to 1.24.x or higher,  but do not have the k8 knowledge to debug and make it happen