### PR TITLE
Endpoint model/view corrections

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -124,12 +124,12 @@ def process_endpoint_view(request, eid, host_view=False):
         endpoints = endpoint.host_endpoints()
         endpoint_metadata = None
         all_findings = endpoint.host_findings()
-        active_findings = endpoint.host_active_findings()
+        active_verified_findings = endpoint.host_active_verified_findings()
     else:
         endpoints = None
         endpoint_metadata = dict(endpoint.endpoint_meta.values_list('name', 'value'))
         all_findings = endpoint.findings.all()
-        active_findings = endpoint.active_findings()
+        active_verified_findings = endpoint.active_verified_findings()
 
     if all_findings:
         start_date = timezone.make_aware(datetime.combine(all_findings.last().date, datetime.min.time()))
@@ -148,11 +148,11 @@ def process_endpoint_view(request, eid, host_view=False):
     monthly_counts = get_period_counts(all_findings, closed_findings, None, months_between, start_date,
                                        relative_delta='months')
 
-    paged_findings = get_page_items(request, active_findings, 25)
+    paged_findings = get_page_items(request, active_verified_findings, 25)
 
     vulnerable = False
 
-    if active_findings.count() != 0:
+    if active_verified_findings.count() != 0:
         vulnerable = True
 
     product_tab = Product_Tab(endpoint.product, "Host" if host_view else "Endpoint", tab="endpoints")

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1273,6 +1273,7 @@ class FindingFilter(FindingFilterWithTags):
     effort_for_fixing = MultipleChoiceFilter(choices=EFFORT_FOR_FIXING_CHOICES)
 
     test_import_finding_action__test_import = NumberFilter(widget=HiddenInput())
+    endpoints = NumberFilter(widget=HiddenInput())
 
     if get_system_setting('enable_jira'):
         has_jira_issue = BooleanFilter(field_name='jira_issue',

--- a/dojo/importers/utils.py
+++ b/dojo/importers/utils.py
@@ -6,6 +6,7 @@ from dojo.decorators import dojo_async_task
 from dojo.celery import app
 from dojo.endpoint.utils import endpoint_get_or_create
 from dojo.utils import max_safe
+from django.urls import reverse
 from dojo.models import IMPORT_CLOSED_FINDING, IMPORT_CREATED_FINDING, \
     IMPORT_REACTIVATED_FINDING, IMPORT_UNTOUCHED_FINDING, Test_Import, Test_Import_Finding_Action, \
     Endpoint_Status, Vulnerability_Id

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1663,7 +1663,17 @@ class Endpoint(models.Model):
 
     def __eq__(self, other):
         if isinstance(other, Endpoint):
-            return str(self) == str(other)
+            # Check if the contents of the endpoint match
+            contents_match = str(self) == str(other)
+            # Determine if products should be used in the equation
+            if self.product is not None and other.product is not None:
+                # Check if the products are the same
+                products_match = (self.product) == other.product
+                # Check if the contents match
+                return products_match and contents_match
+            else:
+                return contents_match
+
         else:
             return NotImplemented
 
@@ -1692,20 +1702,41 @@ class Endpoint(models.Model):
         return self.findings.all().count()
 
     def active_findings(self):
-        findings = self.findings.filter(active=True,
-                                      out_of_scope=False,
-                                      mitigated__isnull=True,
-                                      false_p=False,
-                                      duplicate=False,
-                                      status_finding__mitigated=False,
-                                      status_finding__false_positive=False,
-                                      status_finding__out_of_scope=False,
-                                      status_finding__risk_accepted=False).order_by('numerical_severity')
+        findings = self.findings.filter(
+            active=True,
+            out_of_scope=False,
+            mitigated__isnull=True,
+            false_p=False,
+            duplicate=False,
+            status_finding__mitigated=False,
+            status_finding__false_positive=False,
+            status_finding__out_of_scope=False,
+            status_finding__risk_accepted=False
+        ).order_by('numerical_severity')
+        return findings
+
+    def active_verified_findings(self):
+        findings = self.findings.filter(
+            active=True,
+            verified=True,
+            out_of_scope=False,
+            mitigated__isnull=True,
+            false_p=False,
+            duplicate=False,
+            status_finding__mitigated=False,
+            status_finding__false_positive=False,
+            status_finding__out_of_scope=False,
+            status_finding__risk_accepted=False
+        ).order_by('numerical_severity')
         return findings
 
     @property
     def active_findings_count(self):
         return self.active_findings().count()
+
+    @property
+    def active_verified_findings_count(self):
+        return self.active_verified_findings().count()
 
     def host_endpoints(self):
         return Endpoint.objects.filter(host=self.host,
@@ -1741,21 +1772,43 @@ class Endpoint(models.Model):
         return self.host_findings().count()
 
     def host_active_findings(self):
-        findings = Finding.objects.filter(active=True,
-                                        out_of_scope=False,
-                                        mitigated__isnull=True,
-                                        false_p=False,
-                                        duplicate=False,
-                                        status_finding__mitigated=False,
-                                        status_finding__false_positive=False,
-                                        status_finding__out_of_scope=False,
-                                        status_finding__risk_accepted=False,
-                                        endpoints__in=self.host_endpoints()).order_by('numerical_severity')
+        findings = Finding.objects.filter(
+            active=True,
+            out_of_scope=False,
+            mitigated__isnull=True,
+            false_p=False,
+            duplicate=False,
+            status_finding__mitigated=False,
+            status_finding__false_positive=False,
+            status_finding__out_of_scope=False,
+            status_finding__risk_accepted=False,
+            endpoints__in=self.host_endpoints()
+        ).order_by('numerical_severity')
+        return findings
+
+    def host_active_verified_findings(self):
+        findings = Finding.objects.filter(
+            active=True,
+            verified=True,
+            out_of_scope=False,
+            mitigated__isnull=True,
+            false_p=False,
+            duplicate=False,
+            status_finding__mitigated=False,
+            status_finding__false_positive=False,
+            status_finding__out_of_scope=False,
+            status_finding__risk_accepted=False,
+            endpoints__in=self.host_endpoints()
+        ).order_by('numerical_severity')
         return findings
 
     @property
     def host_active_findings_count(self):
         return self.host_active_findings().count()
+
+    @property
+    def host_active_verified_findings_count(self):
+        return self.host_active_verified_findings().count()
 
     def get_breadcrumbs(self):
         bc = self.product.get_breadcrumbs()

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3702,11 +3702,11 @@ class JIRA_Issue(models.Model):
                                        help_text=_("The date the linked Jira issue was last modified."))
 
     def set_obj(self, obj):
-        if type(obj) == Finding:
+        if isinstance(obj, Finding):
             self.finding = obj
-        elif type(obj) == Finding_Group:
+        elif isinstance(obj, Finding_Group):
             self.finding_group = obj
-        elif type(obj) == Engagement:
+        elif isinstance(obj, Engagement):
             self.engagement = obj
         else:
             raise ValueError('unknown object type while creating JIRA_Issue: %s' % to_str_typed(obj))

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -117,10 +117,10 @@
                                 {% endif %}
                                 <td class="text-center">
                                   {% if host_view %}
-                                      {{ e.host_active_findings_count }}
+                                      {{ e.host_active_verified_findings_count }}
                                   {% else %}
-                                    {% if e.active_findings_count > 0 %}
-                                      <a href="{% url 'verified_findings' %}?endpoints={{ e.id }}">{{ e.active_findings_count }}</a>
+                                    {% if e.active_verified_findings_count > 0 %}
+                                      <a href="{% url 'verified_findings' %}?endpoints={{ e.id }}">{{ e.active_verified_findings_count }}</a>
                                     {% else %}
                                       0
                                     {% endif %}
@@ -133,7 +133,7 @@
                                     {% if e.mitigated %}
                                       Mitigated
                                     {% else %}
-                                      {% if e.active_findings_count > 0 %}
+                                      {% if e.active_verified_findings_count > 0 %}
                                         Vulnerable
                                       {% else %}
                                         No active verified findings

--- a/unittests/test_endpoint_model.py
+++ b/unittests/test_endpoint_model.py
@@ -155,6 +155,52 @@ class TestEndpointModel(DojoTestCase):
         )
         self.assertTrue(created7)
 
+    def test_equality_without_products(self):
+        # Test with all the fields
+        e1 = Endpoint(protocol="https", host="localhost", port=5439, path="test", query="param=value")
+        e2 = Endpoint(protocol="https", host="localhost", port=5439, path="test", query="param=value")
+        e3 = Endpoint(protocol="https", host="localhost", port=5439, path="different", query="param=value")
+        # Verify e1 and e2 are actually equal
+        self.assertTrue(e1 == e2)
+        # Verify e1 and e2 are not equal because the path is different
+        self.assertFalse(e1 == e3)
+
+    def test_equality_with_one_product_one_without(self):
+        # Define the product
+        p = Product.objects.get_or_create(
+            name="test product",
+            description="",
+            prod_type=Product_Type.objects.get_or_create(name="test pt")[0]
+        )[0]
+        e1 = Endpoint(host="localhost")
+        e2 = Endpoint(host="localhost", product=p)
+        # Verify e1 and e2 are actually equal
+        # Since on has a product and the other does not, we cannot use products to aid in equality
+        self.assertTrue(e1 == e2)
+
+    def test_equality_with_products(self):
+        # Define the product
+        p1 = Product.objects.get_or_create(
+            name="test product 1",
+            description="",
+            prod_type=Product_Type.objects.get_or_create(name="test pt")[0]
+        )[0]
+        p2 = Product.objects.get_or_create(
+            name="test product 2",
+            description="",
+            prod_type=Product_Type.objects.get_or_create(name="test pt")[0]
+        )[0]
+        # Define the endpoints
+        e1 = Endpoint(host="localhost", product=p1)
+        e2 = Endpoint(host="localhost", product=p1)
+        e3 = Endpoint(host="localhost", product=p2)
+        # Verify e1 and e2 are actually equal
+        # Since the products match, this should be true
+        self.assertTrue(e1 == e2)
+        # Verify e1 and e2 are not equal
+        # Because the products are different, the endpoint objects are not the same
+        self.assertFalse(e1 == e3)
+
 
 @skip("Outdated - this class was testing clean-up broken entries in old version of model; new version of model doesn't to store broken entries")
 class TestEndpointStatusBrokenModel(DojoTestCase):


### PR DESCRIPTION
This PR fixes a handful of issues observed with the endpoint model and it's views

## Endpoint Equality across products

Deleting a product type with two products that have endpoints with matching contents (protocol + host + port + path + query) result in a mixup of which endpoint belongs where:

![Screenshot 2023-08-21 at 11 20 06 AM](https://github.com/DefectDojo/django-DefectDojo/assets/46459665/c723c9d1-f0ba-4544-864a-11b032f716bb)

This is the error produced:
```
update or delete on table "dojo_product" violates foreign key constraint "dojo_endpoint_product_id_b86dc143_fk_dojo_product_id" on table "dojo_endpoint"
DETAIL:  Key (id)=(10) is still referenced from table "dojo_endpoint".
```

This issue originates from the endpoint equality method. An endpoint was deemed equal to another if the string representation was the same, but failed to take into account that the endpoints could be from different products. The solution there is to incorporate product matching if they are specified. Instances of unsaved endpoints still use the equality method when determining if a given finding already has existing endpoints (at this time, one finding has as a product, and one does not)

## Endpoint filtering on the Findings page

At some point, this filter was removed for the sake of performance (to prevent the page loading all endpoint objectsts in the system on each request) but was actually necessary when filtering findings by endpoint. The correct this, I added a hidden option for "endpoints" on the FindingFilter. This change allows clicking the number of active/verified findings in the screenshot below to actually work:

![Screenshot 2023-08-22 at 11 28 15 AM](https://github.com/DefectDojo/django-DefectDojo/assets/46459665/ba6c898e-8590-4d33-aba1-ac6e46468857)

## Endpoint Views query "Active Verified" findings

Fix multiple places in the endpoint UI that reference "Active Verified" findings, but the query to fetch those findings does not filter for verified findings at all. I added matching helping methods for 
- `active_findings` to also include `active_verified_findings`
- `active_findings_count` to also include `active_verified_findings_count`
- `host_active_findings` to also include `host_active_verified_findings`
- `host_active_findings_count` to also include `host_active_verified_findings_count`

<!-- [sc-1978] -->




