### PR TITLE
[ENHANCEMENT] Add Finding Violates SLA filtering to Report Builder

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2118,6 +2118,7 @@ class ReportFindingFilter(FindingFilterWithTags):
     duplicate = ReportBooleanFilter()
     duplicate_finding = ModelChoiceFilter(queryset=Finding.objects.filter(original_finding__isnull=False).distinct())
     out_of_scope = ReportBooleanFilter()
+    outside_of_sla = FindingSLAFilter(label="Outside of SLA")
 
     file_path = CharFilter(lookup_expr='icontains')
 


### PR DESCRIPTION
This merge request introduces a new feature to the Report Builder.

It enables users to filter findings based on their SLA violation status.

The main use case is to generate reports covering only SLA breaches.

![sla](https://github.com/DefectDojo/django-DefectDojo/assets/981572/6ab4cdb0-a267-4ff0-94d2-75b776a3b021)

**Test results**

Use cases tested manually:

- no value chosen: displays all findings
- "Any" chosen: displays all findings and the field is reset
- "False" and "True": display only a proper subset of findings

**Documentation**

Update not needed for this minor improvement.