### PR TITLE
Added field CVE to GitHub dependendatbot parser

### DIFF
--- a/docs/content/en/integrations/parsers.md
+++ b/docs/content/en/integrations/parsers.md
@@ -578,6 +578,7 @@ vulnerabilityAlerts (RepositoryVulnerabilityAlert object)
                 + description
                 + identifiers
                     + value
+                    + cve (optional)
                 + references (optional)
                     + url (optional)
                 + cvss (optional)

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -80,7 +80,7 @@ class GithubVulnerabilityParser(object):
                 if cwe_nodes and len(cwe_nodes) > 0:
                     finding.cwe = int(cwe_nodes[0].get("cweId")[4:])
             if "identifiers" in alert["securityVulnerability"]["advisory"]:
-                if "cve" in alert ["securityVulnerability"]["advisory"]:
+                if "cve" in alert ["securityVulnerability"]["advisory"]["identifiers"]:
                     cve_unsaved_vulnerability_ids = list()
                     for identifier in alert["securityVulnerability"]["advisory"]["identifiers"]:
                         if identifier.get("type") == "CVE":

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -79,14 +79,14 @@ class GithubVulnerabilityParser(object):
                 cwe_nodes = alert["securityVulnerability"]["advisory"]["cwes"]["nodes"]
                 if cwe_nodes and len(cwe_nodes) > 0:
                     finding.cwe = int(cwe_nodes[0].get("cweId")[4:])
+
             if "identifiers" in alert["securityVulnerability"]["advisory"]:
-                if "cve" in alert["securityVulnerability"]["advisory"]["identifiers"]:
-                    cve_unsaved_vulnerability_ids = list()
-                    for identifier in alert["securityVulnerability"]["advisory"]["identifiers"]:
-                        if identifier.get("type") == "CVE":
-                            cve_unsaved_vulnerability_ids.append(identifier.get("value"))
-                    if cve_unsaved_vulnerability_ids:
-                        finding.cve_unsaved_vulnerability_ids = cve_unsaved_vulnerability_ids
+                cve_vulnerability_ids = list()
+                for identifier in alert["securityVulnerability"]["advisory"]["identifiers"]:
+                    if identifier.get("type") == "CVE":
+                        cve_vulnerability_ids.append(identifier.get("value"))
+                if cve_vulnerability_ids:
+                    finding.cve_vulnerability_ids = cve_vulnerability_ids
 
             dupe_key = finding.unique_id_from_tool
             if dupe_key in dupes:

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -79,6 +79,14 @@ class GithubVulnerabilityParser(object):
                 cwe_nodes = alert["securityVulnerability"]["advisory"]["cwes"]["nodes"]
                 if cwe_nodes and len(cwe_nodes) > 0:
                     finding.cwe = int(cwe_nodes[0].get("cweId")[4:])
+            if "identifiers" in alert["securityVulnerability"]["advisory"]:
+                if "cve" in alert ["securityVulnerability"]["advisory"]:
+                    cve_unsaved_vulnerability_ids = list()
+                    for identifier in alert["securityVulnerability"]["advisory"]["identifiers"]:
+                        if identifier.get("type") == "CVE":
+                            cve_unsaved_vulnerability_ids.append(identifier.get("value"))
+                    if cve_unsaved_vulnerability_ids:
+                        finding.cve_unsaved_vulnerability_ids = cve_unsaved_vulnerability_ids
 
             dupe_key = finding.unique_id_from_tool
             if dupe_key in dupes:

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -80,7 +80,7 @@ class GithubVulnerabilityParser(object):
                 if cwe_nodes and len(cwe_nodes) > 0:
                     finding.cwe = int(cwe_nodes[0].get("cweId")[4:])
             if "identifiers" in alert["securityVulnerability"]["advisory"]:
-                if "cve" in alert ["securityVulnerability"]["advisory"]["identifiers"]:
+                if "cve" in alert["securityVulnerability"]["advisory"]["identifiers"]:
                     cve_unsaved_vulnerability_ids = list()
                     for identifier in alert["securityVulnerability"]["advisory"]["identifiers"]:
                         if identifier.get("type") == "CVE":

--- a/unittests/tools/test_github_vulnerability_parser.py
+++ b/unittests/tools/test_github_vulnerability_parser.py
@@ -231,3 +231,26 @@ class TestGithubVulnerabilityParser(DojoTestCase):
             self.assertEqual(finding.file_path, "apache/cxf/cxf-shiro/pom.xml")
             self.assertEqual(finding.active, False)
             self.assertEqual(finding.is_mitigated, True)
+
+    def test_parse_cve(self):
+        testfile = open("unittests/scans/github_vulnerability/github_h2.json")
+        parser = GithubVulnerabilityParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+        for finding in findings:
+            finding.clean()
+
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual(finding.title, "RCE in H2 Console")
+            self.assertEqual(finding.severity, "Critical")
+            self.assertEqual(len(finding.unsaved_vulnerability_ids), 2)
+            self.assertEqual(finding.unsaved_vulnerability_ids[0], "GHSA-h376-j262-vhq6")
+            self.assertEqual(finding.component_name, "com.h2database:h2")
+            self.assertEqual(finding.cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+            self.assertEqual(finding.cvssv3_score, 9.8)
+            self.assertEqual(finding.cwe, 502)
+            self.assertEqual(datetime.datetime(2022, 5, 9, 9, 43, 40, tzinfo=tzlocal()), finding.date)
+            self.assertEqual(finding.file_path, "apache/cxf/syncope/cxf-syncope/pom.xml")
+            self.assertEqual(finding.active, True)
+            self.assertEqual(finding.cve, "CVE-2021-42392")

--- a/unittests/tools/test_github_vulnerability_parser.py
+++ b/unittests/tools/test_github_vulnerability_parser.py
@@ -232,7 +232,7 @@ class TestGithubVulnerabilityParser(DojoTestCase):
             self.assertEqual(finding.active, False)
             self.assertEqual(finding.is_mitigated, True)
 
-    def test_parse_cve(self):
+    def test_parser_cve(self):
         testfile = open("unittests/scans/github_vulnerability/github_h2.json")
         parser = GithubVulnerabilityParser()
         findings = parser.get_findings(testfile, Test())
@@ -246,6 +246,8 @@ class TestGithubVulnerabilityParser(DojoTestCase):
             self.assertEqual(finding.severity, "Critical")
             self.assertEqual(len(finding.unsaved_vulnerability_ids), 2)
             self.assertEqual(finding.unsaved_vulnerability_ids[0], "GHSA-h376-j262-vhq6")
+            self.assertEqual(finding.cve_unsaved_vulnerability_ids[0], "CVE-2021-42392")
+            self.assertEqual(finding.cve, "CVE-2021-42392")
             self.assertEqual(finding.component_name, "com.h2database:h2")
             self.assertEqual(finding.cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
             self.assertEqual(finding.cvssv3_score, 9.8)
@@ -253,4 +255,3 @@ class TestGithubVulnerabilityParser(DojoTestCase):
             self.assertEqual(datetime.datetime(2022, 5, 9, 9, 43, 40, tzinfo=tzlocal()), finding.date)
             self.assertEqual(finding.file_path, "apache/cxf/syncope/cxf-syncope/pom.xml")
             self.assertEqual(finding.active, True)
-            self.assertEqual(finding.cve, "CVE-2021-42392")

--- a/unittests/tools/test_github_vulnerability_parser.py
+++ b/unittests/tools/test_github_vulnerability_parser.py
@@ -247,7 +247,6 @@ class TestGithubVulnerabilityParser(DojoTestCase):
             self.assertEqual(len(finding.unsaved_vulnerability_ids), 2)
             self.assertEqual(finding.unsaved_vulnerability_ids[0], "GHSA-h376-j262-vhq6")
             self.assertEqual(finding.cve_unsaved_vulnerability_ids[0], "CVE-2021-42392")
-            self.assertEqual(finding.cve, "CVE-2021-42392")
             self.assertEqual(finding.component_name, "com.h2database:h2")
             self.assertEqual(finding.cvssv3, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
             self.assertEqual(finding.cvssv3_score, 9.8)


### PR DESCRIPTION
I´ve added the field CVE to the github vulnerability parser because in SCA it is one of the most important field for a vulnerable component