### PR TITLE
Fix DeprecationWarning and some "noqa W605"

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1220,7 +1220,7 @@ def get_engagements(request):
         if url.startswith('url='):
             url = url[4:]
 
-    path_items = list(filter(None, re.split('/|\?', url))) # noqa W605
+    path_items = list(filter(None, re.split(r'/|\?', url)))
 
     if not path_items or path_items[0] != 'engagement':
         raise ValidationError('URL is not an engagement view')

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -744,7 +744,7 @@ def get_findings(request):
              'false_positive', 'inactive']
     # request.path = url
     obj_name = obj_id = view = query = None
-    path_items = list(filter(None, re.split('/|\?', url))) # noqa W605
+    path_items = list(filter(None, re.split(r'/|\?', url)))
 
     try:
         finding_index = path_items.index('finding')

--- a/dojo/user/validators.py
+++ b/dojo/user/validators.py
@@ -39,7 +39,7 @@ class MaxLengthValidator(object):
 class NumberValidator(object):
     def validate(self, password, user=None):
         self.settings = System_Settings.objects.get()
-        if not re.findall('\d', password) and self.settings.number_character_required:  # noqa W605
+        if not re.findall(r'\d', password) and self.settings.number_character_required:
             raise ValidationError(
                 self.get_help_text(),
                 code='password_no_number')
@@ -81,7 +81,7 @@ class LowercaseValidator(object):
 class SymbolValidator(object):
     def validate(self, password, user=None):
         self.settings = System_Settings.objects.get()
-        contains_special_character = re.findall('[()[\]{}|\\`~!@#$%^&*_\-+=;:\'\",<>./?]', password)  # noqa W605
+        contains_special_character = re.findall(r'[()[\]{}|\\`~!@#$%^&*_\-+=;:\'\",<>./?]', password)
         if not contains_special_character and self.settings.special_character_required:
             raise ValidationError(
                 self.get_help_text(),


### PR DESCRIPTION
1. fix some `noqa W605`
2. DeprecationWarning:
```python
/app/dojo/reports/views.py:747: DeprecationWarning: invalid escape sequence '\?'
  path_items = list(filter(None, re.split('/|\?', url))) # noqa W605
```
