### PR TITLE
New env var DD_HASHCODE_FIELDS_PER_SCANNER

### DIFF
--- a/docs/content/en/usage/features.md
+++ b/docs/content/en/usage/features.md
@@ -152,7 +152,10 @@ DEDUPE_ALGO_LEGACY
 
 The hash_code computation can be configured for each parser using the
 parameter `HASHCODE_FIELDS_PER_SCANNER` in
-`settings.dist.py`.
+`settings.dist.py`, or via the env variable (useful for Kubernetes deployments) `DD_HASHCODE_FIELDS_PER_SCANNER` with a JSON string like 
+```json
+{"ScannerName":["field1", "field2"]}
+```
 
 The parameter `HASHCODE_ALLOWED_FIELDS` list the fields
 from finding table that were tested and are known to be working when

--- a/docs/content/en/usage/features.md
+++ b/docs/content/en/usage/features.md
@@ -156,6 +156,7 @@ parameter `HASHCODE_FIELDS_PER_SCANNER` in
 ```json
 {"ScannerName":["field1", "field2"]}
 ```
+The environment variable will override the settings in `settings.dist.py`, replacing by matching the keys.
 
 The parameter `HASHCODE_ALLOWED_FIELDS` list the fields
 from finding table that were tested and are known to be working when

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -262,6 +262,8 @@ env = environ.Env(
     DD_API_TOKENS_ENABLED=(bool, True),
     # You can set extra Jira headers by suppling a dictionary in header: value format (pass as env var like "headr_name=value,another_header=anohter_value")
     DD_ADDITIONAL_HEADERS=(dict, {}),
+    # Set fields used by the hashcode generator for deduplication, via en env variable that contains a JSON string
+    DD_HASHCODE_FIELDS_PER_SCANNER=(str, '')
 )
 
 
@@ -1237,6 +1239,14 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'NeuVector (compliance)': ['title', 'vuln_id_from_tool', 'description'],
     'Wpscan': ['title', 'description', 'severity'],
 }
+
+# Override the hardcoded settings here via the env var
+if len(env('DD_HASHCODE_FIELDS_PER_SCANNER')) > 0:
+    env_hashcode_fields_per_scanner = json.loads(env('DD_HASHCODE_FIELDS_PER_SCANNER'))
+    for key, value in env_hashcode_fields_per_scanner.items():
+        if key in HASHCODE_FIELDS_PER_SCANNER:
+            print("Replacing {} with value {} from env var DD_HASHCODE_FIELDS_PER_SCANNER".format(key, value))
+            HASHCODE_FIELDS_PER_SCANNER[key] = value
 
 # This tells if we should accept cwe=0 when computing hash_code with a configurable list of fields from HASHCODE_FIELDS_PER_SCANNER (this setting doesn't apply to legacy algorithm)
 # If False and cwe = 0, then the hash_code computation will fallback to legacy algorithm for the concerned finding


### PR DESCRIPTION
**Description**

Simply a new env var that enables users to hardcode their hashcode fields another way, which will be possible for Kubernetes deployments too.
It copies from `DD_CELERY_BROKER_TRANSPORT_OPTIONS`, because it's loading a JSON String from the env, into a dict, and replaces the settings.dist.py values with the ones in the dict

**Test results**

Not much testing to add I think, it works well, no exception handling needed because we don't want the startup to work if the value isn't valid.

**Documentation**

A lot of env vars are kinda undocumented, I think I'll push another commit to mention it.