### PR TITLE
add license parser to trivy scan

### DIFF
--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -43,6 +43,7 @@ LICENSE_DESCRIPTION_TEMPLATE = """{title}
 **Package:** {package}
 """
 
+
 class TrivyParser:
 
     def get_scan_types(self):

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -38,6 +38,10 @@ SECRET_DESCRIPTION_TEMPLATE = """{title}
 **Match:** {match}
 """
 
+LICENSE_DESCRIPTION_TEMPLATE = """{title}
+**Category:** {category}
+**Package:** {package}
+"""
 
 class TrivyParser:
 
@@ -246,6 +250,39 @@ class TrivyParser:
                     description=description,
                     file_path=target_target,
                     line=secret_start_line,
+                    static_finding=True,
+                    dynamic_finding=False,
+                    tags=[target_class],
+                    service=service_name,
+                )
+                items.append(finding)
+
+            licenses = target_data.get('Licenses', [])
+            for license in licenses:
+                license_severity = license.get('Severity')
+                license_category = license.get('Category')
+                license_pkgname = license.get('PkgName')
+                license_filepath = license.get('FilePath')
+                license_name = license.get('Name')
+                license_confidence = license.get('Confidence')
+                license_link = license.get('Link')
+
+                title = f'License detected in {target_target} - {license_name}'
+                description = LICENSE_DESCRIPTION_TEMPLATE.format(
+                    title=license_name,
+                    category=license_category,
+                    package=license_pkgname,
+                )
+                severity = TRIVY_SEVERITIES[license_severity]
+
+                finding = Finding(
+                    test=test,
+                    title=title,
+                    severity=severity,
+                    description=description,
+                    file_path=license_filepath,
+                    scanner_confidence=license_confidence,
+                    url=license_link,
                     static_finding=True,
                     dynamic_finding=False,
                     tags=[target_class],

--- a/unittests/scans/trivy/license_scheme.json
+++ b/unittests/scans/trivy/license_scheme.json
@@ -1,0 +1,239 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "alpine:3.11",
+  "ArtifactType": "container_image",
+  "Metadata": {
+    "OS": {
+      "Family": "alpine",
+      "Name": "3.11.13"
+    },
+    "ImageID": "sha256:a787cb9865032e5b5a407ecdf34b57a23a4a076aaa043d71742ddb6726ec9229",
+    "DiffIDs": [
+      "sha256:69715584ec78c168981b0925dd7c50f4537bc598dcbce814db2803a10b777b5c"
+    ],
+    "RepoTags": [
+      "alpine:3.11"
+    ],
+    "RepoDigests": [
+      "alpine@sha256:bcae378eacedab83da66079d9366c8f5df542d7ed9ab23bf487e3e1a8481375d"
+    ],
+    "ImageConfig": {
+      "architecture": "amd64",
+      "container": "9a36cae78f6934ef1807fa6d7fbe783ef8ef7c719438a53c5ce3d6cabd0ad551",
+      "created": "2021-11-12T17:20:17.61716938Z",
+      "docker_version": "20.10.7",
+      "history": [
+        {
+          "created": "2021-11-12T17:20:17Z",
+          "created_by": "/bin/sh -c #(nop) ADD file:efe2d94a88cdbbd01c3ef095f0a2473cec9e74804b49cd6fb9b837d362631409 in / "
+        },
+        {
+          "created": "2021-11-12T17:20:17Z",
+          "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
+          "empty_layer": true
+        }
+      ],
+      "os": "linux",
+      "rootfs": {
+        "type": "layers",
+        "diff_ids": [
+          "sha256:69715584ec78c168981b0925dd7c50f4537bc598dcbce814db2803a10b777b5c"
+        ]
+      },
+      "config": {
+        "Cmd": [
+          "/bin/sh"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        ],
+        "Image": "sha256:ff3f29274d45b1bf9ebf7c6df3a8021bb2396803c7644ee8306b9f45732a61ea"
+      }
+    }
+  },
+  "Results": [
+    {
+      "Target": "OS Packages",
+      "Class": "license",
+      "Licenses": [
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "alpine-baselayout",
+          "FilePath": "",
+          "Name": "GPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "alpine-keys",
+          "FilePath": "",
+          "Name": "MIT",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "apk-tools",
+          "FilePath": "",
+          "Name": "GPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "busybox",
+          "FilePath": "",
+          "Name": "GPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "MEDIUM",
+          "Category": "reciprocal",
+          "PkgName": "ca-certificates-cacert",
+          "FilePath": "",
+          "Name": "MPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "ca-certificates-cacert",
+          "FilePath": "",
+          "Name": "GPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "libc-utils",
+          "FilePath": "",
+          "Name": "BSD-3-Clause",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "libcrypto1.1",
+          "FilePath": "",
+          "Name": "OpenSSL",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "libssl1.1",
+          "FilePath": "",
+          "Name": "OpenSSL",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "libtls-standalone",
+          "FilePath": "",
+          "Name": "ISC",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "musl",
+          "FilePath": "",
+          "Name": "MIT",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "musl-utils",
+          "FilePath": "",
+          "Name": "MIT",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "musl-utils",
+          "FilePath": "",
+          "Name": "BSD-3-Clause",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "musl-utils",
+          "FilePath": "",
+          "Name": "GPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "scanelf",
+          "FilePath": "",
+          "Name": "GPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "HIGH",
+          "Category": "restricted",
+          "PkgName": "ssl_client",
+          "FilePath": "",
+          "Name": "GPL-2.0",
+          "Confidence": 1,
+          "Link": ""
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "zlib",
+          "FilePath": "",
+          "Name": "Zlib",
+          "Confidence": 1,
+          "Link": ""
+        }
+      ]
+    },
+    {
+      "Target": "Loose File License(s)",
+      "Class": "license-file",
+      "Licenses": [
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "",
+          "FilePath": "/etc/ssl/misc/CA.pl",
+          "Name": "OpenSSL",
+          "Confidence": 1,
+          "Link": "https://spdx.org/licenses/OpenSSL.html"
+        },
+        {
+          "Severity": "LOW",
+          "Category": "notice",
+          "PkgName": "",
+          "FilePath": "/etc/ssl/misc/tsget.pl",
+          "Name": "OpenSSL",
+          "Confidence": 1,
+          "Link": "https://spdx.org/licenses/OpenSSL.html"
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -171,3 +171,20 @@ Container 'follower' of Deployment 'redis-follower' should set 'securityContext.
         self.assertIsNone(finding.component_name)
         self.assertIsNone(finding.component_version)
         self.assertEqual('default / Deployment / redis-follower', finding.service)
+
+    def test_license_scheme(self):
+        test_file = open(sample_path("license_scheme.json"))
+        parser = TrivyParser()
+        findings = parser.get_findings(test_file, Test())
+
+        self.assertEqual(len(findings), 19)
+        finding = findings[0]
+        self.assertEqual("HIGH", finding.severity)
+        self.assertEqual("", finding.file_path)
+        self.assertEqual(1, finding.scanner_confidence)
+        self.assertEqual("", finding.url)
+        description = '''GPL-2.0
+**Category:** restricted
+**Package:** alpine-baselayout
+'''
+        self.assertEqual(description, finding.description)

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -179,7 +179,7 @@ Container 'follower' of Deployment 'redis-follower' should set 'securityContext.
 
         self.assertEqual(len(findings), 19)
         finding = findings[0]
-        self.assertEqual("HIGH", finding.severity)
+        self.assertEqual("High", finding.severity)
         self.assertEqual("", finding.file_path)
         self.assertEqual(1, finding.scanner_confidence)
         self.assertEqual("", finding.url)

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -188,4 +188,3 @@ Container 'follower' of Deployment 'redis-follower' should set 'securityContext.
 **Package:** alpine-baselayout
 '''
         self.assertEqual(description, finding.description)
-

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -188,3 +188,4 @@ Container 'follower' of Deployment 'redis-follower' should set 'securityContext.
 **Package:** alpine-baselayout
 '''
         self.assertEqual(description, finding.description)
+


### PR DESCRIPTION
**Description**

Trivy allows for license scan and the report will be provided in json format. The changes are made to parse the license report











