### PR TITLE
Handle test tags when reimporting with reimport_scan api

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1693,7 +1693,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         allow_null=True,
         default=None,
         queryset=User.objects.all())
-    tags = TagListSerializerField(required=False, help_text="Modify existing tags that help describe this scan.")
+    tags = TagListSerializerField(required=False, help_text="Modify existing tags that help describe this scan. (Existing test tags will be overwritten)")
 
     group_by = serializers.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text='Choose an option to automatically group new findings by the chosen option.')
     create_finding_groups_for_all_findings = serializers.BooleanField(help_text="If set to false, finding groups will only be created when there is more than one grouped finding", required=False, default=True)
@@ -1761,7 +1761,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                 reimporter = ReImporter()
                 test, finding_count, new_finding_count, closed_finding_count, reactivated_finding_count, untouched_finding_count, test_import = \
                     reimporter.reimport_scan(scan, scan_type, test, active=active, verified=verified,
-                                                tags=None, minimum_severity=minimum_severity,
+                                                tags=tags, minimum_severity=minimum_severity,
                                                 endpoints_to_add=endpoints_to_add, scan_date=scan_date_time,
                                                 version=version, branch_tag=branch_tag, build_id=build_id,
                                                 commit_hash=commit_hash, push_to_jira=push_to_jira,

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -428,6 +428,9 @@ class DojoDefaultReImporter(object):
         logger.debug('REIMPORT_SCAN: Updating test/engagement timestamps')
         importer_utils.update_timestamps(test, version, branch_tag, build_id, commit_hash, now, scan_date)
 
+        logger.debug('REIMPORT_SCAN: Updating test tags')
+        importer_utils.update_tags(test, tags)
+
         test_import = None
         if settings.TRACK_IMPORT_HISTORY:
             logger.debug('REIMPORT_SCAN: Updating Import History')

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -39,6 +39,11 @@ def update_timestamps(test, version, branch_tag, build_id, commit_hash, now, sca
     test.save()
     test.engagement.save()
 
+def update_tags(test, tags):
+    if tags:
+        test.tags = tags
+
+    test.save()
 
 def update_import_history(type, active, verified, tags, minimum_severity, endpoints_to_add, version, branch_tag,
                             build_id, commit_hash, push_to_jira, close_old_findings, test,
@@ -53,7 +58,6 @@ def update_import_history(type, active, verified, tags, minimum_severity, endpoi
     import_settings['push_to_jira'] = push_to_jira
     import_settings['tags'] = tags
 
-    # tags=tags TODO no tags field in api for reimport it seems
     if endpoints_to_add:
         import_settings['endpoints'] = [str(endpoint) for endpoint in endpoints_to_add]
 

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -39,11 +39,13 @@ def update_timestamps(test, version, branch_tag, build_id, commit_hash, now, sca
     test.save()
     test.engagement.save()
 
+
 def update_tags(test, tags):
     if tags:
         test.tags = tags
 
     test.save()
+
 
 def update_import_history(type, active, verified, tags, minimum_severity, endpoints_to_add, version, branch_tag,
                             build_id, commit_hash, push_to_jira, close_old_findings, test,


### PR DESCRIPTION
**Description**

see issue #7367

tags are created while using the reimport_api and creating a new, not already existing test.
when the test exists the newly set tags are ignored.

with this pr tags will be overwritten when tags are set while reimporting a existing test object.
if no tags are set the existing tags will remain.

**Test results**

the integration_tests locally ran without any errors.

**Documentation**

i've specified the behaviour in the api help text.
