### PR TITLE
Fixing Helm Ingress Capabilities Check

### DIFF
--- a/helm/defectdojo/templates/django-ingress.yaml
+++ b/helm/defectdojo/templates/django-ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.django.ingress.enabled -}}
 {{- $fullName := include "defectdojo.fullname" . -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -28,7 +28,7 @@ metadata:
   {{- end }}
 {{- end }}
 spec:
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
   {{- if .Values.django.ingress.ingressClassName }}
   ingressClassName: {{ .Values.django.ingress.ingressClassName }}
   {{- end }}
@@ -45,7 +45,7 @@ spec:
   - host: {{ .Values.host }}
     http:
       paths:
-        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+        {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
         - pathType: Prefix
           {{- if .Values.django.ingress.path }}
           path: {{ .Values.django.ingress.path }}


### PR DESCRIPTION
Fixing what was attempted to be fixed in https://github.com/DefectDojo/django-DefectDojo/pull/6759

The original attempted fix checked for the API version plus the resource, when it should have only checked for the API version.