### PR TITLE
Fix Detect Secrets parser when .baseline is not audited

### DIFF
--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -51,7 +51,7 @@ class DetectSecretsParser(object):
                         date=find_date,
                         severity="High",
                         verified=is_verified,
-                        active='is_secret' in item and item['is_secret'] is True,
+                        active='is_secret' in item and item['is_secret'] is True or 'is_secret' not in item,
                         file_path=file,
                         line=line,
                         nb_occurences=1,


### PR DESCRIPTION
**Description**

There was an error when importing not audited reports on Detect Secrets that marked as inactive secrets which haven't "is_secret" field. 


