### PR TITLE
OpenAPI schema: Use renderer with small size by default

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -167,10 +167,23 @@ from drf_spectacular.utils import (
     extend_schema,
     extend_schema_view,
 )
+from drf_spectacular.views import SpectacularAPIView
+from drf_spectacular.renderers import OpenApiJsonRenderer2
 from dojo.authorization.roles_permissions import Permissions
 from dojo.user.utils import get_configuration_permissions_codenames
 
 logger = logging.getLogger(__name__)
+
+
+class DojoOpenApiJsonRenderer(OpenApiJsonRenderer2):
+    def get_indent(self, accepted_media_type, renderer_context):
+        if accepted_media_type and 'indent' in accepted_media_type:
+            return super().get_indent(accepted_media_type, renderer_context)
+        return renderer_context.get('indent', None)
+
+
+class DojoSpectacularAPIView(SpectacularAPIView):
+    renderer_classes = [DojoOpenApiJsonRenderer] + SpectacularAPIView.renderer_classes
 
 
 # Authorization: authenticated users

--- a/dojo/urls.py
+++ b/dojo/urls.py
@@ -59,7 +59,8 @@ from dojo.survey.urls import urlpatterns as survey_urls
 from dojo.components.urls import urlpatterns as component_urls
 from dojo.regulations.urls import urlpatterns as regulations
 from dojo.announcement.urls import urlpatterns as announcement_urls
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularSwaggerView
+from dojo.api_v2.views import DojoSpectacularAPIView as SpectacularAPIView
 
 import logging
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# Optimise API schema size = lead swagger faster

Swagger is loading OpenAPI schema from `.../api/v2/oa3/schema/?format=json`. Bigger file, longer loading.

This PR define custom `OpenApiJsonRenderer` which decreases the size of the OpenAPI definition schema.

How? Default JSON using default `indent=4` which generates a lot of whitespace noise - easier for humans to read but useless for computers.

Plus I replaced the default schema from YAML with smaller JSON.

Fun facts about default renderer:
- You are not able to set a higher indent than 8 (a higher number will be downscaled to 8) - makes sense otherwise, it would be a perfect target for DOS; I didn't override this behaviour
- Even if you set indents in the HTTP header, you are not able to force the renderer to avoid print at least one space newline (compare 1014219 vs 708145)

## Test results

Before
```shell
$ curl 'http://localhost:8080/api/v2/oa3/schema/' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/vnd.oai.openapi; charset=utf-8
Content-Length: 943335
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=yaml' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/vnd.oai.openapi; charset=utf-8
Content-Length: 943335
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/vnd.oai.openapi+json
Content-Length: 1734768
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 1734768
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=4' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 1734768
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=0' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 1734768
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=1' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 1014219
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=8' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 2695500
curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=50' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'Content-Type: application/json
Content-Length: 2695500
```

After:
```shell
$ curl 'http://localhost:8080/api/v2/oa3/schema/' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 708145
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=yaml' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/vnd.oai.openapi; charset=utf-8
Content-Length: 943335
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 708145
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 708145
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=4' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 1734768
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=0' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 1734768
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=1' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 1014219
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=8' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 2695500
$ curl 'http://localhost:8080/api/v2/oa3/schema/?format=json' -H 'Accept: application/json; indent=50' --head 2>/dev/null | grep -e '^Content-Type:\|^Content-Length:'
Content-Type: application/json
Content-Length: 2695500
```
