### PR TITLE
Catch endpoint validation errors in the reimporter

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -75,7 +75,11 @@ class DojoDefaultReImporter(object):
 
             if item.dynamic_finding:
                 for e in item.unsaved_endpoints:
-                    e.clean()
+                    try:
+                        e.clean()
+                    except ValidationError as err:
+                        logger.warning("DefectDojo is storing broken endpoint because cleaning wasn't successful: "
+                                       "{}".format(err))
 
             item.hash_code = item.compute_hash_code()
             deduplicationLogger.debug("item's hash_code: %s", item.hash_code)


### PR DESCRIPTION
A fix for https://github.com/DefectDojo/django-DefectDojo/issues/7451

Like in the importer, we should catch and log endpoint validation errors from Endpoint.clean()

closes #7451 