### PR TITLE
Clean unsaved endpoints before comparing them to existing endpoints

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -73,6 +73,10 @@ class DojoDefaultReImporter(object):
             if service:
                 item.service = service
 
+            if item.dynamic_finding:
+                for e in item.unsaved_endpoints:
+                    e.clean()
+
             item.hash_code = item.compute_hash_code()
             deduplicationLogger.debug("item's hash_code: %s", item.hash_code)
 


### PR DESCRIPTION
A fix for https://github.com/DefectDojo/django-DefectDojo/issues/7403

The problem here is that the port is a String in the Endpoint, something that is cleaned up by clean(). Comparison fails compared to the existing endpoint as a result, and the endpoint gets incorrectly mitigated on reimport.