### PR TITLE
For findings that are out of SLA display them as negative values so t…

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -270,7 +270,6 @@ def finding_sla(finding):
         status_text = 'Remediation for ' + severity.lower() + ' findings in ' + str(sla_age) + ' days or less since ' + finding.get_sla_start_date().strftime("%b %d, %Y") + ')'
         if find_sla and find_sla < 0:
             status = "red"
-            find_sla = abs(find_sla)
             status_text = 'Overdue: Remediation for ' + severity.lower() + ' findings in ' + str(
                 sla_age) + ' days or less since ' + finding.get_sla_start_date().strftime("%b %d, %Y") + ')'
 


### PR DESCRIPTION
…hat we can sort findings according to SLA

I'm not sure @Maffooch if fixes at the end of the month should go against dev or bugfix?

The problem here is that if you want to sort findings by SLA in the dashboard, the out of SLA findings may appear buried in the finding list as they are not negative values. Instead it should display the out of SLA issues first, followed by the issues still in SLA sorted by the days remaining.