### PR TITLE
Bugfix: get_accessible_url should return access_file instead of access_url

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -662,7 +662,7 @@ class FileUpload(models.Model):
         elif isinstance(obj, Finding):
             obj_type = 'Finding'
 
-        return 'access_url/{file_id}/{obj_id}/{obj_type}'.format(
+        return 'access_file/{file_id}/{obj_id}/{obj_type}'.format(
             file_id=self.id,
             obj_id=obj_id,
             obj_type=obj_type


### PR DESCRIPTION
**Description**

The API uses the `get_accessible_url` function in `models.py` when retrieving attached files for engagements/tests/findings. This functions then [returns an URI of the form `access_url/{file_id}/{obj_id}/{obj_type}`](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/models.py#L665). Trying to access attached imaged via the returned file URL will result in an error 404 Not Found.
The [`urls.py` only has a routing entry for `access_file`](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/urls.py#L191) defined, and the views are using that URI, too. So, `get_access_url` should return the same URI path.