### PR TITLE
Update finding templates to use test_type rather then found_by

### DIFF
--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -616,10 +616,17 @@
                                             {% endif %}
                                         </td>
                                         <td>
-                                            <a target="#"
-                                            data-toggle="tooltip"
-                                            data-placement="bottom"
-                                            title="Test: {{ finding.test }}">{{ finding.found_by.all|join:", " }}</a>
+                                            {% if finding.found_by %}
+                                                <a target="#"
+                                                data-toggle="tooltip"
+                                                data-placement="bottom"
+                                                title="Test: {{ finding.test }}">{{ finding.found_by.all|join:", " }}</a>
+                                            {% else %}
+                                                <a target="#"
+                                                data-toggle="tooltip"
+                                                data-placement="bottom"
+                                                title="Test: {{ finding.test }}">{{ finding.test.test_type }}</a>
+                                            {% endif %}
                                         </td>
                                         <td class="nowrap">
                                             {{ finding|finding_display_status|safe }}&nbsp;{{ finding|import_history }}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -421,9 +421,15 @@
                             {% endif %}
                         {% endif %}
                         </td>
-                        <td> {% for scanner in found_by %}
-                            {{ scanner }}
-                        {% endfor %}</td>
+                        <td> 
+                            {% if found_by %}
+                                {% for scanner in found_by %}
+                                    {{ scanner }}
+                                {% endfor %}
+                            {% else %}
+                                {{ finding.test.test_type }}
+                            {% endif %}
+                        </td>
                         {% endwith %}
                         {% if finding.vuln_id_from_tool %}
                             <td>{{ finding.vuln_id_from_tool }}</td>


### PR DESCRIPTION
## Update finding templates to use test_type rather then found_by
[sc-2859]
This feature allows the user see the test_type information when the found_by is not available.

In the Findings list:
![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/0f454dd1-518d-465b-84d7-5cf1c39b7040)

In the Finding view:
![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/056ed57b-f15f-4102-8f14-6cf50bdf6549)
