### PR TITLE
Restructure Release Drafter Flow

### DIFF
--- a/.github/workflows/fetch-oas.yml
+++ b/.github/workflows/fetch-oas.yml
@@ -8,7 +8,7 @@ on:
         description: |
           The version to be associated with the GitHub release that's created or updated.
           This will override any version calculated by the release-drafter.
-        required: false
+        required: true
 
 jobs:
   oas_fetch:

--- a/.github/workflows/fetch-oas.yml
+++ b/.github/workflows/fetch-oas.yml
@@ -2,6 +2,13 @@ name: Fetch OpenAPI Specifications
 
 on:
   workflow_call:
+    inputs:
+      version:
+        type: string
+        description: |
+          The version to be associated with the GitHub release that's created or updated.
+          This will override any version calculated by the release-drafter.
+        required: false
 
 jobs:
   oas_fetch:

--- a/.github/workflows/release-2-tag-docker-push.yml
+++ b/.github/workflows/release-2-tag-docker-push.yml
@@ -46,3 +46,10 @@ jobs:
     with:
       release_number: ${{ github.event.inputs.release_number }}
     secrets: inherit
+
+  release-drafter:
+    needs: release-docker-containers
+    uses: ./.github/workflows/release-drafter.yml
+    with:
+      version: ${{ github.event.inputs.release_number }}
+    secrets: inherit

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,6 +1,13 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          The version to be associated with the GitHub release that's created or updated.
+          This will override any version calculated by the release-drafter.
+        required: true
   workflow_call:
     inputs:
       version:
@@ -8,7 +15,7 @@ on:
         description: |
           The version to be associated with the GitHub release that's created or updated.
           This will override any version calculated by the release-drafter.
-        required: false
+        required: true
 
 jobs:
   # Update the notes in the release drafter first

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,31 +1,21 @@
 name: Release Drafter
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
+        type: string
         description: |
           The version to be associated with the GitHub release that's created or updated.
           This will override any version calculated by the release-drafter.
         required: false
 
-  push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - master
-
 jobs:
-  oas-fetch:
-    uses: ./.github/workflows/fetch-oas.yml
-    secrets: inherit
-
+  # Update the notes in the release drafter first
+  # If the following jobs fail, then we will at least have some release notes present
   update_release_draft:
-    needs: oas-fetch
     runs-on: ubuntu-latest
     steps:
-      - name: Load OAS files from artifacts
-        uses: actions/download-artifact@v3
-
       - name: Create Release
         id: create_release
         uses: release-drafter/release-drafter@v5.25.0
@@ -33,6 +23,20 @@ jobs:
           version: ${{github.event.inputs.version}}  
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # Generate the OAS schemas in another workflow
+  oas-fetch:
+    needs: update_release_draft
+    uses: ./.github/workflows/fetch-oas.yml
+    with:
+      version: ${{github.event.inputs.version}} 
+    secrets: inherit
+  # Upload the OAS schemas to the release object
+  add-oas-to-release:
+    needs: oas-fetch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Load OAS files from artifacts
+        uses: actions/download-artifact@v3
 
       - name: Upload Release Asset - OpenAPI Specification - YAML
         id: upload-release-asset-yaml
@@ -55,3 +59,5 @@ jobs:
           asset_path: ./oas-json/oas.json
           asset_name: oas.json
           asset_content_type: application/json
+
+    


### PR DESCRIPTION
This PR updates the structure and flow of the release drafter process. Now that OAS schemas are appended to each release object, it might be a better approach to make the release drafting process less event driven. Here is what the PR proposes:

- Remove the trigger to run the release drafter on pushes to master
  - This is necessary as the docker images to generate the OAS schemas for a given release X are not public yet
  - One approach is to build the docker images before generating the release, but this slows down the release process overall
- Explicitly run the release drafter workflow as step 2 of the release (this creates the the release, builds/uploads the helm chart, and pushes the newest images to dockerhub) only after the docker images have been pushed
  - The OAS schema generator will pull down the specified version of the. docker images, start them, generate the schemas, and then upload them to a cache where the release drafter will upload them to the correct release object along with the notes
- The release object itself is manually published after verifying the contents have been generated/uploaded correctly, so if there are any failures here, we are able to debug what the issue is without losing too much of the process

@kiblik I encountered a few errors during the release this morning, and had a few thoughts to improve this process as I was going though it. I have not tested this PR in any capacity (it is a bit difficult to do that outside of releases) but please looks it over and let me know your thoughts. Here is the [failed run from today](https://github.com/DefectDojo/django-DefectDojo/actions/runs/7544880466)
