### PR TITLE
Fixing type-error in Finding._age

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2689,6 +2689,10 @@ class Finding(models.Model):
             else:
                 days = get_work_days(self.date, get_current_date())
         else:
+            from datetime import datetime
+            if isinstance(start_date, datetime):
+                start_date = start_date.date()
+
             if self.mitigated:
                 diff = self.mitigated.date() - start_date
             else:

--- a/unittests/tools/test_veracode_parser.py
+++ b/unittests/tools/test_veracode_parser.py
@@ -110,6 +110,7 @@ class TestVeracodeScannerParser(DojoTestCase):
         self.assertTrue(finding.is_mitigated)
         self.assertEqual(datetime.datetime(2020, 6, 1, 10, 2, 1), finding.mitigated)
         self.assertEqual("app-1234_issue-1", finding.unique_id_from_tool)
+        self.assertEqual(0, finding.sla_age)
 
     def test_parse_file_with_mitigated_fixed_finding(self):
         testfile = open("unittests/scans/veracode/mitigated_fixed_finding.xml")

--- a/unittests/tools/test_veracode_sca_parser.py
+++ b/unittests/tools/test_veracode_sca_parser.py
@@ -69,6 +69,7 @@ class TestVeracodeScaScannerParser(DojoTestCase):
         self.assertEqual(665, finding.cwe)
         self.assertEqual("ddcc6e1b-3ed9-45c8-b77a-ead759fb5e2c", finding.unique_id_from_tool)
         self.assertEqual(datetime.datetime(2022, 7, 29, 5, 13, 0, 924000).astimezone(UTC), finding.date)
+        self.assertEqual(320, finding.sla_age)
 
     def test_parse_json_fixed(self):
         testfile = open("unittests/scans/veracode_sca/veracode_sca_fixed.json")


### PR DESCRIPTION
**Description**

There is a bug in the Finding age calculation due to the fact that at least some parsers save a date and not a datetime object:

```
  File "/app/dojo/models.py", line 2695, in _age
    diff = get_current_date() - start_date
           ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'datetime.date' and 'datetime.datetime'
```

**Test results**

Added tests which verify the fix, as they fail before the fix is applied
