### PR TITLE
Correct SLA filter for Finding API

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1247,7 +1247,7 @@ class ApiFindingFilter(DojoFilter):
         help_text='Comma separated list of exact tags not present on product',
         exclude='True')
     has_tags = BooleanFilter(field_name='tags', lookup_expr='isnull', exclude=True, label='Has tags')
-    outside_of_sla = extend_schema_field(OpenApiTypes.NUMBER)(ProductSLAFilter())
+    outside_of_sla = extend_schema_field(OpenApiTypes.NUMBER)(FindingSLAFilter())
 
     o = OrderingFilter(
         # tuple-mapping retains order


### PR DESCRIPTION
Correct stack trace:
```
[04/Dec/2023 10:57:38] ERROR [dojo.api_v2.exception_handler:36] 'Product' object has no attribute 'burprawrequestresponse_set'
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "build/bdist.linux-x86_64/egg/pro_enhancements/finding/api/views.py", line 46, in list
  File "/usr/local/lib/python3.11/site-packages/drf_spectacular/drainage.py", line 193, in wrapped_method
    return method(self, request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/api_v2/prefetch/mixins.py", line 21, in list
    results.append(serializer.to_representation(entry))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/fields.py", line 1838, in to_representation
    return method(value)
           ^^^^^^^^^^^^^
  File "/app/dojo/api_v2/serializers.py", line 1787, in get_request_response
    burp_req_resp = obj.burprawrequestresponse_set.all()
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Product' object has no attribute 'burprawrequestresponse_set'
[04/Dec/2023 10:57:38] ERROR [django.request:241] Internal Server Error: /api/v2/findings/
```