### PR TITLE
Fix findings and endpoints URLs in notifications

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -228,7 +228,7 @@ def delete_endpoint(request, eid):
                                     title='Deletion of %s' % endpoint,
                                     product=product,
                                     description='The endpoint "%s" was deleted by %s' % (endpoint, request.user),
-                                    url=request.build_absolute_uri(reverse('endpoint')),
+                                    url=reverse('endpoint'),
                                     icon="exclamation-triangle")
                 return HttpResponseRedirect(reverse('view_product', args=(product.id,)))
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1445,7 +1445,7 @@ def reopen_finding(request, fid):
         finding=finding,
         description='The finding "%s" was reopened by %s'
         % (finding.title, request.user),
-        url=request.build_absolute_uri(reverse("view_test", args=(finding.test.id,))),
+        url=reverse("view_finding", args=(finding.id,)),
     )
     return HttpResponseRedirect(reverse("view_finding", args=(finding.id,)))
 

--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -599,7 +599,7 @@ class AddFindingView(View):
                 description=_('Finding "%(title)s" was added by %(user)s') % {
                     'title': finding.title, 'user': request.user
                 },
-                url=request.build_absolute_uri(reverse('view_finding', args=(finding.id,))),
+                url=reverse("view_finding", args=(finding.id,)),
                 icon="exclamation-triangle")
             # Add a success message
             messages.add_message(


### PR DESCRIPTION
**Description**

I've discovered that for notifications of findings creation, findings reopening and endpoint deletion, the url indicated contains 2 times the first part of the URL. 
Example of malformed URL : `https://defectdojo.mydomain.frhttps://defectdojo.mydomain.fr/finding/99`

The problem is apparently linked to the use of the "request.build_absolute_uri" function.

I went to investigate how the URL contained in the notifications that don't have this bug was constructed and modified the ones that do in the same way.

**Test results**

I turned on Slack notifications before change to make sure of the problem.

Made changes and replayed notifications containing a buggy URL. Problem fixed.