### PR TITLE
Update the release drafter to make releases less manual

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,9 @@
-name-template: '$NEXT_MINOR_VERSION 🌈'
-tag-template: '$NEXT_MINOR_VERSION'
+name-template: '$RESOLVED_VERSION 🌈'
+tag-template: '$RESOLVED_VERSION'
+
 branches:
   - master
+
 categories:
   - title: '💣 Breaking changes'
     labels:
@@ -44,10 +46,23 @@ categories:
       - 'dependencies'
       - 'maintenance'
 exclude-labels:
-  - 'skip-changelog'      
+  - 'skip-changelog'    
+  
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   Please consult the [Upgrade notes in the documentation ](https://documentation.defectdojo.com/getting_started/upgrading/) for specific instructions for this release, and general upgrade instructions. Below is an automatically generated list of all PRs merged since the previous release.
   
   ## Changes since $PREVIOUS_TAG
   $CHANGES
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch

--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Create release ${{ github.event.inputs.release_number }}
         uses: softprops/action-gh-release@v1
         with:
-          name: Release ${{ github.event.inputs.release_number }}
+          name: '${{ github.event.inputs.release_number }} 🌈'
           tag_name: ${{ github.event.inputs.release_number }}
           body: Run the release drafter to populate the release notes.
           draft: true


### PR DESCRIPTION
This eliminates the need to copy the little rainbow over to the title of the release. It will always be there now. 

The resolver stanza is for the release drafter to not dump the notes into the next minor release every time since we are doing weekly patches now