### PR TITLE
API: replace local swagger (drf-yasg -> sidecar)

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -791,8 +791,8 @@ SPECTACULAR_SETTINGS = {
 }
 
 if not env('DD_DEFAULT_SWAGGER_UI'):
-    SPECTACULAR_SETTINGS['SWAGGER_UI_DIST'] = f'{STATIC_URL}drf-yasg/swagger-ui-dist'
-    SPECTACULAR_SETTINGS['SWAGGER_UI_FAVICON_HREF'] = f'{STATIC_URL}drf-yasg/swagger-ui-dist/favicon-32x32.png'
+    SPECTACULAR_SETTINGS['SWAGGER_UI_DIST'] = 'SIDECAR'
+    SPECTACULAR_SETTINGS['SWAGGER_UI_FAVICON_HREF'] = 'SIDECAR'
 
 # ------------------------------------------------------------------------------
 # TEMPLATES
@@ -848,6 +848,7 @@ INSTALLED_APPS = (
     'social_django',
     'drf_yasg',
     'drf_spectacular',
+    'drf_spectacular_sidecar',  # required for Django collectstatic discovery
     'tagulous',
     'fontawesomefree'
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,6 +74,7 @@ hyperlink==21.0.0
 django-test-migrations==1.3.0
 djangosaml2==1.8.0
 drf-spectacular==0.27.0
+drf-spectacular-sidecar==2023.12.1
 django-ratelimit==4.1.0
 argon2-cffi==23.1.0
 blackduck==1.1.0


### PR DESCRIPTION
The first step to removal of drf-yasg

If somebody uses `DD_DEFAULT_SWAGGER_UI=False` (a.k.a. do not load swagger from CDN but from static resources), this will not point the user to drf-yasg statics but to drf_spectacular_sidecar.

Tested locally.

Inspired by https://drf-spectacular.readthedocs.io/en/latest/readme.html#self-contained-ui-installation