### PR TITLE
Make PostgreSQL database the default for containerized deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ git clone https://github.com/DefectDojo/django-DefectDojo
 cd django-DefectDojo
 # building
 ./dc-build.sh
-# running (for other profiles besides mysql-rabbitmq look at https://github.com/DefectDojo/django-DefectDojo/blob/dev/readme-docs/DOCKER.md)
-./dc-up.sh mysql-rabbitmq
+# running (for other profiles besides postgres-redis look at https://github.com/DefectDojo/django-DefectDojo/blob/dev/readme-docs/DOCKER.md)
+./dc-up.sh postgres-redis
 # obtain admin credentials. the initializer can take up to 3 minutes to run
 # use docker-compose logs -f initializer to track progress
 docker-compose logs initializer | grep "Admin password:"

--- a/dc-build.sh
+++ b/dc-build.sh
@@ -12,4 +12,4 @@ fi
 
 # Building images for all configurations
 # The docker build doesn't supply any environment variables to the Dockerfile, so we can use any profile.
-docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env build $1
+docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env build $1

--- a/dc-down.sh
+++ b/dc-down.sh
@@ -12,4 +12,4 @@ fi
 
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
-docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down $1
+docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env down $1

--- a/dc-stop.sh
+++ b/dc-stop.sh
@@ -12,4 +12,4 @@ fi
 
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
-docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env stop $1
+docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env stop $1

--- a/dc-unittest.sh
+++ b/dc-unittest.sh
@@ -22,7 +22,7 @@ usage() {
   echo "You must specify a test case (arg) and profile (arg or env var)!"
   echo
   echo "Example command:"
-  echo "./dc-unittest.sh --profile mysql-rabbitmq --test-case unittests.tools.test_stackhawk_parser.TestStackHawkParser"
+  echo "./dc-unittest.sh --profile postgres-redis --test-case unittests.tools.test_stackhawk_parser.TestStackHawkParser"
 }
 
 while [[ $# -gt 0 ]]; do

--- a/dc-up-d.sh
+++ b/dc-up-d.sh
@@ -9,15 +9,15 @@ if [ $# -eq 0 ]
 then
     if [ -z $DD_PROFILE ]
     then
-        echo "No profile supplied, running default: mysql-rabbitmq"
-        PROFILE="mysql-rabbitmq"
+        echo "No profile supplied, running default: postgres-redis"
+        PROFILE="postgres-redis"
         echo "Other supported profiles:
-          mysql-rabbitmq*
-          mysql-redis
+          postgres-redis*
           postgres-rabbitmq
-          postgres-redis
+          mysql-redis
+          mysql-rabbitmq
 
-        Usage example: ./dc-up-d.sh mysql-redis
+        Usage example: ./dc-up-d.sh mysql-rabbitmq
         "
     else
         PROFILE=$DD_PROFILE

--- a/dc-up.sh
+++ b/dc-up.sh
@@ -8,15 +8,15 @@ if [[ $? -eq 1 ]]; then exit 1; fi
 if [ $# -eq 0 ]; then
     if [ -z $DD_PROFILE ]
     then
-        echo "No profile supplied, running default: mysql-rabbitmq"
-        PROFILE="mysql-rabbitmq"
+        echo "No profile supplied, running default: postgres-redis"
+        PROFILE="postgres-redis"
         echo "Other supported profiles:
-          mysql-rabbitmq*
-          mysql-redis
+          postgres-redis*
           postgres-rabbitmq
-          postgres-redis
+          mysql-redis
+          mysql-rabbitmq
 
-        Usage example: ./dc-up.sh mysql-redis
+        Usage example: ./dc-up.sh mysql-rabbitmq
         "
     else
         PROFILE=$DD_PROFILE

--- a/docs/content/en/getting_started/architecture.md
+++ b/docs/content/en/getting_started/architecture.md
@@ -43,5 +43,5 @@ itself down after all tasks are performed.
 
 ## Database
 
-The Database stores all the application data of DefectDojo. Currently [MySQL](https://dev.mysql.com/)
-and [PostgreSQL](https://www.postgresql.org/) are supported. Please note the `django-watson` search engine require one or more MyISAM tables, so you cannot use Azure MySQL or Cloud SQL for MySQL. AWS RDS MySQL supports MyISAM tables.
+The Database stores all the application data of DefectDojo. Currently [PostgreSQL](https://www.postgresql.org/) and [MySQL](https://dev.mysql.com/)
+are supported, with PostgreSQL being the recommended option. Please note the `django-watson` search engine require one or more MyISAM tables, so you cannot use Azure MySQL or Cloud SQL for MySQL. AWS RDS MySQL supports MyISAM tables.

--- a/docs/content/en/getting_started/running-in-production.md
+++ b/docs/content/en/getting_started/running-in-production.md
@@ -15,9 +15,9 @@ See [Running with Docker Compose](https://github.com/DefectDojo/django-DefectDoj
 
 ### Database performance and backup
 
-It is recommended to use a dedicated database server and not the preconfigured MySQL database. This will improve the performance of DefectDojo.
+It is recommended to use a dedicated database server and not the preconfigured PostgreSQL database. This will improve the performance of DefectDojo.
 
-In both cases (dedicated DB or containerized, if you are self-hosting, it is recommended that you implement and create periodic backups of your data.
+In both cases (dedicated DB or containerized), if you are self-hosting, it is recommended that you implement and create periodic backups of your data.
 
 ### Backup of Media files
 
@@ -30,7 +30,7 @@ Please read the paragraphs below about key processes tweaks.
 {{% /alert %}}
 
 
-With a seperate database, the minimum recommendations
+With a separate database, the minimum recommendations
 are:
 
 -   2 vCPUs
@@ -83,15 +83,15 @@ and see what is in effect.
 
 Import and Re-Import can also be configured to handle uploads asynchronously to aid in 
 processing especially large scans. It works by batching Findings and Endpoints by a 
-configurable amount. Each batch will be be processed in seperate celery tasks.
+configurable amount. Each batch will be be processed in separate celery tasks.
 
 The following variables impact async imports.
 
 -   `DD_ASYNC_FINDING_IMPORT` defaults to False
--   `DD_ASYNC_FINDING_IMPORT_CHUNK_SIZE` deafults to 100
+-   `DD_ASYNC_FINDING_IMPORT_CHUNK_SIZE` defaults to 100
 
 When using asynchronous imports with dynamic scanners, Endpoints will continue to "trickle" in
-even after the import has returned a successful respsonse. This is becasue processing continues 
+even after the import has returned a successful response. This is because processing continues 
 to occur after the Findings have already been imported.
 
 To determine if an import has been fully completed, please see the progress bar in the appropriate test.

--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -75,7 +75,13 @@ There is a migration process built into the upgrade that will automatically conv
 
 **Breaking Change**
 
-If there is any use of the Nessus or Nessus WAS in automated fashion via the import and reimport API endpoints, the `scan-type` parameter needs to be updated to `Tenable Scan`
+ - If there is any use of the Nessus or Nessus WAS in automated fashion via the import and reimport API endpoints, the `scan-type` parameter needs to be updated to `Tenable Scan`
+ - The default containerized database will now be [PostgreSQL](https://www.postgresql.org/) rather than [MySQL](https://dev.mysql.com/) due to the use of case insensitivity on fields by default
+   - It is recommended to update the [database character set and collation](https://dev.mysql.com/doc/refman/5.7/en/charset-database.html) to use UTF encoding 
+   - If your deployment uses the MySQL containerized database, please see the following updates to run DefectDojo:
+     - Use of the helper script "dc-up": `./dc-up.sh mysql-rabbitmq` or `./dc-up.sh mysql-redis`
+     - Use of the helper script "dc-up-d": `./dc-up-d.sh mysql-rabbitmq` or `./dc-up-d.sh mysql-redis`
+     - Use of Docker Compose directly: `docker-compose --profile mysql-rabbitmq --env-file ./docker/environments/mysql-rabbitmq.env up` or `docker-compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env up`
 
 For all other changes, check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.23.0) for the contents of the release.
 


### PR DESCRIPTION
MySQL supports case insensitivity out of the box which makes searches and exact match operations more challenging/ineffective. We have been talking about not supporting MySQL in v3 already as well. This is a good first step to test the waters
[sc-963]