### PR TITLE
:bug: None Type in cvss score in Trivy #9263

### DIFF
--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -55,17 +55,20 @@ class TrivyParser:
         return "Import trivy JSON scan report."
 
     def convert_cvss_score(self, raw_value):
-        val = float(raw_value)
-        if val == 0.0:
+        if raw_value is None:
             return "Info"
-        elif val < 4.0:
-            return "Low"
-        elif val < 7.0:
-            return "Medium"
-        elif val < 9.0:
-            return "High"
         else:
-            return "Critical"
+            val = float(raw_value)
+            if val == 0.0:
+                return "Info"
+            elif val < 4.0:
+                return "Low"
+            elif val < 7.0:
+                return "Medium"
+            elif val < 9.0:
+                return "High"
+            else:
+                return "Critical"
 
     def get_findings(self, scan_file, test):
         scan_data = scan_file.read()
@@ -173,8 +176,13 @@ class TrivyParser:
                     if severity_source is not None and cvss is not None:
                         cvssclass = cvss.get(severity_source, None)
                         if cvssclass is not None:
-                            severity = self.convert_cvss_score(cvssclass.get("V3Score", None))
-                            cvssv3 = dict(cvssclass).get("V3Vector", None)
+                            if cvssclass.get("V3Score") is not None:
+                                severity = self.convert_cvss_score(cvssclass.get("V3Score"))
+                                cvssv3 = dict(cvssclass).get("V3Vector")
+                            elif cvssclass.get("V2Score") is not None:
+                                severity = self.convert_cvss_score(cvssclass.get("V2Score"))
+                            else:
+                                severity = self.convert_cvss_score(None)
                         else:
                             severity = TRIVY_SEVERITIES[vuln["Severity"]]
                     else:

--- a/unittests/scans/trivy/issue_9263.json
+++ b/unittests/scans/trivy/issue_9263.json
@@ -1,0 +1,75 @@
+{
+  "SchemaVersion": 2,
+  "ArtifactName": "sbom.json",
+  "ArtifactType": "cyclonedx",
+  "Metadata": {
+    "ImageConfig": {
+      "architecture": "",
+      "created": "0001-01-01T00:00:00Z",
+      "os": "",
+      "rootfs": {
+        "type": "",
+        "diff_ids": null
+      },
+      "config": {}
+    }
+  },
+  "Results": [
+    {
+      "Target": "requirements.txt",
+      "Class": "lang-pkgs",
+      "Type": "pip",
+      "Vulnerabilities": [
+        {
+          "VulnerabilityID": "CVE-2013-7445",
+          "PkgID": "linux-libc-dev@6.1.55-1",
+          "PkgName": "linux-libc-dev",
+          "InstalledVersion": "6.1.55-1",
+          "Status": "will_not_fix",
+          "Layer": {
+            "Digest": "sha256:938cae48a646a95127345a544f75f4e0b83f5fa612858e524aedea6981af4a1e",
+            "DiffID": "sha256:dfe25755ef07309fcb76dd47b2bb21e6dd92adedce8d9aa7f5bbceaf7fc726c9"
+          },
+          "SeveritySource": "nvd",
+          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2013-7445",
+          "DataSource": {
+            "ID": "debian",
+            "Name": "Debian Security Tracker",
+            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
+          },
+          "Title": "kernel: memory exhaustion via crafted Graphics Execution Manager (GEM) objects",
+          "Description": "The Direct Rendering Manager (DRM) subsystem in the Linux kernel through 4.x mishandles requests for Graphics Execution Manager (GEM) objects, which allows context-dependent attackers to cause a denial of service (memory consumption) via an application that processes graphics data, as demonstrated by JavaScript code that creates many CANVAS elements for rendering by Chrome or Firefox.",
+          "Severity": "HIGH",
+          "CweIDs": [
+            "CWE-399"
+          ],
+          "VendorSeverity": {
+            "nvd": 3,
+            "redhat": 2,
+            "ubuntu": 2
+          },
+          "CVSS": {
+            "nvd": {
+              "V2Vector": "AV:N/AC:L/Au:N/C:N/I:N/A:C",
+              "V2Score": 7.8
+            },
+            "redhat": {
+              "V2Vector": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+              "V2Score": 4.3
+            }
+          },
+          "References": [
+            "https://access.redhat.com/security/cve/CVE-2013-7445",
+            "https://bugzilla.kernel.org/show_bug.cgi?id=60533",
+            "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-7445",
+            "https://lists.freedesktop.org/archives/dri-devel/2015-September/089778.html (potential start towards fixing)",
+            "https://nvd.nist.gov/vuln/detail/CVE-2013-7445",
+            "https://www.cve.org/CVERecord?id=CVE-2013-7445"
+          ],
+          "PublishedDate": "2015-10-16T01:59:00.12Z",
+          "LastModifiedDate": "2015-10-16T16:22:25.587Z"
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/tools/test_trivy_parser.py
+++ b/unittests/tools/test_trivy_parser.py
@@ -209,3 +209,11 @@ Number  Content
         finding = findings[0]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("KSV116 - Runs with a root primary or supplementary GID", finding.title)
+
+    def test_issue_9263(self):
+        test_file = open(sample_path("issue_9263.json"))
+        parser = TrivyParser()
+        findings = parser.get_findings(test_file, Test())
+        self.assertEqual(len(findings), 1)
+        finding = findings[0]
+        self.assertEqual("High", finding.severity)


### PR DESCRIPTION
Fix #9263 

- Makes None Type in CVSS Score to "Info Finding"
- Adds CVSSv2 