### PR TITLE
Fix for vulns not included in host/endpoint views after reopening

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1716,7 +1716,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False
@@ -1731,7 +1730,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False
@@ -1786,7 +1784,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False,
@@ -1802,7 +1799,6 @@ class Endpoint(models.Model):
             mitigated__isnull=True,
             false_p=False,
             duplicate=False,
-            status_finding__mitigated=False,
             status_finding__false_positive=False,
             status_finding__out_of_scope=False,
             status_finding__risk_accepted=False,

--- a/unittests/test_endpoint_model.py
+++ b/unittests/test_endpoint_model.py
@@ -328,25 +328,25 @@ class TestEndpointStatusModel(DojoTestCase):
 
         with self.subTest('Endpoint with vulnerabilities but all of them are mitigated because of different reasons'):
             self.assertEqual(ep2.findings_count, 4, ep2.findings.all())
-            self.assertEqual(ep2.active_findings_count, 0, ep2.active_findings)
-            self.assertFalse(ep2.vulnerable, ep2.active_findings_count)
-            self.assertTrue(ep2.mitigated, ep2.active_findings_count)
+            self.assertEqual(ep2.active_findings_count, 1, ep2.active_findings)
+            self.assertTrue(ep2.vulnerable, ep2.active_findings_count)
+            self.assertFalse(ep2.mitigated, ep2.active_findings_count)
 
         with self.subTest('Host without vulnerabilities'):
             self.assertEqual(ep1.host_endpoints_count, 2, ep1.host_endpoints)
             self.assertEqual(ep2.host_endpoints_count, 2, ep2.host_endpoints)
             self.assertEqual(ep1.host_findings_count, 4, ep1.host_findings)
             self.assertEqual(ep2.host_findings_count, 4, ep2.host_findings)
-            self.assertEqual(ep1.host_active_findings_count, 0, ep1.host_active_findings)
-            self.assertEqual(ep2.host_active_findings_count, 0, ep2.host_active_findings)
+            self.assertEqual(ep1.host_active_findings_count, 1, ep1.host_active_findings)
+            self.assertEqual(ep2.host_active_findings_count, 1, ep2.host_active_findings)
             self.assertEqual(ep1.host_mitigated_endpoints_count, 1, ep1.host_mitigated_endpoints)
             self.assertEqual(ep2.host_mitigated_endpoints_count, 1, ep2.host_mitigated_endpoints)
 
         with self.subTest('Endpoint with one vulnerabilitiy but EPS is mitigated'):
             self.assertEqual(ep3.findings_count, 1, ep3.findings.all())
-            self.assertEqual(ep3.active_findings_count, 0, ep3.active_findings)
-            self.assertFalse(ep3.vulnerable, ep3.active_findings_count)
-            self.assertTrue(ep3.mitigated, ep3.active_findings_count)
+            self.assertEqual(ep3.active_findings_count, 1, ep3.active_findings)
+            self.assertTrue(ep3.vulnerable, ep3.active_findings_count)
+            self.assertFalse(ep3.mitigated, ep3.active_findings_count)
 
         with self.subTest('Endpoint with one vulnerability'):
             self.assertEqual(ep4.findings_count, 1, ep4.findings.all())
@@ -367,9 +367,9 @@ class TestEndpointStatusModel(DojoTestCase):
             self.assertEqual(ep3.host_findings_count, 2, ep3.host_findings)
             self.assertEqual(ep4.host_findings_count, 2, ep4.host_findings)
             self.assertEqual(ep5.host_findings_count, 2, ep5.host_findings)
-            self.assertEqual(ep3.host_active_findings_count, 1, ep3.host_active_findings)
-            self.assertEqual(ep4.host_active_findings_count, 1, ep4.host_active_findings)
-            self.assertEqual(ep5.host_active_findings_count, 1, ep5.host_active_findings)
+            self.assertEqual(ep3.host_active_findings_count, 2, ep3.host_active_findings)
+            self.assertEqual(ep4.host_active_findings_count, 2, ep4.host_active_findings)
+            self.assertEqual(ep5.host_active_findings_count, 2, ep5.host_active_findings)
             self.assertEqual(ep3.host_mitigated_endpoints_count, 2, ep3.host_mitigated_endpoints)
             self.assertEqual(ep4.host_mitigated_endpoints_count, 2, ep4.host_mitigated_endpoints)
             self.assertEqual(ep5.host_mitigated_endpoints_count, 2, ep5.host_mitigated_endpoints)


### PR DESCRIPTION
Re-doing PR as proposed in: https://github.com/DefectDojo/django-DefectDojo/pull/9181

Fix for vulnerabilities not included in host/endpoint views after reopening. More info: https://github.com/DefectDojo/django-DefectDojo/issues/8450

After commenting the lines on test environment, vulnerabilities that were reopened are properly shown on endpoint and host view. I was trying to find out how "status_finding__mitigated" filter works but couldn't find it. In my opinion it is not necessary to check it when "mitigated__isnull" filter is also verified.
