### PR TITLE
Fix for vulns not included in host/endpoint views after reopening

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1716,7 +1716,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False
@@ -1731,7 +1730,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False
@@ -1786,7 +1784,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False,
@@ -1802,7 +1799,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False,


### PR DESCRIPTION
Fix for vulnerabilities not included in host/endpoint views after reopening. More info: https://github.com/DefectDojo/django-DefectDojo/issues/8450

After commenting the lines on test environment, vulnerabilities that were reopened are properly shown on endpoint and host view. I was trying to find out how "status_finding__mitigated" filter works but couldn't find it. In my opinion it is not necessary to check it when "mitigated__isnull" filter is also verified.