### PR TITLE
Fix for CSS issue for EasyMDE table icon

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1741,6 +1741,10 @@ small {
     min-width:200px;
 }
 
+.EasyMDEContainer .table {
+    width: unset!important;
+}
+
 /* remove spinners (up & down arrow) for integer / number fields
 /* For Firefox */
 


### PR DESCRIPTION
Added CSS selector for all "table" elements that are children of "EasyMDEContainers" to remove the "tables" class 100% width style.

Before:
<img width="1548" alt="Screenshot 2022-12-27 at 7 01 59 PM" src="https://user-images.githubusercontent.com/76979297/209741702-21765100-d141-4c42-9e66-d0175772b6cf.png">

After:
<img width="1504" alt="Screenshot 2022-12-27 at 7 01 49 PM" src="https://user-images.githubusercontent.com/76979297/209741713-b02c6632-182b-4834-b4ed-65e3ed0043c9.png">

[sc-120]