### PR TITLE
sla_deadline doesn't work with mitigated findings

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2729,6 +2729,8 @@ class Finding(models.Model):
     def sla_deadline(self):
         days_remaining = self.sla_days_remaining()
         if days_remaining:
+            if self.mitigated:
+                return self.mitigated.date() + relativedelta(days=days_remaining)
             return get_current_date() + relativedelta(days=days_remaining)
         return None
 

--- a/dojo/tools/veracode_sca/parser.py
+++ b/dojo/tools/veracode_sca/parser.py
@@ -5,6 +5,9 @@ import io
 from cvss import parser as cvss_parser
 from dateutil import parser
 from datetime import datetime
+
+from django.utils import timezone
+
 from dojo.models import Finding
 
 
@@ -108,6 +111,7 @@ class VeracodeScaParser(object):
             if (issue.get('Ignored') and issue.get('Ignored').capitalize() == 'True' or
                     status and (status.capitalize() == 'Resolved' or status.capitalize() == 'Fixed')):
                 finding.is_mitigated = True
+                finding.mitigated = timezone.now()
                 finding.active = False
 
             findings.append(finding)
@@ -170,6 +174,7 @@ class VeracodeScaParser(object):
             if (row.get('Ignored') and row.get('Ignored').capitalize() == 'True' or
                     row.get('Status') and row.get('Status').capitalize() == 'Resolved'):
                 finding.is_mitigated = True
+                finding.mitigated = timezone.now()
                 finding.active = False
 
             findings.append(finding)

--- a/unittests/tools/test_veracode_sca_parser.py
+++ b/unittests/tools/test_veracode_sca_parser.py
@@ -86,3 +86,4 @@ class TestVeracodeScaScannerParser(DojoTestCase):
         self.assertEqual("CVE-2022-31159", finding.unsaved_vulnerability_ids[0])
         self.assertEqual("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N", finding.cvssv3)
         self.assertEqual(22, finding.cwe)
+        self.assertEqual(datetime.date.today(), finding.mitigated.date())


### PR DESCRIPTION
**Description**

The sla_deadline function doesn't work with mitigated findings, as it just applies sla days remaining to the current date, instead of the mitigated date.

Also I added a mitigated date for the Veracode SCA parser when findings are mitigated, as the date isn't contained in the JSON.

**Test results**
 
New tests added in PR.
