### PR TITLE
Fixing some minor typos

### DIFF
--- a/helm/defectdojo/templates/secret-postgresql-ha.yaml
+++ b/helm/defectdojo/templates/secret-postgresql-ha.yaml
@@ -22,8 +22,8 @@ data:
   postgresql-password: {{ $postgresRandomPassword }}
   postgresql-postgres-password: {{ $postgresRandomPassword }}
 {{- end }}
-{{- if .Values.postgresqlha.postgresql.repmgrpassword }}
-  repmgr-password: {{ .Values.postgresqlha.postgresql.repmgrpassword | b64enc | quote }}
+{{- if .Values.postgresqlha.postgresql.repmgrPassword }}
+  repmgr-password: {{ .Values.postgresqlha.postgresql.repmgrPassword | b64enc | quote }}
 {{- else }}
   {{- $repmgrRandomPassword := randAlphaNum 16 | b64enc | quote }}
   repmgr-password: {{ $repmgrRandomPassword }}

--- a/unittests/tools/test_arachni_parser.py
+++ b/unittests/tools/test_arachni_parser.py
@@ -4,7 +4,7 @@ from dojo.tools.arachni.parser import ArachniParser
 from dojo.models import Test
 
 
-class TestAquaParser(DojoTestCase):
+class TestArachniParser(DojoTestCase):
 
     def test_parser_has_one_finding(self):
         with open("unittests/scans/arachni/arachni.afr.json") as testfile:


### PR DESCRIPTION
**Description**

Fixing a couple typos I've encountered:
* `secret-postgresql-ha.yaml`: `repmgrpassword` ➡️  `repmgrPassword`
* `test_arachni_parser.py`: `TestAquaParser` ➡️  `TestArachniParser`

**Test results**

N/A

**Documentation**

N/A