### PR TITLE
Request Review improvements

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1372,7 +1372,7 @@ def request_finding_review(request, fid):
     # in order to review a finding, we need to capture why a review is needed
     # we can do this with a Note
     if request.method == "POST":
-        form = ReviewFindingForm(request.POST)
+        form = ReviewFindingForm(request.POST, finding=finding, user=user)
 
         if form.is_valid():
             now = timezone.now()

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1368,6 +1368,7 @@ def risk_unaccept(request, fid):
 def request_finding_review(request, fid):
     finding = get_object_or_404(Finding, id=fid)
     user = get_object_or_404(Dojo_User, id=request.user.id)
+    form = ReviewFindingForm(finding=finding, user=user)
     # in order to review a finding, we need to capture why a review is needed
     # we can do this with a Note
     if request.method == "POST":
@@ -1445,9 +1446,6 @@ def request_finding_review(request, fid):
             )
             return HttpResponseRedirect(reverse("view_finding", args=(finding.id,)))
 
-    else:
-        form = ReviewFindingForm(finding=finding)
-
     product_tab = Product_Tab(
         finding.test.engagement.product, title="Review Finding", tab="findings"
     )
@@ -1463,12 +1461,14 @@ def request_finding_review(request, fid):
 def clear_finding_review(request, fid):
     finding = get_object_or_404(Finding, id=fid)
     user = get_object_or_404(Dojo_User, id=request.user.id)
-    # in order to clear a review for a finding, we need to capture why and how it was reviewed
-    # we can do this with a Note
-
-    if user != finding.review_requested_by or user not in finding.reviewers.all():
+    # If the user wanting to clear the review is not the user who requested
+    # the review or one of the users requested to provide the review, then
+    # do not allow the user to clear the review.
+    if user != finding.review_requested_by and user not in finding.reviewers.all():
         raise PermissionDenied()
 
+    # in order to clear a review for a finding, we need to capture why and how it was reviewed
+    # we can do this with a Note
     if request.method == "POST":
         form = ClearFindingReviewForm(request.POST, instance=finding)
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1679,10 +1679,11 @@ class ClearFindingReviewForm(forms.ModelForm):
 
 
 class ReviewFindingForm(forms.Form):
-
     reviewers = forms.MultipleChoiceField(
-        help_text=("Select all users who can review Finding. Only users with "
-                   "at least write permission to this finding can be selected")
+        help_text=(
+            "Select all users who can review Finding. Only users with "
+            "at least write permission to this finding can be selected"),
+        required=False,
     )
     entry = forms.CharField(
         required=True, max_length=2400,
@@ -1721,7 +1722,9 @@ class ReviewFindingForm(forms.Form):
     def clean(self):
         cleaned_data = super().clean()
         if cleaned_data.get("allow_all_reviewers", False):
-            cleaned_data["reviewers"] = self.reviewer_queryset
+            cleaned_data["reviewers"] = [user.id for user in self.reviewer_queryset]
+        if len(cleaned_data.get("reviewers", [])) == 0:
+            raise ValidationError("Please select at least one user from the reviewers list")
         return cleaned_data
 
     class Meta:

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1680,36 +1680,52 @@ class ClearFindingReviewForm(forms.ModelForm):
 
 class ReviewFindingForm(forms.Form):
 
-    reviewers = forms.MultipleChoiceField(help_text="Select all users who can review Finding.")
+    reviewers = forms.MultipleChoiceField(
+        help_text=("Select all users who can review Finding. Only users with "
+                   "at least write permission to this finding can be selected")
+    )
     entry = forms.CharField(
         required=True, max_length=2400,
-        help_text='Please provide a message for reviewers.',
-        widget=forms.Textarea, label='Notes:',
-        error_messages={'required': ('The reason for requesting a review is '
-                                     'required, please use the text area '
-                                     'below to provide documentation.')})
+        help_text="Please provide a message for reviewers.",
+        widget=forms.Textarea, label="Notes:",
+        error_messages={"required": ("The reason for requesting a review is "
+                                     "required, please use the text area "
+                                     "below to provide documentation.")})
+    allow_all_reviewers = forms.BooleanField(
+        required=False,
+        label="Allow All Eligible Reviewers",
+        help_text=("Checking this box will allow any user in the drop down "
+                   "above to provide a review for this finding"))
 
     def __init__(self, *args, **kwargs):
-        finding = None
-        if 'finding' in kwargs:
-            finding = kwargs.pop('finding')
-
+        finding = kwargs.pop("finding", None)
+        user = kwargs.pop("user", None)
         super(ReviewFindingForm, self).__init__(*args, **kwargs)
-        self.fields['reviewers'].choices = self._get_choices(get_authorized_users(Permissions.Finding_View).filter(is_active=True))
-
+        # Get the list of users
         if finding is not None:
-            queryset = get_authorized_users_for_product_and_product_type(None, finding.test.engagement.product, Permissions.Finding_Edit)
-            self.fields['reviewers'].choices = self._get_choices(queryset)
+            users = get_authorized_users_for_product_and_product_type(None, finding.test.engagement.product, Permissions.Finding_Edit)
+        else:
+            users = get_authorized_users(Permissions.Finding_Edit).filter(is_active=True)
+        # Remove the current user
+        if user is not None:
+            users = users.exclude(id=user.id)
+        # Save a copy of the original query to be used in the validator
+        self.reviewer_queryset = users
+        # Set the users in the form
+        self.fields["reviewers"].choices = self._get_choices(self.reviewer_queryset)
 
     @staticmethod
     def _get_choices(queryset):
-        l_choices = []
-        for item in queryset:
-            l_choices.append((item.pk, item.get_full_name()))
-        return l_choices
+        return [(item.pk, item.get_full_name()) for item in queryset]
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get("allow_all_reviewers", False):
+            cleaned_data["reviewers"] = self.reviewer_queryset
+        return cleaned_data
 
     class Meta:
-        fields = ['reviewers', 'entry']
+        fields = ["reviewers", "entry", "allow_all_reviewers"]
 
 
 class WeeklyMetricsForm(forms.Form):

--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -8,6 +8,7 @@ import sys
 import os
 from base_test_class import BaseTestCase, on_exception_html_source_logger, set_suite_settings
 from product_test import ProductTest, WaitForPageLoad
+from user_test import UserTest
 from pathlib import Path
 import time
 
@@ -189,7 +190,6 @@ class FindingTest(BaseTestCase):
         # select Reviewer
         # Let's make the first user in the list a reviewer
         # set select element style from 'none' to 'inline'
-
         try:
             WebDriverWait(driver, 5).until(EC.presence_of_element_located((By.ID, 'id_reviewers')))
         except TimeoutException:
@@ -202,8 +202,8 @@ class FindingTest(BaseTestCase):
         Select(element).select_by_value(reviewer_option.get_attribute("value"))
         # Add Review notes
         driver.find_element(By.ID, "id_entry").clear()
-        driver.find_element(By.ID, "id_entry").send_keys("This is to be reveiwed critically. Make sure it is well handled.")
-        # Click 'Mark for reveiw'
+        driver.find_element(By.ID, "id_entry").send_keys("This is to be reviewed critically. Make sure it is well handled.")
+        # Click 'Mark for review'
         driver.find_element(By.NAME, "submit").click()
         # Query the site to determine if the finding has been added
 
@@ -521,6 +521,7 @@ def add_finding_tests_to_suite(suite, jira=False, github=False, block_execution=
     suite.addTest(BaseTestCase('delete_finding_template_if_exists'))
     suite.addTest(ProductTest('test_create_product'))
     suite.addTest(ProductTest('test_add_product_finding'))
+    suite.addTest(UserTest('test_create_user_with_writer_global_role'))
     suite.addTest(FindingTest('test_list_findings_all'))
     suite.addTest(FindingTest('test_list_findings_open'))
     suite.addTest(FindingTest('test_quick_report'))
@@ -548,6 +549,7 @@ def add_finding_tests_to_suite(suite, jira=False, github=False, block_execution=
     suite.addTest(FindingTest('test_delete_finding'))
     suite.addTest(FindingTest('test_delete_finding_template'))
     suite.addTest(ProductTest('test_delete_product'))
+    suite.addTest(UserTest('test_user_with_writer_role_delete'))
     return suite
 
 

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -151,7 +151,7 @@ class UserTest(BaseTestCase):
 
         # Assert ot the query to dtermine status of failure
         self.assertTrue(self.is_success_message_present(text='User and relationships removed.'))
-    
+
     def test_user_with_writer_role_delete(self):
         # Login to the site. Password will have to be modified
         # to match an admin password in your own container

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -3,6 +3,7 @@ import sys
 
 from base_test_class import BaseTestCase
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select
 from selenium.common.exceptions import NoSuchElementException
 
 
@@ -40,6 +41,39 @@ class UserTest(BaseTestCase):
         # Query the site to determine if the user has been created
 
         # Assert ot the query to dtermine status of failure
+        self.assertTrue(self.is_success_message_present(text='User added successfully.') or
+            self.is_help_message_present(text='A user with that username already exists.'))
+
+    def test_create_user_with_writer_global_role(self):
+        # Login to the site.
+        driver = self.driver
+        # Navigate to the User managegement page
+        driver.get(f"{self.base_url}user")
+        # "Click" the dropdown button to see options
+        driver.find_element(By.ID, "dropdownMenu1").click()
+        # "Click" the add prodcut button
+        driver.find_element(By.LINK_TEXT, "New User").click()
+        # Fill in the Necessary User Details
+        # username, first name, last name, email, and permissions
+        # Don't forget to clear before inserting
+        # username
+        driver.find_element(By.ID, "id_username").clear()
+        driver.find_element(By.ID, "id_username").send_keys("userWriter")
+        # First Name
+        driver.find_element(By.ID, "id_first_name").clear()
+        driver.find_element(By.ID, "id_first_name").send_keys("Writer")
+        # Last Name
+        driver.find_element(By.ID, "id_last_name").clear()
+        driver.find_element(By.ID, "id_last_name").send_keys("Permission")
+        # Email Address
+        driver.find_element(By.ID, "id_email").clear()
+        driver.find_element(By.ID, "id_email").send_keys("permissionTest@defectdojo.local")
+        # Select the role 'Reader'
+        Select(driver.find_element(By.ID, "id_role")).select_by_visible_text("Writer")
+        # "Click" the submit button to complete the transaction
+        driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
+        # Query the site to determine if the user has been created
+        # Assert ot the query to determine status of failure
         self.assertTrue(self.is_success_message_present(text='User added successfully.') or
             self.is_help_message_present(text='A user with that username already exists.'))
 
@@ -103,6 +137,34 @@ class UserTest(BaseTestCase):
         # Insert username to filter by into user name box
         driver.find_element(By.ID, "id_username").clear()
         driver.find_element(By.ID, "id_username").send_keys("propersahm")
+        # click on 'apply filter' button
+        driver.find_element(By.CSS_SELECTOR, "button.btn.btn-sm.btn-secondary").click()
+        # only the needed user is now available, proceed with clicking 'View' button
+        driver.find_element(By.ID, "dropdownMenuUser").click()
+        driver.find_element(By.ID, "viewUser").click()
+        # in View User dialog open the menu to click the delete entry
+        driver.find_element(By.ID, "dropdownMenu1").click()
+        driver.find_element(By.ID, "deleteUser").click()
+        # confirm deletion, by clicking delete a second time
+        driver.find_element(By.CSS_SELECTOR, "button.btn.btn-danger").click()
+        # Query the site to determine if the User has been deleted
+
+        # Assert ot the query to dtermine status of failure
+        self.assertTrue(self.is_success_message_present(text='User and relationships removed.'))
+    
+    def test_user_with_writer_role_delete(self):
+        # Login to the site. Password will have to be modified
+        # to match an admin password in your own container
+        driver = self.driver
+        # Navigate to the product page
+        driver.get(self.base_url + "user")
+        # Select A user to edit
+        # The User name is not clickable
+        # so we would have to select specific user by filtering list of users
+        driver.find_element(By.ID, "show-filters").click()  # open d filters
+        # Insert username to filter by into user name box
+        driver.find_element(By.ID, "id_username").clear()
+        driver.find_element(By.ID, "id_username").send_keys("userWriter")
         # click on 'apply filter' button
         driver.find_element(By.CSS_SELECTOR, "button.btn.btn-sm.btn-secondary").click()
         # only the needed user is now available, proceed with clicking 'View' button
@@ -205,6 +267,7 @@ def suite():
     # success and failure is output by the test
     suite.addTest(BaseTestCase('test_login'))
     suite.addTest(UserTest('test_create_user'))
+    suite.addTest(UserTest('test_create_user_with_writer_global_role'))
     suite.addTest(UserTest('test_admin_profile_form'))
     suite.addTest(UserTest('test_standard_user_login'))
     suite.addTest(UserTest('test_user_profile_form_disabled'))
@@ -214,6 +277,7 @@ def suite():
     suite.addTest(BaseTestCase('test_login'))
     suite.addTest(UserTest('test_user_edit_permissions'))
     suite.addTest(UserTest('test_user_delete'))
+    suite.addTest(UserTest('test_user_with_writer_role_delete'))
 
     return suite
 


### PR DESCRIPTION
When requesting reviews on findings, it is possible to select users with read permission that will not have access to actually provide the review. This fix limits the users that can provide reviews to those with at least write access to a given finding. 

In a system with many users, it is pretty annoying to have to select all of them for each review, so I added a checkbox to add all eligible reviews.