### PR TITLE
Fixing typo in endpoint documentation

### DIFF
--- a/dojo/templates/dojo/add_endpoint_meta_data.html
+++ b/dojo/templates/dojo/add_endpoint_meta_data.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     {{ block.super }}
-    <h3> Add Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
+    <h3> Add Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
     <br />
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% include "dojo/form_fields.html" with form=form %}

--- a/dojo/templates/dojo/breadcrumbs/endpoint_breadcrumb.html
+++ b/dojo/templates/dojo/breadcrumbs/endpoint_breadcrumb.html
@@ -9,7 +9,7 @@
     {% if host_view %}
       <li><a data-toggle="tooltip" data-placement="top" title="Test" href="{% url 'view_endpoint_host' endpoint.id %}">{{endpoint.host}}</a></li>
     {% else %}
-      <li><a data-toggle="tooltip" data-placement="top" title="Test" href="{% url 'view_endpoint' endpoint.id %}">{{endpoint}}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a></li>
+      <li><a data-toggle="tooltip" data-placement="top" title="Test" href="{% url 'view_endpoint' endpoint.id %}">{{endpoint}}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a></li>
     {% endif %}
   {% endif %}
   {% if product_tab.title %}

--- a/dojo/templates/dojo/delete_endpoint.html
+++ b/dojo/templates/dojo/delete_endpoint.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
     {{ block.super }}
-    <h3> Delete Endpoint {{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</h3>
+    <h3> Delete Endpoint {{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</h3>
     <p>
         Deleting this Endpoint will disassociate it with any findings and products and other relationships associated
         with it. These relationships are listed below:

--- a/dojo/templates/dojo/edit_endpoint_meta_data.html
+++ b/dojo/templates/dojo/edit_endpoint_meta_data.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     {{ block.super }}
-    <h3> Edit Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
+    <h3> Edit Endpoint ({{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}) Metadata</h3>
     <br/>
     <form class="form-horizontal" method="post">{% csrf_token %}
         {% for cf in endpoint.endpoint_meta.all %}

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -102,7 +102,7 @@
                                   <td><a href="{% url 'view_endpoint_host' e.id %}">{{ e.host }}</a>
                                 {% else %}
                                 <td>
-                                  <a href="{% url 'view_endpoint' e.id %}">{{ e }}{% if e.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
+                                  <a href="{% url 'view_endpoint' e.id %}">{{ e }}{% if e.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a>
                                 {% endif %}
                                   {% include "dojo/snippets/tags.html" with tags=e.tags.all %}
                                 </td>

--- a/dojo/templates/dojo/simple_search.html
+++ b/dojo/templates/dojo/simple_search.html
@@ -264,7 +264,7 @@
                         {% for e in endpoints %}
                             <tr>
                                 <td>
-                                    <a href="{% url 'view_endpoint' e.id %}">{{ e }}{% if e.is_broken %} <span data-toggle="tooltip" title="{% trans "Endpoint is broken. Check documentation for look for fix process" %}" >&#128681;</span>{% endif %}</a>
+                                    <a href="{% url 'view_endpoint' e.id %}">{{ e }}{% if e.is_broken %} <span data-toggle="tooltip" title="{% trans "Endpoint is broken. Check documentation to look for fix process" %}" >&#128681;</span>{% endif %}</a>
                                     {% include "dojo/snippets/tags.html" with tags=e.tags.all %}
                                 </td>
                                 {% if e.product %}
@@ -414,7 +414,7 @@
                             <tr>
                                 <td>{% trans "Endpoint" %}</td>
                                 <td>
-                                    <a class="search-finding" href="{% url 'view_endpoint' endpoint.id %}">{{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
+                                    <a class="search-finding" href="{% url 'view_endpoint' endpoint.id %}">{{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a>
                                     {% include "dojo/snippets/tags.html" with tags=endpoint.tags.all %}
                                 </td>
                             </tr>

--- a/dojo/templates/dojo/snippets/endpoints.html
+++ b/dojo/templates/dojo/snippets/endpoints.html
@@ -23,7 +23,7 @@
                                 <tbody>
                                     {% for endpoint in endpoints %}
                                         <tr>
-                                            <td>{{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</td>
+                                            <td>{{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</td>
                                             <td>{{ endpoint|endpoint_display_status:finding|safe }}</td>
                                             <td>{{ endpoint|endpoint_date:finding|date }}</td>
                                             <td>{{ endpoint|endpoint_update_time:finding|date}}</td>
@@ -55,7 +55,7 @@
                                 <tbody>
                                     {% for endpoint in endpoints %}
                                         <tr>
-                                            <td>{{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</td>
+                                            <td>{{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</td>
                                             <td>{{ endpoint|endpoint_display_status:finding|safe }}</td>
                                             <td>{{ endpoint|endpoint_mitigated_time:finding|date }}</td>
                                             <td>{{ endpoint|endpoint_mitigator:finding|safe }}</td>
@@ -158,7 +158,7 @@
                                             </td>
                                         {% endif %}
                                         <td>
-                                            <a data-toggle="tooltip" data-placement="top" data-original-title="{{ endpoint }}" href="{% url 'view_endpoint' endpoint.id %}">{{ endpoint|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
+                                            <a data-toggle="tooltip" data-placement="top" data-original-title="{{ endpoint }}" href="{% url 'view_endpoint' endpoint.id %}">{{ endpoint|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a>
                                             {% include "dojo/snippets/tags.html" with tags=endpoint.tags.all %}
                                         </td>
                                         <td>{{ endpoint|endpoint_display_status:finding|safe }}</td>
@@ -212,7 +212,7 @@
                                             </td>
                                         {% endif %}
                                         <td>
-                                            <a data-toggle="tooltip" data-placement="top" data-original-title="{{ endpoint }}" href="{% url 'view_endpoint' endpoint.id %}">{{ endpoint|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
+                                            <a data-toggle="tooltip" data-placement="top" data-original-title="{{ endpoint }}" href="{% url 'view_endpoint' endpoint.id %}">{{ endpoint|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a>
                                             {% include "dojo/snippets/tags.html" with tags=endpoint.tags.all %}
                                         </td>
                                         <td>{{ endpoint|endpoint_display_status:finding|safe }}</td>

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -22,7 +22,7 @@
                       Host: {{ endpoint.host }} -
                       {{ endpoint.host_mitigated_endpoints_count }} / {{ endpoint.host_endpoints_count }} mitigated endpoints
                     {% else %}
-                      Endpoint: {{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %} -
+                      Endpoint: {{ endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %} -
                       {% if endpoint.mitigated %}
                         Mitigated
                       {% else %}
@@ -181,7 +181,7 @@
                                       {% else %}
                                         <span class="fa-solid fa-thumbs-up"></span>
                                       {% endif %}
-                                      &nbsp;{{ item|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}</a>
+                                      &nbsp;{{ item|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a>
                                     {% endif %}
                                 </td>
                             {% endfor %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -847,7 +847,7 @@
                                         {% else %}
                                             &#10005;
                                         {% endif %}
-                                         {{ endpoint_status.endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation for look for fix process" >&#128681;</span>{% endif %}<br/>
+                                         {{ endpoint_status.endpoint }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}<br/>
                                     {% endfor %}
                                 " data-placement="right" data-container="body" data-original-title="Endpoints ({{finding.active_endpoint_count}} Active, {{finding.mitigated_endpoint_count}} Mitigated)" title=""></i>
                               {% endif %}


### PR DESCRIPTION
"Check documentation for look for" -> "Check documentation to look for"