### PR TITLE
Fix: use numerical sort for findings column

### DIFF
--- a/dojo/templates/dojo/components.html
+++ b/dojo/templates/dojo/components.html
@@ -36,7 +36,7 @@
                 <tbody>
                     {% for result in result  %}
                     <tr>
-                        <td>
+                        <td data-order="{{ result.component_name }}">
                             {% if result.component_name == none %}
                             <a href="{% url 'all_findings' %}?has_component=false"><b>{{ result.component_name }}</b></a>
                             {% else %}
@@ -45,7 +45,7 @@
                         </td>
 
                         <td>{{result.component_version}} </td>
-                        <td class="text-center">
+                        <td class="text-center" data-order="{{ result.active }}">
                             {% if result.active and result.component_name == none %}
                             <a href="{% url 'open_findings' %}?has_component=false"><b>{{ result.active }}</b></a>
                             {% elif result.active%}
@@ -54,7 +54,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td class="text-center">
+                        <td class="text-center" data-order="{{ result.duplicate }}">
                             {% if result.duplicate and result.component_name == none %}
                             <a href="{% url 'all_findings' %}?has_component=false&duplicate=1"><b>{{ result.duplicate }}</b></a>
                             {% elif result.duplicate %}
@@ -63,7 +63,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td class="text-center">
+                        <td class="text-center" data-order="{{ result.total }}">
                             {% if result.total and result.component_name == none %}
                             <a href="{% url 'all_findings' %}?has_component=false"><b>{{ result.total }}</b></a>
                             {% elif result.total %}
@@ -130,11 +130,11 @@
                 );
              },
              "columns": [
-                    { "data": "Component_name" },
+                    null, // Component_name
                     { "data": "Version" },
-                    { "data": "Active" },
-                    { "data": "Duplicate" },
-                    { "data": "Total" },
+                    null, // Active
+                    null, // Duplicate
+                    null, // Total
             ],
             order: [],
             columnDefs: [

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -590,12 +590,13 @@
                                             {% endif %}
                                         {% endwith %}
                                     </td>
-                                    <td class="nowrap">
-                                        {% if filter_name == 'Closed' %}
-                                            {{ finding.mitigated|date }}
-                                        {% else %}
-                                            {{ finding.date }}
-                                        {% endif %}
+                                    {% if filter_name == 'Closed' %}
+                                    <td class="nowrap" data-order="{{ finding.mitigated|date:"U" }}">
+                                        {{ finding.mitigated|date }}
+                                    {% else %}
+                                    <td class="nowrap" data-order="{{ finding.date|date:"U" }}">
+                                        {{ finding.date }}
+                                    {% endif %}
                                     </td>
                                     <td>
                                         {{ finding.age }}
@@ -733,10 +734,24 @@
                     }},
                     { "data": "cwe" },
                     { "data": "cve" },
-                    { "data": "found_date" },
+                    { "data": "found_date", render: function (data, type, row, meta) {
+                        if(type === 'sort') {
+                            var api = new $.fn.dataTable.Api(meta.settings);
+                            var td = api.cell({row: meta.row, column: meta.col}).node();
+                            var data = $(td).attr("data-order");
+                        }
+                        return data;
+                    }},
                     { "data": "finding_age" },
-                {% if system_settings.enable_finding_sla %}
-                    { "data": "finding_sla" },
+                {% if system_settings.enable_finding_sla %}                
+                    { "data": "finding_sla", "type": "num", render: function (data, type, row, meta) {
+                        if(type === 'sort') {
+                            var api = new $.fn.dataTable.Api(meta.settings);
+                            var td = api.cell({row: meta.row, column: meta.col}).node();
+                            var data = $(td).find("a").text();
+                        }
+                        return data;
+                    }},
                 {% endif %}
                 { "data": "reported_by" },
                 { "data": "found_by_test" },

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -239,7 +239,7 @@
                                 </td>
                                 {% endif %}
 
-                                <td class="text-center">
+                                <td class="text-center" data-order="{{ prod.findings_count }}">
                                     {% if prod.findings_count %}
                                         <a href="{% url 'product_open_findings' prod.id %}?test__engagement__product={{ prod.id }}"><b>{{ prod.findings_count }}</b></a>
                                         &nbsp;(<a href="{% url 'product_verified_findings' prod.id %}?test__engagement__product={{ prod.id }}">{{ prod.findings_active_verified_count }}</a>)
@@ -247,7 +247,7 @@
                                         0
                                     {% endif %}
                                 </td>
-                                <td class="text-center">
+                                <td class="text-center" data-order="{{ prod.endpoint_count }}">
                                   {% if prod.endpoint_count %}
                                     <a href="{% url 'vulnerable_endpoint_hosts' %}?product={{ prod.id }}"><b>{{ prod.endpoint_host_count }}</b></a> /
                                     <a href="{% url 'vulnerable_endpoints' %}?product={{ prod.id }}"><b>{{ prod.endpoint_count }}</b></a>
@@ -341,8 +341,13 @@
                     { "data": "action" },
                     { "data": "product" },
                     { "data": "tags" },
-                    { "data": "criticality" , render: function (data, type, row) {
-                            return type === 'export' ? getDojoExportValueFromTag(data, 'i', 'data-content') :  data;
+                    { "data": "criticality", render: function (data, type, row) {
+                            if(type === 'sort') {
+                              data = $($.parseHTML(data)).find('.fa-solid').length;
+                            } else if(type === 'export') {
+                              data = getDojoExportValueFromTag(data, 'i', 'data-content');
+                            }
+                            return data;
                     }},
                     { "data": "metadata", render: function (data, type, row) {
                             return type === 'export' ? getDojoExportValueFromTag(data, 'i', 'data-content') :  data;
@@ -360,8 +365,8 @@
                             return type === 'export' ? getDojoExportValueFromTag(data, 'i', 'data-content') :  data;
                     }},
                     {% endif %}
-                    { "data": "findings" },
-                    { "data": "endpoints" },
+                    null,
+                    null,
                     { "data": "contacts" },
                     { "data": "product_type" },
                 ],

--- a/dojo/templates/dojo/product_components.html
+++ b/dojo/templates/dojo/product_components.html
@@ -35,7 +35,7 @@
                 <tbody>
                     {% for result in result  %}
                     <tr>
-                        <td>
+                        <td data-order="{{ result.component_name }}">
                             {% if result.component_name == none%}
                                <a href="{% url 'all_findings' %}?has_component=false&test__engagement__product={{prod.id}}"><b>{{ result.component_name }}</b></a>
                             {% else %}
@@ -43,7 +43,7 @@
                             {% endif %}
                         </td>
                         <td>{{result.component_version}} </td>
-                        <td class="text-center">
+                        <td class="text-center" data-order="{{ result.active }}">
                             {% if result.active and result.component_name == none %}
                             <a href="{% url 'open_findings' %}?has_component=false&test__engagement__product={{prod.id}}"><b>{{ result.active }}</b></a>
                             {% elif result.active %}
@@ -52,7 +52,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td class="text-center">
+                        <td class="text-center" data-order="{{ result.duplicate }}">
                             {% if result.duplicate and result.component_name == none %}
                             <a href="{% url 'all_findings' %}?has_component=false&test__engagement__product={{prod.id}}&duplicate=1"><b>{{ result.duplicate }}</b></a>
                             {% elif result.duplicate %}
@@ -61,7 +61,7 @@
                             0
                             {% endif %}
                         </td>
-                        <td class="text-center">
+                        <td class="text-center" data-order="{{ result.total }}">
                             {% if result.total and result.component_name == none %}
                             <a href="{% url 'all_findings' %}?has_component=false&test__engagement__product={{prod.id}}"><b>{{ result.total }}</b></a>
                             {% elif result.total %}
@@ -128,11 +128,11 @@
                 );
             },
             "columns": [
-                { "data": "Component_name" },
+                null, // Component_name
                 { "data": "Version" },
-                { "data": "Active" },
-                { "data": "Duplicate" },
-                { "data": "Total" },
+                null, // Active
+                null, // Duplicate
+                null, // Total
             ],
             order: [],
             columnDefs: [

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -45,7 +45,7 @@
                     <th class="text-left">Date</th>
                     <th class="text-left">Length</th>
                     {% if system_settings.enable_jira %}
-                    <th class="text-center">JIRA</td>
+                    <th class="text-center">JIRA</th>
                     {% endif %}
                     <th class="text-center">Tests</th>
                     <th class="text-center">Active (Verified)</th>
@@ -172,7 +172,7 @@
                           {{ eng.lead |default_if_none:""}}
                       {% endif %}
                     </td>
-                    <td class="text-left" style="width: 200px;">
+                    <td class="text-left" style="width: 200px;" data-order={{ eng.target_start|date:"U" }}>
                       <a target="#" data-toggle="tooltip" data-placement="bottom" title="{{ eng.target_start|date:"l, jS F Y" }} - {{ eng.target_end|date:"l, jS F Y" }}">
                       {{ eng.target_start|date:"jS F" }} {% if eng.target_start|datediff_time:eng.target_end != "1 day" %} - {{ eng.target_end|date:"jS F" }}{% endif %}
                     </a>
@@ -207,7 +207,7 @@
                       {{ eng|jira_project_tag }}
                     </td>
                     {% endif %}
-                    <td class="text-center" class="nowrap">
+                    <td class="text-center" class="nowrap" data-order="{{ eng.count_tests }}">
                       <div class="align-top">
                       {% if eng.count_tests %}
                       <div class="dropdown">
@@ -244,7 +244,7 @@
                       {% endif %}
                       </div>
                     </td>
-                    <td class="text-center">{{ eng.count_findings_open }}&nbsp;({{ eng.count_findings_open_verified}})</td>
+                    <td class="text-center" data-order="{{ eng.count_findings_open }}">{{ eng.count_findings_open }}&nbsp;({{ eng.count_findings_open_verified}})</td>
                     <td class="text-center">{{ eng.count_findings_close }}</td>
                     <td class="text-center">{{ eng.count_findings_accepted }}</td>
                     <td class="text-center">{{ eng.count_findings_all }}</td>
@@ -302,13 +302,18 @@
                     { "data": "eng_name" },
                     { "data": "engagement_type" },
                     { "data": "lead" },
-                    { "data": "date" },
-                    { "data": "length" },
+                    null,
+                    { "data": "length", "type": "num", render: function(data, type, row) {
+                      if(type === 'sort') {
+                        data = data.split(' ')[0];
+                      }
+                      return data
+                    }},
                     {% if system_settings.enable_jira %}
                         { "data": "jira" },
                     {% endif %}
-                    { "data": "tests" },
-                    { "data": "open" },
+                    null,
+                    null,
                     { "data": "mitigated" },
                     { "data": "accepted" },
                     { "data": "all" },

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1183,7 +1183,7 @@
                                         {% endif %}
                                     {% endwith %}
                                 </td>
-                                <td class="nowrap">
+                                <td class="nowrap" data-order="{{ finding.date|date:"U" }}">
                                     {{ finding.date }}
                                 </td>
                                 <td>
@@ -1595,7 +1595,14 @@
                 }},
                 { "data": "cwe" },
                 { "data": "cve" },
-                { "data": "date" },
+                { "data": "date", render: function (data, type, row, meta) {
+                    if(type === 'sort') {
+                        var api = new $.fn.dataTable.Api(meta.settings);
+                        var td = api.cell({row: meta.row, column: meta.col}).node();
+                        var data = $(td).attr("data-order");
+                    }
+                    return data;
+                }},
                 { "data": "age" },
                 {% if system_settings.enable_finding_sla %}
                     { "data": "sla" },


### PR DESCRIPTION
Fixes: #8127

- Sort the findings column using numerical order instead of lexicographical order.

![Peek 2023-06-11 21-49](https://github.com/DefectDojo/django-DefectDojo/assets/71379045/3883f574-1418-41fd-b2b5-c3431da53ca0)
