### PR TITLE
Accept hash_code field in the Generic parser

### DIFF
--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -84,7 +84,7 @@ class GenericParser(object):
                 'scanner_confidence', 'unique_id_from_tool', 'vuln_id_from_tool', 'sast_source_object',
                 'sast_sink_object', 'sast_source_line', 'sast_source_file_path', 'nb_occurences',
                 'publish_date', 'service', 'planned_remediation_date', 'planned_remediation_version',
-                'effort_for_fixing', 'tags'
+                'effort_for_fixing', 'tags', 'hash_code',
             }.union(required)
             not_allowed = sorted(set(item).difference(allowed))
             if not_allowed:


### PR DESCRIPTION
This is useful when the tool knows exactly how to compute the `hash_code` field and does it by itself.

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.