### PR TITLE
requirements: set 'jira' module to 3.5.0 which includes Jira 9 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ djangorestframework==3.14.0
 gunicorn==20.1.0
 html2text==2020.1.16
 humanize==4.6.0
-jira==3.4.1
+jira==3.5.0
 PyGithub==1.58.0
 lxml==4.9.2
 Markdown==3.4.1


### PR DESCRIPTION
**Description**

Fixes: #6963

Fixes Jira 9 support by requiring the "jira" Python module which includes the corresponding fix. See the referenced bug report for more information.

**Test results**

The fix was validated in our on-premise setup.

**Documentation**

N/A