### PR TITLE
Make sure old findings are added to finding groups in the reimporter

### DIFF
--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -160,7 +160,7 @@ class DojoDefaultImporter(object):
                 item.save(push_to_jira=push_to_jira)
 
         for (group_name, findings) in group_names_to_findings_dict.items():
-            finding_helper.add_findings_to_auto_group(group_name, findings, create_finding_groups_for_all_findings, **kwargs)
+            finding_helper.add_findings_to_auto_group(group_name, findings, group_by, create_finding_groups_for_all_findings, **kwargs)
             if push_to_jira:
                 if findings[0].finding_group is not None:
                     jira_helper.push_to_jira(findings[0].finding_group)

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -283,7 +283,7 @@ class DojoDefaultReImporter(object):
         untouched = set(unchanged_items) - set(to_mitigate) - set(new_items)
 
         for (group_name, findings) in group_names_to_findings_dict.items():
-            finding_helper.add_findings_to_auto_group(group_name, findings, create_finding_groups_for_all_findings, **kwargs)
+            finding_helper.add_findings_to_auto_group(group_name, findings, group_by, create_finding_groups_for_all_findings, **kwargs)
             if push_to_jira:
                 if findings[0].finding_group is not None:
                     jira_helper.push_to_jira(findings[0].finding_group)


### PR DESCRIPTION
**Description**

If we didn't previously create finding groups on an import, and if we have a new re-import with a finding that matches a old finding, then a group isn't created.

**Test results**

Tested that a new finding group is correctly created on re-import.