### PR TITLE
Migrate to Compose V2 for dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cd django-DefectDojo
 # use docker-compose logs -f initializer to track progress
 docker compose logs initializer | grep "Admin password:"
 ```
-## For older verion Composer V1
+## For older verion Compose V1
 You can run Compose V1 by adding the hyphen (-) between docker compose and edit below the files. 
 ```sh
      dc-build.sh

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ cd django-DefectDojo
 # use docker-compose logs -f initializer to track progress
 docker-compose logs initializer | grep "Admin password:"
 ```
+## If you are using Compose V2
+For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+
+Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+
+```sh
+git clone https://github.com/DefectDojo/django-DefectDojo
+cd django-DefectDojo
+# building
+./dc-build.sh
+# running (for other profiles besides postgres-redis look at https://github.com/DefectDojo/django-DefectDojo/blob/dev/readme-docs/DOCKER.md)
+./dc-up.sh postgres-redis
+# obtain admin credentials. the initializer can take up to 3 minutes to run
+# use docker-compose logs -f initializer to track progress
+docker compose logs initializer | grep "Admin password:"
+```
+
 
 Navigate to <http://localhost:8080>.
 

--- a/README.md
+++ b/README.md
@@ -41,20 +41,7 @@ Try out the demo server at [demo.defectdojo.org](https://demo.defectdojo.org)
 
 Log in with `admin / 1Defectdojo@demo#appsec`. Please note that the demo is publicly accessible and regularly reset. Do not put sensitive data in the demo.
 
-## Quick Start
-
-```sh
-git clone https://github.com/DefectDojo/django-DefectDojo
-cd django-DefectDojo
-# building
-./dc-build.sh
-# running (for other profiles besides postgres-redis look at https://github.com/DefectDojo/django-DefectDojo/blob/dev/readme-docs/DOCKER.md)
-./dc-up.sh postgres-redis
-# obtain admin credentials. the initializer can take up to 3 minutes to run
-# use docker-compose logs -f initializer to track progress
-docker-compose logs initializer | grep "Admin password:"
-```
-## If you are using Compose V2
+## Quick Start for Compose V2
 For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
 
 Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
@@ -69,6 +56,19 @@ cd django-DefectDojo
 # obtain admin credentials. the initializer can take up to 3 minutes to run
 # use docker-compose logs -f initializer to track progress
 docker compose logs initializer | grep "Admin password:"
+```
+## For older verion Composer V1
+You can run Compose V1 by adding the hyphen (-) between docker compose and edit below the files. 
+```sh
+     dc-build.sh
+     dc-down.sh
+     dc-stop.sh
+     dc-unittest.sh
+     dc-up-d.sh
+     dc-up.sh
+     docker/docker-compose-check.sh
+     docker/entrypoint-initializer.sh
+     docker/setEnv.sh
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Log in with `admin / 1Defectdojo@demo#appsec`. Please note that the demo is publ
 ## Quick Start for Compose V2
 From July 2023 Compose V1 [stopped receiving updates](https://docs.docker.com/compose/reference/).
 
-Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using `docker compose`, instead of `docker-compose`.
 
 ```sh
 git clone https://github.com/DefectDojo/django-DefectDojo

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cd django-DefectDojo
 # use docker-compose logs -f initializer to track progress
 docker compose logs initializer | grep "Admin password:"
 ```
-## For older version Compose V1
+## For Docker Compose V1
 You can run Compose V1 by adding the hyphen (-) between docker compose and edit below the files. 
 ```sh
      dc-build.sh

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Try out the demo server at [demo.defectdojo.org](https://demo.defectdojo.org)
 Log in with `admin / 1Defectdojo@demo#appsec`. Please note that the demo is publicly accessible and regularly reset. Do not put sensitive data in the demo.
 
 ## Quick Start for Compose V2
-For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+From July 2023 Compose V1 [stopped receiving updates](https://docs.docker.com/compose/reference/).
 
 Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ cd django-DefectDojo
 # use docker-compose logs -f initializer to track progress
 docker compose logs initializer | grep "Admin password:"
 ```
-## For older verion Compose V1
+## For older version Compose V1
 You can run Compose V1 by adding the hyphen (-) between docker compose and edit below the files. 
 ```sh
      dc-build.sh

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cd django-DefectDojo
 docker compose logs initializer | grep "Admin password:"
 ```
 ## For Docker Compose V1
-You can run Compose V1 by adding the hyphen (-) between docker compose and edit below the files. 
+You can run Compose V1 by editing the below files to add the hyphen (-) between `docker compose`. 
 ```sh
      dc-build.sh
      dc-down.sh

--- a/dc-build.sh
+++ b/dc-build.sh
@@ -12,4 +12,9 @@ fi
 
 # Building images for all configurations
 # The docker build doesn't supply any environment variables to the Dockerfile, so we can use any profile.
-docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env build $1
+
+# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env build $1
+
+# Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env build $1

--- a/dc-build.sh
+++ b/dc-build.sh
@@ -13,7 +13,7 @@ fi
 # Building images for all configurations
 # The docker build doesn't supply any environment variables to the Dockerfile, so we can use any profile.
 
-# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
 # docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env build $1
 
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.

--- a/dc-build.sh
+++ b/dc-build.sh
@@ -13,8 +13,5 @@ fi
 # Building images for all configurations
 # The docker build doesn't supply any environment variables to the Dockerfile, so we can use any profile.
 
-# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
-# docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env build $1
-
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
 docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env build $1

--- a/dc-down.sh
+++ b/dc-down.sh
@@ -13,7 +13,7 @@ fi
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
 
-# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
 # docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env down $1
 
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.

--- a/dc-down.sh
+++ b/dc-down.sh
@@ -12,4 +12,9 @@ fi
 
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
-docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env down $1
+
+# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env down $1
+
+# Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env down $1

--- a/dc-down.sh
+++ b/dc-down.sh
@@ -13,8 +13,5 @@ fi
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
 
-# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
-# docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env down $1
-
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
 docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env down $1

--- a/dc-stop.sh
+++ b/dc-stop.sh
@@ -13,7 +13,7 @@ fi
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
 
-# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
 # docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env stop $1
 
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.

--- a/dc-stop.sh
+++ b/dc-stop.sh
@@ -12,4 +12,9 @@ fi
 
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
-docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env stop $1
+
+# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env stop $1
+
+# Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env stop $1

--- a/dc-stop.sh
+++ b/dc-stop.sh
@@ -13,8 +13,5 @@ fi
 # Stopping containers for all configurations
 # The environment must be provided but it doesn't make a difference which one
 
-# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
-# docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env stop $1
-
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
 docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/postgres-redis.env stop $1

--- a/dc-unittest.sh
+++ b/dc-unittest.sh
@@ -73,4 +73,8 @@ then
 fi
 
 echo "Running docker compose unit tests with profile $PROFILE and test case $TEST_CASE ..."
-docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2 --keepdb"
+# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2 --keepdb"
+
+# Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+docker compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2 --keepdb"

--- a/dc-unittest.sh
+++ b/dc-unittest.sh
@@ -73,7 +73,7 @@ then
 fi
 
 echo "Running docker compose unit tests with profile $PROFILE and test case $TEST_CASE ..."
-# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
 # docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2 --keepdb"
 
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.

--- a/dc-unittest.sh
+++ b/dc-unittest.sh
@@ -73,8 +73,6 @@ then
 fi
 
 echo "Running docker compose unit tests with profile $PROFILE and test case $TEST_CASE ..."
-# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
-# docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2 --keepdb"
 
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
 docker compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env exec uwsgi bash -c "python manage.py test $TEST_CASE -v2 --keepdb"

--- a/dc-up-d.sh
+++ b/dc-up-d.sh
@@ -27,4 +27,9 @@ else
 fi
 
 echo "Starting docker compose with profile $PROFILE in the background ..."
-docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps -d
+
+# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps -d
+
+# Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+docker compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps -d

--- a/dc-up-d.sh
+++ b/dc-up-d.sh
@@ -28,8 +28,5 @@ fi
 
 echo "Starting docker compose with profile $PROFILE in the background ..."
 
-# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
-# docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps -d
-
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
 docker compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps -d

--- a/dc-up-d.sh
+++ b/dc-up-d.sh
@@ -28,7 +28,7 @@ fi
 
 echo "Starting docker compose with profile $PROFILE in the background ..."
 
-# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
 # docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps -d
 
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.

--- a/dc-up.sh
+++ b/dc-up.sh
@@ -26,4 +26,9 @@ else
 fi
 
 echo "Starting docker compose with profile $PROFILE in the foreground ..."
-docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps
+
+# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps
+
+# Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
+docker compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps

--- a/dc-up.sh
+++ b/dc-up.sh
@@ -27,8 +27,5 @@ fi
 
 echo "Starting docker compose with profile $PROFILE in the foreground ..."
 
-# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
-# docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps
-
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.
 docker compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps

--- a/dc-up.sh
+++ b/dc-up.sh
@@ -27,7 +27,7 @@ fi
 
 echo "Starting docker compose with profile $PROFILE in the foreground ..."
 
-# For Docker Compose V1 [From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/]
+# From July 2023 Compose V1 stopped receiving updates. Reference: https://docs.docker.com/compose/reference/
 # docker-compose --profile $PROFILE --env-file ./docker/environments/$PROFILE.env up --no-deps
 
 # Compose V2 integrates compose functions into the Docker platform, continuing to support most of the previous docker-compose features and flags. You can run Compose V2 by replacing the hyphen (-) with a space, using docker compose, instead of docker-compose.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
     volumes:
       - defectdojo_data:/var/lib/mysql
   postgres:
-    image: postgres:16.0-alpine@sha256:2ccd6655060d7b06c71f86094e8c7a28bdcc8a80b43baca4b1dabb29cff138a2
+    image: postgres:16.0-alpine@sha256:bfd42bb6358aee8a305ec3f51d505d6b9e406cf3ce800914a66741dba18b8263
     profiles: 
       - postgres-rabbitmq
       - postgres-redis

--- a/docker/docker-compose-check.sh
+++ b/docker/docker-compose-check.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-main=`docker-compose  version  --short | cut -d '.' -f 1`
-minor=`docker-compose  version  --short | cut -d '.' -f 2`
-current=`docker-compose  version  --short`
+main=`docker compose  version  --short | cut -d '.' -f 1`
+minor=`docker compose  version  --short | cut -d '.' -f 2`
+current=`docker compose  version  --short`
 
-echo 'Checking docker-compose version'
+echo 'Checking docker compose version'
 if [[ $main -lt 1 ]]; then
   echo "$current is not supported docker-compose version, please upgrade to minimal supported version:1.28"
   exit 1
@@ -15,4 +15,4 @@ elif [[ $main -eq 1 ]]; then
   fi
 fi
 
-echo 'Supported docker-compose version'
+echo 'Supported docker compose version'

--- a/docker/docker-compose-check.sh
+++ b/docker/docker-compose-check.sh
@@ -5,8 +5,8 @@ minor=`docker compose  version  --short | cut -d '.' -f 2`
 current=`docker compose  version  --short`
 
 echo 'Checking docker compose version'
-if [[ $main -lt 1 ]]; then
-  echo "$current is not supported docker-compose version, please upgrade to minimal supported version:1.28"
+if [[ $main -lt 2 ]]; then
+  echo "$current is not a supported docker-compose version, please upgrade to the minimum supported version: 2.0"
   exit 1
 elif [[ $main -eq 1 ]]; then
   if [[ $minor -lt 28 ]]; then

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -78,7 +78,7 @@ if [ ! -z "$ADMIN_EXISTS" ]
 then
     echo "Admin password: Initialization detected that the admin user ${DD_ADMIN_USER} already exists in your database."
     echo "If you don't remember the ${DD_ADMIN_USER} password, you can create a new superuser with:"
-    echo "$ docker-compose exec uwsgi /bin/bash -c 'python manage.py createsuperuser'"
+    echo "$ docker compose exec uwsgi /bin/bash -c 'python manage.py createsuperuser'"
     create_announcement_banner
     initialize_data
     exit

--- a/docker/setEnv.sh
+++ b/docker/setEnv.sh
@@ -53,7 +53,7 @@ function set_release {
     get_current
     if [ "${current_env}" != release ]
     then
-        docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
+        docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
         # In release configuration there is no override file
         rm ${override_link}
         echo "Now using 'release' configuration."
@@ -67,7 +67,7 @@ function set_dev {
     get_current
     if [ "${current_env}" != dev ]
     then
-        docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
+        docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
         rm -f ${override_link}
         ln -s ${override_file_dev} ${override_link}
         echo "Now using 'dev' configuration."
@@ -80,7 +80,7 @@ function set_debug {
     get_current
     if [ "${current_env}" != debug ]
     then
-        docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
+        docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
         rm -f ${override_link}
         ln -s ${override_file_debug} ${override_link}
         echo "Now using 'debug' configuration."
@@ -93,7 +93,7 @@ function set_unit_tests {
     get_current
     if [ "${current_env}" != unit_tests ]
     then
-        docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
+        docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
         rm -f ${override_link}
         ln -s ${override_file_unit_tests} ${override_link}
         echo "Now using 'unit_tests' configuration."
@@ -106,7 +106,7 @@ function set_unit_tests_cicd {
     get_current
     if [ "${current_env}" != unit_tests_cicd ]
     then
-        docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
+        docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
         rm -f ${override_link}
         ln -s ${override_file_unit_tests_cicd} ${override_link}
         echo "Now using 'unit_tests_cicd' configuration."
@@ -119,7 +119,7 @@ function set_integration_tests {
     get_current
     if [ "${current_env}" != integration_tests ]
     then
-        docker-compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
+        docker compose --profile mysql-rabbitmq --profile postgres-redis --env-file ./docker/environments/mysql-rabbitmq.env down
         rm -f ${override_link}
         ln -s ${override_file_integration_tests} ${override_link}
         echo "Now using 'integration_tests' configuration."


### PR DESCRIPTION
⚠️ Note on feature completeness ⚠️
From July 2023 Compose V1 stopped receiving updates. It's also no longer available in new releases of Docker Desktop. Compose V2 is included with all currently supported versions of Docker Desktop. For more information, see [Migrate to Compose V2](https://docs.docker.com/compose/migrate).

Compose V2, which was first released in 2020, is included with all currently supported versions of Docker Desktop. It offers an improved CLI experience, improved build performance with BuildKit, and continued new-feature development.

Description

How do I switch to Compose V2?
The easiest and recommended way is to make sure you have the latest version of Docker Desktop, which bundles the Docker Engine and Docker CLI platform including Compose V2. With Docker Desktop, Compose V2 is always accessible as docker compose.