### PR TITLE
Add prefetching to engagement presets endpoint

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -2658,7 +2658,8 @@ class NotificationsViewSet(prefetch.PrefetchListMixin,
 
 
 class EngagementPresetsViewset(prefetch.PrefetchListMixin,
-                               prefetch.PrefetchRetrieveMixin,mixins.ListModelMixin,
+                               prefetch.PrefetchRetrieveMixin,
+                               mixins.ListModelMixin,
                                mixins.RetrieveModelMixin,
                                mixins.UpdateModelMixin,
                                mixins.DestroyModelMixin,

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -2657,18 +2657,19 @@ class NotificationsViewSet(prefetch.PrefetchListMixin,
         serializers.NotificationsSerializer).to_schema()
 
 
-class EngagementPresetsViewset(mixins.ListModelMixin,
-                         mixins.RetrieveModelMixin,
-                         mixins.UpdateModelMixin,
-                         mixins.DestroyModelMixin,
-                         mixins.CreateModelMixin,
-                         viewsets.GenericViewSet,
-                         dojo_mixins.DeletePreviewModelMixin):
+class EngagementPresetsViewset(prefetch.PrefetchListMixin,
+                               prefetch.PrefetchRetrieveMixin,mixins.ListModelMixin,
+                               mixins.RetrieveModelMixin,
+                               mixins.UpdateModelMixin,
+                               mixins.DestroyModelMixin,
+                               mixins.CreateModelMixin,
+                               viewsets.GenericViewSet,
+                               dojo_mixins.DeletePreviewModelMixin):
     serializer_class = serializers.EngagementPresetsSerializer
     queryset = Engagement_Presets.objects.none()
     filter_backends = (DjangoFilterBackend,)
     filterset_fields = ('id', 'title', 'product')
-
+    swagger_schema = prefetch.get_prefetch_schema(["engagement_presets_list", "engagement_presets_read"], serializers.EngagementPresetsSerializer).to_schema()
     permission_classes = (IsAuthenticated, permissions.UserHasEngagementPresetPermission)
 
     def get_queryset(self):


### PR DESCRIPTION
Reduce the number of calls in engagement presets endpoint from 4 to 1 (engagement presets, product type ID query, test type ID queries, network locations ID queries) [sc-614]
