### PR TITLE
Check for empty cves array in JFrog Xray API Summary Artifact Parser

### DIFF
--- a/dojo/tools/jfrog_xray_api_summary_artifact/parser.py
+++ b/dojo/tools/jfrog_xray_api_summary_artifact/parser.py
@@ -139,7 +139,7 @@ def get_item(
 
     # Add vulnerability ids
     vulnerability_ids = list()
-    if "cve" in cves[0]:
+    if cves and "cve" in cves[0]:
         vulnerability_ids.append(cves[0]["cve"])
     if "issue_id" in vulnerability:
         vulnerability_ids.append(vulnerability["issue_id"])


### PR DESCRIPTION
## :warning: Note on feature completeness :warning:

We are narrowing the scope of acceptable enhancements to DefectDojo in preparation for v3. Learn more here:
https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md

**Description**

Importing findings without CVEs throws error "IndexError: list index out of range"

**Test results**

Tested it locally and import no longer fails.
