### PR TITLE
Add Permissions.Engagement_Add to API_Importer

### DIFF
--- a/docs/content/en/usage/permissions.md
+++ b/docs/content/en/usage/permissions.md
@@ -43,7 +43,7 @@ Users can be assigned as members to Products and Product Types, giving them one 
 |                             |        |        |            |       |              |
 | View Test                   | x      | x      | x          | x     | x            |
 | Add Test                    |        | x      | x          | x     |              |
-| Edit Test                   |        | x      | x          | x     |              |
+| Edit Test                   |        | x      | x          | x     | x            |
 | Delete Test                 |        |        | x          | x     |              |
 |                             |        |        |            |       |              |
 | View Finding                | x      | x      | x          | x     | x            |

--- a/docs/content/en/usage/permissions.md
+++ b/docs/content/en/usage/permissions.md
@@ -36,8 +36,8 @@ Users can be assigned as members to Products and Product Types, giving them one 
 | Delete Product              |        |        |            | x     |              |
 |                             |        |        |            |       |              |
 | View Engagement             | x      | x      | x          | x     |  x           |
-| Add Engagement              |        | x      | x          | x     |              |
-| Edit Engagement             |        | x      | x          | x     |              |
+| Add Engagement              |        | x      | x          | x     |  x           |
+| Edit Engagement             |        | x      | x          | x     |  x           |
 | Risk Acceptance             |        | x      | x          | x     |              |
 | Delete Engagement           |        |        | x          | x     |              |
 |                             |        |        |            |       |              |

--- a/dojo/authorization/roles_permissions.py
+++ b/dojo/authorization/roles_permissions.py
@@ -290,6 +290,7 @@ def get_roles_with_permissions():
             Permissions.Product_Type_View,
             Permissions.Product_View,
             Permissions.Engagement_View,
+            Permissions.Engagement_Add,
             Permissions.Engagement_Edit,
             Permissions.Test_View,
             Permissions.Test_Edit,


### PR DESCRIPTION
**Description**

In some cases, if it useful if `API_Importer` can create Engagement - If developer would like to have each build of software in separated Engagement.
Plus, change from https://github.com/DefectDojo/django-DefectDojo/pull/5324 has not been covered in documentation until now.

**Test results**

-

**Documentation**

Updated

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
