### PR TITLE
Fix checkbox disappear findings (windows resize)

### DIFF
--- a/dojo/templates/dojo/alerts.html
+++ b/dojo/templates/dojo/alerts.html
@@ -17,7 +17,7 @@
                             <th>{% trans "Title" %}</th>
                             <th>{% trans "Description" %}</th>
                             <th>{% trans "Timeframe" %}</th>
-                            <th class="hidden-sm centered" title="{% trans "Select all visible alerts" %}">
+                            <th class="centered" title="{% trans "Select all visible alerts" %}">
                                     <input type="checkbox" name="select_all" id="select_all"/>
                             </th>
                         </tr>
@@ -30,7 +30,7 @@
                                 <td>{%if alert.url %}<a href="{{ alert.url }}">{% endif %}{{ alert.title }}{% if alert.url %}</a>{% endif %}</td>
                                 <td>{{ alert.description|linebreaks }}</td>
                                 <td>{{ alert.created }}</td>
-                                <td class="hidden-sm centered">
+                                <td class="centered">
                                         <input type="checkbox" name="alert_select" value="{{ alert.id }}"
                                                 class="select_one {{ alert.source }}"/>
                                 </td>

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -70,7 +70,7 @@
                            class="tablesorter-bootstrap table table-condensed table-striped table-hover">
                         <tr>
                             {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
-                            <th class="hidden-sm centered" title="Select all visible endpoint." id="bulk_edit">
+                            <th class="centered" title="Select all visible endpoint." id="bulk_edit">
                                 <form class="inline-form centered" action="#">
                                     <input type="checkbox" title="Select All" name="select_all" id="select_all"></input>
                                 </form>
@@ -94,7 +94,7 @@
                         {% for e in endpoints %}
                             <tr>
                                 {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Endpoint_Edit" %}
-                                <td class="hidden-sm centered">
+                                <td class="centered">
                                     <form action="#">
                                         <input type="checkbox" title= "Select_{{ e.id }}" name="select_{{ e.id }}"
                                                id="{{ e.id }}"  class="select_one {{ e.id }}"></input>

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -264,7 +264,7 @@
                         <thead>
                             <tr>
                                 {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
-                                    <th class="hidden-sm centered" title="Select all visible findings.">
+                                    <th class="centered" title="Select all visible findings.">
                                         <div class="dropdown">
                                             <button class="btn btn-primary dropdown-toggle"
                                                     type="button"
@@ -383,7 +383,7 @@
                             {% for finding in findings %}
                                 <tr class="{% if finding.active %}active_finding{% else %}inactive_finding{% endif %}">
                                     {% if not product_tab or product_tab and product_tab.product|has_object_permission:"Finding_Edit" %}
-                                        <td class="hidden-sm centered">
+                                        <td class="centered">
                                             <form action="#">
                                                 <input type="checkbox" name="select_{{ finding.id }}" id="{{ finding.id }}" class="select_one {{ finding.severity }}" aria-label="select-finding"/>
                                             </form>

--- a/dojo/templates/dojo/snippets/endpoints.html
+++ b/dojo/templates/dojo/snippets/endpoints.html
@@ -134,7 +134,7 @@
                         <table id="vuln_endpoints" class="table-striped table table-hover">
                             <thead>
                                 {% if finding|has_object_permission:"Finding_Edit" %}
-                                    <th class="hidden-sm" title="Select all vulnerable endpoints." style="width: 10%;">
+                                    <th class="" title="Select all vulnerable endpoints." style="width: 10%;">
                                         <form class="inline-form" action="#">
                                             <input type="checkbox" label="select_all_vulnerable" name="select_all_vulnerable" id="select_all_vulnerable"/>
                                         </form>
@@ -150,7 +150,7 @@
                                 {% for endpoint in endpoints %}
                                     <tr>
                                         {% if finding|has_object_permission:"Finding_Edit" %}
-                                            <td class="hidden-sm">
+                                            <td class="">
                                                 <form action="#">
                                                     <input type="checkbox" label="select_vulnerable_{{ endpoint.id }}" name="select_vulnerable_{{ endpoint.id }}" id="{{ endpoint.id }}"
                                                         class="select_one"/>
@@ -188,7 +188,7 @@
                         <table id="remd_endpoints" class="table-striped table table-hover">
                             <thead>
                                 {% if finding|has_object_permission:"Finding_Edit" %}
-                                    <th class="hidden-sm" title="Select all mitigated endpoints." style="width: 10%;">
+                                    <th class="" title="Select all mitigated endpoints." style="width: 10%;">
                                         <form class="inline-form" action="#">
                                             <input type="checkbox" label="select_all_mitigated" name="select_all_mitigated" id="select_all_mitigated"/>
                                         </form>
@@ -204,7 +204,7 @@
                                 {% for endpoint in endpoints %}
                                     <tr>
                                         {% if finding|has_object_permission:"Finding_Edit" %}
-                                            <td class="hidden-sm">
+                                            <td class="">
                                                 <form action="#">
                                                     <input type="checkbox" label="select_mitigated_{{ endpoint.id }}" name="select_mitigated_{{ endpoint.id }}" id="{{ endpoint.id }}"
                                                         class="select_one"/>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -859,7 +859,7 @@
                     <thead>
                         <tr>
                             {% if test|has_object_permission:"Test_Edit" or test|has_object_permission:"Test_Delete" %}
-                                <th class="hidden-sm centered" title="Select all visible findings.">
+                                <th class="centered" title="Select all visible findings.">
                                     <div class="dropdown">
                                         <button class="btn btn-primary dropdown-toggle"
                                                 type="button"
@@ -964,7 +964,7 @@
                         {% for finding in findings %}
                             <tr class="{% if finding.active %}active_finding{% else %}inactive_finding{% endif %}">
                                 {% if test|has_object_permission:"Test_Edit" or test|has_object_permission:"Test_Delete" %}
-                                    <td class="hidden-sm centered">
+                                    <td class="centered">
                                         <form action="#">
                                             <input type="checkbox"
                                                 name="select_{{ finding.id }}"


### PR DESCRIPTION
## Fix checkbox disappear findings (windows resize)
This bugfix makes visible the checkboxes 
![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/ca24c9b9-8aea-43d2-a0b0-95d09d4b12a8)

Now the windows looks like this:

![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/14d3c5bd-9c27-43c6-8ef8-a3ac9baa0bb3)