### PR TITLE
Update JIRA when findings are added/removed to/from the finding group

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -3,6 +3,7 @@ from django.db.models.signals import post_delete, pre_delete
 from django.dispatch.dispatcher import receiver
 from dojo.celery import app
 from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
+import dojo.jira_link.helper as jira_helper
 import logging
 from time import strftime
 from django.utils import timezone
@@ -178,6 +179,11 @@ def add_to_finding_group(finding_group, finds):
     available_findings = [find for find in finds if not find.finding_group_set.all()]
     finding_group.findings.add(*available_findings)
 
+    # Now update the JIRA to add the finding to the finding group
+    if finding_group.has_jira_issue and jira_helper.get_jira_instance(finding_group).finding_jira_sync:
+        logger.debug('pushing to jira from finding.finding_bulk_update_all()')
+        jira_helper.push_to_jira(finding_group)
+
     added = len(available_findings)
     skipped = len(finds) - added
     return finding_group, added, skipped
@@ -198,6 +204,12 @@ def remove_from_finding_group(finds):
             affected_groups.add(group)
 
         removed += 1
+
+    # Now update the JIRA to remove the finding from the finding group
+    for group in affected_groups:
+        if group.has_jira_issue and jira_helper.get_jira_instance(group).finding_jira_sync:
+            logger.debug('pushing to jira from finding.finding_bulk_update_all()')
+            jira_helper.push_to_jira(group)
 
     return affected_groups, removed, skipped
 
@@ -268,6 +280,12 @@ def group_findings_by(finds, finding_group_by_option):
             grouped += 1
 
         affected_groups.add(finding_group)
+
+    # Now update the JIRA to add the finding to the finding group
+    for group in affected_groups:
+        if group.has_jira_issue and jira_helper.get_jira_instance(group).finding_jira_sync:
+            logger.debug('pushing to jira from finding.finding_bulk_update_all()')
+            jira_helper.push_to_jira(group)
 
     return affected_groups, grouped, skipped, groups_created
 


### PR DESCRIPTION
**Description**

When adding or removing a finding to/from a finding group, if the finding group is linked with a JIRA, the JIRA is not updated.

**Test results**

Tested:

- Removing a finding from a Finding Group, removes the finding from the linked JIRA
- Adding a finding to a finding group, adds the finding to the linked JIRA
- Adding a finding via group by, adds the finding to the linked JIRA