### PR TITLE
BlackDuck API read timout increased

### DIFF
--- a/dojo/tools/api_blackduck/api_client.py
+++ b/dojo/tools/api_blackduck/api_client.py
@@ -10,7 +10,7 @@ class BlackduckAPI:
         if tool_config.authentication_type == "API":
             self.api_token = tool_config.api_key
             self.base_url = tool_config.url
-            self.client = Client(base_url=tool_config.url, token=tool_config.api_key, timeout=90)
+            self.client = Client(base_url=tool_config.url, token=tool_config.api_key, timeout=120)
         else:
             raise ValueError(
                 "Authentication type {} not supported".format(

--- a/dojo/tools/api_blackduck/api_client.py
+++ b/dojo/tools/api_blackduck/api_client.py
@@ -10,7 +10,7 @@ class BlackduckAPI:
         if tool_config.authentication_type == "API":
             self.api_token = tool_config.api_key
             self.base_url = tool_config.url
-            self.client = Client(base_url=tool_config.url, token=tool_config.api_key)
+            self.client = Client(base_url=tool_config.url, token=tool_config.api_key, timeout=90)
         else:
             raise ValueError(
                 "Authentication type {} not supported".format(


### PR DESCRIPTION
**Description**

Blackduck API request timeout increased from default 15 sec to 120 seconds.
I have faced error, due to slow processing data on my blackduck server, it needed 40 sec to process request and I got error message everytime "message":"The upstream server is timing out".

#7714 
**Test results**

Build and deploy new docker image with this change. Tested on my staging env, worked fine.

**Documentation**

Please update any documentation when needed in the [documentation folder](https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs))

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [ ] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
