### PR TITLE
Set download path to /app instead of media

### DIFF
--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -4,7 +4,7 @@ services:
   integration-tests:
     build:
       context: ./
-      dockerfile: "${INTEGRATION-TESTS_DOCKERFILE:-Dockerfile.integration-tests-debian}"
+      dockerfile: ${INTEGRATION_TESTS_DOCKERFILE:-Dockerfile.integration-tests-debian}
     image: "defectdojo/defectdojo-integration-tests:${INTEGRATION_TESTS_VERSION:-latest}"
     profiles: 
       - mysql-rabbitmq

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -51,7 +51,7 @@ class BaseTestCase(unittest.TestCase):
     def setUpClass(cls):
 
         # Path for automatic downloads, mapped to the media path
-        cls.export_path = "media"
+        cls.export_path = "/app"
 
         global dd_driver
         if not dd_driver:


### PR DESCRIPTION
For some reason, the following option does not have any effect on where downloaded files go
```
# set automatic downloads to test csv and excel export
prefs = {"download.default_directory": cls.export_path}
dd_driver_options.add_experimental_option("prefs", prefs)
```
For the sake of fixing unit tests, I have set the download path to `/app` where the files are ending up
