### PR TITLE
Only alert on a JIRA error where the JIRA is active

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -900,7 +900,9 @@ def update_jira_issue(obj, *args, **kwargs):
     except JIRAError as e:
         logger.exception(e)
         logger.error("jira_meta for project: %s and url: %s meta: %s", jira_project.project_key, jira_project.jira_instance.url, json.dumps(meta, indent=4))  # this is None safe
-        log_jira_alert(e.text, obj)
+        if issue_from_jira_is_active(issue):
+            # Only alert if the upstream JIRA is active, we don't care about closed issues
+            log_jira_alert(e.text, obj)
         return False
 
 


### PR DESCRIPTION
**Description**

If a team resolve a JIRA upstream of DefectDojo, and if the JIRA workflow is such that a JIRA can't be edited when in a resolved/rejected state, then DefectDojo alerts when trying to resolve the Finding if push_to_jira is enabled. Instead we should just log the error, if the upstream JIRA is already resolved/rejected then an alert is not required.

**Test results**

Tested an alert does not happen any more in this scenario.