### PR TITLE
Update unit test flow to build containers once and store in uniform location

### DIFF
--- a/.github/workflows/build-docker-images-for-testing.yml
+++ b/.github/workflows/build-docker-images-for-testing.yml
@@ -1,0 +1,54 @@
+name: "Build Docker Images For Testing"
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    # build with docker so we can use layer caching
+    name: Build Docker Images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker-image: [django, nginx, integration-tests]
+        os: [alpine, debian]
+        exclude:
+          - docker-image: integration-tests
+            os: alpine
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Read Docker Image Identifiers
+        id: read-docker-image-identifiers
+        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+          driver-opts: image=moby/buildkit:master # needed to get the fix for https://github.com/moby/buildkit/issues/2426
+          
+      - name: Build
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          tags: defectdojo/defectdojo-${{ matrix.docker-image }}:${{ matrix.os }}
+          file: Dockerfile.${{ matrix.docker-image }}-${{ matrix.os }}
+          outputs: type=docker,dest=${{ matrix.docker-image }}-${{ matrix.os }}_img
+          cache-from: type=gha,scope=${{ matrix.docker-image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.docker-image }}
+  
+      # export docker images to be used in next jobs below
+      - name: Upload image ${{ matrix.docker-image }} as artifact
+        uses:  actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.docker-image }}
+          path: ${{ matrix.docker-image }}-${{ matrix.os }}_img
+          retention-days: 1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,82 +1,12 @@
 name: Integration tests
-# pull requests:
-# push:
-#      run on every push, which is when something gets merged also
-on:
-  workflow_dispatch:
-  pull_request:
-    branches:
-      - master
-      - dev
-      - bugfix
-      - release/**
-      - hotfix/**
 
-env:
-  DD_DOCKER_REPO: defectdojo
+on:
+  workflow_call:
 
 jobs:
-  build:
-    # build with docker so we can use layer caching
-    name: Build Image
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        docker-image: [django, nginx, integration-tests]
-        os: [alpine, debian]
-        exclude:
-          - docker-image: integration-tests
-            os: alpine
-
-    steps:
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-
-      - name: Read Docker Image Identifiers
-        id: read-docker-image-identifiers
-        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          buildkitd-flags: --debug
-          driver-opts: image=moby/buildkit:master # needed to get the fix for https://github.com/moby/buildkit/issues/2426
-          
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: false
-          tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ matrix.docker-image }}:${{ matrix.os }}
-          file: Dockerfile.${{ matrix.docker-image }}-${{ matrix.os }}
-          outputs: type=docker,dest=${{ matrix.docker-image }}-${{ matrix.os }}_img
-          cache-from: type=gha,scope=${{ matrix.docker-image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.docker-image }}
-          
-      # export docker images to be used in next jobs below
-      - name: Upload image ${{ matrix.docker-image }} as artifact
-        uses:  actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.docker-image }}
-          path: ${{ matrix.docker-image }}-${{ matrix.os }}_img
-          retention-days: 1
-
   integration_tests:
     # run tests with docker-compose
-    name: test
-    needs: build
+    name: User Interface Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -110,7 +40,6 @@ jobs:
       fail-fast: false
 
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -129,7 +58,6 @@ jobs:
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
 
       # phased startup with MySQL and RabbitMQ so we can use the exit code from integrationtest container
-
       - name: Start Dojo MySQL + RabbitMQ
         if: matrix.profile == 'mysql-rabbitmq'
         run: docker-compose --profile ${{ matrix.profile }} --env-file ./docker/environments/${{ matrix.profile }}.env up --no-deps -d mysql nginx celerybeat celeryworker mailhog uwsgi rabbitmq

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -1,17 +1,10 @@
-name: k8s deployment
+name: k8s Deployment
+
 on:
-  pull_request:
-    branches:
-      - master
-      - dev
-      - bugfix
-      - release/**
-      - hotfix/**
+  workflow_call:
 
 env:
-  DD_DOCKER_REPO: defectdojo
   DD_HOSTNAME: defectdojo.default.minikube.local
-  GITHUB_CACHE_REPO: containers.pkg.github.com
   HELM_RABBIT_BROKER_SETTINGS: " \
     --set redis.enabled=false \
     --set rabbitmq.enabled=true \
@@ -45,75 +38,9 @@ env:
     --set createPostgresqlHaPgpoolSecret=true \
    "
 jobs:
-  build:
-    name: Build Image
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        docker-image: [django, nginx]
-        os: [alpine, debian]
-
-    steps:
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-
-      - name: Read Docker Image Identifiers
-        id: read-docker-image-identifiers
-        run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        env:
-          docker-image: ${{ matrix.docker-image }}
-        with:
-          path: /tmp/.buildx-cache-${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-${{ github.workflow }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-${{ github.workflow }}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-${{ github.workflow }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}
-
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v4
-        env:
-          docker-image: ${{ matrix.docker-image }}
-        with:
-          context: .
-          push: false
-          tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ env.docker-image }}:${{ matrix.os }}
-          file: Dockerfile.${{ env.docker-image }}-${{ matrix.os }}
-          outputs: type=docker,dest=${{ env.docker-image }}-${{ matrix.os }}_img
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
-
-      - name: Upload image ${{ env.docker-image }} as artifact
-        uses:  actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.docker-image }}
-          path: ${{ matrix.docker-image }}-${{ matrix.os }}_img
-          retention-days: 1
-
   setting_minikube_cluster:
     name: Kubernetes Deployment
-
     runs-on: ubuntu-latest
-
-    needs: build
 
     strategy:
       matrix:
@@ -147,11 +74,6 @@ jobs:
             os: alpine
 
     steps:
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -193,10 +115,6 @@ jobs:
               echo "redis=${{ env.HELM_REDIS_BROKER_SETTINGS }}" >> $GITHUB_ENV
               echo "rabbit=${{ env.HELM_RABBIT_BROKER_SETTINGS }}" >> $GITHUB_ENV
 
-      # - name: Create image pull Secrets
-      #   run: |-
-      #         kubectl create secret docker-registry defectdojoregistrykey --docker-username=${{ secrets.DOCKERHUB_USERNAME }} --docker-password=${{ secrets.DOCKERHUB_TOKEN }}
-      #         kubectl get secrets
       - name: Deploying Djano application with ${{ matrix.databases }} ${{ matrix.brokers }}
         run: |-
              helm install \

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -1,0 +1,51 @@
+name: Rest Framework Unit Tests
+
+on:
+  workflow_call:
+
+jobs:
+  unit_tests:
+    name: Rest Framework Unit Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [alpine, debian]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      # load docker images from build jobs
+      - name: Load images from artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Load docker images
+        run: |-
+             docker load -i nginx/nginx-${{ matrix.os }}_img
+             docker load -i django/django-${{ matrix.os }}_img
+             docker images
+
+      # run tests with docker-compose
+      - name: Set unit-test mode
+        run: docker/setEnv.sh unit_tests_cicd
+
+      # phased startup so we can use the exit code from unit test container
+      - name: Start MySQL
+        run: docker-compose --env-file ./docker/environments/mysql-redis.env up -d mysql
+
+      # no celery or initializer needed for unit tests
+      - name: Unit tests
+        run: docker-compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env up --no-deps --exit-code-from uwsgi uwsgi
+        env:
+          DJANGO_VERSION: ${{ matrix.os }}
+
+      - name: Logs
+        if: failure()
+        run: docker-compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env logs --tail="2500" uwsgi
+
+      - name: Shutdown
+        if: always()
+        run: docker-compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env down

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,5 @@
 name: Unit tests
-# pull requests:
-# push:
-#      run on every push, which is when something gets merged also
+
 on:
   workflow_dispatch:
   pull_request:
@@ -9,74 +7,20 @@ on:
       - master
       - dev
       - bugfix
-
-env:
-  DD_DOCKER_REPO: defectdojo
-  docker-image: django # we only need to build the django image for unit tests
+      - release/**
+      - hotfix/**
 
 jobs:
-  unit_tests:
-    name: unit tests
-    runs-on: ubuntu-latest
+  build-docker-containers:
+    uses: ./.github/workflows/build-docker-images-for-testing.yml
+    secrets: inherit
+  
+  release-helm-chart:
+    needs: build-docker-containers
+    uses: ./.github/workflows/rest-framework-tests.yml
+    secrets: inherit
 
-    strategy:
-      matrix:
-        os: [alpine, debian]
-
-    steps:
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v1
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          persist-credentials: false
-
-      # - name: Read Docker Image Identifiers
-      #   id: read-docker-image-identifiers
-      #   run: echo "IMAGE_REPOSITORY=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-        with:
-          buildkitd-flags: --debug
-          driver-opts: image=moby/buildkit:master # needed to get the fix for https://github.com/moby/buildkit/issues/2426
-          
-      - name: Build
-        id: docker_build
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: false
-          load: true
-          tags: |
-            ${{ env.DD_DOCKER_REPO }}/defectdojo-${{ env.docker-image }}:${{ matrix.os }}
-          file: Dockerfile.${{ env.docker-image }}-${{ matrix.os }}
-
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # run tests with docker-compose
-      - name: Set unit-test mode
-        run: docker/setEnv.sh unit_tests_cicd
-
-      # phased startup so we can use the exit code from unit test container
-      - name: Start MySQL
-        run: docker-compose --env-file ./docker/environments/mysql-redis.env up -d mysql
-
-      # no celery or initializer needed for unit tests
-      - name: Unit tests
-        run: docker-compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env up --no-deps --exit-code-from uwsgi uwsgi
-        env:
-          DJANGO_VERSION: ${{ matrix.os }}
-
-      - name: Logs
-        if: failure()
-        run: docker-compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env logs --tail="2500" uwsgi
-
-      - name: Shutdown
-        if: always()
-        run: docker-compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env down
+  release-docker-containers:
+    needs: build-docker-containers
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,12 +15,17 @@ jobs:
     uses: ./.github/workflows/build-docker-images-for-testing.yml
     secrets: inherit
   
-  release-helm-chart:
+  test-rest-framework:
     needs: build-docker-containers
     uses: ./.github/workflows/rest-framework-tests.yml
     secrets: inherit
 
-  release-docker-containers:
+  test-user-interface:
     needs: build-docker-containers
     uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
+  
+  test-k8s:
+    needs: build-docker-containers
+    uses: ./.github/workflows/k8s-tests.yml
     secrets: inherit


### PR DESCRIPTION
From our monthly meeting in January, we discussed unifying the docker build/cache steps into a single place to take advantage of GitHubs caching mechanism. This PR makes the unit tests one single action that first builds the docker containers, and then run the following tests in parallel:
- unit tests (renamed to "rest framework tests")
- integration tests (renamed to "user interface tests")
- k8s

The hope here is that if there is a build error, it will fail before any of tests actually run. In the event of an isolated failure (usually in the integration tests) then they can singularly be reran like they are today

<img width="764" alt="image" src="https://user-images.githubusercontent.com/46459665/220174032-8fa46333-d6fb-412c-8a8b-5e1d5d161f88.png">

[sc-515]
