### PR TITLE
feat: New page to display all API scan configurations

### DIFF
--- a/dojo/api_scan_configurations/urls.py
+++ b/dojo/api_scan_configurations/urls.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from . import views
+
+urlpatterns = [
+    re_path(r'^api_scan_configurations$', views.api_scan_configurations, name='api_scan_configurations'),
+]

--- a/dojo/api_scan_configurations/views.py
+++ b/dojo/api_scan_configurations/views.py
@@ -1,15 +1,9 @@
 # #  product
 import logging
 
-from django.contrib import messages
-from django.urls import reverse
-from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from dojo.models import Product_API_Scan_Configuration
-from dojo.utils import dojo_crypto_encrypt, prepare_for_view
 from dojo.utils import add_breadcrumb
-from dojo.forms import ToolConfigForm
-from dojo.tool_config.factory import create_API
 from dojo.authorization.authorization_decorators import user_is_configuration_authorized
 
 logger = logging.getLogger(__name__)

--- a/dojo/api_scan_configurations/views.py
+++ b/dojo/api_scan_configurations/views.py
@@ -1,0 +1,26 @@
+# #  product
+import logging
+
+from django.contrib import messages
+from django.urls import reverse
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from dojo.models import Product_API_Scan_Configuration
+from dojo.utils import dojo_crypto_encrypt, prepare_for_view
+from dojo.utils import add_breadcrumb
+from dojo.forms import ToolConfigForm
+from dojo.tool_config.factory import create_API
+from dojo.authorization.authorization_decorators import user_is_configuration_authorized
+
+logger = logging.getLogger(__name__)
+
+
+@user_is_configuration_authorized('dojo.view_tool_configuration')
+def api_scan_configurations(request):
+    confs = Product_API_Scan_Configuration.objects.all().order_by('product')
+    for c in confs:
+        print(c.product)
+    add_breadcrumb(title="API Scan Configurations List", top_level=not len(request.GET), request=request)
+    return render(request,
+                  'dojo/view_all_product_api_scan_configurations.html',
+                  {'confs': confs})

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -580,6 +580,13 @@
                                                         </a>
                                                     </li>
                                                 {% endif %}
+                                                {% if "dojo.view_api_scan_configurations"|has_configuration_permission %}
+                                                    <li>
+                                                        <a href="{% url 'api_scan_configurations' %}">
+                                                            {% trans "API Scan Configurations" %}
+                                                        </a>
+                                                    </li>
+                                                {% endif %}
                                                 {% if "dojo.view_tool_type"|has_configuration_permission %}
                                                     <li>
                                                         <a href="{% url 'tool_type' %}">

--- a/dojo/templates/dojo/view_all_product_api_scan_configurations.html
+++ b/dojo/templates/dojo/view_all_product_api_scan_configurations.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% load navigation_tags %}
+{% load authorization_tags %}
+{% block content %}
+    {{ block.super }}
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading tight">
+                    <h3 class="has-filters">
+                        All API Scan Configurations
+                    </h3>
+                </div>
+
+            </div>
+            {% if confs %}
+
+                <div class="clearfix">
+                    {% include "dojo/paging_snippet.html" with page=confs page_size=True %}
+                </div>
+                <div class="panel panel-default table-responsive">
+                    <table id="products"
+                           class="tablesorter-bootstrap table table-condensed table-striped">
+                        <thead>
+                        <tr>
+                            <th>Product</th>
+                            <th>Product API Scan Configuration</th>
+                            <th>Service key 1</th>
+                            <th>Service key 2</th>
+                            <th>Service key 3</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for conf in confs %}
+                            <tr>
+                                <td>
+                                    <a href="{% url 'edit_product' conf.product.id %}">{{ conf.product.name }}</a>
+                                </td>
+                                <td>
+                                    {% if "dojo.change_tool_configuration"|has_configuration_permission %}
+                                        <a href="{% url 'edit_api_scan_configuration' conf.product.id conf.id %}">{{ conf.tool_configuration.name }}</a>
+                                    {% else %}
+                                        {{ conf.name }}
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if conf.service_key_1 %}{{ conf.service_key_1 }}{% endif %}
+                                </td>
+                                <td>
+                                    {% if conf.service_key_2 %}{{ conf.service_key_2 }}{% endif %}
+                                </td>
+                                <td>
+                                    {% if conf.service_key_3 %}{{ conf.service_key_3 }}{% endif %}
+                                </td>
+
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+                <div class="clearfix">
+                    {% include "dojo/paging_snippet.html" with page=confs page_size=True %}
+                </div>
+            {% else %}
+                <p class="text-center">No tool mappings found.</p>
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}
+{% block postscript %}
+    {{ block.super }}
+    {% include "dojo/filter_js_snippet.html" %}
+{% endblock %}

--- a/dojo/templates/dojo/view_all_product_api_scan_configurations.html
+++ b/dojo/templates/dojo/view_all_product_api_scan_configurations.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load navigation_tags %}
 {% load authorization_tags %}
+{% load i18n %}
 {% block content %}
     {{ block.super }}
     <div class="row">
@@ -8,7 +9,7 @@
             <div class="panel panel-default">
                 <div class="panel-heading tight">
                     <h3 class="has-filters">
-                        All API Scan Configurations
+                        {% trans "All API Scans Configurations" %}
                     </h3>
                 </div>
 
@@ -23,11 +24,11 @@
                            class="tablesorter-bootstrap table table-condensed table-striped">
                         <thead>
                         <tr>
-                            <th>Product</th>
-                            <th>Product API Scan Configuration</th>
-                            <th>Service key 1</th>
-                            <th>Service key 2</th>
-                            <th>Service key 3</th>
+                            <th>{% trans "Product" %}</th>
+                            <th>{% trans "Product API Scan Configuration" %}</th>
+                            <th>{% trans "Service key 1" %}</th>
+                            <th>{% trans "Service key 2" %}</th>
+                            <th>{% trans "Service key 3" %}</th>
                         </tr>
                         </thead>
                         <tbody>

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -45,6 +45,7 @@ from dojo.jira_link.urls import urlpatterns as jira_urls
 from dojo.github_issue_link.urls import urlpatterns as github_urls
 from dojo.tool_type.urls import urlpatterns as tool_type_urls
 from dojo.tool_config.urls import urlpatterns as tool_config_urls
+from dojo.api_scan_configurations.urls import urlpatterns as api_scan_configurations_urls
 from dojo.tool_product.urls import urlpatterns as tool_product_urls
 from dojo.cred.urls import urlpatterns as cred_urls
 from dojo.sla_config.urls import urlpatterns as sla_urls
@@ -152,6 +153,7 @@ ur += jira_urls
 ur += github_urls
 ur += tool_type_urls
 ur += tool_config_urls
+ur += api_scan_configurations_urls
 ur += tool_product_urls
 ur += cred_urls
 ur += sla_urls


### PR DESCRIPTION
**Description**

Currently, for API Importers, there is no easy way to show how a Tool configuration is used across all products in the instance.
This is primordial to make sense of the overall Vuln management system, to provide an overview of the "mapping"

Further work should also implement a "pre-ingestion" view to show all the discovered scans from all configured API importers, and let the user simply "link" these scans to products, to automate the ingestion. (That's also a work item I think, there is no automated cron ingestion)

**Test results**

![image](https://user-images.githubusercontent.com/6706472/224743687-0ae557b4-c20b-4219-8d8c-7490e76565d9.png)
