### PR TITLE
fix button color in risk acceptance bug

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -52,14 +52,12 @@ a {
 }
 
 .panel-default .btn-primary {
-    background-color: transparent!important;
     border-style: none!important;
     color: #fff!important;
     border: 1px solid #fff!important;
 }
 
 .panel-default .btn-primary:hover {
-    background-color: transparent!important;
     color: #fff!important;
     border: 1px solid #fff!important;
 }

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -51,13 +51,20 @@ a {
   color: #546474;
 }
 
+.btn-in-footer{
+    background-color: #546474!important;
+    color: #fff;
+}
+
 .panel-default .btn-primary {
+    background-color: transparent!important;
     border-style: none!important;
     color: #fff!important;
     border: 1px solid #fff!important;
 }
 
 .panel-default .btn-primary:hover {
+    background-color: transparent!important;
     color: #fff!important;
     border: 1px solid #fff!important;
 }

--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -51,11 +51,6 @@ a {
   color: #546474;
 }
 
-.btn-in-footer{
-    background-color: #546474!important;
-    color: #fff;
-}
-
 .panel-default .btn-primary {
     background-color: transparent!important;
     border-style: none!important;

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -44,7 +44,7 @@
                 {% include "dojo/form_fields.html" with form=risk_acceptance_form %}
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
-                        <input class="btn btn-in-footer" type="submit" value="Save"/>
+                        <input class="btn" type="submit" value="Save"/>
                     </div>
                 </div>
             </form>
@@ -222,8 +222,10 @@
                 <div class="panel-body">
                     {% include "dojo/paging_snippet.html" with page=add_findings prefix="apage" %}
                 </div>
-                <div class="panel-footer text-center">
-                    <input class="btn btn-in-footer" name="add_findings" type="submit" value="Add Selected Findings"/>
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10">
+                        <input class="btn" name="add_findings" type="submit" value="Add Selected Findings"/>
+                    </div>
                 </div>
             </form>
         </div>

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -44,7 +44,7 @@
                 {% include "dojo/form_fields.html" with form=risk_acceptance_form %}
                 <div class="form-group">
                     <div class="col-sm-offset-2 col-sm-10">
-                        <input class="btn btn-primary" type="submit" value="Save"/>
+                        <input class="btn btn-in-footer" type="submit" value="Save"/>
                     </div>
                 </div>
             </form>
@@ -223,7 +223,7 @@
                     {% include "dojo/paging_snippet.html" with page=add_findings prefix="apage" %}
                 </div>
                 <div class="panel-footer text-center">
-                    <input class="btn btn-primary" name="add_findings" type="submit" value="Add Selected Findings"/>
+                    <input class="btn btn-in-footer" name="add_findings" type="submit" value="Add Selected Findings"/>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## fix button color in risk acceptance bug
[sc-3141]

**Description**

This bugfix shows the Add selected Findings button in a visible color  in /engagement/id/risk_acceptance/id/edit url

**Test results**

now it shows like the following.
![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/e67452e3-bebe-4263-b0a5-0c6913cc840f)
