### PR TITLE
fix(commands/jira_status_reconciliation): exception due to missing ar…

### DIFF
--- a/dojo/management/commands/jira_status_reconciliation.py
+++ b/dojo/management/commands/jira_status_reconciliation.py
@@ -143,7 +143,7 @@ def jira_status_reconciliation(*args, **kwargs):
             if action == 'import_status_from_jira':
                 message_action = 'deactivating' if find.active else 'reactivating'
 
-                status_changed = jira_helper.process_resolution_from_jira(find, resolution_id, resolution_name, assignee_name, issue_from_jira.fields.updated) if not dryrun else 'dryrun'
+                status_changed = jira_helper.process_resolution_from_jira(find, resolution_id, resolution_name, assignee_name, issue_from_jira.fields.updated, find.jira_issue) if not dryrun else 'dryrun'
                 if status_changed:
                     message = '%s; %s/finding/%d;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s;%s finding in defectdojo;%s' % \
                         (find.jira_issue.jira_key, settings.SITE_URL, find.id, find.status(), resolution_name, flag1, flag2, flag3,


### PR DESCRIPTION
…gument

**Description**
Using the script jira_status_reconciliation, it appears there is a bug where a function does not have enough arguments. It looks like it is related to an issue raised some time ago: https://github.com/DefectDojo/django-DefectDojo/issues/4856
The bug appears only when there were some changes in JIRA, and the tool tries to sync in DefectDojo.

**Test results**
N/A

**Documentation**
N/A
