### PR TITLE
Docs: Fix typo about API parsers

### DIFF
--- a/docs/content/en/integrations/parsers/api/cobalt.md
+++ b/docs/content/en/integrations/parsers/api/cobalt.md
@@ -5,7 +5,7 @@ toc_hide: true
 ---
 All parsers which using API have common basic configuration step but with different values. Please, [read these steps](../) at first.
 
-In `Tool Configuration`, select `Tool Type` to "Cobalt.io API" and `Authentication Type` "API Key".
+In `Tool Configuration`, select `Tool Type` to "Cobalt.io" and `Authentication Type` "API Key".
 Paste your Cobalt.io API token in the `API Key` field and the desired org token in the `Extras` field.
 
 In `Add API Scan Configuration` provide the ID

--- a/docs/content/en/integrations/parsers/api/sonarqube.md
+++ b/docs/content/en/integrations/parsers/api/sonarqube.md
@@ -4,7 +4,7 @@ toc_hide: true
 ---
 All parsers which using API have common basic configuration step but with different values. Please, [read these steps](../) at first.
 
-In `Tool Configuration`, select `Tool Type` to "SonarQube API" and `Authentication Type` "API Key".
+In `Tool Configuration`, select `Tool Type` to "SonarQube" and `Authentication Type` "API Key".
 Note the url must be in the format of `https://<sonarqube_host>/api`
 Paste your SonarQube API token in the "API Key" field.
 By default the tool will import vulnerabilities issues


### PR DESCRIPTION
Documentation didn't reflect information from the parsers:
- https://github.com/DefectDojo/django-DefectDojo/blob/5dba53afdc87a9d287461da7fa7e15c970da0720/dojo/tools/api_cobalt/parser.py#L31-L32
- https://github.com/DefectDojo/django-DefectDojo/blob/5dba53afdc87a9d287461da7fa7e15c970da0720/dojo/tools/api_sonarqube/parser.py#L23-L24

Fix for: https://owasp.slack.com/archives/C2P5BA8MN/p1686135500050189