### PR TITLE
Add the old finding in the reimporter to the list of unchanged findin…

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -89,6 +89,11 @@ class DojoDefaultReImporter(object):
                 finding = findings[0]
                 if finding.false_p or finding.out_of_scope or finding.risk_accepted:
                     logger.debug('%i: skipping existing finding (it is marked as false positive:%s and/or out of scope:%s or is a risk accepted:%s): %i:%s:%s:%s', i, finding.false_p, finding.out_of_scope, finding.risk_accepted, finding.id, finding, finding.component_name, finding.component_version)
+                    if (finding.false_p == item.false_p and finding.out_of_scope == item.out_of_scope
+                            and finding.risk_accepted == item.risk_accepted):
+                        unchanged_items.append(finding)
+                        unchanged_count += 1
+                        continue
                 elif finding.is_mitigated:
                     # if the reimported item has a mitigation time, we can compare
                     if item.is_mitigated:


### PR DESCRIPTION
…gs if risk acceptance matches

If you have a risk accepted finding, on a re-import it will get additionally marked as mitigated, which isn't necessary. Instead if risk acceptance or false positive or out of scope matches with the new finding, we should add it to the list of unchanged findings.