### PR TITLE
Docs: "Create upgrade notes to documentation" only once

### DIFF
--- a/.github/workflows/release-3-master-into-dev.yml
+++ b/.github/workflows/release-3-master-into-dev.yml
@@ -70,7 +70,7 @@ jobs:
           There are no special instructions for upgrading to $minorv.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/$patchv) for the contents of the release.
           " > docs/content/en/getting_started/upgrading/$minorv.md
           git add docs/content/en/getting_started/upgrading/$minorv.md
-        if: endsWith(github.event.inputs.release_number_dev, '.0-dev')
+        if: endsWith(github.event.inputs.release_number_new, '.0') && endsWith(github.event.inputs.release_number_dev, '.0-dev')
 
       - name: Push version changes
         uses: stefanzweifel/git-auto-commit-action@v5.0.0


### PR DESCRIPTION
Any update of the timestamp in the release-note file every time is not necessary.
First "after release" change is enough.

This kind of change is useless:
https://github.com/DefectDojo/django-DefectDojo/pull/9143/files#diff-99337e27a744dd0c3795c83c1dc92a777e26911585e1707eceeff96d61ffad57R4