### PR TITLE
feat: fix jira errors handling

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -703,6 +703,7 @@ def add_jira_issue(obj, *args, **kwargs):
         logger.warning("The JIRA issue will NOT be created.")
         return False
     logger.debug('Trying to create a new JIRA issue for %s...', to_str_typed(obj))
+    meta = None
     try:
         JIRAError.log_to_tempfile = False
         jira = get_jira_connection(jira_instance)
@@ -825,6 +826,7 @@ def update_jira_issue(obj, *args, **kwargs):
         return False
 
     j_issue = obj.jira_issue
+    meta = None
     try:
         JIRAError.log_to_tempfile = False
         jira = get_jira_connection(jira_instance)


### PR DESCRIPTION
**Description**

I found undefined variables for two functions. It produces an error in a case when **except JIRAError** block is triggered.
