### PR TITLE
Add signal to update Finding `found_by` column

### DIFF
--- a/dojo/apps.py
+++ b/dojo/apps.py
@@ -73,6 +73,7 @@ class DojoAppConfig(AppConfig):
         # Importing the signals file is good enough if using the reciever decorator
         import dojo.announcement.signals  # noqa
         import dojo.product.signals  # noqa
+        import dojo.test.signals  # noqa
 
 
 def get_model_fields_with_extra(model, extra_fields=()):

--- a/dojo/test/signals.py
+++ b/dojo/test/signals.py
@@ -1,0 +1,24 @@
+import contextlib
+from django.db.models import signals
+from django.dispatch import receiver
+import logging
+from dojo.models import Test, Finding
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(signals.pre_save, sender=Test)
+def update_found_byt_for_findings(sender, instance, **kwargs):
+    with contextlib.suppress(sender.DoesNotExist):
+        obj = sender.objects.get(pk=instance.pk)
+        # Check if the test type has changed
+        if obj.test_type != instance.test_type:
+            # Save a reference to the old test type ID to replace with the new one
+            old_test_type = obj.test_type
+            new_test_type = instance.test_type
+            # Get all the findings in this test
+            findings = Finding.objects.filter(test=instance)
+            # Update each of the findings found by column
+            for find in findings:
+                find.found_by.remove(old_test_type)
+                find.found_by.add(new_test_type)

--- a/dojo/test/signals.py
+++ b/dojo/test/signals.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 
 @receiver(signals.pre_save, sender=Test)
-def update_found_byt_for_findings(sender, instance, **kwargs):
+def update_found_by_for_findings(sender, instance, **kwargs):
     with contextlib.suppress(sender.DoesNotExist):
         obj = sender.objects.get(pk=instance.pk)
         # Check if the test type has changed


### PR DESCRIPTION
When updating the test type of a test, all of the findings under that test will now have an outdated `found_by` value. This column is shown in all of the finding lists, so it is important that it is accurate. 