### PR TITLE
Improve Risk Acceptance api endpoint

### DIFF
--- a/dc-unittest.sh
+++ b/dc-unittest.sh
@@ -73,4 +73,4 @@ then
 fi
 
 echo "Running docker compose unit tests with profile $PROFILE and test case $TEST_CASE ..."
-docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2"
+docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2 --keepdb"

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1158,7 +1158,8 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
         risk_acceptance_id = obj.id
         engagement_id = Engagement.objects.filter(risk_acceptance__id__in=[obj.id]).first().id
         path = reverse('download_risk_acceptance', args=(engagement_id, risk_acceptance_id))
-        if request := self.context.get("request"):
+        request = self.context.get("request")
+        if request:
             path = request.build_absolute_uri(path)
         return path
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1140,7 +1140,6 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
     recommendation = serializers.SerializerMethodField()
     decision = serializers.SerializerMethodField()
     path = serializers.SerializerMethodField()
-    engagement = serializers.SerializerMethodField()
 
     @extend_schema_field(serializers.CharField())
     @swagger_serializer_method(serializers.CharField())

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -34,6 +34,7 @@ from django.core.exceptions import ValidationError, PermissionDenied
 from django.contrib.auth.password_validation import validate_password
 from django.contrib.auth.models import Permission
 from django.utils import timezone
+from django.urls import reverse
 from django.db.utils import IntegrityError
 import six
 from django.utils.translation import gettext_lazy as _
@@ -637,6 +638,14 @@ class RawFileSerializer(serializers.ModelSerializer):
         fields = ['file']
 
 
+class RiskAcceptanceProofSerializer(serializers.ModelSerializer):
+    path = serializers.FileField(required=True)
+
+    class Meta:
+        model = Risk_Acceptance
+        fields = ['path']
+
+
 class ProductMemberSerializer(serializers.ModelSerializer):
 
     class Meta:
@@ -1130,6 +1139,8 @@ class TestImportSerializer(serializers.ModelSerializer):
 class RiskAcceptanceSerializer(serializers.ModelSerializer):
     recommendation = serializers.SerializerMethodField()
     decision = serializers.SerializerMethodField()
+    path = serializers.SerializerMethodField()
+    engagement = serializers.SerializerMethodField()
 
     @extend_schema_field(serializers.CharField())
     @swagger_serializer_method(serializers.CharField())
@@ -1140,6 +1151,22 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
     @swagger_serializer_method(serializers.CharField())
     def get_decision(self, obj):
         return Risk_Acceptance.TREATMENT_TRANSLATIONS.get(obj.decision)
+
+    @extend_schema_field(serializers.CharField())
+    @swagger_serializer_method(serializers.CharField())
+    def get_path(self, obj):
+        risk_acceptance_id = obj.id
+        engagement_id = Engagement.objects.filter(risk_acceptance__id__in=[obj.id]).first().id
+        path = reverse('download_risk_acceptance', args=(engagement_id, risk_acceptance_id))
+        if request := self.context.get("request"):
+            path = request.build_absolute_uri(path)
+        return path
+
+    @extend_schema_field(serializers.IntegerField())
+    @swagger_serializer_method(serializers.IntegerField())
+    def get_engagement(self, obj):
+        engagement = Engagement.objects.filter(risk_acceptance__id__in=[obj.id]).first()
+        return EngagementSerializer(read_only=True).to_representation(engagement)
 
     class Meta:
         model = Risk_Acceptance

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -482,6 +482,35 @@ class RiskAcceptanceViewSet(prefetch.PrefetchListMixin,
                 'owner',
                 'accepted_findings').distinct()
 
+    @extend_schema(
+        methods=['GET'],
+        responses={
+            status.HTTP_200_OK: serializers.RiskAcceptanceProofSerializer,
+        }
+    )
+    @swagger_auto_schema(
+        method='get',
+        responses={
+            status.HTTP_200_OK: serializers.RiskAcceptanceProofSerializer,
+        }
+    )
+    @action(detail=True, methods=["get"])
+    def download_proof(self, request, pk=None):
+        risk_acceptance = self.get_object()
+        # Get the file object
+        file_object = risk_acceptance.path
+        if file_object is None:
+            return Response({"error": "Proof has not provided to this risk acceptance..."}, status=status.HTTP_404_NOT_FOUND)
+        # Get the path of the file in media root
+        file_path = f'{settings.MEDIA_ROOT}/{file_object.name}'
+        file_handle = open(file_path, "rb")
+        # send file
+        response = FileResponse(file_handle, content_type=f'{mimetypes.guess_type(file_path)}', status=status.HTTP_200_OK)
+        response['Content-Length'] = file_object.size
+        response['Content-Disposition'] = f'attachment; filename="{risk_acceptance.filename()}"'
+
+        return response
+
 
 # These are technologies in the UI and the API!
 # Authorization: object-based


### PR DESCRIPTION
The risk acceptance API endpoint showed the full media URL path. It has been replaced with the access controlled download link. Also added an api path to download the risk acceptance proof directly