### PR TITLE
Docs: Fix "data model" link in Features

### DIFF
--- a/docs/content/en/usage/features.md
+++ b/docs/content/en/usage/features.md
@@ -8,7 +8,7 @@ weight: 2
 ## Tags
 
 In DefectDojo, tags are a first class citizen and are recognized as the facilitators
-of organization within each level of the [data model](../models.md). Tags are
+of organization within each level of the [data model](../models). Tags are
 ideal for grouping objects in a manner that can be filtered out into smaller, more
 digestible chunks.
 


### PR DESCRIPTION
Small typo -> broken link

Mentioned in https://owasp.slack.com/archives/C2P5BA8MN/p1695843977321899