### PR TITLE
Fixed side navbar cutoff issue

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -126,6 +126,11 @@ a:hover {
   text-decoration: none;
 }
 
+.nav.nav-second-level.nav-up {
+    transform: translateY(-100%);
+    margin-top: 41px;
+}
+
 .nav-tabs {
     border-bottom: 1px solid rgb(148, 168, 187);
 }

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -492,7 +492,7 @@
                                                 <i class="fa-solid fa-gear fa-fw"></i>
                                                 <span>{% trans "Configuration" %}</span>
                                             </a>
-                                            <ul class="nav nav-second-level">
+                                            <ul class="nav nav-second-level nav-up">
                                                 {% if "dojo.change_announcement"|has_configuration_permission:request %}
                                                     <li>
                                                         <a href="{% url 'configure_announcement' %}">


### PR DESCRIPTION
A known issue with the side nav-bar on various display sizes. Prevents users from selecting the bottom configuration options.

**Before:**
<img width="1337" alt="Screenshot 2023-07-17 at 1 54 10 AM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/c3466755-8161-4caf-8700-85f3a5976e7a">

**After:**

<img width="1337" alt="Screenshot 2023-07-17 at 1 54 22 AM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/b9a85fbd-a739-4f4a-a5c0-889479df9623">

