### PR TITLE
Update chromedriver fetching mechanism

### DIFF
--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -11,6 +11,7 @@ RUN \
     curl \
     unzip \
     gpg \
+    jq \
     && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
@@ -28,12 +29,17 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 
-RUN pip install --no-cache-dir selenium==4.9.0 requests chromedriver-autoinstaller
+RUN pip install --no-cache-dir selenium==4.9.0 requests
 
 # Installing Chromedriver
 WORKDIR /opt/chrome-driver
 RUN \
-  python -c "import chromedriver_autoinstaller; chromedriver_autoinstaller.install(cwd=True)" && \
+  chrome_version=$(apt-cache show google-chrome-stable | grep Version | awk '{print $2}' | cut -d '-' -f 1) && \
+  chrome_version_blob=$(curl -k https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq ".versions[] | select(.version==\"$chrome_version\")") && \
+  chromedriver_url=$(echo $chrome_version_blob | jq -r ".downloads.chromedriver[] | select(.platform==\"linux64\") | .url") && \
+  wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.98/linux64/chromedriver-linux64.zip && \
+  unzip -j chromedriver-linux64.zip chromedriver-linux64/chromedriver && \
+  rm -rf chromedriver-linux64.zip && \
   chmod -R 0755 .
 WORKDIR /app
 


### PR DESCRIPTION
High level is unit tests are trying to use chrome 115 as it the latest, but the way to fetch the matching chromedriver changed with chrome version 115. We use a pypi package to fetch the driver and there is an issue open for fixing this: https://github.com/yeongbin-jo/python-chromedriver-autoinstaller/issues/47

The motivation for the path change is to make things more unified, so it might be a good time to get on the right track

[sc-1556]