### PR TITLE
Add default Dockerfile operating system

### DIFF
--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -2,7 +2,7 @@
 # code: language=Dockerfile
 
 # The code for the build image should be identical with the code in
-# Dockerfile.django to use the caching mechanism of Docker.
+# Dockerfile.django-alpine to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
 FROM python:3.11.1-alpine3.16@sha256:0e3c924cea0a1ce7238b5a12a2a95368d8a04139bd58382c7b1bed893b057fe6 as base

--- a/Dockerfile.nginx-debian
+++ b/Dockerfile.nginx-debian
@@ -2,7 +2,7 @@
 # code: language=Dockerfile
 
 # The code for the build image should be identical with the code in
-# Dockerfile.django to use the caching mechanism of Docker.
+# Dockerfile.django-debian to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
 FROM python:3.11.1-slim-bullseye@sha256:3d260508893319ee271989fe16c0ddf13c710ec5ce1d0708cda7bc30da8389e7 as base

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
   nginx:
     build:
       context: ./
-      dockerfile: Dockerfile.nginx
+      dockerfile: "Dockerfile.nginx-${DEFECT_DOJO_OS:-debian}"
     image: "defectdojo/defectdojo-nginx:${NGINX_VERSION:-latest}"
     profiles: 
       - mysql-rabbitmq
@@ -36,7 +36,7 @@ services:
   uwsgi:
     build:
       context: ./
-      dockerfile: Dockerfile.django
+      dockerfile: "Dockerfile.django-${DEFECT_DOJO_OS:-debian}"
       target: django
     image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     profiles: 

--- a/docs/content/en/getting_started/running-in-production.md
+++ b/docs/content/en/getting_started/running-in-production.md
@@ -75,7 +75,7 @@ worker container.
 
 As you\'ve enabled `prefork`, the following variables have
 to be used. The default are working fairly well, see the
-Dockerfile.django for in-file references.
+Dockerfile.django-* for in-file references.
 
 -   `DD_CELERY_WORKER_AUTOSCALE_MIN` defaults to 2.
 -   `DD_CELERY_WORKER_AUTOSCALE_MAX` defaults to 8.

--- a/docs/content/en/integrations/ldap-authentication.md
+++ b/docs/content/en/integrations/ldap-authentication.md
@@ -14,8 +14,8 @@ So long as you don't mind building your own Docker images...
 
 We will need to modify a grand total of 4-5 files, depending on how you want to pass Dojo your LDAP secrets.
 
- - Dockerfile.django
- - Dockerfile.nginx
+ - Dockerfile.django-*
+ - Dockerfile.nginx-*
  - requirements.txt
  - settings.dist.py
  - docker-compose.yml *(Optional)*


### PR DESCRIPTION
**Description**

Building locally with `docker-compose --profile mysql-rabbitmq --env-file ./docker/environments/mysql-rabbitmq.env up --build` would fail with `failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /var/lib/docker/tmp/.../Dockerfile.nginx: no such file or directory`

**Documentation**

Updated references to Dockerfile.django and Dockerfile.nginx

Not sure of the best location to document the `DEFECT_DOJO_OS` environment variable but leaving it undocumented doesn't seem ideal. Open to advice if nothing comes to mind before this has eyes on it.
