### PR TITLE
Add a link to the source code in the JIRA description

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2860,8 +2860,15 @@ class Finding(models.Model):
             return None
         if self.test.engagement.source_code_management_uri is None:
             return escape(self.file_path)
+        link = self.get_file_path_with_raw_link()
+        return create_bleached_link(link, self.file_path)
+
+    def get_file_path_with_raw_link(self):
+        if self.file_path is None:
+            return None
         link = self.test.engagement.source_code_management_uri
-        if "https://github.com/" in self.test.engagement.source_code_management_uri:
+        if (self.test.engagement.source_code_management_uri is not None
+                and "https://github.com/" in self.test.engagement.source_code_management_uri):
             if self.test.commit_hash:
                 link += '/blob/' + self.test.commit_hash + '/' + self.file_path
             elif self.test.engagement.commit_hash:
@@ -2876,7 +2883,7 @@ class Finding(models.Model):
             link += '/' + self.file_path
         if self.line:
             link = link + '#L' + str(self.line)
-        return create_bleached_link(link, self.file_path)
+        return link
 
     def get_references_with_links(self):
         import re

--- a/dojo/templates/issue-trackers/jira_full/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-description.tpl
@@ -61,7 +61,9 @@
 *Source Line*: {{ finding.sast_source_line }}
 *Sink Object*: {{ finding.sast_sink_object }}
 {% elif finding.static_finding %}
-{% if finding.file_path %}
+{% if finding.file_path and finding.get_file_path_with_raw_link %}
+*Source File*: [{{ finding.file_path }} | {{ finding.get_file_path_with_raw_link }}]
+{% elif finding.file_path %}
 *Source File*: {{ finding.file_path }}
 {% endif %}
 {% if finding.line %}


### PR DESCRIPTION
**Description**

When pushing a semgrep finding to JIRA, it would be nice to add a link to the source code, link can be seen in DefectDojo UI,