### PR TITLE
Fix DeprecationWarnings

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2563,7 +2563,7 @@ class Finding(models.Model):
 
         # Make sure that we have a cwe if we need one
         if self.cwe == 0 and not self.test.hash_code_allows_null_cwe:
-            deduplicationLogger.warn(
+            deduplicationLogger.warning(
                 "Cannot compute hash_code based on configured fields because cwe is 0 for finding of title '" + self.title + "' found in file '" + str(self.file_path) +
                 "'. Fallback to legacy mode for this finding.")
             return self.compute_hash_code_legacy()

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -137,8 +137,6 @@ class ImportReimportMixin(object):
         # no notes expected
         self.assertEqual(notes_count_before, self.db_notes_count())
 
-        return test_id
-
     # import zap scan, testing:
     # - import
     # - active/verifed = False
@@ -179,8 +177,6 @@ class ImportReimportMixin(object):
         # no notes expected
         self.assertEqual(notes_count_before, self.db_notes_count())
 
-        return test_id
-
     # Test Scan_Date logic for Import. Reimport without a test_id cannot work for UI, so those tests are only in the API class below.
 
     # import zap scan without dates
@@ -199,8 +195,6 @@ class ImportReimportMixin(object):
         date = findings['results'][0]['date']
         self.assertEqual(date, str(timezone.localtime(timezone.now()).date()))
 
-        return test_id
-
     # import acunetix scan with dates
     # - import
     # - no scan scan_date does not overrides date set by parser
@@ -216,8 +210,6 @@ class ImportReimportMixin(object):
         # Get the date
         date = findings['results'][0]['date']
         self.assertEqual(date, '2018-09-24')
-
-        return test_id
 
     # import zap scan without dates
     # - import
@@ -235,8 +227,6 @@ class ImportReimportMixin(object):
         date = findings['results'][0]['date']
         self.assertEqual(date, '2006-12-26')
 
-        return test_id
-
     # import acunetix scan with dates
     # - import
     # - set scan_date overrides date set by parser
@@ -252,8 +242,6 @@ class ImportReimportMixin(object):
         # Get the date
         date = findings['results'][0]['date']
         self.assertEqual(date, '2006-12-26')
-
-        return test_id
 
     # Test Scan_Date for reimport in UI. UI can only rupload for existing tests, non UI tests are in API class below
 
@@ -345,8 +333,6 @@ class ImportReimportMixin(object):
         # no notes expected
         self.assertEqual(notes_count_before, self.db_notes_count())
 
-        return test_id
-
     # Test re-import with unique_id_from_tool_or_hash_code algorithm
     # import veracode scan, testing:
     # - import
@@ -367,8 +353,6 @@ class ImportReimportMixin(object):
 
         # no notes expected
         self.assertEqual(notes_count_before, self.db_notes_count())
-
-        return test_id
 
     # import veracode and then reimport veracode again
     # - reimport, findings stay the same, stay active
@@ -1680,8 +1664,6 @@ class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):
         date = findings['results'][0]['date']
         self.assertEqual(date, str(timezone.localtime(timezone.now()).date()))
 
-        return test_id
-
     # reimport acunetix scan with dates (non existing test, so import is called inside DD)
     # - reimport
     # - deafult scan_date (today) does not overrides date set by parser
@@ -1698,8 +1680,6 @@ class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):
         # Get the date
         date = findings['results'][0]['date']
         self.assertEqual(date, '2018-09-24')
-
-        return test_id
 
     # reimport zap scan without dates (non existing test, so import is called inside DD)
     # - reimport
@@ -1718,8 +1698,6 @@ class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):
         date = findings['results'][0]['date']
         self.assertEqual(date, '2006-12-26')
 
-        return test_id
-
     # reimport acunetix scan with dates (non existing test, so import is called inside DD)
     # - reimport
     # - set scan_date overrides date set by parser
@@ -1736,8 +1714,6 @@ class ImportReimportTestAPI(DojoAPITestCase, ImportReimportMixin):
         # Get the date
         date = findings['results'][0]['date']
         self.assertEqual(date, '2006-12-26')
-
-        return test_id
 
 
 class ImportReimportTestUI(DojoAPITestCase, ImportReimportMixin):

--- a/unittests/test_jira_import_and_pushing_api.py
+++ b/unittests/test_jira_import_and_pushing_api.py
@@ -72,14 +72,12 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         test_id = import0['test']
         self.assert_jira_issue_count_in_test(test_id, 0)
         self.assert_jira_group_issue_count_in_test(test_id, 0)
-        return test_id
 
     def test_import_with_push_to_jira_is_false(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=False, verified=True)
         test_id = import0['test']
         self.assert_jira_issue_count_in_test(test_id, 0)
         self.assert_jira_group_issue_count_in_test(test_id, 0)
-        return test_id
 
     def test_import_with_push_to_jira(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=True, verified=True)
@@ -88,7 +86,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 0)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_groups_push_to_jira(self):
         # 7 findings, 5 unique component_name+component_version
@@ -99,7 +96,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 3)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_push_to_jira_epic_as_issue_type(self):
         jira_instance = JIRA_Instance.objects.get(id=2)
@@ -113,7 +109,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 0)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_no_push_to_jira_but_push_all(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -123,7 +118,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 0)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_groups_no_push_to_jira_but_push_all(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -133,7 +127,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 3)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_push_to_jira_is_false_but_push_all(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -143,7 +136,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 0)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_groups_with_push_to_jira_is_false_but_push_all(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -153,7 +145,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 3)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_no_push_to_jira_reimport_no_push_to_jira(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, verified=True)
@@ -164,7 +155,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         reimport = self.reimport_scan_with_params(test_id, self.zap_sample5_filename, verified=True)
         self.assert_jira_issue_count_in_test(test_id, 0)
         self.assert_jira_group_issue_count_in_test(test_id, 0)
-        return test_id
 
     def test_import_no_push_to_jira_reimport_push_to_jira_false(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, verified=True)
@@ -175,7 +165,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         reimport = self.reimport_scan_with_params(test_id, self.zap_sample5_filename, push_to_jira=False, verified=True)
         self.assert_jira_issue_count_in_test(test_id, 0)
         self.assert_jira_group_issue_count_in_test(test_id, 0)
-        return test_id
 
     def test_import_no_push_to_jira_reimport_with_push_to_jira(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, verified=True)
@@ -188,7 +177,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 0)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_groups_no_push_to_jira_reimport_with_push_to_jira(self):
         import0 = self.import_scan_with_params(self.npm_groups_sample_filename, scan_type='NPM Audit Scan', group_by='component_name+component_version', verified=True)
@@ -201,7 +189,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 3)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_no_push_to_jira_reimport_no_push_to_jira_but_push_all_issues(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -215,7 +202,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 0)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_groups_no_push_to_jira_reimport_no_push_to_jira_but_push_all_issues(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -229,7 +215,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_group_issue_count_in_test(test_id, 3)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_no_push_to_jira_reimport_push_to_jira_is_false_but_push_all_issues(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -246,7 +231,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         # self.assert_jira_updated_map_changed(test_id, updated_map)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_groups_no_push_to_jira_reimport_push_to_jira_is_false_but_push_all_issues(self):
         self.set_jira_push_all_issues(self.get_engagement(1))
@@ -264,7 +248,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assert_jira_updated_map_unchanged(test_id, updated_map)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_push_to_jira_reimport_with_push_to_jira(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=True, verified=True)
@@ -283,7 +266,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         # self.assert_jira_updated_change(pre_jira_status, post_jira_status)
         # by asserting full cassette is played we know issues have been updated in JIRA
         self.assert_cassette_played()
-        return test_id
 
     def test_import_twice_push_to_jira(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=True, verified=True)
@@ -492,7 +474,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assertEqual(len(self.get_jira_comments(finding_id)), 1)
         # by asserting full cassette is played we know all calls to JIRA have been made as expected
         self.assert_cassette_played()
-        return test_id
 
     def test_import_add_comments_then_push_to_jira(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=False, verified=True)
@@ -512,7 +493,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.assertEqual(len(self.get_jira_comments(finding_id)), 2)
         # by asserting full cassette is played we know all calls to JIRA have been made as expected
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_push_to_jira_add_tags(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=True, verified=True)
@@ -538,7 +518,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
 
         # by asserting full cassette is played we know all calls to JIRA have been made as expected
         self.assert_cassette_played()
-        return test_id
 
     def test_import_with_push_to_jira_update_tags(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, push_to_jira=True, verified=True)
@@ -576,7 +555,6 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
 
         # by asserting full cassette is played we know all calls to JIRA have been made as expected
         self.assert_cassette_played()
-        return test_id
 
     def test_engagement_epic_creation(self):
         eng = self.get_engagement(3)

--- a/unittests/tools/test_stackhawk_parser.py
+++ b/unittests/tools/test_stackhawk_parser.py
@@ -240,7 +240,7 @@ class TestStackHawkParser(DojoTestCase):
         self.assertEqual(severity, actual_finding.severity)
         self.assertEqual("View this finding in the StackHawk platform at:\n[" + finding_url + '](' + finding_url + ')',
                          actual_finding.description)
-        self.assertRegexpMatches(
+        self.assertRegex(
             actual_finding.steps_to_reproduce,
             "Use a specific message link and click 'Validate' to see the cURL!.*"
         )


### PR DESCRIPTION
- /app/dojo/models.py:2566: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
- ... DeprecationWarning: It is deprecated to return a value that is not None from a test case
- /app/unittests/tools/test_stackhawk_parser.py:243: DeprecationWarning: Please use assertRegex instead.
