### PR TITLE
Added amd64 build config for Apple Silicon

### DIFF
--- a/.github/workflows/release-x-manual-docker-containers.yml
+++ b/.github/workflows/release-x-manual-docker-containers.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
           docker-image: [django, nginx]
           os: [alpine, debian]
+          platform: [amd64, arm64]
     steps:
       - name: Login to DockerHub
         uses: docker/login-action@v2
@@ -89,6 +90,7 @@ jobs:
           context: .
           cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
           cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
+          platforms: ${{ matrix.platform }}
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
**Description**

Added a matrix dimension for the buildx platform parameter to build both amd64 and arm64 images.

**Test results**

Without Docker Hub secrets, I cannot test. But the workflow change is really straight-forward.

**Documentation**
As far as I can see there is no architecture mentioned in the docs. If anything, this will make the tutorial in `Docker.md` work on Apple Silicon.