### PR TITLE
Removing redundant information from Veracode SCA description

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1205,7 +1205,7 @@ class FindingEngagementSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Engagement
-        fields = ["id", "name", "description", "product", "target_start", "target_end", "branch_tag", "engagement_type", "build_id", "commit_hash", "version",  "created", "updated"]
+        fields = ["id", "name", "description", "product", "target_start", "target_end", "branch_tag", "engagement_type", "build_id", "commit_hash", "version", "created", "updated"]
 
 
 class FindingEnvironmentSerializer(serializers.ModelSerializer):

--- a/dojo/tools/veracode_sca/parser.py
+++ b/dojo/tools/veracode_sca/parser.py
@@ -65,17 +65,10 @@ class VeracodeScaParser(object):
                 cvss_score = vulnerability.get("cvss3_score")
             severity = self.__cvss_to_severity(cvss_score)
 
-            description = 'This library has known vulnerabilities.\n'
-            description += \
-                "**CVE:** {0} ({1})\n" \
-                "CVS Score: {2} ({3})\n" \
-                "Project name: {4}\n" \
-                "Title: \n>{5}" \
+            description = \
+                "Project name: {0}\n" \
+                "Title: \n>{1}" \
                 "\n\n-----\n\n".format(
-                    vuln_id,
-                    date,
-                    cvss_score,
-                    severity,
                     issue.get("project_name"),
                     vulnerability.get('title'))
 
@@ -151,17 +144,10 @@ class VeracodeScaParser(object):
             severity = self.fix_severity(row.get('Severity', None))
             cvss_score = float(row.get('CVSS score', 0))
             date = datetime.strptime(row.get('Issue opened: Scan date'), '%d %b %Y %H:%M%p %Z')
-            description = 'This library has known vulnerabilities.\n'
-            description += \
-                "**CVE:** {0} ({1})\n" \
-                "CVS Score: {2} ({3})\n" \
-                "Project name: {4}\n" \
-                "Title: \n>{5}" \
+            description = \
+                "Project name: {0}\n" \
+                "Title: \n>{1}" \
                 "\n\n-----\n\n".format(
-                    vuln_id,
-                    date,
-                    cvss_score,
-                    severity,
                     row.get('Project'),
                     row.get('Title'))
 


### PR DESCRIPTION
**Description**

The Veracode SCA description contains redundant information available elsewhere in the finding (CVE, Severity). Once pushed to JIRA it results in a seriously cluttered description. This just removes the CVE/Severity information from the description.

**Test results**

Tested it works OK with a Veracode CSV.