### PR TITLE
setEnv: Fix symlink processing

### DIFF
--- a/docker/setEnv.sh
+++ b/docker/setEnv.sh
@@ -23,7 +23,7 @@ function show_current {
 function get_current {
     if [ -L ${override_link} ]
     then
-        # Check for Mac OSX 
+        # Check for Mac OSX
         if [[ "$OSTYPE" == "darwin"* ]]; then
             # readlink is not native to mac, so this will work in it's place.
             symlink=$(python3 -c "import os; print(os.path.realpath('docker-compose.override.yml'))")
@@ -31,7 +31,7 @@ function get_current {
             # Maintain the cleaner way
             symlink=$(readlink -f docker-compose.override.yml)
         fi
-        current_env=$(expr $(basename symlink) : "^docker-compose.override.\(.*\).yml$")
+        current_env=$(expr $(basename $symlink) : "^docker-compose.override.\(.*\).yml$")
     else
         current_env=release
     fi


### PR DESCRIPTION
Wrong processing of `symlink` variable.

Discovered in https://github.com/DefectDojo/django-DefectDojo/pull/8731#issuecomment-1737175771