### PR TITLE
added open findings burndown for product metrics

### DIFF
--- a/dojo/product/urls.py
+++ b/dojo/product/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
         views.import_scan_results_prod, name='import_scan_results_prod'),
     re_path(r'^product/(?P<pid>\d+)/metrics$', views.view_product_metrics,
         name='view_product_metrics'),
+    re_path(r'^product/(?P<pid>\d+)/async_burndown_metrics$', views.async_burndown_metrics,
+        name='async_burndown_metrics'),
     re_path(r'^product/(?P<pid>\d+)/edit$', views.edit_product,
         name='edit_product'),
     re_path(r'^product/(?P<pid>\d+)/delete$', views.delete_product,

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -39,7 +39,7 @@ from dojo.models import Product_Type, Note_Type, Finding, Product, Engagement, T
 from dojo.utils import add_external_issue, add_error_message_to_response, add_field_errors_to_response, get_page_items, \
     add_breadcrumb, async_delete, \
     get_system_setting, get_setting, Product_Tab, get_punchcard_data, queryset_check, is_title_in_breadcrumbs, \
-    get_enabled_notifications_list, get_zero_severity_level, sum_by_severity_level
+    get_enabled_notifications_list, get_zero_severity_level, sum_by_severity_level, get_open_findings_burndown
 
 from dojo.notifications.helper import create_notification
 from dojo.components.sql_group_concat import Sql_GroupConcat
@@ -632,6 +632,8 @@ def view_product_metrics(request, pid):
 
     open_objs_by_age = {x: len([_ for _ in filters.get('open') if _.age == x]) for x in set([_.age for _ in filters.get('open')])}
 
+    open_findings_burndown = get_open_findings_burndown(prod)
+
     return render(request, 'dojo/product_metrics.html', {
         'prod': prod,
         'product_tab': product_tab,
@@ -643,6 +645,7 @@ def view_product_metrics(request, pid):
         'open_objs': filters.get('open', None),
         'open_objs_by_severity': open_objs_by_severity,
         'open_objs_by_age': open_objs_by_age,
+        'open_findings_burndown': open_findings_burndown,
         'inactive_objs': filters.get('inactive', None),
         'inactive_objs_by_severity': sum_by_severity_level(filters.get('inactive')),
         'closed_objs': filters.get('closed', None),

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -1394,6 +1394,17 @@ div.custom-search-form {
 	border-left: 1px solid #dcdedf;
 }
 
+.graph {
+    min-height: 158px;
+}
+
+.graph-loader {
+    min-height: 158px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
 .panel-footer {
     background-color: #dddedf;
     border-top: 1px solid #ddd;

--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -733,14 +733,15 @@ function accepted_per_week_2(critical, high, medium, low) {
         product_metrics.html
 */
 
-function open_findings_burndown(critical, high, medium, low, info) {
+function open_findings_burndown(critical, high, medium, low, info, y_max, y_min) {
     var options = {
         xaxes: [{
             mode: "time",
             timeformat: "%Y/%m/%d"
         }],
         yaxes: [{
-            min: 0
+            max: y_max,
+            min: y_min
         }],
         series: {
             lines: {

--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -733,6 +733,60 @@ function accepted_per_week_2(critical, high, medium, low) {
         product_metrics.html
 */
 
+function open_findings_burndown(critical, high, medium, low, info) {
+    var options = {
+        xaxes: [{
+            mode: "time",
+            timeformat: "%Y/%m/%d"
+        }],
+        yaxes: [{
+            min: 0
+        }],
+        series: {
+            lines: {
+                show: true
+            },
+            points: {
+                show: true,
+                radius: 1
+            }
+        },
+        grid: {
+            hoverable: true,
+            borderWidth: 1,
+            borderColor: '#e7e7e7',
+    
+        },
+        legend: {
+            position: 'nw'
+        },
+        tooltip: true,
+    };
+
+    var plotObj = $.plot($("#open_findings_burndown"), [{
+                data: critical,
+                label: " Critical",
+                color: "#d9534f",
+            }, {
+                data: high,
+                label: " High",
+                color: '#f0ad4e',
+            }, {
+                data: medium,
+                label: " Medium",
+                color: '#f0de28',
+            }, {
+                data: low,
+                label: " Low",
+                color: '#4cae4c',
+            }, {
+                data: info,
+                label: " Info",
+                color: '#337ab7',
+            }],
+            options);
+}
+
 function accepted_objs(d1, d2, d3, d4, d5, ticks) {
     var data = [
         {

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -268,7 +268,7 @@
                         <small>Ingested since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
-            </div>            
+            </div>
         </div>
     </div>
 

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -268,7 +268,7 @@
                         <small>Ingested since {{ start_date|date:"D., M. d, Y" }}</small>
                     </div>
                 </div>
-            </div>
+            </div>            
         </div>
     </div>
 
@@ -290,7 +290,23 @@
                 </div>
             </div>
         </div>
-      <div class="panel-body product-graphs">
+        <div class="panel-body product-graphs">
+            <div class="col-md-12">
+                <div class="panel panel-default">
+                    <div class="panel-heading">
+                        Open Day to Day by Severity
+                        <i title="Days are only displayed if findings are available."
+                           class="text-info fa-solid fa-circle-info"></i>
+                    </div>
+                    <div class="panel-body">
+                        <div id="open_findings_burndown" class="graph"></div>
+                    </div>
+                    <div class="panel-footer">
+                        <i class="text-info fa-solid fa-circle-info"></i>
+                        <small>Days are only displayed if findings are available.</small>
+                    </div>
+                </div>
+            </div>
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
@@ -514,6 +530,14 @@
             var ticks = [
                 [0, "Critical"], [1, "High"], [2, "Medium"], [3, "Low"], [4, "Info"]
             ];
+
+            open_findings_burndown(
+                {{ open_findings_burndown.Critical }},
+                {{ open_findings_burndown.High }},
+                {{ open_findings_burndown.Medium }},
+                {{ open_findings_burndown.Low }},
+                {{ open_findings_burndown.Info }}
+            );
 
             accepted_objs(
                 [[0, {{ accepted_objs_by_severity.Critical }}]],

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -536,7 +536,9 @@
                 {{ open_findings_burndown.High }},
                 {{ open_findings_burndown.Medium }},
                 {{ open_findings_burndown.Low }},
-                {{ open_findings_burndown.Info }}
+                {{ open_findings_burndown.Info }},
+                {{ open_findings_burndown.y_max }},
+                {{ open_findings_burndown.y_min }}
             );
 
             accepted_objs(

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -4,7 +4,6 @@
 {% load static %}
 {% block add_styles %}
     {{ block.super }}
-    .graph {min-height: 158px;}
 {% endblock %}
 {% block content %}
     {{ block.super }}
@@ -298,7 +297,11 @@
                         <i title="Days are only displayed if findings are available."
                            class="text-info fa-solid fa-circle-info"></i>
                     </div>
-                    <div class="panel-body">
+                    <div class="panel-body text-center">
+                        <div id="id_open_findings_burndown_loader" class="graph-loader">
+                            <p><i class="fas fa-spinner fa-spin fa-2x"></i></p>
+                            <p>Loading Finding Burndown Metrics...</p>
+                        </div>
                         <div id="open_findings_burndown" class="graph"></div>
                     </div>
                     <div class="panel-footer">
@@ -531,15 +534,33 @@
                 [0, "Critical"], [1, "High"], [2, "Medium"], [3, "Low"], [4, "Info"]
             ];
 
-            open_findings_burndown(
-                {{ open_findings_burndown.Critical }},
-                {{ open_findings_burndown.High }},
-                {{ open_findings_burndown.Medium }},
-                {{ open_findings_burndown.Low }},
-                {{ open_findings_burndown.Info }},
-                {{ open_findings_burndown.y_max }},
-                {{ open_findings_burndown.y_min }}
-            );
+            $(document).ready(function() {
+                fetch_burndown_metrics({{ prod.id }});
+            })
+
+            function fetch_burndown_metrics(pid) {
+                $.ajax({
+                    type: 'GET',
+                    url: '/product/' + pid + '/async_burndown_metrics',
+                    beforeSend: function() {
+                        $('#open_findings_burndown').hide();
+                        $('#id_open_findings_burndown_loader').show();
+                    },
+                    success: function(response) {
+                        $('#open_findings_burndown').show();
+                        $('#id_open_findings_burndown_loader').hide();
+                        open_findings_burndown(
+                            response.critical,
+                            response.high,
+                            response.medium,
+                            response.low,
+                            response.info,
+                            response.max,
+                            response.min,
+                        );
+                    }
+                });
+            }
 
             accepted_objs(
                 [[0, {{ accepted_objs_by_severity.Critical }}]],

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2462,8 +2462,6 @@ def get_open_findings_burndown(product):
         past_90_days['Low'].append([d_start * 1000, low_count])
         past_90_days['Info'].append([d_start * 1000, info_count])
 
-    print(running_max)
-    print(running_min)
     past_90_days['y_max'] = running_max
     past_90_days['y_min'] = running_min
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2418,7 +2418,7 @@ def get_open_findings_burndown(product):
 
     for i in range(90, -1, -1):
         start = (curr_date - timedelta(days=i))
-        
+
         d_start = start.timestamp()
         d_end = (start + timedelta(days=1)).timestamp()
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -2192,16 +2192,16 @@ def get_product(obj):
     if not obj:
         return None
 
-    if type(obj) == Finding or type(obj) == Finding_Group:
+    if isinstance(obj, Finding) or isinstance(obj, Finding_Group):
         return obj.test.engagement.product
 
-    if type(obj) == Test:
+    if isinstance(obj, Test):
         return obj.engagement.product
 
-    if type(obj) == Engagement:
+    if isinstance(obj, Engagement):
         return obj.product
 
-    if type(obj) == Product:
+    if isinstance(obj, Product):
         return obj
 
 


### PR DESCRIPTION
Added a new plot to the Product Detailed Metrics section that displays the total count of open findings for all severities.

This graph data is calculated by (for one severity):
1. Getting the count of all findings for the given Product 90 days prior to the current date
2. Iterating over each day to get the counts for total number of findings open and total number of findings mitigated
3. Adding the total number of findings opened to the running total count
4. Subtracting the total number of findings mitigated to the running total count

_Example of graph with Finding data:_
<img width="1919" alt="Screenshot 2023-08-25 at 3 54 59 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/87908a28-5dc1-425c-a7e7-14411459590a">

_Example of graph without any Finding data:_
<img width="1919" alt="Screenshot 2023-08-25 at 3 54 38 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/76979297/39302ce9-f104-4399-9a79-39a37c646f88">
