### PR TITLE
Use sets for required & allowed fields

### DIFF
--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -69,27 +69,24 @@ class GenericParser(object):
                 del item["vulnerability_ids"]
 
             # check for required keys
-            required = ['title', 'severity', 'description']
-            missing = []
-            for field in required:
-                if field not in item.keys():
-                    missing.append(field)
+            required = {'title', 'severity', 'description'}
+            missing = sorted(required.difference(item))
             if missing:
                 raise ValueError(f"Required fields are missing: {missing}")
 
             # check for allowed keys
-            allowed = required + ['date', 'cwe', 'cve', 'cvssv3', 'cvssv3_score', 'mitigation', 'impact',
+            allowed = {
+                'date', 'cwe', 'cve', 'cvssv3', 'cvssv3_score', 'mitigation', 'impact',
                 'steps_to_reproduce', 'severity_justification', 'references', 'active', 'verified',
                 'false_p', 'out_of_scope', 'risk_accepted', 'under_review', 'is_mitigated',
                 'thread_id', 'mitigated', 'numerical_severity', 'param', 'payload', 'line', 'file_path',
                 'component_name', 'component_version', 'static_finding', 'dynamic_finding',
                 'scanner_confidence', 'unique_id_from_tool', 'vuln_id_from_tool', 'sast_source_object',
                 'sast_sink_object', 'sast_source_line', 'sast_source_file_path', 'nb_occurences',
-                'publish_date', 'service', 'planned_remediation_date', 'planned_remediation_version', 'effort_for_fixing', 'tags']
-            not_allowed = []
-            for field in item.keys():
-                if field not in allowed:
-                    not_allowed.append(field)
+                'publish_date', 'service', 'planned_remediation_date', 'planned_remediation_version',
+                'effort_for_fixing', 'tags'
+            }.union(required)
+            not_allowed = sorted(set(item).difference(allowed))
             if not_allowed:
                 raise ValueError(f"Not allowed fields are present: {not_allowed}")
 

--- a/unittests/tools/test_generic_parser.py
+++ b/unittests/tools/test_generic_parser.py
@@ -639,7 +639,7 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
         file = open("unittests/scans/generic/generic_empty.json")
         parser = GenericParser()
         with self.assertRaisesMessage(ValueError,
-                "Required fields are missing: ['title', 'severity', 'description']"):
+                "Required fields are missing: ['description', 'severity', 'title']"):
             findings = parser.get_findings(file, Test())
 
     def test_parse_json_invalid_finding(self):


### PR DESCRIPTION
This will make lookup (much) faster, since sets are data structures dedicated to such operations.

This PR is a prerequisite to another PR (I need to update the allowed fields and wanted to land this change before that.

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [x] Add the proper label to categorize your PR.
