### PR TITLE
Don't create a notification alert when a finding is a duplicate

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -698,9 +698,12 @@ def add_jira_issue(obj, *args, **kwargs):
 
     obj_can_be_pushed_to_jira, error_message, error_code = can_be_pushed_to_jira(obj)
     if not obj_can_be_pushed_to_jira:
-        log_jira_alert(error_message, obj)
-        logger.warning("%s cannot be pushed to JIRA: %s.", to_str_typed(obj), error_message)
-        logger.warning("The JIRA issue will NOT be created.")
+        if type(obj) == Finding and obj.duplicate and not obj.active:
+            logger.warning("%s will not be pushed to JIRA as it's a duplicate finding", to_str_typed(obj))
+        else:
+            log_jira_alert(error_message, obj)
+            logger.warning("%s cannot be pushed to JIRA: %s.", to_str_typed(obj), error_message)
+            logger.warning("The JIRA issue will NOT be created.")
         return False
     logger.debug('Trying to create a new JIRA issue for %s...', to_str_typed(obj))
     try:


### PR DESCRIPTION
**Description**

We noticed a problem when de-duplication is enabled and when multiple engagements report the same CVE in a product with push_to_jira enabled. The first Finding creates the JIRA, but then for all subsequent Findings we get notification alerts that they can't push to JIRA, as the deduplication logic sets the Findings to inactive before push_to_jira is called.

The fix is just to check when push_to_jira fails if the finding is already marked as duplicate, and just log this rather than create an alert.

**Test results**

Test it works locally.
