### PR TITLE
Reporting: Exclude empty fields from report + correct host for HTML reports

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2967,20 +2967,41 @@ class Finding(models.Model):
                 'url': reverse('view_finding', args=(self.id,))}]
         return bc
 
+    def get_valid_request_response_pairs(self):
+        empty_value = base64.b64encode("".encode())
+        # Get a list of all req/resp pairs
+        all_req_resps = self.burprawrequestresponse_set.all()
+        # Filter away those that do not have any contents
+        valid_req_resps = all_req_resps.exclude(
+            burpRequestBase64__exact=empty_value,
+            burpResponseBase64__exact=empty_value,
+        )
+
+        return valid_req_resps
+
     def get_report_requests(self):
-        if self.burprawrequestresponse_set.count() >= 3:
-            return self.burprawrequestresponse_set.all()[0:3]
-        elif self.burprawrequestresponse_set.count() > 0:
-            return self.burprawrequestresponse_set.all()
+        # Get the list of request response pairs that are non empty
+        request_response_pairs = self.get_valid_request_response_pairs()
+        # Determine how many to return
+        if request_response_pairs.count() >= 3:
+            return request_response_pairs[0:3]
+        elif request_response_pairs.count() > 0:
+            return request_response_pairs
 
     def get_request(self):
-        if self.burprawrequestresponse_set.count() > 0:
-            reqres = self.burprawrequestresponse_set().first()
+        # Get the list of request response pairs that are non empty
+        request_response_pairs = self.get_valid_request_response_pairs()
+        # Determine what to return
+        if request_response_pairs.count() > 0:
+            reqres = request_response_pairs.first()
         return base64.b64decode(reqres.burpRequestBase64)
 
     def get_response(self):
-        if self.burprawrequestresponse_set.count() > 0:
-            reqres = self.burprawrequestresponse_set.first()
+        # Get the list of request response pairs that are non empty
+        request_response_pairs = self.get_valid_request_response_pairs()
+        # Determine what to return
+        if request_response_pairs.count() > 0:
+            reqres = request_response_pairs.first()
         res = base64.b64decode(reqres.burpResponseBase64)
         # Removes all blank lines
         res = re.sub(r'\n\s*\n', '\n', res)

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -110,7 +110,7 @@ def custom_report(request):
             return render(request,
                           'dojo/custom_html_report.html',
                           {"widgets": widgets,
-                           "host": host,
+                           "host": "",
                            "finding_notes": finding_notes,
                            "finding_images": finding_images,
                            "user_id": request.user.id})

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -170,32 +170,55 @@
 
                     {% include "dojo/snippets/endpoints.html" with finding=finding destination="Report" %}
 
-                    <h6>CVSS v3</h6>
-                    <pre>{{ finding.cvssv3 }}</pre>
+                    {% if finding.cvssv3 %}
+                        <h6>CVSS v3</h6>
+                        <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% endif %}
 
                     <h6>Description</h6>
-                    <pre>{{ finding.description }}</pre>
-                    <h6>Mitigation</h6>
-                    <pre>{{ finding.mitigation }}</pre>
-                 {% if finding.get_report_requests %}
+                    <pre>{{ finding.description|markdown_render }}</pre>
+
+                    {% if finding.mitigation %}
+                        <h6>Mitigation</h6>
+                        <pre>{{ finding.mitigation|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.get_report_requests %}
                         <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
                         {% for req in finding.get_report_requests %}
-                           <h6>Request {{forloop.counter}} </h6>
-                           <pre>{{ req.get_request }}</pre>
-                        {% if req.get_response %}
-                           <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
-                        {% endif %}
+                        <h6>Request {{forloop.counter}} </h6>
+                        <pre class="raw_request">{{ req.get_request }}</pre>
+                            {% if req.get_response != "" %}
+                            <h6>Response {{forloop.counter}}</h6>
+                            <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
+                            {% endif %}
                         {% endfor %}
-                        {% endif %}
+                    {% endif %}
 
-                    <h6>Impact</h6>
-                    <pre>{{ finding.impact }}</pre>
-                    <h6>References</h6>
-                    <pre>{{ finding.references }}</pre>
+                    {% if finding.impact %}
+                        <h6>Impact</h6>
+                        <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% endif %}
+                    
+                    {% if finding.steps_to_reproduce %}
+                        <h6>Steps to Reproduce</h6>
+                        <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.severity_justification %}
+                        <h6>Severity Justification</h6>
+                        <pre>{{ finding.severity_justification|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.references %}
+                        <h6>References</h6>
+                        <pre>{{ finding.references|markdown_render }}</pre>
+                    {% endif %}
+                    
                     {% if include_finding_images %}
                         {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
                     {% endif %}
+                    
                     {% if include_finding_notes %}
                         {% with notes=finding.notes.all|get_public_notes %}
                             {% if notes.count > 0 %}

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -295,41 +295,55 @@
 
                     {% include "dojo/snippets/endpoints.html" with finding=finding destination="Report" %}
 
-                    <h6>CVSS v3</h6>
-                    <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% if finding.cvssv3 %}
+                        <h6>CVSS v3</h6>
+                        <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% endif %}
 
                     <h6>Description</h6>
                     <pre>{{ finding.description|markdown_render }}</pre>
 
-                    <h6>Mitigation</h6>
-                    <pre>{{ finding.mitigation|markdown_render }}</pre>
-                 {% if finding.get_report_requests %}
+                    {% if finding.mitigation %}
+                        <h6>Mitigation</h6>
+                        <pre>{{ finding.mitigation|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.get_report_requests %}
                         <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
                         {% for req in finding.get_report_requests %}
-                           <h6>Request {{forloop.counter}} </h6>
-                           <pre>{{ req.get_request }}</pre>
-                        {% if req.get_response %}
-                           <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
-                        {% endif %}
+                        <h6>Request {{forloop.counter}} </h6>
+                        <pre class="raw_request">{{ req.get_request }}</pre>
+                            {% if req.get_response != "" %}
+                            <h6>Response {{forloop.counter}}</h6>
+                            <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
+                            {% endif %}
                         {% endfor %}
-                        {% endif %}
+                    {% endif %}
 
-                    <h6>Impact</h6>
-                    <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% if finding.impact %}
+                        <h6>Impact</h6>
+                        <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% endif %}
+                    
                     {% if finding.steps_to_reproduce %}
-                    <h6>Steps to Reproduce</h6>
-                    <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
+                        <h6>Steps to Reproduce</h6>
+                        <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
                     {% endif %}
+
                     {% if finding.severity_justification %}
-                    <h6>Severity Justification</h6>
-                    <pre>{{ finding.severity_justification|markdown_render }}</pre>
+                        <h6>Severity Justification</h6>
+                        <pre>{{ finding.severity_justification|markdown_render }}</pre>
                     {% endif %}
-                    <h6>References</h6>
-                    <pre>{{ finding.references|markdown_render }}</pre>
+
+                    {% if finding.references %}
+                        <h6>References</h6>
+                        <pre>{{ finding.references|markdown_render }}</pre>
+                    {% endif %}
+                    
                     {% if include_finding_images %}
                         {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
                     {% endif %}
+                    
                     {% if include_finding_notes %}
                         {% with notes=finding.notes.all|get_public_notes %}
                             {% if notes.count > 0 %}

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -146,30 +146,55 @@
 
                     {% include "dojo/snippets/endpoints.html" with finding=finding destination="Report" %}
 
-                    <h6>CVSS v3</h6>
-                    <pre>{{ finding.cvssv3 }}</pre>
+                    {% if finding.cvssv3 %}
+                        <h6>CVSS v3</h6>
+                        <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% endif %}
+
                     <h6>Description</h6>
-                    <pre>{{ finding.description }}</pre>
-                    <h6>Mitigation</h6>
-                    <pre>{{ finding.mitigation }}</pre>
-                 {% if finding.get_report_requests %}
+                    <pre>{{ finding.description|markdown_render }}</pre>
+
+                    {% if finding.mitigation %}
+                        <h6>Mitigation</h6>
+                        <pre>{{ finding.mitigation|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.get_report_requests %}
                         <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
                         {% for req in finding.get_report_requests %}
-                           <h6>Request {{forloop.counter}} </h6>
-                           <pre>{{ req.get_request }}</pre>
-                        {% if req.get_response %}
-                           <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
-                        {% endif %}
+                        <h6>Request {{forloop.counter}} </h6>
+                        <pre class="raw_request">{{ req.get_request }}</pre>
+                            {% if req.get_response != "" %}
+                            <h6>Response {{forloop.counter}}</h6>
+                            <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
+                            {% endif %}
                         {% endfor %}
-                        {% endif %}
-                    <h6>Impact</h6>
-                    <pre>{{ finding.impact }}</pre>
-                    <h6>References</h6>
-                    <pre>{{ finding.references }}</pre>
+                    {% endif %}
+
+                    {% if finding.impact %}
+                        <h6>Impact</h6>
+                        <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% endif %}
+                    
+                    {% if finding.steps_to_reproduce %}
+                        <h6>Steps to Reproduce</h6>
+                        <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.severity_justification %}
+                        <h6>Severity Justification</h6>
+                        <pre>{{ finding.severity_justification|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.references %}
+                        <h6>References</h6>
+                        <pre>{{ finding.references|markdown_render }}</pre>
+                    {% endif %}
+                    
                     {% if include_finding_images %}
                        {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
                     {% endif %}
+                    
                     {% if include_finding_notes %}
                         {% with notes=finding.notes.all|get_public_notes %}
                             {% if notes.count > 0 %}

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -218,32 +218,55 @@
 
                         {% include "dojo/snippets/endpoints.html" with finding=finding destination="Report" %}
 
-                        <h6>CVSS v3</h6>
-                        <pre>{{ finding.cvssv3 }}</pre>
+                        {% if finding.cvssv3 %}
+                            <h6>CVSS v3</h6>
+                            <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                        {% endif %}
 
                         <h6>Description</h6>
-                        <pre>{{ finding.description }}</pre>
+                        <pre>{{ finding.description|markdown_render }}</pre>
 
-                        <h6>Mitigation</h6>
-                        <pre>{{ finding.mitigation }}</pre>
-                 {% if finding.get_report_requests %}
-                        <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
-                        {% for req in finding.get_report_requests %}
-                           <h6>Request {{forloop.counter}} </h6>
-                           <pre>{{ req.get_request }}</pre>
-                        {% if req.get_response %}
-                           <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
+                        {% if finding.mitigation %}
+                            <h6>Mitigation</h6>
+                            <pre>{{ finding.mitigation|markdown_render }}</pre>
                         {% endif %}
-                        {% endfor %}
+
+                        {% if finding.get_report_requests %}
+                            <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
+                            {% for req in finding.get_report_requests %}
+                            <h6>Request {{forloop.counter}} </h6>
+                            <pre class="raw_request">{{ req.get_request }}</pre>
+                                {% if req.get_response != "" %}
+                                <h6>Response {{forloop.counter}}</h6>
+                                <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
+                                {% endif %}
+                            {% endfor %}
                         {% endif %}
-                        <h6>Impact</h6>
-                        <pre>{{ finding.impact }}</pre>
-                        <h6>References</h6>
-                        <pre>{{ finding.references }}</pre>
+
+                        {% if finding.impact %}
+                            <h6>Impact</h6>
+                            <pre>{{ finding.impact|markdown_render }}</pre>
+                        {% endif %}
+                        
+                        {% if finding.steps_to_reproduce %}
+                            <h6>Steps to Reproduce</h6>
+                            <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
+                        {% endif %}
+
+                        {% if finding.severity_justification %}
+                            <h6>Severity Justification</h6>
+                            <pre>{{ finding.severity_justification|markdown_render }}</pre>
+                        {% endif %}
+
+                        {% if finding.references %}
+                            <h6>References</h6>
+                            <pre>{{ finding.references|markdown_render }}</pre>
+                        {% endif %}
+                        
                         {% if include_finding_images %}
                             {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
                         {% endif %}
+                        
                         {% if include_finding_notes %}
                             {% with notes=finding.notes.all|get_public_notes %}
                                 {% if notes.count > 0 %}

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -275,43 +275,55 @@
 
                     {% include "dojo/snippets/endpoints.html" with finding=finding destination="Report" %}
 
-                    <h6>CVSS v3</h6>
-                    <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% if finding.cvssv3 %}
+                        <h6>CVSS v3</h6>
+                        <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% endif %}
 
                     <h6>Description</h6>
                     <pre>{{ finding.description|markdown_render }}</pre>
 
-                    <h6>Mitigation</h6>
-                    <pre>{{ finding.mitigation|markdown_render }}</pre>
+                    {% if finding.mitigation %}
+                        <h6>Mitigation</h6>
+                        <pre>{{ finding.mitigation|markdown_render }}</pre>
+                    {% endif %}
+
                     {% if finding.get_report_requests %}
                         <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
                         {% for req in finding.get_report_requests %}
                            <h6>Request {{forloop.counter}} </h6>
                            <pre class="raw_request">{{ req.get_request }}</pre>
-                        {% if req.get_response != "" %}
-                           <h6>Response {{forloop.counter}}</h6>
-                           <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
-                        {% endif %}
+                            {% if req.get_response != "" %}
+                            <h6>Response {{forloop.counter}}</h6>
+                            <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
+                            {% endif %}
                         {% endfor %}
-                        {% endif %}
+                    {% endif %}
 
-                    <h6>Impact</h6>
-                    <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% if finding.impact %}
+                        <h6>Impact</h6>
+                        <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% endif %}
+                    
                     {% if finding.steps_to_reproduce %}
-                    <h6>Steps to Reproduce</h6>
-                    <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
+                        <h6>Steps to Reproduce</h6>
+                        <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
                     {% endif %}
+
                     {% if finding.severity_justification %}
-                    <h6>Severity Justification</h6>
-                    <pre>{{ finding.severity_justification|markdown_render }}</pre>
+                        <h6>Severity Justification</h6>
+                        <pre>{{ finding.severity_justification|markdown_render }}</pre>
                     {% endif %}
+
                     {% if finding.references %}
-                    <h6>References</h6>
-                    <pre>{{ finding.references|markdown_render }}</pre>
+                        <h6>References</h6>
+                        <pre>{{ finding.references|markdown_render }}</pre>
                     {% endif %}
+
                     {% if include_finding_images %}
                         {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
                     {% endif %}
+                    
                     {% if include_finding_notes %}
                         {% with notes=finding.notes.all|get_public_notes %}
                             {% if notes.count > 0 %}

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -204,29 +204,51 @@
 
                         {% include "dojo/snippets/endpoints.html" with finding=finding destination="Report" %}
 
-                        <h6>CVSS v3</h6>
-                        <pre>{{ finding.cvssv3 }}</pre>
+                        {% if finding.cvssv3 %}
+                            <h6>CVSS v3</h6>
+                            <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                        {% endif %}
 
                         <h6>Description</h6>
-                        <pre>{{ finding.description }}</pre>
+                        <pre>{{ finding.description|markdown_render }}</pre>
 
-                        <h6>Mitigation</h6>
-                        <pre>{{ finding.mitigation }}</pre>
+                        {% if finding.mitigation %}
+                            <h6>Mitigation</h6>
+                            <pre>{{ finding.mitigation|markdown_render }}</pre>
+                        {% endif %}
+
                         {% if finding.get_report_requests %}
                             <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
                             {% for req in finding.get_report_requests %}
-                                <h6>Request {{forloop.counter}} </h6>
-                                <pre>{{ req.get_request }}</pre>
-                                {% if req.get_response %}
+                            <h6>Request {{forloop.counter}} </h6>
+                            <pre class="raw_request">{{ req.get_request }}</pre>
+                                {% if req.get_response != "" %}
                                 <h6>Response {{forloop.counter}}</h6>
-                                <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
+                                <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
                                 {% endif %}
                             {% endfor %}
                         {% endif %}
-                        <h6>Impact</h6>
-                        <pre>{{ finding.impact }}</pre>
-                        <h6>References</h6>
-                        <pre>{{ finding.references }}</pre>
+
+                        {% if finding.impact %}
+                            <h6>Impact</h6>
+                            <pre>{{ finding.impact|markdown_render }}</pre>
+                        {% endif %}
+                        
+                        {% if finding.steps_to_reproduce %}
+                            <h6>Steps to Reproduce</h6>
+                            <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
+                        {% endif %}
+
+                        {% if finding.severity_justification %}
+                            <h6>Severity Justification</h6>
+                            <pre>{{ finding.severity_justification|markdown_render }}</pre>
+                        {% endif %}
+
+                        {% if finding.references %}
+                            <h6>References</h6>
+                            <pre>{{ finding.references|markdown_render }}</pre>
+                        {% endif %} 
+                        
                         {% if include_finding_images %}
                             {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
                         {% endif %}

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -309,41 +309,55 @@
 
                     {% include "dojo/snippets/endpoints.html" with finding=finding destination="Report" %}
 
-                     <h6>CVSS v3</h6>
-                    <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% if finding.cvssv3 %}
+                        <h6>CVSS v3</h6>
+                        <pre>{{ finding.cvssv3|markdown_render }}</pre>
+                    {% endif %}
 
                     <h6>Description</h6>
                     <pre>{{ finding.description|markdown_render }}</pre>
 
-                    <h6>Mitigation</h6>
-                    <pre>{{ finding.mitigation|markdown_render }}</pre>
-                 {% if finding.get_report_requests %}
+                    {% if finding.mitigation %}
+                        <h6>Mitigation</h6>
+                        <pre>{{ finding.mitigation|markdown_render }}</pre>
+                    {% endif %}
+
+                    {% if finding.get_report_requests %}
                         <h5>Sample Request(s): Displaying {{finding.get_report_requests.count}} of {{finding.burprawrequestresponse_set.count}}</h5>
                         {% for req in finding.get_report_requests %}
-                           <h6>Request {{forloop.counter}} </h6>
-                           <pre>{{ req.get_request }}</pre>
-                        {% if req.get_response %}
-                           <h6>Response {{forloop.counter}}</h6>
-                           <pre>{{ req.get_response|truncatechars_html:800 }}</pre>
-                        {% endif %}
+                        <h6>Request {{forloop.counter}} </h6>
+                        <pre class="raw_request">{{ req.get_request }}</pre>
+                            {% if req.get_response != "" %}
+                            <h6>Response {{forloop.counter}}</h6>
+                            <pre class="raw_request">{{ req.get_response|truncatechars_html:800 }}</pre>
+                            {% endif %}
                         {% endfor %}
-                        {% endif %}
+                    {% endif %}
 
-                    <h6>Impact</h6>
-                    <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% if finding.impact %}
+                        <h6>Impact</h6>
+                        <pre>{{ finding.impact|markdown_render }}</pre>
+                    {% endif %}
+                    
                     {% if finding.steps_to_reproduce %}
-                    <h6>Steps to Reproduce</h6>
-                    <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
+                        <h6>Steps to Reproduce</h6>
+                        <pre>{{ finding.steps_to_reproduce|markdown_render }}</pre>
                     {% endif %}
+
                     {% if finding.severity_justification %}
-                    <h6>Severity Justification</h6>
-                    <pre>{{ finding.severity_justification|markdown_render }}</pre>
+                        <h6>Severity Justification</h6>
+                        <pre>{{ finding.severity_justification|markdown_render }}</pre>
                     {% endif %}
-                    <h6>References</h6>
-                    <pre>{{ finding.references|markdown_render }}</pre>
+
+                    {% if finding.references %}
+                        <h6>References</h6>
+                        <pre>{{ finding.references|markdown_render }}</pre>
+                    {% endif %}
+                    
                     {% if include_finding_images %}
                         {% include "dojo/snippets/file_images.html" with size='original' obj=finding size="original" format="HTML" %}
                     {% endif %}
+                    
                     {% if include_finding_notes %}
                         {% with notes=finding.notes.all|get_public_notes %}
                             {% if notes.count > 0 %}


### PR DESCRIPTION
- Removed some fields in HTML reports that does not have any contents to avoid extraneous sections for a given finding
- Removed the FQDN from HTML reports as it often exposed proxy ports and prevented images from being rendered in the report

<!--[sc-3183]-->
<!--[sc-3184]-->