### PR TITLE
[Github parser] Parse dependabot alert number and add link in description

### DIFF
--- a/docs/content/en/integrations/parsers/file/github_vulnerability.md
+++ b/docs/content/en/integrations/parsers/file/github_vulnerability.md
@@ -37,65 +37,27 @@ References:
  - https://docs.github.com/en/graphql/reference/objects#repositoryvulnerabilityalert
  - https://docs.github.com/en/graphql/reference/objects#securityvulnerability
 
-Github v4 graphql query to fetch data:
+Github v4 graphql query to fetch data, with extended information like the repository name and url, alert number.
 
 {{< highlight graphql >}}
-    query getVulnerabilitiesByOwner($owner: String!) {
-    search(query: $owner, type: REPOSITORY, first: 100) {
-      nodes {
-        ... on Repository {
-          name
-          vulnerabilityAlerts(last: 100) {
-            nodes {
-              id
-              vulnerableManifestPath
-              securityVulnerability {
-                severity
-                package {
-                  name
-                }
-                advisory {
-                  description
-                  summary
-                  identifiers {
-                    type
-                    value
-                  }
-                  references {
-                    url
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-{{< /highlight >}}
-
-Another example of Python script that query one repository:
-
-```python
-
-import json
-import requests
-
-
-query = """
 query getVulnerabilitiesByRepoAndOwner($name: String!, $owner: String!) {
   repository(name: $name, owner: $owner) {
-    vulnerabilityAlerts(first: 100) {
+    vulnerabilityAlerts(first: 100, after:AFTER, states: OPEN) {
       nodes {
         id
         createdAt
         vulnerableManifestPath
         securityVulnerability {
           severity
+          updatedAt
           package {
             name
             ecosystem
           }
+          firstPatchedVersion {
+            identifier
+          }
+          vulnerableVersionRange
           advisory {
             description
             summary
@@ -112,27 +74,138 @@ query getVulnerabilitiesByRepoAndOwner($name: String!, $owner: String!) {
           }
         }
         vulnerableManifestPath
+        state
+        vulnerableManifestFilename
+        vulnerableRequirements
+        number
+        dependencyScope
+        dismissComment
+        dismissReason
+        dismissedAt
+        fixedAt
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        hasNextPage
+        hasPreviousPage
+        startCursor
       }
     }
+    nameWithOwner
+    url
   }
 }
-"""
+{{< /highlight >}}
 
-token = '...' # generated from GitHub settings
-headers = {"Authorization": "Bearer " + token}
+Another example of Python script, to have a function that queries any repository, with support for paginated responses and get all findings.
+Has a filter to only get OPEN dependabot alerts but this can be removed in the GraphQL query
 
+```python
+def make_query(after_cursor=None):
+    return """
+query getVulnerabilitiesByRepoAndOwner($name: String!, $owner: String!) {
+  repository(name: $name, owner: $owner) {
+    vulnerabilityAlerts(first: 100, after:AFTER, states: OPEN) {
+      nodes {
+        id
+        createdAt
+        vulnerableManifestPath
+        securityVulnerability {
+          severity
+          updatedAt
+          package {
+            name
+            ecosystem
+          }
+          firstPatchedVersion {
+            identifier
+          }
+          vulnerableVersionRange
+          advisory {
+            description
+            summary
+            identifiers {
+              value
+              type
+            }
+            references {
+              url
+            }
+            cvss {
+              vectorString
+            }
+          }
+        }
+        vulnerableManifestPath
+        state
+        vulnerableManifestFilename
+        vulnerableRequirements
+        number
+        dependencyScope
+        dismissComment
+        dismissReason
+        dismissedAt
+        fixedAt
+      }
+      totalCount
+      pageInfo {
+        endCursor
+        hasNextPage
+        hasPreviousPage
+        startCursor
+      }
+    }
+    nameWithOwner
+    url
+  }
+}
+""".replace(
+        "AFTER", '"{}"'.format(after_cursor) if after_cursor else "null"
+    )
 
-request = requests.post(url='https://api.github.com/graphql',
-                        json={
-                          "operationName": "getVulnerabilitiesByRepoAndOwner",
-                          'query': query,
-                          'variables': {
-                            'name': 'gogoph',
-                            'owner': 'damiencarol'
-                          }
-                        },
-                        headers=headers)
+# accumulates all pages data into a single object
+def get_dependabot_alerts_repository(repo, owner):
+    keep_fetching = True
+    after_cursor = None
+    output_result = {"data": {"repository": {"vulnerabilityAlerts": {"nodes": []}}}}
+    while keep_fetching:
+        headers = {"Authorization": AUTH_TOKEN}
 
-result = request.json()
-print(json.dumps(result, indent=2))
+        request = requests.post(
+            url="https://api.github.com/graphql",
+            json={
+                "operationName": "getVulnerabilitiesByRepoAndOwner",
+                "query": make_query(after_cursor),
+                "variables": {"name": repo, "owner": owner},
+            },
+            headers=headers,
+        )
+
+        result = request.json()
+        output_result["data"]["repository"]["name"] = result["data"]["repository"][
+            "name"
+        ]
+        output_result["data"]["repository"]["url"] = result["data"]["repository"]["url"]
+        if result["data"]["repository"]["vulnerabilityAlerts"]["totalCount"] == 0:
+            return None
+
+        output_result["data"]["repository"]["vulnerabilityAlerts"]["nodes"] += result[
+            "data"
+        ]["repository"]["vulnerabilityAlerts"]["nodes"]
+
+        keep_fetching = result["data"]["repository"]["vulnerabilityAlerts"]["pageInfo"][
+            "hasNextPage"
+        ]
+        after_cursor = result["data"]["repository"]["vulnerabilityAlerts"]["pageInfo"][
+            "endCursor"
+        ]
+    print(
+        "Fetched {} alerts for repo {}/{}".format(
+            result["data"]["repository"]["vulnerabilityAlerts"]["totalCount"],
+            owner,
+            repo,
+        )
+    )
+    return json.dumps(output_result, indent=2)
 ```

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -36,7 +36,8 @@ class GithubVulnerabilityParser(object):
             description = alert["securityVulnerability"]["advisory"]["description"]
 
             if "number" in alert and repository_url is not None:
-                description = repository_url + '/security/dependabot/{}'.format(alert["number"]) + '\n' + description
+                dependabot_url = repository_url + '/security/dependabot/{}'.format(alert["number"])
+                description =  '[{}]({})\n'.format(dependabot_url, dependabot_url) + description
 
             finding = Finding(
                 title=alert["securityVulnerability"]["advisory"]["summary"],

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -23,21 +23,21 @@ class GithubVulnerabilityParser(object):
         vulnerabilityAlerts = self._search_vulnerability_alerts(data["data"])
         if not vulnerabilityAlerts:
             raise ValueError("Invalid report, no 'vulnerabilityAlerts' node found")
-        
+
         repository_url = None
         if "repository" in data["data"]:
             if "nameWithOwner" in  data["data"]["repository"]:
                 repository_url = 'https://github.com/{}'.format(data["data"]["repository"]["nameWithOwner"])
             if "url" in data["data"]["repository"]:
                 repository_url = data["data"]["repository"]["url"]
-                
+
         dupes = dict()
         for alert in vulnerabilityAlerts["nodes"]:
             description = alert["securityVulnerability"]["advisory"]["description"]
-            
+
             if "number" in alert and repository_url is not None:
                 description = repository_url + '/security/dependabot/{}'.format(alert["number"]) + '\n' + description
-                
+
             finding = Finding(
                 title=alert["securityVulnerability"]["advisory"]["summary"],
                 test=test,

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -23,13 +23,25 @@ class GithubVulnerabilityParser(object):
         vulnerabilityAlerts = self._search_vulnerability_alerts(data["data"])
         if not vulnerabilityAlerts:
             raise ValueError("Invalid report, no 'vulnerabilityAlerts' node found")
-
+        
+        repository_url = None
+        if "repository" in data["data"]:
+            if "nameWithOwner" in  data["data"]["repository"]:
+                repository_url = 'https://github.com/{}'.format(data["data"]["repository"]["nameWithOwner"])
+            if "url" in data["data"]["repository"]:
+                repository_url = data["data"]["repository"]["url"]
+                
         dupes = dict()
         for alert in vulnerabilityAlerts["nodes"]:
+            description = alert["securityVulnerability"]["advisory"]["description"]
+            
+            if "number" in alert and repository_url is not None:
+                description = repository_url + '/security/dependabot/{}'.format(alert["number"]) + '\n' + description
+                
             finding = Finding(
                 title=alert["securityVulnerability"]["advisory"]["summary"],
                 test=test,
-                description=alert["securityVulnerability"]["advisory"]["description"],
+                description=description,
                 severity=self._convert_security(alert["securityVulnerability"].get("severity", "MODERATE")),
                 static_finding=True,
                 dynamic_finding=False,

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -26,7 +26,7 @@ class GithubVulnerabilityParser(object):
 
         repository_url = None
         if "repository" in data["data"]:
-            if "nameWithOwner" in  data["data"]["repository"]:
+            if "nameWithOwner" in data["data"]["repository"]:
                 repository_url = 'https://github.com/{}'.format(data["data"]["repository"]["nameWithOwner"])
             if "url" in data["data"]["repository"]:
                 repository_url = data["data"]["repository"]["url"]

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -37,7 +37,7 @@ class GithubVulnerabilityParser(object):
 
             if "number" in alert and repository_url is not None:
                 dependabot_url = repository_url + '/security/dependabot/{}'.format(alert["number"])
-                description =  '[{}]({})\n'.format(dependabot_url, dependabot_url) + description
+                description = '[{}]({})\n'.format(dependabot_url, dependabot_url) + description
 
             finding = Finding(
                 title=alert["securityVulnerability"]["advisory"]["summary"],

--- a/unittests/scans/github_vulnerability/github-1-vuln-repo-dependabot-link.json
+++ b/unittests/scans/github_vulnerability/github-1-vuln-repo-dependabot-link.json
@@ -1,0 +1,46 @@
+{
+  "data": {
+    "repository": {
+      "nameWithOwner": "OWASP/test-repository",
+      "search": {
+        "nodes": [
+          {
+            "vulnerabilityAlerts": {
+              "nodes": [
+                {
+                  "id": "aabbccddeeff1122334401",
+                  "number": "1",
+                  "securityVulnerability": {
+                    "severity": "CRITICAL",
+                    "package": {
+                      "name": "package"
+                    },
+                    "advisory": {
+                      "description": "This is a sample description for sample description from Github API.",
+                      "summary": "Critical severity vulnerability that affects package",
+                      "identifiers": [
+                        {
+                          "type": "TEST_SOURCE_1",
+                          "value": "TEST-aaaa-bbbb-cccc"
+                        },
+                        {
+                          "type": "TEST_SOURCE_2",
+                          "value": "TEST-1111-2222-3333"
+                        }
+                      ],
+                      "references": [
+                        {
+                          "url": "https://help.github.com/en/github/managing-security-vulnerabilities"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/unittests/tools/test_github_vulnerability_parser.py
+++ b/unittests/tools/test_github_vulnerability_parser.py
@@ -35,6 +35,26 @@ class TestGithubVulnerabilityParser(DojoTestCase):
             self.assertEqual(finding.component_name, "package")
             self.assertEqual(finding.unique_id_from_tool, "aabbccddeeff1122334401")
 
+    def test_parse_file_with_one_vuln_has_one_finding_and_dependabot_direct_link(self):
+        """sample with one vulnerability"""
+        testfile = open("unittests/scans/github_vulnerability/github-1-vuln-repo-dependabot-link.json")
+        parser = GithubVulnerabilityParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+        for finding in findings:
+            finding.clean()
+
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual(finding.title, "Critical severity vulnerability that affects package")
+            self.assertEqual(
+                finding.description,
+                "[https://github.com/OWASP/test-repository/security/dependabot/1](https://github.com/OWASP/test-repository/security/dependabot/1)\nThis is a sample description for sample description from Github API.",
+            )
+            self.assertEqual(finding.severity, "Critical")
+            self.assertEqual(finding.component_name, "package")
+            self.assertEqual(finding.unique_id_from_tool, "aabbccddeeff1122334401")
+
     def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
         """sample with five vulnerability"""
         testfile = open("unittests/scans/github_vulnerability/github-5-vuln.json")


### PR DESCRIPTION
It's currently quite unusable to view dependabot alerts because they don't give a direct link into the Github platform, to maybe triage things there, get more details... view the PR attached etc...

Funny thing is, Github doesn't return a direct link to the alert, so you must either return the repo URL, or at least the full name with the org/owner, and build from there.

Another thing that I can't fix unfortunately: directly linking to the file in Github is hard, because yet again, Github's API isn't telling you the branch where the issue was detected. Dependabot opens PRs properly though, so maybe you could introspect the PR it has opened and find out the target branch... if someone reads this and wants to bother