### PR TITLE
Revert Docker Compose version guidance

### DIFF
--- a/readme-docs/DOCKER.md
+++ b/readme-docs/DOCKER.md
@@ -418,9 +418,7 @@ OpenSSL version: OpenSSL 1.0.1t  3 May 2016
 
 In this case, both docker (version 17.09.0-ce) and docker-compose (1.18.0) need to be updated.
 
-**NOTE** - Docker Compose version 2.19.0 and greater includes syntax restrictions that are not compatible with our compose files.  As a temporary workaround while a more complete solution is determined, please do not update docker compose to a version greater than 2.18.1.
-
-Follow [Dockers' documentation](https://docs.docker.com/install/) for your OS to get the latest version of Docker* (see above Note). For the docker command, most OSes have a built-in update mechanism like "apt upgrade".
+Follow [Docker's documentation](https://docs.docker.com/install/) for your OS to get the latest version of Docker. For the docker command, most OSes have a built-in update mechanism like "apt upgrade".
 
 Docker Compose isn't packaged like Docker and you'll need to manually update an existing install if using Linux. For Linux, either follow the instructions in the [Docker Compose documentation](https://docs.docker.com/compose/install/) or use the shell script below. The script below will update docker-compose to the latest version automatically. You will need to make the script executable and have sudo privileges to upgrade docker-compose:
 


### PR DESCRIPTION
**Description**

Reverting the guidance we previously issued regarding versions of Docker Compose greater than 2.18.1. The original issue (#8303) has been resolved by PR #8598 from @kiblik. 

**Test results**

```sh
$ docker compose version
Docker Compose version v2.22.0-desktop.2

$ ./dc-up-d.sh
Checking docker compose version
Supported docker compose version
No profile supplied, running default: postgres-redis
Other supported profiles:
          postgres-redis*
          postgres-rabbitmq
          mysql-redis
          mysql-rabbitmq

        Usage example: ./dc-up-d.sh mysql-rabbitmq

Starting docker compose with profile postgres-redis in the background ...

...

[+] Running 10/10
 ✔ Network django-defectdojo_default                                                                                                                      Created             0.0s
 ✔ Container django-defectdojo-redis-1                                                                                                                    Started             0.0s
 ✔ Container django-defectdojo-mailhog-1                                                                                                                  Started             0.0s
 ✔ Container django-defectdojo-postgres-1                                                                                                                 Started             0.0s
 ! mailhog The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                     0.0s
 ✔ Container django-defectdojo-celerybeat-1                                                                                                               Started             0.0s
 ✔ Container django-defectdojo-initializer-1                                                                                                              Started             0.0s
 ✔ Container django-defectdojo-celeryworker-1                                                                                                             Started             0.0s
 ✔ Container django-defectdojo-uwsgi-1                                                                                                                    Started             0.0s
 ✔ Container django-defectdojo-nginx-1                                                                                                                    Started             0.0s
```

[sc-1639]