### PR TITLE
Consolidation of notification creation

### DIFF
--- a/dojo/apps.py
+++ b/dojo/apps.py
@@ -72,8 +72,13 @@ class DojoAppConfig(AppConfig):
         # Load any signals here that will be ready for runtime
         # Importing the signals file is good enough if using the reciever decorator
         import dojo.announcement.signals  # noqa: F401
+        import dojo.endpoint.signals  # noqa: F401
+        import dojo.engagement.signals  # noqa: F401
+        import dojo.finding_group.signals  # noqa: F401
         import dojo.product.signals  # noqa: F401
+        import dojo.product_type.signals  # noqa: F401
         import dojo.sla_config.helpers  # noqa: F401
+        import dojo.tags_signals  # noqa: F401
         import dojo.test.signals  # noqa: F401
 
 

--- a/dojo/endpoint/signals.py
+++ b/dojo/endpoint/signals.py
@@ -15,9 +15,9 @@ def endpoint_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
         if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
-                    action=LogEntry.Action.DELETE,
-                    content_type=ContentType.objects.get(app_label='dojo', model='endpoint'),
-                    object_id=instance.id
+                action=LogEntry.Action.DELETE,
+                content_type=ContentType.objects.get(app_label='dojo', model='endpoint'),
+                object_id=instance.id
             )
             description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
                                 'name': str(instance), 'user': le.actor}

--- a/dojo/endpoint/signals.py
+++ b/dojo/endpoint/signals.py
@@ -1,4 +1,5 @@
 from auditlog.models import LogEntry
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
@@ -7,13 +8,12 @@ from django.utils.translation import gettext as _
 
 from dojo.models import Endpoint
 from dojo.notifications.helper import create_notification
-from dojo.utils import get_system_setting
 
 
 @receiver(post_delete, sender=Endpoint)
 def endpoint_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
-        if get_system_setting('enable_auditlog'):
+        if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
                     action=LogEntry.Action.DELETE,
                     content_type=ContentType.objects.get(app_label='dojo', model='endpoint'),

--- a/dojo/endpoint/signals.py
+++ b/dojo/endpoint/signals.py
@@ -1,0 +1,30 @@
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from dojo.models import Endpoint
+from dojo.notifications.helper import create_notification
+from dojo.utils import get_system_setting
+
+
+@receiver(post_delete, sender=Endpoint)
+def endpoint_post_delete(sender, instance, using, origin, **kwargs):
+    if instance == origin:
+        if get_system_setting('enable_auditlog'):
+            le = LogEntry.objects.get(
+                    action=LogEntry.Action.DELETE,
+                    content_type=ContentType.objects.get(app_label='dojo', model='endpoint'),
+                    object_id=instance.id
+            )
+            description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
+                                'name': str(instance), 'user': le.actor}
+        else:
+            description = _('The endpoint "%(name)s" was deleted') % {'name': str(instance)}
+        create_notification(event='endpoint_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                            title=_('Deletion of %(name)s') % {'name': str(instance)},
+                            description=description,
+                            url=reverse('endpoint'),
+                            icon="exclamation-triangle")

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -1,17 +1,22 @@
 import logging
 from datetime import datetime
 
+from auditlog.models import LogEntry
 from dateutil.relativedelta import relativedelta
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
+from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Count, Q, QuerySet
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.translation import gettext as _
 
 from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.authorization_decorators import user_is_authorized
@@ -222,12 +227,6 @@ def delete_endpoint(request, eid):
                                      messages.SUCCESS,
                                      'Endpoint and relationships removed.',
                                      extra_tags='alert-success')
-                create_notification(event='other',
-                                    title=f'Deletion of {endpoint}',
-                                    product=product,
-                                    description=f'The endpoint "{endpoint}" was deleted by {request.user}',
-                                    url=reverse('endpoint'),
-                                    icon="exclamation-triangle")
                 return HttpResponseRedirect(reverse('view_product', args=(product.id,)))
 
     collector = NestedObjects(using=DEFAULT_DB_ALIAS)
@@ -516,3 +515,23 @@ def import_endpoint_meta(request, pid):
         'product_tab': product_tab,
         'form': form,
     })
+
+
+@receiver(post_delete, sender=Endpoint)
+def endpoint_post_delete(sender, instance, using, origin, **kwargs):
+    if instance == origin:
+        if get_system_setting('enable_auditlog'):
+            le = LogEntry.objects.get(
+                    action=LogEntry.Action.DELETE,
+                    content_type=ContentType.objects.get(app_label='dojo', model='endpoint'),
+                    object_id=instance.id
+            )
+            description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
+                                'name': str(instance), 'user': le.actor}
+        else:
+            description = _('The endpoint "%(name)s" was deleted') % {'name': str(instance)}
+        create_notification(event='endpoint_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                            title=_('Deletion of %(name)s') % {'name': str(instance)},
+                            description=description,
+                            url=reverse('endpoint'),
+                            icon="exclamation-triangle")

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -1,22 +1,17 @@
 import logging
 from datetime import datetime
 
-from auditlog.models import LogEntry
 from dateutil.relativedelta import relativedelta
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
-from django.contrib.contenttypes.models import ContentType
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Count, Q, QuerySet
-from django.db.models.signals import post_delete
-from django.dispatch import receiver
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import gettext as _
 
 from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.authorization.authorization_decorators import user_is_authorized
@@ -26,7 +21,6 @@ from dojo.endpoint.utils import clean_hosts_run, endpoint_meta_import
 from dojo.filters import EndpointFilter, EndpointFilterWithoutObjectLookups
 from dojo.forms import AddEndpointForm, DeleteEndpointForm, DojoMetaDataForm, EditEndpointForm, ImportEndpointMetaForm
 from dojo.models import DojoMeta, Endpoint, Endpoint_Status, Finding, Product
-from dojo.notifications.helper import create_notification
 from dojo.utils import (
     Product_Tab,
     add_breadcrumb,
@@ -515,23 +509,3 @@ def import_endpoint_meta(request, pid):
         'product_tab': product_tab,
         'form': form,
     })
-
-
-@receiver(post_delete, sender=Endpoint)
-def endpoint_post_delete(sender, instance, using, origin, **kwargs):
-    if instance == origin:
-        if get_system_setting('enable_auditlog'):
-            le = LogEntry.objects.get(
-                    action=LogEntry.Action.DELETE,
-                    content_type=ContentType.objects.get(app_label='dojo', model='endpoint'),
-                    object_id=instance.id
-            )
-            description = _('The endpoint "%(name)s" was deleted by %(user)s') % {
-                                'name': str(instance), 'user': le.actor}
-        else:
-            description = _('The endpoint "%(name)s" was deleted') % {'name': str(instance)}
-        create_notification(event='endpoint_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
-                            title=_('Deletion of %(name)s') % {'name': str(instance)},
-                            description=description,
-                            url=reverse('endpoint'),
-                            icon="exclamation-triangle")

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -40,9 +40,9 @@ def engagement_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
         if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
-                    action=LogEntry.Action.DELETE,
-                    content_type=ContentType.objects.get(app_label='dojo', model='engagement'),
-                    object_id=instance.id
+                action=LogEntry.Action.DELETE,
+                content_type=ContentType.objects.get(app_label='dojo', model='engagement'),
+                object_id=instance.id
             )
             description = _('The engagement "%(name)s" was deleted by %(user)s') % {
                                 'name': instance.name, 'user': le.actor}

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -1,0 +1,57 @@
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_delete, post_save, pre_save
+from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from dojo.models import Engagement
+from dojo.notifications.helper import create_notification
+from dojo.utils import get_system_setting
+
+
+@receiver(post_save, sender=Engagement)
+def engagement_post_save(sender, instance, created, **kwargs):
+    if created:
+        title = 'Engagement created for ' + str(instance.product) + ': ' + str(instance.name)
+        create_notification(event='engagement_added', title=title, engagement=instance, product=instance.product,
+                            url=reverse('view_engagement', args=(instance.id,)))
+
+
+@receiver(pre_save, sender=Engagement)
+def engagement_pre_save(sender, instance, **kwargs):
+    old = sender.objects.filter(pk=instance.pk).first()
+    if old and instance.status != old.status:
+        if instance.status in ["Cancelled", "Completed"]:
+            create_notification(event='close_engagement',
+                                title=_('Closure of %s') % instance.name,
+                                description=_('The engagement "%s" was closed') % (instance.name),
+                                engagement=instance, url=reverse('engagement_all_findings', args=(instance.id, )))
+        elif instance.status in ["In Progress"]:
+            create_notification(event='reopen_engagement',
+                                title=_('Reopening of %s') % instance.name,
+                                engagement=instance,
+                                description=_('The engagement "%s" was reopened') % (instance.name),
+                                url=reverse('view_engagement', args=(instance.id, )))
+
+
+@receiver(post_delete, sender=Engagement)
+def engagement_post_delete(sender, instance, using, origin, **kwargs):
+    if instance == origin:
+        if get_system_setting('enable_auditlog'):
+            le = LogEntry.objects.get(
+                    action=LogEntry.Action.DELETE,
+                    content_type=ContentType.objects.get(app_label='dojo', model='engagement'),
+                    object_id=instance.id
+            )
+            description = _('The engagement "%(name)s" was deleted by %(user)s') % {
+                                'name': instance.name, 'user': le.actor}
+        else:
+            description = _('The engagement "%(name)s" was deleted') % {'name': instance.name}
+        create_notification(event='engagement_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                            title=_('Deletion of %(name)s') % {'name': instance.name},
+                            description=description,
+                            product=instance.product,
+                            url=reverse('view_product', args=(instance.product.id, )),
+                            recipients=[instance.lead],
+                            icon="exclamation-triangle")

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -27,7 +27,7 @@ def engagement_pre_save(sender, instance, **kwargs):
                                 title=_('Closure of %s') % instance.name,
                                 description=_('The engagement "%s" was closed') % (instance.name),
                                 engagement=instance, url=reverse('engagement_all_findings', args=(instance.id, )))
-        elif instance.status in ["In Progress"]:
+        elif instance.status in ["In Progress"] and old.status not in ["Not Started"]:
             create_notification(event='engagement_reopened',
                                 title=_('Reopening of %s') % instance.name,
                                 engagement=instance,

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -23,12 +23,12 @@ def engagement_pre_save(sender, instance, **kwargs):
     old = sender.objects.filter(pk=instance.pk).first()
     if old and instance.status != old.status:
         if instance.status in ["Cancelled", "Completed"]:
-            create_notification(event='close_engagement',
+            create_notification(event='engagement_closed',
                                 title=_('Closure of %s') % instance.name,
                                 description=_('The engagement "%s" was closed') % (instance.name),
                                 engagement=instance, url=reverse('engagement_all_findings', args=(instance.id, )))
         elif instance.status in ["In Progress"]:
-            create_notification(event='reopen_engagement',
+            create_notification(event='engagement_reopened',
                                 title=_('Reopening of %s') % instance.name,
                                 engagement=instance,
                                 description=_('The engagement "%s" was reopened') % (instance.name),

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -1,4 +1,5 @@
 from auditlog.models import LogEntry
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
@@ -7,7 +8,6 @@ from django.utils.translation import gettext as _
 
 from dojo.models import Engagement
 from dojo.notifications.helper import create_notification
-from dojo.utils import get_system_setting
 
 
 @receiver(post_save, sender=Engagement)
@@ -38,7 +38,7 @@ def engagement_pre_save(sender, instance, **kwargs):
 @receiver(post_delete, sender=Engagement)
 def engagement_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
-        if get_system_setting('enable_auditlog'):
+        if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
                     action=LogEntry.Action.DELETE,
                     content_type=ContentType.objects.get(app_label='dojo', model='engagement'),

--- a/dojo/engagement/signals.py
+++ b/dojo/engagement/signals.py
@@ -13,7 +13,7 @@ from dojo.notifications.helper import create_notification
 @receiver(post_save, sender=Engagement)
 def engagement_post_save(sender, instance, created, **kwargs):
     if created:
-        title = 'Engagement created for ' + str(instance.product) + ': ' + str(instance.name)
+        title = _('Engagement created for "%(product)s": %(name)s') % {'product': instance.product, 'name': instance.name}
         create_notification(event='engagement_added', title=title, engagement=instance, product=instance.product,
                             url=reverse('view_engagement', args=(instance.id,)))
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -16,8 +16,6 @@ from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import DEFAULT_DB_ALIAS
 from django.db.models import Count, Q
 from django.db.models.query import Prefetch, QuerySet
-from django.db.models.signals import post_delete, post_save, pre_save
-from django.dispatch import receiver
 from django.http import FileResponse, HttpRequest, HttpResponse, HttpResponseRedirect, QueryDict, StreamingHttpResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import Resolver404, reverse

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -394,7 +394,7 @@ def copy_engagement(request, eid):
                 messages.SUCCESS,
                 'Engagement Copied successfully.',
                 extra_tags='alert-success')
-            create_notification(event='copy_engagement',  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
+            create_notification(event='engagement_copied',  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
                                 title='Copying of %s' % engagement.name,
                                 description=f'The engagement "{engagement.name}" was copied by {request.user}',
                                 product=product,

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -393,7 +393,7 @@ def copy_engagement(request, eid):
                 'Engagement Copied successfully.',
                 extra_tags='alert-success')
             create_notification(event='engagement_copied',  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
-                                title='Copying of %s' % engagement.name,
+                                title=_('Copying of %s') % engagement.name,
                                 description=f'The engagement "{engagement.name}" was copied by {request.user}',
                                 product=product,
                                 url=request.build_absolute_uri(reverse('view_engagement', args=(engagement_copy.id, ))),

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1169,9 +1169,13 @@ class DeleteFinding(View):
                 "Finding deleted successfully.",
                 extra_tags="alert-success",
             )
+
+            # TODO this notification might be moved to "@receiver(post_delete, sender=Finding)" method as many other notifications
+            # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+
             # Send a notification that the finding had been deleted
             create_notification(
-                event="other",
+                event="delete_finding",
                 title=f"Deletion of {finding.title}",
                 description=f'The finding "{finding.title}" was deleted by {request.user}',
                 product=product,
@@ -1288,9 +1292,13 @@ def close_finding(request, fid):
                     "Finding closed.",
                     extra_tags="alert-success",
                 )
+
+                # TODO this notification might be moved to "@receiver(pre_save, sender=Finding)" method as many other notifications
+                # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+
                 create_notification(
-                    event="other",
-                    title=f"Closing of {finding.title}",
+                    event="close_finding",
+                    title="Closing of %s" % finding.title,
                     finding=finding,
                     description=f'The finding "{finding.title}" was closed by {request.user}',
                     url=reverse("view_finding", args=(finding.id,)),
@@ -1451,9 +1459,13 @@ def reopen_finding(request, fid):
     messages.add_message(
         request, messages.SUCCESS, "Finding Reopened.", extra_tags="alert-success"
     )
+
+    # TODO this notification might be moved to "@receiver(pre_save, sender=Finding)" method as many other notifications
+    # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+
     create_notification(
-        event="other",
-        title=f"Reopening of {finding.title}",
+        event="reopen_finding",
+        title="Reopening of %s" % finding.title,
         finding=finding,
         description=f'The finding "{finding.title}" was reopened by {request.user}',
         url=reverse("view_finding", args=(finding.id,)),
@@ -1510,8 +1522,8 @@ def copy_finding(request, fid):
                 extra_tags="alert-success",
             )
             create_notification(
-                event="other",
-                title=f"Copying of {finding.title}",
+                event="copy_finding",  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
+                title="Copying of %s" % finding.title,
                 description=f'The finding "{finding.title}" was copied by {request.user} to {test.title}',
                 product=product,
                 url=request.build_absolute_uri(
@@ -1686,7 +1698,7 @@ def request_finding_review(request, fid):
             logger.debug(f"Asking {reviewers_string} for review")
 
             create_notification(
-                event="review_requested",
+                event="review_requested",  # TODO - if 'review_requested' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
                 title="Finding review requested",
                 requested_by=user,
                 note=new_note,

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1170,8 +1170,9 @@ class DeleteFinding(View):
                 extra_tags="alert-success",
             )
 
-            # TODO this notification might be moved to "@receiver(post_delete, sender=Finding)" method as many other notifications
-            # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+            # Note: this notification has not be moved to "@receiver(post_delete, sender=Finding)" method as many other notifications
+            # Because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+            # TODO: but same should be implemented for API endpoint
 
             # Send a notification that the finding had been deleted
             create_notification(
@@ -1293,8 +1294,9 @@ def close_finding(request, fid):
                     extra_tags="alert-success",
                 )
 
-                # TODO this notification might be moved to "@receiver(pre_save, sender=Finding)" method as many other notifications
-                # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+                # Note: this notification has not be moved to "@receiver(pre_save, sender=Finding)" method as many other notifications
+                # Because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+                # TODO: but same should be implemented for API endpoint
 
                 create_notification(
                     event="finding_closed",
@@ -1460,8 +1462,9 @@ def reopen_finding(request, fid):
         request, messages.SUCCESS, "Finding Reopened.", extra_tags="alert-success"
     )
 
-    # TODO this notification might be moved to "@receiver(pre_save, sender=Finding)" method as many other notifications
-    # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+    # Note: this notification has not be moved to "@receiver(pre_save, sender=Finding)" method as many other notifications
+    # Because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+    # TODO: but same should be implemented for API endpoint
 
     create_notification(
         event="finding_reopened",

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -117,7 +117,7 @@ from dojo.utils import (
     get_system_setting,
     get_words_for_field,
     match_finding_to_existing_findings,
-    process_notifications,
+    process_tag_notifications,
     redirect,
     redirect_to_return_url_or_else,
     reopen_external_issue,
@@ -716,7 +716,7 @@ class ViewFinding(View):
                 reverse("view_finding", args=(finding.id,))
             )
             title = f"Finding: {finding.title}"
-            process_notifications(request, new_note, url, title)
+            process_tag_notifications(request, new_note, url, title)
             # Add a message to the request
             messages.add_message(
                 request, messages.SUCCESS, "Note saved.", extra_tags="alert-success"

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -22,6 +22,7 @@ from django.template.defaultfilters import pluralize
 from django.urls import reverse
 from django.utils import formats, timezone
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.http import require_POST
 from imagekit import ImageSpec
@@ -1300,7 +1301,7 @@ def close_finding(request, fid):
 
                 create_notification(
                     event="finding_closed",
-                    title="Closing of %s" % finding.title,
+                    title=_("Closing of %s") % finding.title,
                     finding=finding,
                     description=f'The finding "{finding.title}" was closed by {request.user}',
                     url=reverse("view_finding", args=(finding.id,)),
@@ -1468,7 +1469,7 @@ def reopen_finding(request, fid):
 
     create_notification(
         event="finding_reopened",
-        title="Reopening of %s" % finding.title,
+        title=_("Reopening of %s") % finding.title,
         finding=finding,
         description=f'The finding "{finding.title}" was reopened by {request.user}',
         url=reverse("view_finding", args=(finding.id,)),
@@ -1526,7 +1527,7 @@ def copy_finding(request, fid):
             )
             create_notification(
                 event="finding_copied",  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
-                title="Copying of %s" % finding.title,
+                title=_("Copying of %s") % finding.title,
                 description=f'The finding "{finding.title}" was copied by {request.user} to {test.title}',
                 product=product,
                 url=request.build_absolute_uri(

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1175,7 +1175,7 @@ class DeleteFinding(View):
 
             # Send a notification that the finding had been deleted
             create_notification(
-                event="delete_finding",
+                event="finding_deleted",
                 title=f"Deletion of {finding.title}",
                 description=f'The finding "{finding.title}" was deleted by {request.user}',
                 product=product,
@@ -1297,7 +1297,7 @@ def close_finding(request, fid):
                 # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
 
                 create_notification(
-                    event="close_finding",
+                    event="finding_closed",
                     title="Closing of %s" % finding.title,
                     finding=finding,
                     description=f'The finding "{finding.title}" was closed by {request.user}',
@@ -1464,7 +1464,7 @@ def reopen_finding(request, fid):
     # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
 
     create_notification(
-        event="reopen_finding",
+        event="finding_reopened",
         title="Reopening of %s" % finding.title,
         finding=finding,
         description=f'The finding "{finding.title}" was reopened by {request.user}',
@@ -1522,7 +1522,7 @@ def copy_finding(request, fid):
                 extra_tags="alert-success",
             )
             create_notification(
-                event="copy_finding",  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
+                event="finding_copied",  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
                 title="Copying of %s" % finding.title,
                 description=f'The finding "{finding.title}" was copied by {request.user} to {test.title}',
                 product=product,

--- a/dojo/finding_group/signals.py
+++ b/dojo/finding_group/signals.py
@@ -1,0 +1,32 @@
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from dojo.models import Finding_Group
+from dojo.notifications.helper import create_notification
+from dojo.utils import get_system_setting
+
+
+@receiver(post_delete, sender=Finding_Group)
+def finding_group_post_delete(sender, instance, using, origin, **kwargs):
+    print(f"xxx: sender {sender}, instance {instance}, using {using}, origin {origin}")
+    if instance == origin:
+        if get_system_setting('enable_auditlog'):
+            le = LogEntry.objects.get(
+                    action=LogEntry.Action.DELETE,
+                    content_type=ContentType.objects.get(app_label='dojo', model='finding_group'),
+                    object_id=instance.id
+            )
+            description = _('The finding group "%(name)s" was deleted by %(user)s') % {
+                                'name': instance.name, 'user': le.actor}
+        else:
+            description = _('The finding group "%(name)s" was deleted') % {'name': instance.name}
+        create_notification(event='finding_group_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                            title=_('Deletion of %(name)s') % {'name': instance.name},
+                            description=description,
+                            product=instance.test.engagement.product,
+                            url=reverse('view_test', args=(instance.test.id, )),
+                            icon="exclamation-triangle")

--- a/dojo/finding_group/signals.py
+++ b/dojo/finding_group/signals.py
@@ -12,7 +12,6 @@ from dojo.utils import get_system_setting
 
 @receiver(post_delete, sender=Finding_Group)
 def finding_group_post_delete(sender, instance, using, origin, **kwargs):
-    print(f"xxx: sender {sender}, instance {instance}, using {using}, origin {origin}")
     if instance == origin:
         if get_system_setting('enable_auditlog'):
             le = LogEntry.objects.get(

--- a/dojo/finding_group/signals.py
+++ b/dojo/finding_group/signals.py
@@ -15,9 +15,9 @@ def finding_group_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
         if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
-                    action=LogEntry.Action.DELETE,
-                    content_type=ContentType.objects.get(app_label='dojo', model='finding_group'),
-                    object_id=instance.id
+                action=LogEntry.Action.DELETE,
+                content_type=ContentType.objects.get(app_label='dojo', model='finding_group'),
+                object_id=instance.id
             )
             description = _('The finding group "%(name)s" was deleted by %(user)s') % {
                                 'name': instance.name, 'user': le.actor}

--- a/dojo/finding_group/signals.py
+++ b/dojo/finding_group/signals.py
@@ -1,4 +1,5 @@
 from auditlog.models import LogEntry
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
@@ -7,13 +8,12 @@ from django.utils.translation import gettext as _
 
 from dojo.models import Finding_Group
 from dojo.notifications.helper import create_notification
-from dojo.utils import get_system_setting
 
 
 @receiver(post_delete, sender=Finding_Group)
 def finding_group_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
-        if get_system_setting('enable_auditlog'):
+        if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
                     action=LogEntry.Action.DELETE,
                     content_type=ContentType.objects.get(app_label='dojo', model='finding_group'),

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -16,7 +16,6 @@ from dojo.filters import FindingFilter, FindingFilterWithoutObjectLookups
 from dojo.finding.views import prefetch_for_findings
 from dojo.forms import DeleteFindingGroupForm, EditFindingGroupForm, FindingBulkUpdateForm
 from dojo.models import Engagement, Finding, Finding_Group, GITHUB_PKey, Product
-from dojo.notifications.helper import create_notification
 from dojo.utils import Product_Tab, add_breadcrumb, get_page_items, get_system_setting, get_words_for_field
 
 logger = logging.getLogger(__name__)
@@ -115,19 +114,11 @@ def delete_finding_group(request, fgid):
         if 'id' in request.POST and str(finding_group.id) == request.POST['id']:
             form = DeleteFindingGroupForm(request.POST, instance=finding_group)
             if form.is_valid():
-                product = finding_group.test.engagement.product
                 finding_group.delete()
                 messages.add_message(request,
                                      messages.SUCCESS,
                                      'Finding Group and relationships removed.',
                                      extra_tags='alert-success')
-
-                create_notification(event='other',
-                                    title=f'Deletion of {finding_group.name}',
-                                    product=product,
-                                    description=f'The finding group "{finding_group.name}" was deleted by {request.user}',
-                                    url=request.build_absolute_uri(reverse('view_test', args=(finding_group.test.id,))),
-                                    icon="exclamation-triangle")
                 return HttpResponseRedirect(reverse('view_test', args=(finding_group.test.id,)))
 
     collector = NestedObjects(using=DEFAULT_DB_ALIAS)

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -541,7 +541,7 @@ class DeleteJiraView(View):
                         extra_tags='alert-success')
                     create_notification(
                         event='jira_config_deleted',
-                        title='Deletion of JIRA: %s' % jira_instance.configuration_name,
+                        title=_('Deletion of JIRA: %s') % jira_instance.configuration_name,
                         description=f"JIRA \"{jira_instance.configuration_name}\" was deleted by {request.user}",
                         url=request.build_absolute_uri(reverse('jira')))
                     return HttpResponseRedirect(reverse('jira'))

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -239,10 +239,10 @@ def check_for_and_create_comment(parsed_json):
     findings = None
     if jissue.finding:
         findings = [jissue.finding]
-        create_notification(event='jira', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding", args=(jissue.finding.id,)), icon='check')
+        create_notification(event='jira_comment', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding", args=(jissue.finding.id,)), icon='check')
     elif jissue.finding_group:
         findings = [jissue.finding_group.findings.all()]
-        create_notification(event='jira', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
+        create_notification(event='jira_comment', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
     elif jissue.engagement:
         return webhook_responser_handler("debug", "Comment for engagement ignored")
     else:
@@ -378,7 +378,7 @@ class ExpressJiraView(View):
                 'JIRA Configuration Successfully Created.',
                 extra_tags='alert-success')
             create_notification(
-                event='jira',
+                event='jira_config_added',
                 title=f"New addition of JIRA: {jform.cleaned_data.get('configuration_name')}",
                 description=f"JIRA \"{jform.cleaned_data.get('configuration_name')}\" was added by {request.user}",
                 url=request.build_absolute_uri(reverse('jira')))
@@ -423,7 +423,7 @@ class NewJiraView(View):
                 'JIRA Configuration Successfully Created.',
                 extra_tags='alert-success')
             create_notification(
-                event='jira',
+                event='jira_config_added',
                 title=f"New addition of JIRA: {jform.cleaned_data.get('configuration_name')}",
                 description=f"JIRA \"{jform.cleaned_data.get('configuration_name')}\" was added by {request.user}",
                 url=request.build_absolute_uri(reverse('jira')))
@@ -478,7 +478,7 @@ class EditJiraView(View):
                 'JIRA Configuration Successfully Saved.',
                 extra_tags='alert-success')
             create_notification(
-                event='jira',
+                event='jira_config_edited',
                 title=f"Edit of JIRA: {jform.cleaned_data.get('configuration_name')}",
                 description=f"JIRA \"{jform.cleaned_data.get('configuration_name')}\" was edited by {request.user}",
                 url=request.build_absolute_uri(reverse('jira')))
@@ -540,7 +540,7 @@ class DeleteJiraView(View):
                         'JIRA Conf and relationships removed.',
                         extra_tags='alert-success')
                     create_notification(
-                        event='jira',
+                        event='jira_config_deleted',
                         title='Deletion of JIRA: %s' % jira_instance.configuration_name,
                         description=f"JIRA \"{jira_instance.configuration_name}\" was deleted by {request.user}",
                         url=request.build_absolute_uri(reverse('jira')))

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -239,10 +239,10 @@ def check_for_and_create_comment(parsed_json):
     findings = None
     if jissue.finding:
         findings = [jissue.finding]
-        create_notification(event='other', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding", args=(jissue.finding.id,)), icon='check')
+        create_notification(event='jira', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding", args=(jissue.finding.id,)), icon='check')
     elif jissue.finding_group:
         findings = [jissue.finding_group.findings.all()]
-        create_notification(event='other', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
+        create_notification(event='jira', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
     elif jissue.engagement:
         return webhook_responser_handler("debug", "Comment for engagement ignored")
     else:
@@ -378,7 +378,7 @@ class ExpressJiraView(View):
                 'JIRA Configuration Successfully Created.',
                 extra_tags='alert-success')
             create_notification(
-                event='other',
+                event='jira',
                 title=f"New addition of JIRA: {jform.cleaned_data.get('configuration_name')}",
                 description=f"JIRA \"{jform.cleaned_data.get('configuration_name')}\" was added by {request.user}",
                 url=request.build_absolute_uri(reverse('jira')))
@@ -423,7 +423,7 @@ class NewJiraView(View):
                 'JIRA Configuration Successfully Created.',
                 extra_tags='alert-success')
             create_notification(
-                event='other',
+                event='jira',
                 title=f"New addition of JIRA: {jform.cleaned_data.get('configuration_name')}",
                 description=f"JIRA \"{jform.cleaned_data.get('configuration_name')}\" was added by {request.user}",
                 url=request.build_absolute_uri(reverse('jira')))
@@ -478,7 +478,7 @@ class EditJiraView(View):
                 'JIRA Configuration Successfully Saved.',
                 extra_tags='alert-success')
             create_notification(
-                event='other',
+                event='jira',
                 title=f"Edit of JIRA: {jform.cleaned_data.get('configuration_name')}",
                 description=f"JIRA \"{jform.cleaned_data.get('configuration_name')}\" was edited by {request.user}",
                 url=request.build_absolute_uri(reverse('jira')))
@@ -540,8 +540,8 @@ class DeleteJiraView(View):
                         'JIRA Conf and relationships removed.',
                         extra_tags='alert-success')
                     create_notification(
-                        event='other',
-                        title=f'Deletion of JIRA: {jira_instance.configuration_name}',
+                        event='jira',
+                        title='Deletion of JIRA: %s' % jira_instance.configuration_name,
                         description=f"JIRA \"{jira_instance.configuration_name}\" was deleted by {request.user}",
                         url=request.build_absolute_uri(reverse('jira')))
                     return HttpResponseRedirect(reverse('jira'))

--- a/dojo/middleware.py
+++ b/dojo/middleware.py
@@ -3,10 +3,13 @@ from re import compile
 from threading import local
 from urllib.parse import quote
 
+from auditlog.context import set_actor
+from auditlog.middleware import AuditlogMiddleware as _AuditlogMiddleware
 from django.conf import settings
 from django.db import models
 from django.http import HttpResponseRedirect
 from django.urls import reverse
+from django.utils.functional import SimpleLazyObject
 
 logger = logging.getLogger(__name__)
 
@@ -164,3 +167,17 @@ class AdditionalHeaderMiddleware:
     def __call__(self, request):
         request.META.update(settings.ADDITIONAL_HEADERS)
         return self.get_response(request)
+
+
+# This solution comes from https://github.com/jazzband/django-auditlog/issues/115#issuecomment-1539262735
+# It fix situation when TokenAuthentication is used in API. Otherwise, actor in AuditLog would be set to None
+class AuditlogMiddleware(_AuditlogMiddleware):
+    def __call__(self, request):
+        remote_addr = self._get_remote_addr(request)
+
+        user = SimpleLazyObject(lambda: getattr(request, "user", None))
+
+        context = set_actor(actor=user, remote_addr=remote_addr)
+
+        with context:
+            return self.get_response(request)

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -4524,6 +4524,7 @@ if settings.ENABLE_AUDITLOG:
     auditlog.register(Endpoint)
     auditlog.register(Engagement)
     auditlog.register(Finding)
+    auditlog.register(Finding_Group)
     auditlog.register(Product_Type)
     auditlog.register(Product)
     auditlog.register(Test)

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -171,15 +171,15 @@ def process_notifications(event, notifications=None, **kwargs):
     msteams_enabled = get_system_setting('enable_msteams_notifications')
     mail_enabled = get_system_setting('enable_mail_notifications')
 
-    if slack_enabled and 'slack' in getattr(notifications, event):
+    if slack_enabled and 'slack' in getattr(notifications, event, getattr(notifications, 'other')):
         logger.debug('Sending Slack Notification')
         send_slack_notification(event, notifications.user, **kwargs)
 
-    if msteams_enabled and 'msteams' in getattr(notifications, event):
+    if msteams_enabled and 'msteams' in getattr(notifications, event, getattr(notifications, 'other')):
         logger.debug('Sending MSTeams Notification')
         send_msteams_notification(event, notifications.user, **kwargs)
 
-    if mail_enabled and 'mail' in getattr(notifications, event):
+    if mail_enabled and 'mail' in getattr(notifications, event, getattr(notifications, 'other')):
         logger.debug('Sending Mail Notification')
         send_mail_notification(event, notifications.user, **kwargs)
 

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -2,6 +2,7 @@ import logging
 
 import requests
 from django.conf import settings
+from django.core.exceptions import FieldDoesNotExist
 from django.core.mail import EmailMessage
 from django.db.models import Count, Prefetch, Q
 from django.template import TemplateDoesNotExist
@@ -182,8 +183,8 @@ def process_notifications(event, notifications=None, **kwargs):
         logger.debug('Sending Mail Notification')
         send_mail_notification(event, notifications.user, **kwargs)
 
-    if 'alert' in getattr(notifications, event, None):
-        logger.debug('Sending Alert')
+    if 'alert' in getattr(notifications, event, getattr(notifications, 'other')):
+        logger.debug(f'Sending Alert to {notifications.user}')
         send_alert_notification(event, notifications.user, **kwargs)
 
 
@@ -314,13 +315,18 @@ def send_alert_notification(event, user=None, *args, **kwargs):
     try:
         # no need to differentiate between user/no user
         icon = kwargs.get('icon', 'info-circle')
+        try:
+            source = Notifications._meta.get_field(event).verbose_name.title()[:100]
+        except FieldDoesNotExist:
+            source = event.replace("_", " ").title()[:100]
+        logger.debug(f'Souce: {source}')
         alert = Alerts(
             user_id=user,
             title=kwargs.get('title')[:250],
             description=create_notification_message(event, user, 'alert', *args, **kwargs)[:2000],
             url=kwargs.get('url', reverse('alerts')),
             icon=icon[:25],
-            source=Notifications._meta.get_field(event).verbose_name.title()[:100]
+            source=source,
         )
         # relative urls will fail validation
         alert.clean_fields(exclude=['url'])

--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -319,7 +319,6 @@ def send_alert_notification(event, user=None, *args, **kwargs):
             source = Notifications._meta.get_field(event).verbose_name.title()[:100]
         except FieldDoesNotExist:
             source = event.replace("_", " ").title()[:100]
-        logger.debug(f'Souce: {source}')
         alert = Alerts(
             user_id=user,
             title=kwargs.get('title')[:250],

--- a/dojo/product/signals.py
+++ b/dojo/product/signals.py
@@ -1,4 +1,5 @@
 from auditlog.models import LogEntry
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -7,7 +8,6 @@ from django.utils.translation import gettext as _
 
 from dojo.models import Product
 from dojo.notifications.helper import create_notification
-from dojo.utils import get_system_setting
 
 
 @receiver(post_save, sender=Product)
@@ -21,7 +21,7 @@ def product_post_save(sender, instance, created, **kwargs):
 
 @receiver(post_delete, sender=Product)
 def product_post_delete(sender, instance, **kwargs):
-    if get_system_setting('enable_auditlog'):
+    if settings.ENABLE_AUDITLOG:
         le = LogEntry.objects.get(
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label='dojo', model='product'),

--- a/dojo/product/signals.py
+++ b/dojo/product/signals.py
@@ -23,9 +23,9 @@ def product_post_save(sender, instance, created, **kwargs):
 def product_post_delete(sender, instance, **kwargs):
     if settings.ENABLE_AUDITLOG:
         le = LogEntry.objects.get(
-                action=LogEntry.Action.DELETE,
-                content_type=ContentType.objects.get(app_label='dojo', model='product'),
-                object_id=instance.id
+            action=LogEntry.Action.DELETE,
+            content_type=ContentType.objects.get(app_label='dojo', model='product'),
+            object_id=instance.id
         )
         description = _('The product "%(name)s" was deleted by %(user)s') % {
                             'name': instance.name, 'user': le.actor}

--- a/dojo/product/signals.py
+++ b/dojo/product/signals.py
@@ -1,79 +1,38 @@
-import contextlib
-import logging
-
-from django.db.models import signals
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext as _
 
-from dojo.models import Endpoint, Engagement, Finding, Product, Test
-from dojo.product import helpers as async_product_funcs
+from dojo.models import Product
+from dojo.notifications.helper import create_notification
 from dojo.utils import get_system_setting
 
-logger = logging.getLogger(__name__)
+
+@receiver(post_save, sender=Product)
+def product_post_save(sender, instance, created, **kwargs):
+    if created:
+        create_notification(event='product_added',
+                            title=instance.name,
+                            product=instance,
+                            url=reverse('view_product', args=(instance.id,)))
 
 
-@receiver(signals.m2m_changed, sender=Product.tags.through)
-def product_tags_post_add_remove(sender, instance, action, **kwargs):
-    if action in ["post_add", "post_remove"]:
-        running_async_process = False
-        with contextlib.suppress(AttributeError):
-            running_async_process = instance.running_async_process
-        # Check if the async process is already running to avoid calling it a second time
-        if not running_async_process and inherit_product_tags(instance):
-            async_product_funcs.propagate_tags_on_product(instance.id, countdown=5)
-            instance.running_async_process = True
-
-
-@receiver(signals.m2m_changed, sender=Endpoint.tags.through)
-@receiver(signals.m2m_changed, sender=Engagement.tags.through)
-@receiver(signals.m2m_changed, sender=Test.tags.through)
-@receiver(signals.m2m_changed, sender=Finding.tags.through)
-def make_inherited_tags_sticky(sender, instance, action, **kwargs):
-    if action in ["post_add", "post_remove"]:
-        if inherit_product_tags(instance):
-            tag_list = [tag.name for tag in instance.tags.all()]
-            if propagate_inheritance(instance, tag_list=tag_list):
-                instance.inherit_tags(tag_list)
-
-
-@receiver(signals.post_save, sender=Endpoint)
-@receiver(signals.post_save, sender=Engagement)
-@receiver(signals.post_save, sender=Test)
-@receiver(signals.post_save, sender=Finding)
-def inherit_tags_on_instance(sender, instance, created, **kwargs):
-    if inherit_product_tags(instance):
-        tag_list = instance._tags_tagulous.get_tag_list()
-        if propagate_inheritance(instance, tag_list=tag_list):
-            instance.inherit_tags(tag_list)
-
-
-def propagate_inheritance(instance, tag_list=[]):
-    # Get the expected product tags
-    product_inherited_tags = [tag.name for tag in get_product(instance).tags.all()]
-    existing_inherited_tags = [tag.name for tag in instance.inherited_tags.all()]
-    # Check if product tags already matches inherited tags
-    product_tags_equals_inherited_tags = product_inherited_tags == existing_inherited_tags
-    # Check if product tags have already been inherited
-    tags_have_already_been_inherited = set(product_inherited_tags) <= set(tag_list)
-    return not (product_tags_equals_inherited_tags and tags_have_already_been_inherited)
-
-
-def inherit_product_tags(instance) -> bool:
-    product = get_product(instance)
-    # Save a read in the db
-    if product and product.enable_product_tag_inheritance:
-        return True
-
-    return get_system_setting('enable_product_tag_inheritance')
-
-
-def get_product(instance):
-    if isinstance(instance, Product):
-        return instance
-    if isinstance(instance, Endpoint):
-        return instance.product
-    if isinstance(instance, Engagement):
-        return instance.product
-    if isinstance(instance, Test):
-        return instance.engagement.product
-    if isinstance(instance, Finding):
-        return instance.test.engagement.product
+@receiver(post_delete, sender=Product)
+def product_post_delete(sender, instance, **kwargs):
+    if get_system_setting('enable_auditlog'):
+        le = LogEntry.objects.get(
+                action=LogEntry.Action.DELETE,
+                content_type=ContentType.objects.get(app_label='dojo', model='product'),
+                object_id=instance.id
+        )
+        description = _('The product "%(name)s" was deleted by %(user)s') % {
+                            'name': instance.name, 'user': le.actor}
+    else:
+        description = _('The product "%(name)s" was deleted') % {'name': instance.name}
+    create_notification(event='product_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                        title=_('Deletion of %(name)s') % {'name': instance.name},
+                        description=description,
+                        url=reverse('product'),
+                        icon="exclamation-triangle")

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -6,19 +6,15 @@ from collections import OrderedDict
 from datetime import date, datetime, timedelta
 from math import ceil
 
-from auditlog.models import LogEntry
 from dateutil.relativedelta import relativedelta
 from django.contrib import messages
 from django.contrib.admin.utils import NestedObjects
-from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.aggregates import StringAgg
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import DEFAULT_DB_ALIAS, connection
 from django.db.models import Count, F, Max, OuterRef, Prefetch, Q, Subquery, Sum
 from django.db.models.expressions import Value
 from django.db.models.query import QuerySet
-from django.db.models.signals import post_delete, post_save
-from django.dispatch import receiver
 from django.http import Http404, HttpRequest, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
@@ -95,7 +91,6 @@ from dojo.models import (
     Test,
     Test_Type,
 )
-from dojo.notifications.helper import create_notification
 from dojo.product.queries import (
     get_authorized_groups_for_product,
     get_authorized_members_for_product,
@@ -1988,31 +1983,3 @@ def add_product_group(request, pid):
         'form': group_form,
         'product_tab': product_tab,
     })
-
-
-@receiver(post_save, sender=Product)
-def product_post_save(sender, instance, created, **kwargs):
-    if created:
-        create_notification(event='product_added',
-                            title=instance.name,
-                            product=instance,
-                            url=reverse('view_product', args=(instance.id,)))
-
-
-@receiver(post_delete, sender=Product)
-def product_post_delete(sender, instance, **kwargs):
-    if get_system_setting('enable_auditlog'):
-        le = LogEntry.objects.get(
-                action=LogEntry.Action.DELETE,
-                content_type=ContentType.objects.get(app_label='dojo', model='product'),
-                object_id=instance.id
-        )
-        description = _('The product "%(name)s" was deleted by %(user)s') % {
-                            'name': instance.name, 'user': le.actor}
-    else:
-        description = _('The product "%(name)s" was deleted') % {'name': instance.name}
-    create_notification(event='product_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
-                        title=_('Deletion of %(name)s') % {'name': instance.name},
-                        description=description,
-                        url=reverse('product'),
-                        icon="exclamation-triangle")

--- a/dojo/product_type/signals.py
+++ b/dojo/product_type/signals.py
@@ -1,0 +1,39 @@
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext as _
+
+from dojo.models import Product_Type
+from dojo.notifications.helper import create_notification
+from dojo.utils import get_system_setting
+
+
+@receiver(post_save, sender=Product_Type)
+def product_type_post_save(sender, instance, created, **kwargs):
+    if created:
+        create_notification(event='product_type_added',
+                            title=instance.name,
+                            product_type=instance,
+                            url=reverse('view_product_type', args=(instance.id,)))
+
+
+@receiver(post_delete, sender=Product_Type)
+def product_type_post_delete(sender, instance, **kwargs):
+    if get_system_setting('enable_auditlog'):
+        le = LogEntry.objects.get(
+                action=LogEntry.Action.DELETE,
+                content_type=ContentType.objects.get(app_label='dojo', model='product_type'),
+                object_id=instance.id
+        )
+        description = _('The product type "%(name)s" was deleted by %(user)s') % {
+                            'name': instance.name, 'user': le.actor}
+    else:
+        description = _('The product type "%(name)s" was deleted') % {'name': instance.name}
+    create_notification(event='product_type_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                        title=_('Deletion of %(name)s') % {'name': instance.name},
+                        description=description,
+                        no_users=True,
+                        url=reverse('product_type'),
+                        icon="exclamation-triangle")

--- a/dojo/product_type/signals.py
+++ b/dojo/product_type/signals.py
@@ -23,9 +23,9 @@ def product_type_post_save(sender, instance, created, **kwargs):
 def product_type_post_delete(sender, instance, **kwargs):
     if settings.ENABLE_AUDITLOG:
         le = LogEntry.objects.get(
-                action=LogEntry.Action.DELETE,
-                content_type=ContentType.objects.get(app_label='dojo', model='product_type'),
-                object_id=instance.id
+            action=LogEntry.Action.DELETE,
+            content_type=ContentType.objects.get(app_label='dojo', model='product_type'),
+            object_id=instance.id
         )
         description = _('The product type "%(name)s" was deleted by %(user)s') % {
                             'name': instance.name, 'user': le.actor}

--- a/dojo/product_type/signals.py
+++ b/dojo/product_type/signals.py
@@ -1,4 +1,5 @@
 from auditlog.models import LogEntry
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
@@ -7,7 +8,6 @@ from django.utils.translation import gettext as _
 
 from dojo.models import Product_Type
 from dojo.notifications.helper import create_notification
-from dojo.utils import get_system_setting
 
 
 @receiver(post_save, sender=Product_Type)
@@ -21,7 +21,7 @@ def product_type_post_save(sender, instance, created, **kwargs):
 
 @receiver(post_delete, sender=Product_Type)
 def product_type_post_delete(sender, instance, **kwargs):
-    if get_system_setting('enable_auditlog'):
+    if settings.ENABLE_AUDITLOG:
         le = LogEntry.objects.get(
                 action=LogEntry.Action.DELETE,
                 content_type=ContentType.objects.get(app_label='dojo', model='product_type'),

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -857,7 +857,7 @@ DJANGO_MIDDLEWARE_CLASSES = [
     'dojo.middleware.AdditionalHeaderMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'watson.middleware.SearchContextMiddleware',
-    'auditlog.middleware.AuditlogMiddleware',
+    'dojo.middleware.AuditlogMiddleware',
     'crum.CurrentRequestUserMiddleware',
     'dojo.request_cache.middleware.RequestCacheMiddleware',
 ]

--- a/dojo/tags_signals.py
+++ b/dojo/tags_signals.py
@@ -1,0 +1,79 @@
+import contextlib
+import logging
+
+from django.db.models import signals
+from django.dispatch import receiver
+
+from dojo.models import Endpoint, Engagement, Finding, Product, Test
+from dojo.product import helpers as async_product_funcs
+from dojo.utils import get_system_setting
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(signals.m2m_changed, sender=Product.tags.through)
+def product_tags_post_add_remove(sender, instance, action, **kwargs):
+    if action in ["post_add", "post_remove"]:
+        running_async_process = False
+        with contextlib.suppress(AttributeError):
+            running_async_process = instance.running_async_process
+        # Check if the async process is already running to avoid calling it a second time
+        if not running_async_process and inherit_product_tags(instance):
+            async_product_funcs.propagate_tags_on_product(instance.id, countdown=5)
+            instance.running_async_process = True
+
+
+@receiver(signals.m2m_changed, sender=Endpoint.tags.through)
+@receiver(signals.m2m_changed, sender=Engagement.tags.through)
+@receiver(signals.m2m_changed, sender=Test.tags.through)
+@receiver(signals.m2m_changed, sender=Finding.tags.through)
+def make_inherited_tags_sticky(sender, instance, action, **kwargs):
+    if action in ["post_add", "post_remove"]:
+        if inherit_product_tags(instance):
+            tag_list = [tag.name for tag in instance.tags.all()]
+            if propagate_inheritance(instance, tag_list=tag_list):
+                instance.inherit_tags(tag_list)
+
+
+@receiver(signals.post_save, sender=Endpoint)
+@receiver(signals.post_save, sender=Engagement)
+@receiver(signals.post_save, sender=Test)
+@receiver(signals.post_save, sender=Finding)
+def inherit_tags_on_instance(sender, instance, created, **kwargs):
+    if inherit_product_tags(instance):
+        tag_list = instance._tags_tagulous.get_tag_list()
+        if propagate_inheritance(instance, tag_list=tag_list):
+            instance.inherit_tags(tag_list)
+
+
+def propagate_inheritance(instance, tag_list=[]):
+    # Get the expected product tags
+    product_inherited_tags = [tag.name for tag in get_product(instance).tags.all()]
+    existing_inherited_tags = [tag.name for tag in instance.inherited_tags.all()]
+    # Check if product tags already matches inherited tags
+    product_tags_equals_inherited_tags = product_inherited_tags == existing_inherited_tags
+    # Check if product tags have already been inherited
+    tags_have_already_been_inherited = set(product_inherited_tags) <= set(tag_list)
+    return not (product_tags_equals_inherited_tags and tags_have_already_been_inherited)
+
+
+def inherit_product_tags(instance) -> bool:
+    product = get_product(instance)
+    # Save a read in the db
+    if product and product.enable_product_tag_inheritance:
+        return True
+
+    return get_system_setting('enable_product_tag_inheritance')
+
+
+def get_product(instance):
+    if isinstance(instance, Product):
+        return instance
+    if isinstance(instance, Endpoint):
+        return instance.product
+    if isinstance(instance, Engagement):
+        return instance.product
+    if isinstance(instance, Test):
+        return instance.engagement.product
+    if isinstance(instance, Finding):
+        return instance.test.engagement.product

--- a/dojo/test/signals.py
+++ b/dojo/test/signals.py
@@ -1,6 +1,7 @@
 import contextlib
 
 from auditlog.models import LogEntry
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
@@ -9,13 +10,12 @@ from django.utils.translation import gettext as _
 
 from dojo.models import Finding, Test
 from dojo.notifications.helper import create_notification
-from dojo.utils import get_system_setting
 
 
 @receiver(post_delete, sender=Test)
 def test_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
-        if get_system_setting('enable_auditlog'):
+        if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
                     action=LogEntry.Action.DELETE,
                     content_type=ContentType.objects.get(app_label='dojo', model='test'),

--- a/dojo/test/signals.py
+++ b/dojo/test/signals.py
@@ -17,9 +17,9 @@ def test_post_delete(sender, instance, using, origin, **kwargs):
     if instance == origin:
         if settings.ENABLE_AUDITLOG:
             le = LogEntry.objects.get(
-                    action=LogEntry.Action.DELETE,
-                    content_type=ContentType.objects.get(app_label='dojo', model='test'),
-                    object_id=instance.id
+                action=LogEntry.Action.DELETE,
+                content_type=ContentType.objects.get(app_label='dojo', model='test'),
+                object_id=instance.id
             )
             description = _('The test "%(name)s" was deleted by %(user)s') % {
                                 'name': str(instance), 'user': le.actor}

--- a/dojo/test/signals.py
+++ b/dojo/test/signals.py
@@ -1,15 +1,40 @@
 import contextlib
-import logging
 
-from django.db.models import signals
+from auditlog.models import LogEntry
+from django.contrib.contenttypes.models import ContentType
+from django.db.models.signals import post_delete, pre_save
 from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext as _
 
 from dojo.models import Finding, Test
+from dojo.notifications.helper import create_notification
+from dojo.utils import get_system_setting
 
-logger = logging.getLogger(__name__)
+
+@receiver(post_delete, sender=Test)
+def test_post_delete(sender, instance, using, origin, **kwargs):
+    if instance == origin:
+        if get_system_setting('enable_auditlog'):
+            le = LogEntry.objects.get(
+                    action=LogEntry.Action.DELETE,
+                    content_type=ContentType.objects.get(app_label='dojo', model='test'),
+                    object_id=instance.id
+            )
+            description = _('The test "%(name)s" was deleted by %(user)s') % {
+                                'name': str(instance), 'user': le.actor}
+        else:
+            description = _('The test "%(name)s" was deleted') % {'name': str(instance)}
+        create_notification(event='test_deleted',  # template does not exists, it will default to "other" but this event name needs to stay because of unit testing
+                            title=_('Deletion of %(name)s') % {'name': str(instance)},
+                            description=description,
+                            product=instance.engagement.product,
+                            url=reverse('view_engagement', args=(instance.engagement.id, )),
+                            recipients=[instance.engagement.lead],
+                            icon="exclamation-triangle")
 
 
-@receiver(signals.pre_save, sender=Test)
+@receiver(pre_save, sender=Test)
 def update_found_by_for_findings(sender, instance, **kwargs):
     with contextlib.suppress(sender.DoesNotExist):
         obj = sender.objects.get(pk=instance.pk)

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -616,8 +616,10 @@ class AddFindingView(View):
                 )
                 burp_rr.clean()
                 burp_rr.save()
+
             # TODO this notification might be moved to "@receiver(post_save, sender=Finding)" method as many other notifications
-            # However, it is not migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+            # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+
             # Create a notification
             create_notification(
                 event='other',

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -372,7 +372,7 @@ def copy_test(request, tid):
                 messages.SUCCESS,
                 'Test Copied successfully.',
                 extra_tags='alert-success')
-            create_notification(event='copy_test',  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
+            create_notification(event='test_copied',  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
                                 title=f'Copying of {test.title}',
                                 description=f'The test "{test.title}" was copied by {request.user} to {engagement.name}',
                                 product=product,
@@ -622,7 +622,7 @@ class AddFindingView(View):
 
             # Create a notification
             create_notification(
-                event='other',
+                event='finding_added',
                 title=_(f'Addition of {finding.title}'),
                 finding=finding,
                 description=_(f'Finding "{finding.title}" was added by {request.user}'),

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -617,8 +617,9 @@ class AddFindingView(View):
                 burp_rr.clean()
                 burp_rr.save()
 
-            # TODO this notification might be moved to "@receiver(post_save, sender=Finding)" method as many other notifications
-            # However, it hasn't been migrated because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+            # Note: this notification has not be moved to "@receiver(post_save, sender=Finding)" method as many other notifications
+            # Because it could generate too much noise, we keep it here only for findings created by hand in WebUI
+            # TODO: but same should be implemented for API endpoint
 
             # Create a notification
             create_notification(

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -372,7 +372,7 @@ def copy_test(request, tid):
                 messages.SUCCESS,
                 'Test Copied successfully.',
                 extra_tags='alert-success')
-            create_notification(event='other',
+            create_notification(event='copy_test', # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
                                 title=f'Copying of {test.title}',
                                 description=f'The test "{test.title}" was copied by {request.user} to {engagement.name}',
                                 product=product,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -75,7 +75,7 @@ from dojo.utils import (
     get_setting,
     get_system_setting,
     get_words_for_field,
-    process_notifications,
+    process_tag_notifications,
     redirect_to_return_url_or_else,
 )
 
@@ -230,7 +230,7 @@ class ViewTest(View):
             # Make a notification for this actions
             url = request.build_absolute_uri(reverse("view_test", args=(test.id,)))
             title = f"Test: {test.test_type.name} on {test.engagement.product.name}"
-            process_notifications(request, new_note, url, title)
+            process_tag_notifications(request, new_note, url, title)
             messages.add_message(
                 request,
                 messages.SUCCESS,

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -372,7 +372,7 @@ def copy_test(request, tid):
                 messages.SUCCESS,
                 'Test Copied successfully.',
                 extra_tags='alert-success')
-            create_notification(event='copy_test', # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
+            create_notification(event='copy_test',  # TODO - if 'copy' functionality will be supported by API as well, 'create_notification' needs to be migrated to place where it will be able to cover actions from both interfaces
                                 title=f'Copying of {test.title}',
                                 description=f'The test "{test.title}" was copied by {request.user} to {engagement.name}',
                                 product=product,

--- a/dojo/tools/api_sonarqube/importer.py
+++ b/dojo/tools/api_sonarqube/importer.py
@@ -207,7 +207,7 @@ class SonarQubeApiImporter:
         except Exception as e:
             logger.exception(e)
             create_notification(
-                event="other",
+                event="sonarqube_failed",
                 title="SonarQube API import issue",
                 description=e,
                 icon="exclamation-triangle",
@@ -330,7 +330,7 @@ class SonarQubeApiImporter:
         except Exception as e:
             logger.exception(e)
             create_notification(
-                event="other",
+                event="sonarqube_failed",
                 title="SonarQube API import issue",
                 description=e,
                 icon="exclamation-triangle",

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1381,7 +1381,7 @@ def reopen_external_issue(find, note, external_issue_provider, **kwargs):
         reopen_external_issue_github(find, note, prod, eng)
 
 
-def process_notifications(request, note, parent_url, parent_title):
+def process_tag_notifications(request, note, parent_url, parent_title):
     regex = re.compile(r'(?:\A|\s)@(\w+)\b')
 
     usernames_to_check = set(un.lower() for un in regex.findall(note.entry))  # noqa: C401

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1763,15 +1763,6 @@ def user_post_save(sender, instance, created, **kwargs):
         instance.save()
 
 
-@receiver(post_save, sender=Engagement)
-def engagement_post_Save(sender, instance, created, **kwargs):
-    if created:
-        engagement = instance
-        title = 'Engagement created for ' + str(engagement.product) + ': ' + str(engagement.name)
-        create_notification(event='engagement_added', title=title, engagement=engagement, product=engagement.product,
-                            url=reverse('view_engagement', args=(engagement.id,)))
-
-
 def is_safe_url(url):
     try:
         # available in django 3+

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -32,6 +32,7 @@ from dojo.models import (
     Test,
     Test_Type,
     User,
+    enable_disable_auditlog,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ class DojoTestUtilsMixin:
         disable_jira_webhook_secret=False,
         jira_webhook_secret=None,
         enable_product_tag_inehritance=False,
+        enable_auditlog=True,
     ):
         ss = System_Settings.objects.get()
         ss.enable_jira = enable_jira
@@ -60,6 +62,8 @@ class DojoTestUtilsMixin:
         ss.disable_jira_webhook_secret = disable_jira_webhook_secret
         ss.jira_webhook_secret = jira_webhook_secret
         ss.enable_product_tag_inheritance = enable_product_tag_inehritance
+        ss.enable_auditlog = enable_auditlog
+        enable_disable_auditlog(enable=enable_auditlog)
         ss.save()
 
     def create_product_type(self, name, *args, description='dummy description', **kwargs):

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -32,7 +32,6 @@ from dojo.models import (
     Test,
     Test_Type,
     User,
-    enable_disable_auditlog,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,7 +53,6 @@ class DojoTestUtilsMixin:
         disable_jira_webhook_secret=False,
         jira_webhook_secret=None,
         enable_product_tag_inehritance=False,
-        enable_auditlog=True,
     ):
         ss = System_Settings.objects.get()
         ss.enable_jira = enable_jira
@@ -62,8 +60,6 @@ class DojoTestUtilsMixin:
         ss.disable_jira_webhook_secret = disable_jira_webhook_secret
         ss.jira_webhook_secret = jira_webhook_secret
         ss.enable_product_tag_inheritance = enable_product_tag_inehritance
-        ss.enable_auditlog = enable_auditlog
-        enable_disable_auditlog(enable=enable_auditlog)
         ss.save()
 
     def create_product_type(self, name, *args, description='dummy description', **kwargs):

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -315,3 +315,19 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_args_list[-1].args[0], 'finding_group_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The finding group "fg test" was deleted by {get_current_user()}')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/test/{test2.id}')
+
+    @patch('dojo.notifications.helper.process_notifications')
+    def test_auditlog_on_off(self, mock):
+        with self.subTest('enable_auditlog'):
+            self.system_settings(enable_auditlog=True)
+            prod_type = Product_Type.objects.create(name='notif prod type')
+            prod_type.delete()
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
+
+        with self.subTest('disable_auditlog'):
+            self.system_settings(enable_auditlog=False)
+            prod_type = Product_Type.objects.create(name='notif prod type')
+            prod_type.delete()
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted')
+
+        self.system_settings(enable_auditlog=True)

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -110,8 +110,9 @@ class TestNotificationTriggers(DojoTestCase):
     fixtures = ['dojo_testdata.json']
 
     @patch('dojo.notifications.helper.process_notifications')
-    def test_engagement_added(self, mock):
-        prod = Product.objects.first()
-        Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
-        self.assertTrue(mock.called)
-        self.assertEqual(mock.call_args.args[0], 'engagement_added')
+    def test_engagements(self, mock):
+        with self.subTest('engagement_added'):
+            prod = Product.objects.first()
+            Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
+            self.assertEqual(mock.call_count, 5)
+            self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_added')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -220,6 +220,20 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_added')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}')
 
+        with self.subTest('close_engagement'):
+            eng.status = "Completed"
+            eng.save()
+            self.assertEqual(mock.call_count, 10)
+            self.assertEqual(mock.call_args_list[-1].args[0], 'close_engagement')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}/finding/all')
+
+        with self.subTest('reopen_engagement'):
+            eng.status = "In Progress"
+            eng.save()
+            self.assertEqual(mock.call_count, 15)
+            self.assertEqual(mock.call_args_list[-1].args[0], 'reopen_engagement')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}')
+
         prod_type = Product_Type.objects.first()
         prod1, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name 1')
         _ = Engagement.objects.create(product=prod1, target_start=timezone.now(), target_end=timezone.now(), lead=User.objects.get(username='admin'))
@@ -233,7 +247,7 @@ class TestNotificationTriggers(DojoTestCase):
 
         with self.subTest('engagement_deleted itself'):
             eng2.delete()
-            self.assertEqual(mock.call_count, 28)
+            self.assertEqual(mock.call_count, 38)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The engagement "Testing engagement" was deleted by {get_current_user()}')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/product/{prod2.id}')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -1,9 +1,13 @@
+from unittest.mock import patch
+
+from auditlog.context import set_actor
 from django.test import override_settings
 from django.utils import timezone
 
 from dojo.models import (
     DEFAULT_NOTIFICATION,
     Alerts,
+    Dojo_User,
     Endpoint,
     Engagement,
     Finding_Group,
@@ -78,7 +82,7 @@ class TestNotifications(DojoTestCase):
         notif_user, _ = Notifications.objects.get_or_create(user=User.objects.get(username='admin'))
         notif_system, _ = Notifications.objects.get_or_create(user=None, template=False)
 
-        last_count = 0
+        last_count = mock.call_count
         with self.subTest('user off, system off'):
             notif_user.user_mentioned = ()  # no alert
             notif_user.save()
@@ -121,7 +125,7 @@ class TestNotifications(DojoTestCase):
         notif_user, _ = Notifications.objects.get_or_create(user=User.objects.get(username='admin'))
         notif_system, _ = Notifications.objects.get_or_create(user=None, template=False)
 
-        last_count = 0
+        last_count = mock.call_count
         with self.subTest('do not notify other'):
             notif_user.other = ()  # no alert
             notif_user.save()
@@ -179,57 +183,77 @@ class TestNotifications(DojoTestCase):
 class TestNotificationTriggers(DojoTestCase):
     fixtures = ['dojo_testdata.json']
 
+    def setUp(self):
+        self.notification_tester = Dojo_User.objects.get(username="admin")
+
     @patch('dojo.notifications.helper.process_notifications')
     def test_product_types(self, mock):
+
+        last_count = mock.call_count
         with self.subTest('product_type_added'):
-            prod_type = Product_Type.objects.create(name='notif prod type')
-            self.assertEqual(mock.call_count, 4)
+            with set_actor(self.notification_tester):
+                prod_type = Product_Type.objects.create(name='notif prod type')
+            self.assertEqual(mock.call_count, last_count + 4)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_type_added')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/product/type/{prod_type.id}')
 
+        last_count = mock.call_count
         with self.subTest('product_type_deleted'):
-            prod_type.delete()
-            self.assertEqual(mock.call_count, 5)
+            with set_actor(self.notification_tester):
+                prod_type.delete()
+            self.assertEqual(mock.call_count, last_count + 1)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_type_deleted')
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted by admin')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/product/type')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_products(self, mock):
+
+        last_count = mock.call_count
         with self.subTest('product_added'):
-            prod_type = Product_Type.objects.first()
-            prod, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name')
-            self.assertEqual(mock.call_count, 5)
+            with set_actor(self.notification_tester):
+                prod_type = Product_Type.objects.first()
+                prod, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name')
+            self.assertEqual(mock.call_count, last_count + 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_added')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/product/{prod.id}')
 
+        last_count = mock.call_count
         with self.subTest('product_deleted'):
-            prod.delete()
-            self.assertEqual(mock.call_count, 7)
+            with set_actor(self.notification_tester):
+                prod.delete()
+            self.assertEqual(mock.call_count, last_count + 2)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_deleted')
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product "prod name" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product "prod name" was deleted by admin')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/product')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_engagements(self, mock):
+
+        last_count = mock.call_count
         with self.subTest('engagement_added'):
-            prod = Product.objects.first()
-            eng = Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
-            self.assertEqual(mock.call_count, 5)
+            with set_actor(self.notification_tester):
+                prod = Product.objects.first()
+                eng = Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
+            self.assertEqual(mock.call_count, last_count + 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_added')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}')
 
+        last_count = mock.call_count
         with self.subTest('close_engagement'):
-            eng.status = "Completed"
-            eng.save()
-            self.assertEqual(mock.call_count, 10)
+            with set_actor(self.notification_tester):
+                eng.status = "Completed"
+                eng.save()
+            self.assertEqual(mock.call_count, last_count + 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_closed')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}/finding/all')
 
+        last_count = mock.call_count
         with self.subTest('reopen_engagement'):
-            eng.status = "In Progress"
-            eng.save()
-            self.assertEqual(mock.call_count, 15)
+            with set_actor(self.notification_tester):
+                eng.status = "In Progress"
+                eng.save()
+            self.assertEqual(mock.call_count, last_count + 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_reopened')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}')
 
@@ -240,15 +264,18 @@ class TestNotificationTriggers(DojoTestCase):
         eng2 = Engagement.objects.create(product=prod2, name="Testing engagement", target_start=timezone.now(), target_end=timezone.now(), lead=User.objects.get(username='admin'))
 
         with self.subTest('engagement_deleted by product'):  # in case of product removal, we are not notifying about removal
-            prod1.delete()
+            with set_actor(self.notification_tester):
+                prod1.delete()
             for call in mock.call_args_list:
                 self.assertNotEqual(call.args[0], 'engagement_deleted')
 
+        last_count = mock.call_count
         with self.subTest('engagement_deleted itself'):
-            eng2.delete()
-            self.assertEqual(mock.call_count, 38)
+            with set_actor(self.notification_tester):
+                eng2.delete()
+            self.assertEqual(mock.call_count, last_count + 1)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_deleted')
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The engagement "Testing engagement" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The engagement "Testing engagement" was deleted by admin')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/product/{prod2.id}')
 
     @patch('dojo.notifications.helper.process_notifications')
@@ -260,15 +287,18 @@ class TestNotificationTriggers(DojoTestCase):
         endpoint2, _ = Endpoint.objects.get_or_create(product=prod2, host='host2')
 
         with self.subTest('endpoint_deleted by product'):  # in case of product removal, we are not notifying about removal
-            prod1.delete()
+            with set_actor(self.notification_tester):
+                prod1.delete()
             for call in mock.call_args_list:
                 self.assertNotEqual(call.args[0], 'endpoint_deleted')
 
+        last_count = mock.call_count
         with self.subTest('endpoint_deleted itself'):
-            endpoint2.delete()
-            self.assertEqual(mock.call_count, 14)
+            with set_actor(self.notification_tester):
+                endpoint2.delete()
+            self.assertEqual(mock.call_count, last_count + 2)
             self.assertEqual(mock.call_args_list[-1].args[0], 'endpoint_deleted')
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The endpoint "host2" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The endpoint "host2" was deleted by admin')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/endpoint')
 
     @patch('dojo.notifications.helper.process_notifications')
@@ -281,15 +311,18 @@ class TestNotificationTriggers(DojoTestCase):
         test2 = Test.objects.create(engagement=eng2, target_start=timezone.now(), target_end=timezone.now(), test_type_id=Test_Type.objects.first().id)
 
         with self.subTest('test_deleted by engagement'):  # in case of engagement removal, we are not notifying about removal
-            eng1.delete()
+            with set_actor(self.notification_tester):
+                eng1.delete()
             for call in mock.call_args_list:
                 self.assertNotEqual(call.args[0], 'test_deleted')
 
+        last_count = mock.call_count
         with self.subTest('test_deleted itself'):
-            test2.delete()
-            self.assertEqual(mock.call_count, 17)
+            with set_actor(self.notification_tester):
+                test2.delete()
+            self.assertEqual(mock.call_count, last_count + 1)
             self.assertEqual(mock.call_args_list[-1].args[0], 'test_deleted')
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The test "Acunetix Scan" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The test "Acunetix Scan" was deleted by admin')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng2.id}')
 
     @patch('dojo.notifications.helper.process_notifications')
@@ -303,27 +336,32 @@ class TestNotificationTriggers(DojoTestCase):
         fg2, _ = Finding_Group.objects.get_or_create(test=test2, name="fg test", creator=User.objects.get(username='admin'))
 
         with self.subTest('test_deleted by engagement'):  # in case of engagement removal, we are not notifying about removal
-            test1.delete()
+            with set_actor(self.notification_tester):
+                test1.delete()
             for call in mock.call_args_list:
                 self.assertNotEqual(call.args[0], 'finding_group_deleted')
 
+        last_count = mock.call_count
         with self.subTest('test_deleted itself'):
-            fg2.delete()
-            self.assertEqual(mock.call_count, 16)
+            with set_actor(self.notification_tester):
+                fg2.delete()
+            self.assertEqual(mock.call_count, last_count + 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'finding_group_deleted')
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The finding group "fg test" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The finding group "fg test" was deleted by admin')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/test/{test2.id}')
 
     @patch('dojo.notifications.helper.process_notifications')
     @override_settings(ENABLE_AUDITLOG=True)
     def test_auditlog_on(self, mock):
         prod_type = Product_Type.objects.create(name='notif prod type')
-        prod_type.delete()
-        self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
+        with set_actor(self.notification_tester):
+            prod_type.delete()
+        self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted by admin')
 
     @patch('dojo.notifications.helper.process_notifications')
     @override_settings(ENABLE_AUDITLOG=False)
     def test_auditlog_off(self, mock):
         prod_type = Product_Type.objects.create(name='notif prod type')
-        prod_type.delete()
+        with set_actor(self.notification_tester):
+            prod_type.delete()
         self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -289,10 +289,10 @@ class TestNotificationTriggers(DojoTestCase):
 
         with self.subTest('test_deleted itself'):
             test2.delete()
-            self.assertEqual(mock.call_count, 16)
+            self.assertEqual(mock.call_count, 17)
             self.assertEqual(mock.call_args_list[-1].args[0], 'test_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The test "BURP Scan" was deleted by {get_current_user()}')
-            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{end2.id}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng2.id}')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_finding_groups(self, mock):
@@ -313,5 +313,5 @@ class TestNotificationTriggers(DojoTestCase):
             fg2.delete()
             self.assertEqual(mock.call_count, 16)
             self.assertEqual(mock.call_args_list[-1].args[0], 'finding_group_deleted')
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The test "fg test" was deleted by {get_current_user()}')
-            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{test2.id}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The finding group "fg test" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/test/{test2.id}')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -1,9 +1,6 @@
-from unittest.mock import patch
-
-from crum import get_current_user
 from django.utils import timezone
 
-from dojo.models import DEFAULT_NOTIFICATION, Alerts, Engagement, Notifications, Product, Product_Type, User
+from dojo.models import DEFAULT_NOTIFICATION, Alerts, Endpoint, Engagement, Notifications, Product, Product_Type, User
 from dojo.notifications.helper import create_notification, send_alert_notification
 
 from .dojo_test_case import DojoTestCase
@@ -176,7 +173,7 @@ class TestNotificationTriggers(DojoTestCase):
     def test_products(self, mock):
         with self.subTest('product_added'):
             prod_type = Product_Type.objects.first()
-            prod = Product.objects.create(prod_type=prod_type, name='prod name')
+            prod, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name')
             self.assertEqual(mock.call_count, 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_added')
 
@@ -193,3 +190,22 @@ class TestNotificationTriggers(DojoTestCase):
             Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
             self.assertEqual(mock.call_count, 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_added')
+
+    @patch('dojo.notifications.helper.process_notifications')
+    def test_endpoints(self, mock):
+        prod_type = Product_Type.objects.first()
+        prod1, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name 1')
+        Endpoint.objects.get_or_create(product=prod1, host='host1')
+        prod2, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name 2')
+        endpoint2, _ = Endpoint.objects.get_or_create(product=prod2, host='host2')
+
+        with self.subTest('endpoint_deleted by product'):  # in case of product removal, we are not notifing about removal
+            prod1.delete()
+            for call in mock.call_args_list:
+                self.assertNotEqual(call.args[0], 'endpoint_deleted')
+
+        with self.subTest('endpoint_deleted itself'):
+            endpoint2.delete()
+            self.assertEqual(mock.call_count, 14)
+            self.assertEqual(mock.call_args_list[-1].args[0], 'endpoint_deleted')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The endpoint "host2" was deleted by {get_current_user()}')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
-from dojo.models import DEFAULT_NOTIFICATION, Notifications, Product, User
+from django.utils import timezone
+
+from dojo.models import DEFAULT_NOTIFICATION, Engagement, Notifications, Product, User
 from dojo.notifications.helper import create_notification, send_alert_notification
 
 from .dojo_test_case import DojoTestCase
@@ -102,3 +104,14 @@ class TestNotifications(DojoTestCase):
             create_notification(event="user_mentioned", title="user_mentioned", recipients=['admin'])
             self.assertEqual(mock.call_count, last_count + 1)
         last_count = mock.call_count
+
+
+class TestNotificationTriggers(DojoTestCase):
+    fixtures = ['dojo_testdata.json']
+
+    @patch('dojo.notifications.helper.process_notifications')
+    def test_engagement_added(self, mock):
+        prod = Product.objects.first()
+        Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
+        self.assertTrue(mock.called)
+        self.assertEqual(mock.call_args.args[0], 'engagement_added')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -236,7 +236,7 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_count, 28)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The engagement "Testing engagement" was deleted by {get_current_user()}')
-            self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/product/5')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/product/{prod2.id}')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_endpoints(self, mock):
@@ -277,4 +277,4 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_count, 16)
             self.assertEqual(mock.call_args_list[-1].args[0], 'test_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The test "BURP Scan" was deleted by {get_current_user()}')
-            self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/engagement/8')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{end2.id}')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -318,27 +318,27 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The finding group "fg test" was deleted by {get_current_user()}')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/test/{test2.id}')
 
-    @patch('dojo.notifications.helper.process_notifications')
-    def test_auditlog_on_off(self, mock):
-        ss = System_Settings.objects.get()
-        original_auditlog = ss.enable_auditlog
-
-        with self.subTest('enable_auditlog'):
-            ss.enable_auditlog = True
-            ss.save()
-            enable_disable_auditlog(enable=True)
-            prod_type = Product_Type.objects.create(name='notif prod type')
-            prod_type.delete()
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
-
-        with self.subTest('disable_auditlog'):
-            ss.enable_auditlog = False
-            ss.save()
-            enable_disable_auditlog(enable=False)
-            prod_type = Product_Type.objects.create(name='notif prod type')
-            prod_type.delete()
-            self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted')
-
-        ss.enable_auditlog = original_auditlog
-        ss.save()
-        enable_disable_auditlog(enable=original_auditlog)
+#     @patch('dojo.notifications.helper.process_notifications')
+#     def test_auditlog_on_off(self, mock):
+#         ss = System_Settings.objects.get()
+#         original_auditlog = ss.enable_auditlog
+#
+#         with self.subTest('enable_auditlog'):
+#             ss.enable_auditlog = True
+#             ss.save()
+#             enable_disable_auditlog(enable=True)
+#             prod_type = Product_Type.objects.create(name='notif prod type')
+#             prod_type.delete()
+#             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
+#
+#         with self.subTest('disable_auditlog'):
+#             ss.enable_auditlog = False
+#             ss.save()
+#             enable_disable_auditlog(enable=False)
+#             prod_type = Product_Type.objects.create(name='notif prod type')
+#             prod_type.delete()
+#             self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted')
+#
+#         ss.enable_auditlog = original_auditlog
+#         ss.save()
+#         enable_disable_auditlog(enable=original_auditlog)

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -257,6 +257,15 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_reopened')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}')
 
+        eng.status = "Not Started"
+        eng.save()
+        last_count = mock.call_count
+        with self.subTest('no reopen_engagement from not started'):
+            with set_actor(self.notification_tester):
+                eng.status = "In Progress"
+                eng.save()
+            self.assertEqual(mock.call_count, last_count)
+
         prod_type = Product_Type.objects.first()
         prod1, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name 1')
         _ = Engagement.objects.create(product=prod1, target_start=timezone.now(), target_end=timezone.now(), lead=User.objects.get(username='admin'))

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -227,14 +227,14 @@ class TestNotificationTriggers(DojoTestCase):
             eng.status = "Completed"
             eng.save()
             self.assertEqual(mock.call_count, 10)
-            self.assertEqual(mock.call_args_list[-1].args[0], 'close_engagement')
+            self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_closed')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}/finding/all')
 
         with self.subTest('reopen_engagement'):
             eng.status = "In Progress"
             eng.save()
             self.assertEqual(mock.call_count, 15)
-            self.assertEqual(mock.call_args_list[-1].args[0], 'reopen_engagement')
+            self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_reopened')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}')
 
         prod_type = Product_Type.objects.first()

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -180,7 +180,7 @@ class TestNotificationTriggers(DojoTestCase):
         with self.subTest('product_type_deleted'):
             prod_type.delete()
             self.assertEqual(mock.call_count, 5)
-            self.assertEqual(mock.call_args_list[-1].args[0], 'produc_type_deleted')
+            self.assertEqual(mock.call_args_list[-1].args[0], 'product_type_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/product/type')
 

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -170,6 +170,19 @@ class TestNotificationTriggers(DojoTestCase):
     fixtures = ['dojo_testdata.json']
 
     @patch('dojo.notifications.helper.process_notifications')
+    def test_product_types(self, mock):
+        with self.subTest('product_type_added'):
+            prod_type = Product_Type.objects.create(name='notif prod type')
+            self.assertEqual(mock.call_count, 4)
+            self.assertEqual(mock.call_args_list[-1].args[0], 'product_type_added')
+
+        with self.subTest('product_type_deleted'):
+            prod_type.delete()
+            self.assertEqual(mock.call_count, 5)
+            self.assertEqual(mock.call_args_list[-1].args[0], 'produc_type_deleted')
+            self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
+
+    @patch('dojo.notifications.helper.process_notifications')
     def test_products(self, mock):
         with self.subTest('product_added'):
             prod_type = Product_Type.objects.first()

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -1,3 +1,4 @@
+from django.test import override_settings
 from django.utils import timezone
 
 from dojo.models import (
@@ -9,11 +10,9 @@ from dojo.models import (
     Notifications,
     Product,
     Product_Type,
-    System_Settings,
     Test,
     Test_Type,
     User,
-    enable_disable_auditlog,
 )
 from dojo.notifications.helper import create_notification, send_alert_notification
 
@@ -318,27 +317,16 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The finding group "fg test" was deleted by {get_current_user()}')
             self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/test/{test2.id}')
 
-#     @patch('dojo.notifications.helper.process_notifications')
-#     def test_auditlog_on_off(self, mock):
-#         ss = System_Settings.objects.get()
-#         original_auditlog = ss.enable_auditlog
-#
-#         with self.subTest('enable_auditlog'):
-#             ss.enable_auditlog = True
-#             ss.save()
-#             enable_disable_auditlog(enable=True)
-#             prod_type = Product_Type.objects.create(name='notif prod type')
-#             prod_type.delete()
-#             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
-#
-#         with self.subTest('disable_auditlog'):
-#             ss.enable_auditlog = False
-#             ss.save()
-#             enable_disable_auditlog(enable=False)
-#             prod_type = Product_Type.objects.create(name='notif prod type')
-#             prod_type.delete()
-#             self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted')
-#
-#         ss.enable_auditlog = original_auditlog
-#         ss.save()
-#         enable_disable_auditlog(enable=original_auditlog)
+    @patch('dojo.notifications.helper.process_notifications')
+    @override_settings(ENABLE_AUDITLOG=True)
+    def test_auditlog_on(self, mock):
+        prod_type = Product_Type.objects.create(name='notif prod type')
+        prod_type.delete()
+        self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
+
+    @patch('dojo.notifications.helper.process_notifications')
+    @override_settings(ENABLE_AUDITLOG=False)
+    def test_auditlog_off(self, mock):
+        prod_type = Product_Type.objects.create(name='notif prod type')
+        prod_type.delete()
+        self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -332,10 +332,13 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
 
         with self.subTest('disable_auditlog'):
+            ss.enable_auditlog = False
+            ss.save()
             enable_disable_auditlog(enable=False)
             prod_type = Product_Type.objects.create(name='notif prod type')
             prod_type.delete()
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], 'The product type "notif prod type" was deleted')
 
         ss.enable_auditlog = original_auditlog
+        ss.save()
         enable_disable_auditlog(enable=original_auditlog)

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -1,8 +1,6 @@
-from unittest.mock import patch
-
 from django.utils import timezone
 
-from dojo.models import DEFAULT_NOTIFICATION, Engagement, Notifications, Product, Product_Type, User
+from dojo.models import DEFAULT_NOTIFICATION, Alerts, Engagement, Notifications, Product, Product_Type, User
 from dojo.notifications.helper import create_notification, send_alert_notification
 
 from .dojo_test_case import DojoTestCase
@@ -104,6 +102,25 @@ class TestNotifications(DojoTestCase):
             create_notification(event="user_mentioned", title="user_mentioned", recipients=['admin'])
             self.assertEqual(mock.call_count, last_count + 1)
         last_count = mock.call_count
+
+    @patch('dojo.notifications.helper.send_alert_notification', wraps=send_alert_notification)
+    def test_other_notifications(self, mock):
+        notif, _ = Notifications.objects.get_or_create(user=User.objects.get(username='admin'))
+
+        with self.subTest('do not notify other'):
+            notif.other = ()  # no alert
+            notif.save()
+            create_notification(event="dummy_bar_event", recipients=['admin'])
+            self.assertEqual(mock.call_count, 0)
+
+        with self.subTest('notify other'):
+            notif.other = DEFAULT_NOTIFICATION  # alert only
+            notif.save()
+            create_notification(event="dummy_foo_event", title="title_for_dummy_foo_event", description="description_for_dummy_foo_event", recipients=['admin'])
+            self.assertEqual(mock.call_count, 1)
+            self.assertEqual(mock.call_args_list[0].args[0], 'dummy_foo_event')
+            alert = Alerts.objects.get(title='title_for_dummy_foo_event')
+            self.assertEqual(alert.source, "Dummy Foo Event")
 
 
 class TestNotificationTriggers(DojoTestCase):

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -175,12 +175,14 @@ class TestNotificationTriggers(DojoTestCase):
             prod_type = Product_Type.objects.create(name='notif prod type')
             self.assertEqual(mock.call_count, 4)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_type_added')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/product/type/{prod_type.id}')
 
         with self.subTest('product_type_deleted'):
             prod_type.delete()
             self.assertEqual(mock.call_count, 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'produc_type_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product type "notif prod type" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/product/type')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_products(self, mock):
@@ -189,20 +191,23 @@ class TestNotificationTriggers(DojoTestCase):
             prod, _ = Product.objects.get_or_create(prod_type=prod_type, name='prod name')
             self.assertEqual(mock.call_count, 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_added')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/product/{prod.id}')
 
         with self.subTest('product_deleted'):
             prod.delete()
             self.assertEqual(mock.call_count, 7)
             self.assertEqual(mock.call_args_list[-1].args[0], 'product_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The product "prod name" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/product')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_engagements(self, mock):
         with self.subTest('engagement_added'):
             prod = Product.objects.first()
-            Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
+            eng = Engagement.objects.create(product=prod, target_start=timezone.now(), target_end=timezone.now())
             self.assertEqual(mock.call_count, 5)
             self.assertEqual(mock.call_args_list[-1].args[0], 'engagement_added')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], f'/engagement/{eng.id}')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_endpoints(self, mock):
@@ -222,3 +227,4 @@ class TestNotificationTriggers(DojoTestCase):
             self.assertEqual(mock.call_count, 14)
             self.assertEqual(mock.call_args_list[-1].args[0], 'endpoint_deleted')
             self.assertEqual(mock.call_args_list[-1].kwargs['description'], f'The endpoint "host2" was deleted by {get_current_user()}')
+            self.assertEqual(mock.call_args_list[-1].kwargs['url'], '/endpoint')

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 from django.utils import timezone
 
-from dojo.models import DEFAULT_NOTIFICATION, Engagement, Notifications, Product, User
+from dojo.models import DEFAULT_NOTIFICATION, Engagement, Notifications, Product, Product_Type, User
 from dojo.notifications.helper import create_notification, send_alert_notification
 
 from .dojo_test_case import DojoTestCase
@@ -108,6 +108,14 @@ class TestNotifications(DojoTestCase):
 
 class TestNotificationTriggers(DojoTestCase):
     fixtures = ['dojo_testdata.json']
+
+    @patch('dojo.notifications.helper.process_notifications')
+    def test_products(self, mock):
+        with self.subTest('product_added'):
+            prod_type = Product_Type.objects.first()
+            Product.objects.create(prod_type=prod_type, name='prod name')
+            self.assertEqual(mock.call_count, 5)
+            self.assertEqual(mock.call_args_list[-1].args[0], 'product_added')
 
     @patch('dojo.notifications.helper.process_notifications')
     def test_engagements(self, mock):

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -159,21 +159,18 @@ class TestNotifications(DojoTestCase):
             self.assertEqual(mock.call_count, last_count + 1)
         last_count = mock.call_count
 
-    @patch('dojo.notifications.helper.send_alert_notification', wraps=send_alert_notification)
-    def test_non_default_other_notifications(self, mock):
-        notif, _ = Notifications.objects.get_or_create(user=User.objects.get(username='admin'))
-
         with self.subTest('do not notify other'):
             notif.other = ()  # no alert
             notif.save()
             create_notification(event="dummy_bar_event", recipients=['admin'])
-            self.assertEqual(mock.call_count, 0)
+            self.assertEqual(mock.call_count, last_count)
+        last_count = mock.call_count
 
         with self.subTest('notify other'):
             notif.other = DEFAULT_NOTIFICATION  # alert only
             notif.save()
             create_notification(event="dummy_foo_event", title="title_for_dummy_foo_event", description="description_for_dummy_foo_event", recipients=['admin'])
-            self.assertEqual(mock.call_count, 1)
+            self.assertEqual(last_count, 1)
             self.assertEqual(mock.call_args_list[0].args[0], 'dummy_foo_event')
             alert = Alerts.objects.get(title='title_for_dummy_foo_event')
             self.assertEqual(alert.source, "Dummy Foo Event")

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1708,7 +1708,7 @@ class UsersTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {"first_name": "test changed", "configuration_permissions": [219, 220]}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
-        self.deleted_objects = 25  # TODO
+        self.deleted_objects = 25
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_create_user_with_non_configuration_permissions(self):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1708,7 +1708,7 @@ class UsersTest(BaseClass.RESTEndpointTest):
         }
         self.update_fields = {"first_name": "test changed", "configuration_permissions": [219, 220]}
         self.test_type = TestType.CONFIGURATION_PERMISSIONS
-        self.deleted_objects = 19
+        self.deleted_objects = 25  # TODO
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
     def test_create_user_with_non_configuration_permissions(self):


### PR DESCRIPTION
Purpose of this PR: If some action triggers the creation of a notification during clicking in UI. The same notification should be triggered also if the same happens via API. Until now many actions have been avoiding these notifications. Implementation is done by Django Signals.

Some notes:
- General rule: if the object is removed in cascade (e.g. removal product triggers removal of all engagements, tests, ...) notification is created only for the highest removed element (to avoid spamming).
- The only exception to this ^ general rule is the removal of the Product. If Product Type is removed, notification is triggered for all Products as well
- PR hasn't announced any new notifications. All of them have been created based on existing implementation.
- There is a set of notifications which hasn't been migrated and they are performed only for UI actions because they would generate useless noise. E.g. "creation of findings" vs "creation of findings during scan imports". But "TODO" comments have been added.
- If AuditLog is enabled, the message might contain also the actor's name. If the user disabled Auditlog, the user will be notified without knowing who did it. This is a small step back compared to the previous implementation.
- Most of the actions have been with the label `event="other"`. Now notification engine accepts any event name as meaningful and for Alerts event is translated to source name. If event type does not exist as the field in Notification, the engine works with the event as with `other`

<!--[sc-3791]-->