### PR TITLE
Debug: Avoid useless error in logs

### DIFF
--- a/dojo/wsgi.py
+++ b/dojo/wsgi.py
@@ -51,9 +51,11 @@ if os.environ.get("DD_DEBUG") == "True" and not os.getenv("RUN_MAIN") and is_deb
             logger.info("Waiting for the debugging client to connect on port {}".format(debugpy_port))
             debugpy.wait_for_client()
             print("Debugging client connected, resuming execution")
+    except RuntimeError as e:
+        if str(e) != "Can't listen for client connections: [Errno 98] Address already in use":
+            logger.exception(e)
     except Exception as e:
         logger.exception(e)
-        pass
 
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION


### PR DESCRIPTION
Drop
```python

django-defectdojo-uwsgi-1         | Can't listen for client connections: [Errno 98] Address already in use
django-defectdojo-uwsgi-1         | Traceback (most recent call last):
django-defectdojo-uwsgi-1         |   File "/app/dojo/wsgi.py", line 50, in <module>
django-defectdojo-uwsgi-1         |     debugpy.listen(("0.0.0.0", debugpy_port))
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/debugpy/public_api.py", line 31, in wrapper
django-defectdojo-uwsgi-1         |     return wrapped(*args, **kwargs)
django-defectdojo-uwsgi-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/debugpy/server/api.py", line 143, in debug
django-defectdojo-uwsgi-1         |     log.reraise_exception("{0}() failed:", func.__name__, level="info")
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/debugpy/server/api.py", line 141, in debug
django-defectdojo-uwsgi-1         |     return func(address, settrace_kwargs, **kwargs)
django-defectdojo-uwsgi-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/debugpy/server/api.py", line 262, in listen
django-defectdojo-uwsgi-1         |     raise RuntimeError(str(endpoints["error"]))
django-defectdojo-uwsgi-1         | RuntimeError: Can't listen for client connections: [Errno 98] Address already in use
```
from all reload logs