### PR TITLE
Fix regression in blocktranslate

### DIFF
--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -27,7 +27,7 @@
     {{ block.super }}
     <div class="row navbar-fixed-top">
         <div class="col-md-12">
-            <h2>{% blocktrans %}{{ name }} for {{ start_date.date }} - {{ end_date.date }}{% endblocktrans %}
+            <h2>{% blocktrans with start_date=start_date.date end_date=end_date.date%}{{ name }} for {{ start_date }} - {{ end_date }}{% endblocktrans %}
                 <a class="btn close pull-right" href="{% url 'metrics' %}" aria-hidden="true">&times;</a>
                 <div class="dropdown pull-right">
                     <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
@@ -101,7 +101,7 @@
         {% if top_ten_products %}
             <div class="col-md-12 section-start">
                 <div class="panel panel-default">
-                    <div class="panel-heading">{% blocktrans %}Top {{ top_ten_products|length }} Products By Bug Severity{% endblocktrans %}</div>
+                    <div class="panel-heading">{% blocktrans with length=top_ten_products|length %}Top {{ length }} Products By Bug Severity{% endblocktrans %}</div>
                     <!-- /.panel-heading -->
                     <div class="panel-body">
                         <div id="top-ten" class="graph"></div>

--- a/dojo/templates/dojo/edit_product_type.html
+++ b/dojo/templates/dojo/edit_product_type.html
@@ -16,7 +16,7 @@
 {% endblock %}
 {% block content %}
     {{ block.super }}
-    <h3>{% blocktrans %}Edit Product Type {{ pt.name }}{% endblocktrans %}</h3>
+    <h3>{% blocktrans with name=pt.name %}Edit Product Type {{ name }}{% endblocktrans %}</h3>
     <form class="form-horizontal" action="{% url 'edit_product_type' pt.id %}" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=pt_form %}
         {{ delete_pt_form }}

--- a/dojo/templates/dojo/metrics.html
+++ b/dojo/templates/dojo/metrics.html
@@ -168,7 +168,7 @@
                                  start="{{ c_prod.calc_health }}"></div>
                             <div>
                                 {% if c_prod.critical_present and c_prod.high_present %}
-                                    <p>{% blocktranslate %}{{ c_prod.name }} is affected by <b>both</b> critical and
+                                    <p>{% blocktranslate with name=c_prod.name%}{{ name }} is affected by <b>both</b> critical and
                                         high severity vulnerabilities.{% endblocktranslate %} </p>
                                     <p>
                                         <a href="{{ url_prefix }}/finding/open?title=&date=&severity=Critical&mitigated_by=&last_reviewed_by=&last_reviewed=&test__engagement__product__prod_type={{ c_prod.id }}&o=numerical_severity&page_size=25">
@@ -177,15 +177,15 @@
                                         <a href="{{ url_prefix }}/finding/open?title=&date=&severity=High&mitigated_by=&last_reviewed_by=&last_reviewed=&test__engagement__product__prod_type={{ c_prod.id }}&o=numerical_severity&page_size=25">
                                             {% trans "High Severity Vulnerabilities" %}</a></p>
                                 {% elif c_prod.critical_present %}
-                                    <p>{% blocktranslate %}
-                                        {{ c_prod.name }} is affected by critical vulnerabilities.{% endblocktranslate %}
+                                    <p>{% blocktranslate with name=c_prod.name%}
+                                        {{ name }} is affected by critical vulnerabilities.{% endblocktranslate %}
                                     </p>
                                     <p>
                                         <a href="{{ url_prefix }}/finding/open?title=&date=&severity=Critical&mitigated_by=&last_reviewed_by=&last_reviewed=&test__engagement__product__prod_type={{ c_prod.id }}&o=numerical_severity&page_size=25">
                                             {% trans "Critical Severity Vulnerabilities" %}</a></p>
                                 {% elif c_prod.high_present %}
-                                    <p>{% blocktranslate %}
-                                        {{ c_prod.name }} is affected by high severity vulnerabilities.{% endblocktranslate %}
+                                    <p>{% blocktranslate with name=c_prod.name%}
+                                        {{ name }} is affected by high severity vulnerabilities.{% endblocktranslate %}
                                     </p>
                                     <p>
                                         <a href="{{ url_prefix }}/finding/open?title=&date=&severity=High&mitigated_by=&last_reviewed_by=&last_reviewed=&test__engagement__product__prod_type={{ c_prod.id }}&o=numerical_severity&page_size=25">

--- a/dojo/templates/dojo/paging_snippet.html
+++ b/dojo/templates/dojo/paging_snippet.html
@@ -5,7 +5,9 @@
 {% with page_param=prefix|add:'page' %}
 {% with page_size_param=prefix|add:'page_size' %}
 <div class="pull-left pagination  pagination-sm">
-    {% blocktrans %}Showing entries {{ page.start_index }} to {{ page.end_index }} of {{ page.paginator.count }}{% endblocktrans %}
+    {% blocktrans with start_index=page.start_index end_index=page.end_index count=page.paginator.count %}
+    Showing entries {{ start_index }} to {{ end_index }} of {{ count }}
+    {% endblocktrans %}
 </div>
 
 <nav class="pull-right">

--- a/dojo/templates/dojo/pt_counts.html
+++ b/dojo/templates/dojo/pt_counts.html
@@ -18,7 +18,8 @@
     </form>
     <br/>
     {% if pt %}
-        <h2>{% blocktrans %}Finding Information For Period of {{ start_date.date }} - {{ end_date.date }}{% endblocktrans %}</h2>
+        <h2>{% blocktrans with start_date=start_date.date end_date=end_date.date%}Finding Information For Period of {{ start_date }} - {{ end_date }}
+            {% endblocktrans %}</h2>
         <h3 class="inline-block">{{ pt.name }}</h3> [
         <a href="{% url 'product_type_metrics' pt.id %}" class="inline-block">{% trans "View Details" %}</a>]
         <div class="panel panel-default table-responsive">

--- a/dojo/templates/dojo/view_note_history.html
+++ b/dojo/templates/dojo/view_note_history.html
@@ -11,9 +11,9 @@
                     <div class="row-sm-2">
                         <strong>{{ entry.current_editor }}</strong> 
                         {% if forloop.first %}
-                            <span class="text-muted">{% blocktranslate %}commented {{ entry.time }}{% endblocktranslate %}</span>
+                            <span class="text-muted">{% blocktranslate with time=entry.time%}commented {{ time }}{% endblocktranslate %}</span>
                         {% else %}
-                            <span class="text-muted">{% blocktranslate %}made changes on {{ entry.time }}{% endblocktranslate %}</span>
+                            <span class="text-muted">{% blocktranslate with time=entry.time%}made changes on {{ time }}{% endblocktranslate %}</span>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
The following commit introduced some regressions:

commit 7942d70f23c231ebaf29fa0bed82e03cdae4362d
Author: Dmitry <mukovkin@yandex.ru>
Date:   Sat Dec 10 10:04:02 2022 +0700

    Translate product type (#7255)

You can't reference a property in blocktranslate, so there was a bunch of empty text in the UI in various places.