### PR TITLE
Improve Request Review Notifications

### DIFF
--- a/dojo/templates/notifications/alert/review_requested.tpl
+++ b/dojo/templates/notifications/alert/review_requested.tpl
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed %}
+    User {{ requested_by }} has requested that the following users review the finding "{{ finding }}" for accuracy:
+{% endblocktranslate %}
+
+{% for user in reviewers %}
+    - {{ user.get_full_name }}    
+{% endfor %}
+
+{% blocktranslate trimmed %}
+    {{ note }}
+{% endblocktranslate %}
+
+{% trans "Full details of the finding can be reviewed at" %} {{ url|full_url }}
+
+{% if system_settings.disclaimer and system_settings.disclaimer.strip %}    
+    {% trans "Disclaimer:" %}
+    {{ system_settings.disclaimer }}
+{% endif %}

--- a/dojo/templates/notifications/mail/review_requested.tpl
+++ b/dojo/templates/notifications/mail/review_requested.tpl
@@ -1,0 +1,45 @@
+{% load i18n %}
+{% load navigation_tags %}
+{% load display_tags %}
+<html>
+    <body>
+        {% autoescape on %}
+            <p>
+                {% trans "Hello" %},
+            </p>
+            <p>
+                {% blocktranslate trimmed %}
+                    User {{ requested_by }} has requested that the following users review the finding "{{ finding }}" for accuracy:
+                {% endblocktranslate %}
+                {% for user in reviewers %}
+                    <li>{{ user.get_full_name }}</li>    
+                {% endfor %}
+                <br/>
+                {{ note }}
+                <br/>
+                <br/>
+                It can be reviewed at {{ url|full_url }}
+            </p>
+            <br/>
+                {% trans "Kind regards" %}, <br/>
+                {% if system_settings.team_name %}
+                    {{ system_settings.team_name }}
+                {% else %}
+                    Defect Dojo
+                {% endif %}
+            <br/>
+            <br/>
+            <p>
+                {% url 'notifications' as notification_url %}
+                {% trans "You can manage your notification settings here" %}: <a href="{{ notification_url|full_url }}">{{ notification_url|full_url }}</a>
+            </p>
+            {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
+                <br/>
+                <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+                    <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">{% trans "Disclaimer" %}</span><br/>
+                    <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ system_settings.disclaimer }}</p>
+                </div>
+            {% endif %}
+        {% endautoescape %}
+    </body>
+</html>

--- a/dojo/templates/notifications/msteams/review_requested.tpl
+++ b/dojo/templates/notifications/msteams/review_requested.tpl
@@ -1,0 +1,51 @@
+{% load i18n %}
+{% load display_tags %}
+{
+    "@context": "https://schema.org/extensions",
+    "@type": "MessageCard",
+    "title": "{% trans "Review Requested" %}",
+    "summary": "{% trans "Review Requested" %}",
+    "sections": [
+        {
+            "activityTitle": "DefectDojo",
+            "activityImage": "https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/master/dojo/static/dojo/img/chop.png",
+            "text": "{% trans "A user has requested that the following users review the finding below for accuracy" %}.",
+            "facts": [
+                {
+                    "name": "{% trans "Requested By" %}:",
+                    "value": "{{ requested_by }}"
+                },
+                {
+                    "name": "{% trans "Finding" %}:",
+                    "value": "{{ finding }}"
+                },
+                {
+                    "name": "{% trans "Reviewers" %}:",
+                    "value": "{{ reviewers }}"
+                },
+                {
+                    "name": "{% trans "note" %}:",
+                    "value": "{{ note }}"
+                }
+            ]
+        }
+        {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
+            ,{
+                "activityTitle": "{% trans "Disclaimer" %}",
+                "text": "{{ system_settings.disclaimer }}"
+            }
+        {% endif %}
+    ],
+    "potentialAction": [
+        {
+            "@type": "OpenUri",
+            "name": "{% trans "View" %}",
+            "targets": [
+                {
+                    "os": "default",
+                    "uri": "{{ url|full_url }}"
+                }
+            ]
+        }
+    ]
+}

--- a/dojo/templates/notifications/slack/review_requested.tpl
+++ b/dojo/templates/notifications/slack/review_requested.tpl
@@ -1,0 +1,21 @@
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed %}
+    User {{ requested_by }} has requested that the following users review the finding "{{ finding }}" for accuracy:
+{% endblocktranslate %}
+
+{% for user in reviewers %}
+    - {{ user.get_full_name }}    
+{% endfor %}
+
+{% blocktranslate trimmed %}
+    {{ note }}
+{% endblocktranslate %}
+
+
+{% trans "Full details of the finding can be reviewed at" %} {{ url|full_url }}
+
+{% if system_settings.disclaimer and system_settings.disclaimer.strip %}    
+    {% trans "Disclaimer:" %}
+    {{ system_settings.disclaimer }}
+{% endif %}

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1722,11 +1722,7 @@ def max_safe(list):
 
 
 def get_full_url(relative_url):
-    if settings.SITE_URL:
-        return settings.SITE_URL + relative_url
-    else:
-        logger.warning('SITE URL undefined in settings, full_url cannot be created')
-        return "settings.SITE_URL" + relative_url
+    return f"{get_site_url()}{relative_url}"
 
 
 def get_site_url():


### PR DESCRIPTION
This PR does the following:
- Implements notification templates for finding review requests
- Overrides user notification settings for request reviews with system level notification settings
  - Before this change, if the system level notifications for finding review requests were enabled, but a given user did not have the notifications enabled on their personal scope, then that user would not receive a notification. This means that the system level notifications were being ignored for this action
 - Clean up the `get_full_url` function to remove redundancy with another function

<!--[sc-3605]-->

### Teams:
I do not have access to a teams instance to test this template. I modeled it as closely to other teams notifications templates as I could

### Mail:
<img width="893" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/46459665/4582358b-96fb-4c14-883e-f3da427d5276">

### Slack:
<img width="748" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/46459665/424cd94a-ac96-45c7-8663-b0d67da39d74">

### Alerts:
<img width="1047" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/46459665/49f01d14-00e2-4df6-9a80-5be4ac0d7c4d">