### PR TITLE
Adding/Simplify Assign Issue for Cloud/Premises

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -733,7 +733,7 @@ def add_jira_issue(obj, *args, **kwargs):
         logger.debug('sending fields to JIRA: %s', fields)
         new_issue = jira.create_issue(fields)
         if jira_project.default_assignee:
-            new_issue.update(assignee={'name': jira_project.default_assignee})
+            jira.assign_issue(new_issue.key, jira_project.default_assignee)
 
         # Upload dojo finding screenshots to Jira
         findings = [obj]


### PR DESCRIPTION
**Description**

before: update function send "name" key field for assigning issue. but it will have a problem if users use Jira cloud where the "name" key is deprecated (https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/)

proposed: using the Jira library function assign_issue, it will use user search in the jira for users that have a similar name then take and use the "name" (for premise) or "accountId" (for cloud) then send it using the correct key.


