### PR TITLE
Fix: removing typo from PVC name

### DIFF
--- a/helm/defectdojo/templates/media-pvc.yaml
+++ b/helm/defectdojo/templates/media-pvc.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
     helm.sh/chart: {{ include "defectdojo.chart" $ }}
-  name: {{ $fullName }}-media
+  name: {{ $fullName }}
 spec:
   accessModes: 
   {{- toYaml .persistentVolumeClaim.accessModes |nindent 4 }}


### PR DESCRIPTION
Removing of extra media from the naming 