### PR TITLE
Fix: anchorectl_policies crash when 'detail' is null 

### DIFF
--- a/dojo/tools/anchorectl_policies/parser.py
+++ b/dojo/tools/anchorectl_policies/parser.py
@@ -29,47 +29,48 @@ class AnchoreCTLPoliciesParser:
         find_date = datetime.now()
         items = list()
         try:
-            for image in data:
-                for result in image["detail"]:
-                    try:
-                        gate = result["gate"]
-                        description = result["description"]
-                        policy_id = result["policyId"]
-                        status = result["status"]
-                        image_name = result["tag"]
-                        trigger_id = result["triggerId"]
-                        repo, tag = image_name.split(":", 2)
-                        severity = map_gate_action_to_severity(status)
-                        vulnerability_id = extract_vulnerability_id(trigger_id)
-                        title = (
-                            policy_id
-                            + " - gate|"
-                            + gate
-                            + " - trigger|"
-                            + trigger_id
-                        )
-                        find = Finding(
-                            title=title,
-                            test=test,
-                            description=description,
-                            severity=severity,
-                            references="Policy ID: {}\nTrigger ID: {}".format(
-                                policy_id, trigger_id
-                            ),
-                            file_path=search_filepath(description),
-                            component_name=repo,
-                            component_version=tag,
-                            date=find_date,
-                            static_finding=True,
-                            dynamic_finding=False,
-                        )
-                        if vulnerability_id:
-                            find.unsaved_vulnerability_ids = [vulnerability_id]
-                        items.append(find)
-                    except (KeyError, IndexError) as err:
-                        raise ValueError(
-                            "Invalid format: {} key not found".format(err)
-                        )
+            if image['detail'] is not None:
+                for image in data:
+                    for result in image["detail"]:
+                        try:
+                            gate = result["gate"]
+                            description = result["description"]
+                            policy_id = result["policyId"]
+                            status = result["status"]
+                            image_name = result["tag"]
+                            trigger_id = result["triggerId"]
+                            repo, tag = image_name.split(":", 2)
+                            severity = map_gate_action_to_severity(status)
+                            vulnerability_id = extract_vulnerability_id(trigger_id)
+                            title = (
+                                policy_id
+                                + " - gate|"
+                                + gate
+                                + " - trigger|"
+                                + trigger_id
+                            )
+                            find = Finding(
+                                title=title,
+                                test=test,
+                                description=description,
+                                severity=severity,
+                                references="Policy ID: {}\nTrigger ID: {}".format(
+                                    policy_id, trigger_id
+                                ),
+                                file_path=search_filepath(description),
+                                component_name=repo,
+                                component_version=tag,
+                                date=find_date,
+                                static_finding=True,
+                                dynamic_finding=False,
+                            )
+                            if vulnerability_id:
+                                find.unsaved_vulnerability_ids = [vulnerability_id]
+                            items.append(find)
+                        except (KeyError, IndexError) as err:
+                            raise ValueError(
+                                "Invalid format: {} key not found".format(err)
+                            )
         except AttributeError as err:
             # import empty policies without error (e.g. policies or images
             # objects are not a dictionary)

--- a/dojo/tools/anchorectl_policies/parser.py
+++ b/dojo/tools/anchorectl_policies/parser.py
@@ -29,8 +29,8 @@ class AnchoreCTLPoliciesParser:
         find_date = datetime.now()
         items = list()
         try:
-            if image['detail'] is not None:
-                for image in data:
+            for image in data:
+                if image['detail'] is not None:
                     for result in image["detail"]:
                         try:
                             gate = result["gate"]


### PR DESCRIPTION
**Description**

This pull request fixes a bug. This bug occurs when uploading an Anchore policies report with an empty details. Exemple : 

```
[
  {
    "detail": null,
    "digest": "sha256:2207ab33cd91cf042751d355536b612f4123497befe67041f0aee1f522b4c26f",
    "finalAction": "go",
    "finalActionReason": "policy_evaluation",
    "lastEvaluation": "2019-08-07T19:27:03Z",
    "policyId": "2c53a13c-1765-11e8-82ef-23527761d060",
    "status": "pass",
    "tag": "<image_tag>"
  }
]
```

<img width="1721" alt="crash" src="https://github.com/DefectDojo/django-DefectDojo/assets/138585151/fdc2d1f3-4745-4d9f-9b22-ce07f26c1218">

This pull request add a verification inside the file 'dojo/tools/anchorectl_policies/parser.py' to not iterate thought the list 'image['detail']' if it's  None.

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.

