### PR TITLE
Change Endpoint.host_mitigated_endpoints not to include active Findings

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1662,7 +1662,8 @@ class Endpoint(models.Model):
                           Q(finding__out_of_scope=True) |
                           Q(finding__mitigated__isnull=False) |
                           Q(finding__false_p=True) |
-                          Q(finding__duplicate=True))
+                          Q(finding__duplicate=True) |
+                          Q(finding__active=False))
         return Endpoint.objects.filter(status_endpoint__in=meps).distinct()
 
     @property


### PR DESCRIPTION
I noticed in the Endpoints tab for a product that an Endpoint will be shown as mitigated, but an endpoint associated with a Host will not be shown as mitigated, when the Finding is inactive (but not mitigated). This change excludes inactive findings from Endpoint.host_mitigated_endpoints to make it consistent.