### PR TITLE
updated helm chart to allow setting a different port for external redis

### DIFF
--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
   DD_CELERY_BROKER_SCHEME: {{ if eq .Values.celery.broker "rabbitmq" }}amqp{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ template "redis.scheme" . }}{{ end }}
   DD_CELERY_BROKER_USER: '{{ if eq .Values.celery.broker "rabbitmq" }}user{{ end }}'
   DD_CELERY_BROKER_HOST: {{ if eq .Values.celery.broker "rabbitmq" }}{{ template "rabbitmq.hostname" . }}{{ else if eq .Values.celery.broker "redis" }}{{ template "redis.hostname" . }}{{ end }}
-  DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}5672{{ end }}{{ if eq .Values.celery.broker "redis" }}6379{{ end }}'
+  DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}5672{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ .Values.redis.redisServerPort | default "6379"}}{{ end }}'
   DD_CELERY_BROKER_PARAMS: '{{ if eq .Values.celery.broker "redis" }}{{- if .Values.redis.transportEncryption.enabled -}}{{ .Values.redis.transportEncryption.params | default "ssl_cert_reqs=optional" }}{{ end }}{{ end }}'
   DD_CELERY_BROKER_PATH: '{{ .Values.celery.path | default "//" }}'
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
   DD_CELERY_BROKER_SCHEME: {{ if eq .Values.celery.broker "rabbitmq" }}amqp{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ template "redis.scheme" . }}{{ end }}
   DD_CELERY_BROKER_USER: '{{ if eq .Values.celery.broker "rabbitmq" }}user{{ end }}'
   DD_CELERY_BROKER_HOST: {{ if eq .Values.celery.broker "rabbitmq" }}{{ template "rabbitmq.hostname" . }}{{ else if eq .Values.celery.broker "redis" }}{{ template "redis.hostname" . }}{{ end }}
-  DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}{{ .Values.service.ports.amqp | default "5672" }}{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ .Values.redis.master.service.ports.redis | default "6379" }}{{ end }}'
+  DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}{{ .Values.rabbitmq.service.ports.amqp | default "5672" }}{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ .Values.redis.master.service.ports.redis | default "6379" }}{{ end }}'
   DD_CELERY_BROKER_PARAMS: '{{ if eq .Values.celery.broker "redis" }}{{- if .Values.redis.transportEncryption.enabled -}}{{ .Values.redis.transportEncryption.params | default "ssl_cert_reqs=optional" }}{{ end }}{{ end }}'
   DD_CELERY_BROKER_PATH: '{{ .Values.celery.path | default "//" }}'
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -18,7 +18,7 @@ data:
   DD_CELERY_BROKER_SCHEME: {{ if eq .Values.celery.broker "rabbitmq" }}amqp{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ template "redis.scheme" . }}{{ end }}
   DD_CELERY_BROKER_USER: '{{ if eq .Values.celery.broker "rabbitmq" }}user{{ end }}'
   DD_CELERY_BROKER_HOST: {{ if eq .Values.celery.broker "rabbitmq" }}{{ template "rabbitmq.hostname" . }}{{ else if eq .Values.celery.broker "redis" }}{{ template "redis.hostname" . }}{{ end }}
-  DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}5672{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ .Values.redis.redisServerPort | default "6379"}}{{ end }}'
+  DD_CELERY_BROKER_PORT: '{{ if eq .Values.celery.broker "rabbitmq" }}{{ .Values.service.ports.amqp | default "5672" }}{{ end }}{{ if eq .Values.celery.broker "redis" }}{{ .Values.redis.master.service.ports.redis | default "6379" }}{{ end }}'
   DD_CELERY_BROKER_PARAMS: '{{ if eq .Values.celery.broker "redis" }}{{- if .Values.redis.transportEncryption.enabled -}}{{ .Values.redis.transportEncryption.params | default "ssl_cert_reqs=optional" }}{{ end }}{{ end }}'
   DD_CELERY_BROKER_PATH: '{{ .Values.celery.path | default "//" }}'
   DD_CELERY_LOG_LEVEL: {{ .Values.celery.logLevel }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -521,7 +521,8 @@ redis:
   # To use an external Redis instance, set enabled to false and uncomment
   # the line below:
   # redisServer: myrediscluster
-
+  # To use a different port for Redis (default: 6379) add a port number and uncomment the line below:
+  # redisServerPort: xxxx
 
 # To add extra variables not predefined by helm config it is possible to define in extraConfigs block, e.g. below:
 # NOTE  Do not store any kind of sensitive information inside of it

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -521,8 +521,11 @@ redis:
   # To use an external Redis instance, set enabled to false and uncomment
   # the line below:
   # redisServer: myrediscluster
-  # To use a different port for Redis (default: 6379) add a port number and uncomment the line below:
-  # redisServerPort: xxxx
+  # To use a different port for Redis (default: 6379) add a port number and uncomment the lines below:
+  # master:
+  #   service:
+  #     ports:
+  #       redis: xxxx
 
 # To add extra variables not predefined by helm config it is possible to define in extraConfigs block, e.g. below:
 # NOTE  Do not store any kind of sensitive information inside of it


### PR DESCRIPTION
**Description**

I've updated the values.yaml file and the configmap template in the helm chart to be able to set a different port for external redis. It was hardcoded to the default 6379.

**Test results**

tested it with empty values.yaml (no external redis), values.yaml with an external redis without specifying port (defaulted to 6379) and with port 6380 (azure cache for redis ssl port).

**Documentation**

documentation added inline to values.yaml

**Checklist**

This checklist is for your information.

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
