### PR TITLE
UserContactInfo admin improvements

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -242,6 +242,16 @@ class UserContactInfo(models.Model):
     block_execution = models.BooleanField(default=False, help_text=_("Instead of async deduping a finding the findings will be deduped synchronously and will 'block' the user until completion."))
     force_password_reset = models.BooleanField(default=False, help_text=_('Forces this user to reset their password on next login.'))
 
+    def __str__(self):
+        return f"UserContactInfo<{self.user}>"
+
+
+class UserContactInfoAdmin(admin.ModelAdmin):
+
+    def get_list_display(self, request):
+        list_fields = [field.name for field in self.model._meta.fields]
+        return list_fields
+
 
 class Dojo_Group(models.Model):
     AZURE = 'AzureAD'
@@ -4360,7 +4370,7 @@ admin.site.register(Endpoint_Status)
 admin.site.register(Endpoint)
 admin.site.register(Product)
 admin.site.register(Product_Type)
-admin.site.register(UserContactInfo)
+admin.site.register(UserContactInfo, UserContactInfoAdmin)
 admin.site.register(Notes)
 admin.site.register(Note_Type)
 admin.site.register(Alerts)


### PR DESCRIPTION
User's contact details can change, and the administrator should be able to edit them.

Currently, picking the right object to edit is difficult:

![image](https://github.com/DefectDojo/django-DefectDojo/assets/981572/67ac8776-cf46-44e7-9139-9cc961268826)

This PR configures Django Admin to display a table with the values:

![image](https://github.com/DefectDojo/django-DefectDojo/assets/981572/7fc49011-ce94-46a9-9396-df72f88180cd)