### PR TITLE
Use the product name as the description in the importer

### DIFF
--- a/dojo/importers/reimporter/utils.py
+++ b/dojo/importers/reimporter/utils.py
@@ -189,7 +189,7 @@ def get_or_create_product(product_name=None, product_type_name=None, auto_create
             member.role = Role.objects.get(is_owner=True)
             member.save()
 
-        product = Product.objects.create(name=product_name, prod_type=product_type)
+        product = Product.objects.create(name=product_name, prod_type=product_type, description=product_name)
         member = Product_Member()
         member.user = get_current_user()
         member.product = product


### PR DESCRIPTION
**Description**

When using the importer, you can create a product with no description. Then if you try to edit the product in the UI it errors if you don't add a description. I think description should be optional in the UI as well.