### PR TITLE
Finding Template: Correct save ordering

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -2303,10 +2303,10 @@ def add_template(request):
             template.numerical_severity = Finding.get_numerical_severity(
                 template.severity
             )
+            template.save()
             finding_helper.save_vulnerability_ids_template(
                 template, form.cleaned_data["vulnerability_ids"].split()
             )
-            template.save()
             form.save_m2m()
             count = apply_cwe_mitigation(
                 form.cleaned_data["apply_to_findings"], template


### PR DESCRIPTION
Corrects the order of object saves to prevent the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/authorization/authorization_decorators.py", line 45, in _wrapped
    return func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/finding/views.py", line 2081, in add_template
    finding_helper.save_vulnerability_ids_template(
  File "/app/dojo/finding/helper.py", line 660, in save_vulnerability_ids_template
    Vulnerability_Id_Template(finding_template=finding_template, vulnerability_id=vulnerability_id).save()
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 768, in save
    self._prepare_related_fields_for_save(operation_name="save")
  File "/usr/local/lib/python3.11/site-packages/django/db/models/base.py", line 1079, in _prepare_related_fields_for_save
    raise ValueError(
ValueError: save() prohibited to prevent data loss due to unsaved related object 'finding_template'.
```

<!--[sc-3460]-->