### PR TITLE
Add subcomponent labels for celery beat and worker helm templates

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ $fullName }}-celery-beat
   labels:
     defectdojo.org/component: celery
+    defectdojo.org/subcomponent: beat
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ $fullName }}-celery-worker
   labels:
     defectdojo.org/component: celery
+    defectdojo.org/subcomponent: worker
     app.kubernetes.io/name: {{ include "defectdojo.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}


### PR DESCRIPTION
This can be useful to use pod affinity/antiaffinity for celery components.
