### PR TITLE
Add drf-spectacular preprocessing hooks to keep a rigid definition of rendered API endpoints

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -770,9 +770,11 @@ SPECTACULAR_SETTINGS = {
     'TITLE': 'Defect Dojo API v2',
     'DESCRIPTION': 'Defect Dojo - Open Source vulnerability Management made easy. Prefetch related parameters/responses not yet in the schema.',
     'VERSION': __version__,
+    'SCHEMA_PATH_PREFIX': "/api/v2",
     # OTHER SETTINGS
     # the following set to False could help some client generators
     # 'ENUM_ADD_EXPLICIT_BLANK_NULL_CHOICE': False,
+    'PREPROCESSING_HOOKS': ['dojo.urls.drf_spectacular_preprocessing_filter_spec'],
     'POSTPROCESSING_HOOKS': ['dojo.api_v2.prefetch.schema.prefetch_postprocessing_hook'],
     # show file selection dialogue, see https://github.com/tfranzel/drf-spectacular/issues/455
     "COMPONENT_SPLIT_REQUEST": True,

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -232,3 +232,13 @@ if hasattr(settings, 'DJANGO_ADMIN_ENABLED'):
 # sometimes urlpatterns needed be added from local_settings.py to avoid having to modify core defect dojo files
 if hasattr(settings, 'EXTRA_URL_PATTERNS'):
     urlpatterns += settings.EXTRA_URL_PATTERNS
+
+
+# Remove any other endpoints that drf-spectacular is guessing should be in the swagger
+def drf_spectacular_preprocessing_filter_spec(endpoints):
+    filtered = []
+    for (path, path_regex, method, callback) in endpoints:
+        # Remove all but DRF API endpoints
+        if path.startswith("/api/v2/"):
+            filtered.append((path, path_regex, method, callback))
+    return filtered


### PR DESCRIPTION
[sc-1449]