### PR TITLE
fix: dont create sast object when nothing given

### DIFF
--- a/dojo/tools/gitlab_sast/parser.py
+++ b/dojo/tools/gitlab_sast/parser.py
@@ -94,18 +94,23 @@ class GitlabSastParser(object):
         file_path = location['file'] if 'file' in location else None
 
         line = location['start_line'] if 'start_line' in location else None
-        if 'end_line' in location:
-            line = location['end_line']
-
-        sast_source_line = location['start_line'] if 'start_line' in location else None
 
         sast_object = None
+        sast_source_file_path = None
+        sast_source_line = None
         if 'class' in location and 'method' in location:
             sast_object = f"{location['class']}#{location['method']}"
         elif 'class' in location:
             sast_object = location['class']
         elif 'method' in location:
             sast_object = location['method']
+
+        if sast_object is not None:
+            sast_source_file_path = file_path
+            sast_source_line = line
+
+        if 'end_line' in location:
+            line = location['end_line']
 
         severity = vuln.get('severity')
         if severity is None or severity == 'Undefined' or severity == 'Unknown':
@@ -148,7 +153,7 @@ class GitlabSastParser(object):
             line=line,
             sast_source_object=sast_object,
             sast_sink_object=sast_object,
-            sast_source_file_path=file_path,
+            sast_source_file_path=sast_source_file_path,
             sast_source_line=sast_source_line,
             cwe=cwe,
             static_finding=True,


### PR DESCRIPTION
**Description**

When importing a gitlab sast report you end up with something like.
<img width="1382" alt="Screenshot 2023-06-20 at 15 20 19" src="https://github.com/DefectDojo/django-DefectDojo/assets/699436/2bf39aff-6ad1-4283-8342-9aee1f6ae931">

Gitlab sast data model for location looks like this:

```
"location": {
            "type": "object",
            "description": "Identifies the vulnerability's location.",
            "properties": {
              "file": {
                "type": "string",
                "description": "Path to the file where the vulnerability is located."
              },
              "start_line": {
                "type": "number",
                "description": "The first line of the code affected by the vulnerability."
              },
              "end_line": {
                "type": "number",
                "description": "The last line of the code affected by the vulnerability."
              },
              "class": {
                "type": "string",
                "description": "Provides the name of the class where the vulnerability is located."
              },
              "method": {
                "type": "string",
                "description": "Provides the name of the method where the vulnerability is located."
              }
            }
          },
```

Its debatable if we should even use sink or source objects in the finding since all we have is class/method but this PR takes a more limited aproach and just uses these when we have class and method information. This results in a more clean output on the finding page with just the location instead of the same filename/line information being duplicated 3 times.

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.

