### PR TITLE
added django service annotations option to helm values file to set an…

### DIFF
--- a/helm/defectdojo/templates/django-service.yaml
+++ b/helm/defectdojo/templates/django-service.yaml
@@ -9,6 +9,12 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "defectdojo.chart" . }}
+{{- if .Values.django.service.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.django.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
 spec:
   selector:
     defectdojo.org/component: django

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -187,6 +187,8 @@ celery:
 
 django:
   annotations: {}
+  service:
+    annotations: {}
   affinity: {}
   ingress:
     enabled: true


### PR DESCRIPTION
…notations on django service template for monitoring purpose

**Description**

This fixes not being able to set annotations on the django service from the helm values file when using the helm chart to deploy DefectDojo to Kubernetes.

**Test results**

Tested with helm template cmd with and without annotations.

**Documentation**

This change to the values file is self-documenting.

**Checklist**

This checklist is for your information.

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [x] Add the proper label to categorize your PR.