### PR TITLE
Fixbug: sonarqube severity property and remove sonarqube whitespace lead and trail properties

### DIFF
--- a/dojo/tools/sonarqube/parser.py
+++ b/dojo/tools/sonarqube/parser.py
@@ -218,7 +218,7 @@ class SonarQubeParser(object):
             find.nb_occurences = find.nb_occurences + 1
 
     def convert_sonar_severity(self, sonar_severity):
-        sev = sonar_severity.lower()
+        sev = sonar_severity.trim().lower()
         if sev == "blocker":
             return "Critical"
         elif sev == "critical":

--- a/dojo/tools/sonarqube/parser.py
+++ b/dojo/tools/sonarqube/parser.py
@@ -56,21 +56,22 @@ class SonarQubeParser(object):
             rulesDic = dict()
             for rule in rules_table:
                 rule_properties = list(rule.iter("td"))
-                rule_name = list(rule_properties[0].iter("a"))[0].text
+                rule_name = list(rule_properties[0].iter("a"))[0].text.strip()
                 rule_details = list(rule_properties[1].iter("details"))[0]
                 rulesDic[rule_name] = rule_details
 
             for vuln in vulnerabilities_table:
                 vuln_properties = list(vuln.iter("td"))
-                vuln_rule_name = list(vuln_properties[0].iter("a"))[0].text
+                rule_key = list(vuln_properties[0].iter("a"))[0].text
+                vuln_rule_name = rule_key and rule_key.strip()
                 vuln_severity = self.convert_sonar_severity(
-                    vuln_properties[1].text
+                    vuln_properties[1].text and vuln_properties[1].text.strip()
                 )
-                vuln_file_path = vuln_properties[2].text
-                vuln_line = vuln_properties[3].text
-                vuln_title = vuln_properties[4].text
-                vuln_mitigation = vuln_properties[5].text
-                vuln_key = vuln_properties[6].text
+                vuln_file_path = vuln_properties[2].text and vuln_properties[2].text.strip()
+                vuln_line = vuln_properties[3].text and vuln_properties[3].text.strip()
+                vuln_title = vuln_properties[4].text and vuln_properties[4].text.strip()
+                vuln_mitigation = vuln_properties[5].text and vuln_properties[5].text.strip()
+                vuln_key = vuln_properties[6].text and vuln_properties[6].text.strip()
                 if vuln_title is None or vuln_mitigation is None:
                     raise ValueError(
                         "Parser ValueError: can't find a title or a mitigation for vulnerability of name "
@@ -218,7 +219,7 @@ class SonarQubeParser(object):
             find.nb_occurences = find.nb_occurences + 1
 
     def convert_sonar_severity(self, sonar_severity):
-        sev = sonar_severity.trim().lower()
+        sev = sonar_severity.lower()
         if sev == "blocker":
             return "Critical"
         elif sev == "critical":

--- a/unittests/scans/sonarqube/sonar-table-in-table-with-whitespace.html
+++ b/unittests/scans/sonarqube/sonar-table-in-table-with-whitespace.html
@@ -1,0 +1,598 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>SonarQube Vulnerability Report</title>
+    <style>
+        /*
+        The sss stylesheet is released under the MIT license.
+        <https://github.com/Thiht/sss>
+        */
+        pre,
+        td,
+        th {
+            padding: 5px 10px
+        }
+
+        code,
+        hr,
+        pre,
+        thead {
+            background: #EEE
+        }
+
+        body {
+            color: #333;
+            font-family: 'Segoe UI', 'Lucida Grande', Helvetica, sans-serif;
+            line-height: 1.5;
+        }
+
+        div.summup {
+            max-width: 800px;
+            margin: 50px auto;
+        }
+
+        div.detail {
+            padding: 20px;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            font-weight: 400;
+            line-height: 1em;
+            margin: 20px 0
+        }
+
+        h1 {
+            font-size: 2.25em
+        }
+
+        h2 {
+            font-size: 1.75em
+        }
+
+        h3 {
+            font-size: 1.5em
+        }
+
+        h4,
+        h5,
+        h6 {
+            font-size: 1.25em
+        }
+
+        a {
+            color: #08C;
+            text-decoration: none
+        }
+
+        a:focus,
+        a:hover {
+            text-decoration: underline
+        }
+
+        a:visited {
+            color: #058
+        }
+
+        img {
+            max-width: 100%
+        }
+
+        li + li {
+            margin-top: 3px
+        }
+
+        dt {
+            font-weight: 700
+        }
+
+        code {
+            font-family: Consolas, "Lucida Console", monospace;
+            padding: 1px 5px
+        }
+
+        pre {
+            white-space: pre-wrap
+        }
+
+        pre code {
+            padding: 0
+        }
+
+        blockquote {
+            border-left: 5px solid #EEE;
+            margin: 0;
+            padding: 0 10px
+        }
+
+        table {
+            border-collapse: collapse;
+            width: 100%
+        }
+
+        table + table {
+            margin-top: 1em
+        }
+
+        thead {
+            text-align: left
+        }
+
+        td,
+        th {
+            border: 1px solid #EEE
+        }
+
+        td.component {
+            word-break: break-all;
+        }
+
+        hr {
+            border: 0;
+            height: 1px
+        }
+
+        .banner {
+            text-align: center;
+        }
+
+        canvas {
+            display: block;
+            margin: 10px auto;
+        }
+
+        .statusOK {
+            background-color: #0a0
+        }
+
+        .statusERROR {
+            background-color: #d4333f
+        }
+
+        .sevBLOCKER {
+            background-color: #2c3e50
+        }
+
+        .sevCRITICAL {
+            background-color: #d43223
+        }
+
+        .sevMAJOR {
+            background-color: #f39c12
+        }
+
+        .sevMINOR {
+            background-color: #319ddb
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        .rulestable {
+            table-layout: fixed;
+            word-wrap: break-word
+        }
+
+
+    </style>
+</head>
+
+<body>
+<div class=summup>
+    <!-- insert your company banner here -->
+    <!--
+    <p class="banner">
+        <a href="https://www.soprasteria.com/" target="_blank">
+            <img src="https://upload.wikimedia.org/wikipedia/en/thumb/0/02/Sopra_Steria_logo.svg/1280px-Sopra_Steria_logo.svg.png" alt="Sopra Steria" height="50">
+        </a>
+    </p>
+    -->
+    <h1>SonarQube Vulnerability Report</h1>
+    <dl>
+        <dt>Report Generated On</dt>
+        <dd>Fri Aug 02 2019</dd>
+        <dt>Project Name</dt>
+        <dd>java tomcat</dd>
+        <dt>Application</dt>
+        <dd>tomcat</dd>
+        <dt>Release</dt>
+        <dd>1.0.0</dd>
+        <dt>Delta analysis</dt>
+        <dd>No</dd>
+    </dl>
+    <h2>Summary of the Detected Vulnerabilities
+    </h2>
+    <table>
+        <thead>
+        <tr>
+            <th></th>
+            <th>Severity</th>
+            <th>Number of Issues</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td class="sevBLOCKER"></td>
+            <td>BLOCKER</td>
+            <td>
+                0
+            </td>
+        </tr>
+        <tr>
+            <td class="sevCRITICAL"></td>
+            <td>CRITICAL</td>
+            <td>
+                2
+            </td>
+        </tr>
+        <tr>
+            <td class="sevMAJOR"></td>
+            <td>MAJOR</td>
+            <td>
+                0
+            </td>
+        </tr>
+        <tr>
+            <td class="sevMINOR"></td>
+            <td>MINOR</td>
+            <td>
+                5
+            </td>
+        </tr>
+        </tbody>
+    </table>
+
+
+    <canvas id="vulnerabilitiesPieChart" width="200" height="200"></canvas>
+
+</div>
+
+<div class=detail>
+
+    <h2>Detail of the Detected Vulnerabilities
+    </h2>
+    <table>
+        <thead>
+        <tr>
+            <th>Rule</th>
+            <th>Severity</th>
+            <th>Component</th>
+            <th>Line</th>
+            <th>Description</th>
+            <th>Message</th>
+            <th class="hidden">Key</th>
+            <th>Status</th>
+        </tr>
+        </thead>
+        <tbody>
+
+        <tr>
+            <td><a href="https://sonarcloud.io/coding_rules#rule_key=squid:S2975">
+                squid:S2975
+            </a></td>
+            <td>
+                BLOCKER
+            </td>
+            <td class="component">
+                java/org/apache/catalina/util/URLEncoder.java
+            </td>
+            <td>
+                190
+            </td>
+            <td>
+                &#34;clone&#34; should not be overridden
+            </td>
+            <td>
+                Remove this &#34;clone&#34; implementation; use a copy constructor or copy factory instead.
+            </td>
+            <td class="hidden">
+                AWK40IMu-pl6AHs22MnV
+            </td>
+            <td>TO_REVIEW</td>
+        </tr>
+        </tbody>
+    </table>
+    <h3>Known Security Rules</h3>
+    <table style="table-layout: fixed; word-wrap: break-word">
+        <thead>
+        <tr>
+            <th>Rule</th>
+            <th>Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td><a href="https://next.sonarqube.com/sonarqube/coding_rules#rule_key=squid:S864">squid:S864</a>
+            </td>
+            <td>
+                <details>
+                    <p>The rules of operator precedence are complicated and can lead to errors. For this reason,
+                        parentheses should be used for clarification in complex
+                        statements. However, this does not mean that parentheses should be gratuitously added around
+                        every operation. </p>
+                    <p>This rule raises issues when <code>&amp;&amp;</code> and <code>||</code> are used in
+                        combination, when assignment and equality or relational
+                        operators are used in together in a condition, and for other operator combinations according
+                        to the following table:</p>
+                    <table>
+                        <tbody>
+                        <tr>
+                            <td></td>
+                            <td><code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>%</code></td>
+                            <td><code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>&gt;&gt;&gt;</code></td>
+                            <td><code>&amp;</code></td>
+                            <td><code>^</code></td>
+                            <td><code>|</code></td>
+                        </tr>
+                        <tr>
+                            <td><code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>%</code></td>
+                            <td></td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td>x</td>
+                        </tr>
+                        <tr>
+                            <td><code>&lt;&lt;</code>, <code>&gt;&gt;</code>, <code>&gt;&gt;&gt;</code></td>
+                            <td>x</td>
+                            <td></td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td>x</td>
+                        </tr>
+                        <tr>
+                            <td><code>&amp;</code></td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td></td>
+                            <td>x</td>
+                            <td>x</td>
+                        </tr>
+                        <tr>
+                            <td><code>^</code></td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td></td>
+                            <td>x</td>
+                        </tr>
+                        <tr>
+                            <td><code>|</code></td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td>x</td>
+                            <td></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                    <h2>Noncompliant Code Example</h2>
+                    <pre>
+x = a + b - c;
+x = a + 1 &lt;&lt; b;  // Noncompliant
+
+if ( a &gt; b || c &lt; d || a == d) {...}
+if ( a &gt; b &amp;&amp; c &lt; d || a == b) {...}  // Noncompliant
+if (a = f(b,c) == 1) { ... } // Noncompliant; == evaluated first
+</pre>
+                    <h2>Compliant Solution</h2>
+                    <pre>
+x = a + b - c;
+x = (a + 1) &lt;&lt; b;
+
+if ( a &gt; b || c &lt; d || a == d) {...}
+if ( (a &gt; b &amp;&amp; c &lt; d) || a == b) {...}
+if ( (a = f(b,c)) == 1) { ... }
+</pre>
+                    <h2>See</h2>
+                    <ul>
+                        <li> MISRA C:2004, 12.1 - Limited dependence should be placed on C's operator precedence
+                            rules in expressions
+                        </li>
+                        <li> MISRA C:2004, 12.2 - The value of an expression shall be the same under any order of
+                            evaluation that the standard permits.
+                        </li>
+                        <li> MISRA C:2004, 12.5 - The operands of a logical &amp;&amp; or || shall be
+                            primary-expressions.
+                        </li>
+                        <li> MISRA C++:2008, 5-0-1 - The value of an expression shall be the same under any order of
+                            evaluation that the standard permits.
+                        </li>
+                        <li> MISRA C++:2008, 5-0-2 - Limited dependence should be placed on C++ operator precedence
+                            rules in expressions
+                        </li>
+                        <li> MISRA C++:2008, 5-2-1 - Each operand of a logical &amp;&amp; or || shall be a
+                            postfix-expression.
+                        </li>
+                        <li> MISRA C:2012, 12.1 - The precedence of operators within expressions should be made
+                            explicit
+                        </li>
+                        <li><a href="https://www.securecoding.cert.org/confluence/x/_wI">CERT, EXP00-C.</a> - Use
+                            parentheses for precedence of operation
+                        </li>
+                        <li><a href="https://www.securecoding.cert.org/confluence/x/9wHEAw">CERT, EXP53-J.</a> - Use
+                            parentheses for precedence of operation
+                        </li>
+                        <li><a href="http://cwe.mitre.org/data/definitions/783.html">MITRE, CWE-783</a> - Operator
+                            Precedence Logic Error
+                        </li>
+                    </ul>
+                </details>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://next.sonarqube.com/sonarqube/coding_rules#rule_key=squid:S2115">squid:S2115</a>
+            </td>
+            <td>
+                <details>
+                    <p>Failure to password-protect a database is so careless or naive as to be almost negligent.
+                        Databases should always be password protected, but the
+                        use of a database connection with an empty password is a clear indication of a database that
+                        is not protected.</p>
+                    <p>This rule flags database connections with empty passwords.</p>
+                    <h2>Noncompliant Code Example</h2>
+                    <pre>
+Connection conn = DriverManager.getConnection("jdbc:derby:memory:myDB;create=true", "AppLogin", "");
+Connection conn2 = DriverManager.getConnection("jdbc:derby:memory:myDB;create=true?user=user&amp;password=");
+</pre>
+                    <h2>Compliant Solution</h2>
+                    <pre>
+DriverManager.getConnection("jdbc:derby:memory:myDB;create=true?user=user&amp;password=password");
+
+DriverManager.getConnection("jdbc:mysql://address=(host=myhost1)(port=1111)(key1=value1)(user=sandy)(password=secret),address=(host=myhost2)(port=2222)(key2=value2)(user=sandy)(password=secret)/db");
+
+DriverManager.getConnection("jdbc:mysql://sandy:secret@[myhost1:1111,myhost2:2222]/db");
+
+String url = "jdbc:postgresql://localhost/test";
+Properties props = new Properties();
+props.setProperty("user", "fred");
+props.setProperty("password", "secret");
+DriverManager.getConnection(url, props);
+</pre>
+                    <h2>See</h2>
+                    <ul>
+                        <li><a href="https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure">OWASP
+                            Top 10 2017 Category A3</a> - Sensitive Data Exposure
+                        </li>
+                        <li><a href="https://cwe.mitre.org/data/definitions/521.html">MITRE, CWE-521</a> - Weak
+                            Password Requirements
+                        </li>
+                    </ul>
+                </details>
+            </td>
+        </tr>
+        <tr>
+            <td><a href="https://next.sonarqube.com/sonarqube/coding_rules#rule_key=squid:S1148">squid:S1148</a>
+            </td>
+            <td>
+                <details>
+                    <p><code>Throwable.printStackTrace(...)</code> prints a <code>Throwable</code> and its stack
+                        trace to some stream. By default that stream
+                        <code>System.Err</code>, which could inadvertently expose sensitive information.</p>
+                    <p>Loggers should be used instead to print <code>Throwable</code>s, as they have many
+                        advantages:</p>
+                    <ul>
+                        <li> Users are able to easily retrieve the logs.</li>
+                        <li> The format of log messages is uniform and allow users to browse the logs easily.</li>
+                    </ul>
+                    <p>This rule raises an issue when <code>printStackTrace</code> is used without arguments, i.e.
+                        when the stack trace is printed to the default
+                        stream.</p>
+                    <h2>Noncompliant Code Example</h2>
+                    <pre>
+try {
+  /* ... */
+} catch(Exception e) {
+  e.printStackTrace();        // Noncompliant
+}
+</pre>
+                    <h2>Compliant Solution</h2>
+                    <pre>
+try {
+  /* ... */
+} catch(Exception e) {
+  LOGGER.log("context", e);
+}
+</pre>
+                            <h2>See</h2>
+                            <ul>
+                                <li> <a href="https://www.owasp.org/index.php/Top_10-2017_A3-Sensitive_Data_Exposure">OWASP Top 10 2017 Category A3</a> - Sensitive Data Exposure
+                                </li>
+                                <li> <a href="http://cwe.mitre.org/data/definitions/489.html">MITRE, CWE-489</a> - Leftover Debug Code </li>
+                            </ul>
+                        </details>
+                    </td>
+                </tr>
+                <tr>
+                    <td><a
+                            href="https://next.sonarqube.com/sonarqube/coding_rules#rule_key=squid:S2975">squid:S2975</a>
+                    </td>
+                    <td>
+                        <details>
+                            <p>Many consider <code>clone</code> and <code>Cloneable</code> broken in Java, largely because the rules for overriding <code>clone</code> are tricky
+and difficult to get right, according to Joshua Bloch:</p>
+<blockquote>
+  Object's clone method is very tricky. It's based on field copies, and it's "extra-linguistic." It creates an object without calling a constructor.
+  There are no guarantees that it preserves the invariants established by the constructors. There have been lots of bugs over the years, both in and
+  outside Sun, stemming from the fact that if you just call super.clone repeatedly up the chain until you have cloned an object, you have a shallow
+  copy of the object. The clone generally shares state with the object being cloned. If that state is mutable, you don't have two independent objects.
+  If you modify one, the other changes as well. And all of a sudden, you get random behavior.
+</blockquote>
+<p>A copy constructor or copy factory should be used instead.</p>
+<p>This rule raises an issue when <code>clone</code> is overridden, whether or not <code>Cloneable</code> is implemented.</p>
+<h2>Noncompliant Code Example</h2>
+<pre>
+public class MyClass {
+  // ...
+
+  public Object clone() { // Noncompliant
+    //...
+  }
+}
+</pre>
+<h2>Compliant Solution</h2>
+<pre>
+public class MyClass {
+  // ...
+
+  MyClass (MyClass source) {
+    //...
+  }
+}
+</pre>
+                    <h2>See</h2>
+                    <ul>
+                        <li><a href="http://www.artima.com/intv/bloch13.html">Copy Constructor versus Cloning</a>
+                        </li>
+                    </ul>
+                    <h3>See Also</h3>
+                    <ul>
+                        <li><a href='/coding_rules#rule_key=squid%3AS2157'>S2157</a> - "Cloneables" should implement
+                            "clone"
+                        </li>
+                        <li><a href='/coding_rules#rule_key=squid%3AS1182'>S1182</a> - Classes that override "clone"
+                            should be "Cloneable" and call "super.clone()"
+                        </li>
+                    </ul>
+                </details>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<script>
+    var canvas = document.getElementById("vulnerabilitiesPieChart");
+    var ctx = canvas.getContext("2d");
+
+    var data = [
+        67,
+        1774,
+        3229,
+        2276
+    ];
+    var total = data.reduce(function (sum, n) {
+        return sum + n;
+    })
+    var colors = ['#2c3e50', '#d43223', '#f39c12', '#319ddb'];
+
+    for (var i = 0, lastend = 0; i < data.length; i++) {
+        ctx.fillStyle = colors[i];
+        ctx.beginPath();
+        ctx.moveTo(canvas.width / 2, canvas.height / 2);
+        ctx.arc(canvas.width / 2, canvas.height / 2, canvas.height / 2, lastend, lastend + (Math.PI * 2 * (data[i] /
+            total)), false);
+        ctx.lineTo(canvas.width / 2, canvas.height / 2);
+        ctx.fill();
+        lastend += Math.PI * 2 * (data[i] / total);
+    }
+</script>
+</body>
+
+</html>

--- a/unittests/tools/test_sonarqube_parser.py
+++ b/unittests/tools/test_sonarqube_parser.py
@@ -408,3 +408,88 @@ class TestSonarQubeParser(DojoTestCase):
         findings = parser.get_findings(my_file_handle, test)
         # specific verifications
         self.assertEqual(322, len(findings))
+
+    def test_detailed_parse_file_table_has_whitespace(self):
+        """
+        from version 3.1.1: sonarqube-report has new template with some change.
+        see: https://github.com/soprasteria/sonar-report/commit/7dab559e7ecf9ed319345e9262a8b160bd3af94f
+        Data table will have some whitespaces, parser should strip it before compare or use these properties.
+        """
+        my_file_handle, product, engagement, test = self.init(
+            get_unit_tests_path() + "/scans/sonarqube/sonar-table-in-table-with-whitespace.html"
+        )
+        parser = SonarQubeParser()
+        parser.set_mode('detailed')
+        findings = parser.get_findings(my_file_handle, test)
+        self.assertEqual(1, len(findings))
+
+        # check content
+        item = findings[0]
+        self.assertEqual(str, type(findings[0].title))
+        self.assertEqual('"clone" should not be overridden', item.title)
+        self.assertEqual(int, type(item.cwe))
+        self.assertEqual(0, item.cwe)
+        self.assertEqual(bool, type(item.active))
+        self.assertEqual(True, item.active)
+        self.assertEqual(bool, type(item.verified))
+        self.assertEqual(False, item.verified)
+        self.assertEqual(str, type(item.description))
+        self.assertMultiLineEqual(
+            "Many consider clone and Cloneable broken in Java, largely because the rules for overriding clone are tricky\n"
+            "and difficult to get right, according to Joshua Bloch:\n"
+            "\n"
+            "  Object's clone method is very tricky. It's based on field copies, and it's \"extra-linguistic.\" It creates an object without calling a constructor.\n"
+            "  There are no guarantees that it preserves the invariants established by the constructors. There have been lots of bugs over the years, both in and\n"
+            "  outside Sun, stemming from the fact that if you just call super.clone repeatedly up the chain until you have cloned an object, you have a shallow\n"
+            "  copy of the object. The clone generally shares state with the object being cloned. If that state is mutable, you don't have two independent objects.\n"
+            "  If you modify one, the other changes as well. And all of a sudden, you get random behavior.\n"
+            "\n"
+            "A copy constructor or copy factory should be used instead.\n"
+            "This rule raises an issue when clone is overridden, whether or not Cloneable is implemented.\n"
+            "**Noncompliant Code Example**\n"
+            "\n"
+            "public class MyClass {\n"
+            "  // ...\n"
+            "\n"
+            "  public Object clone() { // Noncompliant\n"
+            "    //...\n"
+            "  }\n"
+            "}\n"
+            "\n"
+            "**Compliant Solution**\n"
+            "\n"
+            "public class MyClass {\n"
+            "  // ...\n"
+            "\n"
+            "  MyClass (MyClass source) {\n"
+            "    //...\n"
+            "  }\n"
+            "}",
+            item.description,
+        )
+        self.assertEqual(str, type(item.severity))
+        self.assertEqual("Critical", item.severity)
+        self.assertEqual(str, type(item.mitigation))
+        self.assertEqual(
+            'Remove this "clone" implementation; use a copy constructor or copy factory instead.',
+            item.mitigation,
+        )
+        self.assertEqual(str, type(item.references))
+        self.assertMultiLineEqual(
+            "squid:S2975\n" "Copy Constructor versus Cloning\n" "S2157\n" "S1182",
+            item.references,
+        )
+        self.assertEqual(str, type(item.file_path))
+        self.assertEqual(
+            "java/org/apache/catalina/util/URLEncoder.java", item.file_path
+        )
+        self.assertEqual(str, type(item.line))
+        self.assertEqual("190", item.line)
+        self.assertEqual(str, type(item.unique_id_from_tool))
+        self.assertEqual("AWK40IMu-pl6AHs22MnV", item.unique_id_from_tool)
+        self.assertEqual(bool, type(item.static_finding))
+        self.assertEqual(True, item.static_finding)
+        self.assertEqual(bool, type(item.dynamic_finding))
+        self.assertEqual(False, item.dynamic_finding)
+
+

--- a/unittests/tools/test_sonarqube_parser.py
+++ b/unittests/tools/test_sonarqube_parser.py
@@ -491,5 +491,3 @@ class TestSonarQubeParser(DojoTestCase):
         self.assertEqual(True, item.static_finding)
         self.assertEqual(bool, type(item.dynamic_finding))
         self.assertEqual(False, item.dynamic_finding)
-
-


### PR DESCRIPTION
**Description**

[sonar-report 3.1.1](https://github.com/soprasteria/sonar-report/releases/tag/3.1.1) has somechange in report template. It leads to some information parsed not correctly as Severity and some whitespace remains. 
See: [https://github.com/soprasteria/sonar-report/commit/7dab559e7ecf9ed319345e9262a8b160bd3af94f](https://github.com/soprasteria/sonar-report/commit/7dab559e7ecf9ed319345e9262a8b160bd3af94f)

This pull request fixes the Severity compare and removes some whitespace lead and trail of properties. 

**Test results**

I added a new Test for the new template format and ran `unittests.tools.test_sonarqube_parser.TestSonarQubeParser` to make sure that works with old unitest.

**Documentation**

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

**Extra information**

Please clear everything below when submitting your pull request, it's here purely for your information.

Moderators: Labels currently accepted for PRs:
- enhancement
- bugfix
- maintenance (a.k.a chores)
