### PR TITLE
Azure Group Mapping: Make group mapping less atomic

### DIFF
--- a/docs/content/en/integrations/social-authentication.md
+++ b/docs/content/en/integrations/social-authentication.md
@@ -198,7 +198,23 @@ To import groups from Azure AD users, the following environment variable needs t
     {{< /highlight >}}
 
 This will ensure the user is added to all the groups found in the Azure AD Token. Any missing groups will be created in DefectDojo (unless filtered). This group synchronization allows for product access via groups to limit the products a user can interact with.
-Do not activate `Emit groups as role claims` within the Azure AD "Token configuration".
+
+The Azure AD token returned by Azure will also need to be configured to include group IDs. Without this step, the
+token will not contain any notion of a group, and the mapping process will report that the current user is not a member of any 
+groups. To update the the format of the token, add a group claim that applies to whatever group type you are using.
+If unsure of what type that is, select `All Groups`. Do not activate `Emit groups as role claims` within the Azure AD 
+"Token configuration" page.
+
+Application API permissions need to be updated with the `Group.Read.All` permission so that groups can be read on behalf
+of the user that has successfully signed in.
+
+To limit the amount of groups imported from Azure AD, a regular expression can be used as the following:
+    
+    {{< highlight python >}}
+    DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_GROUPS_FILTER='^team-.*' # or 'teamA|teamB|groupC'
+    {{< /highlight >}}
+
+### Automatic Cleanup of User-Groups
 
 To prevent authorization creep, old Azure AD groups a user is not having anymore can be deleted with the following environment parameter:
 
@@ -206,11 +222,8 @@ To prevent authorization creep, old Azure AD groups a user is not having anymore
     DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_CLEANUP_GROUPS=True
     {{< /highlight >}}
 
- To limit the amount of groups imported from Azure AD, a regular expression can be used as the following:
-    
-    {{< highlight python >}}
-    DD_SOCIAL_AUTH_AZUREAD_TENANT_OAUTH2_GROUPS_FILTER='^team-.*' # or 'teamA|teamB|groupC'
-    {{< /highlight >}}
+When a user is removed from a given group in Azure AD, they will also be removed from the corresponding group in DefectDojo.
+If there is a group in DefectDojo, that no longer has any members, it will be left as is for record purposes.
 
 ## Gitlab
 

--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -2,8 +2,6 @@ import gitlab
 import re
 import logging
 import requests
-import traceback
-
 
 import social_core.pipeline.user
 from django.conf import settings

--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -69,7 +69,9 @@ def modify_permissions(backend, uid, user=None, social=None, *args, **kwargs):
 
 def update_azure_groups(backend, uid, user=None, social=None, *args, **kwargs):
     if settings.AZUREAD_TENANT_OAUTH2_ENABLED and settings.AZUREAD_TENANT_OAUTH2_GET_GROUPS and isinstance(backend, AzureADTenantOAuth2):
-        soc = user.social_auth.get()
+        # In some wild cases, there could be two social auth users
+        # connected to the same DefectDojo user. Grab the newest one
+        soc = user.social_auth.order_by("-created").first()
         token = soc.extra_data['access_token']
         group_names = []
         if 'groups' not in kwargs['response'] or kwargs['response']['groups'] == "":

--- a/dojo/pipeline.py
+++ b/dojo/pipeline.py
@@ -76,8 +76,8 @@ def update_azure_groups(backend, uid, user=None, social=None, *args, **kwargs):
             logger.warning("No groups in response. Stopping to update groups of user based on azureAD")
             return
         group_IDs = kwargs['response']['groups']
-        try:
-            for group_from_response in group_IDs:
+        for group_from_response in group_IDs:
+            try:
                 logger.debug("Analysing Group_ID " + group_from_response)
                 request_headers = {'Authorization': 'Bearer ' + token}
                 if is_group_id(group_from_response):
@@ -95,10 +95,10 @@ def update_azure_groups(backend, uid, user=None, social=None, *args, **kwargs):
                 else:
                     logger.debug("Skipping group " + group_name + " due to AZUREAD_TENANT_OAUTH2_GROUPS_FILTER " + settings.AZUREAD_TENANT_OAUTH2_GROUPS_FILTER)
                     continue
+            except Exception as e:
+                logger.error(f"Could not call microsoft graph API or save groups to member: {e}")
+        if len(group_names) > 0:
             assign_user_to_groups(user, group_names, 'AzureAD')
-        except:
-            logger.error("Could not call microsoft graph API or save groups to member")
-            traceback.print_exc()
         if settings.AZUREAD_TENANT_OAUTH2_CLEANUP_GROUPS:
             cleanup_old_groups_for_user(user, group_names)
 


### PR DESCRIPTION
When playing around with the azure group mapping, I found that there was an object ID in the groups response that did not match any resource I had in tenant. I tried deleting the application and all groups, and still the same object ID was blocking  my groups from being created in dojo. 

This change updates the exception handling to raise on each error, and then continue attempting the operation for the rest of the groups in the list. This way, if one apple gets in the bunch, the feature is still useful

Also had a very hard time figuring out what needed to be set on the Azure side to make this process work. Added some docs to clear this up for future folks
[sc-1078]