### PR TITLE
fix: uncheck verified box when toggle false positive to fix test_retr…

### DIFF
--- a/tests/false_positive_history_test.py
+++ b/tests/false_positive_history_test.py
@@ -73,6 +73,8 @@ class FalsePositiveHistoryTest(BaseTestCase):
         driver.find_element(By.LINK_TEXT, "Edit Finding").click()
         # Click on Active checkbox
         driver.find_element(By.ID, "id_active").click()
+        # Click on Verified checkbox
+        driver.find_element(By.ID, "id_verified").click()
         # Click on False Positive checkbox
         driver.find_element(By.ID, "id_false_p").click()
         # Send


### PR DESCRIPTION
**Description**
* commit #8363 added the new default verified options to all new findings added via ui
* therefore the function edit_toggle_false_positive could not toggle findings as false positives so the test test_retroactive_edit_finding failed
* added a click to uncheck the verified box when toggle false positive

**Test results**

* All tests passed

**Documentation**

* No update of the documentation needed

**Checklist**

This checklist is for your information.

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [x] Add the proper label to categorize your PR.

