### PR TITLE
Entrypoints permissions fix

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -104,7 +104,8 @@ RUN \
     chmod -R 775 /app/dojo/settings && \
     mkdir /var/run/${appuser} && \
     chown ${appuser} /var/run/${appuser} && \
-	  chmod g=u /var/run/${appuser} && \
+    chmod g=u /var/run/${appuser} && \
+    chmod 775 /*.sh && \
     mkdir -p media/threat && chown -R ${uid} media
 USER ${uid}
 ENV \

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -109,7 +109,8 @@ RUN \
     chmod -R 775 /app/dojo/settings && \
     mkdir /var/run/${appuser} && \
     chown ${appuser} /var/run/${appuser} && \
-	  chmod g=u /var/run/${appuser} && \
+    chmod g=u /var/run/${appuser} && \
+    chmod 775 /*.sh && \
     mkdir -p media/threat && chown -R ${uid} media
 USER ${uid}
 ENV \


### PR DESCRIPTION
Description

It is a fix for problems with "permission denied" error running Defect Dojo on Oracle Linux 8 (RHEL) in rootless mode. Permissions are preserved from the host system during copy so we have to make sure that the files will have execution permission in container.
More details: https://github.com/DefectDojo/django-DefectDojo/issues/5973

Test results

DD works as expected, not a big of a change.