### PR TITLE
Strip spaces from tags before pushing to jira

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -528,13 +528,16 @@ def get_labels(obj):
 
 
 def get_tags(obj):
+    # Set an invalid characeter list
+    invalid_characters = [':', ';', ',', '.', ' ', '?', '&', '[', ']', '(', ')', '#', '^', '*', '@', '!']
     # Update Label with system setttings label
     tags = []
     if isinstance(obj, Finding) or isinstance(obj, Engagement):
         obj_tags = obj.tags.all()
         if obj_tags:
             for tag in obj_tags:
-                tags.append(str(tag.name.replace(' ', '-')))
+                cleaned_tag = '-'.join([invalid_character for invalid_character in tag if invalid_character not in invalid_characters])
+                tags.append(str(cleaned_tag))
     return tags
 
 

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -534,7 +534,7 @@ def get_tags(obj):
         obj_tags = obj.tags.all()
         if obj_tags:
             for tag in obj_tags:
-                tags.append(str(tag.name))
+                tags.append(str(tag.name.replace(' ', '-')))
     return tags
 
 

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -528,17 +528,14 @@ def get_labels(obj):
 
 
 def get_tags(obj):
-    # Set an invalid characeter list
-    invalid_characters = [':', ';', ',', '.', ' ', '?', '&', '[', ']', '(', ')', '#', '^', '*', '@', '!']
     # Update Label with system setttings label
     tags = []
     if isinstance(obj, Finding) or isinstance(obj, Engagement):
-        obj_tags = obj.tags.all()
-        if obj_tags:
-            for tag in obj_tags:
-                cleaned_tag = '-'.join([invalid_character for invalid_character in tag if invalid_character not in invalid_characters])
-                tags.append(str(cleaned_tag))
-    return tags
+         obj_tags = obj.tags.all()
+         if obj_tags:
+             for tag in obj_tags:
+                 tags.append(str(tag.name.replace(' ', '-')))
+     return tags
 
 
 def jira_summary(obj):

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -531,11 +531,11 @@ def get_tags(obj):
     # Update Label with system setttings label
     tags = []
     if isinstance(obj, Finding) or isinstance(obj, Engagement):
-         obj_tags = obj.tags.all()
-         if obj_tags:
-             for tag in obj_tags:
-                 tags.append(str(tag.name.replace(' ', '-')))
-     return tags
+        obj_tags = obj.tags.all()
+        if obj_tags:
+            for tag in obj_tags:
+                tags.append(str(tag.name.replace(' ', '-')))
+    return tags
 
 
 def jira_summary(obj):


### PR DESCRIPTION
Jira does not allow spaces in their tags. Remove the spaces in tags coming from dojo before they are pushed out to jira
