### PR TITLE
Adds a code review process section to the contributors guide

### DIFF
--- a/readme-docs/CONTRIBUTING.md
+++ b/readme-docs/CONTRIBUTING.md
@@ -88,3 +88,12 @@ DefectDojo.
 [dojo_settings]: /dojo/settings/settings.dist.py "DefectDojo settings file"
 [pep8]: https://www.python.org/dev/peps/pep-0008/ "PEP8"
 [flake8 built-in commit hooks]: https://flake8.pycqa.org/en/latest/user/using-hooks.html#built-in-hook-integration
+
+
+## Code Review Process
+
+During the review process, one or more reviewers may provide feedback on your changes.
+Requested changes from reviewers should stay within the scope of the PR.
+Please do not resolve comments without any discussion. If you decide not to make a suggested change,
+make sure to leave a brief reply as a response so that everyone
+is on the same page. The reviewer can then resolve the comment if the reasoning is acceptable.


### PR DESCRIPTION
## :warning: Note on feature completeness :warning:

We are narrowing the scope of acceptable enhancements to DefectDojo in preparation for v3. Learn more here:
https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md

**Description**

Standards are easier to follow when they are documented. This commit is an initial start to properly set expectations about the code review process so that both contributors and reviewers feel that their opinions have been respected.

**Test results**

No code was changed

