### PR TITLE
If findings are mitigated for AWS Security Hub then set them to inactive

### DIFF
--- a/dojo/tools/awssecurityhub/parser.py
+++ b/dojo/tools/awssecurityhub/parser.py
@@ -45,8 +45,9 @@ def get_item(finding, test):
     references = finding.get('Remediation', {}).get('Recommendation', {}).get('Url')
     false_p = False
 
-    if finding.get('Compliance', {}).get('Status', "PASSED"):
+    if finding.get('Compliance', {}).get('Status', "PASSED") == 'PASSED':
         is_Mitigated = True
+        active = False
         if finding.get('LastObservedAt', None):
             try:
                 mitigated = datetime.strptime(finding.get('LastObservedAt'), "%Y-%m-%dT%H:%M:%S.%fZ")
@@ -57,6 +58,7 @@ def get_item(finding, test):
     else:
         mitigated = None
         is_Mitigated = False
+        active = True
 
     finding = Finding(title=f"Resource: {resource_id} - {title}",
                       test=test,
@@ -64,7 +66,7 @@ def get_item(finding, test):
                       mitigation=mitigation,
                       references=references,
                       severity=severity,
-                      active=True,
+                      active=active,
                       verified=False,
                       false_p=false_p,
                       unique_id_from_tool=finding_id,

--- a/unittests/scans/awssecurityhub/one_finding_active.json
+++ b/unittests/scans/awssecurityhub/one_finding_active.json
@@ -1,0 +1,62 @@
+{
+    "findings": [
+        {
+            "SchemaVersion": "2018-10-08",
+            "Id": "arn:aws:securityhub:us-east-1:012345678912:subscription/aws-foundational-security-best-practices/v/1.0.0/IAM.5/finding/de861909-2d26-4e45-bd86-19d2ab6ceef1",
+            "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/securityhub",
+            "GeneratorId": "aws-foundational-security-best-practices/v/1.0.0/IAM.5",
+            "AwsAccountId": "012345678912",
+            "Types": [
+                "Software and Configuration Checks/Industry and Regulatory Standards/AWS-Foundational-Security-Best-Practices"
+            ],
+            "FirstObservedAt": "2020-06-08T14:33:07.560Z",
+            "LastObservedAt": "2020-06-14T21:02:53.940Z",
+            "CreatedAt": "2020-06-08T14:33:07.560Z",
+            "UpdatedAt": "2020-06-14T21:02:53.454Z",
+            "Severity": {
+                "Product": 40,
+                "Label": "MEDIUM",
+                "Normalized": 40,
+                "Original": "MEDIUM"
+            },
+            "Title": "IAM.5 MFA should be enabled for all IAM users that have console password",
+            "Description": "This AWS control checks whether AWS Multi-Factor Authentication (MFA) is enabled for all AWS Identity and Access Management (IAM) users that use a console password.",
+            "Remediation": {
+                "Recommendation": {
+                    "Text": "For directions on how to fix this issue, please consult the AWS Security Hub Foundational Security Best Practices documentation.",
+                    "Url": "https://docs.aws.amazon.com/console/securityhub/IAM.5/remediation"
+                }
+            },
+            "ProductFields": {
+                "StandardsArn": "arn:aws:securityhub:::standards/aws-foundational-security-best-practices/v/1.0.0",
+                "StandardsSubscriptionArn": "arn:aws:securityhub:us-east-1:012345678912:subscription/aws-foundational-security-best-practices/v/1.0.0",
+                "ControlId": "IAM.5",
+                "RecommendationUrl": "https://docs.aws.amazon.com/console/securityhub/IAM.5/remediation",
+                "RelatedAWSResources:0/name": "securityhub-mfa-enabled-for-iam-console-access-9ae73a2f",
+                "RelatedAWSResources:0/type": "AWS::Config::ConfigRule",
+                "StandardsControlArn": "arn:aws:securityhub:us-east-1:012345678912:control/aws-foundational-security-best-practices/v/1.0.0/IAM.5",
+                "aws/securityhub/SeverityLabel": "MEDIUM",
+                "aws/securityhub/ProductName": "Security Hub",
+                "aws/securityhub/CompanyName": "AWS",
+                "aws/securityhub/annotation": "AWS Config evaluated your resources against the rule. The rule did not apply to the AWS resources in its scope, the specified resources were deleted, or the evaluation results were deleted.",
+                "aws/securityhub/FindingId": "arn:aws:securityhub:us-east-1::product/aws/securityhub/arn:aws:securityhub:us-east-1:012345678912:subscription/aws-foundational-security-best-practices/v/1.0.0/IAM.5/finding/de861909-2d26-4e45-bd86-19d2ab6ceef1"
+            },
+            "Resources": [
+                {
+                    "Type": "AwsAccount",
+                    "Id": "AWS::::Account:012345678912",
+                    "Partition": "aws",
+                    "Region": "us-east-1"
+                }
+            ],
+            "Compliance": {
+                "Status": "FAILED"
+            },
+            "WorkflowState": "NEW",
+            "Workflow": {
+                "Status": "NEW"
+            },
+            "RecordState": "ACTIVE"
+        }
+    ]
+}

--- a/unittests/tools/test_awssecurityhub_parser.py
+++ b/unittests/tools/test_awssecurityhub_parser.py
@@ -16,6 +16,20 @@ class TestAwsSecurityHubParser(DojoTestCase):
             parser = AwsSecurityHubParser()
             findings = parser.get_findings(test_file, Test())
             self.assertEqual(1, len(findings))
+            finding = findings[0]
+            self.assertEqual("Informational", finding.severity)
+            self.assertTrue(finding.is_mitigated)
+            self.assertFalse(finding.active)
+
+    def test_one_finding_active(self):
+        with open(get_unit_tests_path() + sample_path("one_finding_active.json")) as test_file:
+            parser = AwsSecurityHubParser()
+            findings = parser.get_findings(test_file, Test())
+            self.assertEqual(1, len(findings))
+            finding = findings[0]
+            self.assertEqual("Medium", finding.severity)
+            self.assertFalse(finding.is_mitigated)
+            self.assertTrue(finding.active)
 
     def test_many_findings(self):
         with open(get_unit_tests_path() + sample_path("many_findings.json")) as test_file:


### PR DESCRIPTION
A fix for https://github.com/DefectDojo/django-DefectDojo/issues/7437

It fixes two bugs in the AWS Security Hub parser:

1. When a finding is mitigated, set it to inactive.
2. The code was setting all issues to mitigated!