### PR TITLE
Avoid "STATICFILES_DIRS" warning

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -407,7 +407,7 @@ STATICFILES_DIRS = (
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    # e.g.: os.path.join(os.path.dirname(DOJO_ROOT), 'components', 'node_modules'),
+    os.path.join(os.path.dirname(DOJO_ROOT), 'components', 'node_modules'),
 )
 
 # List of finder classes that know how to find static files in

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -407,7 +407,7 @@ STATICFILES_DIRS = (
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    os.path.join(os.path.dirname(DOJO_ROOT), 'components', 'node_modules'),
+    # e.g.: os.path.join(os.path.dirname(DOJO_ROOT), 'components', 'node_modules'),
 )
 
 # List of finder classes that know how to find static files in


### PR DESCRIPTION
Avoid this warning:
```python
django-defectdojo-initializer-1   | System check identified some issues:
django-defectdojo-initializer-1   |
django-defectdojo-initializer-1   | WARNINGS:
django-defectdojo-initializer-1   | ?: (staticfiles.W004) The directory '/app/components/node_modules' in the STATICFILES_DIRS setting does not exist.
```