### PR TITLE
Fix: anchorectl_policies crash when 'detail' is null

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "defectdojo",
-  "version": "2.26.0-dev",
+  "version": "2.27.0-dev",
   "license" : "BSD-3-Clause",
   "private": true,
   "dependencies": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
     volumes:
        - defectdojo_rabbitmq:/var/lib/rabbitmq
   redis:
-    image: redis:7.2.0-alpine@sha256:fd5de2340bc46cbc2241975ab027797c350dec6fd86349e3ac384e3a41be6fee
+    image: redis:7.2.1-alpine@sha256:ef3296cb1b3a7eb40f2a992a398777a1c0b5b21df44f1a5bef84067f772daf54
     profiles: 
       - mysql-redis
       - postgres-redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     volumes:
       - defectdojo_postgres:/var/lib/postgresql/data
   rabbitmq:
-    image: rabbitmq:3.12.4-alpine@sha256:89bd42a2e4d2f76ea1026f7b8fb2f0020fb9fe484fe0326c12ae50444e451087
+    image: rabbitmq:3.12.4-alpine@sha256:9280bf00c0fcf986560e757ad86d8c933dc07bd2cef043e91041fb9e2b048243
     profiles: 
       - mysql-rabbitmq
       - postgres-rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     volumes:
       - defectdojo_postgres:/var/lib/postgresql/data
   rabbitmq:
-    image: rabbitmq:3.12.4-alpine@sha256:1db3f856e6628e2ac512a91959437ca5bab5112c856fe730b6b5ff5087e5e3d0
+    image: rabbitmq:3.12.4-alpine@sha256:89bd42a2e4d2f76ea1026f7b8fb2f0020fb9fe484fe0326c12ae50444e451087
     profiles: 
       - mysql-rabbitmq
       - postgres-rabbitmq

--- a/dojo/__init__.py
+++ b/dojo/__init__.py
@@ -4,6 +4,6 @@
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app  # noqa
 
-__version__ = '2.26.0-dev'
+__version__ = '2.27.0-dev'
 __url__ = 'https://github.com/DefectDojo/django-DefectDojo'
 __docs__ = 'https://documentation.defectdojo.com'

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -22,7 +22,8 @@ from django.db.models import Q
 from dojo.models import Dojo_User, Finding_Group, Product_API_Scan_Configuration, Product_Type, Finding, Product, Test_Import, Test_Type, \
     Endpoint, Development_Environment, Finding_Template, Note_Type, Risk_Acceptance, Cred_Mapping, \
     Engagement_Survey, Question, TextQuestion, ChoiceQuestion, Endpoint_Status, Engagement, \
-    ENGAGEMENT_STATUS_CHOICES, Test, App_Analysis, SEVERITY_CHOICES, EFFORT_FOR_FIXING_CHOICES, Dojo_Group, Vulnerability_Id
+    ENGAGEMENT_STATUS_CHOICES, Test, App_Analysis, SEVERITY_CHOICES, EFFORT_FOR_FIXING_CHOICES, Dojo_Group, Vulnerability_Id, \
+    Test_Import_Finding_Action, IMPORT_ACTIONS
 from dojo.utils import get_system_setting
 from django.contrib.contenttypes.models import ContentType
 import tagulous
@@ -2235,6 +2236,20 @@ class TestImportFilter(DojoFilter):
 
     class Meta:
         model = Test_Import
+        fields = []
+
+
+class TestImportFindingActionFilter(DojoFilter):
+    action = MultipleChoiceFilter(choices=IMPORT_ACTIONS)
+    o = OrderingFilter(
+        # tuple-mapping retains order
+        fields=(
+            ('action', 'action'),
+        )
+    )
+
+    class Meta:
+        model = Test_Import_Finding_Action
         fields = []
 
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -31,6 +31,7 @@ from dojo.utils import (
     reopen_external_issue,
     do_false_positive_history,
     match_finding_to_existing_findings,
+    get_page_items_and_count,
 )
 import copy
 from dojo.filters import (
@@ -38,6 +39,8 @@ from dojo.filters import (
     SimilarFindingFilter,
     FindingFilter,
     AcceptedFindingFilter,
+    TestImportFindingActionFilter,
+    TestImportFilter,
 )
 from dojo.forms import (
     EditPlannedRemediationDateFindingForm,
@@ -81,6 +84,7 @@ from dojo.models import (
     Cred_Mapping,
     Test,
     Product,
+    Test_Import,
     Test_Import_Finding_Action,
     User,
     Engagement,
@@ -301,7 +305,7 @@ def findings(
     )
 
 
-def prefetch_for_findings(findings, prefetch_type="all"):
+def prefetch_for_findings(findings, prefetch_type="all", exclude_untouched=True):
     prefetched_findings = findings
     if isinstance(
         findings, QuerySet
@@ -334,15 +338,20 @@ def prefetch_for_findings(findings, prefetch_type="all"):
                 "duplicate_finding"
             )
 
-        # filter out noop reimport actions from finding status history
-        prefetched_findings = prefetched_findings.prefetch_related(
-            Prefetch(
-                "test_import_finding_action_set",
-                queryset=Test_Import_Finding_Action.objects.exclude(
-                    action=IMPORT_UNTOUCHED_FINDING
-                ),
+        if exclude_untouched:
+            # filter out noop reimport actions from finding status history
+            prefetched_findings = prefetched_findings.prefetch_related(
+                Prefetch(
+                    "test_import_finding_action_set",
+                    queryset=Test_Import_Finding_Action.objects.exclude(
+                        action=IMPORT_UNTOUCHED_FINDING
+                    ),
+                )
             )
-        )
+        else:
+            prefetched_findings = prefetched_findings.prefetch_related(
+                "test_import_finding_action_set"
+            )
         """
         we could try to prefetch only the latest note with SubQuery and OuterRef,
         but I'm getting that MySql doesn't support limits in subqueries.
@@ -428,7 +437,7 @@ def prefetch_for_similar_findings(findings):
 
 @user_is_authorized(Finding, Permissions.Finding_View, "fid")
 def view_finding(request, fid):
-    finding_qs = prefetch_for_findings(Finding.objects.all())
+    finding_qs = prefetch_for_findings(Finding.objects.all(), exclude_untouched=False)
     finding = get_object_or_404(finding_qs, id=fid)
     findings = (
         Finding.objects.filter(test=finding.test)
@@ -569,6 +578,19 @@ def view_finding(request, fid):
             )
         )
 
+    test_imports = Test_Import.objects.filter(findings_affected=finding)
+    test_import_filter = TestImportFilter(request.GET, test_imports)
+
+    test_import_finding_actions = finding.test_import_finding_action_set
+    test_import_finding_actions_count = test_import_finding_actions.all().count()
+    test_import_finding_actions = test_import_finding_actions.filter(test_import__in=test_import_filter.qs)
+    test_import_finding_action_filter = TestImportFindingActionFilter(request.GET, test_import_finding_actions)
+
+    paged_test_import_finding_actions = get_page_items_and_count(request, test_import_finding_action_filter.qs, 5, prefix='test_import_finding_actions')
+    paged_test_import_finding_actions.object_list = paged_test_import_finding_actions.object_list.prefetch_related('test_import')
+
+    latest_test_import_finding_action = finding.test_import_finding_action_set.order_by('-created').first
+
     product_tab = Product_Tab(
         finding.test.engagement.product, title="View Finding", tab="findings"
     )
@@ -607,6 +629,11 @@ def view_finding(request, fid):
             "similar_findings_filter": similar_findings_filter,
             "can_be_pushed_to_jira": can_be_pushed_to_jira,
             "can_be_pushed_to_jira_error": can_be_pushed_to_jira_error,
+            "test_import_filter": test_import_filter,
+            "test_import_finding_action_filter": test_import_finding_action_filter,
+            "paged_test_import_finding_actions": paged_test_import_finding_actions,
+            "latest_test_import_finding_action": latest_test_import_finding_action,
+            "test_import_finding_actions_count": test_import_finding_actions_count,
         },
     )
 

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -42,6 +42,9 @@
                       {{ finding.date | naturalday }}
                     {% endif %}
                     </small>
+                    {% if latest_test_import_finding_action %}
+                        <small>, Last Mentioned in (Re)Import: {{ latest_test_import_finding_action.created | naturalday }} as {{ latest_test_import_finding_action.get_action_display }}</small>
+                    {% endif %}
                 </h3>
                     <div class="dropdown pull-right">
                         <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenu1"
@@ -770,6 +773,107 @@
             </div>
         </div>
     </div>
+
+    <!--Import History begin -->
+    {% if 'TRACK_IMPORT_HISTORY'|setting_enabled and latest_test_import_finding_action %}
+        <div class="panel panel-default collapse in">
+            <div class="panel-heading">
+                <div class="clearfix">
+                    <h4 class="has-filters">
+                        {% trans "Import History" %} ({{ test_import_finding_actions_count }})
+                        <i class="fa-solid fa-circle-question has-popover"
+                        data-trigger="hover"
+                        data-content="List of imports/reimports that created/closed/reactivated this finding in any test."
+                        data-placement="right"
+                        data-container="body"
+                        data-original-title=""
+                        title="">
+                        </i>
+                        <div class="dropdown pull-right">
+                            <button id="show-filters"
+                                    data-toggle="collapse"
+                                    data-target="#import-history-filters"
+                                    class="btn btn-primary toggle-filters">
+                                <i class="fa-solid fa-filter"></i> <i class="caret"></i>
+                            </button>
+                            &nbsp;
+                            <span class="pull-right">
+                                <a data-toggle="collapse" href="#import_history">
+                                    <i class="glyphicon glyphicon-chevron-down"></i>
+                                </a>
+                            </span>
+                        </div>
+                    </h4>
+                </div>
+            </div>
+            <div id="import-history-filters" class="is-filters panel-body collapse">
+                {% include "dojo/filter_snippet.html" with form=test_import_filter.form %}
+                {% include "dojo/filter_snippet.html" with form=test_import_finding_action_filter.form %}
+            </div>
+            <div id="import_history" class="panel panel-body table-responsive collapse">
+                {% if paged_test_import_finding_actions %}
+                    <table class="table-striped tablesorter-bootstrap table table-hover centered">
+                        <thead>
+                            <tr>
+                                <th>{% trans "Action" %}</th>
+                                <th>{% trans "Date/Time" %}</th>
+                                <th>{% trans "Import Type" %}</th>
+                                <th>{% trans "Branch/Tag" %}</th>
+                                <th>{% trans "Build ID" %}</th>
+                                <th>{% trans "Commit" %}</th>
+                                <th>{% trans "Version" %}</th>
+                                <th>{% trans "Endpoint" %}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for test_import_finding_action in paged_test_import_finding_actions %}
+                                <tr>
+                                    <td>
+                                        {{ test_import_finding_action.get_action_display }}
+                                    </td>
+                                    <td>
+                                        <a href="{% url 'engagement_all_findings' test_import_finding_action.test_import.test.engagement.id %}?test_import_finding_action__test_import={{ test_import_finding_action.test_import.id }}">
+                                            {{ test_import_finding_action.test_import.created|date:"DATETIME_FORMAT" }}
+                                        </a>
+                                        {{ test_import_finding_action.test_import|import_settings_tag }}
+                                    </td>
+                                    <td>
+                                        {{ test_import_finding_action.test_import.type }}
+                                    </td>
+                                    <td>
+                                        {{ test_import_finding_action.test_import.branch_tag|default_if_none:"" }}
+                                    </td>
+                                    <td>
+                                        {{ test_import_finding_action.test_import.build_id|default_if_none:"" }}
+                                    </td>
+                                    <td>
+                                        {{ test_import_finding_action.test_import.commit_hash|default_if_none:"" }}
+                                    </td>
+                                    <td>
+                                        {{ test_import_finding_action.test_import.version|default_if_none:"" }}
+                                    </td>
+                                    <td>
+                                        {{ test_import_finding_action.test_import.import_settings.endpoint|default_if_none:"" }}
+                                    </td>
+
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <div class="panel-body">
+                        <p class="text-center">
+                            {% trans "No import history found." %}
+                        </p>
+                    </div>
+                {% endif %}
+                <div class="clearfix">
+                    {% include "dojo/paging_snippet.html" with page=paged_test_import_finding_actions prefix='test_import_finding_actions' page_size=True %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    <!--Import activity end -->
 
     {% include "dojo/snippets/endpoints.html" with finding=finding destination="UI" %}
 

--- a/dojo/tools/anchorectl_policies/parser.py
+++ b/dojo/tools/anchorectl_policies/parser.py
@@ -29,47 +29,48 @@ class AnchoreCTLPoliciesParser:
         find_date = datetime.now()
         items = list()
         try:
-            for image in data:
-                for result in image["detail"]:
-                    try:
-                        gate = result["gate"]
-                        description = result["description"]
-                        policy_id = result["policyId"]
-                        status = result["status"]
-                        image_name = result["tag"]
-                        trigger_id = result["triggerId"]
-                        repo, tag = image_name.split(":", 2)
-                        severity = map_gate_action_to_severity(status)
-                        vulnerability_id = extract_vulnerability_id(trigger_id)
-                        title = (
-                            policy_id
-                            + " - gate|"
-                            + gate
-                            + " - trigger|"
-                            + trigger_id
-                        )
-                        find = Finding(
-                            title=title,
-                            test=test,
-                            description=description,
-                            severity=severity,
-                            references="Policy ID: {}\nTrigger ID: {}".format(
-                                policy_id, trigger_id
-                            ),
-                            file_path=search_filepath(description),
-                            component_name=repo,
-                            component_version=tag,
-                            date=find_date,
-                            static_finding=True,
-                            dynamic_finding=False,
-                        )
-                        if vulnerability_id:
-                            find.unsaved_vulnerability_ids = [vulnerability_id]
-                        items.append(find)
-                    except (KeyError, IndexError) as err:
-                        raise ValueError(
-                            "Invalid format: {} key not found".format(err)
-                        )
+            if image['detail'] is not None:
+                for image in data:
+                    for result in image["detail"]:
+                        try:
+                            gate = result["gate"]
+                            description = result["description"]
+                            policy_id = result["policyId"]
+                            status = result["status"]
+                            image_name = result["tag"]
+                            trigger_id = result["triggerId"]
+                            repo, tag = image_name.split(":", 2)
+                            severity = map_gate_action_to_severity(status)
+                            vulnerability_id = extract_vulnerability_id(trigger_id)
+                            title = (
+                                policy_id
+                                + " - gate|"
+                                + gate
+                                + " - trigger|"
+                                + trigger_id
+                            )
+                            find = Finding(
+                                title=title,
+                                test=test,
+                                description=description,
+                                severity=severity,
+                                references="Policy ID: {}\nTrigger ID: {}".format(
+                                    policy_id, trigger_id
+                                ),
+                                file_path=search_filepath(description),
+                                component_name=repo,
+                                component_version=tag,
+                                date=find_date,
+                                static_finding=True,
+                                dynamic_finding=False,
+                            )
+                            if vulnerability_id:
+                                find.unsaved_vulnerability_ids = [vulnerability_id]
+                            items.append(find)
+                        except (KeyError, IndexError) as err:
+                            raise ValueError(
+                                "Invalid format: {} key not found".format(err)
+                            )
         except AttributeError as err:
             # import empty policies without error (e.g. policies or images
             # objects are not a dictionary)

--- a/dojo/tools/asff/parser.py
+++ b/dojo/tools/asff/parser.py
@@ -30,11 +30,19 @@ class AsffParser(object):
         data = json.load(file)
         result = list()
         for item in data:
+            if item.get("Remediation"):
+                mitigation = item.get("Remediation").get("Recommendation").get("Text")
+                references = item.get("Remediation").get("Recommendation").get("Url")
+            else:
+                mitigation = None
+                references = None
             result.append(
                 Finding(
                     title=item.get("Title"),
                     description=item.get("Description"),
                     date=dateutil.parser.parse(item.get("CreatedAt")),
+                    mitigation=mitigation,
+                    references=references,
                     severity=self.get_severity(item.get("Severity")),
                     active=True,  # TODO manage attribute 'RecordState'
                     unique_id_from_tool=item.get("Id"),

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -70,10 +70,11 @@ class TrivyParser:
             return self.get_result_items(test, data)
         else:
             schema_version = data.get("SchemaVersion", None)
+            artifact_name = data.get("ArtifactName", "")
             cluster_name = data.get("ClusterName")
             if schema_version == 2:
                 results = data.get("Results", [])
-                return self.get_result_items(test, results)
+                return self.get_result_items(test, results, artifact_name=artifact_name)
             elif cluster_name:
                 findings = list()
                 vulnerabilities = data.get("Vulnerabilities", [])
@@ -116,7 +117,7 @@ class TrivyParser:
                     "Schema of Trivy json report is not supported"
                 )
 
-    def get_result_items(self, test, results, service_name=None):
+    def get_result_items(self, test, results, service_name=None, artifact_name=""):
         items = list()
         for target_data in results:
             if (
@@ -204,13 +205,19 @@ class TrivyParser:
                 misc_severity = misconfiguration.get("Severity")
                 misc_primary_url = misconfiguration.get("PrimaryURL")
                 misc_references = misconfiguration.get("References", [])
+                misc_causemetadata = misconfiguration.get("CauseMetadata", {})
+                misc_cause_code = misc_causemetadata.get("Code", {})
+                misc_cause_lines = misc_cause_code.get("Lines", [])
+                string_lines_table = self.get_lines_as_string_table(misc_cause_lines)
+                if string_lines_table != "":
+                    misc_message += ("\n" + string_lines_table)
 
                 title = f"{misc_id} - {misc_title}"
                 description = MISC_DESCRIPTION_TEMPLATE.format(
                     target=target_target,
                     type=misc_type,
                     description=misc_description,
-                    message=misc_message,
+                    message=misc_message
                 )
                 severity = TRIVY_SEVERITIES[misc_severity]
                 references = None
@@ -301,3 +308,20 @@ class TrivyParser:
                 items.append(finding)
 
         return items
+
+    def get_lines_as_string_table(self, lines):
+        if lines is None:
+            return ""
+        # Define column headers
+        headers = ["Number", "Content"]
+
+        # Create the header row
+        header_row = "\t".join(headers)
+
+        # Create the table string
+        table_string = f"{header_row}\n"
+        for item in lines:
+            row = "\t".join(str(item.get(header, '')) for header in headers)
+            table_string += f"{row}\n"
+
+        return table_string

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.26.0-dev"
+appVersion: "2.27.0-dev"
 description: A Helm chart for Kubernetes to install DefectDojo
 name: defectdojo
-version: 1.6.84-dev
+version: 1.6.85-dev
 icon: https://www.defectdojo.org/img/favicon.ico
 maintainers:
   - name: madchap

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ django-ratelimit==4.1.0
 argon2-cffi==23.1.0
 blackduck==1.1.0
 pycurl==7.45.2  # Required for Celery Broker AWS (SQS) support
-boto3==1.28.41  # Required for Celery Broker AWS (SQS) support
+boto3==1.28.42  # Required for Celery Broker AWS (SQS) support
 netaddr==0.8.0
 vulners==2.0.10
 fontawesomefree==6.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ django-ratelimit==4.1.0
 argon2-cffi==23.1.0
 blackduck==1.1.0
 pycurl==7.45.2  # Required for Celery Broker AWS (SQS) support
-boto3==1.28.42  # Required for Celery Broker AWS (SQS) support
+boto3==1.28.43  # Required for Celery Broker AWS (SQS) support
 netaddr==0.8.0
 vulners==2.0.10
 fontawesomefree==6.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ asteval==0.9.31
 bleach==6.0.0
 bleach[css]
 celery==5.3.4
-coverage==7.3.0
+coverage==7.3.1
 defusedxml==0.7.1
 django_celery_results==2.5.1
 django-auditlog==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ django-ratelimit==4.1.0
 argon2-cffi==23.1.0
 blackduck==1.1.0
 pycurl==7.45.2  # Required for Celery Broker AWS (SQS) support
-boto3==1.28.40  # Required for Celery Broker AWS (SQS) support
+boto3==1.28.41  # Required for Celery Broker AWS (SQS) support
 netaddr==0.8.0
 vulners==2.0.10
 fontawesomefree==6.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ Pillow==10.0.0  # required by django-imagekit
 psycopg2-binary==2.9.7
 cryptography==41.0.3
 python-dateutil==2.8.2
-pytz==2023.3
+pytz==2023.3.post1
 redis==5.0.0
 requests==2.31.0
 sqlalchemy==2.0.19  # Required by Celery broker transport

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ uWSGI==2.0.22
 vobject==0.9.6.1
 whitenoise==5.2.0
 titlecase==2.3
-social-auth-app-django==5.2.0
+social-auth-app-django==5.3.0
 social-auth-core==4.4.2
 Python-jose==3.3.0
 gitpython==3.1.34

--- a/unittests/scans/drheader/multiple_urls.json
+++ b/unittests/scans/drheader/multiple_urls.json
@@ -1,0 +1,44 @@
+[
+    {
+      "url": "https://example.com",
+      "report": [
+        {
+          "rule": "Content-Security-Policy",
+          "message": "Header not included in response",
+          "severity": "high"
+        },
+        {
+          "rule": "Pragma",
+          "message": "Header not included in response",
+          "severity": "high",
+          "expected": [
+            "no-cache"
+          ]
+        }
+      ]
+    },
+    {
+      "url": "http://example2.com",
+      "report": [
+        {
+          "rule": "X-Frame-Options",
+          "message": "Header not included in response",
+          "severity": "high",
+          "expected": [
+            "DENY",
+            "SAMEORIGIN"
+          ]
+        },
+        {
+          "rule": "X-XSS-Protection",
+          "message": "Header not included in response",
+          "severity": "high",
+          "expected": [
+            "1",
+            "mode=block"
+          ],
+          "delimiter": ";"
+        }
+      ]
+    }
+]

--- a/unittests/scans/jfrog_xray_api_summary_artifact/malformed_cvssv3.json
+++ b/unittests/scans/jfrog_xray_api_summary_artifact/malformed_cvssv3.json
@@ -1,0 +1,47 @@
+{
+  "artifacts": [
+    {
+      "general": {
+        "name": "artifact1:1.0",
+        "component_id": "artifact1:1.0",
+        "pkg_type": "Docker",
+        "path": "artifact_path/artifact1/1.0/",
+        "sha256": "eaab06c0a28618bfb65481bf31bce7d6dd3a15dac528297690111c202a1cd468"
+      },
+      "issues": [
+        {
+          "issue_id": "XRAY-523195",
+          "summary": "Okio GzipSource unhandled exception Denial of Service",
+          "description": "GzipSource does not handle an exception that might be raised when parsing a malformed gzip buffer. This may lead to denial of service of the Okio client when handling a crafted GZIP archive, by using the GzipSource class.",
+          "issue_type": "security",
+          "severity": "Medium",
+          "provider": "JFrog",
+          "cves": [
+            { "cve": "CVE-2023-3635", "cwe": ["CWE-195"], "cvss_v3": "5.9" }
+          ],
+          "created": "2023-06-12T00:00:00.585Z",
+          "impact_path": [
+            "default/local/com.evel.corp/snoop/2023.2.1-build00008-j8uwlfh3728dj2h16dk9f1f93/deployments/main.jar/BOOT-INF/lib/okio-jvm-2.8.0.jar"
+          ]
+        }
+      ],
+      "licenses": [
+        {
+          "name": "OpenSSL",
+          "full_name": "OpenSSL LICENSE",
+          "more_info_url": [
+            "https://spdx.org/licenses/OpenSSL.html",
+            "http://www.openssl.org/source/license.html",
+            "https://www.openssl.org/source/license.html",
+            "https://spdx.org/licenses/OpenSSL"
+          ],
+          "components": [
+            "alpine://3.12:libcrypto1.1:1.1.1k-r0",
+            "alpine://3.12:libssl1.1:1.1.1k-r0",
+            "alpine://3.12:openssl:1.1.1k-r0"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/tools/test_drheader_parser.py
+++ b/unittests/tools/test_drheader_parser.py
@@ -32,3 +32,18 @@ class TestDrHeaderParser(DojoTestCase):
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(11, len(findings))
+
+    def test_parse_file_has_many_finding_multiple_urls(self):
+        testfile = open("unittests/scans/drheader/multiple_urls.json")
+        parser = DrHeaderParser()
+        findings = parser.get_findings(testfile, Test())
+        for finding in findings:
+            for endpoint in finding.unsaved_endpoints:
+                endpoint.clean()
+        testfile.close()
+        self.assertEqual(4, len(findings))
+        with self.subTest(i=0):
+            finding = findings[0]
+            endpoint = finding.unsaved_endpoints[0]
+            self.assertEqual(443, endpoint.port)
+            self.assertEqual("example.com", endpoint.host)

--- a/unittests/tools/test_jfrog_xray_api_summary_artifact_parser.py
+++ b/unittests/tools/test_jfrog_xray_api_summary_artifact_parser.py
@@ -1,11 +1,12 @@
 from ..dojo_test_case import DojoTestCase
 from dojo.models import Test
-from dojo.tools.jfrog_xray_api_summary_artifact.parser import JFrogXrayApiSummaryArtifactParser
+from dojo.tools.jfrog_xray_api_summary_artifact.parser import (
+    JFrogXrayApiSummaryArtifactParser,
+)
 import hashlib
 
 
 class TestJFrogXrayApiSummaryArtifactParser(DojoTestCase):
-
     def test_parse_file_with_no_vuln(self):
         testfile = open("unittests/scans/jfrog_xray_api_summary_artifact/no_vuln.json")
         parser = JFrogXrayApiSummaryArtifactParser()
@@ -24,7 +25,10 @@ class TestJFrogXrayApiSummaryArtifactParser(DojoTestCase):
         self.assertEqual(1, len(item.unsaved_vulnerability_ids))
         self.assertEqual("XRAY-124116", item.unsaved_vulnerability_ids[0])
         self.assertEqual("Critical", item.severity)
-        self.assertEqual("3.12:openssl:1.1.1k-r0 -> OpenSSL contains an overflow", item.description[:54])
+        self.assertEqual(
+            "3.12:openssl:1.1.1k-r0 -> OpenSSL contains an overflow",
+            item.description[:54],
+        )
         self.assertEqual(" code.", item.description[-6:])
         self.assertIsNone(item.mitigation)
         self.assertEqual("artifact1", item.component_name)
@@ -37,16 +41,37 @@ class TestJFrogXrayApiSummaryArtifactParser(DojoTestCase):
         self.assertIsNone(item.impact)
         self.assertEqual("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", item.cvssv3)
         result = hashlib.sha256()
-        unique_id = "eaab06c0a28618bfb65481bf31bce7d6dd3a15dac528297690111c202a1cd468" + "3.12:openssl" + "1.1.1k-r0" + "XRAY-124116"
+        unique_id = (
+            "eaab06c0a28618bfb65481bf31bce7d6dd3a15dac528297690111c202a1cd468"
+            + "3.12:openssl"
+            + "1.1.1k-r0"
+            + "XRAY-124116"
+        )
         result.update(unique_id.encode())
         self.assertEqual(result.hexdigest(), item.unique_id_from_tool)
 
     def test_parse_file_with_many_vulns(self):
-        testfile = open("unittests/scans/jfrog_xray_api_summary_artifact/many_vulns.json")
+        testfile = open(
+            "unittests/scans/jfrog_xray_api_summary_artifact/many_vulns.json"
+        )
         parser = JFrogXrayApiSummaryArtifactParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(15, len(findings))
         finding = findings[0]
         self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
-        self.assertEqual('CVE-2021-42385', finding.unsaved_vulnerability_ids[0])
+        self.assertEqual("CVE-2021-42385", finding.unsaved_vulnerability_ids[0])
+
+    def test_parse_file_with_malformed_cvssv3_score(self):
+        testfile = open(
+            "unittests/scans/jfrog_xray_api_summary_artifact/malformed_cvssv3.json"
+        )
+        parser = JFrogXrayApiSummaryArtifactParser()
+        findings = parser.get_findings(testfile, Test())
+        testfile.close()
+        self.assertEqual(1, len(findings))
+
+        finding = findings[0]
+        self.assertIsNone(finding.cvssv3)
+        self.assertEqual(2, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("XRAY-523195", finding.unsaved_vulnerability_ids[1])

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -1,4 +1,5 @@
 import os.path
+import re
 
 from ..dojo_test_case import DojoTestCase, get_unit_tests_path
 from dojo.tools.trivy.parser import TrivyParser
@@ -163,8 +164,20 @@ APT had several integer overflows and underflows while parsing .deb packages, ak
 
 A program inside the container can elevate its own privileges and run as root, which might give the program control over the container and node.
 Container 'follower' of Deployment 'redis-follower' should set 'securityContext.allowPrivilegeEscalation' to false
-'''
-        self.assertEqual(description, finding.description)
+Number  Content
+132                     - image: gcr.io/google_samples/gb-redis-follower:v2
+133                       imagePullPolicy: IfNotPresent
+134                       name: follower
+135                       ports:
+136                         - containerPort: 6379
+137                           protocol: TCP
+138                       resources:
+139                         requests:
+140                             cpu: 100m
+141'''
+        re_description = re.sub(r"\s+", " ", description)
+        re_finding_description = re.sub(r"\s+", " ", finding.description)
+        self.assertEqual(re_description.strip(), re_finding_description.strip())
         self.assertEqual('Set \'set containers[].securityContext.allowPrivilegeEscalation\' to \'false\'.', finding.mitigation)
         self.assertIsNone(finding.unsaved_vulnerability_ids)
         self.assertEqual(['config', 'kubernetes'], finding.tags)


### PR DESCRIPTION
**Description**

This pull request fix a bug. This bug occurs when uploading an Anchore policies report with an empty details. Exemple : 

report.json
```
[
  {
    "detail": null,
    "digest": "sha256:2207ab33cd91cf042751d355536b612f4123497befe67041f0aee1f522b4c26f",
    "finalAction": "go",
    "finalActionReason": "policy_evaluation",
    "lastEvaluation": "2019-08-07T19:27:03Z",
    "policyId": "2c53a13c-1765-11e8-82ef-23527761d060",
    "status": "pass",
    "tag": "<image_tag>"
  }
]
```

The error :
<img width="1721" alt="crash" src="https://github.com/DefectDojo/django-DefectDojo/assets/138585151/fdc2d1f3-4745-4d9f-9b22-ce07f26c1218">

This pull request add a verification inside the file 'dojo/tools/anchorectl_policies/parser.py' to not iterate thought the list 'image['detail']' if it's  None.

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [ ] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

