### PR TITLE
support csi volumes in helm chart

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -61,6 +61,11 @@ spec:
           {{- else if (eq .type "hostPath") }}
           type: {{ .pathType | default "Directory" }}
           path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
           {{- end }}
       {{- end }}
       containers:
@@ -114,6 +119,7 @@ spec:
             name: {{ $fullName }}-extrasecrets
             optional: true
         env:
+        {{- if not .Values.externalBrokerPassword }}
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -124,6 +130,8 @@ spec:
               name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
               key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
+        {{- end }}
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -137,6 +145,7 @@ spec:
                 name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
                 key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
+        {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -59,6 +59,11 @@ spec:
           {{- else if (eq .type "hostPath") }}
           type: {{ .pathType | default "Directory" }}
           path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
           {{- end }}
       {{- end }}
       containers:
@@ -109,6 +114,7 @@ spec:
             name: {{ $fullName }}-extrasecrets
             optional: true
         env:
+        {{- if not .Values.externalBrokerPassword }}
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -119,6 +125,8 @@ spec:
               name: {{ .Values.redis.auth.existingSecret| default "defectdojo-redis-specific" }}
               key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
+        {{- end }}
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -132,6 +140,7 @@ spec:
                 name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
                 key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
+        {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -71,6 +71,11 @@ spec:
           {{- else if (eq .type "hostPath") }}
           type: {{ .pathType | default "Directory" }}
           path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
           {{- end }}
       {{- end }}
       {{- if .Values.django.mediaPersistentVolume.enabled }}
@@ -159,6 +164,7 @@ spec:
             name: {{ $fullName }}-extrasecrets
             optional: true
         env:
+        {{- if not .Values.externalBrokerPassword }}
         - name: DD_CELERY_BROKER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -169,10 +175,12 @@ spec:
               name: {{ .Values.redis.auth.existingSecret | default "defectdojo-redis-specific" }}
               key: {{ .Values.redis.auth.existingSecretPasswordKey | default "redis-password" }}
             {{- end }}
+        {{- end }}
         {{- if .Values.django.uwsgi.enable_debug }}
         - name: DD_DEBUG
           value: 'True'
         {{- end }}
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -186,6 +194,7 @@ spec:
                 name: {{ .Values.mysql.auth.existingSecret | default "defectdojo-mysql-specific" }}
                 key: {{ .Values.mysql.auth.secretKey | default "mysql-password" }}
               {{- end }}
+        {{- end }}
         - name: DD_SECRET_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -68,7 +68,9 @@ spec:
             name: {{ $fullName }}
         - secretRef:
             name: {{ $fullName }}
+        {{- if or (not .Values.externalDatabasePassword) .Values.extraEnv }}
         env:
+        {{- if not .Values.externalDatabasePassword }}
         - name: DD_DATABASE_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -82,8 +84,19 @@ spec:
               name: {{ .Values.mysql.auth.existingSecret }}
               key: {{ .Values.mysql.auth.secretKey }}
               {{- end }}
+        {{- end }}
         {{- if .Values.extraEnv }}
         {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.initializer.extraVolumes }}
+        volumeMounts:
+        {{- range .Values.initializer.extraVolumes }}
+        - name: userconfig-{{ .name }}
+          readOnly: true
+          mountPath: {{ .path }}
+          subPath: {{ .subPath }}
+        {{- end }}
         {{- end }}
         resources:
           {{- toYaml .Values.initializer.resources | nindent 10 }}
@@ -99,6 +112,26 @@ spec:
       {{- with .Values.initializer.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initializer.extraVolumes }}
+      volumes:
+      {{- range .Values.initializer.extraVolumes }}
+      - name: userconfig-{{ .name }}
+        {{ .type }}:
+          {{- if (eq .type "configMap") }}
+          name: {{ .name }}
+          {{- else if (eq .type "secret") }}
+          secretName: {{ .name }}
+          {{- else if (eq .type "hostPath") }}
+          type: {{ .pathType | default "Directory" }}
+          path: {{ .hostPath }}
+          {{- else if (eq .type "csi") }}
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: {{ .secretProviderClass }}
+          {{- end }}
+      {{- end }}
       {{- end }}
   backoffLimit: 1
 {{- end }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -20,6 +20,9 @@ createPostgresqlHaPgpoolSecret: false
 # - enabled, enables tracking configuration changes based on SHA256
 # trackConfig: disabled
 
+externalDatabasePassword: false
+externalBrokerPassword: false
+
 # Enables application network policy
 # For more info follow https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy:
@@ -173,7 +176,7 @@ celery:
   #
   # Each object supports the following keys:
   #
-  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath". Case sensitive.
+  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath", "csi". Case sensitive.
   #    Even is supported we are highly recommending to avoid hostPath for security reasons (usually blocked by PSP)
   # - `name` - Name of the configMap or secret to be mounted. This also controls
   #    the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
@@ -193,7 +196,8 @@ django:
     ingressClassName: ""
     activateTLS: true
     secretName: defectdojo-tls
-    annotations: {}
+    annotations:
+      {}
       # Restricts the type of ingress controller that can interact with our chart (nginx, traefik, ...)
       # kubernetes.io/ingress.class: nginx
       # Depending on the size and complexity of your scans, you might want to increase the default ingress timeouts if you see repeated 504 Gateway Timeouts
@@ -232,11 +236,11 @@ django:
     app_settings:
       processes: 2
       threads: 2
-    enable_debug: false  # this also requires DD_DEBUG to be set to True
+    enable_debug: false # this also requires DD_DEBUG to be set to True
     certificates:
-    # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
-    # to create configMap `kubectl create  cm defectdojo-ca-certs --from-file=ca.crt`
-    # NOTE: it reflects REQUESTS_CA_BUNDLE for celery workers, beats as well
+      # includes additional CA certificate as volume, it refrences REQUESTS_CA_BUNDLE env varible
+      # to create configMap `kubectl create  cm defectdojo-ca-certs --from-file=ca.crt`
+      # NOTE: it reflects REQUESTS_CA_BUNDLE for celery workers, beats as well
       enabled: false
       configName: defectdojo-ca-certs
       certMountPath: /certs/
@@ -265,7 +269,7 @@ django:
   #
   # Each object supports the following keys:
   #
-  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath". Case sensitive.
+  # - `type` - Type of the volume, must be one of "configMap", "secret", "hostPath", "csi". Case sensitive.
   #    Even is supported we are highly recommending to avoid hostPath for security reasons (usually blocked by PSP)
   # - `name` - Name of the configMap or secret to be mounted. This also controls
   #    the path that it is mounted to. The volume will be mounted to `/consul/userconfig/<name>`.
@@ -293,14 +297,12 @@ django:
       name:
       size: 5Gi
       accessModes:
-      - ReadWriteMany  # check KUBERNETES.md doc first for option to choose
+        - ReadWriteMany # check KUBERNETES.md doc first for option to choose
       storageClassName:
 
 initializer:
   run: true
-  jobAnnotations: {
-    helm.sh/hook: "post-install,post-upgrade"
-  }
+  jobAnnotations: { helm.sh/hook: "post-install,post-upgrade" }
   annotations: {}
   keepSeconds: 60
   affinity: {}
@@ -477,7 +479,7 @@ redis:
   scheme: "redis"
   transportEncryption:
     enabled: false
-    params: ''
+    params: ""
   auth:
     existingSecret: defectdojo-redis-specific
     existingSecretPasswordKey: redis-password
@@ -486,7 +488,6 @@ redis:
   # To use an external Redis instance, set enabled to false and uncomment
   # the line below:
   # redisServer: myrediscluster
-
 
 # To add extra variables not predefined by helm config it is possible to define in extraConfigs block, e.g. below:
 # NOTE  Do not store any kind of sensitive information inside of it
@@ -500,7 +501,6 @@ redis:
 # extraSecrets:
 #   DD_SOCIAL_AUTH_AUTH0_SECRET: 'xxx'
 extraConfigs: {}
-
 # To add (or override) extra variables which need to be pulled from another configMap, you can
 # use extraEnv. For example:
 # extraEnv:


### PR DESCRIPTION
This PR:

Adds support for csi volumes, extending currently supported types
Add .Values.externalDatabasePassword and .Values.externalBrokerPassword to remove mandatory usage of secrets from the chart
By adding the two values, it becomes possible to pass DD_DATABASE_PASSWORD and DD_CELERY_BROKER_PASSWORD via csi volumes and external secret systems (e.g. vault).

Closes https://github.com/DefectDojo/django-DefectDojo/issues/5535