### PR TITLE
msteams notifications template fix

### DIFF
--- a/dojo/templates/notifications/msteams/engagement_added.tpl
+++ b/dojo/templates/notifications/msteams/engagement_added.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {
     "@context": "https://schema.org/extensions",
     "@type": "MessageCard",

--- a/dojo/templates/notifications/msteams/other.tpl
+++ b/dojo/templates/notifications/msteams/other.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {
     "@context": "https://schema.org/extensions",
     "@type": "MessageCard",

--- a/dojo/templates/notifications/msteams/product_added.tpl
+++ b/dojo/templates/notifications/msteams/product_added.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {
     "@context": "https://schema.org/extensions",
     "@type": "MessageCard",

--- a/dojo/templates/notifications/msteams/product_type_added.tpl
+++ b/dojo/templates/notifications/msteams/product_type_added.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {
     "@context": "https://schema.org/extensions",
     "@type": "MessageCard",

--- a/dojo/templates/notifications/msteams/report_created.tpl
+++ b/dojo/templates/notifications/msteams/report_created.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {
     "@context": "https://schema.org/extensions",
     "@type": "MessageCard",

--- a/dojo/templates/notifications/msteams/risk_acceptance_expiration.tpl
+++ b/dojo/templates/notifications/msteams/risk_acceptance_expiration.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {% url 'view_test' test.id as test_url %}
 {
     "@context": "https://schema.org/extensions",

--- a/dojo/templates/notifications/msteams/scan_added.tpl
+++ b/dojo/templates/notifications/msteams/scan_added.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {% url 'view_test' test.id as test_url %}
 {
     "@context": "https://schema.org/extensions",

--- a/dojo/templates/notifications/msteams/sla_breach.tpl
+++ b/dojo/templates/notifications/msteams/sla_breach.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {% url 'view_finding' finding.id as finding_url %}
     {
         "@context": "https://schema.org/extensions",

--- a/dojo/templates/notifications/msteams/test_added.tpl
+++ b/dojo/templates/notifications/msteams/test_added.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {% url 'view_test' test.id as test_url %}
 {
     "@context": "https://schema.org/extensions",

--- a/dojo/templates/notifications/msteams/upcoming_engagement.tpl
+++ b/dojo/templates/notifications/msteams/upcoming_engagement.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {% url 'view_engagement' engagement.id as engagement_url %}
 {
     "@context": "https://schema.org/extensions",

--- a/dojo/templates/notifications/msteams/user_mentioned.tpl
+++ b/dojo/templates/notifications/msteams/user_mentioned.tpl
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load display_tags %}
 {
     "@context": "https://schema.org/extensions",
     "@type": "MessageCard",


### PR DESCRIPTION
Fix for MS Teams notifications template.
Display tags were added for Slack notifications, but were missed out for Teams.

labels: `bugfix` `msteams` `notifications`