### PR TITLE
Replace incorrect link in slack alert for product deletion + add product to SLA breach alert

### DIFF
--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -955,7 +955,7 @@ def delete_product(request, pid):
                                     product_type=product_type,
                                     description=_('The product "%(name)s" was deleted by %(user)s') % {
                                         'name': product.name, 'user': request.user},
-                                    url=request.build_absolute_uri(reverse('product')),
+                                    url=reverse('product'),
                                     icon="exclamation-triangle")
                 logger.debug('delete_product: POST RETURN')
                 return HttpResponseRedirect(reverse('product'))

--- a/dojo/templates/notifications/alert/sla_breach.tpl
+++ b/dojo/templates/notifications/alert/sla_breach.tpl
@@ -1,3 +1,3 @@
-{% load i18n %}{% blocktranslate trimmed with finding_id=finding.id %}
-SLA breach alert for finding {{ finding_id }}. Relative days count to SLA due date: {{sla_age}}.
+{% load i18n %}{% blocktranslate trimmed with finding_id=finding.id product_name=finding.test.engagement.product %}
+SLA breach alert for finding {{ finding_id }} in product {{ product_name }}. Relative days count to SLA due date: {{sla_age}}.
 {% endblocktranslate %}

--- a/dojo/templates/notifications/slack/sla_breach.tpl
+++ b/dojo/templates/notifications/slack/sla_breach.tpl
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load display_tags %}
-{% blocktranslate trimmed with id=finding.id title=finding.title severity=finding.severity sla_url=url|full_url %}
-SLA breach alert for finding {{ id }}. Relative days count to SLA due date: {{sla_age}}.
+{% blocktranslate trimmed with id=finding.id product_name=finding.test.engagement.product title=finding.title severity=finding.severity sla_url=url|full_url %}
+SLA breach alert for finding {{ id }} in product {{ product_name }}. Relative days count to SLA due date: {{sla_age}}.
 Title: {{title}}
 Severity: {{severity}}
 You can find details here: {{ sla_url }}

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1896,7 +1896,7 @@ def sla_compute_and_notify(*args, **kwargs):
                     logger.info("Security SLA breach warning. Finding ID {} breaching today ({})".format(finding.id, sla_age))
                     _notify(finding, "Finding {} - SLA is breaching today".format(finding.id))
 
-            logger.info("SLA run results: Pre-breach: {}, at-breach: {}, post-breach: {} post-breach-no-notify: {}, with-jira: {}, TOTAL: {}".format(
+            logger.info("SLA run results: Pre-breach: {}, at-breach: {}, post-breach: {}, post-breach-no-notify: {}, with-jira: {}, TOTAL: {}".format(
                 pre_breach_count,
                 at_breach_count,
                 post_breach_count,


### PR DESCRIPTION
**Description**

If you delete a product with slack alerting enabled, you get a bad link like:

The product "Test Product2" was deleted by coheigea
More information on this event can be found here: http://localhost:8080http://localhost:8080/product

I changed it just to link to the main product page. I also added in the product name to the SLA breach alert, as I think it's useful to see this information.

**Test results**

Tested both with slack.