### PR TITLE
Patch 1

### DIFF
--- a/.github/workflows/release-x-manual-docker-containers.yml
+++ b/.github/workflows/release-x-manual-docker-containers.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
           docker-image: [django, nginx]
           os: [alpine, debian]
+          platform: [amd64, arm64]
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -87,6 +88,7 @@ jobs:
           context: .
           cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
+          platforms: ${{ matrix.platform }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/release-x-manual-docker-containers.yml
+++ b/.github/workflows/release-x-manual-docker-containers.yml
@@ -61,7 +61,7 @@ jobs:
             ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-
 
       - name: Build and push images with debian
-        if: ${{ matrix.os }} == 'debian'
+        if: ${{ matrix.os  == 'debian' }}
         uses: docker/build-push-action@v4
         env:
           REPO_ORG: ${{ env.repoorg }}
@@ -75,7 +75,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
       - name: Build and push images with alpine
-        if: ${{ matrix.os }} == 'alpine'
+        if: ${{ matrix.os  == 'alpine' }}
         uses: docker/build-push-action@v4
         env:
           REPO_ORG: ${{ env.repoorg }}

--- a/.github/workflows/release-x-manual-docker-containers.yml
+++ b/.github/workflows/release-x-manual-docker-containers.yml
@@ -61,14 +61,13 @@ jobs:
             ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-
 
       - name: Build and push images with debian
-        uses: docker/build-push-action@v4
         if: ${{ matrix.os }} == 'debian'
+        uses: docker/build-push-action@v4
         env:
           REPO_ORG: ${{ env.repoorg }}
           docker-image: ${{ matrix.docker-image }}
         with:
           push: true
-          if: ${{ matrix.os }} == 'debian'
           tags: ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}-${{ matrix.os }}, ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:latest
           file: ./Dockerfile.${{ env.docker-image }}-${{ matrix.os }}
           context: .
@@ -76,14 +75,13 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
       - name: Build and push images with alpine
-        uses: docker/build-push-action@v4
         if: ${{ matrix.os }} == 'alpine'
+        uses: docker/build-push-action@v4
         env:
           REPO_ORG: ${{ env.repoorg }}
           docker-image: ${{ matrix.docker-image }}
         with:
           push: true
-          if: ${{ matrix.os }} == 'alpine'
           tags: ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}-${{ matrix.os }}
           file: ./Dockerfile.${{ env.docker-image }}-${{ matrix.os }}
           context: .


### PR DESCRIPTION
**Description**

Added a matrix dimension for the buildx platform parameter to build both amd64 and arm64 images. 

**Test results**

Without Docker Hub secrets, I cannot test. But the workflow change is really straight-forward.

**Documentation**

As far as I can see there is no architecture mentioned in the docs. If anything, this will make the tutorial in `Docker.md` work on Apple Silicon. 

