### PR TITLE
Verified defaults to true when adding a Finding from web UI

### DIFF
--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -371,7 +371,7 @@ def add_findings(request, tid):
     test = Test.objects.get(id=tid)
     form_error = False
     jform = None
-    form = AddFindingForm(initial={'date': timezone.now().date()}, req_resp=None, product=test.engagement.product)
+    form = AddFindingForm(initial={'date': timezone.now().date(), 'verified': True}, req_resp=None, product=test.engagement.product)
     push_all_jira_issues = jira_helper.is_push_all_issues(test)
     use_jira = jira_helper.get_jira_project(test) is not None
 


### PR DESCRIPTION
Since PR #7470 a few months ago, Verified is set to false by default on a finding.
It makes perfectly sense when importing from a scanner, as “Verified” should mean that it has been checked by a human like it was explained in the previous PR.
However, as a side effect, we also noticed that when you add a finding using the web interface, the Verified checkbox is set to false. I think it should be true in this case, because if you add a finding manually, it actually had been checked by a human.

The goal of this PR is just to set the checkbox Active value to true when a Finding is added from the web UI, keeping the default to false in other cases.