### PR TITLE
[ENHANCEMENT] Add Product Lifecycle filtering to Report Builder

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2106,6 +2106,7 @@ class ReportFindingFilter(FindingFilterWithTags):
     test__engagement__product__prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.none(),
         label="Product Type")
+    test__engagement__product__lifecycle = MultipleChoiceFilter(choices=Product.LIFECYCLE_CHOICES, label="Product Lifecycle")
     severity = MultipleChoiceFilter(choices=SEVERITY_CHOICES)
     active = ReportBooleanFilter()
     is_mitigated = ReportBooleanFilter()


### PR DESCRIPTION
This merge request introduces a new feature to the Report Builder.

It enables users to filter findings based on the lifecycle of a product.

The main use case is to provide the possibility to generate reports covering only production-grade products.

![lifecycle](https://github.com/DefectDojo/django-DefectDojo/assets/981572/c7d5d1ec-89c7-466e-ace5-92bc534586d6)

**Test results**

Use cases tested manually:
* no value chosen: displays all findings
* all values chosen: same, displays all findings
* "production" lifecycle chosen: only products with lifecycle "production" are taken into account

**Documentation**

Update not needed for this minor improvement.