### PR TITLE
Allow pushing to JIRA and specifying the JIRA URL from the finding gr…

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -279,6 +279,23 @@ class DeleteProductForm(forms.ModelForm):
 
 class EditFindingGroupForm(forms.ModelForm):
     name = forms.CharField(max_length=255, required=True, label='Finding Group Name')
+    jira_issue = forms.CharField(max_length=255, required=False, label='Linked JIRA Issue',
+                                 help_text='Leave empty and check push to jira to create a new JIRA issue for this finding group.')
+
+    def __init__(self, *args, **kwargs):
+        super(EditFindingGroupForm, self).__init__(*args, **kwargs)
+        import dojo.jira_link.helper as jira_helper
+
+        self.fields['push_to_jira'] = forms.BooleanField()
+        self.fields['push_to_jira'].required = False
+        self.fields['push_to_jira'].help_text = "Checking this will overwrite content of your JIRA issue, or create one."
+
+        self.fields['push_to_jira'].label = "Push to JIRA"
+
+        if hasattr(self.instance, 'has_jira_issue') and self.instance.has_jira_issue:
+            jira_url = jira_helper.get_jira_url(self.instance)
+            self.fields['jira_issue'].initial = jira_url
+            self.fields['push_to_jira'].widget.attrs['checked'] = 'checked'
 
     class Meta:
         model = Finding_Group


### PR DESCRIPTION
…oup edit page

**Description**

There is no way to specify a JIRA for a finding group, unlike for findings. This improvement adds the ability to both push to JIRA in the finding group edit/view page, as well as to specify a JIRA URL to link instead.

**Test results**

Tested all scenarios I could think of with JIRA.

<img width="1682" alt="Screenshot 2023-03-15 at 11 08 53" src="https://user-images.githubusercontent.com/472162/225292423-1bc8932d-b515-41b1-9992-4c02d9ecd9e1.png">
