### PR TITLE
Fix for overscroll issue

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -41,6 +41,12 @@ textarea,
     margin-left: 6px;
 }
 
+.min,
+.max {
+    overscroll-behavior: none!important;
+    overflow-x: clip!important;
+}
+
 a {
   color: #546474;
 }


### PR DESCRIPTION
The extra padding added when expanding the sidebar caused the new footer to expand outside of the main page wrapper. This should (hopefully) fix the issue without impacting anything else.

Example of the issue:
![overscroll-issue](https://user-images.githubusercontent.com/76979297/208271760-a0ab96bd-8e12-4a36-bc0c-66fc88ec3e4d.gif)

[sc-177]