### PR TITLE
Fixing TypeError during Trivy report upload

### DIFF
--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -173,7 +173,12 @@ class TrivyParser:
                     if severity_source is not None and cvss is not None:
                         cvssclass = cvss.get(severity_source, None)
                         if cvssclass is not None:
-                            severity = self.convert_cvss_score(cvssclass.get("V3Score", None))
+                            v3score = cvssclass.get("V3Score", None)
+                            # Check if the severity score V3score not none before parsing it
+                            if v3score is not None:
+                                severity = self.convert_cvss_score(cvssclass.get("V3Score", None))
+                            else:
+                                severity = TRIVY_SEVERITIES[vuln["Severity"]]
                             cvssv3 = dict(cvssclass).get("V3Vector", None)
                         else:
                             severity = TRIVY_SEVERITIES[vuln["Severity"]]


### PR DESCRIPTION
Fixing a parsing error during the upload of Aqua Trivy scan.

While I was trying to upload a Aqua Trivy scan to defectDojo api I encountered a Internal Server Error:

<img width="1490" alt="Screenshot 2024-01-16 at 10 11 50 AM" src="https://github.com/DefectDojo/django-DefectDojo/assets/143202415/511cfb73-a8f3-4cea-866c-7aa799454353">

**Server Logs:**
```bash
[pid: 27|app: -|req: -/-] 192.168.65.1 (admin) {50 vars in 1016 bytes} [Tue Jan 16 09:51:43 2024] GET /alerts/count => generated 13 bytes in 959 msecs (HTTP/1.1 200) 7 headers in 212 bytes (1 switches on core 0)
[16/Jan/2024 09:51:51] ERROR [dojo.api_v2.exception_handler:36] float() argument must be a string or a real number, not 'NoneType'
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/rest_framework/mixins.py", line 19, in create
    self.perform_create(serializer)
  File "/app/dojo/api_v2/views.py", line 3047, in perform_create
    serializer.save(push_to_jira=push_to_jira)
  File "/app/dojo/api_v2/serializers.py", line 2219, in save
    ) = importer.import_scan(
        ^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/importers/importer/importer.py", line 315, in import_scan
    parsed_findings = parser.get_findings(scan, test)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/tools/trivy/parser.py", line 90, in get_findings
    return self.get_result_items(test, results, artifact_name=artifact_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/tools/trivy/parser.py", line 176, in get_result_items
    severity = self.convert_cvss_score(cvssclass.get("V3Score", None))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/tools/trivy/parser.py", line 58, in convert_cvss_score
    val = float(raw_value)
          ^^^^^^^^^^^^^^^^
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

The error raise when the parser try to get the V3score value without checking if it's not null.

Here:

```bash
severity = self.convert_cvss_score(cvssclass.get("V3Score", None))
```

The error exactly raise here in this function that try convert a None value to float

```python
    def convert_cvss_score(self, raw_value):
        val = float(raw_value) # Here it would raise a TypeError exception if the raw_value is None
        if val == 0.0:
            return "Info"
        elif val < 4.0:
            return "Low"
        elif val < 7.0:
            return "Medium"
        elif val < 9.0:
            return "High"
        else:
            return "Critical"
```

Here's an example scan report that doesn't contain a V3score (Only V2score which is not user by the parser). which does cause the Internal Server error while uploading it.

```json
      "Vulnerabilities": [
        {
          "VulnerabilityID": "CVE-2011-3374",
          "PkgID": "apt@2.6.1",
          "PkgName": "apt",
          "InstalledVersion": "2.6.1",
          "Status": "affected",
          "Layer": {
            "DiffID": "sha256:77ad615d04d44851061fc9c4340bdd0134b18a878e3c170ecf305dca2ddcfc62"
          },
          "SeveritySource": "nvd",
          "PrimaryURL": "https://avd.aquasec.com/nvd/cve-2011-3374",
          "DataSource": {
            "ID": "nvd",
            "Name": "Debian Security Tracker",
            "URL": "https://salsa.debian.org/security-tracker-team/security-tracker"
          },
          "Title": "It was found that apt-key in apt, all versions, do not correctly valid ...",
          "Description": "It was found that apt-key in apt, all versions, do not correctly validate gpg keys with the master keyring, leading to a potential man-in-the-middle attack.",
          "Severity": "LOW",
          "CweIDs": [
            "CWE-347"
          ],
          "VendorSeverity": {
            "debian": 1,
            "nvd": 1
          },
          "CVSS": {
            "nvd": {
              "V2Vector": "AV:N/AC:M/Au:N/C:N/I:P/A:N",
              "V2Score": 4.3
            }
          },
          "References": [
            "https://access.redhat.com/security/cve/cve-2011-3374",
            "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=642480",
            "https://people.canonical.com/~ubuntu-security/cve/2011/CVE-2011-3374.html",
            "https://seclists.org/fulldisclosure/2011/Sep/221",
            "https://security-tracker.debian.org/tracker/CVE-2011-3374",
            "https://snyk.io/vuln/SNYK-LINUX-APT-116518",
            "https://ubuntu.com/security/CVE-2011-3374"
          ],
          "PublishedDate": "2019-11-26T00:15:11.03Z",
          "LastModifiedDate": "2021-02-09T16:08:18.683Z"
        }
```

After the fix I was able to upload the scan file without problem.

<img width="1487" alt="Screenshot 2024-01-16 at 12 31 32 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/143202415/7defae0b-f972-4f9f-8c38-2b6cf491c735">




