### PR TITLE
Disable GHA unit tests on push to branch, limit only to PR

### DIFF
--- a/.github/workflows/detect-merge-conflicts.yaml
+++ b/.github/workflows/detect-merge-conflicts.yaml
@@ -1,8 +1,8 @@
 name: "Detect Merge Conflicts"
 on:
   workflow_dispatch:
-  push:
-    branch:
+  pull_request:
+    branches:
       - dev
       - master
       - release/*

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - dev
+      - bugfix
 
 # Taken from https://github.com/marketplace/actions/hugo-setup#%EF%B8%8F-workflow-for-autoprefixer-and-postcss-cli
 # Both builds have to be one worflow as otherwise one publish will overwrite the other

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,7 +5,6 @@ name: Integration tests
 on:
   workflow_dispatch:
   pull_request:
-  push:
     branches:
       - master
       - dev

--- a/.github/workflows/k8s-testing.yml
+++ b/.github/workflows/k8s-testing.yml
@@ -1,7 +1,6 @@
 name: k8s deployment
 on:
   pull_request:
-  push:
     branches:
       - master
       - dev

--- a/.github/workflows/test-helm-chart.yml
+++ b/.github/workflows/test-helm-chart.yml
@@ -1,7 +1,6 @@
 name: Lint Helm chart
 on:
   pull_request:
-  push:
     branches:
       - master
       - dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,6 @@ name: Unit tests
 on:
   workflow_dispatch:
   pull_request:
-  push:
     branches:
       - master
       - dev


### PR DESCRIPTION
I have been noticing that unit tests have been running twice on during the merge process:
1. In the PR itself on each commit
2. After merging from contributor branch X to dev/bugfix/master

This is redundant and clogs the actions queue. 

I suspect this may also fix the helm lint tests on master since the primary reason for failing is that the test is running post merge to master (checking master helm version for an increased helm version after it has already been bumped)