### PR TITLE
Support "_FILE" environmental variables

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -75,6 +75,7 @@ COPY \
   docker/entrypoint-unit-tests.sh \
   docker/entrypoint-unit-tests-devDocker.sh \
   docker/wait-for-it.sh \
+  docker/secret-file-loader.sh \
   docker/certs/* \
   /
 COPY wsgi.py manage.py docker/unit-tests.sh ./

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -80,6 +80,7 @@ COPY \
   docker/entrypoint-unit-tests.sh \
   docker/entrypoint-unit-tests-devDocker.sh \
   docker/wait-for-it.sh \
+  docker/secret-file-loader.sh \
   docker/certs/* \
   /
 COPY wsgi.py manage.py docker/unit-tests.sh ./

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -61,6 +61,7 @@ WORKDIR /app
 COPY --from=openapitools /opt/openapi-generator/modules/openapi-generator-cli/target/openapi-generator-cli.jar /usr/local/bin/openapi-generator-cli.jar
 
 COPY docker/wait-for-it.sh \
+  docker/secret-file-loader.sh \
   docker/entrypoint-integration-tests.sh \
   /
 

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -3,6 +3,8 @@ umask 0002
 
 id
 
+. /secret-file-loader.sh
+
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
 NUM_FILES=$(echo "$FILES" | wc -w)

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /secret-file-loader.sh
+
 initialize_data()
 {
     # Test types shall be initialized every time by the initializer, to make sure test types are complete

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. /secret-file-loader.sh
+
 echo "Testing DefectDojo Service"
 
 echo "Waiting max 60s for services to start"

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -6,6 +6,8 @@ set -x
 set -e
 set -v
 
+. /secret-file-loader.sh
+
 cd /app
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)
 unset DD_DATABASE_URL

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -6,6 +6,8 @@
 # set -e
 # set -v
 
+. /secret-file-loader.sh
+
 cd /app
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)
 unset DD_DATABASE_URL

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /secret-file-loader.sh
+
 
 cd /app
 

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /secret-file-loader.sh
+
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
 NUM_FILES=$(echo "$FILES" | wc -w)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /secret-file-loader.sh
+
 # Waits for the database to come up.
 ./docker/wait-for-it.sh $DD_DATABASE_HOST:$DD_DATABASE_PORT
 

--- a/docker/secret-file-loader.sh
+++ b/docker/secret-file-loader.sh
@@ -8,8 +8,7 @@
 for VAR_NAME in $(env | grep '^DD_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
     VAR_NAME_FILE="$VAR_NAME"_FILE
     if [ -n "$(eval echo "\$$VAR_NAME")" ]; then
-        echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
-        exit 1
+        echo >&2 "WARNING: Both $VAR_NAME and $VAR_NAME_FILE are set. Content of $VAR_NAME will be overridden."
     fi
     echo "Getting secret $VAR_NAME from $(eval echo "\$$VAR_NAME_FILE")"
     export "$VAR_NAME"="$(cat "$(eval echo "\$$VAR_NAME_FILE")")"

--- a/docker/secret-file-loader.sh
+++ b/docker/secret-file-loader.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Convert all environment variables with names ending in _FILE into the content of
+# the file that they point at and use the name without the trailing _FILE.
+# This can be used to carry in Docker secrets.
+# Inspired by https://github.com/grafana/grafana-docker/pull/166
+# But rewrote for /bin/sh
+for VAR_NAME in $(env | grep '^DD_[^=]\+_FILE=.\+' | sed -r "s/([^=]*)_FILE=.*/\1/g"); do
+    VAR_NAME_FILE="$VAR_NAME"_FILE
+    if [ -n "$(eval echo "\$$VAR_NAME")" ]; then
+        echo >&2 "ERROR: Both $VAR_NAME and $VAR_NAME_FILE are set (but are exclusive)"
+        exit 1
+    fi
+    echo "Getting secret $VAR_NAME from $(eval echo "\$$VAR_NAME_FILE")"
+    export "$VAR_NAME"="$(cat "$(eval echo "\$$VAR_NAME_FILE")")"
+    unset "$VAR_NAME_FILE"
+done

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 root = environ.Path(__file__) - 3  # Three folders back
 
 # reference: https://pypi.org/project/django-environ/
-env = environ.Env(
+env = environ.FileAwareEnv(
     # Set casting and default values
     DD_SITE_URL=(str, 'http://localhost:8080'),
     DD_DEBUG=(bool, False),


### PR DESCRIPTION
Follow the security recommendation for Kubernetes deployments: https://django-environ.readthedocs.io/en/latest/tips.html#docker-style-file-based-variables


Local test:

```diff
diff --git a/docker-compose.override.debug.yml b/docker-compose.override.debug.yml
index 40bb4e4c3..2c651eff1 100644
--- a/docker-compose.override.debug.yml
+++ b/docker-compose.override.debug.yml
@@ -8,8 +8,12 @@ services:
     environment:
       DD_DEBUG: 'True'
       DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
-      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
+      DD_ADMIN_PASSWORD_FILE: "/run/secrets/dd_admin_password"
       DD_EMAIL_URL: "smtp://mailhog:1025"
+      DD_SECRET_KEY_FILE: "/run/secrets/dd_secret_key"
+    secrets:
+      - dd_admin_password
+      - dd_secret_key
     ports:
       - target: ${DD_DEBUG_PORT:-3000}
         published: ${DD_DEBUG_PORT:-3000}
@@ -20,7 +24,16 @@ services:
       - '.:/app:z'
     environment:
       DD_EMAIL_URL: "smtp://mailhog:1025"
+      DD_SECRET_KEY_FILE: "/run/secrets/dd_secret_key"
+    secrets:
+      - dd_admin_password
+      - dd_secret_key
   celerybeat:
+    environment:
+      DD_SECRET_KEY_FILE: "/run/secrets/dd_secret_key"
+    secrets:
+      - dd_admin_password
+      - dd_secret_key
     volumes:
       - '.:/app:z'
   initializer:
@@ -28,7 +41,11 @@ services:
       - '.:/app:z'
     environment:
       DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
-      DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
+      DD_ADMIN_PASSWORD_FILE: "/run/secrets/dd_admin_password"
+      DD_SECRET_KEY_FILE: "/run/secrets/dd_secret_key"
+    secrets:
+      - dd_admin_password
+      - dd_secret_key
   nginx:
     volumes:
       - './dojo/static/dojo:/usr/share/nginx/html/static/dojo
'
@@ -57,3 +74,8 @@ services:
         published: 8025
         protocol: tcp
         mode: host
+secrets:
+  dd_admin_password:
+    file: ./secrets/admin_password
+  dd_secret_key:
+    file: ./secrets/secret_key
diff --git a/secrets/admin_password b/secrets/admin_password
new file mode 100644
index 000000000..b3d42a4e5
--- /dev/null
+++ b/secrets/admin_password
@@ -0,0 +1 @@
+thisIsMyPassword
\ No newline at end of file
diff --git a/secrets/secret_key b/secrets/secret_key
new file mode 100644
index 000000000..627d4834b
--- /dev/null
+++ b/secrets/secret_key
@@ -0,0 +1 @@
+thisIsMySecretKey
\ No newline at end of file
```

```python
$ docker exec -it django-defectdojo-uwsgi-1 ./manage.py shell
...
>>> from django.conf import settings
>>> settings.SECRET_KEY
'thisIsMySecretKey'
```

```shell
curl -X 'POST' 'http://localhost:8080/api/v2/api-token-auth/' -H 'Content-Type: application/json' \
  -d '{"username": "admin","password": "thisIsMyPassword"}'
{"token":"9df486ed37c82ccd4df82fb05270135839dfa232"}%       
```