### PR TITLE
bugfix - Add support for current close old findings behavior to UI

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -622,6 +622,11 @@ def import_scan_results(request, eid=None, pid=None):
             api_scan_configuration = form.cleaned_data.get('api_scan_configuration', None)
             service = form.cleaned_data.get('service', None)
             close_old_findings = form.cleaned_data.get('close_old_findings', None)
+            # close_old_findings_prodct_scope is a modifier of close_old_findings.
+            # If it is selected, close_old_findings should also be selected.
+            close_old_findings_product_scope = form.cleaned_data.get('close_old_findings_product_scope', None)
+            if close_old_findings_product_scope == True:
+                close_old_findings = True
             # Will save in the provided environment or in the `Development` one if absent
             environment_id = request.POST.get('environment', 'Development')
             environment = Development_Environment.objects.get(id=environment_id)
@@ -682,7 +687,7 @@ def import_scan_results(request, eid=None, pid=None):
                 test, finding_count, closed_finding_count, _ = importer.import_scan(scan, scan_type, engagement, user, environment, active=active, verified=verified, tags=tags,
                             minimum_severity=minimum_severity, endpoints_to_add=list(form.cleaned_data['endpoints']) + added_endpoints, scan_date=scan_date,
                             version=version, branch_tag=branch_tag, build_id=build_id, commit_hash=commit_hash, push_to_jira=push_to_jira,
-                            close_old_findings=close_old_findings, group_by=group_by, api_scan_configuration=api_scan_configuration, service=service,
+                            close_old_findings=close_old_findings, close_old_findings_product_scope=close_old_findings_product_scope, group_by=group_by, api_scan_configuration=api_scan_configuration, service=service,
                             create_finding_groups_for_all_findings=create_finding_groups_for_all_findings)
 
                 message = f'{scan_type} processed a total of {finding_count} findings'

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -625,7 +625,7 @@ def import_scan_results(request, eid=None, pid=None):
             # close_old_findings_prodct_scope is a modifier of close_old_findings.
             # If it is selected, close_old_findings should also be selected.
             close_old_findings_product_scope = form.cleaned_data.get('close_old_findings_product_scope', None)
-            if close_old_findings_product_scope == True:
+            if close_old_findings_product_scope:
                 close_old_findings = True
             # Will save in the provided environment or in the `Development` one if absent
             environment_id = request.POST.get('environment', 'Development')

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -455,19 +455,19 @@ class ImportScanForm(forms.Form):
         required=False)
 
     # Close Old Findings has changed. The default is engagement only, and it requires a second flag to expand to the product scope.
-    # Exposing the choice as two different check boxes. 
+    # Exposing the choice as two different check boxes.
     # If 'close_old_findings_product_scope' is selected, the backend will ensure that both flags are set.
     close_old_findings = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
                                                         "If service has been set, only the findings for this service will be closed. "
                                                         "This only affects findings within the same engagement.",
-                                            label="Close old findings within this engagement", 
-                                            required=False, 
+                                            label="Close old findings within this engagement",
+                                            required=False,
                                             initial=False)
     close_old_findings_product_scope = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
                                                         "If service has been set, only the findings for this service will be closed. "
                                                         "This only affects findings within the same product.",
                                             label="Close old findings within this product",
-                                            required=False, 
+                                            required=False,
                                             initial=False)
 
     if is_finding_groups_enabled():

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -454,10 +454,21 @@ class ImportScanForm(forms.Form):
         allow_empty_file=True,
         required=False)
 
-    close_old_findings = forms.BooleanField(help_text="Select if old findings no longer present in the report get closed as mitigated when importing. "
+    # Close Old Findings has changed. The default is engagement only, and it requires a second flag to expand to the product scope.
+    # Exposing the choice as two different check boxes. 
+    # If 'close_old_findings_product_scope' is selected, the backend will ensure that both flags are set.
+    close_old_findings = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
                                                         "If service has been set, only the findings for this service will be closed. "
-                                                        "This affects the whole engagement/product depending on your deduplication scope.",
-                                            required=False, initial=False)
+                                                        "This only affects findings within the same engagement.",
+                                            label="Close old findings within this engagement", 
+                                            required=False, 
+                                            initial=False)
+    close_old_findings_product_scope = forms.BooleanField(help_text="Old findings no longer present in the new report get closed as mitigated when importing. "
+                                                        "If service has been set, only the findings for this service will be closed. "
+                                                        "This only affects findings within the same product.",
+                                            label="Close old findings within this product",
+                                            required=False, 
+                                            initial=False)
 
     if is_finding_groups_enabled():
         group_by = forms.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text='Choose an option to automatically group new findings by the chosen option.')


### PR DESCRIPTION
**Description**

A couple months ago import_scan changed its default behavior for closing findings. The `close_old_findings` flag now only covers the same engagement. If you want it to cover all findings in the same product you have to send a second flag along with the first, `close_old_findings_product_scope`. The Import Scan page does not reflect this change, and currently only supports closing findings within the same engagement. 

This PR adds a check box for 'close_old_findings_product_scope' to the Import Scan page. Instead of requiring both check boxes to be selected, which could be confusing, the checkboxes are presented as two separate choices. One to close old findings at the engagement scope, and one for closing old findings at the product scope. The backend code ensures both flags are set to true when 'close_old_findings_product_scope' is selected.

This issue isn't operating system dependent, but I replicated it using docker compose on my Mac OS 13.3.1.

**Test results**

Tested closing old findings at both the engagement and product level using the UI.
Existing unit tests passed. 



