### PR TITLE
Fix menu items disappearing on error pages

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -319,7 +319,7 @@
                                                         {% trans "Risk Accepted Findings" %}
                                                     </a>
                                                 </li>
-                                                {% if "dojo.view_finding_template"|has_configuration_permission %}
+                                                {% if "dojo.view_finding_template"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'templates' %}">
                                                             {% trans "Finding Templates" %}
@@ -426,7 +426,7 @@
                                             </ul>
                                             <!-- /.nav-second-level -->
                                         </li>
-                                        {% if "auth.view_user"|has_configuration_permission or "auth.view_group"|has_configuration_permission %}
+                                        {% if "auth.view_user"|has_configuration_permission:request or "auth.view_group"|has_configuration_permission:request %}
                                             <li>
                                                 <a href="{% url 'users' %}" aria-disabled="true" aria-expanded="false" aria-label="Users" id="id_user_menu">
                                                     <i class="fa-solid fa-user fa-fw"></i>
@@ -434,14 +434,14 @@
                                                     <span class="glyphicon arrow"></span>
                                                 </a>
                                                 <ul class="nav nav-second-level">
-                                                    {% if "auth.view_user"|has_configuration_permission %}
+                                                    {% if "auth.view_user"|has_configuration_permission:request %}
                                                         <li>    
                                                             <a href="{% url 'users' %}">
                                                                 {% trans "Users" %}
                                                             </a>
                                                         </li>
                                                     {% endif %}
-                                                    {% if "auth.view_group"|has_configuration_permission %}
+                                                    {% if "auth.view_group"|has_configuration_permission:request %}
                                                         <li>
                                                             <a href="{% url 'groups' %}"  id="id_group_menu">
                                                                 {% trans "Groups" %}
@@ -460,7 +460,7 @@
                                         </li>
                                         {% endif %}
                                         {% if system_settings.enable_questionnaires %}
-                                            {% if "dojo.view_engagement_survey"|has_configuration_permission or "dojo.view_question"|has_configuration_permission %}
+                                            {% if "dojo.view_engagement_survey"|has_configuration_permission:request or "dojo.view_question"|has_configuration_permission:request %}
                                                 <li>
                                                     <a href="#">
                                                         <i class="fa-solid fa-house-medical-flag fa-fw"></i>
@@ -468,14 +468,14 @@
                                                         <span class="glyphicon arrow"></span>
                                                     </a>
                                                     <ul class="nav nav-second-level">
-                                                        {% if "dojo.view_engagement_survey"|has_configuration_permission  %}
+                                                        {% if "dojo.view_engagement_survey"|has_configuration_permission:request  %}
                                                             <li>
                                                                 <a href="{% url 'questionnaire' %}">
                                                                     {% trans "All Questionnaires" %}
                                                                 </a>
                                                             </li>
                                                         {% endif %}
-                                                        {% if "dojo.view_question"|has_configuration_permission %}
+                                                        {% if "dojo.view_question"|has_configuration_permission:request %}
                                                             <li>
                                                                 <a href="{% url 'questions' %}">
                                                                     {% trans "All Questions" %}
@@ -493,49 +493,49 @@
                                                 <span>{% trans "Configuration" %}</span>
                                             </a>
                                             <ul class="nav nav-second-level">
-                                                {% if "dojo.change_announcement"|has_configuration_permission %}
+                                                {% if "dojo.change_announcement"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'configure_announcement' %}">
                                                             {% trans "Announcement" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if system_settings.enable_credentials and "dojo.view_cred_user"|has_configuration_permission %}
+                                                {% if system_settings.enable_credentials and "dojo.view_cred_user"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'cred' %}">
                                                             {% trans "Credential Manager" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if system_settings.enable_github  and "dojo.view_github_conf"|has_configuration_permission%}
+                                                {% if system_settings.enable_github  and "dojo.view_github_conf"|has_configuration_permission:request%}
                                                     <li>
                                                         <a href="{% url 'github' %}">
                                                             {% trans "GitHub" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if system_settings.enable_google_sheets and "dojo.change_google_sheet"|has_configuration_permission %}
+                                                {% if system_settings.enable_google_sheets and "dojo.change_google_sheet"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'configure_google_sheets' %}">
                                                             {% trans "Google Sheets Sync" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if system_settings.enable_jira and "dojo.view_jira_instance"|has_configuration_permission %}
+                                                {% if system_settings.enable_jira and "dojo.view_jira_instance"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'jira' %}">
                                                             {% trans "JIRA" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if "dojo.change_bannerconf"|has_configuration_permission %}
+                                                {% if "dojo.change_bannerconf"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'configure_banner' %}">
                                                             {% trans "Login Banner" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if "dojo.view_note_type"|has_configuration_permission %}
+                                                {% if "dojo.view_note_type"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'note_type' %}">
                                                             {% trans "Note Types" %}
@@ -552,14 +552,14 @@
                                                         {% trans "Regulations" %}
                                                     </a>
                                                 </li>
-                                                {% if system_settings.enable_rules_framework and "dojo.view_rule"|has_configuration_permission %}
+                                                {% if system_settings.enable_rules_framework and "dojo.view_rule"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'rules' %}">
                                                             {% trans "Rules Framework" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if system_settings.enable_finding_sla and "dojo.view_sla_configuration"|has_configuration_permission %}
+                                                {% if system_settings.enable_finding_sla and "dojo.view_sla_configuration"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'sla_config' %}">
                                                             {% trans "SLA Configuration" %}
@@ -573,14 +573,14 @@
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if "dojo.view_tool_configuration"|has_configuration_permission %}
+                                                {% if "dojo.view_tool_configuration"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'tool_config' %}">
                                                             {% trans "Tool Configuration" %}
                                                         </a>
                                                     </li>
                                                 {% endif %}
-                                                {% if "dojo.view_tool_type"|has_configuration_permission %}
+                                                {% if "dojo.view_tool_type"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'tool_type' %}">
                                                             {% trans "Tool Type" %}

--- a/dojo/templates/defectDojo-engagement-survey/create_questionnaire.html
+++ b/dojo/templates/defectDojo-engagement-survey/create_questionnaire.html
@@ -12,7 +12,7 @@
                     <input class="btn btn-primary" type="submit" label="create_questionnaire" name="create_questionnaire" value="Update Questionnaire"/>
                     <input class="btn btn-primary" type="submit" label="add_questions" name="add_questions"
                            value="Edit Questions"/>
-                    {% if "dojo.delete_engagement_survey"|has_configuration_permission %}
+                    {% if "dojo.delete_engagement_survey"|has_configuration_permission:request %}
                     <a class="btn btn-danger" href="{% url 'delete_questionnaire' survey.id %}">Delete Questionnaire</a>
                     {% endif %}
                 {% else %}

--- a/dojo/templates/defectDojo-engagement-survey/list_questions.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_questions.html
@@ -28,7 +28,7 @@
                         {% for question in questions %}
                             <tr>
                                 <td>
-                                    {% if "dojo.change_question"|has_configuration_permission %}
+                                    {% if "dojo.change_question"|has_configuration_permission:request %}
                                     <a title="{{ question.text }}" href="{% url 'edit_question' question.id %}">{{ question.text }}</a>
                                     {% else %}
                                     {{ question.text }}
@@ -51,7 +51,7 @@
         <div class="col-md-2">
             <div class="panel panel-default filters">
                 {% if filtered.form %}
-                    {% if "dojo.add_question"|has_configuration_permission %}
+                    {% if "dojo.add_question"|has_configuration_permission:request %}
                         <div class="panel-heading">Actions</div>
                         <div class="panel-body centered">
                             <a class="btn btn-sm btn-secondary" href="{% url 'create_question' %}">

--- a/dojo/templates/defectDojo-engagement-survey/list_surveys.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_surveys.html
@@ -24,7 +24,7 @@
                         {% for survey in surveys %}
                             <tr>
                                 <td>
-                                    {% if "dojo.change_engagement_survey"|has_configuration_permission %}
+                                    {% if "dojo.change_engagement_survey"|has_configuration_permission:request %}
                                     <a title="{{ survey.name }}" href="{% url 'edit_questionnaire' survey.id %}">{{ survey.name }}</a>
                                     {% else %}
                                     {{ survey.name }}
@@ -47,7 +47,7 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     General Questionnaires
-                    {% if "dojo.add_engagement_survey"|has_configuration_permission %}
+                    {% if "dojo.add_engagement_survey"|has_configuration_permission:request %}
                     <a title="Add Questionnaire" class="pull-right btn btn-sm btn-primary" href="/empty_questionnaire"><span class="fa-solid fa-plus"></span></a>
                     {% endif %}
                 </div>
@@ -76,7 +76,7 @@
                                                     data-whatever="/empty_questionnaire/{{ survey.id }}/answer">
                                                 <i class="fa-solid fa-share"></i> Share Questionnaire
                                             </button>
-                                            {% if "dojo.delete_engagement_survey"|has_configuration_permission %}
+                                            {% if "dojo.delete_engagement_survey"|has_configuration_permission:request %}
                                             <a class="btn btn-sm btn-danger"
                                                 href="general_questionnaire/{{ survey.id }}/delete"> Delete
                                             Questionnaire </a>
@@ -98,7 +98,7 @@
         <div class="col-md-2">
             <div class="panel panel-default filters">
                 {% if filtered.form %}
-                {% if "dojo.add_engagement_survey"|has_configuration_permission %}
+                {% if "dojo.add_engagement_survey"|has_configuration_permission:request %}
                         <div class="panel-heading">Actions</div>
                         <div class="panel-body centered">
                             <a class="btn btn-sm btn-secondary" href="{% url 'create_questionnaire' %}">

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -148,7 +148,7 @@
         </div>
     {% endblock %}
     {% block surveys %}
-        {% if system_settings.enable_questionnaires and "dojo.view_engagement_survey"|has_configuration_permission  %}
+        {% if system_settings.enable_questionnaires and "dojo.view_engagement_survey"|has_configuration_permission:request  %}
             <div class="row">
                 <div class="col-lg-12">
                     <div class="panel panel-default">

--- a/dojo/templates/dojo/dev_env.html
+++ b/dojo/templates/dojo/dev_env.html
@@ -11,7 +11,7 @@
                         Environment List
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa-solid fa-filter"></i> <i class="caret"></i> </button>
-                            {% if "dojo.add_development_environment"|has_configuration_permission %}
+                            {% if "dojo.add_development_environment"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -47,7 +47,7 @@
                         <tbody>
                         {% for de in devs %}
                             <tr>
-                                {% if "dojo.change_development_environment"|has_configuration_permission %}
+                                {% if "dojo.change_development_environment"|has_configuration_permission:request %}
                                     <td><a href="{% url 'edit_dev_env' de.id %}"> {{ de.name }} </a></td>
                                 {% else %}
                                     <td> {{ de.name }} </a> </td>

--- a/dojo/templates/dojo/edit_dev_env.html
+++ b/dojo/templates/dojo/edit_dev_env.html
@@ -9,7 +9,7 @@
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <input class="btn btn-primary" name="edit_dev_env" type="submit" value="Submit"/>
-                {% if "dojo.delete_development_environment"|has_configuration_permission %}
+                {% if "dojo.delete_development_environment"|has_configuration_permission:request %}
                 <input class="btn btn-danger" name="delete_dev_env" type="submit" value="Delete"/>
                 {% endif %}
             </div>

--- a/dojo/templates/dojo/edit_regulation.html
+++ b/dojo/templates/dojo/edit_regulation.html
@@ -10,7 +10,7 @@
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <button class="btn btn-primary" type="submit" name="submit"  id="submit" value="Submit">Update</button>
-                {% if "dojo.delete_regulation"|has_configuration_permission %}
+                {% if "dojo.delete_regulation"|has_configuration_permission:request %}
                 <button class="btn btn-danger" type="submit" name="delete" id="delete" value="Delete">Delete</button>
                 {% endif %}
             </div>

--- a/dojo/templates/dojo/edit_sla_config.html
+++ b/dojo/templates/dojo/edit_sla_config.html
@@ -10,7 +10,7 @@
         <div class="form-group">
             <div class="col-sm-offset-2 col-sm-10">
                 <button class="btn btn-primary" type="submit" name="submit"  id="submit" value="Submit">Update</button>
-                {% if "dojo.delete_sla_configuration"|has_configuration_permission %}
+                {% if "dojo.delete_sla_configuration"|has_configuration_permission:request %}
                 <button class="btn btn-danger" type="submit" name="delete" id="delete" value="Delete">Delete</button>
                 {% endif %}
             </div>

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -282,14 +282,14 @@
                                               </a>
                                           </li>
                                        {% endif %}
-                                       {% if "dojo.add_finding_template"|has_configuration_permission %}
+                                       {% if "dojo.add_finding_template"|has_configuration_permission:request %}
                                           <li role="presentation">
                                               <a href="{% url 'mktemplate' finding.id %}">
                                                   <i class="fa-solid fa-copy"></i> Make Finding a Template
                                               </a>
                                           </li>
                                        {% endif %}
-                                       {% if finding|has_object_permission:"Finding_Edit" and "dojo.view_finding_template"|has_configuration_permission %}
+                                       {% if finding|has_object_permission:"Finding_Edit" and "dojo.view_finding_template"|has_configuration_permission:request %}
                                           <li role="presentation">
                                               <a href="{% url 'find_template_to_apply' finding.id %}">
                                                   <i class="fa-solid fa-copy"></i> Apply Template to Finding

--- a/dojo/templates/dojo/github.html
+++ b/dojo/templates/dojo/github.html
@@ -10,7 +10,7 @@
                     <h3 class="has-filters">
                         GitHub Configuration List
                         <div class="dropdown pull-right">
-                            {% if "dojo.add_github_conf"|has_configuration_permission %}
+                            {% if "dojo.add_github_conf"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -51,7 +51,7 @@
                                         {{ conf.configuration_name }}
                                 </td>
                                 <td class="text-right">
-                                    {% if "dojo.delete_github_conf"|has_configuration_permission %}
+                                    {% if "dojo.delete_github_conf"|has_configuration_permission:request %}
                                     <a href="{% url 'delete_github' conf.id %}" class="btn btn-sm btn-danger">
                                         <i class="fa-solid fa-trash" style="color:white"></i>
                                         Delete

--- a/dojo/templates/dojo/groups.html
+++ b/dojo/templates/dojo/groups.html
@@ -11,7 +11,7 @@
                         {{ name }}
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa-solid fa-filter"></i> <i class="caret"></i> </button>
-                            {% if "auth.add_group"|has_configuration_permission %}
+                            {% if "auth.add_group"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>

--- a/dojo/templates/dojo/jira.html
+++ b/dojo/templates/dojo/jira.html
@@ -10,7 +10,7 @@
                     <h3 class="has-filters">
                         JIRA Instances
                         <div class="dropdown pull-right">
-                            {% if "dojo.add_jira_instance"|has_configuration_permission %}
+                            {% if "dojo.add_jira_instance"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -55,7 +55,7 @@
                         {% for jira_instance in jira_instances %}
                             <tr>
                                 <td>
-                                    {% if "dojo.change_jira_instance"|has_configuration_permission %}
+                                    {% if "dojo.change_jira_instance"|has_configuration_permission:request %}
                                     <a href="{% url 'edit_jira' jira_instance.id %}"><b>{{ jira_instance.configuration_name }}</b></a>
                                     {% else %}
                                     {{ jira_instance.configuration_name }}
@@ -70,13 +70,13 @@
                                         {{ jira_instance.username }}
                                 </td>
                                 <td>
-                                    {% if "dojo.change_jira_instance"|has_configuration_permission %}
+                                    {% if "dojo.change_jira_instance"|has_configuration_permission:request %}
                                     <a href="{% url 'edit_jira' jira_instance.id %}" class="btn btn-sm btn-warning">
                                         <i class="fa-solid fa-file"></i>
                                         Edit
                                     </a>
                                     {% endif %}
-                                    {% if "dojo.delete_jira_instance"|has_configuration_permission %}
+                                    {% if "dojo.delete_jira_instance"|has_configuration_permission:request %}
                                     <a href="{% url 'delete_jira' jira_instance.id %}" class="btn btn-sm btn-danger">
                                         <i class="fa-solid fa-trash" style="color:white"></i>
                                         Delete

--- a/dojo/templates/dojo/note_type.html
+++ b/dojo/templates/dojo/note_type.html
@@ -11,7 +11,7 @@
                         Note Type List
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa-solid fa-filter"></i> <i class="caret"></i> </button>
-                            {% if "dojo.add_note_type"|has_configuration_permission %}
+                            {% if "dojo.add_note_type"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                   data-toggle="dropdown" aria-expanded="true">
                               <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -77,7 +77,7 @@
                                 <a>Disabled</a>
                                 {% endif %}
                               </td>
-                              {% if "dojo.change_note_type"|has_configuration_permission %}
+                              {% if "dojo.change_note_type"|has_configuration_permission:request %}
                                     <td>
                                         <div class="centered">
                                             <div class="btn-group" role="group">

--- a/dojo/templates/dojo/regulations.html
+++ b/dojo/templates/dojo/regulations.html
@@ -9,7 +9,7 @@
                 <div class="panel-heading tight">
                     <h3 class="has-filters">
                         Regulations
-                        {% if "dojo.add_regulation"|has_configuration_permission %}
+                        {% if "dojo.add_regulation"|has_configuration_permission:request %}
                         <div class="dropdown pull-right">
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
@@ -52,7 +52,7 @@
                         {% for conf in confs %}
                             <tr>
                                 <td>
-                                    {% if "dojo.change_regulation"|has_configuration_permission %}
+                                    {% if "dojo.change_regulation"|has_configuration_permission:request %}
                                     <a href="{% url 'edit_regulations' conf.id %}"><b>{{ conf.name }}</b></a>
                                     {% else %}
                                     {{ conf.name }}

--- a/dojo/templates/dojo/rules.html
+++ b/dojo/templates/dojo/rules.html
@@ -14,7 +14,7 @@
                         Rules Framework
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa-solid fa-filter"></i> <i class="caret"></i> </button>
-                            {% if "dojo.add_rule"|has_configuration_permission %}
+                            {% if "dojo.add_rule"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -63,13 +63,13 @@
                                 <td>
                                     <div class="centered">
                                         <div class="btn-group" role="group">
-                                            {% if "dojo.change_rule"|has_configuration_permission %}
+                                            {% if "dojo.change_rule"|has_configuration_permission:request %}
                                             <a class="btn btn-sm btn-warning"
                                                 href="{% url 'Edit Rule' rule.id %}">
                                                 <i class="fa-solid fa-file"></i> Edit
                                             </a>
                                             {% endif %}
-                                            {% if "dojo.delete_rule"|has_configuration_permission %}
+                                            {% if "dojo.delete_rule"|has_configuration_permission:request %}
                                             <a class="btn btn-sm btn-danger"
                                                 href="{% url 'Delete Rule' rule.id %}">
                                                 <i class="fa-solid fa-file"></i> Delete

--- a/dojo/templates/dojo/sla_config.html
+++ b/dojo/templates/dojo/sla_config.html
@@ -10,7 +10,7 @@
                     <h3 class="has-filters">
                         SLA Configurations
                         <div class="dropdown pull-right">
-                            {% if "dojo.add_sla_configuration"|has_configuration_permission %}
+                            {% if "dojo.add_sla_configuration"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" name="sla_dropdown" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -51,7 +51,7 @@
                         {% for conf in confs %}
                             <tr>
                                 <td>
-                                    {% if "dojo.change_sla_configuration"|has_configuration_permission %}
+                                    {% if "dojo.change_sla_configuration"|has_configuration_permission:request %}
                                         <a href="{% url 'edit_sla_config' conf.id %}"><b>{{ conf.name }}</b></a>
                                     {% else %}
                                         {{ conf.name }}

--- a/dojo/templates/dojo/templates.html
+++ b/dojo/templates/dojo/templates.html
@@ -17,7 +17,7 @@
                         {% endif %}
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa-solid fa-filter"></i> <i class="caret"></i> </button>
-                            {% if "dojo.add_finding_template"|has_configuration_permission and not add_from_template and not apply_template %}
+                            {% if "dojo.add_finding_template"|has_configuration_permission:request and not add_from_template and not apply_template %}
                                 <a href="{% url 'add_template' %}" class="btn btn-primary"
                                    title="Add Finding Template">
                                     <i class="fa-solid fa-plus"></i>
@@ -92,7 +92,7 @@
                                             {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                         </a>
                                     {% else %}
-                                        {% if "dojo.change_finding_template"|has_configuration_permission %}
+                                        {% if "dojo.change_finding_template"|has_configuration_permission:request %}
                                         <a title="{{ finding.title }}" href="{% url 'edit_template' finding.id %}">
                                             {{ finding.title }}
                                             {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
@@ -121,11 +121,11 @@
                                     </td>
                                 {% else %}
                                     <td nowrap="nowrap">
-                                        {% if "dojo.change_finding_template"|has_configuration_permission %}
+                                        {% if "dojo.change_finding_template"|has_configuration_permission:request %}
                                         <a href="{% url 'edit_template' finding.id %}"
                                             class="btn btn-sm btn-secondary">Edit</a>
                                         {% endif %}
-                                        {% if "dojo.delete_finding_template"|has_configuration_permission %}
+                                        {% if "dojo.delete_finding_template"|has_configuration_permission:request %}
                                         <form method="post" action="{% url 'delete_template' finding.id %}"
                                               style="display: inline" class="form-inline form">
                                             {% csrf_token %}

--- a/dojo/templates/dojo/test_type.html
+++ b/dojo/templates/dojo/test_type.html
@@ -11,7 +11,7 @@
                         Test Type List
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa-solid fa-filter"></i> <i class="caret"></i> </button>
-                            {% if "dojo.add_test_type"|has_configuration_permission %}
+                            {% if "dojo.add_test_type"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -47,7 +47,7 @@
                         <tbody>
                         {% for tt in tts %}
                             <tr>
-                                {% if "dojo.change_test_type"|has_configuration_permission %}
+                                {% if "dojo.change_test_type"|has_configuration_permission:request %}
                                     <td><a href="{% url 'edit_test_type' tt.id %}"> {{ tt.name }} </a></td>
                                 {% else %}
                                     <td> {{ tt.name }} </a> </td>

--- a/dojo/templates/dojo/tool_config.html
+++ b/dojo/templates/dojo/tool_config.html
@@ -10,7 +10,7 @@
                     <h3 class="has-filters">
                         Tool Configurations
                         <div class="dropdown pull-right">
-                            {% if "dojo.add_tool_configuration"|has_configuration_permission %}
+                            {% if "dojo.add_tool_configuration"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -50,7 +50,7 @@
                         {% for conf in confs %}
                             <tr>
                                 <td>
-                                    {% if "dojo.change_tool_configuration"|has_configuration_permission %}
+                                    {% if "dojo.change_tool_configuration"|has_configuration_permission:request %}
                                         <a href="{% url 'edit_tool_config' conf.id %}"><b>{{ conf.name }}</b></a>
                                     {% else %}
                                         {{ conf.name }}

--- a/dojo/templates/dojo/tool_type.html
+++ b/dojo/templates/dojo/tool_type.html
@@ -11,7 +11,7 @@
                 <div class="panel-heading tight">
                     <h3 class="has-filters">
                         {% trans "Tool Types" %}
-                        {% if "dojo.add_tool_type"|has_configuration_permission %}
+                        {% if "dojo.add_tool_type"|has_configuration_permission:request %}
                         <div class="dropdown pull-right">
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
@@ -50,7 +50,7 @@
                         {% for conf in confs %}
                             <tr>
                                 <td>
-                                    {% if "dojo.change_tool_type"|has_configuration_permission %}
+                                    {% if "dojo.change_tool_type"|has_configuration_permission:request %}
                                     <a href="{% url 'edit_tool_type' conf.id %}"><b>{{ conf.name }}</b></a>
                                     {% else %}
                                     {{ conf.name }}

--- a/dojo/templates/dojo/users.html
+++ b/dojo/templates/dojo/users.html
@@ -19,7 +19,7 @@
                         {{ name }}
                         <div class="dropdown pull-right">
                             <button id="show-filters" data-toggle="collapse" data-target="#the-filters" class="btn btn-primary toggle-filters"> <i class="fa-solid fa-filter"></i> <i class="caret"></i> </button>
-                            {% if "auth.add_user"|has_configuration_permission %}
+                            {% if "auth.add_user"|has_configuration_permission:request %}
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
                                 <span class="fa-solid fa-screwdriver-wrench"></span>
@@ -78,7 +78,7 @@
                                                             <a class="" href="{% url 'view_user' u.id %}" id="viewUser">
                                                             <i class="fa-solid fa-rectangle-list"></i> {% trans "View" %}</a>
                                                         </li>
-                                                        {% if "auth.change_user"|has_configuration_permission %}
+                                                        {% if "auth.change_user"|has_configuration_permission:request %}
                                                         <li role="presentation">
                                                             <a class="" href="{% url 'edit_user' u.id %}"  id="editUser">
                                                             <i class="fa-solid fa-pen-to-square"></i> {% trans "Edit" %}</a>
@@ -90,7 +90,7 @@
                                                             <i class="fa-solid fa-clock-rotate-left"></i> {% trans "View History" %}
                                                         </a>
                                                         </li>
-                                                        {% if "auth.delete_user"|has_configuration_permission and u.id != request.user.id %}
+                                                        {% if "auth.delete_user"|has_configuration_permission:request and u.id != request.user.id %}
                                                         <li role="separator" class="divider"></li>
                                                         <li role="presentation">
                                                             <a class="" href="{% url 'delete_user' u.id %}">

--- a/dojo/templates/dojo/view_cred.html
+++ b/dojo/templates/dojo/view_cred.html
@@ -10,7 +10,7 @@
                 <div class="panel-heading tight">
                     <h3 class="has-filters">
                         Credential Manager
-                        {% if "DB_KEY"|get_config_setting == True and "dojo.add_cred_user"|has_configuration_permission %}
+                        {% if "DB_KEY"|get_config_setting == True and "dojo.add_cred_user"|has_configuration_permission:request %}
                         <div class="dropdown pull-right">
                             <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
                                     data-toggle="dropdown" aria-expanded="true">
@@ -63,11 +63,11 @@
                                     <div class="btn-group">
                                         <a class="btn btn-sm btn-secondary"
                                            href="{% url 'view_cred_details' conf.id  %}">View</a>
-                                        {% if "dojo.change_cred_user"|has_configuration_permission %}
+                                        {% if "dojo.change_cred_user"|has_configuration_permission:request %}
                                         <a class="btn btn-sm btn-warning"
                                            href="{% url 'edit_cred' conf.id  %}">Edit</a>
                                         {% endif %}
-                                        {% if "dojo.delete_cred_user"|has_configuration_permission %}
+                                        {% if "dojo.delete_cred_user"|has_configuration_permission:request %}
                                         <a class="btn btn-sm btn-danger delete-finding"
                                            href="{% url 'delete_cred' conf.id  %}">Delete</a>
                                         {% endif %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -89,7 +89,7 @@
                                 </li>
                             {% endif %}
                             <li role="separator" class="divider"></li>
-                            {% if "dojo.add_finding_template"|has_configuration_permission %}
+                            {% if "dojo.add_finding_template"|has_configuration_permission:request %}
                                 <li role="presentation">
                                     <a href="{% url 'mktemplate' finding.id %}">
                                         <i class="fa-solid fa-copy"></i> Make Finding a Template
@@ -107,14 +107,14 @@
                                         <input type="hidden" label="apply_template" aria-label="apply_template" name="id" value="{{ finding.id }}"/>
                                     </form>
                             {% endif %}
-                            {% if not cwe_template.cwe and "dojo.add_finding_template"|has_configuration_permission %}
+                            {% if not cwe_template.cwe and "dojo.add_finding_template"|has_configuration_permission:request %}
                                     <li role="presentation">
                                         <a href="{% url 'add_template' %}">
                                             <i class="fa-solid fa-copy"></i> Create a CWE Remediation Template
                                         </a>
                                     </li>
                             {% endif %}
-                            {% if finding|has_object_permission:"Finding_Edit" and "dojo.view_finding_template"|has_configuration_permission %}
+                            {% if finding|has_object_permission:"Finding_Edit" and "dojo.view_finding_template"|has_configuration_permission:request %}
                                 <li role="presentation">
                                     <a href="{% url 'find_template_to_apply' finding.id %}">
                                         <i class="fa-solid fa-copy"></i> Apply Template to Finding

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -735,14 +735,14 @@
                                             </a>
                                         </li>
                                     {% endif %}
-                                    {% if "dojo.add_finding_template"|has_configuration_permission %}
+                                    {% if "dojo.add_finding_template"|has_configuration_permission:request %}
                                         <li role="presentation">
                                             <a href="{% url 'mktemplate' finding.id %}">
                                                 <i class="fa-solid fa-copy"></i> Make Finding a Template
                                             </a>
                                         </li>
                                     {% endif %}
-                                    {% if finding|has_object_permission:"Finding_Edit" and "dojo.view_finding_template"|has_configuration_permission %}
+                                    {% if finding|has_object_permission:"Finding_Edit" and "dojo.view_finding_template"|has_configuration_permission:request %}
                                         <li role="presentation">
                                             <a href="{% url 'find_template_to_apply' finding.id %}">
                                                 <i class="fa-solid fa-copy"></i> Apply Template to Finding

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -20,7 +20,7 @@
                                 <span class="caret"></span>
                             </button>
                             <ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="dropdownMenu1">
-                                {% if "auth.change_user"|has_configuration_permission %}
+                                {% if "auth.change_user"|has_configuration_permission:request %}
                                 <li>
                                     <a class="" href="{% url 'edit_user' user.id %}">
                                         <i class="fa-solid fa-pen-to-square"></i>{% trans "Edit" %}</a>
@@ -31,7 +31,7 @@
                                     <a href="{% url 'action_history' user|content_type user.id %}">
                                         <i class="fa-solid fa-clock-rotate-left"></i>{% trans "View History" %}</a>
                                 </li>
-                                {% if "auth.delete_user"|has_configuration_permission and user.id != request.user.id %}
+                                {% if "auth.delete_user"|has_configuration_permission:request and user.id != request.user.id %}
                                 <li role="separator" class="divider"></li>
                                 <li>
                                     <a class="" href="{% url 'delete_user' user.id %}" id="deleteUser"> 

--- a/dojo/templatetags/authorization_tags.py
+++ b/dojo/templatetags/authorization_tags.py
@@ -19,8 +19,12 @@ def has_global_permission(permission):
 
 
 @register.filter
-def has_configuration_permission(permission):
-    return configuration_permission(crum.get_current_user(), permission)
+def has_configuration_permission(permission, request):
+    if request == None:
+        user = crum.get_current_user()
+    else:
+        user = crum.get_current_user() or request.user
+    return configuration_permission(user, permission)
 
 
 @cache_for_request

--- a/dojo/templatetags/authorization_tags.py
+++ b/dojo/templatetags/authorization_tags.py
@@ -20,7 +20,7 @@ def has_global_permission(permission):
 
 @register.filter
 def has_configuration_permission(permission, request):
-    if request == None:
+    if request is None:
         user = crum.get_current_user()
     else:
         user = crum.get_current_user() or request.user

--- a/unittests/authorization/test_authorization_tags.py
+++ b/unittests/authorization/test_authorization_tags.py
@@ -54,7 +54,7 @@ class TestAuthorizationTags(DojoTestCase):
         mock_configuration_permission.return_value = True
         mock_current_user.return_value = self.user
 
-        result = has_configuration_permission('test')
+        result = has_configuration_permission('test', None)
 
         self.assertTrue(result)
         mock_configuration_permission.assert_called_with(self.user, 'test')


### PR DESCRIPTION
When an error page is shown, various menu items will be unavailable due to a permissions issue.

[sc-724]