### PR TITLE
Store CVSS score and vector in Whitesource imports

### DIFF
--- a/unittests/scans/whitesource/okhttp_one_vuln.json
+++ b/unittests/scans/whitesource/okhttp_one_vuln.json
@@ -1,29 +1,72 @@
 {  
    "vulnerabilities":[  
-      {  
-         "name":"WS-2009-0001",
-         "type":"WS",
-         "severity":"low",
-         "score":"0.0",
-         "publishDate":"2007-10-07",
-         "lastUpdatedDate":"2009-08-06",
-         "url":"https://issues.apache.org/jira/browse/CODEC-55",
-         "description":"Not all \"business\" method implementations of public API in Apache Commons Codec 1.x are thread safe, which might disclose the wrong data or allow an attacker to change non-private fields.\n\nUpdated 2018-10-07 - an additional review by WhiteSource research team could not indicate on a clear security vulnerability",
-         "project":"okhttp",
+{
+         "name":"CVE-2019-9658",
+         "type":"CVE",
+         "severity":"medium",
+         "score":"5.0",
+         "cvss3_severity":"MEDIUM",
+         "cvss3_score":"5.3",
+         "publishDate":"2019-03-11",
+         "lastUpdatedDate":"2019-05-21",
+         "scoreMetadataVector":"CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+         "url":"https://cve.mitre.org/cgi-bin/cvename.cgi?name\u003dCVE-2019-9658",
+         "description":"Checkstyle before 8.18 loads external DTDs by default.",
+         "project":"slack",
          "product":"okhttp",
-         "library":{  
-            "keyUuid":"9aa14ac7-e415-4ed5-be35-bd2957fd7fd2",
-            "filename":"commons-codec-1.3.jar",
-            "name":"Codec",
-            "groupId":"commons-codec",
-            "artifactId":"commons-codec",
-            "version":"1.3",
-            "sha1":"fd32786786e2adb664d5ecc965da47629dca14ba",
+         "cvss3Attributes":{
+            "attackVector":"NETWORK",
+            "attackComplexity":"LOW",
+            "userInteraction":"NONE",
+            "privilegesRequired":"NONE",
+            "scope":"UNCHANGED",
+            "confidentialityImpact":"LOW",
+            "integrityImpact":"NONE",
+            "availabilityImpact":"NONE"
+         },
+         "library":{
+            "keyUuid":"31e26373-8f25-4c7c-9ada-63a688494afb",
+            "filename":"checkstyle-8.15.jar",
+            "name":"checkstyle",
+            "groupId":"com.puppycrawl.tools",
+            "artifactId":"checkstyle",
+            "version":"8.15",
+            "sha1":"8584d88c6aefcfb079adb8d102928b3eeb4de6ad",
             "type":"MAVEN_ARTIFACT",
-            "description":"The codec package contains simple encoder and decoders for\n   various formats such as Base64 and Hexadecimal.  In addition to these\n   widely used encoders and decoders, the codec package also maintains a\n   collection of phonetic encoding utilities.",
+            "description":"Checkstyle is a development tool to help programmers write Java code\n    that adheres to a coding standard",
             "architecture":"",
             "languageVersion":""
-         }
+         },
+         "topFix":{
+            "vulnerability":"CVE-2019-9658",
+            "type":"UPGRADE_VERSION",
+            "origin":"WHITESOURCE_EXPERT",
+            "url":"https://github.com/checkstyle/checkstyle/issues/6474",
+            "fixResolution":"Upgrade To Version checkstyle-8.18",
+            "date":"2019-03-11 05:29:01",
+            "message":"Upgrade To Version"
+         },
+         "allFixes":[
+            {
+               "vulnerability":"CVE-2019-9658",
+               "type":"UPGRADE_VERSION",
+               "origin":"WHITESOURCE_EXPERT",
+               "url":"https://github.com/checkstyle/checkstyle/issues/6474",
+               "fixResolution":"Upgrade To Version checkstyle-8.18",
+               "date":"2019-03-11 05:29:01",
+               "message":"Upgrade To Version"
+            },
+            {
+               "vulnerability":"CVE-2019-9658",
+               "type":"CHANGE_FILES",
+               "origin":"GITHUB_COMMIT",
+               "url":"https://github.com/checkstyle/checkstyle/commit/180b4fe37a2249d4489d584505f2b7b3ab162ec6",
+               "fixResolution":"Replace or update the following files: XmlLoader.java, ConfigurationLoaderTest.java, config_reporting.xml, pmd.xml, pom.xml, XmlLoaderTest.java",
+               "date":"2019-02-25 00:00:00",
+               "message":"Issue #6474: disable external dtd load by default",
+               "extraData":"key\u003d180b4fe\u0026committerName\u003dromani\u0026committerUrl\u003dhttps://github.com/romani\u0026committerAvatar\u003dhttps://avatars3.githubusercontent.com/u/812984?v\u003d4"
+            }
+         ]
       }
    ]
 }

--- a/unittests/tools/test_whitesource_parser.py
+++ b/unittests/tools/test_whitesource_parser.py
@@ -18,7 +18,9 @@ class TestWhitesourceParser(DojoTestCase):
         self.assertEqual(1, len(findings))
         finding = list(findings)[0]
         self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
-        self.assertEqual("WS-2009-0001", finding.unsaved_vulnerability_ids[0])
+        self.assertEqual("CVE-2019-9658", finding.unsaved_vulnerability_ids[0])
+        self.assertEqual("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N", finding.cvssv3)
+        self.assertEqual(5.3, finding.cvssv3_score)
 
     def test_parse_file_with_multiple_vuln_has_multiple_finding(self):
         testfile = open("unittests/scans/whitesource/okhttp_many_vuln.json")


### PR DESCRIPTION
**Description**

I've extended the Whitesource parser so that it stores CVSS score and vector in the corresponding fields of the generated findings.

**Test results**

I've extended the `tools.test_whitesource_parser.TestWhitesourceParser.test_parse_file_with_one_vuln_has_one_findings` to check these two new filled fields.

**Documentation**

n/a

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

**Extra information**

Please clear everything below when submitting your pull request, it's here purely for your information.

Moderators: Labels currently accepted for PRs:
- Import Scans (for new scanners/importers)
- enhancement
- performance
- feature
- bugfix
- maintenance (a.k.a chores)
- dependencies
- New Migration (when the PR introduces a DB migration)
- settings_changes (when the PR introduces changes or new settings in settings.dist.py)
