### PR TITLE
[ENHANCEMENT] Allow filtering Products and Engagements on unset properties

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -725,7 +725,7 @@ class EngagementDirectFilter(DojoFilter):
         queryset=Product_Type.objects.none(),
         label="Product Type")
     test__engagement__product__lifecycle = MultipleChoiceFilter(
-        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle')
+        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle', null_label='Unknown')
     status = MultipleChoiceFilter(choices=ENGAGEMENT_STATUS_CHOICES,
                                               label="Status")
 
@@ -791,7 +791,7 @@ class EngagementFilter(DojoFilter):
         queryset=Product_Type.objects.none(),
         label="Product Type")
     engagement__product__lifecycle = MultipleChoiceFilter(
-        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle')
+        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle', null_label='Unknown')
     engagement__status = MultipleChoiceFilter(choices=ENGAGEMENT_STATUS_CHOICES,
                                               label="Status")
 
@@ -947,10 +947,10 @@ class ProductFilter(DojoFilter):
     prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.none(),
         label="Product Type")
-    business_criticality = MultipleChoiceFilter(choices=Product.BUSINESS_CRITICALITY_CHOICES)
-    platform = MultipleChoiceFilter(choices=Product.PLATFORM_CHOICES)
-    lifecycle = MultipleChoiceFilter(choices=Product.LIFECYCLE_CHOICES)
-    origin = MultipleChoiceFilter(choices=Product.ORIGIN_CHOICES)
+    business_criticality = MultipleChoiceFilter(choices=Product.BUSINESS_CRITICALITY_CHOICES, null_label="Unknown")
+    platform = MultipleChoiceFilter(choices=Product.PLATFORM_CHOICES, null_label="Unknown")
+    lifecycle = MultipleChoiceFilter(choices=Product.LIFECYCLE_CHOICES, null_label="Unknown")
+    origin = MultipleChoiceFilter(choices=Product.ORIGIN_CHOICES, null_label="Unknown")
     external_audience = BooleanFilter(field_name='external_audience')
     internet_accessible = BooleanFilter(field_name='internet_accessible')
 

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -725,7 +725,7 @@ class EngagementDirectFilter(DojoFilter):
         queryset=Product_Type.objects.none(),
         label="Product Type")
     test__engagement__product__lifecycle = MultipleChoiceFilter(
-        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle', null_label='Unknown')
+        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle', null_label='Empty')
     status = MultipleChoiceFilter(choices=ENGAGEMENT_STATUS_CHOICES,
                                               label="Status")
 
@@ -791,7 +791,7 @@ class EngagementFilter(DojoFilter):
         queryset=Product_Type.objects.none(),
         label="Product Type")
     engagement__product__lifecycle = MultipleChoiceFilter(
-        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle', null_label='Unknown')
+        choices=Product.LIFECYCLE_CHOICES, label='Product lifecycle', null_label='Empty')
     engagement__status = MultipleChoiceFilter(choices=ENGAGEMENT_STATUS_CHOICES,
                                               label="Status")
 
@@ -947,10 +947,10 @@ class ProductFilter(DojoFilter):
     prod_type = ModelMultipleChoiceFilter(
         queryset=Product_Type.objects.none(),
         label="Product Type")
-    business_criticality = MultipleChoiceFilter(choices=Product.BUSINESS_CRITICALITY_CHOICES, null_label="Unknown")
-    platform = MultipleChoiceFilter(choices=Product.PLATFORM_CHOICES, null_label="Unknown")
-    lifecycle = MultipleChoiceFilter(choices=Product.LIFECYCLE_CHOICES, null_label="Unknown")
-    origin = MultipleChoiceFilter(choices=Product.ORIGIN_CHOICES, null_label="Unknown")
+    business_criticality = MultipleChoiceFilter(choices=Product.BUSINESS_CRITICALITY_CHOICES, null_label="Empty")
+    platform = MultipleChoiceFilter(choices=Product.PLATFORM_CHOICES, null_label="Empty")
+    lifecycle = MultipleChoiceFilter(choices=Product.LIFECYCLE_CHOICES, null_label="Empty")
+    origin = MultipleChoiceFilter(choices=Product.ORIGIN_CHOICES, null_label="Empty")
     external_audience = BooleanFilter(field_name='external_audience')
     internet_accessible = BooleanFilter(field_name='internet_accessible')
 


### PR DESCRIPTION
This merge request introduces an "Unknown" option to the existing filters in Product and Engagement lists for:
* Product lifecycle,
* Business Criticality,
* Platform, 
* Origin.

This is how it looks like:

![Screenshot_2023-11-29_18-16-16](https://github.com/DefectDojo/django-DefectDojo/assets/981572/59a669ae-6917-4e73-a9e7-5f9e4a702545)

It follows the scheme already used in other filters, like the boolean ones:

![Screenshot_2023-11-29_17-48-40](https://github.com/DefectDojo/django-DefectDojo/assets/981572/bd891c90-f3a2-4f1e-b135-85572fb3560e)