### PR TITLE
Make sure that we search for finding groups for "group by" in the sam…

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -256,7 +256,7 @@ def group_findings_by(finds, finding_group_by_option):
             skipped += 1
             continue
 
-        finding_group = Finding_Group.objects.filter(name=group_name).first()
+        finding_group = Finding_Group.objects.filter(test=find.test, name=group_name).first()
         if not finding_group:
             finding_group, added, skipped = create_finding_group([find], group_name)
             groups_created += 1


### PR DESCRIPTION
…e test

**Description**

I noticed that when grouping findings in one product, they appeared in a finding group in a different product/test which shared the same name.

**Test results**

Tested that finding groups are jailed to the test associated with the finding.
