### PR TITLE
Old finding endpoints are not reactivated in the reimporter

### DIFF
--- a/dojo/importers/reimporter/utils.py
+++ b/dojo/importers/reimporter/utils.py
@@ -62,13 +62,23 @@ def update_endpoint_status(existing_finding, new_finding, user):
     existing_finding_endpoint_status_list = existing_finding.status_finding.all()
     new_finding_endpoints_list = new_finding.unsaved_endpoints
     if new_finding.is_mitigated:
+        # New finding is mitigated, so mitigate all old endpoints
         endpoint_status_to_mitigate = existing_finding_endpoint_status_list
     else:
+        # Mitigate any endpoints in the old finding not found in the new finding
         endpoint_status_to_mitigate = list(
             filter(
                 lambda existing_finding_endpoint_status: existing_finding_endpoint_status.endpoint not in new_finding_endpoints_list,
                 existing_finding_endpoint_status_list)
         )
+        # Re-activate any endpoints in the old finding that are in the new finding
+        endpoint_status_to_reactivate = list(
+            filter(
+                lambda existing_finding_endpoint_status: existing_finding_endpoint_status.endpoint in new_finding_endpoints_list,
+                existing_finding_endpoint_status_list)
+        )
+        chunk_endpoints_and_reactivate(endpoint_status_to_reactivate)
+
     # Determine if this can be run async
     if settings.ASYNC_FINDING_IMPORT:
         chunk_list = importer_utils.chunk_list(endpoint_status_to_mitigate)


### PR DESCRIPTION
**Description**

A fix for the last issue raised on https://github.com/DefectDojo/django-DefectDojo/issues/7403#issuecomment-1413909653. When a finding is re-imported, it closes all endpoints not contained in the new finding. However it doesn't reactivate all findings that *are* contained in the new finding. If there is a change in the new finding where an endpoint is reactivated, the existing finding won't have the correct endpoint status.

**Test results**

Tested the scenario with Nessus files in the link above.