### PR TITLE
Fix for mobsfscan parser 2

### DIFF
--- a/dojo/tools/mobsfscan/parser.py
+++ b/dojo/tools/mobsfscan/parser.py
@@ -32,7 +32,7 @@ class MobsfscanParser(object):
             dupes = {}
             for key, item in data.get('results').items():
                 metadata = item.get('metadata')
-                cwe = int(re.match(r'CWE-([0-9]+)', metadata.get('cwe')).group(1))
+                cwe = int(re.match(r'cwe-([0-9]+)|CWE-([0-9]+)', metadata.get('cwe')).group(1))
                 masvs = metadata.get('masvs')
                 owasp_mobile = metadata.get('owasp-mobile')
                 description = "\n".join([

--- a/dojo/tools/mobsfscan/parser.py
+++ b/dojo/tools/mobsfscan/parser.py
@@ -32,7 +32,7 @@ class MobsfscanParser(object):
             dupes = {}
             for key, item in data.get('results').items():
                 metadata = item.get('metadata')
-                cwe = int(re.match(r'cwe-([0-9]+)|CWE-([0-9]+)', metadata.get('cwe')).group(1))
+                cwe = int(re.match(r'(cwe|CWE)-([0-9]+)', metadata.get('cwe')).group(2))
                 masvs = metadata.get('masvs')
                 owasp_mobile = metadata.get('owasp-mobile')
                 description = "\n".join([

--- a/unittests/scans/mobsfscan/many_findings_cwe_lower.json
+++ b/unittests/scans/mobsfscan/many_findings_cwe_lower.json
@@ -1,0 +1,90 @@
+{
+    "errors": [],
+    "mobsfscan_version": "0.2.0",
+    "results": {
+      "android_certificate_transparency": {
+        "metadata": {
+          "cwe": "cwe-295",
+          "description": "This app does not enforce TLS Certificate Transparency which helps to  detect SSL certificates that have been mistakenly issued by a  certificate authority or maliciously acquired from an otherwise  unimpeachable certificate authority.",
+          "masvs": "MSTG-NETWORK-4",
+          "owasp-mobile": "M3: Insecure Communication",
+          "reference": "https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4",
+          "severity": "INFO"
+        }
+      },
+      "android_kotlin_hardcoded": {
+        "files": [
+          {
+            "file_path": "app/src/main/java/com/routes/domain/analytics/event/Signatures.kt",
+            "match_lines": [
+              10,
+              10
+            ],
+            "match_position": [
+              243,
+              271
+            ],
+            "match_string": "key = \"hmi_busroutes_health\""
+          }
+        ],
+        "metadata": {
+          "cwe": "cwe-798",
+          "description": "Files may contain hardcoded sensitive information like usernames, passwords, keys etc.",
+          "masvs": "MSTG-STORAGE-14",
+          "owasp-mobile": "M9: Reverse Engineering",
+          "reference": "https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#storing-a-key---example",
+          "severity": "WARNING"
+        }
+      },
+      "android_prevent_screenshot": {
+        "metadata": {
+          "cwe": "cwe-200",
+          "description": "This app does not have capabilities to prevent against Screenshots from Recent Task History/ Now On Tap etc.",
+          "masvs": "MSTG-STORAGE-9",
+          "owasp-mobile": "M2: Insecure Data Storage",
+          "reference": "https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05d-Testing-Data-Storage.md#finding-sensitive-information-in-auto-generated-screenshots-mstg-storage-9",
+          "severity": "INFO"
+        }
+      },
+      "android_root_detection": {
+        "metadata": {
+          "cwe": "cwe-919",
+          "description": "This app does not have root detection capabilities. Running a sensitive application on a rooted device questions the device integrity and affects users data.",
+          "masvs": "MSTG-RESILIENCE-1",
+          "owasp-mobile": "M8: Code Tampering",
+          "reference": "https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md#testing-root-detection-mstg-resilience-1",
+          "severity": "INFO"
+        }
+      },
+      "android_safetynet": {
+        "metadata": {
+          "cwe": "cwe-353",
+          "description": "This app does not uses SafetyNet Attestation API that provides cryptographically-signed attestation, assessing the device's integrity. This check helps to ensure that the servers are interacting with the genuine app running on a genuine Android device. ",
+          "masvs": "MSTG-RESILIENCE-1",
+          "owasp-mobile": "M8: Code Tampering",
+          "reference": "https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05j-Testing-Resiliency-Against-Reverse-Engineering.md#testing-root-detection-mstg-resilience-1",
+          "severity": "INFO"
+        }
+      },
+      "android_ssl_pinning": {
+        "metadata": {
+          "cwe": "cwe-295",
+          "description": "This app does not use TLS/SSL certificate or public key pinning to detect or prevent MITM attacks in secure communication channel.",
+          "masvs": "MSTG-NETWORK-4",
+          "owasp-mobile": "M3: Insecure Communication",
+          "reference": "https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05g-Testing-Network-Communication.md#testing-custom-certificate-stores-and-certificate-pinning-mstg-network-4",
+          "severity": "INFO"
+        }
+      },
+      "android_tapjacking": {
+        "metadata": {
+          "cwe": "cwe-200",
+          "description": "This app does not have capabilities to prevent tapjacking attacks.",
+          "masvs": "MSTG-PLATFORM-9",
+          "owasp-mobile": "M1: Improper Platform Usage",
+          "reference": "https://github.com/MobSF/owasp-mstg/blob/master/Document/0x05h-Testing-Platform-Interaction.md#testing-for-overlay-attacks-mstg-platform-9",
+          "severity": "INFO"
+        }
+      }
+    }
+  }

--- a/unittests/tools/test_mobsfscan_parser.py
+++ b/unittests/tools/test_mobsfscan_parser.py
@@ -83,3 +83,75 @@ class TestMobsfscanParser(DojoTestCase):
             self.assertIsNotNone(finding.description)
             self.assertEqual(200, finding.cwe)
             self.assertIsNotNone(finding.references)
+
+    def test_parse_many_findings_cwe_lower(self):
+        testfile = open("unittests/scans/mobsfscan/many_findings_cwe_lower.json")
+        parser = MobsfscanParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(7, len(findings))
+
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual("android_certificate_transparency", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertIsNotNone(finding.description)
+            self.assertEqual(295, finding.cwe)
+            self.assertIsNotNone(finding.references)
+
+        with self.subTest(i=1):
+            finding = findings[1]
+            self.assertEqual("android_kotlin_hardcoded", finding.title)
+            self.assertEqual("Medium", finding.severity)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertIsNotNone(finding.description)
+            self.assertEqual(798, finding.cwe)
+            self.assertIsNotNone(finding.references)
+            self.assertEqual("app/src/main/java/com/routes/domain/analytics/event/Signatures.kt", finding.file_path)
+            self.assertEqual(10, finding.line)
+
+        with self.subTest(i=2):
+            finding = findings[2]
+            self.assertEqual("android_prevent_screenshot", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertIsNotNone(finding.description)
+            self.assertEqual(200, finding.cwe)
+            self.assertIsNotNone(finding.references)
+
+        with self.subTest(i=3):
+            finding = findings[3]
+            self.assertEqual("android_root_detection", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertIsNotNone(finding.description)
+            self.assertEqual(919, finding.cwe)
+            self.assertIsNotNone(finding.references)
+
+        with self.subTest(i=4):
+            finding = findings[4]
+            self.assertEqual("android_safetynet", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertIsNotNone(finding.description)
+            self.assertEqual(353, finding.cwe)
+            self.assertIsNotNone(finding.references)
+
+        with self.subTest(i=5):
+            finding = findings[5]
+            self.assertEqual("android_ssl_pinning", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertIsNotNone(finding.description)
+            self.assertEqual(295, finding.cwe)
+            self.assertIsNotNone(finding.references)
+
+        with self.subTest(i=6):
+            finding = findings[6]
+            self.assertEqual("android_tapjacking", finding.title)
+            self.assertEqual("Low", finding.severity)
+            self.assertEqual(1, finding.nb_occurences)
+            self.assertIsNotNone(finding.description)
+            self.assertEqual(200, finding.cwe)
+            self.assertIsNotNone(finding.references)


### PR DESCRIPTION
Hello!
Fix for #7630. This error appeared due to the fact that in the new report, mobsfscan CWE was written in lower case.
Thank you!