### PR TITLE
Fix UnboundLocalError when user remove all options for password

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2290,7 +2290,7 @@ def get_password_requirements_string():
         password_requirements_string = s.rsplit(', ', 1)[0] + ' and ' + s.rsplit(', ', 1)[1]
     elif s.count(', ') > 1:
         password_requirements_string = s.rsplit(', ', 1)[0] + ', and ' + s.rsplit(', ', 1)[1]
-    else :
+    else:
         password_requirements_string = s
 
     return password_requirements_string + '.'

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2290,6 +2290,8 @@ def get_password_requirements_string():
         password_requirements_string = s.rsplit(', ', 1)[0] + ' and ' + s.rsplit(', ', 1)[1]
     elif s.count(', ') > 1:
         password_requirements_string = s.rsplit(', ', 1)[0] + ', and ' + s.rsplit(', ', 1)[1]
+    else :
+        password_requirements_string = s
 
     return password_requirements_string + '.'
 


### PR DESCRIPTION
## Bug description

When attempting to add a new user, a 500 error is generated. This error occurs when all options for creating a difficult password for new users have been removed.
![image](https://user-images.githubusercontent.com/63105226/221153400-7c83dcd5-1074-4796-a19a-cc6680b2cc33.png)

## Steps to reproduce
1. Remove all options for new users to create a difficult password.
![image](https://user-images.githubusercontent.com/63105226/221153660-cd2d6baf-452b-4bae-a7fa-ad29e357c962.png)
2. Attempt to add a new user.



## Deployment method

    Docker Compose
    nginx

## Environment information

    Operating System: Kali 6.0.0
    DefectDojo version: V2.19.1


____

You can view the issue that I opened for this at: https://github.com/DefectDojo/django-DefectDojo/issues/7673

This is my first time creating a PR, so please let me know if I have missed anything.