### PR TITLE
[bugfix] Whispers 2.2 report importing support

### DIFF
--- a/dojo/tools/whispers/parser.py
+++ b/dojo/tools/whispers/parser.py
@@ -9,11 +9,18 @@ class WhispersParser(object):
     """
 
     SEVERITY_MAP = {
+        # Whispers 2.1
         "BLOCKER": "Critical",
         "CRITICAL": "High",
         "MAJOR": "Medium",
         "MINOR": "Low",
         "INFO": "Info",
+        # Whispers 2.2
+        "Critical": "Critical",
+        "High": "High",
+        "Medium": "Medium",
+        "Low": "Low",
+        "Info": "Info",
     }
 
     @staticmethod

--- a/unittests/scans/whispers/whispers_one_vul_v2.2.json
+++ b/unittests/scans/whispers/whispers_one_vul_v2.2.json
@@ -1,0 +1,1 @@
+[{"key": "pip password", "value": "hardcoded", "file": "src/pip.conf", "line": 2, "rule_id": "pip", "message": "pip.conf Password", "severity": "High"}]

--- a/unittests/tools/test_whispers_parser.py
+++ b/unittests/tools/test_whispers_parser.py
@@ -5,6 +5,20 @@ from dojo.models import Test
 
 class TestWhispersParser(TestCase):
 
+    def test_whispers_parser_severity_map(self):
+        fixtures = [
+            "unittests/scans/whispers/whispers_one_vul.json",  # v2.1 format
+            "unittests/scans/whispers/whispers_one_vul_v2.2.json",  # v2.2 format
+        ]
+        expected_severity = "High"
+
+        for fixture in fixtures:
+            testfile = open(fixture)
+            parser = WhispersParser()
+            findings = parser.get_findings(testfile, Test())
+            testfile.close()
+            self.assertEqual(expected_severity, findings[0].severity)
+
     def test_whispers_parser_with_no_vuln_has_no_findings(self):
         testfile = open("unittests/scans/whispers/whispers_zero_vul.json")
         parser = WhispersParser()


### PR DESCRIPTION
**Description**

Hey team, this is a bugfix for importing results from a newer version of a currently implemented parser.

Whispers reports versions up to 2.1.5 use the following severity levels: `BLOCKER`, `CRITICAL`, `MAJOR`, `MINOR`, `INFO`
Whispers reports versions 2.2.0+ use a different nomenclature: `Critical`, `High`, `Medium`, `Low`, `Info`

When importing new Whispers 2.2 reports into DefectDojo, everything comes out as `Info` due to:

https://github.com/DefectDojo/django-DefectDojo/blob/584371d8dd51404646936097f9dc6c5b843663c4/dojo/tools/whispers/parser.py#L58

This happens because `SEVERITY_MAP` includes only old severity names:

https://github.com/DefectDojo/django-DefectDojo/blob/584371d8dd51404646936097f9dc6c5b843663c4/dojo/tools/whispers/parser.py#L11-L17

The present bugfix adds new severity names to `SEVERITY_MAP`, as well as a new report fixture + unit test to ensure both types of reports produce the expected result.


**Test results**

* Added a fixture with new report format
* Added unit test for testing the parser 

**Documentation**

No update needed.
