### PR TITLE
Tenable parser cleanups and improvements

### DIFF
--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -28,6 +28,14 @@ class TenableXMLParser(object):
         # Read the XML
         nscan = ElementTree.parse(filename)
         root = nscan.getroot()
+
+        if 'NessusClientData_v2' not in root.tag:
+            raise ValueError(
+                'This version of Nessus report is not supported. '
+                'Please make sure the export is '
+                'formatted using the NessusClientData_v2 schema.'
+            )
+
         dupes = {}
         for report in root.iter("Report"):
             for host in report.iter("ReportHost"):
@@ -124,12 +132,11 @@ class TenableXMLParser(object):
                     else:
                         find = dupes[dupe_key]
                         if plugin_output is not None:
-                            find.description += plugin_output
+                            find.description += f"\n\n{plugin_output}"
 
                     # Update existing vulnerability IDs
                     if vulnerability_id:
                         find.unsaved_vulnerability_ids.append(vulnerability_id)
-
                     # Create a new endpoint object
                     if fqdn and "://" in fqdn:
                         endpoint = Endpoint.from_uri(fqdn)


### PR DESCRIPTION
Went through the old Nessus/NessusWas parsers to look for any deviations between the original parsers and the consolidated parser. Here is what I found:
- CSV
  - Endpoint related fields may have been getting set to ""(empty string) in cases of rows being empty
  - Removed the duplicated code of adding plugin output to description
  - Added default "Info" severity in case one is not found in the report 
  - Reverted the dupe key calculation to what was originally in place
- XML
  - Returned the check for `NessusClientData_v2` data (though I believe it may be very outdated now)
  - Added some light formatting to the description output
[sc-1089]