### PR TITLE
Pinning of django versions into a helm release

### DIFF
--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -56,6 +56,16 @@ jobs:
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
       
+            - name: Add yq
+        uses: mikefarah/yq@master
+
+      - name: Pin version docker version
+        id: pin_image
+        run: |-
+          yq --version
+          yq -i '.tag="${{ github.event.inputs.release_number }}"'  helm/defectdojo/values.yaml
+          echo "Current image tag:`yq -r '.tag' helm/defectdojo/values.yaml`"
+
       - name: Package Helm chart
         id: package-helm-chart
         run: |

--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -1,3 +1,4 @@
+---
 name: "release-X: Release helm chart"
 
 env:

--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -56,7 +56,7 @@ jobs:
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo
       
-            - name: Add yq
+      - name: Add yq
         uses: mikefarah/yq@master
 
       - name: Pin version docker version


### PR DESCRIPTION
- Pinning of django images during a release. 
- fix to show the real name of "release-X: Release helm chart" in the list of actions 