### PR TITLE
[bugfix] Update whispers parser references field type

### DIFF
--- a/dojo/tools/whispers/parser.py
+++ b/dojo/tools/whispers/parser.py
@@ -1,6 +1,6 @@
 import json
 
-from dojo.models import Endpoint, Finding
+from dojo.models import Finding
 
 
 class WhispersParser(object):

--- a/dojo/tools/whispers/parser.py
+++ b/dojo/tools/whispers/parser.py
@@ -52,9 +52,7 @@ class WhispersParser(object):
                         "Supply the new secret through a placeholder to avoid disclosing "
                         "sensitive information in code."
                     ),
-                    references=Endpoint.from_uri(
-                        "https://cwe.mitre.org/data/definitions/798.html"
-                    ),
+                    references="https://cwe.mitre.org/data/definitions/798.html",
                     cwe=798,
                     severity=self.SEVERITY_MAP.get(
                         vuln.get("severity"), "Info"


### PR DESCRIPTION
**Description**

Field type mismatch is preventing results from being imported correctly.

See details:
* https://github.com/DefectDojo/django-DefectDojo/issues/7097
* https://github.com/adeptex/whispers/issues/100

This bugfix resolves the issue.
