### PR TITLE
Update rate limiting on the login page to only block on unsafe requests

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 from django_ratelimit.exceptions import Ratelimited
 from django_ratelimit.core import is_ratelimited
-from django_ratelimit import ALL
+from django_ratelimit import UNSAFE
 
 import logging
 
@@ -163,7 +163,7 @@ def on_exception_log_kwarg(func):
     return wrapper
 
 
-def dojo_ratelimit(key='ip', rate=None, method=ALL, block=False):
+def dojo_ratelimit(key='ip', rate=None, method=UNSAFE, block=False):
     def decorator(fn):
         @wraps(fn)
         def _wrapped(request, *args, **kw):

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -103,9 +103,8 @@ def api_v2_key(request):
                    'form': form,
                    })
 
+
 # #  user specific
-
-
 @dojo_ratelimit(key='post:username')
 @dojo_ratelimit(key='post:password')
 def login_view(request):


### PR DESCRIPTION
I noticed that users are getting 403 errors on the login page if any users are hitting it at the same time via VPN