### PR TITLE
Remove naive format warnings during import

### DIFF
--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -35,14 +35,20 @@ class DojoDefaultImporter(object):
         if created:
             logger.info('Created new Test_Type with name %s because a report is being imported', test_type.name)
 
+        if scan_date and not scan_date.tzinfo:
+            scan_date = timezone.make_aware(scan_date)
+
+        if now and not now.tzinfo:
+            now = timezone.make_aware(now)
+
         test = Test(
             title=title,
             engagement=engagement,
             lead=lead,
             test_type=test_type,
             scan_type=scan_type,
-            target_start=scan_date if scan_date else now.date(),
-            target_end=scan_date if scan_date else now.date(),
+            target_start=scan_date or now,
+            target_end=scan_date or now,
             environment=environment,
             percent_complete=100,
             version=version,

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -1,6 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.core.exceptions import MultipleObjectsReturned
 from django.conf import settings
+from django.utils.timezone import make_aware
 from dojo.decorators import dojo_async_task
 from dojo.celery import app
 from dojo.endpoint.utils import endpoint_get_or_create
@@ -21,7 +22,10 @@ def update_timestamps(test, version, branch_tag, build_id, commit_hash, now, sca
     if test.engagement.engagement_type == 'CI/CD':
         test.engagement.target_end = max_safe([scan_date.date(), test.engagement.target_end])
 
-    test.target_end = max_safe([scan_date, test.target_end])
+    max_test_start_date = max_safe([scan_date, test.target_end])
+    if not max_test_start_date.tzinfo:
+        max_test_start_date = make_aware(max_test_start_date)
+    test.target_end = max_test_start_date
 
     if version:
         test.version = version


### PR DESCRIPTION
fixes #970 (removes the warnings in the logs anyways)
[sc-1952]