### PR TITLE
Configure deduplication algorithm for Kubehunter Scan and kube-bench …

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1257,6 +1257,8 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Popeye Scan': ['title', 'description'],
     'Wazuh Scan': ['title'],
     'Nuclei Scan': ['title', 'cwe', 'severity'],
+    'KubeHunter Scan': ['title', 'description', 'steps_to_reproduce'],
+    'kube-bench Scan': ['title', 'vuln_id_from_tool', 'description'],
 }
 
 # Override the hardcoded settings here via the env var
@@ -1450,6 +1452,8 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     'Wpscan': DEDUPE_ALGO_HASH_CODE,
     'Popeye Scan': DEDUPE_ALGO_HASH_CODE,
     'Nuclei Scan': DEDUPE_ALGO_HASH_CODE,
+    'KubeHunter Scan': DEDUPE_ALGO_HASH_CODE,
+    'kube-bench Scan': DEDUPE_ALGO_HASH_CODE,
 }
 
 # Override the hardcoded settings here via the env var


### PR DESCRIPTION
**Description**

DefectDojo does not deduplicate findings produced by the [kube-bench](https://github.com/aquasecurity/kube-bench) and [kube-hunter](https://github.com/aquasecurity/kube-hunter) parsers.

This Pull request configures the deduplication algorithm for these two parsers. I have used the "DEDUPE_ALGO_HASH_CODE" algorithm for both parsers.

**Test results**

I haven't added tests, let me know if it is required for the configuration of the deduplication algorithm.
