### PR TITLE
Release-drafter: Checkout to version

### DIFF
--- a/.github/workflows/fetch-oas.yml
+++ b/.github/workflows/fetch-oas.yml
@@ -13,22 +13,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      # load docker images from build jobs
-      - name: Load images from artifacts
-        uses: actions/download-artifact@v3
+        with:
+          ref: ${{github.event.inputs.version}}
 
       - name: Load docker images
         run: |-
-             docker load -i nginx/nginx-alpine_img
-             docker load -i django/django-alpine_img
+             docker pull defectdojo/defectdojo-django:${{github.event.inputs.version}}-alpine
+             docker pull defectdojo/defectdojo-nginx:${{github.event.inputs.version}}-alpine
              docker images
 
       - name: Start Dojo
         run: docker-compose --profile postgres-redis --env-file ./docker/environments/postgres-redis.env up --no-deps -d postgres nginx uwsgi
         env:
-          DJANGO_VERSION: alpine
-          NGINX_VERSION: alpine
+          DJANGO_VERSION: ${{github.event.inputs.version}}-alpine
+          NGINX_VERSION: ${{github.event.inputs.version}}-alpine
 
       - name: Download OpenAPI Specifications
         run: |-

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,12 +15,7 @@ on:
       - master
 
 jobs:
-  build-docker-containers:
-    uses: ./.github/workflows/build-docker-images-for-testing.yml
-    secrets: inherit
-
   oas-fetch:
-    needs: build-docker-containers
     uses: ./.github/workflows/fetch-oas.yml
     secrets: inherit
 


### PR DESCRIPTION
- The test stack was built on top of the `dev` branch by default. It needs to be built from the version tag.
  - Wrong code was used, wrong tags have been placed to OpenAPI Speficications
- Build of images is skipped, docker hub images are used (time save).

## Before

<img width="652" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/5609770/cbe9e107-db89-44f3-8fc5-873230df7aee">

```
$ curl -L https://github.com/DefectDojo/django-DefectDojo/releases/download/2.29.4/oas.yaml | head
info:
  title: Defect Dojo API v2
  version: 2.30.0-dev
  description: Defect Dojo - Open Source vulnerability Management made easy. Prefetch
    related parameters/responses not yet in the schema.
paths:
  /api/v2/api-token-auth/:
    post:
      operationId: api_token_auth_create
```

## After

<img width="305" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/5609770/41072146-aed3-4d19-9897-2321b64d5df2">
```

```
