### PR TITLE
Catch malformed CVSSv3 bug in JFrog Xray API Summary parser

### DIFF
--- a/unittests/scans/jfrog_xray_api_summary_artifact/malformed_cvssv3.json
+++ b/unittests/scans/jfrog_xray_api_summary_artifact/malformed_cvssv3.json
@@ -1,0 +1,47 @@
+{
+  "artifacts": [
+    {
+      "general": {
+        "name": "artifact1:1.0",
+        "component_id": "artifact1:1.0",
+        "pkg_type": "Docker",
+        "path": "artifact_path/artifact1/1.0/",
+        "sha256": "eaab06c0a28618bfb65481bf31bce7d6dd3a15dac528297690111c202a1cd468"
+      },
+      "issues": [
+        {
+          "issue_id": "XRAY-523195",
+          "summary": "Okio GzipSource unhandled exception Denial of Service",
+          "description": "GzipSource does not handle an exception that might be raised when parsing a malformed gzip buffer. This may lead to denial of service of the Okio client when handling a crafted GZIP archive, by using the GzipSource class.",
+          "issue_type": "security",
+          "severity": "Medium",
+          "provider": "JFrog",
+          "cves": [
+            { "cve": "CVE-2023-3635", "cwe": ["CWE-195"], "cvss_v3": "5.9" }
+          ],
+          "created": "2023-06-12T00:00:00.585Z",
+          "impact_path": [
+            "default/local/com.evel.corp/snoop/2023.2.1-build00008-j8uwlfh3728dj2h16dk9f1f93/deployments/main.jar/BOOT-INF/lib/okio-jvm-2.8.0.jar"
+          ]
+        }
+      ],
+      "licenses": [
+        {
+          "name": "OpenSSL",
+          "full_name": "OpenSSL LICENSE",
+          "more_info_url": [
+            "https://spdx.org/licenses/OpenSSL.html",
+            "http://www.openssl.org/source/license.html",
+            "https://www.openssl.org/source/license.html",
+            "https://spdx.org/licenses/OpenSSL"
+          ],
+          "components": [
+            "alpine://3.12:libcrypto1.1:1.1.1k-r0",
+            "alpine://3.12:libssl1.1:1.1.1k-r0",
+            "alpine://3.12:openssl:1.1.1k-r0"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/tools/test_jfrog_xray_api_summary_artifact_parser.py
+++ b/unittests/tools/test_jfrog_xray_api_summary_artifact_parser.py
@@ -1,11 +1,12 @@
 from ..dojo_test_case import DojoTestCase
 from dojo.models import Test
-from dojo.tools.jfrog_xray_api_summary_artifact.parser import JFrogXrayApiSummaryArtifactParser
+from dojo.tools.jfrog_xray_api_summary_artifact.parser import (
+    JFrogXrayApiSummaryArtifactParser,
+)
 import hashlib
 
 
 class TestJFrogXrayApiSummaryArtifactParser(DojoTestCase):
-
     def test_parse_file_with_no_vuln(self):
         testfile = open("unittests/scans/jfrog_xray_api_summary_artifact/no_vuln.json")
         parser = JFrogXrayApiSummaryArtifactParser()
@@ -24,7 +25,10 @@ class TestJFrogXrayApiSummaryArtifactParser(DojoTestCase):
         self.assertEqual(1, len(item.unsaved_vulnerability_ids))
         self.assertEqual("XRAY-124116", item.unsaved_vulnerability_ids[0])
         self.assertEqual("Critical", item.severity)
-        self.assertEqual("3.12:openssl:1.1.1k-r0 -> OpenSSL contains an overflow", item.description[:54])
+        self.assertEqual(
+            "3.12:openssl:1.1.1k-r0 -> OpenSSL contains an overflow",
+            item.description[:54],
+        )
         self.assertEqual(" code.", item.description[-6:])
         self.assertIsNone(item.mitigation)
         self.assertEqual("artifact1", item.component_name)
@@ -37,16 +41,37 @@ class TestJFrogXrayApiSummaryArtifactParser(DojoTestCase):
         self.assertIsNone(item.impact)
         self.assertEqual("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", item.cvssv3)
         result = hashlib.sha256()
-        unique_id = "eaab06c0a28618bfb65481bf31bce7d6dd3a15dac528297690111c202a1cd468" + "3.12:openssl" + "1.1.1k-r0" + "XRAY-124116"
+        unique_id = (
+            "eaab06c0a28618bfb65481bf31bce7d6dd3a15dac528297690111c202a1cd468"
+            + "3.12:openssl"
+            + "1.1.1k-r0"
+            + "XRAY-124116"
+        )
         result.update(unique_id.encode())
         self.assertEqual(result.hexdigest(), item.unique_id_from_tool)
 
     def test_parse_file_with_many_vulns(self):
-        testfile = open("unittests/scans/jfrog_xray_api_summary_artifact/many_vulns.json")
+        testfile = open(
+            "unittests/scans/jfrog_xray_api_summary_artifact/many_vulns.json"
+        )
         parser = JFrogXrayApiSummaryArtifactParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(15, len(findings))
         finding = findings[0]
         self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
-        self.assertEqual('CVE-2021-42385', finding.unsaved_vulnerability_ids[0])
+        self.assertEqual("CVE-2021-42385", finding.unsaved_vulnerability_ids[0])
+
+    def test_parse_file_with_malformed_cvssv3_score(self):
+        testfile = open(
+            "unittests/scans/jfrog_xray_api_summary_artifact/malformed_cvssv3.json"
+        )
+        parser = JFrogXrayApiSummaryArtifactParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(findings))
+
+        finding = findings[0]
+        self.assertIsNone(finding.cvssv3)
+        self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("XRAY-523195", finding.unsaved_vulnerability_ids[1])


### PR DESCRIPTION
**Description**

JFrog Xray scan results sometimes have malformed CVSSv3 scores. The current implementation of the parser fails completely when a malformed CVSS v3 score is given to it what results in no findings are imported at all.

**Test results**

Tested that a malformed CVSS v3 score will lead to an empty cvssv3 field in the single finding but not break the whole parsing of the file.

**Documentation**

not needed

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
