### PR TITLE
Fixing the sla_deadline function to work with the current date and no…

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2655,7 +2655,7 @@ class Finding(models.Model):
     def sla_deadline(self):
         days_remaining = self.sla_days_remaining()
         if days_remaining:
-            return self.date + relativedelta(days=days_remaining)
+            return get_current_date() + relativedelta(days=days_remaining)
         return None
 
     def github(self):


### PR DESCRIPTION
…t the date the finding was created

I noticed that JIRAs were created with the incorrect due date - which were the date the finding was created + the number of SLA days left at the time of JIRA creation.