### PR TITLE
addition of has_tags and product/finding sla filters

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -145,7 +145,7 @@ class FindingStatusFilter(ChoiceFilter):
 class FindingSLAFilter(ChoiceFilter):
     def any(self, qs, name):
         return qs
-    
+
     def satisfies_sla(self, qs, name):
         non_sla_violations = [finding.id for finding in qs if not finding.violates_sla]
         return Finding.objects.filter(id__in=non_sla_violations)
@@ -176,7 +176,7 @@ class FindingSLAFilter(ChoiceFilter):
 class ProductSLAFilter(ChoiceFilter):
     def any(self, qs, name):
         return qs
-    
+
     def satisfies_sla(self, qs, name):
         non_sla_violations = [product.id for product in qs if not product.violates_sla]
         return Product.objects.filter(id__in=non_sla_violations)
@@ -1032,9 +1032,9 @@ class ProductFilter(DojoFilter):
     )
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
-    
+
     outside_of_sla = ProductSLAFilter(label="Outside of SLA")
-    
+
     has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
 
     o = OrderingFilter(
@@ -1112,7 +1112,7 @@ class ApiProductFilter(DojoFilter):
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
                                  help_text='Comma separated list of exact tags not present on product', exclude='True')
     has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
-    outside_of_sla = ProductSLAFilter()
+    outside_of_sla = extend_schema_field(OpenApiTypes.NUMBER)(ProductSLAFilter())
 
     # DateRangeFilter
     created = DateRangeFilter()
@@ -1240,7 +1240,7 @@ class ApiFindingFilter(DojoFilter):
         help_text='Comma separated list of exact tags not present on product',
         exclude='True')
     has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
-    outside_of_sla = FindingSLAFilter()
+    outside_of_sla = extend_schema_field(OpenApiTypes.NUMBER)(ProductSLAFilter())
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -1410,9 +1410,9 @@ class FindingFilter(FindingFilterWithTags):
     )
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
-    
+
     outside_of_sla = FindingSLAFilter(label="Outside of SLA")
-    
+
     has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
 
     o = OrderingFilter(

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -142,6 +142,68 @@ class FindingStatusFilter(ChoiceFilter):
         return self.options[value][1](self, qs, self.field_name)
 
 
+class FindingSLAFilter(ChoiceFilter):
+    def any(self, qs, name):
+        return qs
+    
+    def satisfies_sla(self, qs, name):
+        non_sla_violations = [finding.id for finding in qs if not finding.violates_sla]
+        return Finding.objects.filter(id__in=non_sla_violations)
+
+    def violates_sla(self, qs, name):
+        sla_violations = [finding.id for finding in qs if finding.violates_sla]
+        return Finding.objects.filter(id__in=sla_violations)
+
+    options = {
+        None: (_('Any'), any),
+        0: (_('False'), satisfies_sla),
+        1: (_('True'), violates_sla),
+    }
+
+    def __init__(self, *args, **kwargs):
+        kwargs['choices'] = [
+            (key, value[0]) for key, value in six.iteritems(self.options)]
+        super(FindingSLAFilter, self).__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        try:
+            value = int(value)
+        except (ValueError, TypeError):
+            value = None
+        return self.options[value][1](self, qs, self.field_name)
+
+
+class ProductSLAFilter(ChoiceFilter):
+    def any(self, qs, name):
+        return qs
+    
+    def satisfies_sla(self, qs, name):
+        non_sla_violations = [product.id for product in qs if not product.violates_sla]
+        return Product.objects.filter(id__in=non_sla_violations)
+
+    def violates_sla(self, qs, name):
+        sla_violations = [product.id for product in qs if product.violates_sla]
+        return Product.objects.filter(id__in=sla_violations)
+
+    options = {
+        None: (_('Any'), any),
+        0: (_('False'), satisfies_sla),
+        1: (_('True'), violates_sla),
+    }
+
+    def __init__(self, *args, **kwargs):
+        kwargs['choices'] = [
+            (key, value[0]) for key, value in six.iteritems(self.options)]
+        super(ProductSLAFilter, self).__init__(*args, **kwargs)
+
+    def filter(self, qs, value):
+        try:
+            value = int(value)
+        except (ValueError, TypeError):
+            value = None
+        return self.options[value][1](self, qs, self.field_name)
+
+
 def get_earliest_finding(queryset=None):
     if queryset is None:  # don't to 'if not queryset' which will trigger the query
         queryset = Finding.objects.all()
@@ -683,6 +745,8 @@ class EngagementDirectFilter(DojoFilter):
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
 
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
+
     o = OrderingFilter(
         # tuple-mapping retains order
         fields=(
@@ -744,6 +808,8 @@ class EngagementFilter(DojoFilter):
     )
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
+
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -842,6 +908,7 @@ class ApiEngagementFilter(DojoFilter):
                                                 lookup_expr='in',
                                                 help_text='Comma separated list of exact tags not present on product',
                                                 exclude='True')
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -965,6 +1032,10 @@ class ProductFilter(DojoFilter):
     )
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
+    
+    outside_of_sla = ProductSLAFilter(label="Outside of SLA")
+    
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -1040,6 +1111,8 @@ class ApiProductFilter(DojoFilter):
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
                                  help_text='Comma separated list of exact tags not present on product', exclude='True')
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
+    outside_of_sla = ProductSLAFilter()
 
     # DateRangeFilter
     created = DateRangeFilter()
@@ -1166,6 +1239,8 @@ class ApiFindingFilter(DojoFilter):
         lookup_expr='in',
         help_text='Comma separated list of exact tags not present on product',
         exclude='True')
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
+    outside_of_sla = FindingSLAFilter()
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -1335,6 +1410,10 @@ class FindingFilter(FindingFilterWithTags):
     )
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
+    
+    outside_of_sla = FindingSLAFilter(label="Outside of SLA")
+    
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
 
     o = OrderingFilter(
         # tuple-mapping retains order
@@ -1770,6 +1849,8 @@ class EndpointFilter(DojoFilter):
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
 
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
+
     o = OrderingFilter(
         # tuple-mapping retains order
         fields=(
@@ -1803,6 +1884,8 @@ class ApiEndpointFilter(DojoFilter):
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
                                  help_text='Comma separated list of exact tags not present on model', exclude='True')
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
+
     o = OrderingFilter(
         # tuple-mapping retains order
         fields=(
@@ -1863,6 +1946,8 @@ class EngagementTestFilter(DojoFilter):
 
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Not tag name contains', exclude=True)
 
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
+
     o = OrderingFilter(
         # tuple-mapping retains order
         fields=(
@@ -1914,6 +1999,7 @@ class ApiTestFilter(DojoFilter):
                                                                   lookup_expr='in',
                                                                   help_text='Comma separated list of exact tags not present on product',
                                                                   exclude='True')
+    has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
 
     o = OrderingFilter(
         # tuple-mapping retains order

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3662,11 +3662,11 @@ class JIRA_Issue(models.Model):
                                        help_text=_("The date the linked Jira issue was last modified."))
 
     def set_obj(self, obj):
-        if type(obj) == Finding:
+        if isinstance(obj, Finding):
             self.finding = obj
-        elif type(obj) == Finding_Group:
+        elif isinstance(obj, Finding_Group):
             self.finding_group = obj
-        elif type(obj) == Engagement:
+        elif isinstance(obj, Engagement):
             self.engagement = obj
         else:
             raise ValueError('unknown object type while creating JIRA_Issue: %s' % to_str_typed(obj))


### PR DESCRIPTION
New filter field to query for object that `Has tags`. Can be used for Products, Engagements, Tests, Findings and Endpoints (API filter fields also added). Selects objects that do not have any tags at all (i.e. untagged objects).

**Example of Has tags for Products**
_All Products:_
<img width="1919" alt="Screenshot 2023-08-23 at 2 52 07 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/5f1f2a50-d8a1-40aa-91d6-9a4d2f6fd786">
_Products filtered by Has tags:_
<img width="1919" alt="Screenshot 2023-08-23 at 2 52 48 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/fe4171b9-5cf6-44a7-844f-873e48809313">
<img width="1919" alt="Screenshot 2023-08-23 at 2 54 22 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/c00503c1-0923-40ea-b819-c20b378572c5">


New filter field to query for objects that are `Outside of SLA`. Can be used for Products and Findings (API filter fields also added). Selects objects that violate their SLA. For products, this is determined by if any of the findings within its engagements violate SLA. For findings, this is determined by if any of the findings themselves violate SLA.

**Example of Outside of SLA for Products**
_All Products:_
<img width="1919" alt="Screenshot 2023-08-23 at 2 52 07 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/5f1f2a50-d8a1-40aa-91d6-9a4d2f6fd786">
_Products filtered that are Outside of SLA:_
<img width="1919" alt="Screenshot 2023-08-23 at 2 55 44 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/0f77b967-09cc-4440-8fd1-838f94d6f1eb">
<img width="1919" alt="Screenshot 2023-08-23 at 2 56 36 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/d93854d8-de03-409c-b445-9ae98c0eda3e">

