### PR TITLE
Avoid unnecessary save for dynamic findings on reimport

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -166,7 +166,8 @@ class DojoDefaultReImporter(object):
                             finding.active = False
                             if verified is not None:
                                 finding.verified = verified
-                    if not finding.component_name or not finding.component_version:
+
+                    if (component_name is not None and not finding.component_name) or (component_version is not None and not finding.component_version):
                         finding.component_name = finding.component_name if finding.component_name else component_name
                         finding.component_version = finding.component_version if finding.component_version else component_version
                         finding.save(dedupe_option=False)


### PR DESCRIPTION
On re-import, if an open duplicate finding is found it will save the finding if the finding has no component name/version, which will be the case for dynamic findings. It should only save if the new finding has a defined component name/version.