### PR TITLE
Fixing error in importer if active is not specified

### DIFF
--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -183,7 +183,7 @@ class DojoDefaultImporter(object):
             if finding["is_mitigated"]:
                 mitigated_hash_codes.append(finding["hash_code"])
                 for hash_code in new_hash_codes:
-                    if hash_code["hash_code"] == finding["hash_code"]:
+                    if hash_code == finding["hash_code"]:
                         new_hash_codes.remove(hash_code)
         if close_old_findings_product_scope:
             # Close old findings of the same test type in the same product


### PR DESCRIPTION
**Description**

If "active" is not specified in the importer you get a TypeError:

django-defectdojo-uwsgi-1         |     if hash_code["hash_code"] == finding["hash_code"]:
django-defectdojo-uwsgi-1         |        ~~~~~~~~~^^^^^^^^^^^^^
django-defectdojo-uwsgi-1         | TypeError: string indices must be integers, not 'str'

**Test results**

Tested the fix works correctly.
