### PR TITLE
Fix missing information in notifications

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -290,7 +290,7 @@ def send_mail_notification(event, user=None, *args, **kwargs):
         )
         email.content_subtype = 'html'
         logger.debug('sending email alert')
-        # logger.info(create_notification_message(event, 'mail'))
+        # logger.info(create_notification_message(event, user, 'mail', *args, **kwargs))
         email.send(fail_silently=False)
 
     except Exception as e:

--- a/dojo/templates/notifications/alert/engagement_added.tpl
+++ b/dojo/templates/notifications/alert/engagement_added.tpl
@@ -1,3 +1,3 @@
-{% load i18n %}{% blocktranslate trimmed %}
-The engagement "{{ engagement.name }}" has been created in the product "{{ engagement.product }}".
+{% load i18n %}{% blocktranslate trimmed with eng_name=engagement.name eng_product=engagement.product %}
+The engagement "{{ eng_name }}" has been created in the product "{{ eng_product }}".
 {% endblocktranslate %}

--- a/dojo/templates/notifications/alert/report_created.tpl
+++ b/dojo/templates/notifications/alert/report_created.tpl
@@ -1,3 +1,3 @@
-{% load i18n %}{% blocktranslate trimmed %}
-Your report "{{ report.name }}" is ready.
+{% load i18n %}{% blocktranslate trimmed with name=report.name %}
+Your report "{{ name }}" is ready.
 {% endblocktranslate %}

--- a/dojo/templates/notifications/alert/sla_breach.tpl
+++ b/dojo/templates/notifications/alert/sla_breach.tpl
@@ -1,3 +1,3 @@
-{% load i18n %}{% blocktranslate trimmed %}
-SLA breach alert for finding {{ finding.id }}. Relative days count to SLA due date: {{sla_age}}.
+{% load i18n %}{% blocktranslate trimmed with finding_id=finding.id %}
+SLA breach alert for finding {{ finding_id }}. Relative days count to SLA due date: {{sla_age}}.
 {% endblocktranslate %}

--- a/dojo/templates/notifications/alert/test_added.tpl
+++ b/dojo/templates/notifications/alert/test_added.tpl
@@ -1,3 +1,3 @@
-{% load i18n %}{% blocktranslate trimmed %}
-New test added for engagement {{ engagement.product }}: {{ test.test_type }}.
+{% load i18n %}{% blocktranslate trimmed with eng_product=engagement.product test_type=test.test_type %}
+New test added for engagement {{ eng_product }}: {{ test_type }}.
 {% endblocktranslate %}

--- a/dojo/templates/notifications/alert/upcoming_engagement.tpl
+++ b/dojo/templates/notifications/alert/upcoming_engagement.tpl
@@ -1,3 +1,3 @@
-{% load i18n %}{% blocktranslate trimmed %}
-The engagement "{{ engagement.product }}" is starting on {{ engagement.target_start }}.
+{% load i18n %}{% blocktranslate trimmed with eng_product=engagement.product start=engagement.target_start %}
+The engagement "{{ eng_product }}" is starting on {{ start }}.
 {% endblocktranslate %}

--- a/dojo/templates/notifications/mail/engagement_added.tpl
+++ b/dojo/templates/notifications/mail/engagement_added.tpl
@@ -10,8 +10,8 @@
                 {% trans "Hello" %},
             </p>
             <p>
-              {% blocktranslate trimmed %}
-                The engagement "{{ engagement.name }}" has been created in the product "{{ engagement.product }}". It can be viewed here: <a href="{{product_url|full_url}}">{{product}}</a> / <a href="{{engagement_url|full_url}}">{{ engagement.name }}</a>
+              {% blocktranslate trimmed with engagement_name=engagement.name engagement_product=engagement.product prod_url=product_url|full_url eng_url=engagement_url|full_url%}
+                The engagement "{{ engagement_name }}" has been created in the product "{{ engagement_product }}". It can be viewed here: <a href="{{prod_url}}">{{product}}</a> / <a href="{{eng_url}}">{{ engagement_name }}</a>
               {% endblocktranslate %}
             </p>
             <br/>

--- a/dojo/templates/notifications/mail/other.tpl
+++ b/dojo/templates/notifications/mail/other.tpl
@@ -13,8 +13,8 @@
             {% if url is not None %}
                 <br/>
                 <br/>
-              {% blocktranslate trimmed %}
-                More information on this event can be found here: {{ url|full_url }}
+              {% blocktranslate trimmed with event_url=url|full_url %}
+                More information on this event can be found here: {{ event_url }}
               {% endblocktranslate %}
             {% endif %}
             <br/>

--- a/dojo/templates/notifications/mail/product_added.tpl
+++ b/dojo/templates/notifications/mail/product_added.tpl
@@ -8,8 +8,8 @@
                 {% trans "Hello" %},
             </p>
             <p>
-              {% blocktranslate trimmed %}
-                The new product "{{ title }}" has been added. It can be viewed here: <a href="{{ url|full_url }}">{{ title }}</a>
+              {% blocktranslate trimmed with prod_url=url|full_url %}
+                The new product "{{ title }}" has been added. It can be viewed here: <a href="{{ prod_url }}">{{ title }}</a>
               {% endblocktranslate %}
             </p>
             <br/>

--- a/dojo/templates/notifications/mail/product_type_added.tpl
+++ b/dojo/templates/notifications/mail/product_type_added.tpl
@@ -8,8 +8,8 @@
                 {% trans "Hello" %},
             </p>
             <p>
-              {% blocktranslate trimmed %}
-                The new product type "{{ title }}" has been added. It can be viewed here: <a href="{{ url|full_url }}">{{ title }}</a>
+              {% blocktranslate trimmed prod_url=url|full_url %}
+                The new product type "{{ title }}" has been added. It can be viewed here: <a href="{{ prod_url }}">{{ title }}</a>
               {% endblocktranslate %}
             </p>
             <br/>

--- a/dojo/templates/notifications/mail/report_created.tpl
+++ b/dojo/templates/notifications/mail/report_created.tpl
@@ -8,8 +8,8 @@
                 {% trans "Greetings" %},
             </p>
             <p>
-              {% blocktranslate trimmed %}
-                Your report "{{ report.name }}" is ready. It can be downloaded here: {{ url|full_url }}
+              {% blocktranslate trimmed with report_name=report.name report_url=url|full_url %}
+                Your report "{{ report_name }}" is ready. It can be downloaded here: {{ report_url }}
               {% endblocktranslate %}
             </p>
                 {% trans "Kind regards" %}, <br/>

--- a/dojo/templates/notifications/mail/risk_acceptance_expiration.tpl
+++ b/dojo/templates/notifications/mail/risk_acceptance_expiration.tpl
@@ -15,9 +15,9 @@
                 <br/><br/>
             
                 {% if risk_acceptance.is_expired %}
-                    {% blocktranslate %}<a href="{{risk_acceptance_url|full_url}}">Risk acceptance {{ risk_acceptance }}</a> with {{ risk_acceptance.accepted_findings.all| length }} has expired {{ risk_acceptance.expiration_date_handled|date }}{% endblocktranslate %}
+                    {% blocktranslate with risk_url=risk_acceptance_url|full_url risk_findings=risk_acceptance.accepted_findings.all|length risk_date=risk_acceptance.expiration_date_handled|date %}<a href="{{risk_url}}">Risk acceptance {{ risk_acceptance }}</a> with {{ risk_findings }} has expired {{ risk_date }}{% endblocktranslate %}
                 {% else %}
-                    {% blocktranslate %}<a href="{{risk_acceptance_url|full_url}}">Risk acceptance {{ risk_acceptance }}</a> with {{ risk_acceptance.accepted_findings.all| length }} will expire {{ risk_acceptance.expiration_date|date }}{% endblocktranslate %}
+                    {% blocktranslate with risk_url=risk_acceptance_url|full_url risk_findings=risk_acceptance.accepted_findings.all|length risk_date=risk_acceptance.expiration_date|date %}<a href="{{risk_url}}">Risk acceptance {{ risk_acceptance }}</a> with {{ risk_findings }} will expire {{ risk_date }}{% endblocktranslate %}
                 {% endif %}
                 <br/>
                 {% if risk_acceptance.reactivate_expired %}

--- a/dojo/templates/notifications/mail/test_added.tpl
+++ b/dojo/templates/notifications/mail/test_added.tpl
@@ -11,8 +11,8 @@
                 {% trans "Hello" %} {{ user.get_full_name }},
             </p>
             <p>
-              {% blocktranslate trimmed %}
-                A new test has been added: <a href="{{product_url|full_url}}">{{product}}</a> / <a href="{{engagement_url|full_url}}">{{ engagement.name }}</a> / <a href="{{ test_url|full_url }}">{{ test }}</a><br/>
+              {% blocktranslate trimmed with prod_url=product_url|full_url eng_url=engagement_url|full_url eng_name=engagement.name t_url=test_url|full_url %}
+                A new test has been added: <a href="{{prod_url}}">{{product}}</a> / <a href="{{eng_url}}">{{ eng_name }}</a> / <a href="{{ t_url }}">{{ test }}</a><br/>
                 Finding details in the 'scan_added' email, which is a separate notification (for now).
               {% endblocktranslate %}
             </p>    

--- a/dojo/templates/notifications/mail/upcoming_engagement.tpl
+++ b/dojo/templates/notifications/mail/upcoming_engagement.tpl
@@ -8,8 +8,8 @@
                 {% trans "Hello" %},
             </p>
             <p>
-              {% blocktranslate trimmed %}
-                this is a reminder that the engagement "{{ engagement.product }}" is about to start shortly.
+              {% blocktranslate trimmed with product=engagement.product%}
+                this is a reminder that the engagement "{{ product }}" is about to start shortly.
               {% endblocktranslate %}
             </p>
             {% trans "Project start" %}: {{ engagement.target_start }}<br/>

--- a/dojo/templates/notifications/msteams/risk_acceptance_expiration.tpl
+++ b/dojo/templates/notifications/msteams/risk_acceptance_expiration.tpl
@@ -15,9 +15,9 @@
             "activityTitle": "DefectDojo",
             "activityImage": "https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/master/dojo/static/dojo/img/chop.png",
             {% if risk_acceptance.is_expired %}
-                "text": "{% blocktranslate %}Risk acceptance {{ risk_acceptance }} with {{ risk_acceptance.accepted_findings.all| length }} has expired {{ risk_acceptance.expiration_date_handled|date }}{% endblocktranslate %}",
+                "text": "{% blocktranslate with accepted_findings=risk_acceptance.accepted_findings.all|length exp_date=risk_acceptance.expiration_date_handled|date %}Risk acceptance {{ risk_acceptance }} with {{ accepted_findings }} has expired {{ exp_date }}{% endblocktranslate %}",
             {% else %}
-                "text": "{% blocktranslate %}Risk acceptance {{ risk_acceptance }} with {{ risk_acceptance.accepted_findings.all| length }} will expire {{ risk_acceptance.expiration_date|date }}{% endblocktranslate %}",
+                "text": "{% blocktranslate with accepted_findings=risk_acceptance.accepted_findings.all|length exp_date=risk_acceptance.expiration_date|date %}Risk acceptance {{ risk_acceptance }} with {{ accepted_findings }} will expire {{ exp_date }}{% endblocktranslate %}",
             {% endif %}
             "facts": [
                 {

--- a/dojo/templates/notifications/slack/other.tpl
+++ b/dojo/templates/notifications/slack/other.tpl
@@ -1,8 +1,8 @@
 {% load i18n %}
 {{ description|safe }}
 {% if url is not None %}
-{% blocktranslate trimmed %}
-    More information on this event can be found here: {{ url|full_url }}
+{% blocktranslate trimmed with event_url=url|full_url %}
+    More information on this event can be found here: {{ event_url }}
 {% endblocktranslate %}
 {% endif %}
 {% if system_settings.disclaimer|length %}

--- a/dojo/templates/notifications/slack/product_added.tpl
+++ b/dojo/templates/notifications/slack/product_added.tpl
@@ -1,5 +1,5 @@
-{% load i18n %}{% blocktranslate trimmed %}
-The new product "{{ title }}" has been added. It can be viewed here: {{ url|full_url }}
+{% load i18n %}{% blocktranslate trimmed with prod_url=url|full_url %}
+The new product "{{ title }}" has been added. It can be viewed here: {{ prod_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     

--- a/dojo/templates/notifications/slack/product_type_added.tpl
+++ b/dojo/templates/notifications/slack/product_type_added.tpl
@@ -1,5 +1,5 @@
-{% load i18n %}{% blocktranslate trimmed %}
-The new product type "{{ title }}" has been added. It can be viewed here: {{ url|full_url }}
+{% load i18n %}{% blocktranslate trimmed with prod_url=url|full_url %}
+The new product type "{{ title }}" has been added. It can be viewed here: {{ prod_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     

--- a/dojo/templates/notifications/slack/report_created.tpl
+++ b/dojo/templates/notifications/slack/report_created.tpl
@@ -1,5 +1,5 @@
-{% load i18n %}{% blocktranslate trimmed %}
-Your report "{{ report.name }}" is ready. It can be downloaded here: {{ url|full_url }}
+{% load i18n %}{% blocktranslate trimmed with name=report.name report_url=url|full_url %}
+Your report "{{ name }}" is ready. It can be downloaded here: {{ report_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     

--- a/dojo/templates/notifications/slack/risk_acceptance_expiration.tpl
+++ b/dojo/templates/notifications/slack/risk_acceptance_expiration.tpl
@@ -7,8 +7,8 @@
     {% trans "Risk Acceptance Will Expire Soon" %}
 {% endif %}
 
-{% blocktranslate trimmed %}
-Risk Acceptance can be viewed here: {{ risk_acceptance_url|full_url }}
+{% blocktranslate trimmed with risk_url=risk_acceptance_url|full_url %}
+Risk Acceptance can be viewed here: {{ risk_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     

--- a/dojo/templates/notifications/slack/scan_added.tpl
+++ b/dojo/templates/notifications/slack/scan_added.tpl
@@ -2,9 +2,9 @@
 {{ description }}
 {% if url is not None %}
     
-  {% blocktranslate trimmed %}
+  {% blocktranslate trimmed with scan_url=url|full_url %}
     {{ test }} results have been uploaded.
-    They can be viewed here: {{ url|full_url }}
+    They can be viewed here: {{ scan_url }}
   {% endblocktranslate %}
 {% endif %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}

--- a/dojo/templates/notifications/slack/sla_breach.tpl
+++ b/dojo/templates/notifications/slack/sla_breach.tpl
@@ -1,8 +1,8 @@
-{% load i18n %}{% blocktranslate trimmed %}
-SLA breach alert for finding {{ finding.id }}. Relative days count to SLA due date: {{sla_age}}.
-Title: {{finding.title}}
-Severity: {{finding.severity}}
-You can find details here: {{ url|full_url }}
+{% load i18n %}{% blocktranslate trimmed with id=finding.id title=finding.title severity=finding.severity sla_url=url|full_url %}
+SLA breach alert for finding {{ id }}. Relative days count to SLA due date: {{sla_age}}.
+Title: {{title}}
+Severity: {{severity}}
+You can find details here: {{ sla_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     

--- a/dojo/templates/notifications/slack/test_added.tpl
+++ b/dojo/templates/notifications/slack/test_added.tpl
@@ -1,8 +1,8 @@
-{% load i18n %}{% blocktranslate trimmed %}
-New test added for engagement {{engagement.name }} in product {{ engagement.product}}.
-Title: {{test.title}}
-Type: {{ test.test_type }}
-You can find details here: {{ url|full_url }}
+{% load i18n %}{% blocktranslate trimmed with eng_name=engagement.name eng_product=engagement.product title=test.title test_type=test.test_type test_url=url|full_url %}
+New test added for engagement {{eng_name }} in product {{ eng_product}}.
+Title: {{title}}
+Type: {{ test_type }}
+You can find details here: {{ test_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     

--- a/dojo/templates/notifications/slack/upcoming_engagement.tpl
+++ b/dojo/templates/notifications/slack/upcoming_engagement.tpl
@@ -1,5 +1,5 @@
-{% load i18n %}{% blocktranslate trimmed %}
-The engagement "{{ engagement.product }}" is starting on {{ engagement.target_start }}.
+{% load i18n %}{% blocktranslate trimmed with eng_product=engagement.product start=engagement.target_start %}
+The engagement "{{ eng_product }}" is starting on {{ start }}.
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     


### PR DESCRIPTION
There is a regression in 2.19.0 caused by https://github.com/DefectDojo/django-DefectDojo/pull/7315. Alerts are missing key information, i.e. on slack:
```
DefectDojo
APP  [3:01 PM]
The engagement "" has been created in the product "". It can be viewed here:
```
It's the same fix as for https://github.com/DefectDojo/django-DefectDojo/pull/7301
I tested most of the changes for mails + alerts.