### PR TITLE
Browser tests should use the latest Chrome stable release

### DIFF
--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -66,8 +66,6 @@ RUN \
 
 RUN pip install --no-cache-dir selenium==4.9.0 requests
 
-# Install dependencies for Google Chrome
-RUN apt-get -y install xvfb
 # Install the latest Google Chrome stable release
 WORKDIR /opt/chrome
 RUN \
@@ -75,8 +73,7 @@ RUN \
   wget $chrome_url && \
   unzip -j chrome-linux64.zip chrome-linux64/chrome && \
   rm -rf chrome-linux64.zip && \
-  chmod -R 0755 . && \
-  ln -s /opt/chrome/chrome /usr/local/bin/chrome
+  chmod -R 0755 .
 
 # Installing the latest stable Google Chrome release
 WORKDIR /opt/chrome-driver

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -19,26 +19,21 @@ RUN \
   rm -rf /var/lib/apt/lists && \
   true
 
-# Installing Google Chrome browser
-RUN \
-  curl -sS -o - https://dl.google.com/linux/linux_signing_key.pub | apt-key add && \
-  echo "deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
-  apt-get -y update && \
-  apt-get -y install \
-    google-chrome-stable=117.0.5938.132-1 \
-  && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists && \
-  true
-
 RUN pip install --no-cache-dir selenium==4.9.0 requests
 
-# Installing Chromedriver
+# Install the latest Google Chrome stable release
+WORKDIR /opt/chrome
+RUN \
+  chrome_url=$(curl https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels[] | select(.channel == "Stable") | .downloads.chrome[] | select(.platform == "linux64").url') && \
+  wget $chrome_url && \
+  unzip -j chrome-linux64.zip chrome-linux64/chrome && \
+  rm -rf chrome-linux64.zip && \
+  chmod -R 0755 .
+
+# Installing the latest stable Google Chrome release
 WORKDIR /opt/chrome-driver
 RUN \
-  chrome_version=$(apt-cache show google-chrome-stable | grep Version | awk '{print $2}' | cut -d '-' -f 1) && \
-  chrome_version_blob=$(curl -k https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json | jq ".versions[] | select(.version==\"$chrome_version\")") && \
-  chromedriver_url=https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/117.0.5938.92/linux64/chromedriver-linux64.zip && \
+  chromedriver_url=$(curl https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels[] | select(.channel == "Stable") | .downloads.chromedriver[] | select(.platform == "linux64").url') && \
   wget $chromedriver_url && \
   unzip -j chromedriver-linux64.zip chromedriver-linux64/chromedriver && \
   rm -rf chromedriver-linux64.zip && \

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -14,6 +14,51 @@ RUN \
     gpg \
     default-jre-headless \
     jq \
+    xvfb \
+    libxi6 \
+    libgconf-2-4 \
+    libjq1 \
+    libonig5 \
+    libxkbcommon0 \
+    libxss1 \
+    libglib2.0-0 \
+    libnss3 \
+    libfontconfig1 \
+    libatk-bridge2.0-0 \
+    libatspi2.0-0 \
+    libgtk-3-0 \
+    libpango-1.0-0 \
+    libgdk-pixbuf2.0-0 \
+    libxcomposite1 \
+    libxcursor1 \
+    libxdamage1 \
+    libxtst6 \
+    libappindicator3-1 \
+    libasound2 \
+    libatk1.0-0 \
+    libc6 \
+    libcairo2 \
+    libcups2 \
+    libxfixes3 \
+    libdbus-1-3 \
+    libexpat1 \
+    libgcc1 \
+    libnspr4 \
+    libgbm1 \
+    libpangocairo-1.0-0 \
+    libstdc++6 \
+    libx11-6 \
+    libx11-xcb1 \
+    libxcb1 \
+    libxext6 \
+    libxrandr2 \
+    libxrender1 \
+    gconf-service \
+    ca-certificates \
+    fonts-liberation \
+    libappindicator1 \
+    lsb-release \
+    xdg-utils \
     && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists && \
@@ -21,6 +66,8 @@ RUN \
 
 RUN pip install --no-cache-dir selenium==4.9.0 requests
 
+# Install dependencies for Google Chrome
+RUN apt-get -y install xvfb
 # Install the latest Google Chrome stable release
 WORKDIR /opt/chrome
 RUN \
@@ -28,7 +75,8 @@ RUN \
   wget $chrome_url && \
   unzip -j chrome-linux64.zip chrome-linux64/chrome && \
   rm -rf chrome-linux64.zip && \
-  chmod -R 0755 .
+  chmod -R 0755 . && \
+  ln -s /opt/chrome/chrome /usr/local/bin/chrome
 
 # Installing the latest stable Google Chrome release
 WORKDIR /opt/chrome-driver

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -14,54 +14,9 @@ RUN \
     gpg \
     default-jre-headless \
     jq \
-    xvfb \
-    libxi6 \
-    libgconf-2-4 \
-    libjq1 \
-    libonig5 \
-    libxkbcommon0 \
-    libxss1 \
-    libglib2.0-0 \
-    libnss3 \
-    libfontconfig1 \
-    libatk-bridge2.0-0 \
-    libatspi2.0-0 \
-    libgtk-3-0 \
-    libpango-1.0-0 \
-    libgdk-pixbuf2.0-0 \
-    libxcomposite1 \
-    libxcursor1 \
-    libxdamage1 \
-    libxtst6 \
-    libappindicator3-1 \
-    libasound2 \
-    libatk1.0-0 \
-    libc6 \
-    libcairo2 \
-    libcups2 \
-    libxfixes3 \
-    libdbus-1-3 \
-    libexpat1 \
-    libgcc1 \
-    libnspr4 \
-    libgbm1 \
-    libpangocairo-1.0-0 \
-    libstdc++6 \
-    libx11-6 \
-    libx11-xcb1 \
-    libxcb1 \
-    libxext6 \
-    libxrandr2 \
-    libxrender1 \
-    gconf-service \
-    ca-certificates \
-    fonts-liberation \
-    libappindicator1 \
-    lsb-release \
-    xdg-utils \
+    apt-file \
     && \
   apt-get clean && \
-  rm -rf /var/lib/apt/lists && \
   true
 
 RUN pip install --no-cache-dir selenium==4.9.0 requests
@@ -75,7 +30,14 @@ RUN \
   rm -rf chrome-linux64.zip && \
   chmod -R 0755 .
 
-# Installing the latest stable Google Chrome release
+# Install the dependencies for Google Chrome
+RUN apt-file update
+COPY docker/install_chrome_dependencies.py install_chrome_dependencies.py
+RUN \
+  missing_chrome_deps=$(python install_chrome_dependencies.py) \
+  apt-get -y install $missing_chrome_deps
+
+# Installing the latest stable Google Chrome driver release
 WORKDIR /opt/chrome-driver
 RUN \
   chromedriver_url=$(curl https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels[] | select(.channel == "Stable") | .downloads.chromedriver[] | select(.platform == "linux64").url') && \

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -15,6 +15,8 @@ RUN \
     default-jre-headless \
     jq \
     apt-file \
+    libnss3 \
+    xvfb \
     && \
   apt-get clean && \
   true
@@ -26,9 +28,10 @@ WORKDIR /opt/chrome
 RUN \
   chrome_url=$(curl https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json | jq -r '.channels[] | select(.channel == "Stable") | .downloads.chrome[] | select(.platform == "linux64").url') && \
   wget $chrome_url && \
-  unzip -j chrome-linux64.zip chrome-linux64/chrome && \
+  unzip chrome-linux64.zip && \
   rm -rf chrome-linux64.zip && \
-  chmod -R 0755 .
+  chmod -R 0755 . && \
+  ln -s /opt/chrome/chrome-linux64/chrome /usr/bin/chrome
 
 # Install the dependencies for Google Chrome
 RUN apt-file update
@@ -36,6 +39,13 @@ COPY docker/install_chrome_dependencies.py install_chrome_dependencies.py
 RUN \
   missing_chrome_deps=$(python install_chrome_dependencies.py) && \
   apt-get -y install $missing_chrome_deps
+
+# Install the random list of packages
+RUN apt-get install -y unzip xvfb libxi6 libgconf-2-4 jq libjq1 libonig5 libxkbcommon0 libxss1 libglib2.0-0 libnss3 \
+  libfontconfig1 libatk-bridge2.0-0 libatspi2.0-0 libgtk-3-0 libpango-1.0-0 libgdk-pixbuf2.0-0 libxcomposite1 \
+  libxcursor1 libxdamage1 libxtst6 libappindicator3-1 libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libxfixes3 \
+  libdbus-1-3 libexpat1 libgcc1 libnspr4 libgbm1 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxext6 \
+  libxrandr2 libxrender1 gconf-service ca-certificates fonts-liberation libappindicator1 lsb-release xdg-utils
 
 # Installing the latest stable Google Chrome driver release
 WORKDIR /opt/chrome-driver

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -34,7 +34,7 @@ RUN \
 RUN apt-file update
 COPY docker/install_chrome_dependencies.py install_chrome_dependencies.py
 RUN \
-  missing_chrome_deps=$(python install_chrome_dependencies.py) \
+  missing_chrome_deps=$(python install_chrome_dependencies.py) && \
   apt-get -y install $missing_chrome_deps
 
 # Installing the latest stable Google Chrome driver release

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -40,8 +40,8 @@ RUN \
   missing_chrome_deps=$(python install_chrome_dependencies.py) && \
   apt-get -y install $missing_chrome_deps
 
-# Install the random list of packages
-RUN apt-get install -y unzip xvfb libxi6 libgconf-2-4 jq libjq1 libonig5 libxkbcommon0 libxss1 libglib2.0-0 libnss3 \
+# Install a suggested list of additional packages (https://stackoverflow.com/a/76734752)
+RUN apt-get install -y libxi6 libgconf-2-4 jq libjq1 libonig5 libxkbcommon0 libxss1 libglib2.0-0 libnss3 \
   libfontconfig1 libatk-bridge2.0-0 libatspi2.0-0 libgtk-3-0 libpango-1.0-0 libgdk-pixbuf2.0-0 libxcomposite1 \
   libxcursor1 libxdamage1 libxtst6 libappindicator3-1 libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libxfixes3 \
   libdbus-1-3 libexpat1 libgcc1 libnspr4 libgbm1 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxext6 \

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -23,6 +23,7 @@ if [ $COUNTER -gt 10 ]; then
 fi
 
 export CHROMEDRIVER=$(find /opt/chrome-driver -name chromedriver)
+export CHROME_PATH=$(find /opt/chrome -name chrome)
 
 # Run available unittests with a simple setup
 # All available Integrationtest Scripts are activated below

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -23,7 +23,7 @@ if [ $COUNTER -gt 10 ]; then
 fi
 
 export CHROMEDRIVER=$(find /opt/chrome-driver -name chromedriver)
-export CHROME_PATH=$(find /opt/chrome -name chrome)
+export CHROME_PATH=/opt/chrome/chrome
 
 # Run available unittests with a simple setup
 # All available Integrationtest Scripts are activated below

--- a/docker/install_chrome_dependencies.py
+++ b/docker/install_chrome_dependencies.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 
 

--- a/docker/install_chrome_dependencies.py
+++ b/docker/install_chrome_dependencies.py
@@ -1,3 +1,8 @@
+"""
+This solution is largely based on the Playwright's browser dependencies script at
+https://github.com/microsoft/playwright/blob/main/utils/linux-browser-dependencies/inside_docker/list_dependencies.js
+"""
+
 import subprocess
 
 

--- a/docker/install_chrome_dependencies.py
+++ b/docker/install_chrome_dependencies.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+
+
+def find_packages(library_name):
+    stdout = run_command(["apt-file", "search", library_name])
+    if not stdout.strip():
+        return []
+    libs = [line.split(":")[0] for line in stdout.strip().split("\n")]
+    return list(set(libs))
+
+
+def run_command(cmd, cwd=None, env=None):
+    result = subprocess.run(cmd, cwd=cwd, env=env, capture_output=True, text=True)
+    return result.stdout
+
+
+def ldd(file_path):
+    stdout = run_command(["ldd", file_path])
+    # For simplicity, I'm assuming if we get an error, the code is non-zero.
+    try:
+        result = subprocess.run(
+            ["ldd", file_path], capture_output=True, text=True
+        )
+        stdout = result.stdout
+        code = result.returncode
+    except subprocess.CalledProcessError:
+        stdout = ""
+        code = 1
+    return stdout, code
+
+
+raw_deps = ldd("/opt/chrome/chrome")
+dependencies = raw_deps[0].splitlines()
+
+missing_deps = {
+    r[0].strip()
+    for d in dependencies
+    for r in [d.split("=>")]
+    if len(r) == 2 and r[1].strip() == "not found"
+}
+
+missing_packages = []
+for d in missing_deps:
+    all_packages = find_packages(d)
+    packages = [
+        p
+        for p in all_packages
+        if not any(
+            p.endswith(suffix) for suffix in ["-dbg", "-test", "tests", "-dev", "-mesa"]
+        )
+    ]
+    for p in packages:
+        missing_packages.append(p)
+
+print(" ".join(missing_packages))

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -86,6 +86,9 @@ class BaseTestCase(unittest.TestCase):
             prefs = {"download.default_directory": cls.export_path}
             dd_driver_options.add_experimental_option("prefs", prefs)
 
+            # set the location of the chrome browser
+            dd_driver_options.binary_location = os.environ["CHROME_PATH"]
+
             # change path of chromedriver according to which directory you have chromedriver.
             print(
                 "starting chromedriver with options: ", vars(dd_driver_options), desired

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -86,9 +86,6 @@ class BaseTestCase(unittest.TestCase):
             prefs = {"download.default_directory": cls.export_path}
             dd_driver_options.add_experimental_option("prefs", prefs)
 
-            # set the location of the chrome browser
-            dd_driver_options.binary_location = os.environ["CHROME_PATH"]
-
             # change path of chromedriver according to which directory you have chromedriver.
             print(
                 "starting chromedriver with options: ", vars(dd_driver_options), desired


### PR DESCRIPTION
**Description**

This PR is a follow-up to #8755. There is no guarantee that the version of Chrome installed via apt has a valid chromedriver version. apt also does not keep previous versions of Chrome available for installation. To ensure that we always get a valid pairing of Chrome and chromedriver, this change instead targets the latest stable version of Chrome and chromedriver.

**Test results**

TBD
