### PR TITLE
Feature: Add Auditlog Retention and Cleanup

### DIFF
--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -171,6 +171,54 @@
     }
   },
   {
+    "model": "auditlog.logentry",
+    "pk": 803,
+    "fields": {
+      "content_type": 28,
+      "object_pk": "1",
+      "object_id": 1,
+      "object_repr": "BodgeIt",
+      "action": 0,
+      "changes": "{\"product\": [\"None\", \"dojo.Cred_Mapping.None\"], \"product_meta\": [\"None\", \"dojo.DojoMeta.None\"], \"name\": [\"None\", \"BodgeIt\"], \"description\": [\"None\", \"[Features](https://github.com/psiinon/bodgeit) and characteristics:\\r\\n\\r\\n* Easy to install - just requires java and a servlet engine, e.g. Tomcat\\r\\n* Self contained (no additional dependencies other than to 2 in the above line)\\r\\n* Easy to change on the fly - all the functionality is implemented in JSPs, so no IDE required\\r\\n* Cross platform\\r\\n* Open source\\r\\n* No separate db to install and configure - it uses an 'in memory' db that is automatically (re)initialized on start up\"], \"product_manager\": [\"None\", \"(admin)\"], \"technical_contact\": [\"None\", \"(user2)\"], \"team_manager\": [\"None\", \"(product_manager)\"], \"prod_type\": [\"None\", \"Commerce\"], \"id\": [\"None\", \"1\"], \"tid\": [\"None\", \"0\"], \"prod_numeric_grade\": [\"None\", \"5\"], \"business_criticality\": [\"None\", \"high\"], \"platform\": [\"None\", \"web\"], \"lifecycle\": [\"None\", \"production\"], \"origin\": [\"None\", \"internal\"], \"user_records\": [\"None\", \"1000000000\"], \"revenue\": [\"None\", \"1000.00\"], \"external_audience\": [\"None\", \"True\"], \"internet_accessible\": [\"None\", \"True\"], \"enable_simple_risk_acceptance\": [\"None\", \"False\"], \"enable_full_risk_acceptance\": [\"None\", \"True\"]}",
+      "actor": null,
+      "remote_addr": null,
+      "timestamp": "2021-10-22T01:24:54.921Z",
+      "additional_data": null
+      }
+    },
+    {
+      "model": "auditlog.logentry",
+      "pk": 804,
+      "fields": {
+        "content_type": 28,
+        "object_pk": "2",
+        "object_id": 2,
+        "object_repr": "Internal CRM App",
+        "action": 0,
+        "changes": "{\"product\": [\"None\", \"dojo.Cred_Mapping.None\"], \"product_meta\": [\"None\", \"dojo.DojoMeta.None\"], \"name\": [\"None\", \"Internal CRM App\"], \"description\": [\"None\", \"* New product in development that attempts to follow all best practices\"], \"product_manager\": [\"None\", \"(product_manager)\"], \"technical_contact\": [\"None\", \"(product_manager)\"], \"team_manager\": [\"None\", \"(user2)\"], \"prod_type\": [\"None\", \"Commerce\"], \"id\": [\"None\", \"2\"], \"tid\": [\"None\", \"0\"], \"business_criticality\": [\"None\", \"medium\"], \"platform\": [\"None\", \"web\"], \"lifecycle\": [\"None\", \"construction\"], \"origin\": [\"None\", \"internal\"], \"external_audience\": [\"None\", \"False\"], \"internet_accessible\": [\"None\", \"False\"], \"enable_simple_risk_acceptance\": [\"None\", \"False\"], \"enable_full_risk_acceptance\": [\"None\", \"True\"]}",
+        "actor": null,
+        "remote_addr": null,
+        "timestamp": "2021-10-22T01:24:55.044Z",
+        "additional_data": null
+      }
+    },
+    {
+      "model": "auditlog.logentry",
+      "pk": 805,
+      "fields": {
+        "content_type": 28,
+        "object_pk": "3",
+        "object_id": 3,
+        "object_repr": "Apple Accounting Software",
+        "action": 0,
+        "changes": "{\"product\": [\"None\", \"dojo.Cred_Mapping.None\"], \"product_meta\": [\"None\", \"dojo.DojoMeta.None\"], \"name\": [\"None\", \"Apple Accounting Software\"], \"description\": [\"None\", \"Accounting software is typically composed of various modules, different sections dealing with particular areas of accounting. Among the most common are:\\r\\n\\r\\n**Core modules**\\r\\n\\r\\n* Accounts receivable\\u2014where the company enters money received\\r\\n* Accounts payable\\u2014where the company enters its bills and pays money it owes\\r\\n* General ledger\\u2014the company's \\\"books\\\"\\r\\n* Billing\\u2014where the company produces invoices to clients/customers\"], \"product_manager\": [\"None\", \"(admin)\"], \"technical_contact\": [\"None\", \"(user2)\"], \"team_manager\": [\"None\", \"(user2)\"], \"prod_type\": [\"None\", \"Billing\"], \"id\": [\"None\", \"3\"], \"tid\": [\"None\", \"0\"], \"business_criticality\": [\"None\", \"high\"], \"platform\": [\"None\", \"web\"], \"lifecycle\": [\"None\", \"production\"], \"origin\": [\"None\", \"purchased\"], \"user_records\": [\"None\", \"5000\"], \"external_audience\": [\"None\", \"True\"], \"internet_accessible\": [\"None\", \"False\"], \"enable_simple_risk_acceptance\": [\"None\", \"False\"], \"enable_full_risk_acceptance\": [\"None\", \"True\"]}",
+        "actor": null,
+        "remote_addr": null,
+        "timestamp": "2021-10-22T01:24:55.071Z",
+        "additional_data": null
+      }
+    },
+  {
     "pk": 1,
     "model": "dojo.system_settings",
     "fields": {

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -223,7 +223,8 @@ env = environ.Env(
     DD_EDITABLE_MITIGATED_DATA=(bool, False),
     # new feature that tracks history across multiple reimports for the same test
     DD_TRACK_IMPORT_HISTORY=(bool, True),
-
+    # Delete Auditlogs older than x month; -1 to keep all logs
+    DD_AUDITLOG_FLUSH_RETENTION_PERIOD=(int, 12),
     # Allow grouping of findings in the same test, for example to group findings per dependency
     # DD_FEATURE_FINDING_GROUPS feature is moved to system_settings, will be removed from settings file
     DD_FEATURE_FINDING_GROUPS=(bool, True),
@@ -1130,6 +1131,10 @@ CELERY_BEAT_SCHEDULE = {
         'schedule': timedelta(minutes=1),
         'args': [timedelta(minutes=1)]
     },
+    'flush_auditlog': {
+        'task': 'dojo.tasks.flush_auditlog',
+        'schedule': timedelta(hours=8),
+    },
     'update-findings-from-source-issues': {
         'task': 'dojo.tools.tool_issue_updater.update_findings_from_source_issues',
         'schedule': timedelta(hours=3),
@@ -1704,4 +1709,8 @@ ADDITIONAL_HEADERS = env('DD_ADDITIONAL_HEADERS')
 # Dictates whether cloud banner is created or not
 CREATE_CLOUD_BANNER = env('DD_CREATE_CLOUD_BANNER')
 
+# ------------------------------------------------------------------------------
+# Auditlog
+# ------------------------------------------------------------------------------
+AUDITLOG_FLUSH_RETENTION_PERIOD = env('DD_AUDITLOG_FLUSH_RETENTION_PERIOD')
 ENABLE_AUDITLOG = env('DD_ENABLE_AUDITLOG')

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -224,7 +224,7 @@ env = environ.Env(
     # new feature that tracks history across multiple reimports for the same test
     DD_TRACK_IMPORT_HISTORY=(bool, True),
     # Delete Auditlogs older than x month; -1 to keep all logs
-    DD_AUDITLOG_FLUSH_RETENTION_PERIOD=(int, 12),
+    DD_AUDITLOG_FLUSH_RETENTION_PERIOD=(int, -1),
     # Allow grouping of findings in the same test, for example to group findings per dependency
     # DD_FEATURE_FINDING_GROUPS feature is moved to system_settings, will be removed from settings file
     DD_FEATURE_FINDING_GROUPS=(bool, True),

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -91,7 +91,7 @@ def flush_auditlog(*args, **kwargs):
     try:
         retention_period = settings.AUDITLOG_FLUSH_RETENTION_PERIOD
     except System_Settings.DoesNotExist:
-        retention_period = -1    
+        retention_period = -1
 
     if retention_period < 0:
         logger.info("Flushing auditlog is disabled")

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -90,10 +90,7 @@ def cleanup_alerts(*args, **kwargs):
 
 @app.task(bind=True)
 def flush_auditlog(*args, **kwargs):
-    try:
-        retention_period = settings.AUDITLOG_FLUSH_RETENTION_PERIOD
-    except System_Settings.DoesNotExist:
-        retention_period = -1
+    retention_period = settings.AUDITLOG_FLUSH_RETENTION_PERIOD
 
     if retention_period < 0:
         logger.info("Flushing auditlog is disabled")

--- a/dojo/tasks.py
+++ b/dojo/tasks.py
@@ -1,5 +1,7 @@
 import logging
-from datetime import timedelta
+from auditlog.models import LogEntry
+from datetime import timedelta, date
+from dateutil.relativedelta import relativedelta
 from django.db.models import Count, Prefetch
 from django.conf import settings
 from django.urls import reverse

--- a/unittests/test_flush_auditlog.py
+++ b/unittests/test_flush_auditlog.py
@@ -1,7 +1,7 @@
 from dojo.tasks import flush_auditlog
 from .dojo_test_case import DojoTestCase
 from django.conf import settings
-from auditlog.models import LogEntry, LogEntryManager
+from auditlog.models import LogEntry
 from datetime import date, datetime
 from dojo.models import Finding
 from dateutil.relativedelta import relativedelta
@@ -25,7 +25,7 @@ class TestFlushAuditlog(DojoTestCase):
         flush_auditlog()
         entries_after = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
         # we have three old log entries in our testdata
-        self.assertEqual(entries_before-3, entries_after)
+        self.assertEqual(entries_before - 3, entries_after)
 
     def test_delete_entries_with_retention_period(self):
         settings.AUDITLOG_FLUSH_RETENTION_PERIOD = 1
@@ -33,7 +33,7 @@ class TestFlushAuditlog(DojoTestCase):
         two_weeks_ago = datetime.today() - relativedelta(weeks=2)
         log_entry = LogEntry.objects.log_create(
             instance=Finding.objects.all()[0],
-            timestamp= two_weeks_ago,
+            timestamp=two_weeks_ago,
             changes="foo",
             action=LogEntry.Action.UPDATE,
         )
@@ -42,4 +42,4 @@ class TestFlushAuditlog(DojoTestCase):
         flush_auditlog()
         entries_after = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
         # we have three old log entries in our testdata and added a new one
-        self.assertEqual(entries_before-3+1, entries_after)
+        self.assertEqual(entries_before - 3 + 1, entries_after)

--- a/unittests/test_flush_auditlog.py
+++ b/unittests/test_flush_auditlog.py
@@ -27,8 +27,8 @@ class TestFlushAuditlog(DojoTestCase):
         # we have three old log entries in our testdata
         self.assertEqual(entries_before - 3, entries_after)
 
+    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD = 1)
     def test_delete_entries_with_retention_period(self):
-        settings.AUDITLOG_FLUSH_RETENTION_PERIOD = 1
         entries_before = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
         two_weeks_ago = datetime.today() - relativedelta(weeks=2)
         log_entry = LogEntry.objects.log_create(

--- a/unittests/test_flush_auditlog.py
+++ b/unittests/test_flush_auditlog.py
@@ -1,6 +1,6 @@
 from dojo.tasks import flush_auditlog
 from .dojo_test_case import DojoTestCase
-from django.conf import settings
+from django.test import override_settings
 from auditlog.models import LogEntry
 from datetime import date, datetime
 from dojo.models import Finding

--- a/unittests/test_flush_auditlog.py
+++ b/unittests/test_flush_auditlog.py
@@ -19,8 +19,8 @@ class TestFlushAuditlog(DojoTestCase):
         entries_after = LogEntry.objects.all().count()
         self.assertEqual(entries_before, entries_after)
 
+    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD = 0)
     def test_delete_all_entries(self):
-        settings.AUDITLOG_FLUSH_RETENTION_PERIOD = 0
         entries_before = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
         flush_auditlog()
         entries_after = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()

--- a/unittests/test_flush_auditlog.py
+++ b/unittests/test_flush_auditlog.py
@@ -1,0 +1,45 @@
+from dojo.tasks import flush_auditlog
+from .dojo_test_case import DojoTestCase
+from django.conf import settings
+from auditlog.models import LogEntry, LogEntryManager
+from datetime import date, datetime
+from dojo.models import Finding
+from dateutil.relativedelta import relativedelta
+import logging
+logger = logging.getLogger(__name__)
+
+
+class TestFlushAuditlog(DojoTestCase):
+    fixtures = ['dojo_testdata.json']
+
+    def test_flush_auditlog_disabled(self):
+        settings.AUDITLOG_FLUSH_RETENTION_PERIOD = -1
+        entries_before = LogEntry.objects.all().count()
+        flush_auditlog()
+        entries_after = LogEntry.objects.all().count()
+        self.assertEqual(entries_before, entries_after)
+
+    def test_delete_all_entries(self):
+        settings.AUDITLOG_FLUSH_RETENTION_PERIOD = 0
+        entries_before = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
+        flush_auditlog()
+        entries_after = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
+        # we have three old log entries in our testdata
+        self.assertEqual(entries_before-3, entries_after)
+
+    def test_delete_entries_with_retention_period(self):
+        settings.AUDITLOG_FLUSH_RETENTION_PERIOD = 1
+        entries_before = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
+        two_weeks_ago = datetime.today() - relativedelta(weeks=2)
+        log_entry = LogEntry.objects.log_create(
+            instance=Finding.objects.all()[0],
+            timestamp= two_weeks_ago,
+            changes="foo",
+            action=LogEntry.Action.UPDATE,
+        )
+        log_entry.timestamp = two_weeks_ago
+        log_entry.save()
+        flush_auditlog()
+        entries_after = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
+        # we have three old log entries in our testdata and added a new one
+        self.assertEqual(entries_before-3+1, entries_after)

--- a/unittests/test_flush_auditlog.py
+++ b/unittests/test_flush_auditlog.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 class TestFlushAuditlog(DojoTestCase):
     fixtures = ['dojo_testdata.json']
 
+    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD = -1)
     def test_flush_auditlog_disabled(self):
-        settings.AUDITLOG_FLUSH_RETENTION_PERIOD = -1
         entries_before = LogEntry.objects.all().count()
         flush_auditlog()
         entries_after = LogEntry.objects.all().count()

--- a/unittests/test_flush_auditlog.py
+++ b/unittests/test_flush_auditlog.py
@@ -12,14 +12,14 @@ logger = logging.getLogger(__name__)
 class TestFlushAuditlog(DojoTestCase):
     fixtures = ['dojo_testdata.json']
 
-    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD = -1)
+    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD=-1)
     def test_flush_auditlog_disabled(self):
         entries_before = LogEntry.objects.all().count()
         flush_auditlog()
         entries_after = LogEntry.objects.all().count()
         self.assertEqual(entries_before, entries_after)
 
-    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD = 0)
+    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD=0)
     def test_delete_all_entries(self):
         entries_before = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
         flush_auditlog()
@@ -27,7 +27,7 @@ class TestFlushAuditlog(DojoTestCase):
         # we have three old log entries in our testdata
         self.assertEqual(entries_before - 3, entries_after)
 
-    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD = 1)
+    @override_settings(AUDITLOG_FLUSH_RETENTION_PERIOD=1)
     def test_delete_entries_with_retention_period(self):
         entries_before = LogEntry.objects.filter(timestamp__date__lt=date.today()).count()
         two_weeks_ago = datetime.today() - relativedelta(weeks=2)


### PR DESCRIPTION
**Description**

This PR creates the possiblity to recycle the auditlogs that are generated by DefectDojo.
You can simply specify a retention period in the settings-file DD_AUDITLOG_FLUSH_RETENTION_PERIOD. If you set the value to "-1" the flushing is disabled.

1 Point to highlight is that I explicitly used the raw_delete method since we had a lot of trouble with the performance of the default delete. I also think that it is feasible here, since we do not have external references to the log-entries.

**Test results**

There are 3 more tests added in the unit-tests that should cover the most important points of the new feature (check if disabling works, check if logs are flushed, check if only the logs are flushed that fall into the specified period)


**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.



On behalf of DB Systel GmbH