### PR TITLE
Fix slack notifications

### DIFF
--- a/dojo/templates/notifications/slack/engagement_added.tpl
+++ b/dojo/templates/notifications/slack/engagement_added.tpl
@@ -1,5 +1,7 @@
-{% load i18n %}{% blocktranslate trimmed %}
-The engagement "{{ engagement.name }}" has been created in the product "{{ engagement.product }}". It can be viewed here: {{ url|full_url }}
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with name=engagement.name eng_product=engagement.product eng_url=url|full_url %}
+The engagement "{{ name }}" has been created in the product "{{ eng_product }}". It can be viewed here: {{ eng_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
     

--- a/dojo/templates/notifications/slack/other.tpl
+++ b/dojo/templates/notifications/slack/other.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {{ description|safe }}
 {% if url is not None %}
 {% blocktranslate trimmed with event_url=url|full_url %}

--- a/dojo/templates/notifications/slack/product_added.tpl
+++ b/dojo/templates/notifications/slack/product_added.tpl
@@ -1,4 +1,6 @@
-{% load i18n %}{% blocktranslate trimmed with prod_url=url|full_url %}
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with prod_url=url|full_url %}
 The new product "{{ title }}" has been added. It can be viewed here: {{ prod_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}

--- a/dojo/templates/notifications/slack/product_type_added.tpl
+++ b/dojo/templates/notifications/slack/product_type_added.tpl
@@ -1,4 +1,6 @@
-{% load i18n %}{% blocktranslate trimmed with prod_url=url|full_url %}
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with prod_url=url|full_url %}
 The new product type "{{ title }}" has been added. It can be viewed here: {{ prod_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}

--- a/dojo/templates/notifications/slack/report_created.tpl
+++ b/dojo/templates/notifications/slack/report_created.tpl
@@ -1,4 +1,6 @@
-{% load i18n %}{% blocktranslate trimmed with name=report.name report_url=url|full_url %}
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with name=report.name report_url=url|full_url %}
 Your report "{{ name }}" is ready. It can be downloaded here: {{ report_url }}
 {% endblocktranslate %}
 {% if system_settings.disclaimer and system_settings.disclaimer.strip %}

--- a/dojo/templates/notifications/slack/risk_acceptance_expiration.tpl
+++ b/dojo/templates/notifications/slack/risk_acceptance_expiration.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {{ description }}
 
 {% if risk_acceptance.is_expired %}

--- a/dojo/templates/notifications/slack/scan_added.tpl
+++ b/dojo/templates/notifications/slack/scan_added.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {{ description }}
 {% if url is not None %}
     

--- a/dojo/templates/notifications/slack/sla_breach.tpl
+++ b/dojo/templates/notifications/slack/sla_breach.tpl
@@ -1,4 +1,6 @@
-{% load i18n %}{% blocktranslate trimmed with id=finding.id title=finding.title severity=finding.severity sla_url=url|full_url %}
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with id=finding.id title=finding.title severity=finding.severity sla_url=url|full_url %}
 SLA breach alert for finding {{ id }}. Relative days count to SLA due date: {{sla_age}}.
 Title: {{title}}
 Severity: {{severity}}

--- a/dojo/templates/notifications/slack/test_added.tpl
+++ b/dojo/templates/notifications/slack/test_added.tpl
@@ -1,4 +1,6 @@
-{% load i18n %}{% blocktranslate trimmed with eng_name=engagement.name eng_product=engagement.product title=test.title test_type=test.test_type test_url=url|full_url %}
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with eng_name=engagement.name eng_product=engagement.product title=test.title test_type=test.test_type test_url=url|full_url %}
 New test added for engagement {{eng_name }} in product {{ eng_product}}.
 Title: {{title}}
 Type: {{ test_type }}


### PR DESCRIPTION
**Description**

There's a further issue with slack notifications, where the display_tags template is not imported leading to errors like:

```
[14/Feb/2023 08:14:03] ERROR [dojo.notifications.helper:141] error during rendering of template notifications/slack/other.tpl exception is Invalid filter: 'full_url'
[14/Feb/2023 08:14:03] ERROR [dojo.notifications.helper:236] Invalid filter: 'full_url'
Traceback (most recent call last):
```

**Test results**

Tested a range of slack notifications.