### PR TITLE
QualysParser: add cvss value to finding

### DIFF
--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -79,7 +79,6 @@ def split_cvss(value, _temp):
             _temp["CVSS_value"] = float(value)
 
 
-
 def parse_finding(host, tree):
     ret_rows = []
     issue_row = {}

--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -67,13 +67,17 @@ def split_cvss(value, _temp):
         return
     if len(value) > 4:
         split = value.split(" (")
-        _temp["CVSS_value"] = float(split[0])
-        # remove ")" at the end
-        _temp["CVSS_vector"] = CVSS3(
-            "CVSS:3.0/" + split[1][:-1]
-        ).clean_vector()
+        if _temp.get("CVSS_value") is None:
+            _temp["CVSS_value"] = float(split[0])
+            # remove ")" at the end
+        if _temp.get("CVSS_vector") is None:
+            _temp["CVSS_vector"] = CVSS3(
+                "CVSS:3.0/" + split[1][:-1]
+            ).clean_vector()
     else:
-        _temp["CVSS_value"] = float(value)
+        if _temp.get("CVSS_value") is None:
+            _temp["CVSS_value"] = float(value)
+
 
 
 def parse_finding(host, tree):
@@ -252,6 +256,8 @@ def parse_finding(host, tree):
         finding.active = _temp["active"]
         if _temp.get("CVSS_vector") is not None:
             finding.cvssv3 = _temp.get("CVSS_vector")
+        if _temp.get("CVSS_value") is not None:
+            finding.cvssv3_score = _temp.get("CVSS_value")
         finding.verified = True
         finding.unsaved_endpoints = list()
         finding.unsaved_endpoints.append(ep)

--- a/unittests/tools/test_qualys_parser.py
+++ b/unittests/tools/test_qualys_parser.py
@@ -20,12 +20,12 @@ class TestQualysParser(DojoTestCase):
         parser = QualysParser()
         findings = parser.get_findings(testfile, Test())
         for finding in findings:
-                if finding.unsaved_endpoints[0].host == "demo14.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":
-                    finding_cvssv3_score = finding
-                if finding.unsaved_endpoints[0].host == "demo13.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":
-                    finding_no_cvssv3_at_detection = finding
-                if finding.unsaved_endpoints[0].host == "demo14.s02.sjc01.qualys.com" and finding.title == "QID-121695 | NTP \"monlist\"  Feature Denial of Service Vulnerability":
-                    finding_no_cvssv3 = finding
+            if finding.unsaved_endpoints[0].host == "demo14.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":
+                finding_cvssv3_score = finding
+            if finding.unsaved_endpoints[0].host == "demo13.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":
+                finding_no_cvssv3_at_detection = finding
+            if finding.unsaved_endpoints[0].host == "demo14.s02.sjc01.qualys.com" and finding.title == "QID-121695 | NTP \"monlist\"  Feature Denial of Service Vulnerability":
+                finding_no_cvssv3 = finding
         # The CVSS Vector is not used from the Knowledgebase
         self.assertEqual(
             # CVSS_FINAL is defined without a cvssv3 vector

--- a/unittests/tools/test_qualys_parser.py
+++ b/unittests/tools/test_qualys_parser.py
@@ -20,7 +20,6 @@ class TestQualysParser(DojoTestCase):
         parser = QualysParser()
         findings = parser.get_findings(testfile, Test())
         for finding in findings:
-            for finding in findings:
                 if finding.unsaved_endpoints[0].host == "demo14.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":
                     finding_cvssv3_score = finding
                 if finding.unsaved_endpoints[0].host == "demo13.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":

--- a/unittests/tools/test_qualys_parser.py
+++ b/unittests/tools/test_qualys_parser.py
@@ -13,6 +13,43 @@ class TestQualysParser(DojoTestCase):
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(0, len(findings))
 
+    def test_parse_file_with_cvss_values_and_scores(self):
+        testfile = open(
+            get_unit_tests_path() + "/scans/qualys/Qualys_Sample_Report.xml"
+        )
+        parser = QualysParser()
+        findings = parser.get_findings(testfile, Test())
+        for finding in findings:
+            for finding in findings:
+                if finding.unsaved_endpoints[0].host == "demo14.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":
+                    finding_cvssv3_score = finding
+                if finding.unsaved_endpoints[0].host == "demo13.s02.sjc01.qualys.com" and finding.title == "QID-370876 | AMD Processors Multiple Security Vulnerabilities (RYZENFALL/MASTERKEY/CHIMERA-FW/FALLOUT)":
+                    finding_no_cvssv3_at_detection = finding
+                if finding.unsaved_endpoints[0].host == "demo14.s02.sjc01.qualys.com" and finding.title == "QID-121695 | NTP \"monlist\"  Feature Denial of Service Vulnerability":
+                    finding_no_cvssv3 = finding
+        # The CVSS Vector is not used from the Knowledgebase
+        self.assertEqual(
+            # CVSS_FINAL is defined without a cvssv3 vector
+            finding_cvssv3_score.cvssv3, None
+        )
+        # Nevertheless the CVSSv3 Score should be set
+        self.assertEqual(
+            finding_cvssv3_score.cvssv3_score, 8.2
+        )
+        # If no cvss information is present in detection and not in knowledgebase values should be empty
+        self.assertEqual(
+            finding_no_cvssv3.cvssv3, None
+        )
+        self.assertEqual(
+            finding_no_cvssv3.cvssv3_score, None
+        )
+        # No CVSS Values available in detection and it uses the knowledgebase then
+        self.assertEqual(finding_no_cvssv3_at_detection.cvssv3,
+                         "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H")
+        self.assertEqual(
+            finding_no_cvssv3_at_detection.cvssv3_score, 9.0
+        )
+
     def test_parse_file_with_multiple_vuln_has_multiple_findings(self):
         testfile = open(
             get_unit_tests_path() + "/scans/qualys/Qualys_Sample_Report.xml"


### PR DESCRIPTION
Add cvss value to finding and only overwrite values if not already set

This is because of XML Report Layout of Qualys. It has CVSS Values on concrete Finding and in the Knowledgebase.   The values in the concrete Finding are more accurate and are parsed at first. It would be much better to stick with those values and only use the ones from the Knowledgebase if CVSS values from concrete finding are missing


**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.


On behalf of DB Systel GmbH
