### PR TITLE
Set a default environment for tests in DefectDojo

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -576,7 +576,6 @@ def add_tests(request, eid):
 # Cant use the easy decorator because of the potential for either eid/pid being used
 def import_scan_results(request, eid=None, pid=None):
     environment = Development_Environment.objects.get(name='Development')
-    
     engagement = None
     form = ImportScanForm(initial={'environment': environment})
     cred_form = CredMappingForm()

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -575,8 +575,10 @@ def add_tests(request, eid):
 
 # Cant use the easy decorator because of the potential for either eid/pid being used
 def import_scan_results(request, eid=None, pid=None):
+    environment = Development_Environment.objects.get(name='Development')
+    
     engagement = None
-    form = ImportScanForm()
+    form = ImportScanForm(initial={'environment': environment})
     cred_form = CredMappingForm()
     finding_count = 0
     jform = None


### PR DESCRIPTION
## Set a default environment for tests in DefectDojo
**Description**
![tempsnip](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/475b3671-6a90-4202-bfe0-4b319d85ae50)

During an import, the Environment will default to "Development", reducing clicks for the user 

<!-- [sc-1253] -->