### PR TITLE
Fix GitHub dedupe

### DIFF
--- a/docs/content/en/integrations/parsers/file/github_vulnerability.md
+++ b/docs/content/en/integrations/parsers/file/github_vulnerability.md
@@ -13,7 +13,7 @@ Here is the mandatory objects and attributes:
 vulnerabilityAlerts (RepositoryVulnerabilityAlert object)
     + id
     + createdAt (optional)
-    + vulnerableManifestPath (optional)
+    + vulnerableManifestPath
     + state (optional)
     + securityVulnerability (SecurityVulnerability object)
         + severity (CRITICAL/HIGH/LOW/MODERATE)
@@ -48,6 +48,7 @@ Github v4 graphql query to fetch data:
           vulnerabilityAlerts(last: 100) {
             nodes {
               id
+              vulnerableManifestPath
               securityVulnerability {
                 severity
                 package {
@@ -88,6 +89,7 @@ query getVulnerabilitiesByRepoAndOwner($name: String!, $owner: String!) {
       nodes {
         id
         createdAt
+        vulnerableManifestPath
         securityVulnerability {
           severity
           package {

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1207,7 +1207,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Scout Suite Scan': ['file_path', 'vuln_id_from_tool'],  # for now we use file_path as there is no attribute for "service"
     'AWS Security Hub Scan': ['unique_id_from_tool'],
     'Meterian Scan': ['cwe', 'component_name', 'component_version', 'description', 'severity'],
-    'Github Vulnerability Scan': ['title', 'severity', 'component_name', 'vulnerability_ids'],
+    'Github Vulnerability Scan': ['title', 'severity', 'component_name', 'vulnerability_ids', 'file_path'],
     'Azure Security Center Recommendations Scan': ['unique_id_from_tool'],
     'Solar Appscreener Scan': ['title', 'file_path', 'line', 'severity'],
     'pip-audit Scan': ['vuln_id_from_tool', 'component_name', 'component_version'],


### PR DESCRIPTION
The GitHub Vulnerability Scan hash list (for dedupe) is too flexible. In a big project with more than one, for instance, Pipfile you should have the same vulnerability (from dependabot for instance) in more than one file. In this case, all these vulnerabilities are deleted because of deduplication.
Adding 'file_path' you are able to maintain both instances of the vulnerability.
