### PR TITLE
:sparkles: Add option for additional labels on initializer

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -22,6 +22,9 @@ spec:
         defectdojo.org/component: initializer
         app.kubernetes.io/name: {{ include "defectdojo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.initializer.labels }}
+        {{- toYaml .Values.initializer.labels | nindent 8 }}
+        {{- end }}
       annotations:
       {{- with .Values.initializer.annotations }}
         {{- toYaml . | nindent 8 }}

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -304,6 +304,7 @@ initializer:
     helm.sh/hook: "post-install,post-upgrade"
   }
   annotations: {}
+  labels: {}
   keepSeconds: 60
   affinity: {}
   nodeSelector: {}


### PR DESCRIPTION
Closes #9267

**Description**

This PR adds the option to add additional labels to the initializer job. This can be done in the values file like:

```yaml
initializer:
    labels: {
        key: value
    }
```

Contrary to what I mentioned in the Issue, it is already possible to add labels to the Deployment Pods via `podLabels`, see [here](https://github.com/DefectDojo/django-DefectDojo/blob/master/helm/defectdojo/values.yaml#L65-L68). Which only made it necessary to add the option to the Job aswell. 

I saw 3 options to make this possible: 

1. Add `labels` directly to initializer, same as annotations and therefore scope the additional labels only to the initializer job (which is as of writing this the only job).
2. Add `jobLabels` as a global value, same as `podLabels`. This would be more future-proof in case of addition of more jobs. But to me this option would be a bit confusing in the end, as it is not really "jobLabels" and rather "jobPodLabels", as `spec.template.metadata.labels` sets the labels that apply to pods managed by the job (or deployment). But this would be more of a wording discussion.
3. Add `jobLabels` next to `jobAnnotations`, same as [here](https://github.com/DefectDojo/django-DefectDojo/blob/master/helm/defectdojo/values.yaml#L303-L305). But this would as option 2 be misleading in my opinion, as `jobAnnotations` are adding annotations to the job metadata and not to `spec.template.metadata.labels`.

In the initial form of this PR I chose number 1, but I am happy to adjust my code to option number 2 if there is strong opinions towards it.
