### PR TITLE
Updated actions/labeler version, labeler.yml format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,39 +1,62 @@
+---
 docs:
-- docs/**/*
-- readme-docs/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - docs/**/*
+      - readme-docs/**/*
 
 docker:
-- docker/**/*
-- docker**
-- Docker*
+  - changed-files:
+    - any-glob-to-any-file:
+      - docker/**/*
+      - docker**
+      - Docker*
 
 helm:
-- helm/defectdojo/*
-- helm/defectdojo/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - helm/defectdojo/*
+      - helm/defectdojo/**/*
 
 "New Migration":
-- dojo/db_migrations/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - dojo/db_migrations/*
 
 unittests:
-- unittests/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - unittests/**/*
 
 integration_tests:
-- tests/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - tests/**/*
 
 settings_changes:
-- dojo/settings/settings.dist.py
+  - changed-files:
+    - any-glob-to-any-file:
+      - dojo/settings/settings.dist.py
 
 apiv2:
-- dojo/api_v2/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - dojo/api_v2/**/*
 
 ui:
-  - dojo/static/**/*
-  - dojo/templates/**/*
-  - dojo/templatetags/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - dojo/static/**/*
+      - dojo/templates/**/*
+      - dojo/templatetags/**/*
 
 parser:
-  - dojo/tools/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - dojo/tools/**/*
 
 localization:
-  - dojo/locale/*
-  - dojo/locale/**/*
+  - changed-files:
+    - any-glob-to-any-file:
+      - dojo/locale/*
+      - dojo/locale/**/*

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     name: "Autolabeler"
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,6 +12,6 @@ jobs:
     name: "Autolabeler"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**Description**

Making changes to the `labeler.yml` file to upgrade to [`v5` of the labeler action](https://github.com/actions/labeler/releases/tag/v5.0.0), which requires a new format.

See the docs here for more details: https://github.com/actions/labeler#match-object

[sc-3543]