### PR TITLE
Deprecation: OpenAPI 2.0 Documentation page

### DIFF
--- a/docs/content/en/getting_started/upgrading.md
+++ b/docs/content/en/getting_started/upgrading.md
@@ -72,6 +72,19 @@ godojo installations
 
 If you have installed DefectDojo on "iron" and wish to upgrade the installation, please see the [instructions in the repo](https://github.com/DefectDojo/godojo/blob/master/docs-and-scripts/upgrading.md).
 
+## Upgrading to DefectDojo Version 2.25.x.
+
+There are no special instruction for upgrading to 2.25.0. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.25.0) for the contents of the release.
+
+**Deprecation**
+
+The OpenAPI 2.0 Swagger API documentation is being deprecated in favor of the existing
+OpenAPI 3.0 API documentation page. The OpenAPI 2.0 Swagger API documentation page is
+slated for removal in version 2.30.0
+
+*Note*: The API has not changed in any way and behaves the same between OAPI2 and OAPI3
+
+
 ## Upgrading to DefectDojo Version 2.24.x.
 
 There are no special instruction for upgrading to 2.24.0. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.24.0) for the contents of the release.

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -173,7 +173,7 @@
                                     <li>
                                         <a href="{% url 'api_v2_schema' %}" target="_blank">
                                             <i class="fa-solid fa-book fa-fw" title="OpenAPI v2 Docs"></i>
-                                            {% trans "API v2 OpenAPI2 Docs" %}
+                                            {% trans "API v2 OpenAPI2 Docs (Deprecated)" %}
                                         </a>
                                     </li>
                                     <li>

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -184,7 +184,7 @@ schema_view = get_schema_view(
     openapi.Info(
         title="Defect Dojo API",
         default_version='v2',
-        description="To use the API you need be authorized.",
+        description="To use the API you need be authorized.\n\n## Deprecated - Removal in v2.30.0\n#### Please use the [OpenAPI3 version](/api/v2/oa3/swagger-ui/)",
     ),
     # if public=False, includes only endpoints the current user has access to
     public=True,


### PR DESCRIPTION
The package used to generate the OpenAPIv2 swagger page has a note pointing folks to [def-spectacular](https://github.com/tfranzel/drf-spectacular) which we are already using for the OpenAPIv3 swagger page

The OAPI2 page should be deprecated for the 2.25.0 release with a planned removal in 2.30.0 (Jan2024)