### PR TITLE
Eliminate possibility of adding single finding to multiple risk exceptions

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1046,7 +1046,7 @@ def view_edit_risk_acceptance(request, eid, raid, edit_mode=False):
     accepted_findings = risk_acceptance.accepted_findings.order_by('numerical_severity')
     fpage = get_page_items(request, accepted_findings, 15)
 
-    unaccepted_findings = Finding.objects.filter(test__in=eng.test_set.all()) \
+    unaccepted_findings = Finding.objects.filter(test__in=eng.test_set.all(), risk_accepted=False) \
         .exclude(id__in=accepted_findings).order_by("title")
     add_fpage = get_page_items(request, unaccepted_findings, 10, 'apage')
     # on this page we need to add unaccepted findings as possible findings to add as accepted

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -109,7 +109,7 @@ def remove_finding_from_risk_acceptance(risk_acceptance, finding):
 
 def add_findings_to_risk_acceptance(risk_acceptance, findings):
     for finding in findings:
-        if not finding.duplicate:
+        if not finding.duplicate or finding.risk_accepted:
             finding.active = False
             finding.risk_accepted = True
             finding.save(dedupe_option=False)


### PR DESCRIPTION
There was a possibility to add the same finding to multiple risk exceptions. This was discouraged in the UI, but it was possible to do so by unaccepting, creating a new risk acceptance, and then adding the finding back to the original risk acceptance.