### PR TITLE
A finding isn't added to an existing finding group in the re-importer…

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -272,17 +272,28 @@ def group_findings_by(finds, finding_group_by_option):
     return affected_groups, grouped, skipped, groups_created
 
 
-def add_finding_to_auto_group(finding, group_by, **kwargs):
-    test = finding.test
-    name = get_group_by_group_name(finding, group_by)
-    if name is not None:
+def add_findings_to_auto_group(name, findings, create_finding_groups_for_all_findings=True, **kwargs):
+    if name is not None and findings is not None and len(findings) > 0:
         creator = get_current_user()
         if not creator:
             creator = kwargs.get('async_user', None)
-        finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name)
-        if created:
-            logger.debug('Created Finding Group %d:%s for test %d:%s', finding_group.id, finding_group, test.id, test)
-        finding_group.findings.add(finding)
+        test = findings[0].test
+
+        if create_finding_groups_for_all_findings or len(findings) > 1:
+            # Only create a finding group if we have more than one finding for a given finding group, unless configured otherwise
+            finding_group, created = Finding_Group.objects.get_or_create(test=test, creator=creator, name=name)
+            if created:
+                logger.debug('Created Finding Group %d:%s for test %d:%s', finding_group.id, finding_group, test.id, test)
+            finding_group.findings.add(*findings)
+        else:
+            # Otherwise add to an existing finding group if it exists only
+            try:
+                finding_group = Finding_Group.objects.get(test=test, name=name)
+                if finding_group:
+                    finding_group.findings.add(*findings)
+            except:
+                # If the finding group doesn't exist we don't have to take any action
+                pass
 
 
 @dojo_model_to_id

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -160,10 +160,7 @@ class DojoDefaultImporter(object):
                 item.save(push_to_jira=push_to_jira)
 
         for (group_name, findings) in group_names_to_findings_dict.items():
-            # Only create a finding group if we have more than one finding for a given finding group, unless configured otherwise
-            if create_finding_groups_for_all_findings or len(findings) > 1:
-                for finding in findings:
-                    finding_helper.add_finding_to_auto_group(finding, group_by, **kwargs)
+            finding_helper.add_findings_to_auto_group(group_name, findings, create_finding_groups_for_all_findings, **kwargs)
             if push_to_jira:
                 if findings[0].finding_group is not None:
                     jira_helper.push_to_jira(findings[0].finding_group)

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -283,10 +283,7 @@ class DojoDefaultReImporter(object):
         untouched = set(unchanged_items) - set(to_mitigate) - set(new_items)
 
         for (group_name, findings) in group_names_to_findings_dict.items():
-            # Only create a finding group if we have more than one finding for a given finding group, unless configured otherwise
-            if create_finding_groups_for_all_findings or len(findings) > 1:
-                for finding in findings:
-                    finding_helper.add_finding_to_auto_group(finding, group_by, **kwargs)
+            finding_helper.add_findings_to_auto_group(group_name, findings, create_finding_groups_for_all_findings, **kwargs)
             if push_to_jira:
                 if findings[0].finding_group is not None:
                     jira_helper.push_to_jira(findings[0].finding_group)


### PR DESCRIPTION
… if create_finding_groups_for_all_findings is disabled

**Description**

If we have an existing finding group, and you reimporter one finding that should go into that finding group with create_finding_groups_for_all_findings disabled, then the finding isn't added to the group.

**Test results**

Tested it now works correctly.