### PR TITLE
Fix occurrence where product exists, but cannot be found

### DIFF
--- a/dojo/importers/reimporter/utils.py
+++ b/dojo/importers/reimporter/utils.py
@@ -219,12 +219,13 @@ def get_or_create_product(product_name=None, product_type_name=None, auto_create
             member.role = Role.objects.get(is_owner=True)
             member.save()
 
-        product = Product.objects.create(name=product_name, prod_type=product_type, description=product_name)
-        member = Product_Member()
-        member.user = get_current_user()
-        member.product = product
-        member.role = Role.objects.get(is_owner=True)
-        member.save()
+        product, created = Product.objects.get_or_create(name=product_name, prod_type=product_type, description=product_name)
+        if created:
+            member = Product_Member()
+            member.user = get_current_user()
+            member.product = product
+            member.role = Role.objects.get(is_owner=True)
+            member.save()
 
         return product
 


### PR DESCRIPTION
For some reason, I have seen cases where the product exists, but is not fetched by the `get_target_product_if_exists` function, but it does exist. 

Updating the `create` function to `get_or_create` makes this process safer across the board
