### PR TITLE
Unify push to jira logic for finding/groups  review/open/close

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -454,7 +454,7 @@ def close_finding(request, fid):
                 # Determine if the finding is in a group. if so, not push to jira
                 finding_in_group = finding.has_finding_group
                 # Check if there is a jira issue that needs to be updated
-                jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+                jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
                 # Only push if the finding is not in a group
                 if jira_issue_exists:
                     # Determine if any automatic sync should occur
@@ -544,7 +544,7 @@ def defect_finding_review(request, fid):
             # Determine if the finding is in a group. if so, not push to jira
             finding_in_group = finding.has_finding_group
             # Check if there is a jira issue that needs to be updated
-            jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+            jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
             # Only push if the finding is not in a group
             if jira_issue_exists:
                 # Determine if any automatic sync should occur
@@ -608,7 +608,7 @@ def reopen_finding(request, fid):
     # Determine if the finding is in a group. if so, not push to jira
     finding_in_group = finding.has_finding_group
     # Check if there is a jira issue that needs to be updated
-    jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+    jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
     # Only push if the finding is not in a group
     if jira_issue_exists:
         # Determine if any automatic sync should occur
@@ -1070,7 +1070,7 @@ def request_finding_review(request, fid):
             # Determine if the finding is in a group. if so, not push to jira
             finding_in_group = finding.has_finding_group
             # Check if there is a jira issue that needs to be updated
-            jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+            jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
             # Only push if the finding is not in a group
             if jira_issue_exists:
                 # Determine if any automatic sync should occur
@@ -1089,11 +1089,11 @@ def request_finding_review(request, fid):
 
             reviewers = ""
             reviewers_short = []
-            for suser in form.cleaned_data['reviewers']:
-                full_user = Dojo_User.generate_full_name(Dojo_User.objects.get(id=suser))
+            for user in form.cleaned_data['reviewers']:
+                full_user = Dojo_User.generate_full_name(Dojo_User.objects.get(id=user))
                 logger.debug("Asking %s for review", full_user)
                 reviewers += str(full_user) + ", "
-                reviewers_short.append(Dojo_User.objects.get(id=suser).username)
+                reviewers_short.append(Dojo_User.objects.get(id=user).username)
             reviewers = reviewers[:-2]
 
             create_notification(event='review_requested',
@@ -1162,7 +1162,7 @@ def clear_finding_review(request, fid):
             # Determine if the finding is in a group. if so, not push to jira
             finding_in_group = finding.has_finding_group
             # Check if there is a jira issue that needs to be updated
-            jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+            jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
             # Only push if the finding is not in a group
             if jira_issue_exists:
                 # Determine if any automatic sync should occur

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -449,18 +449,27 @@ def close_finding(request, fid):
                     status.last_modified = timezone.now()
                     status.save()
 
+                # Manage the jira status changes
                 push_to_jira = False
-                # Check if there is a jira issue that needs to be updated and that
-                # the finding is not in a group
-                if finding.has_jira_issue and not finding.has_finding_group:
+                # Determine if the finding is in a group. if so, not push to jira
+                finding_in_group = finding.has_finding_group
+                # Check if there is a jira issue that needs to be updated
+                jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+                # Only push if the finding is not in a group
+                if jira_issue_exists:
                     # Determine if any automatic sync should occur
                     push_to_jira = jira_helper.is_push_all_issues(finding) \
                         or jira_helper.get_jira_instance(finding).finding_jira_sync
                 # Add the closing note
-                if push_to_jira:
+                if push_to_jira and not finding_in_group:
                     jira_helper.add_comment(finding, new_note, force_push=True)
                 # Save the finding
-                finding.save(push_to_jira=push_to_jira)
+                finding.save(push_to_jira=(push_to_jira and not finding_in_group))
+
+                # we only push the group after saving the finding to make sure
+                # the updated data of the finding is pushed as part of the group
+                if push_to_jira and finding_in_group:
+                    jira_helper.push_to_jira(finding.finding_group)
 
                 messages.add_message(
                     request,
@@ -514,44 +523,47 @@ def defect_finding_review(request, fid):
 
             if defect_choice == "Close Finding":
                 finding.active = False
+                finding.verified = True
                 finding.mitigated = now
                 finding.mitigated_by = request.user
                 finding.is_mitigated = True
                 finding.last_reviewed = finding.mitigated
                 finding.last_reviewed_by = request.user
                 finding.endpoints.clear()
+            else:
+                finding.active = True
+                finding.verified = True
+                finding.mitigated = None
+                finding.mitigated_by = None
+                finding.is_mitigated = False
+                finding.last_reviewed = now
+                finding.last_reviewed_by = request.user
 
-            # TODO: JIRA: Code below should move to jira_helper. But I have no idea what it is doin so don't want move/break it
-
-            jira = jira_helper.get_jira_connection(finding)
-            if jira and finding.has_jira_issue:
-                j_issue = finding.jira_issue
-                issue = jira.issue(j_issue.jira_id)
-
+            # Manage the jira status changes
+            push_to_jira = False
+            # Determine if the finding is in a group. if so, not push to jira
+            finding_in_group = finding.has_finding_group
+            # Check if there is a jira issue that needs to be updated
+            jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+            # Only push if the finding is not in a group
+            if jira_issue_exists:
+                # Determine if any automatic sync should occur
+                push_to_jira = jira_helper.is_push_all_issues(finding) \
+                    or jira_helper.get_jira_instance(finding).finding_jira_sync
+            # Add the closing note
+            if push_to_jira and not finding_in_group:
                 if defect_choice == "Close Finding":
-                    # If the issue id is closed jira will return Reopen Issue
-                    resolution_id = jira_helper.jira_get_resolution_id(jira, issue,
-                                                           "Reopen Issue")
-                    if resolution_id is None:
-                        resolution_id = jira_helper.jira_get_resolution_id(
-                            jira, issue, "Resolve Issue")
-                        jira_helper.jira_transition(jira, issue, resolution_id)
-                        new_note.entry = new_note.entry + "\nJira issue set to resolved."
+                    new_note.entry = new_note.entry + "\nJira issue set to resolved."
                 else:
-                    # Re-open finding with notes stating why re-open
-                    resolution_id = jira_helper.jira_get_resolution_id(jira, issue,
-                                                        "Resolve Issue")
-                    if resolution_id is not None:
-                        jira_helper.jira_transition(jira, issue, resolution_id)
-                        new_note.entry = new_note.entry + "\nJira issue re-opened."
-
-            # Update Dojo and Jira with a notes
-            if finding.has_jira_issue:
+                    new_note.entry = new_note.entry + "\nJira issue re-opened."
                 jira_helper.add_comment(finding, new_note, force_push=True)
-            elif finding.has_jira_group_issue:
-                jira_helper.add_comment(finding.finding_group, new_note, force_push=True)
+            # Save the finding
+            finding.save(push_to_jira=(push_to_jira and not finding_in_group))
 
-            finding.save()
+            # we only push the group after saving the finding to make sure
+            # the updated data of the finding is pushed as part of the group
+            if push_to_jira and finding_in_group:
+                jira_helper.push_to_jira(finding.finding_group)
 
             messages.add_message(
                 request,
@@ -591,14 +603,24 @@ def reopen_finding(request, fid):
         status.last_modified = timezone.now()
         status.save()
 
+    # Manage the jira status changes
     push_to_jira = False
-    # Check if there is a jira issue that needs to be updated and that
-    # the finding is not in a group
-    if finding.has_jira_issue and not finding.has_finding_group:
+    # Determine if the finding is in a group. if so, not push to jira
+    finding_in_group = finding.has_finding_group
+    # Check if there is a jira issue that needs to be updated
+    jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+    # Only push if the finding is not in a group
+    if jira_issue_exists:
         # Determine if any automatic sync should occur
         push_to_jira = jira_helper.is_push_all_issues(finding) \
             or jira_helper.get_jira_instance(finding).finding_jira_sync
-    finding.save(push_to_jira=push_to_jira)
+    # Save the finding
+    finding.save(push_to_jira=(push_to_jira and not finding_in_group))
+
+    # we only push the group after saving the finding to make sure
+    # the updated data of the finding is pushed as part of the group
+    if push_to_jira and finding_in_group:
+        jira_helper.push_to_jira(finding.finding_group)
 
     reopen_external_issue(finding, 're-opened by defectdojo', 'github')
 
@@ -1032,7 +1054,7 @@ def request_finding_review(request, fid):
             new_note.date = now
             new_note.save()
             finding.notes.add(new_note)
-            finding.active = False
+            finding.active = True
             finding.verified = False
             finding.is_mitigated = False
             finding.under_review = True
@@ -1042,7 +1064,29 @@ def request_finding_review(request, fid):
 
             users = form.cleaned_data['reviewers']
             finding.reviewers.set(users)
-            finding.save()
+
+            # Manage the jira status changes
+            push_to_jira = False
+            # Determine if the finding is in a group. if so, not push to jira
+            finding_in_group = finding.has_finding_group
+            # Check if there is a jira issue that needs to be updated
+            jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+            # Only push if the finding is not in a group
+            if jira_issue_exists:
+                # Determine if any automatic sync should occur
+                push_to_jira = jira_helper.is_push_all_issues(finding) \
+                    or jira_helper.get_jira_instance(finding).finding_jira_sync
+            # Add the closing note
+            if push_to_jira and not finding_in_group:
+                jira_helper.add_comment(finding, new_note, force_push=True)
+            # Save the finding
+            finding.save(push_to_jira=(push_to_jira and not finding_in_group))
+
+            # we only push the group after saving the finding to make sure
+            # the updated data of the finding is pushed as part of the group
+            if push_to_jira and finding_in_group:
+                jira_helper.push_to_jira(finding.finding_group)
+
             reviewers = ""
             reviewers_short = []
             for suser in form.cleaned_data['reviewers']:
@@ -1111,9 +1155,29 @@ def clear_finding_review(request, fid):
             finding.last_reviewed_by = request.user
 
             finding.reviewers.set([])
-            finding.save()
-
             finding.notes.add(new_note)
+
+            # Manage the jira status changes
+            push_to_jira = False
+            # Determine if the finding is in a group. if so, not push to jira
+            finding_in_group = finding.has_finding_group
+            # Check if there is a jira issue that needs to be updated
+            jira_issue_exists = finding.has_jira_issue or finding.finding_group.has_jira_issue
+            # Only push if the finding is not in a group
+            if jira_issue_exists:
+                # Determine if any automatic sync should occur
+                push_to_jira = jira_helper.is_push_all_issues(finding) \
+                    or jira_helper.get_jira_instance(finding).finding_jira_sync
+            # Add the closing note
+            if push_to_jira and not finding_in_group:
+                jira_helper.add_comment(finding, new_note, force_push=True)
+            # Save the finding
+            finding.save(push_to_jira=(push_to_jira and not finding_in_group))
+
+            # we only push the group after saving the finding to make sure
+            # the updated data of the finding is pushed as part of the group
+            if push_to_jira and finding_in_group:
+                jira_helper.push_to_jira(finding.finding_group)
 
             messages.add_message(
                 request,

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -295,7 +295,8 @@ def express_new_jira(request):
                 open_status_key=open_key,
                 close_status_key=close_key,
                 finding_text='',
-                default_issue_type=jform.cleaned_data.get('default_issue_type'))
+                default_issue_type=jform.cleaned_data.get('default_issue_type'),
+                finding_jira_sync=jform.cleaned_data.get('finding_jira_sync'))
             jira_instance.save()
             messages.add_message(
                 request,


### PR DESCRIPTION
Sometimes when working with the jira integration, there are instances of a finding being pushed to jira when modifying the status of a finding via the edit page, but not when using the open/close/review buttons. This is confusing and creates disparity.

Here is what this PR does
 - [x] Update single/grouped findings in Jira when a single finding is closed/open
- [x] Update single/grouped findings in Jira when a single finding has a requested review, cleared review, or actually reviewed
- [x] Correct statuses of findings under review to be Active instead of Inactive. This makes more sense as the decision for whether the finding is valid/mitigated is still up for debate and should not be marked as inactive until confirmed via review
- [x] Correct statuses of findings that have been reviewed when "not fixed" was selected. Previously, the finding would not be updated and would stay in an inactive state. This is crazy. The behavior now is the finding will be active and verified since it is confirmed the finding was not actually fixed and should this fact has been verified.
- [x] Correct statuses of findings that have been reviewed when "Closed" was selected. Previously, the finding would not be marked as verified, but that is the whole point of the review. So now the finding will be marked as inactive, mitigated, and verified.
- [x] Express Jira instance creation would not save the "automatically sync findings" flag. It does now
[sc-1040]