### PR TITLE
Fixing extraVolumeMounts for deployments

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -89,7 +89,7 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run/defectdojo
-        {{- range .Values.celery.extraVolumes }}
+        {{- range .Values.celery.extraVolumeMounts }}
         - name: userconfig-{{ .name }}
           readOnly: true
           mountPath: {{ .path }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -84,7 +84,7 @@ spec:
         {{- end }}
         command: ['/entrypoint-celery-worker.sh']
         volumeMounts:
-        {{- range .Values.celery.extraVolumes }}
+        {{- range .Values.celery.extraVolumeMounts }}
         - name: userconfig-{{ .name }}
           readOnly: true
           mountPath: {{ .path }}

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -128,7 +128,7 @@ spec:
         - name: cert-mount
           mountPath: {{ .Values.django.uwsgi.certificates.certMountPath }}
         {{- end }}
-        {{- range .Values.django.extraVolumes }}
+        {{- range .Values.django.extraVolumeMounts }}
         {{- if (eq .container "uwsgi") }}
         - name: userconfig-{{ .name }}
           readOnly: true
@@ -226,7 +226,7 @@ spec:
         volumeMounts:
         - name: run
           mountPath: /run/defectdojo
-        {{- range .Values.django.extraVolumes }}
+        {{- range .Values.django.extraVolumeMounts }}
         {{- if (eq .container "nginx") }}
         - name: userconfig-{{ .name }}
           readOnly: true


### PR DESCRIPTION
**Description**

Helm Chart doesn't support extraVolumeMounts for deployments

