### PR TITLE
Add a link to the source code in the JIRA description for finding groups

### DIFF
--- a/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
@@ -55,7 +55,9 @@ h3. [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]
 *Source Line*: {{ finding.sast_source_line }}
 *Sink Object*: {{ finding.sast_sink_object }}
 {% elif finding.static_finding %}
-{% if finding.file_path %}
+{% if finding.file_path and finding.get_file_path_with_raw_link %}
+*Source File*: [{{ finding.file_path }} | {{ finding.get_file_path_with_raw_link }}]
+{% elif finding.file_path %}
 *Source File*: {{ finding.file_path }}
 {% endif %}
 {% if finding.line %}


### PR DESCRIPTION
**Description**

Link directly to the source code in JIRAs for Finding Group findings. We already do it for plain Findings.

**Test results**

Tested the links work OK in JIRA for Finding Groups.