### PR TITLE
New env var DD_JIRA_EXTRA_ISSUE_TYPES to add Jira issue types

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -195,7 +195,8 @@ env = environ.Env(
     DD_SIMILAR_FINDINGS_MAX_RESULTS=(int, 25),
     DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
     DD_JIRA_SSL_VERIFY=(bool, True),
-    DD_JIRA_EXTRA_ISSUE_TYPES=(str, ''), # You can set extra Jira issue types via a simple env var that supports a csv format, like "Work Item,Vulnerability"
+    # You can set extra Jira issue types via a simple env var that supports a csv format, like "Work Item,Vulnerability"
+    DD_JIRA_EXTRA_ISSUE_TYPES=(str, ''),
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
     DD_LOGGING_HANDLER=(str, 'console'),
     DD_ALERT_REFRESH=(bool, True),

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -195,6 +195,7 @@ env = environ.Env(
     DD_SIMILAR_FINDINGS_MAX_RESULTS=(int, 25),
     DD_MAX_AUTOCOMPLETE_WORDS=(int, 20000),
     DD_JIRA_SSL_VERIFY=(bool, True),
+    DD_JIRA_EXTRA_ISSUE_TYPES=(str, ''), # You can set extra Jira issue types via a simple env var that supports a csv format, like "Work Item,Vulnerability"
     # if you want to keep logging to the console but in json format, change this here to 'json_console'
     DD_LOGGING_HANDLER=(str, 'console'),
     DD_ALERT_REFRESH=(bool, True),
@@ -1415,6 +1416,13 @@ JIRA_ISSUE_TYPE_CHOICES_CONFIG = (
     ('Bug', 'Bug'),
     ('Security', 'Security')
 )
+
+if env('DD_JIRA_EXTRA_ISSUE_TYPES') != '':
+    if env('DD_JIRA_EXTRA_ISSUE_TYPES').count(',') > 0:
+        for extra_type in env('DD_JIRA_EXTRA_ISSUE_TYPES').split(','):
+            JIRA_ISSUE_TYPE_CHOICES_CONFIG += (extra_type, extra_type)
+    else:
+        JIRA_ISSUE_TYPE_CHOICES_CONFIG += (env('DD_JIRA_EXTRA_ISSUE_TYPES'), env('DD_JIRA_EXTRA_ISSUE_TYPES'))
 
 JIRA_SSL_VERIFY = env('DD_JIRA_SSL_VERIFY')
 


### PR DESCRIPTION
**Description**
Simpler than https://github.com/DefectDojo/django-DefectDojo/pull/7411 for now, this is simply to expose the settings.dist.py as an env var, that can be used via the Helm chart, to add other Jira issue types.