### PR TITLE
Django Admin pages for editing Notifications

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3837,6 +3837,18 @@ class Notifications(models.Model):
                 result.risk_acceptance_expiration = merge_sets_safe(result.risk_acceptance_expiration, notifications.risk_acceptance_expiration)
 
         return result
+    
+    def __str__(self):
+        return f"Notifications about {self.product or 'all projects'} for {self.user}"
+
+
+class NotificationsAdmin(admin.ModelAdmin):
+    list_filter = ('user', 'product')
+
+    def get_list_display(self, request):
+        list_fields = ['user', 'product']
+        list_fields += [field.name for field in self.model._meta.fields if field.name not in list_fields]
+        return list_fields
 
 
 class Tool_Product_Settings(models.Model):
@@ -4414,7 +4426,7 @@ admin.site.register(BurpRawRequestResponse)
 admin.site.register(Announcement)
 admin.site.register(UserAnnouncement)
 admin.site.register(BannerConf)
-admin.site.register(Notifications)
+admin.site.register(Notifications, NotificationsAdmin)
 admin.site.register(Tool_Product_History)
 admin.site.register(General_Survey)
 admin.site.register(Test_Import)

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3837,7 +3837,7 @@ class Notifications(models.Model):
                 result.risk_acceptance_expiration = merge_sets_safe(result.risk_acceptance_expiration, notifications.risk_acceptance_expiration)
 
         return result
-    
+
     def __str__(self):
         return f"Notifications about {self.product or 'all projects'} for {self.user}"
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3839,7 +3839,7 @@ class Notifications(models.Model):
         return result
 
     def __str__(self):
-        return f"Notifications about {self.product or 'all projects'} for {self.user}"
+        return f"Notifications about {self.product or 'all projects'} for {self.user or 'system notifications'}"
 
 
 class NotificationsAdmin(admin.ModelAdmin):


### PR DESCRIPTION
**Description**

This customizes the built-in (and enabled by default) Django Admin interface, and adds a visual way to add, remove, and modify notifications in DefectDojo.

This is a workaround for #9192.

This is how the notification list will look like:

![Screenshot_2023-12-19_13-15-12](https://github.com/DefectDojo/django-DefectDojo/assets/981572/e0557d91-3d97-4bb1-8eb5-d65b30fd973a)

This is how the a single notification editor will look like:

![Screenshot_2023-12-19_13-21-51](https://github.com/DefectDojo/django-DefectDojo/assets/981572/b3c7f0a6-2ea1-4604-aae9-cbeb81cc0a63)


**Test results**

Tested manually.

**Documentation**

Django Admin functionality is not described in the documentation.