### PR TITLE
API-bugfix: Endpoint_status - do not fail if date is missing

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -20,7 +20,7 @@ from dojo.models import IMPORT_ACTIONS, SEVERITIES, SLA_Configuration, STATS_FIE
     Product_Group, Product_Type_Group, Dojo_Group, Role, Global_Role, Dojo_Group_Member, \
     Language_Type, Languages, Notifications, NOTIFICATION_CHOICES, Engagement_Presets, \
     Network_Locations, UserContactInfo, Product_API_Scan_Configuration, DEFAULT_NOTIFICATION, \
-    Vulnerability_Id, Vulnerability_Id_Template
+    Vulnerability_Id, Vulnerability_Id_Template, get_current_date
 
 from dojo.tools.factory import requires_file, get_choices_sorted, requires_tool_type
 from dojo.utils import is_scan_file_too_large
@@ -840,7 +840,7 @@ class EndpointStatusSerializer(serializers.ModelSerializer):
         status.false_positive = validated_data.get('false_positive', False)
         status.out_of_scope = validated_data.get('out_of_scope', False)
         status.risk_accepted = validated_data.get('risk_accepted', False)
-        status.date = validated_data.get('date', timezone.now())
+        status.date = validated_data.get('date', get_current_date())
         status.save()
         return status
 

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -810,6 +810,18 @@ class EndpointStatusTest(BaseClass.RESTEndpointTest):
         self.assertEqual(400, response.status_code, response.content[:1000])
         self.assertIn('This endpoint-finding relation already exists', response.content.decode("utf-8"))
 
+    def test_create_minimal(self):
+        # This call should not fail even if there is not date defined
+        minimal_payload = {
+            'endpoint': 1,
+            'finding': 3,
+        }
+        response = self.client.post(self.url, minimal_payload)
+        logger.debug('test_create_response:')
+        logger.debug(response)
+        logger.debug(response.data)
+        self.assertEqual(201, response.status_code, response.content[:1000])
+       
     def test_update_patch_unsuccessful(self):
         anoher_finding_payload = self.payload.copy()
         anoher_finding_payload['finding'] = 3

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -821,7 +821,7 @@ class EndpointStatusTest(BaseClass.RESTEndpointTest):
         logger.debug(response)
         logger.debug(response.data)
         self.assertEqual(201, response.status_code, response.content[:1000])
-       
+
     def test_update_patch_unsuccessful(self):
         anoher_finding_payload = self.payload.copy()
         anoher_finding_payload['finding'] = 3


### PR DESCRIPTION
Fix for #7336