### PR TITLE
Update and rename whitesource.md to mend.md

### DIFF
--- a/docs/content/en/integrations/parsers/file/mend.md
+++ b/docs/content/en/integrations/parsers/file/mend.md
@@ -1,0 +1,15 @@
+---
+title: "Mend Scan"
+toc_hide: true
+---
+
+### File Types
+Accepts a JSON file, generated from the Mend* Unified Agent.  
+
+### Sample Scan Data / Unit Tests
+Unit tests for Mend JSON files can be found at https://github.com/DefectDojo/django-DefectDojo/blob/76e11c21e88fb84b67b6da27c78fbbe1899e7e78/unittests/scans/whitesource/cli_generated_many_vulns.json
+
+### Link To Tool
+See documentation: https://docs.mend.io/bundle/unified_agent/page/example_of_a_unified_agent_json_report.html
+
+*Formerly known as Whitesource.

--- a/docs/content/en/integrations/parsers/file/mend.md
+++ b/docs/content/en/integrations/parsers/file/mend.md
@@ -7,7 +7,7 @@ toc_hide: true
 Accepts a JSON file, generated from the Mend* Unified Agent.  
 
 ### Sample Scan Data / Unit Tests
-Unit tests for Mend JSON files can be found at https://github.com/DefectDojo/django-DefectDojo/blob/76e11c21e88fb84b67b6da27c78fbbe1899e7e78/unittests/scans/whitesource/cli_generated_many_vulns.json
+Unit tests for Mend JSON files can be found at https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/mend
 
 ### Link To Tool
 See documentation: https://docs.mend.io/bundle/unified_agent/page/example_of_a_unified_agent_json_report.html

--- a/docs/content/en/integrations/parsers/file/whitesource.md
+++ b/docs/content/en/integrations/parsers/file/whitesource.md
@@ -1,5 +1,0 @@
----
-title: "Whitesource Scan"
-toc_hide: true
----
-Import JSON report


### PR DESCRIPTION
Changes the title of Whitesource documentation to reflect Whitesource's rebrand to Mend.io .  See https://www.mend.io/ .

Also adds Parser documentation template along with link to Mend.io documentation for reference.