### PR TITLE
Pin version of selenium to maintain test coverage

### DIFF
--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -28,7 +28,7 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 
-RUN pip install --no-cache-dir selenium requests chromedriver-autoinstaller
+RUN pip install --no-cache-dir selenium==4.9.0 requests chromedriver-autoinstaller
 
 # Installing Chromedriver
 WORKDIR /opt/chrome-driver


### PR DESCRIPTION
Selenium 4.10.0 removes a lot of deprecated code. Turns out we are relying on a lot of those deprecations. The correct fix will require a minor rewrite of how we set up the driver

This PR is intended to be a quick patch to get the ball rolling again