### PR TITLE
Fix bug with mitigated findings

### DIFF
--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -142,6 +142,8 @@ class DojoDefaultReImporter(object):
                 elif finding.is_mitigated:
                     # if the reimported item has a mitigation time, we can compare
                     if item.is_mitigated:
+                        unchanged_items.append(finding)
+                        unchanged_count += 1
                         if item.mitigated:
                             logger.debug(
                                 "item mitigated time: "
@@ -283,6 +285,10 @@ class DojoDefaultReImporter(object):
                             finding.active = False
                             if verified is not None:
                                 finding.verified = verified
+                        else:
+                            # if finding is the same but list of affected was changed, finding is marked as unchanged. This is a known issue
+                            unchanged_items.append(finding)
+                            unchanged_count += 1
 
                     if (component_name is not None and not finding.component_name) or (
                         component_version is not None and not finding.component_version
@@ -299,9 +305,6 @@ class DojoDefaultReImporter(object):
                         )
                         finding.save(dedupe_option=False)
 
-                    # if finding is the same but list of affected was changed, finding is marked as unchanged. This is a known issue
-                    unchanged_items.append(finding)
-                    unchanged_count += 1
                 if finding.dynamic_finding:
                     logger.debug(
                         "Re-import found an existing dynamic finding for this new finding. Checking the status of endpoints"
@@ -449,7 +452,7 @@ class DojoDefaultReImporter(object):
                 [
                     finding.finding_group
                     for finding in reactivated_items + unchanged_items
-                    if finding.finding_group is not None
+                    if finding.finding_group is not None and not finding.is_mitigated
                 ]
             ):
                 jira_helper.push_to_jira(finding_group)

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -385,7 +385,7 @@ class ImportReimportMixin(object):
         notes_count_before = self.db_notes_count()
 
         # reimport exact same report
-        with assertTestImportModelsCreated(self, reimports=1, affected_findings=0, created=0, closed=0, reactivated=0, untouched=1):
+        with assertTestImportModelsCreated(self, reimports=1, affected_findings=1, created=0, closed=1, reactivated=0, untouched=0):
             reimport_veracode_mitigated_findings = self.reimport_scan_with_params(test_id, self.veracode_mitigated_findings, scan_type=self.scan_type_veracode)
 
         test_id = reimport_veracode_mitigated_findings['test']
@@ -395,16 +395,15 @@ class ImportReimportMixin(object):
         self.log_finding_summary_json_api(findings)
 
         # reimported count must match count in veracode report
-        # we set verified=False in this reimport but DD keeps true as per the previous import (reimport doesn't "unverify" findings)
         findings = self.get_test_findings_api(test_id, verified=True)
-        self.assert_finding_count_json(0, findings)
+        self.assert_finding_count_json(1, findings)
 
         # inversely, we should see no findings with verified=False
         findings = self.get_test_findings_api(test_id, verified=False)
-        self.assert_finding_count_json(1, findings)
+        self.assert_finding_count_json(0, findings)
 
-        # reimporting the exact same scan shouldn't create any notes
-        self.assertEqual(notes_count_before, self.db_notes_count())
+        # reimporting the exact same scan shouldn't create any notes, but there will be a new mitigated note
+        self.assertEqual(notes_count_before, self.db_notes_count() - 1)
         mitigated_findings = self.get_test_findings_api(test_id, is_mitigated=True)
         self.assert_finding_count_json(1, mitigated_findings)
 


### PR DESCRIPTION
**Description**

When parsing a mitigated finding in the re-importer that is already mitigated, it doesn't add it to the list of unchanged items, so it always tries to close the old finding (which causes a JIRA ping if JIRA is enabled for the finding). There is a second bug fixed where newly mitigated findings aren't added to the mitigated list. 

**Test results**

Tested it manually. I fixed the test logic which was incorrect IMO, reimporting a newly mitigated finding should show an issue being closed and not remaining "untouched".
