### PR TITLE
Add logging statement for failed password reset validation logic

### DIFF
--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -8,7 +8,7 @@ cd /app
 
 DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
-if [ ${DD_DEBUG} == "True" ]; then
+if [ ${DD_DEBUG} = "True" ]; then
   echo "Debug mode enabled, reducing # of processes and threads to 1"
   DD_UWSGI_NUM_OF_PROCESSES=1
   DD_UWSGI_NUM_OF_THREADS=1

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -643,7 +643,8 @@ class DojoPasswordResetForm(PasswordResetForm):
             if isinstance(connection, EmailBackend):
                 connection.open()
                 connection.close()
-        except Exception:
+        except Exception as e:
+            logger.error(f"SMTP Server Connection Failure: {str(e)}")
             raise ValidationError("SMTP server is not configured correctly...")
 
 


### PR DESCRIPTION
Add some error logging to SMTP server failures when attempting to reset user password

```
[01/Dec/2023 03:15:20] ERROR [dojo.user.views:647] SMTP Server Connection Failure: [Errno 111] Connection refused
```

<!--[sc-3459]-->