### PR TITLE
Add API endpoint download files by ID

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -628,6 +628,14 @@ class FileSerializer(serializers.ModelSerializer):
         fields = '__all__'
 
 
+class RawFileSerializer(serializers.ModelSerializer):
+    file = serializers.FileField(required=True)
+
+    class Meta:
+        model = FileUpload
+        fields = ['file']
+
+
 class ProductMemberSerializer(serializers.ModelSerializer):
 
     class Meta:

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -423,14 +423,14 @@ class EngagementViewSet(mixins.ListModelMixin,
         methods=['GET'],
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: OpenApiResponse(description="Returned if file ID does not exist in the Engagement"),
+            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Engagement",
         }
     )
     @swagger_auto_schema(
         method='get',
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: OpenApiResponse(description="Returned if file ID does not exist in the Engagement"),
+            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Engagement",
         }
     )
     @action(detail=True, methods=["get"], url_path=r'files/download/(?P<file_id>\d+)')
@@ -804,14 +804,14 @@ class FindingViewSet(prefetch.PrefetchListMixin,
         methods=['GET'],
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: OpenApiResponse(description="Returned if file ID does not exist in the Finding"),
+            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Finding",
         }
     )
     @swagger_auto_schema(
         method='get',
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: OpenApiResponse(description="Returned if file ID does not exist in the Finding"),
+            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Finding",
         }
     )
     @action(detail=True, methods=["get"], url_path=r'files/download/(?P<file_id>\d+)')
@@ -1851,14 +1851,14 @@ class TestsViewSet(mixins.ListModelMixin,
         methods=['GET'],
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: OpenApiResponse(description="Returned if file ID does not exist in the Test"),
+            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Test",
         }
     )
     @swagger_auto_schema(
         method='get',
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: OpenApiResponse(description="Returned if file ID does not exist in the Test"),
+            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Test",
         }
     )
     @action(detail=True, methods=["get"], url_path=r'files/download/(?P<file_id>\d+)')

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -423,14 +423,12 @@ class EngagementViewSet(mixins.ListModelMixin,
         methods=['GET'],
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Engagement",
         }
     )
     @swagger_auto_schema(
         method='get',
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Engagement",
         }
     )
     @action(detail=True, methods=["get"], url_path=r'files/download/(?P<file_id>\d+)')
@@ -804,14 +802,12 @@ class FindingViewSet(prefetch.PrefetchListMixin,
         methods=['GET'],
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Finding",
         }
     )
     @swagger_auto_schema(
         method='get',
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Finding",
         }
     )
     @action(detail=True, methods=["get"], url_path=r'files/download/(?P<file_id>\d+)')
@@ -1851,14 +1847,12 @@ class TestsViewSet(mixins.ListModelMixin,
         methods=['GET'],
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Test",
         }
     )
     @swagger_auto_schema(
         method='get',
         responses={
             status.HTTP_200_OK: serializers.RawFileSerializer,
-            status.HTTP_404_NOT_FOUND: "Returned if file ID does not exist in the Test",
         }
     )
     @action(detail=True, methods=["get"], url_path=r'files/download/(?P<file_id>\d+)')

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -956,7 +956,7 @@ class FilesTest(DojoAPITestCase):
         token = Token.objects.get(user=testuser)
         self.client = APIClient()
         self.client.credentials(HTTP_AUTHORIZATION=f'Token {token.key}')
-        self.path = pathlib.Path(__file__).parent.absolute() 
+        self.path = pathlib.Path(__file__).parent.absolute()
         # model: file_id
         self.url_levels = {
             'findings/7': 0,


### PR DESCRIPTION
When we moved static files from being served by nginx to uwsgi for added RBAC support, the API endpoint for downloading files was forgotten. I have added endpoints to Finding, Test, and Engagement levels so that RBAC permissions can be inherited from the object rather than creating file based permissions

closes #7608 

[sc-533]