### PR TITLE
Remove Github OAuth dependencies

### DIFF
--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -116,7 +116,6 @@ def login_view(request):
         settings.GITLAB_OAUTH2_ENABLED,
         settings.AUTH0_OAUTH2_ENABLED,
         settings.KEYCLOAK_OAUTH2_ENABLED,
-        settings.GITHUB_OAUTH2_ENABLED,
         settings.GITHUB_ENTERPRISE_OAUTH2_ENABLED,
         settings.SAML2_ENABLED
     ]) == 1 and not ('force_login_form' in request.GET):
@@ -132,8 +131,6 @@ def login_view(request):
             social_auth = 'keycloak'
         elif settings.AUTH0_OAUTH2_ENABLED:
             social_auth = 'auth0'
-        elif settings.GITHUB_OAUTH2_ENABLED:
-            social_auth = 'github'
         elif settings.GITHUB_ENTERPRISE_OAUTH2_ENABLED:
             social_auth = 'github-enterprise'
         else:


### PR DESCRIPTION


**Description**
Support for Github integration is removed in release [2.19.3](https://github.com/DefectDojo/django-DefectDojo/pull/7691) with commit [https://github.com/DefectDojo/django-DefectDojo/commit/659b3e9d590f8465f14d13824332cd79eb3466a5](https://github.com/DefectDojo/django-DefectDojo/commit/659b3e9d590f8465f14d13824332cd79eb3466a5). 

But there are still references of 'GITHUB_OAUTH2_ENABLED' which is breaking the login page. Removed the references in views.py as they are no longer required.

