### PR TITLE
Change url -> re-path in template-local_settings

### DIFF
--- a/dojo/settings/template-local_settings
+++ b/dojo/settings/template-local_settings
@@ -58,4 +58,4 @@ DEBUG_TOOLBAR_PANELS = [
 ]
 
 import debug_toolbar
-EXTRA_URL_PATTERNS = [url(r"^__debug__/", include(debug_toolbar.urls))]
+EXTRA_URL_PATTERNS = [re_path(r"^__debug__/", include(debug_toolbar.urls))]


### PR DESCRIPTION
**Description**

I changed the method "url" to "re_path" by requirement of Django 4 in template-local_settings
