### PR TITLE
Create env var DD_JIRA_DEFAULT_ISSUE_TYPE

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3361,10 +3361,13 @@ class JIRA_Instance(models.Model):
                                         ('Bug', 'Bug'),
                                         ('Security', 'Security')
                                     )
-    default_issue_type = models.CharField(max_length=15,
-                                          choices=default_issue_type_choices,
-                                          default='Bug',
-                                          help_text=_('You can define extra issue types in settings.py'))
+    if hasattr(settings, 'JIRA_DEFAULT_ISSUE_TYPE'):
+        default_issue_type = settings.JIRA_DEFAULT_ISSUE_TYPE
+    else:
+        default_issue_type = models.CharField(max_length=15,
+                                            choices=default_issue_type_choices,
+                                            default='Bug',
+                                            help_text=_('You can define extra issue types in settings.py'))
     issue_template_dir = models.CharField(max_length=255,
                                       null=True,
                                       blank=True,

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -220,7 +220,7 @@ env = environ.Env(
     # DD_FEATURE_FINDING_GROUPS feature is moved to system_settings, will be removed from settings file
     DD_FEATURE_FINDING_GROUPS=(bool, True),
     DD_JIRA_TEMPLATE_ROOT=(str, 'dojo/templates/issue-trackers'),
-    DD_JIRA_DEFAULT_ISSUE_TYPE=(str,'Bug'),
+    DD_JIRA_DEFAULT_ISSUE_TYPE=(str, 'Bug'),
     DD_TEMPLATE_DIR_PREFIX=(str, 'dojo/templates/'),
 
     # Initial behaviour in Defect Dojo was to delete all duplicates when an original was deleted

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -220,6 +220,7 @@ env = environ.Env(
     # DD_FEATURE_FINDING_GROUPS feature is moved to system_settings, will be removed from settings file
     DD_FEATURE_FINDING_GROUPS=(bool, True),
     DD_JIRA_TEMPLATE_ROOT=(str, 'dojo/templates/issue-trackers'),
+    DD_JIRA_DEFAULT_ISSUE_TYPE=(str,'Bug'),
     DD_TEMPLATE_DIR_PREFIX=(str, 'dojo/templates/'),
 
     # Initial behaviour in Defect Dojo was to delete all duplicates when an original was deleted
@@ -1564,6 +1565,7 @@ USE_L10N = True
 # FEATURE_FINDING_GROUPS feature is moved to system_settings, will be removed from settings file
 FEATURE_FINDING_GROUPS = env('DD_FEATURE_FINDING_GROUPS')
 JIRA_TEMPLATE_ROOT = env('DD_JIRA_TEMPLATE_ROOT')
+JIRA_DEFAULT_ISSUE_TYPE = env('DD_JIRA_DEFAULT_ISSUE_TYPE')
 TEMPLATE_DIR_PREFIX = env('DD_TEMPLATE_DIR_PREFIX')
 
 DUPLICATE_CLUSTER_CASCADE_DELETE = env('DD_DUPLICATE_CLUSTER_CASCADE_DELETE')


### PR DESCRIPTION
**Description**
I'd like to be able to configure Jira through the helm chart, because otherwise, the deployment requires a lot of manual set-up after deployment, it's not fully configured. This PR might need to be extended to configure much more than just the default ticket type, but maybe the whole Jira configuration should be (and with support for multiple Jira instances too perhaps?)

**Test results**
No tests yet, I hope this won't be needed for simple changes, and the helm chart would mostly just inject things in extraConfigs: {}
Ideally you extend the test suite in `tests/` and `dojo/unittests` to cover the changed in this PR.
Alternatively, describe what you have and haven't tested.