### PR TITLE
SLA computation throws exception when a FindingGroup doesn't have a JIRA

### DIFF
--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -154,6 +154,7 @@ def async_sla_compute_and_notify_task(*args, **kwargs):
         if system_settings.enable_finding_sla:
             sla_compute_and_notify(*args, **kwargs)
     except Exception as e:
+        logger.exception(e)
         logger.error("An unexpected error was thrown calling the SLA code: {}".format(e))
 
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1847,7 +1847,7 @@ def sla_compute_and_notify(*args, **kwargs):
                 jira_issue = None
                 if finding.has_jira_issue:
                     jira_issue = finding.jira_issue
-                elif finding.has_finding_group:
+                elif finding.has_jira_group_issue:
                     jira_issue = finding.finding_group.jira_issue
 
                 if jira_issue:


### PR DESCRIPTION
**Description**

We get this error with SLA computation when a FindingGroup doesn't have a JIRA:

[03/May/2023 07:30:00] INFO [dojo.utils:1796] About to process findings for SLA notifications.
[03/May/2023 07:30:03] ERROR [dojo.tasks:157] An unexpected error was thrown calling the SLA code: Finding_Group has no jira_issue.