### PR TITLE
Adding Betterscan.io scan type to SARIF parser

### DIFF
--- a/docs/content/en/integrations/parsers.md
+++ b/docs/content/en/integrations/parsers.md
@@ -85,6 +85,9 @@ Azure Security Center recommendations can be exported from the user interface in
 
 JSON report format
 
+### Betterscan
+
+Betterscan findings can be exported in SARIF from Betterscan and imported via SARIF format.
 
 ### Blackduck API
 

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -18,12 +18,14 @@ class SarifParser(object):
     """
 
     def get_scan_types(self):
-        return ["SARIF"]
+        return ["SARIF", "Betterscan.io"]
 
     def get_label_for_scan_types(self, scan_type):
         return scan_type  # no custom label for now
 
     def get_description_for_scan_types(self, scan_type):
+        if scan_type == "Betterscan.io":
+            return "Import Betterscan.io report. Currently only SARIF Format is supported."
         return "SARIF report file can be imported in SARIF format."
 
     def get_findings(self, filehandle, test):


### PR DESCRIPTION
**Description**

Adding Betterscan.io as a new "Scan Type"

https://github.com/DefectDojo/django-DefectDojo/issues/7354

Used current SARIF implementation

**Test results**

Use SARIF parsing, so no need for test

**Documentation**

Not needed, since explained in the UI

