### PR TITLE
Update naming convention for product tags in related objects

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -72,6 +72,24 @@ godojo installations
 
 If you have installed DefectDojo on "iron" and wish to upgrade the installation, please see the [instructions in the repo](https://github.com/DefectDojo/godojo/blob/master/docs-and-scripts/upgrading.md).
 
+## Upgrading to DefectDojo Version 2.25.x.
+
+A few query parameters related to filtering object via API related to a products tags have been renamed to be more consistent with the other "related object tags":
+
+**Breaking Change**
+
+ - Engagement
+   - `product__tags__name` -> `product__tags` 
+   - `not_product__tags__name` -> `not_product__tags` 
+ - Test
+   - `engagement__product__tags__name` -> `engagement__product__tags`
+   - `not_engagement__product__tags__name` -> `not_engagement__product__tags`
+ - Finding
+   - `test__engagement__product__tags__name` -> `test__engagement__product__tags`
+   - `not_test__engagement__product__tags__name` -> `not_test__engagement__product__tags`
+
+For all other changes, check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.25.0) for the contents of the release.
+
 ## Upgrading to DefectDojo Version 2.24.x.
 
 There are no special instruction for upgrading to 2.24.0. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.24.0) for the contents of the release.

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -830,17 +830,17 @@ class ApiEngagementFilter(DojoFilter):
     product__prod_type = NumberInFilter(field_name='product__prod_type', lookup_expr='in')
     tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Tag name contains')
     tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                             help_text='Comma seperated list of exact tags')
-    product__tags__name = CharFieldInFilter(field_name='product__tags__name',
+                             help_text='Comma separated list of exact tags')
+    product__tags = CharFieldInFilter(field_name='product__tags__name',
                                             lookup_expr='in',
-                                            help_text='Comma seperated list of exact tags present on product')
+                                            help_text='Comma separated list of exact tags present on product')
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                                 help_text='Comma seperated list of exact tags not present on model', exclude='True')
-    not_product__tags__name = CharFieldInFilter(field_name='product__tags__name',
+                                 help_text='Comma separated list of exact tags not present on model', exclude='True')
+    not_product__tags = CharFieldInFilter(field_name='product__tags__name',
                                                 lookup_expr='in',
-                                                help_text='Comma seperated list of exact tags not present on product',
+                                                help_text='Comma separated list of exact tags not present on product',
                                                 exclude='True')
 
     o = OrderingFilter(
@@ -1035,11 +1035,11 @@ class ApiProductFilter(DojoFilter):
 
     tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Tag name contains')
     tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                             help_text='Comma seperated list of exact tags')
+                             help_text='Comma separated list of exact tags')
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                                 help_text='Comma seperated list of exact tags not present on product', exclude='True')
+                                 help_text='Comma separated list of exact tags not present on product', exclude='True')
 
     # DateRangeFilter
     created = DateRangeFilter()
@@ -1145,26 +1145,26 @@ class ApiFindingFilter(DojoFilter):
 
     tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Tag name contains')
     tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                             help_text='Comma seperated list of exact tags')
+                             help_text='Comma separated list of exact tags')
     test__tags = CharFieldInFilter(field_name='test__tags__name', lookup_expr='in',
-                                   help_text='Comma seperated list of exact tags present on test')
+                                   help_text='Comma separated list of exact tags present on test')
     test__engagement__tags = CharFieldInFilter(field_name='test__engagement__tags', lookup_expr='in',
-                                               help_text='Comma seperated list of exact tags present on engagement')
-    test__engagement__product__tags__name = CharFieldInFilter(field_name='test__engagement__product__tags__name',
+                                               help_text='Comma separated list of exact tags present on engagement')
+    test__engagement__product__tags = CharFieldInFilter(field_name='test__engagement__product__tags__name',
                                                               lookup_expr='in',
-                                                              help_text='Comma seperated list of exact tags present on product')
+                                                              help_text='Comma separated list of exact tags present on product')
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                                 help_text='Comma seperated list of exact tags not present on model', exclude='True')
+                                 help_text='Comma separated list of exact tags not present on model', exclude='True')
     not_test__tags = CharFieldInFilter(field_name='test__tags__name', lookup_expr='in',
-                                       help_text='Comma seperated list of exact tags not present on test', exclude='True')
+                                       help_text='Comma separated list of exact tags not present on test', exclude='True')
     not_test__engagement__tags = CharFieldInFilter(field_name='test__engagement__tags', lookup_expr='in',
-                                                   help_text='Comma seperated list of exact tags not present on engagement',
+                                                   help_text='Comma separated list of exact tags not present on engagement',
                                                    exclude='True')
-    not_test__engagement__product__tags__name = CharFieldInFilter(field_name='test__engagement__product__tags__name',
+    not_test__engagement__product__tags = CharFieldInFilter(field_name='test__engagement__product__tags__name',
                                                                   lookup_expr='in',
-                                                                  help_text='Comma seperated list of exact tags not present on product',
+                                                                  help_text='Comma separated list of exact tags not present on product',
                                                                   exclude='True')
 
     o = OrderingFilter(
@@ -1556,11 +1556,11 @@ class TemplateFindingFilter(DojoFilter):
 class ApiTemplateFindingFilter(DojoFilter):
     tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Tag name contains')
     tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                             help_text='Comma seperated list of exact tags')
+                             help_text='Comma separated list of exact tags')
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                                 help_text='Comma seperated list of exact tags not present on model', exclude='True')
+                                 help_text='Comma separated list of exact tags not present on model', exclude='True')
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -1798,11 +1798,11 @@ class EndpointFilter(DojoFilter):
 class ApiEndpointFilter(DojoFilter):
     tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Tag name contains')
     tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                             help_text='Comma seperated list of exact tags')
+                             help_text='Comma separated list of exact tags')
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                                 help_text='Comma seperated list of exact tags not present on model', exclude='True')
+                                 help_text='Comma separated list of exact tags not present on model', exclude='True')
     o = OrderingFilter(
         # tuple-mapping retains order
         fields=(
@@ -1897,22 +1897,22 @@ class EngagementTestFilter(DojoFilter):
 class ApiTestFilter(DojoFilter):
     tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Tag name contains')
     tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                             help_text='Comma seperated list of exact tags')
+                             help_text='Comma separated list of exact tags')
     engagement__tags = CharFieldInFilter(field_name='engagement__tags', lookup_expr='in',
-                                               help_text='Comma seperated list of exact tags present on engagement')
-    engagement__product__tags__name = CharFieldInFilter(field_name='engagement__product__tags__name',
+                                               help_text='Comma separated list of exact tags present on engagement')
+    engagement__product__tags = CharFieldInFilter(field_name='engagement__product__tags__name',
                                                               lookup_expr='in',
-                                                              help_text='Comma seperated list of exact tags present on product')
+                                                              help_text='Comma separated list of exact tags present on product')
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                                 help_text='Comma seperated list of exact tags not present on model', exclude='True')
+                                 help_text='Comma separated list of exact tags not present on model', exclude='True')
     not_engagement__tags = CharFieldInFilter(field_name='engagement__tags', lookup_expr='in',
-                                                   help_text='Comma seperated list of exact tags not present on engagement',
+                                                   help_text='Comma separated list of exact tags not present on engagement',
                                                    exclude='True')
-    not_engagement__product__tags__name = CharFieldInFilter(field_name='engagement__product__tags__name',
+    not_engagement__product__tags = CharFieldInFilter(field_name='engagement__product__tags__name',
                                                                   lookup_expr='in',
-                                                                  help_text='Comma seperated list of exact tags not present on product',
+                                                                  help_text='Comma separated list of exact tags not present on product',
                                                                   exclude='True')
 
     o = OrderingFilter(
@@ -1950,11 +1950,11 @@ class ApiTestFilter(DojoFilter):
 class ApiAppAnalysisFilter(DojoFilter):
     tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Tag name contains')
     tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                             help_text='Comma seperated list of exact tags')
+                             help_text='Comma separated list of exact tags')
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
-                                 help_text='Comma seperated list of exact tags not present on model', exclude='True')
+                                 help_text='Comma separated list of exact tags not present on model', exclude='True')
 
     class Meta:
         model = App_Analysis


### PR DESCRIPTION
PR Fixes a few issues:
- Rename product tag filters. The naming convention was different from all the other tag related queries.
  - Add release notes for 2.25.x indicating potentially breaking changes
- Fix all instances of `seperated` -> `separated` in the filters