### PR TITLE
add filtering on product lifecycles

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -724,6 +724,8 @@ class EngagementDirectFilter(DojoFilter):
     product__prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.none(),
         label="Product Type")
+    test__engagement__product__lifecycle = MultipleChoiceFilter(
+        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle')
     status = MultipleChoiceFilter(choices=ENGAGEMENT_STATUS_CHOICES,
                                               label="Status")
 
@@ -788,6 +790,8 @@ class EngagementFilter(DojoFilter):
     prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.none(),
         label="Product Type")
+    engagement__product__lifecycle = MultipleChoiceFilter(
+        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle')
     engagement__status = MultipleChoiceFilter(choices=ENGAGEMENT_STATUS_CHOICES,
                                               label="Status")
 
@@ -1186,6 +1190,8 @@ class ApiFindingFilter(DojoFilter):
     title = CharFilter(lookup_expr='icontains')
     product_name = CharFilter(lookup_expr='engagement__product__name__iexact', field_name='test', label='exact product name')
     product_name_contains = CharFilter(lookup_expr='engagement__product__name__icontains', field_name='test', label='exact product name')
+    product_lifecycle = CharFilter(method=custom_filter, lookup_expr='engagement__product__lifecycle',
+                                   field_name='test__engagement__product__lifecycle', label='Comma separated list of exact product lifecycles')
     # DateRangeFilter
     created = DateRangeFilter()
     date = DateRangeFilter()
@@ -1312,6 +1318,9 @@ class FindingFilter(FindingFilterWithTags):
     test__engagement__product__prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.none(),
         label="Product Type")
+
+    test__engagement__product__lifecycle = MultipleChoiceFilter(
+        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle')
 
     test__engagement__product = ModelMultipleChoiceFilter(
         queryset=Product.objects.none(),


### PR DESCRIPTION
Closes #8673

**Description**
This pull request introduces a new feature that allows users to filter by product lifecycle stages. This enhancement was made in response to issue #8673.

Changes include:
1. the addition of a filtering dropdown "Product lifecycle" in the following screens:
  a. Findings,
  b. Engagements,
  c. Engagements By Product,
3. and a `product_lifecycle` parameter in the `/findings` API, which takes a comma-separated string of product lifecycles.

Screenshot of the filter in Findings:
![image](https://github.com/DefectDojo/django-DefectDojo/assets/981572/320ab085-73d9-4352-b373-e9d9e7a41ce8)

Filtering in the API could be done in several ways. If it should rather receive several `product_lifecycle=` parameters, then please let me know.

**Test results**

Changes were tested manually. The dropdowns work properly on the three screens, and the API parameter works correctly when called with comma-separated values, for example using a request to `http://localhost:8080/api/v2/findings/?product_lifecycle=production,retirement`.

**Documentation**

* OpenAPI specification is automatically updated to include the new parameter.
* Screenshots could be updated to include recent additions in filtering. I haven't seen this done after previous filter additions, so I'm ignoring this for now.