### PR TITLE
Dependency Check parser mark suppressed findings as mitigated

### DIFF
--- a/docs/content/en/integrations/parsers/file/dependency_check.md
+++ b/docs/content/en/integrations/parsers/file/dependency_check.md
@@ -5,6 +5,6 @@ toc_hide: true
 OWASP Dependency Check output can be imported in Xml format. This parser ingests the vulnerable dependencies and inherits the suppressions.
 
 * Suppressed vulnerabilities are tagged with the tag: `suppressed`.
-* Suppressed vulnerabilities are marked as inactive, but not as mitigated.
+* Suppressed vulnerabilities are marked as mitigated.
 * If the suppression is missing any `<notes>` tag, it tags them as `no_suppression_document`.
 * Related vulnerable dependencies are tagged with `related` tag.

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -6,6 +6,7 @@ import dateutil
 from cpe import CPE
 from defusedxml import ElementTree
 from packageurl import PackageURL
+from datetime import datetime
 
 from dojo.models import Finding
 
@@ -122,6 +123,8 @@ class DependencyCheckParser(object):
             return None
 
         tags = []
+        mitigated = None
+        is_Mitigated = False
         name = vulnerability.findtext(f'{namespace}name')
         if vulnerability.find(f'{namespace}cwes'):
             cwe_field = vulnerability.find(f'{namespace}cwes').findtext(f'{namespace}cwe')
@@ -213,7 +216,8 @@ class DependencyCheckParser(object):
                 tags.append("no_suppression_document")
             mitigation = '**This vulnerability is mitigated and/or suppressed:** {}\n'.format(notes)
             mitigation = mitigation + 'Update {}:{} to at least the version recommended in the description'.format(component_name, component_version)
-
+            mitigated = datetime.utcnow()
+            is_Mitigated = True
             active = False
             tags.append("suppressed")
 
@@ -230,6 +234,8 @@ class DependencyCheckParser(object):
             description=description,
             severity=severity,
             mitigation=mitigation,
+            mitigated=mitigated,
+            is_mitigated=is_Mitigated,
             tags=tags,
             active=active,
             dynamic_finding=False,

--- a/unittests/tools/test_dependency_check_parser.py
+++ b/unittests/tools/test_dependency_check_parser.py
@@ -238,6 +238,7 @@ class TestDependencyCheckParser(DojoTestCase):
             )
             self.assertEqual(items[9].tags, ["suppressed", "no_suppression_document"])
             self.assertEqual(items[10].severity, "Critical")
+            self.assertEqual(items[10].is_mitigated, True)
 
         with self.subTest(i=10):
             self.assertEqual(items[10].active, False)
@@ -247,6 +248,7 @@ class TestDependencyCheckParser(DojoTestCase):
             )
             self.assertEqual(items[10].tags, "suppressed")
             self.assertEqual(items[10].severity, "Critical")
+            self.assertEqual(items[10].is_mitigated, True)
 
     def test_parse_java_6_5_3(self):
         """Test with version 6.5.3"""


### PR DESCRIPTION
**Description**

The Dependency Check parser currently tags suppressed findings but don't mitigate them. The documentation says they are marked as inactive. But this is not true if you import them via API and the active=true flag.

Suppressing a finding in Dependency Check is usually because these are false positives. So they should be marked as mitigated and not as inactive. When you looking into the code this was also the intended behaviour for the parser (see https://owasp.slack.com/archives/C2P5BA8MN/p1683267640152279).

**Test results**

I have added assertions for the mitigation.

**Documentation**

I have change the documentation: "Suppressed vulnerabilities are marked as mitigated."