### PR TITLE
Fix container name in DOCKER.md

### DIFF
--- a/readme-docs/DOCKER.md
+++ b/readme-docs/DOCKER.md
@@ -208,10 +208,10 @@ Make sure you write down the first password generated as you'll need it when re-
 ## Option to change the password
 * If you dont have admin password use the below command to change the password.
 * After starting the container and open another tab in the same folder.
-* django-defectdojo_uwsgi_1 -- name obtained from running containers using ```zsh docker ps ``` command
+* django-defectdojo-uwsgi-1 -- name obtained from running containers using ```zsh docker ps ``` command
 
 ```zsh
-docker exec -it django-defectdojo_uwsgi_1 ./manage.py changepassword admin
+docker exec -it django-defectdojo-uwsgi-1 ./manage.py changepassword admin
 ```
 
 # Logging


### PR DESCRIPTION
Just a typo fix.

The container name is "django-defectdojo-uwsgi-1" instead of "django-defectdojo_uwsgi_1". Probably it isn't just for me, right?

![image](https://github.com/DefectDojo/django-DefectDojo/assets/71379045/6988929c-e36d-4772-8ab0-c837e360fc2b)
