### PR TITLE
Add TAGS from SARIF rules and results to findings

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -80,13 +80,11 @@ def get_rules(run):
     return rules
 
 
-def get_rule_tags(rule):
-    if 'properties' not in rule:
+# Rules and results have de sames scheme for tags
+def get_properties_tags(value):
+    if not value:
         return []
-    if 'tags' not in rule['properties']:
-        return []
-    else:
-        return rule['properties']['tags']
+    return value.get('properties', {}).get('tags', [])
 
 
 def search_cwe(value, cwes):
@@ -104,7 +102,7 @@ def get_rule_cwes(rule):
             search_cwe(value, cwes)
         return cwes
 
-    for tag in get_rule_tags(rule):
+    for tag in get_properties_tags(rule):
         search_cwe(tag, cwes)
     return cwes
 
@@ -371,6 +369,10 @@ def get_item(result, rules, artifacts, run_date):
 
     if run_date:
         finding.date = run_date
+
+    # manage tags provided in the report and rule and remove duplicated
+    tags = list(set(get_properties_tags(rule) + get_properties_tags(result)))
+    finding.tags = tags
 
     # manage fingerprints
     # fingerprinting in SARIF is more complete than in current implementation

--- a/unittests/tools/test_sarif_parser.py
+++ b/unittests/tools/test_sarif_parser.py
@@ -559,3 +559,10 @@ class TestSarifParser(DojoTestCase):
             {"stableResultHash": {"version": 2, "value": "234567900abcd"}},
             get_fingerprints_hashes(data2["fingerprints"]),
         )
+
+    def test_tags_from_result_properties(self):
+        testfile = open(path.join(path.dirname(__file__), "../scans/sarif/taint-python-report.sarif"))
+        parser = SarifParser()
+        findings = parser.get_findings(testfile, Test())
+        item = findings[0]
+        self.assertEqual(["Scan"], item.tags)


### PR DESCRIPTION
**Description**

This pull request introduces a new feature to the SARIF parser in DefectDojo. The feature enhances the parser's functionality by extracting tags from both the rules and results sections of the SARIF file. This addition allows users to have a more comprehensive understanding of the findings and better categorize them based on the extracted tags.

**Test results**
- unittests/tools/test_sarif_parser.py 
Updated the parser's unit tests to include a new test case, test_tags_from_result_properties, which verifies the correct extraction and assignment of tags to the findings.

**Documentation**

no needed

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is flake8 compliant.
- [X] Your code is python 3.11 compliant.
- [X] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [X] Add applicable tests to the unit tests.
- [X] Add the proper label to categorize your PR.
