### PR TITLE
Set Engagement status created from `auto_create_context`

### DIFF
--- a/dojo/importers/reimporter/utils.py
+++ b/dojo/importers/reimporter/utils.py
@@ -251,7 +251,7 @@ def get_or_create_engagement(engagement_id=None, engagement_name=None, product_n
             target_end = (timezone.now() + timedelta(days=365)).date()
 
         engagement = Engagement.objects.create(engagement_type="CI/CD", name=engagement_name, product=product, lead=get_current_user(),
-                                               target_start=target_start, target_end=target_end,
+                                               target_start=target_start, target_end=target_end, status="In Progress",
                                                deduplication_on_engagement=deduplication_on_engagement,
                                                source_code_management_uri=source_code_management_uri)
 


### PR DESCRIPTION
When Engagements are created from `auto_create_context`, they come in with no status.
