### PR TITLE
Improve kiuwan import parser

### DIFF
--- a/dojo/tools/kiuwan/parser.py
+++ b/dojo/tools/kiuwan/parser.py
@@ -62,7 +62,7 @@ class KiuwanParser(object):
                 + row["Software characteristic"]
                 + "\n\n"
                 + "**Vulnerability type** : "
-                + row["Vulnerability type"]
+                + (row["Vulnerability type"] if "Vulnerability type" in row else "")
                 + "\n\n"
                 + "**CWE Scope** : "
                 + row["CWE Scope"]

--- a/dojo/tools/kiuwan/parser.py
+++ b/dojo/tools/kiuwan/parser.py
@@ -67,6 +67,9 @@ class KiuwanParser(object):
                 + "**CWE Scope** : "
                 + row["CWE Scope"]
                 + "\n\n"
+                + "**File** : "
+                + row["File"]
+                + "\n\n"
                 + "**Line number** : "
                 + row["Line number"]
                 + "\n\n"

--- a/unittests/scans/kiuwan/issue_9308.csv
+++ b/unittests/scans/kiuwan/issue_9308.csv
@@ -1,3 +1,3 @@
 Rule code,Rule,Priority,CWE,Software characteristic,Vulnerability type,Language,Effort,File,Line number,Line text,Source file,Source line number,Source line text,Muted,Normative,Status,CWE Scope,Framework
 OPT.JAVASCRIPT.ERRORCOMUN.UnusedLocalVar,Avoid unused local variable,High,101,Maintainability,Other,Typescript,03m,file.js,12,self = this,,,,No,"Agile Alliance:Concise-CDED,CWE:563",none,,
-OPT.JAVASCRIPT.ERRORCOMUN.UnusedLocalVar,Avoid unused local variable,High,102,Maintainability,Other,Typescript,03m,another-file.js,12,self = this,,,,No,"Agile Alliance:Concise-CDED,CWE:563",none,,
+OPT.JAVASCRIPT.ERRORCOMUN.UnusedLocalVar,Avoid unused local variable,High,101,Maintainability,Other,Typescript,03m,another-file.js,12,self = this,,,,No,"Agile Alliance:Concise-CDED,CWE:563",none,,

--- a/unittests/scans/kiuwan/kiuwan_defects.csv
+++ b/unittests/scans/kiuwan/kiuwan_defects.csv
@@ -1,0 +1,2 @@
+Rule code,Rule,Priority,Software characteristic,Language,Effort,File,Line number,Line text,Source file,Source line number,Source line text,Muted,Normative,Status,CWE Scope,Framework
+OPT.PLSQL.GEN_PLSQL.VAR2,"Define variables as VARCHAR2, nor as VARCHAR",Very High,Efficiency,PL-SQL,03m,file.sql,3,"  userid varchar(250),",,,,No,,none,,

--- a/unittests/tools/test_kiuwan_parser.py
+++ b/unittests/tools/test_kiuwan_parser.py
@@ -6,7 +6,6 @@ from dojo.models import Test
 class TestKiuwanParser(DojoTestCase):
 
     def test_parse_file_with_no_vuln_has_no_findings(self):
-
         testfile = open("unittests/scans/kiuwan/kiuwan_no_vuln.csv")
         parser = KiuwanParser()
         findings = parser.get_findings(testfile, Test())
@@ -23,6 +22,12 @@ class TestKiuwanParser(DojoTestCase):
         parser = KiuwanParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(131, len(findings))
+
+    def test_parse_file_with_defects(self):
+        testfile = open("unittests/scans/kiuwan/kiuwan_defects.csv")
+        parser = KiuwanParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
 
     def test_parse_file_issue_9308(self):
         testfile = open("unittests/scans/kiuwan/issue_9308.csv")


### PR DESCRIPTION
**Description**

Updated the kiuwan parser to fix some imports. 

1. Added the file to the description to have a unique hash for findings that are the same except the file name. This solves issue #9308
2. Added a check if the vulnerability column is present in the import. This solves issue #9307

**Test results**

After making the changes in the parser the import ran successfully for the attached import file from the issues.
Tested with larger CSV exports from kiuwan production instances as well.
