### PR TITLE
Veracode: Add additional severity mappings for other informational findings

### DIFF
--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -39,7 +39,7 @@ RUN \
   chrome_version=$(apt-cache show google-chrome-stable | grep Version | awk '{print $2}' | cut -d '-' -f 1) && \
   chrome_version_blob=$(curl -k https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq ".versions[] | select(.version==\"$chrome_version\")") && \
   chromedriver_url=$(echo $chrome_version_blob | jq -r ".downloads.chromedriver[] | select(.platform==\"linux64\") | .url") && \
-  wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/115.0.5790.98/linux64/chromedriver-linux64.zip && \
+  wget $chromedriver_url && \
   unzip -j chromedriver-linux64.zip chromedriver-linux64/chromedriver && \
   rm -rf chromedriver-linux64.zip && \
   chmod -R 0755 .

--- a/dojo/tools/veracode/json_parser.py
+++ b/dojo/tools/veracode/json_parser.py
@@ -25,6 +25,7 @@ class VeracodeJSONParser(object):
     """
 
     severity_mapping = {
+        0: "Info",
         1: "Info",
         2: "Low",
         3: "Medium",
@@ -89,7 +90,7 @@ class VeracodeJSONParser(object):
 
     def create_finding_from_details(self, finding_details, scan_type, policy_violated) -> Finding:
         # Fetch the common attributes that should be in every scan type
-        severity = self.severity_mapping.get(finding_details.get("severity", 1))
+        severity = self.severity_mapping.get(finding_details.get("severity", 1), 1)
         # Set up the finding with just severity for now
         finding = Finding(
             title=f"{scan_type} Finding",


### PR DESCRIPTION
From a CVSS perspective, [Veracode offers two levels of informational based findings](https://docs.veracode.com/r/review_severity_exploitability#veracode-finding-severities) each with a CVSS score of 0.0

This PR adds another level of information mapping to accommodate these other informational findings

<!--[sc-2234]-->