### PR TITLE
Adding pre-commit library to update code with PEP8 standards #2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: check-yaml
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-json
+      - id: name-tests-test
+      - id: no-commit-to-branch
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+        args:
+          - --line-length=120
+  - repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.5
+    hooks:
+      - id: autopep8
+        args:
+          - --in-place
+          - --aggressive
+          - --max-line-length=120
+          - --verbose
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.2
+    hooks:
+      - id: autoflake
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args:
+          - --ignore=E203,W503,C901,E731,W605,E402
+          - --max-line-length=120

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,3 +82,4 @@ boto3==1.28.66  # Required for Celery Broker AWS (SQS) support
 netaddr==0.8.0
 vulners==2.1.1
 fontawesomefree==6.4.2
+pre-commit==3.2.2


### PR DESCRIPTION
Be informative
Add a mechanism to update code with PEP8 standars using tool [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks)

Feature Description
This feature include 6 hooks to help developers for identifying simple issues formatting with standars PEP8 before submission to code review.

Additional context
In some cases developers will require manual intervention in formating code, but this tool help to reconize what files require this intervention.

Form example
In project root folder run following command

pre-commit run --files dojo/tools/anchore_grype/*

Result of this process would be something like following

check yaml...........................................(no files to check)Skipped
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
check json...........................................(no files to check)Skipped
python tests naming..................................(no files to check)Skipped
don't commit to branch...................................................Passed
black....................................................................Failed

hook id: black
files were modified by this hook
reformatted dojo/tools/anchore_grype/parser.py

All done! ✨ 🍰 ✨
1 file reformatted, 1 file left unchanged.

autopep8.................................................................Passed
bandit...................................................................Passed
autoflake................................................................Passed
flake8...................................................................Failed

hook id: flake8
exit code: 1
dojo/tools/anchore_grype/parser.py:21:121: E501 line too long (122 > 120 characters)

The output is indicating that the dojo/tools/anchore_grype/parser.py file has more than 120 characters on line 21.

This file was not modified by flake8 and requires manual intervention to comply with PEP8 standards.