### PR TITLE
fix: Sonarqube re-upload #8379

### DIFF
--- a/dojo/tools/api_sonarqube/api_client.py
+++ b/dojo/tools/api_sonarqube/api_client.py
@@ -261,11 +261,13 @@ class SonarQubeAPI:
             if issue["key"] == issue_key:
                 return issue
         raise Exception(
-            f"""Expected Issue "{issue_key}", but it returned "
-            "{[x.get('key') for x in response.json().get('issues')]}."""
+            f"""Expected Issue "{issue_key}", but it returned 
+            "{[x.get('key') for x in response.json().get('issues')]}."
+            full response: "
+            "{response.json()}"""
         )
 
-    def get_rule(self, rule_id):
+    def get_rule(self, rule_id, organization=None):
         """
         Get detailed information about a rule
         :param rule_id:
@@ -273,9 +275,17 @@ class SonarQubeAPI:
         """
         rule = self.rules_cache.get(rule_id)
         if not rule:
+            request_filter = {
+                "key": rule_id
+            }
+            if organization:
+                print(organization)
+                request_filter["organization"] = organization
+            elif self.org_id:
+                request_filter["organization"] = self.org_id
             response = self.session.get(
                 url=f"{self.sonar_api_url}/rules/show",
-                params={"key": rule_id},
+                params=request_filter,
                 headers=self.default_headers,
             )
             if not response.ok:

--- a/dojo/tools/api_sonarqube/api_client.py
+++ b/dojo/tools/api_sonarqube/api_client.py
@@ -261,10 +261,10 @@ class SonarQubeAPI:
             if issue["key"] == issue_key:
                 return issue
         raise Exception(
-            f"""Expected Issue "{issue_key}", but it returned
-            "{[x.get('key') for x in response.json().get('issues')]}."
-            full response: "
-            "{response.json()}"""
+            f'Expected Issue "{issue_key}", but it returned' \
+            f"{[x.get('key') for x in response.json().get('issues')]}. " \
+            "Full response: " \
+            f"{response.json()}"
         )
 
     def get_rule(self, rule_id, organization=None):

--- a/dojo/tools/api_sonarqube/api_client.py
+++ b/dojo/tools/api_sonarqube/api_client.py
@@ -279,7 +279,6 @@ class SonarQubeAPI:
                 "key": rule_id
             }
             if organization:
-                print(organization)
                 request_filter["organization"] = organization
             elif self.org_id:
                 request_filter["organization"] = self.org_id

--- a/dojo/tools/api_sonarqube/api_client.py
+++ b/dojo/tools/api_sonarqube/api_client.py
@@ -261,9 +261,9 @@ class SonarQubeAPI:
             if issue["key"] == issue_key:
                 return issue
         raise Exception(
-            f'Expected Issue "{issue_key}", but it returned' \
-            f"{[x.get('key') for x in response.json().get('issues')]}. " \
-            "Full response: " \
+            f"Expected Issue \"{issue_key}\", but it returned"
+            f"{[x.get('key') for x in response.json().get('issues')]}. "
+            "Full response: "
             f"{response.json()}"
         )
 

--- a/dojo/tools/api_sonarqube/api_client.py
+++ b/dojo/tools/api_sonarqube/api_client.py
@@ -261,7 +261,7 @@ class SonarQubeAPI:
             if issue["key"] == issue_key:
                 return issue
         raise Exception(
-            f"""Expected Issue "{issue_key}", but it returned 
+            f"""Expected Issue "{issue_key}", but it returned
             "{[x.get('key') for x in response.json().get('issues')]}."
             full response: "
             "{response.json()}"""

--- a/dojo/tools/api_sonarqube/importer.py
+++ b/dojo/tools/api_sonarqube/importer.py
@@ -144,7 +144,7 @@ class SonarQubeApiImporter(object):
                 component_key = issue["component"]
                 line = issue.get("line")
                 rule_id = issue["rule"]
-                rule = client.get_rule(rule_id)
+                rule = client.get_rule(rule_id,organization=organization)
                 severity = self.convert_sonar_severity(issue["severity"])
                 try:
                     sonarqube_permalink = f"[Issue permalink]({sonarUrl}project/issues?issues={issue['key']}&open={issue['key']}&resolved={issue['status']}&id={issue['project']}) \n"

--- a/dojo/tools/api_sonarqube/importer.py
+++ b/dojo/tools/api_sonarqube/importer.py
@@ -144,7 +144,7 @@ class SonarQubeApiImporter(object):
                 component_key = issue["component"]
                 line = issue.get("line")
                 rule_id = issue["rule"]
-                rule = client.get_rule(rule_id,organization=organization)
+                rule = client.get_rule(rule_id, organization=organization)
                 severity = self.convert_sonar_severity(issue["severity"])
                 try:
                     sonarqube_permalink = f"[Issue permalink]({sonarUrl}project/issues?issues={issue['key']}&open={issue['key']}&resolved={issue['status']}&id={issue['project']}) \n"


### PR DESCRIPTION
Description

This PR fixes #8379 by extending the required api calls with the "organization" parameter, which is required for Sonarcloud imports.

Test results
works as expected. Doesn't solve the issue with empty return of get_issue but this doesn't seem to have any effect at all.