### PR TITLE
Fix 404 for Metrics/Endpoints

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1404,9 +1404,9 @@ class Endpoint_Status(models.Model):
     def age(self):
 
         if self.mitigated:
-            diff = self.mitigated_time.date() - self.date.date()
+            diff = self.mitigated_time.date() - self.date
         else:
-            diff = get_current_date() - self.date.date()
+            diff = get_current_date() - self.date
         days = diff.days
         return days if days > 0 else 0
 


### PR DESCRIPTION
You get a 404 on Metrics/Endpoints due to the fact that it's trying to call a function which doesn't exist - date()