### PR TITLE
✨ advance import-scan api to have an additional field to finetune vulnerability parsers

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2135,6 +2135,10 @@ class ImportScanSerializer(serializers.Serializer):
         help_text="If set to True, the tags will be applied to the findings",
         required=False,
     )
+    parser_custom_setting = serializers.CharField(
+        help_text="You can specify custom parser settings, but please take a look at the docs",
+        required=False,
+    )
 
     def save(self, push_to_jira=False):
         data = self.validated_data
@@ -2157,6 +2161,7 @@ class ImportScanSerializer(serializers.Serializer):
         source_code_management_uri = data.get(
             "source_code_management_uri", None
         )
+        parser_custom_setting = data.get("parser_custom_setting", None)
 
         if "active" in self.initial_data:
             active = data.get("active")
@@ -2247,6 +2252,7 @@ class ImportScanSerializer(serializers.Serializer):
                 title=test_title,
                 create_finding_groups_for_all_findings=create_finding_groups_for_all_findings,
                 apply_tags_to_findings=apply_tags_to_findings,
+                parser_custom_setting=parser_custom_setting,
             )
 
             if test:
@@ -2419,6 +2425,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         help_text="If set to True, the tags will be applied to the findings",
         required=False
     )
+    parser_custom_setting = serializers.CharField(
+        help_text="You can specify custom parser settings, but please take a look at the docs",
+        required=False,
+    )
 
     def save(self, push_to_jira=False):
         logger.debug("push_to_jira: %s", push_to_jira)
@@ -2432,6 +2442,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
             "close_old_findings_product_scope"
         )
         apply_tags_to_findings = data.get("apply_tags_to_findings", False)
+        parser_custom_setting = data.get("parser_custom_setting", False)
         do_not_reactivate = data.get("do_not_reactivate", False)
         version = data.get("version", None)
         build_id = data.get("build_id", None)
@@ -2533,6 +2544,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     do_not_reactivate=do_not_reactivate,
                     create_finding_groups_for_all_findings=create_finding_groups_for_all_findings,
                     apply_tags_to_findings=apply_tags_to_findings,
+                    parser_custom_setting = parser_custom_setting,
                 )
 
                 if test_import:

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2544,7 +2544,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     do_not_reactivate=do_not_reactivate,
                     create_finding_groups_for_all_findings=create_finding_groups_for_all_findings,
                     apply_tags_to_findings=apply_tags_to_findings,
-                    parser_custom_setting = parser_custom_setting,
+                    parser_custom_setting=parser_custom_setting,
                 )
 
                 if test_import:

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -3203,6 +3203,7 @@ class ReImportScanView(mixins.CreateModelMixin, viewsets.GenericViewSet):
             auto_create_context,
             deduplication_on_engagement,
             do_not_reactivate,
+            parser_custom_setting,
         ) = serializers.get_import_meta_data_from_dict(
             serializer.validated_data
         )

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -3203,7 +3203,6 @@ class ReImportScanView(mixins.CreateModelMixin, viewsets.GenericViewSet):
             auto_create_context,
             deduplication_on_engagement,
             do_not_reactivate,
-            parser_custom_setting,
         ) = serializers.get_import_meta_data_from_dict(
             serializer.validated_data
         )

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -477,7 +477,7 @@ class ImportScanForm(forms.Form):
         required=False,
         initial=False
     )
-    parser_custom_setting = forms.CharField(max_length=100, required=False, help_text="TODO.")
+    parser_custom_setting = forms.CharField(max_length=100, required=False, help_text="This is a field to customize (finetune) the behavior of single parsers.")
 
     if is_finding_groups_enabled():
         group_by = forms.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text='Choose an option to automatically group new findings by the chosen option.')

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -477,6 +477,7 @@ class ImportScanForm(forms.Form):
         required=False,
         initial=False
     )
+    parser_custom_setting = forms.CharField(max_length=100, required=False, help_text="TODO.")
 
     if is_finding_groups_enabled():
         group_by = forms.ChoiceField(required=False, choices=Finding_Group.GROUP_BY_OPTIONS, help_text='Choose an option to automatically group new findings by the chosen option.')

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -244,7 +244,7 @@ class DojoDefaultImporter(object):
     def import_scan(self, scan, scan_type, engagement, lead, environment, active=None, verified=None, tags=None, minimum_severity=None,
                     user=None, endpoints_to_add=None, scan_date=None, version=None, branch_tag=None, build_id=None,
                     commit_hash=None, push_to_jira=None, close_old_findings=False, close_old_findings_product_scope=False,
-                    group_by=None, api_scan_configuration=None, service=None, title=None, create_finding_groups_for_all_findings=True, apply_tags_to_findings=False):
+                    group_by=None, api_scan_configuration=None, service=None, title=None, create_finding_groups_for_all_findings=True, apply_tags_to_findings=False, parser_custom_setting=False):
 
         logger.debug(f'IMPORT_SCAN: parameters: {locals()}')
 
@@ -367,7 +367,8 @@ class DojoDefaultImporter(object):
                 for finding in test_import.findings_affected.all():
                     for tag in tags:
                         finding.tags.add(tag)
-
+        if parser_custom_setting:
+            print(parser_custom_setting) #TODO
         logger.debug('IMPORT_SCAN: Generating notifications')
         notifications_helper.notify_test_created(test)
         updated_count = len(new_findings) + len(closed_findings)

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -244,7 +244,7 @@ class DojoDefaultImporter(object):
     def import_scan(self, scan, scan_type, engagement, lead, environment, active=None, verified=None, tags=None, minimum_severity=None,
                     user=None, endpoints_to_add=None, scan_date=None, version=None, branch_tag=None, build_id=None,
                     commit_hash=None, push_to_jira=None, close_old_findings=False, close_old_findings_product_scope=False,
-                    group_by=None, api_scan_configuration=None, service=None, title=None, create_finding_groups_for_all_findings=True, apply_tags_to_findings=False, parser_custom_setting=False):
+                    group_by=None, api_scan_configuration=None, service=None, title=None, create_finding_groups_for_all_findings=True, apply_tags_to_findings=False, parser_custom_setting=None):
 
         logger.debug(f'IMPORT_SCAN: parameters: {locals()}')
 
@@ -312,7 +312,7 @@ class DojoDefaultImporter(object):
             logger.debug('IMPORT_SCAN: Parse findings')
             parser = get_parser(scan_type)
             try:
-                parsed_findings = parser.get_findings(scan, test)
+                parsed_findings = parser.get_findings(scan, test, parser_custom_setting)
             except ValueError as e:
                 logger.warning(e)
                 raise ValidationError(e)
@@ -367,8 +367,6 @@ class DojoDefaultImporter(object):
                 for finding in test_import.findings_affected.all():
                     for tag in tags:
                         finding.tags.add(tag)
-        if parser_custom_setting:
-            print(parser_custom_setting) #TODO
         logger.debug('IMPORT_SCAN: Generating notifications')
         notifications_helper.notify_test_created(test)
         updated_count = len(new_findings) + len(closed_findings)

--- a/dojo/importers/reimporter/reimporter.py
+++ b/dojo/importers/reimporter/reimporter.py
@@ -572,6 +572,7 @@ class DojoDefaultReImporter(object):
         do_not_reactivate=False,
         create_finding_groups_for_all_findings=True,
         apply_tags_to_findings=False,
+        parser_custom_setting=None,
     ):
 
         logger.debug(f"REIMPORT_SCAN: parameters: {locals()}")
@@ -607,7 +608,7 @@ class DojoDefaultReImporter(object):
         else:
             logger.debug("REIMPORT_SCAN: Parse findings")
             try:
-                parsed_findings = parser.get_findings(scan, test)
+                parsed_findings = parser.get_findings(scan, test, parser_custom_setting)
             except ValueError as e:
                 logger.warning(e)
                 raise ValidationError(e)

--- a/dojo/tools/acunetix/parser.py
+++ b/dojo/tools/acunetix/parser.py
@@ -23,7 +23,7 @@ class AcunetixParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "XML format"
 
-    def get_findings(self, xml_output, test):
+    def get_findings(self, xml_output, test, parser_custom_setting=None):
         root = parse(xml_output).getroot()
 
         dupes = dict()

--- a/dojo/tools/acunetix360/parser.py
+++ b/dojo/tools/acunetix360/parser.py
@@ -16,7 +16,7 @@ class Acunetix360Parser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Acunetix360 JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = dict()
         scan_date = parser.parse(data["Generated"])

--- a/dojo/tools/anchore_engine/parser.py
+++ b/dojo/tools/anchore_engine/parser.py
@@ -13,7 +13,7 @@ class AnchoreEngineParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Anchore-CLI JSON vulnerability report format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = dict()
         for item in data["vulnerabilities"]:

--- a/dojo/tools/anchore_enterprise/parser.py
+++ b/dojo/tools/anchore_enterprise/parser.py
@@ -19,7 +19,7 @@ class AnchoreEnterpriseParser:
     def get_description_for_scan_types(self, scan_type):
         return "Anchore-CLI JSON policy check report format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         try:
             data = json.loads(str(content, "utf-8"))

--- a/dojo/tools/anchore_grype/parser.py
+++ b/dojo/tools/anchore_grype/parser.py
@@ -23,7 +23,7 @@ class AnchoreGrypeParser(object):
             "format"
         )
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         data = json.load(file)
         dupes = dict()
         for item in data.get("matches", []):

--- a/dojo/tools/anchorectl_policies/parser.py
+++ b/dojo/tools/anchorectl_policies/parser.py
@@ -19,7 +19,7 @@ class AnchoreCTLPoliciesParser:
     def get_description_for_scan_types(self, scan_type):
         return "AnchoreCTLs JSON policies report format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         try:
             data = json.loads(str(content, "utf-8"))

--- a/dojo/tools/anchorectl_vulns/parser.py
+++ b/dojo/tools/anchorectl_vulns/parser.py
@@ -13,7 +13,7 @@ class AnchoreCTLVulnsParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "AnchoreCTLs JSON vulnerability report format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = dict()
         for item in data:

--- a/dojo/tools/api_blackduck/importer.py
+++ b/dojo/tools/api_blackduck/importer.py
@@ -11,7 +11,7 @@ class BlackduckApiImporter(object):
 
     config_id = "BlackDuck API"
 
-    def get_findings(self, test):
+    def get_findings(self, test, parser_custom_setting=None):
         client, config = self.prepare_client(test)
         project = client.get_project_by_name(config.service_key_1)
         version = client.get_version_by_name(project, config.service_key_2)

--- a/dojo/tools/api_blackduck/parser.py
+++ b/dojo/tools/api_blackduck/parser.py
@@ -36,7 +36,7 @@ class ApiBlackduckParser(object):
             "<b>Service key 2</b> has to be set to the version of the project"
         )
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file is None:
             data = BlackduckApiImporter().get_findings(test)
         else:

--- a/dojo/tools/api_bugcrowd/importer.py
+++ b/dojo/tools/api_bugcrowd/importer.py
@@ -11,7 +11,7 @@ class BugcrowdApiImporter(object):
     Import from Bugcrowd API
     """
 
-    def get_findings(self, test):
+    def get_findings(self, test, parser_custom_setting=None):
         client, config = self.prepare_client(test)
         logger.debug(
             "Fetching submissions program {} and target {}".format(

--- a/dojo/tools/api_bugcrowd/parser.py
+++ b/dojo/tools/api_bugcrowd/parser.py
@@ -46,7 +46,7 @@ class ApiBugcrowdParser(object):
             "if not supplied, will fetch all submissions in the program"
         )
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         api_scan_config = None
         if file is None:
             data, api_scan_config = BugcrowdApiImporter().get_findings(test)

--- a/dojo/tools/api_cobalt/importer.py
+++ b/dojo/tools/api_cobalt/importer.py
@@ -11,7 +11,7 @@ class CobaltApiImporter(object):
     Import from Cobalt.io API
     """
 
-    def get_findings(self, test):
+    def get_findings(self, test, parser_custom_setting=None):
         client, config = self.prepare_client(test)
         findings = client.get_findings(config.service_key_1)
         return findings

--- a/dojo/tools/api_cobalt/parser.py
+++ b/dojo/tools/api_cobalt/parser.py
@@ -37,7 +37,7 @@ class ApiCobaltParser(object):
             "be populated with the asset name while saving the configuration."
         )
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file is None:
             data = CobaltApiImporter().get_findings(test)
         else:

--- a/dojo/tools/api_edgescan/importer.py
+++ b/dojo/tools/api_edgescan/importer.py
@@ -8,7 +8,7 @@ class EdgescanImporter(object):
     Import from Edgescan API
     """
 
-    def get_findings(self, test):
+    def get_findings(self, test, parser_custom_setting=None):
         client, config = self.prepare_client(test)
         findings = client.get_findings(config.service_key_1)
         return findings

--- a/dojo/tools/api_edgescan/parser.py
+++ b/dojo/tools/api_edgescan/parser.py
@@ -31,7 +31,7 @@ class ApiEdgescanParser(object):
     def api_scan_configuration_hint(self):
         return "In the field <b>Service key 1</b>, provide the Edgescan asset ID(s). Leaving it blank will import all assets' findings."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file:
             data = json.load(file)
         else:

--- a/dojo/tools/api_sonarqube/importer.py
+++ b/dojo/tools/api_sonarqube/importer.py
@@ -20,7 +20,7 @@ class SonarQubeApiImporter(object):
      findings.
     """
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         items = self.import_issues(test)
         if settings.SONARQUBE_API_PARSER_HOTSPOTS:
             if items:

--- a/dojo/tools/api_sonarqube/parser.py
+++ b/dojo/tools/api_sonarqube/parser.py
@@ -29,5 +29,5 @@ class ApiSonarQubeParser(object):
             "can be used for the Organization ID if using SonarCloud."
         )
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         return SonarQubeApiImporter().get_findings(json_output, test)

--- a/dojo/tools/api_vulners/importer.py
+++ b/dojo/tools/api_vulners/importer.py
@@ -11,7 +11,7 @@ class VulnersImporter(object):
     Import from Vulners API
     """
 
-    def get_findings(self, test):
+    def get_findings(self, test, parser_custom_setting=None):
         client, config = self.prepare_client(test)
         findings = client.get_findings()
         return findings

--- a/dojo/tools/api_vulners/parser.py
+++ b/dojo/tools/api_vulners/parser.py
@@ -38,7 +38,7 @@ class ApiVulnersParser(object):
     def requires_file(self, scan_type):
         return False
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         findings = []
 
         if file:

--- a/dojo/tools/appspider/parser.py
+++ b/dojo/tools/appspider/parser.py
@@ -16,7 +16,7 @@ class AppSpiderParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "AppSpider (Rapid7) - Use the VulnerabilitiesSummary.xml file found in the zipped report download."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return
 

--- a/dojo/tools/aqua/parser.py
+++ b/dojo/tools/aqua/parser.py
@@ -13,7 +13,7 @@ class AquaParser(object):
     def get_description_for_scan_types(self, scan_type):
         return ""
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/arachni/parser.py
+++ b/dojo/tools/arachni/parser.py
@@ -23,7 +23,7 @@ class ArachniParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Arachni JSON report format (generated with `arachni_reporter --reporter 'json'`)."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/asff/parser.py
+++ b/dojo/tools/asff/parser.py
@@ -26,7 +26,7 @@ class AsffParser(object):
         return """AWS Security Finding Format (ASFF).
         https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-findings-format-syntax.html"""
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         data = json.load(file)
         result = list()
         for item in data:

--- a/dojo/tools/auditjs/parser.py
+++ b/dojo/tools/auditjs/parser.py
@@ -32,7 +32,7 @@ class AuditJSParser(object):
         else:
             return "Informational"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         try:
             data = json.load(filename)
         except JSONDecodeError:

--- a/dojo/tools/aws_prowler/parser.py
+++ b/dojo/tools/aws_prowler/parser.py
@@ -20,7 +20,7 @@ class AWSProwlerParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Export of AWS Prowler in CSV or JSON format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file.name.lower().endswith(".csv"):
             return self.process_csv(file, test)
         elif file.name.lower().endswith(".json"):

--- a/dojo/tools/aws_prowler_v3/parser.py
+++ b/dojo/tools/aws_prowler_v3/parser.py
@@ -19,7 +19,7 @@ class AWSProwlerV3Parser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Export of AWS Prowler JSON V3 format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file.name.lower().endswith('.json'):
             return self.process_json(file, test)
         else:

--- a/dojo/tools/aws_scout2/parser.py
+++ b/dojo/tools/aws_scout2/parser.py
@@ -20,7 +20,7 @@ class AWSScout2Parser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JS file in scout2-report/inc-awsconfig/aws_config.js."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8")

--- a/dojo/tools/awssecurityhub/parser.py
+++ b/dojo/tools/awssecurityhub/parser.py
@@ -14,7 +14,7 @@ class AwsSecurityHubParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "AWS Security Hub exports in JSON format."
 
-    def get_findings(self, filehandle, test):
+    def get_findings(self, filehandle, test, parser_custom_setting=None):
         tree = json.load(filehandle)
         if not isinstance(tree, dict):
             raise ValueError("Incorrect Security Hub report format")

--- a/dojo/tools/azure_security_center_recommendations/parser.py
+++ b/dojo/tools/azure_security_center_recommendations/parser.py
@@ -18,7 +18,7 @@ class AzureSecurityCenterRecommendationsParser(object):
             "CSV format."
         )
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file.name.lower().endswith(".csv"):
             return self.process_csv(file, test)
         else:

--- a/dojo/tools/bandit/parser.py
+++ b/dojo/tools/bandit/parser.py
@@ -14,7 +14,7 @@ class BanditParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON report format"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
 
         results = list()

--- a/dojo/tools/blackduck/parser.py
+++ b/dojo/tools/blackduck/parser.py
@@ -20,7 +20,7 @@ class BlackduckParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Upload the zip file containing the security.csv and components.csv for Security and License risks."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         normalized_findings = self.normalize_findings(filename)
         return self.ingest_findings(normalized_findings, test)
 

--- a/dojo/tools/blackduck_binary_analysis/parser.py
+++ b/dojo/tools/blackduck_binary_analysis/parser.py
@@ -20,7 +20,7 @@ class BlackduckBinaryAnalysisParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Blackduck Binary Analysis CSV file containing vulnerable binaries."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         sorted_findings = self.sort_findings(filename)
         return self.ingest_findings(sorted_findings, test)
 

--- a/dojo/tools/blackduck_component_risk/parser.py
+++ b/dojo/tools/blackduck_component_risk/parser.py
@@ -18,7 +18,7 @@ class BlackduckComponentRiskParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Upload the zip file containing the security.csv and files.csv."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         """
         Function initializes the parser with a file and returns the items.
         :param filename: Input in Defect Dojo

--- a/dojo/tools/brakeman/parser.py
+++ b/dojo/tools/brakeman/parser.py
@@ -17,7 +17,7 @@ class BrakemanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Brakeman Scanner findings in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return ()
 

--- a/dojo/tools/bugcrowd/parser.py
+++ b/dojo/tools/bugcrowd/parser.py
@@ -16,7 +16,7 @@ class BugCrowdParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "BugCrowd CSV report format"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return ()
 

--- a/dojo/tools/bundler_audit/parser.py
+++ b/dojo/tools/bundler_audit/parser.py
@@ -16,7 +16,7 @@ class BundlerAuditParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "'bundler-audit check' output (in plain text)"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         lines = filename.read()
         if isinstance(lines, bytes):
             lines = lines.decode("utf-8")  # passes in unittests, but would fail in production

--- a/dojo/tools/burp/parser.py
+++ b/dojo/tools/burp/parser.py
@@ -28,7 +28,7 @@ class BurpParser(object):
             "response fields. These fields will be processed and made available in the 'Finding View' page."
         )
 
-    def get_findings(self, xml_output, test):
+    def get_findings(self, xml_output, test, parser_custom_setting=None):
         tree = etree.parse(xml_output, etree.XMLParser())
         return self.get_items(tree, test)
 

--- a/dojo/tools/burp_api/parser.py
+++ b/dojo/tools/burp_api/parser.py
@@ -27,7 +27,7 @@ class BurpApiParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Burp REST API scan data in JSON format (/scan/[task_id] endpoint)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         # API export is a JSON file
         tree = json.load(file)
 

--- a/dojo/tools/burp_enterprise/parser.py
+++ b/dojo/tools/burp_enterprise/parser.py
@@ -18,7 +18,7 @@ class BurpEnterpriseParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Burp Enterprise Edition findings in HTML format"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         parser = etree.HTMLParser()
         tree = etree.parse(filename, parser)
         if tree:

--- a/dojo/tools/burp_graphql/parser.py
+++ b/dojo/tools/burp_graphql/parser.py
@@ -19,7 +19,7 @@ class BurpGraphQLParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Burp Enterprise Edition findings from the GraphQL API"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
 
         if "Issues" not in data:

--- a/dojo/tools/cargo_audit/parser.py
+++ b/dojo/tools/cargo_audit/parser.py
@@ -17,7 +17,7 @@ class CargoAuditParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON output for cargo audit scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = {}
         if data.get("vulnerabilities"):

--- a/dojo/tools/checkmarx/parser.py
+++ b/dojo/tools/checkmarx/parser.py
@@ -381,7 +381,7 @@ class CheckmarxParser(object):
         verifiedStates = ["2", "3"]
         return state in verifiedStates
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file.name.strip().lower().endswith(".json"):
             return self._get_findings_json(file, test)
         else:

--- a/dojo/tools/checkmarx_osa/parser.py
+++ b/dojo/tools/checkmarx_osa/parser.py
@@ -19,7 +19,7 @@ class CheckmarxOsaParser(object):
             "CxOSAVulnerabilities.json CxOSALibraries.json`"
         )
 
-    def get_findings(self, filehandle, test):
+    def get_findings(self, filehandle, test, parser_custom_setting=None):
         tree = json.load(filehandle)
         if len(tree) != 2:
             logger.error(

--- a/dojo/tools/checkov/parser.py
+++ b/dojo/tools/checkov/parser.py
@@ -13,7 +13,7 @@ class CheckovParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON reports of Infrastructure as Code vulnerabilities."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         findings = []
         if json_output:
             deserialized = self.parse_json(json_output)

--- a/dojo/tools/clair/parser.py
+++ b/dojo/tools/clair/parser.py
@@ -13,7 +13,7 @@ class ClairParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON reports of Docker image vulnerabilities."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = self.parse_json(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/clair_klar/parser.py
+++ b/dojo/tools/clair_klar/parser.py
@@ -16,7 +16,7 @@ class ClairKlarParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON reports of Docker image vulnerabilities from clair klar client."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = self.parse_json(json_output)
 
         items = list()

--- a/dojo/tools/cloudsploit/parser.py
+++ b/dojo/tools/cloudsploit/parser.py
@@ -22,7 +22,7 @@ class CloudsploitParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Cloudsploit report file can be imported in JSON format (option --json)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         data = json.load(file)
         find_date = datetime.now()
         dupes = dict()

--- a/dojo/tools/cobalt/parser.py
+++ b/dojo/tools/cobalt/parser.py
@@ -17,7 +17,7 @@ class CobaltParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "CSV Report"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return list()
 

--- a/dojo/tools/codechecker/parser.py
+++ b/dojo/tools/codechecker/parser.py
@@ -16,7 +16,7 @@ class CodeCheckerParser(object):
     def get_requires_file(self, scan_type):
         return True
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         if json_output is None:
             return
 

--- a/dojo/tools/contrast/parser.py
+++ b/dojo/tools/contrast/parser.py
@@ -19,7 +19,7 @@ class ContrastParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "CSV Report"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8")

--- a/dojo/tools/coverity_api/parser.py
+++ b/dojo/tools/coverity_api/parser.py
@@ -16,7 +16,7 @@ class CoverityApiParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Coverity API view data in JSON format (/api/viewContents/issues endpoint)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = json.load(file)
 
         if "viewContentsV1" not in tree:

--- a/dojo/tools/crashtest_security/parser.py
+++ b/dojo/tools/crashtest_security/parser.py
@@ -16,7 +16,7 @@ class CrashtestSecurityJsonParser(object):
     @param test The test to which the finding belongs
     """
 
-    def get_findings(self, filename, test, parser_custom_setting=None):
+    def get_findings(self, file, test, parser_custom_setting=None):
         # Load the data
         tree = file.read()
         try:

--- a/dojo/tools/crashtest_security/parser.py
+++ b/dojo/tools/crashtest_security/parser.py
@@ -16,7 +16,7 @@ class CrashtestSecurityJsonParser(object):
     @param test The test to which the finding belongs
     """
 
-    def get_findings(self, file, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         # Load the data
         tree = file.read()
         try:

--- a/dojo/tools/cred_scan/parser.py
+++ b/dojo/tools/cred_scan/parser.py
@@ -22,7 +22,7 @@ class CredScanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import CSV output of CredScan scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8-sig")

--- a/dojo/tools/cyclonedx/parser.py
+++ b/dojo/tools/cyclonedx/parser.py
@@ -359,7 +359,7 @@ class CycloneDXParser(object):
         m = re.match(r"\{.*\}", element.tag)
         return m.group(0) if m else ""
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file.name.strip().lower().endswith(".json"):
             return self._get_findings_json(file, test)
         else:

--- a/dojo/tools/dawnscanner/parser.py
+++ b/dojo/tools/dawnscanner/parser.py
@@ -17,7 +17,7 @@ class DawnScannerParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Dawnscanner (-j) output file can be imported in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
 
         find_date = parser.parse(data["scan_started"])

--- a/dojo/tools/dependency_check/parser.py
+++ b/dojo/tools/dependency_check/parser.py
@@ -354,7 +354,7 @@ class DependencyCheckParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "OWASP Dependency Check output can be imported in Xml format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         dupes = dict()
         namespace = ""
         content = filename.read()

--- a/dojo/tools/dependency_track/parser.py
+++ b/dojo/tools/dependency_track/parser.py
@@ -247,7 +247,7 @@ class DependencyTrackParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "The Finding Packaging Format (FPF) from OWASP Dependency Track can be imported in JSON format. See here for more info on this JSON format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
 
         # Exit if file is not provided
         if file is None:

--- a/dojo/tools/detect_secrets/parser.py
+++ b/dojo/tools/detect_secrets/parser.py
@@ -18,7 +18,7 @@ class DetectSecretsParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON output for detect-secrets scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = {}
         if data.get("generated_at"):

--- a/dojo/tools/dockerbench/parser.py
+++ b/dojo/tools/dockerbench/parser.py
@@ -14,7 +14,7 @@ class DockerBenchParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON reports of Docker CIS benchmark scans."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
 
         return get_tests(tree, test)

--- a/dojo/tools/dockle/parser.py
+++ b/dojo/tools/dockle/parser.py
@@ -24,7 +24,7 @@ class DockleParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON output for Dockle scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = {}
         for item in data["details"]:

--- a/dojo/tools/drheader/parser.py
+++ b/dojo/tools/drheader/parser.py
@@ -38,7 +38,7 @@ class DrHeaderParser(object):
             find.unsaved_endpoints = [Endpoint.from_uri(url)]
         return find
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         items = []
         try:
             data = json.load(filename)

--- a/dojo/tools/dsop/parser.py
+++ b/dojo/tools/dsop/parser.py
@@ -14,7 +14,7 @@ class DsopParser:
     def get_description_for_scan_types(self, scan_type):
         return "Import XLSX findings from DSOP vulnerability scan pipelines."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         book = load_workbook(file)
         items = list()
         self.__parse_disa(test, items, book["OpenSCAP - DISA Compliance"])

--- a/dojo/tools/eslint/parser.py
+++ b/dojo/tools/eslint/parser.py
@@ -21,7 +21,7 @@ class ESLintParser(object):
         else:
             return "Info"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         tree = filename.read()
         try:
             data = json.loads(str(tree, "utf-8"))

--- a/dojo/tools/fortify/parser.py
+++ b/dojo/tools/fortify/parser.py
@@ -17,7 +17,7 @@ class FortifyParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Findings from XML file format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         fortify_scan = ElementTree.parse(filename)
         root = fortify_scan.getroot()
 

--- a/dojo/tools/generic/parser.py
+++ b/dojo/tools/generic/parser.py
@@ -21,7 +21,7 @@ class GenericParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Generic findings in CSV or JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename.name.lower().endswith(".csv"):
             return self._get_findings_csv(filename)
         elif filename.name.lower().endswith(".json"):

--- a/dojo/tools/ggshield/parser.py
+++ b/dojo/tools/ggshield/parser.py
@@ -18,7 +18,7 @@ class GgshieldParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Ggshield Scan findings in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         """
         Converts a Ggshield report to DefectDojo findings
         """

--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -15,7 +15,7 @@ class GithubVulnerabilityParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import vulnerabilities from Github API (GraphQL Query)"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         if "data" not in data:
             raise ValueError("Invalid report file, no 'data' node found")

--- a/dojo/tools/gitlab_api_fuzzing/parser.py
+++ b/dojo/tools/gitlab_api_fuzzing/parser.py
@@ -19,7 +19,7 @@ class GitlabAPIFuzzingParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "GitLab API Fuzzing Report report file can be imported in JSON format (option --json)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         findings = []
         data = json.load(file)
         vulnerabilities = data["vulnerabilities"]

--- a/dojo/tools/gitlab_container_scan/parser.py
+++ b/dojo/tools/gitlab_container_scan/parser.py
@@ -68,7 +68,7 @@ class GitlabContainerScanParser(object):
             else None
         )
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         findings = []
         data = json.load(file)
         # parse date

--- a/dojo/tools/gitlab_dast/parser.py
+++ b/dojo/tools/gitlab_dast/parser.py
@@ -18,7 +18,7 @@ class GitlabDastParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "GitLab DAST Report in JSON format (option --json)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file is None:
             return None
 

--- a/dojo/tools/gitlab_dep_scan/parser.py
+++ b/dojo/tools/gitlab_dep_scan/parser.py
@@ -13,7 +13,7 @@ class GitlabDepScanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import GitLab SAST Report vulnerabilities in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         if json_output is None:
             return
 

--- a/dojo/tools/gitlab_sast/parser.py
+++ b/dojo/tools/gitlab_sast/parser.py
@@ -15,7 +15,7 @@ class GitlabSastParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import GitLab SAST Report vulnerabilities in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
 
         if json_output is None:
             return

--- a/dojo/tools/gitlab_secret_detection_report/parser.py
+++ b/dojo/tools/gitlab_secret_detection_report/parser.py
@@ -18,7 +18,7 @@ class GitlabSecretDetectionReportParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "GitLab Secret Detection Report file can be imported in JSON format (option --json)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         # Load JSON data from uploaded file
         data = json.load(file)
 

--- a/dojo/tools/gitleaks/parser.py
+++ b/dojo/tools/gitleaks/parser.py
@@ -18,7 +18,7 @@ class GitleaksParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Gitleaks Scan findings in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         """
         Converts a Gitleaks report to DefectDojo findings
         """

--- a/dojo/tools/gosec/parser.py
+++ b/dojo/tools/gosec/parser.py
@@ -13,7 +13,7 @@ class GosecParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Gosec Scanner findings in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         tree = filename.read()
         try:
             data = json.loads(str(tree, "utf-8"))

--- a/dojo/tools/govulncheck/parser.py
+++ b/dojo/tools/govulncheck/parser.py
@@ -37,7 +37,7 @@ class GovulncheckParser:
     def get_version(data, node):
         return data["Requires"]["Modules"][str(node)]["Version"]
 
-    def get_findings(self, scan_file, test):
+    def get_findings(self, scan_file, test, parser_custom_setting=None):
         findings = []
         try:
             data = json.load(scan_file)

--- a/dojo/tools/h1/parser.py
+++ b/dojo/tools/h1/parser.py
@@ -21,7 +21,7 @@ class H1Parser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import HackerOne cases findings in JSON format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         """
         Converts a HackerOne reports to a DefectDojo finding
         """

--- a/dojo/tools/hadolint/parser.py
+++ b/dojo/tools/hadolint/parser.py
@@ -13,7 +13,7 @@ class HadolintParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Hadolint Dockerfile check findings in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -18,7 +18,6 @@ class HarborVulnerabilityParser(object):
         return "Import vulnerabilities from Harbor API."
 
     def get_findings(self, filename, test, parser_custom_setting=None):
-        print("\n\n" + str(parser_custom_setting) + "\n\n")
         tree = filename.read()
         try:
             data = json.loads(str(tree, "utf-8"))

--- a/dojo/tools/harbor_vulnerability/parser.py
+++ b/dojo/tools/harbor_vulnerability/parser.py
@@ -17,7 +17,8 @@ class HarborVulnerabilityParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import vulnerabilities from Harbor API."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
+        print("\n\n" + str(parser_custom_setting) + "\n\n")
         tree = filename.read()
         try:
             data = json.loads(str(tree, "utf-8"))

--- a/dojo/tools/hcl_appscan/parser.py
+++ b/dojo/tools/hcl_appscan/parser.py
@@ -13,7 +13,7 @@ class HCLAppScanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import XML output of HCL AppScan."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         findings = []
         tree = ET.parse(file)
         root = tree.getroot()

--- a/dojo/tools/horusec/parser.py
+++ b/dojo/tools/horusec/parser.py
@@ -25,7 +25,7 @@ class HorusecParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON output of Horusec cli."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         report_date = datetime.strptime(
             data.get("createdAt")[0:10], "%Y-%m-%d"

--- a/dojo/tools/humble/parser.py
+++ b/dojo/tools/humble/parser.py
@@ -14,7 +14,7 @@ class HumbleParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON output of Humble scan."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         items = []
         try:
             data = json.load(filename)

--- a/dojo/tools/huskyci/parser.py
+++ b/dojo/tools/huskyci/parser.py
@@ -18,7 +18,7 @@ class HuskyCIParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import HuskyCI Report vulnerabilities in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         if json_output is None:
             return
 

--- a/dojo/tools/hydra/parser.py
+++ b/dojo/tools/hydra/parser.py
@@ -34,7 +34,7 @@ class HydraParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Hydra Scan can be imported in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         report = self.__parse_json(json_output)
 
         metadata = HydraScanMetadata(report["generator"])

--- a/dojo/tools/ibm_app/parser.py
+++ b/dojo/tools/ibm_app/parser.py
@@ -18,7 +18,7 @@ class IbmAppParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "XML file from IBM App Scanner."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         ibm_scan_tree = ElementTree.parse(file)
         root = ibm_scan_tree.getroot()
 

--- a/dojo/tools/immuniweb/parser.py
+++ b/dojo/tools/immuniweb/parser.py
@@ -17,7 +17,7 @@ class ImmuniwebParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "XML Scan Result File from Imuniweb Scan."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         ImmuniScanTree = ElementTree.parse(file)
         root = ImmuniScanTree.getroot()
         # validate XML file

--- a/dojo/tools/intsights/parser.py
+++ b/dojo/tools/intsights/parser.py
@@ -183,7 +183,7 @@ class IntSightsParser(object):
         )
         return description
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         duplicates = dict()
 
         if file.name.lower().endswith(".json"):

--- a/dojo/tools/jfrog_xray_api_summary_artifact/parser.py
+++ b/dojo/tools/jfrog_xray_api_summary_artifact/parser.py
@@ -24,7 +24,7 @@ class JFrogXrayApiSummaryArtifactParser(object):
         return "Import Xray findings in JSON format from the JFrog Xray API Summary/Artifact JSON response"
 
     # This function return a list of findings
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/jfrog_xray_on_demand_binary_scan/parser.py
+++ b/dojo/tools/jfrog_xray_on_demand_binary_scan/parser.py
@@ -18,7 +18,7 @@ class JFrogXrayOnDemandBinaryScanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Xray findings in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree)
 

--- a/dojo/tools/jfrog_xray_unified/parser.py
+++ b/dojo/tools/jfrog_xray_unified/parser.py
@@ -16,7 +16,7 @@ class JFrogXrayUnifiedParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Xray Unified (i.e. Xray version 3+) findings in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/jfrogxray/parser.py
+++ b/dojo/tools/jfrogxray/parser.py
@@ -18,7 +18,7 @@ class JFrogXrayParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Xray findings in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/kics/parser.py
+++ b/dojo/tools/kics/parser.py
@@ -25,7 +25,7 @@ class KICSParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON output for KICS scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = {}
         for query in data["queries"]:

--- a/dojo/tools/kiuwan/parser.py
+++ b/dojo/tools/kiuwan/parser.py
@@ -35,7 +35,7 @@ class KiuwanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Kiuwan Scan in CSV format. Export as CSV Results on Kiuwan."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8")

--- a/dojo/tools/kubebench/parser.py
+++ b/dojo/tools/kubebench/parser.py
@@ -13,7 +13,7 @@ class KubeBenchParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON reports of Kubernetes CIS benchmark scans."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         if "Controls" in tree:
             return self.get_chapters(tree["Controls"], test)

--- a/dojo/tools/kubehunter/parser.py
+++ b/dojo/tools/kubehunter/parser.py
@@ -17,7 +17,7 @@ class KubeHunterParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "KubeHunter JSON vulnerability report format.."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         data = json.load(file)
 
         dupes = dict()

--- a/dojo/tools/meterian/parser.py
+++ b/dojo/tools/meterian/parser.py
@@ -14,7 +14,7 @@ class MeterianParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Meterian JSON report output file can be imported."
 
-    def get_findings(self, report, test):
+    def get_findings(self, report, test, parser_custom_setting=None):
         findings = []
 
         report_json = json.load(report)

--- a/dojo/tools/microfocus_webinspect/parser.py
+++ b/dojo/tools/microfocus_webinspect/parser.py
@@ -19,7 +19,7 @@ class MicrofocusWebinspectParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import XML report"
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = parse(file)
         # get root of tree.
         root = tree.getroot()

--- a/dojo/tools/mobsf/parser.py
+++ b/dojo/tools/mobsf/parser.py
@@ -18,7 +18,7 @@ class MobSFParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Export a JSON file using the API, api/v1/report_json."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         tree = filename.read()
         try:
             data = json.loads(str(tree, 'utf-8'))

--- a/dojo/tools/mobsfscan/parser.py
+++ b/dojo/tools/mobsfscan/parser.py
@@ -24,7 +24,7 @@ class MobsfscanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON report for mobsfscan report file."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         if len(data.get("results")) == 0:
             return []

--- a/dojo/tools/mozilla_observatory/parser.py
+++ b/dojo/tools/mozilla_observatory/parser.py
@@ -22,7 +22,7 @@ class MozillaObservatoryParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON report."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         data = json.load(file)
         # format from the CLI
         if "tests" in data:

--- a/dojo/tools/ms_defender/parser.py
+++ b/dojo/tools/ms_defender/parser.py
@@ -19,7 +19,7 @@ class MSDefenderParser(object):
     def get_description_for_scan_types(self, scan_type):
         return ("MSDefender findings can be retrieved using the REST API")
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if str(file.name).endswith('.json'):
             vulnerabilityfile = json.load(file)
             vulnerabilitydata = vulnerabilityfile['value']

--- a/dojo/tools/netsparker/parser.py
+++ b/dojo/tools/netsparker/parser.py
@@ -16,7 +16,7 @@ class NetsparkerParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Netsparker JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         tree = filename.read()
         try:
             data = json.loads(str(tree, "utf-8-sig"))

--- a/dojo/tools/neuvector/parser.py
+++ b/dojo/tools/neuvector/parser.py
@@ -139,7 +139,7 @@ class NeuVectorParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON output of /v1/scan/{entity}/{id} endpoint."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return list()
 

--- a/dojo/tools/neuvector_compliance/parser.py
+++ b/dojo/tools/neuvector_compliance/parser.py
@@ -145,7 +145,7 @@ class NeuVectorComplianceParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Imports compliance scans returned by REST API."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return list()
 

--- a/dojo/tools/nexpose/parser.py
+++ b/dojo/tools/nexpose/parser.py
@@ -26,7 +26,7 @@ class NexposeParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Use the full XML export template from Nexpose."
 
-    def get_findings(self, xml_output, test):
+    def get_findings(self, xml_output, test, parser_custom_setting=None):
         tree = ElementTree.parse(xml_output)
         vuln_definitions = self.get_vuln_definitions(tree)
         return self.get_items(tree, vuln_definitions, test)

--- a/dojo/tools/nikto/parser.py
+++ b/dojo/tools/nikto/parser.py
@@ -33,7 +33,7 @@ class NiktoParser(object):
             'XML output (old and new nxvmlversion="1.2" type) or JSON output'
         )
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename.name.lower().endswith(".xml"):
             return self.process_xml(filename, test)
         elif filename.name.lower().endswith(".json"):

--- a/dojo/tools/nmap/parser.py
+++ b/dojo/tools/nmap/parser.py
@@ -15,7 +15,7 @@ class NmapParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "XML output (use -oX)"
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = parse(file)
         root = tree.getroot()
         dupes = dict()

--- a/dojo/tools/npm_audit/parser.py
+++ b/dojo/tools/npm_audit/parser.py
@@ -18,7 +18,7 @@ class NpmAuditParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "NPM Audit Scan json output up to v6 can be imported in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = self.parse_json(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/nsp/parser.py
+++ b/dojo/tools/nsp/parser.py
@@ -13,7 +13,7 @@ class NspParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Node Security Platform (NSP) output file can be imported in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = self.parse_json(json_output)
         if tree:
             return self.get_items(tree, test)

--- a/dojo/tools/nuclei/parser.py
+++ b/dojo/tools/nuclei/parser.py
@@ -25,7 +25,7 @@ class NucleiParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON output for nuclei scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         filecontent = filename.read()
         if isinstance(filecontent, bytes):
             filecontent = filecontent.decode("utf-8")

--- a/dojo/tools/openscap/parser.py
+++ b/dojo/tools/openscap/parser.py
@@ -18,7 +18,7 @@ class OpenscapParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Openscap Vulnerability Scan in XML formats."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = parse(file)
         # get root of tree.
         root = tree.getroot()

--- a/dojo/tools/openvas_csv/parser.py
+++ b/dojo/tools/openvas_csv/parser.py
@@ -248,7 +248,7 @@ class OpenVASCsvParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import OpenVAS Scan in CSV format. Export as CSV Results on OpenVAS."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         column_names = dict()
         dupes = dict()
         chain = self.create_chain()

--- a/dojo/tools/openvas_xml/parser.py
+++ b/dojo/tools/openvas_xml/parser.py
@@ -26,7 +26,7 @@ class OpenVASXMLParser(object):
         else:
             return "Critical"
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         findings = []
         tree = ET.parse(file)
         root = tree.getroot()

--- a/dojo/tools/ort/parser.py
+++ b/dojo/tools/ort/parser.py
@@ -17,7 +17,7 @@ class OrtParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Outpost24 endpoint vulnerability scan in XML format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         if json_output is None:
             return list()
 

--- a/dojo/tools/ossindex_devaudit/parser.py
+++ b/dojo/tools/ossindex_devaudit/parser.py
@@ -19,7 +19,7 @@ class OssIndexDevauditParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import OssIndex Devaudit SCA Scan in json format."
 
-    def get_findings(self, json_file, test):
+    def get_findings(self, json_file, test, parser_custom_setting=None):
         tree = self.parse_json(json_file)
 
         if tree:

--- a/dojo/tools/outpost24/parser.py
+++ b/dojo/tools/outpost24/parser.py
@@ -17,7 +17,7 @@ class Outpost24Parser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Outpost24 endpoint vulnerability scan in XML format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = ElementTree.parse(file)
         items = list()
         for detail in tree.iterfind(".//detaillist/detail"):

--- a/dojo/tools/php_security_audit_v2/parser.py
+++ b/dojo/tools/php_security_audit_v2/parser.py
@@ -14,7 +14,7 @@ class PhpSecurityAuditV2Parser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import PHP Security Audit v2 Scan in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         tree = filename.read()
         try:
             data = json.loads(str(tree, "utf-8"))

--- a/dojo/tools/php_symfony_security_check/parser.py
+++ b/dojo/tools/php_symfony_security_check/parser.py
@@ -13,7 +13,7 @@ class PhpSymfonySecurityCheckParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import results from the PHP Symfony Security Checker by Sensioslabs."
 
-    def get_findings(self, json_file, test):
+    def get_findings(self, json_file, test, parser_custom_setting=None):
         tree = self.parse_json(json_file)
         return self.get_items(tree, test)
 

--- a/dojo/tools/pip_audit/parser.py
+++ b/dojo/tools/pip_audit/parser.py
@@ -16,7 +16,7 @@ class PipAuditParser:
     def requires_file(self, scan_type):
         return True
 
-    def get_findings(self, scan_file, test):
+    def get_findings(self, scan_file, test, parser_custom_setting=None):
         data = json.load(scan_file)
 
         findings = list()

--- a/dojo/tools/pmd/parser.py
+++ b/dojo/tools/pmd/parser.py
@@ -14,7 +14,7 @@ class PmdParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "CSV Report"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         dupes = dict()
 
         content = filename.read()

--- a/dojo/tools/popeye/parser.py
+++ b/dojo/tools/popeye/parser.py
@@ -18,7 +18,7 @@ class PopeyeParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Popeye report file can be imported in JSON format (option --json)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         data = json.load(file)
 
         dupes = dict()

--- a/dojo/tools/pwn_sast/parser.py
+++ b/dojo/tools/pwn_sast/parser.py
@@ -18,7 +18,7 @@ class PWNSASTParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import pwn_sast Driver findings in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         results = json.load(filename)
 
         if results is not None:

--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -285,7 +285,7 @@ class QualysParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Qualys WebGUI output files can be imported in XML format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file.name.lower().endswith(".csv"):
             return csv_parser.parse_csv(file)
         else:

--- a/dojo/tools/qualys_infrascan_webgui/parser.py
+++ b/dojo/tools/qualys_infrascan_webgui/parser.py
@@ -136,7 +136,7 @@ class QualysInfrascanWebguiParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Qualys WebGUI output files can be imported in XML format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         data = ElementTree.parse(file).getroot()
 
         # fetch scan date e.g.: <KEY value="DATE">2020-01-30T09:45:41Z</KEY>

--- a/dojo/tools/retirejs/parser.py
+++ b/dojo/tools/retirejs/parser.py
@@ -14,7 +14,7 @@ class RetireJsParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Retire.js JavaScript scan (--js) output file can be imported in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/risk_recon/parser.py
+++ b/dojo/tools/risk_recon/parser.py
@@ -15,7 +15,7 @@ class RiskReconParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Risk Recon ApI will be accessed to gather finding information. Report format here."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename:
             tree = filename.read()
             try:

--- a/dojo/tools/rubocop/parser.py
+++ b/dojo/tools/rubocop/parser.py
@@ -33,7 +33,7 @@ class RubocopParser:
     def requires_file(self, scan_type):
         return True
 
-    def get_findings(self, scan_file, test):
+    def get_findings(self, scan_file, test, parser_custom_setting=None):
         """Load a file as JSON file and create findings"""
         data = json.load(scan_file)
         findings = list()

--- a/dojo/tools/rusty_hog/parser.py
+++ b/dojo/tools/rusty_hog/parser.py
@@ -13,7 +13,7 @@ class RustyhogParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Rusty Hog Scan - JSON Report"
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -28,7 +28,7 @@ class SarifParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "SARIF report file can be imported in SARIF format."
 
-    def get_findings(self, filehandle, test):
+    def get_findings(self, filehandle, test, parser_custom_setting=None):
         """For simple interface of parser contract we just aggregate everything"""
         tree = json.load(filehandle)
         items = list()

--- a/dojo/tools/scantist/parser.py
+++ b/dojo/tools/scantist/parser.py
@@ -27,7 +27,7 @@ class ScantistParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Scantist Dependency Scanning Report vulnerabilities in JSON format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = json.load(file)
         return self.get_items(tree, test)
 

--- a/dojo/tools/scout_suite/parser.py
+++ b/dojo/tools/scout_suite/parser.py
@@ -84,7 +84,7 @@ class ScoutSuiteParser(object):
         tests.append(test)
         return tests
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8")

--- a/dojo/tools/semgrep/parser.py
+++ b/dojo/tools/semgrep/parser.py
@@ -13,7 +13,7 @@ class SemgrepParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import Semgrep output (--json)"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
 
         dupes = dict()

--- a/dojo/tools/skf/parser.py
+++ b/dojo/tools/skf/parser.py
@@ -91,7 +91,7 @@ class SKFParser(object):
             column_names[index] = column
             index += 1
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8")

--- a/dojo/tools/snyk/parser.py
+++ b/dojo/tools/snyk/parser.py
@@ -14,7 +14,7 @@ class SnykParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Snyk output file (snyk test --json > snyk.json) can be imported in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         reportTree = self.parse_json(json_output)
 
         if isinstance(reportTree, list):

--- a/dojo/tools/solar_appscreener/parser.py
+++ b/dojo/tools/solar_appscreener/parser.py
@@ -17,7 +17,7 @@ class SolarAppscreenerParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Solar Appscreener report file can be imported in CSV format from Detailed_Results.csv."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return ()
 

--- a/dojo/tools/sonarqube/parser.py
+++ b/dojo/tools/sonarqube/parser.py
@@ -27,7 +27,7 @@ class SonarQubeParser(object):
         else:
             return "Import all findings from sonarqube html report. SonarQube output file can be imported in HTML format. Generate with https://github.com/soprasteria/sonar-report version >= 1.1.0"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         parser = etree.HTMLParser()
         tree = etree.parse(filename, parser)
         if self.mode not in [None, "detailed"]:

--- a/dojo/tools/sonatype/parser.py
+++ b/dojo/tools/sonatype/parser.py
@@ -19,7 +19,7 @@ class SonatypeParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Can be imported in JSON format"
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         tree = json.load(json_output)
         return self.get_items(tree, test)
 

--- a/dojo/tools/spotbugs/parser.py
+++ b/dojo/tools/spotbugs/parser.py
@@ -16,7 +16,7 @@ class SpotbugsParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "XML report of textui cli."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         mitigation_patterns = dict()
         reference_patterns = dict()
         dupes = dict()

--- a/dojo/tools/ssh_audit/parser.py
+++ b/dojo/tools/ssh_audit/parser.py
@@ -31,7 +31,7 @@ class SSHAuditParser(object):
         else:
             return "Critical"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         items = []
         try:
             data = json.load(filename)

--- a/dojo/tools/ssl_labs/parser.py
+++ b/dojo/tools/ssl_labs/parser.py
@@ -16,7 +16,7 @@ class SslLabsParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON Output of ssllabs-scan cli."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         tree = filename.read()
         try:
             data = json.loads(str(tree, "utf-8"))

--- a/dojo/tools/sslscan/parser.py
+++ b/dojo/tools/sslscan/parser.py
@@ -18,7 +18,7 @@ class SslscanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import XML output of sslscan report."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = ET.parse(file)
         # get root of tree.
         root = tree.getroot()

--- a/dojo/tools/sslyze/parser.py
+++ b/dojo/tools/sslyze/parser.py
@@ -16,7 +16,7 @@ class SslyzeParser(object):
             return "Import JSON report of SSLyze version 3 and higher."
         return "Import XML report of SSLyze version 2 scan."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return list()
 

--- a/dojo/tools/sslyze/parser_json.py
+++ b/dojo/tools/sslyze/parser_json.py
@@ -69,7 +69,7 @@ REFERENCES = "TLS recommendations of German BSI: " + BSI_LINK
 
 
 class SSLyzeJSONParser(object):
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         if json_output is None:
             return
 

--- a/dojo/tools/sslyze/parser_xml.py
+++ b/dojo/tools/sslyze/parser_xml.py
@@ -50,7 +50,7 @@ PROTOCOLS = ["sslv2", "sslv3", "tlsv1", "tlsv1_1", "tlsv1_2", "tlsv1_3"]
 
 
 class SSLyzeXMLParser(object):
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = ET.parse(file)
         # get root of tree.
         root = tree.getroot()

--- a/dojo/tools/stackhawk/parser.py
+++ b/dojo/tools/stackhawk/parser.py
@@ -28,7 +28,7 @@ class StackHawkParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "StackHawk webhook event can be imported in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         completed_scan = self.__parse_json(json_output)
 
         metadata = StackHawkScanMetadata(completed_scan)

--- a/dojo/tools/sysdig_reports/parser.py
+++ b/dojo/tools/sysdig_reports/parser.py
@@ -19,7 +19,7 @@ class SysdigReportsParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import of Sysdig Pipeline, Registry and Runtime Vulnerability Report Scans in CSV format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
 
         if filename is None:
             return ()

--- a/dojo/tools/talisman/parser.py
+++ b/dojo/tools/talisman/parser.py
@@ -27,7 +27,7 @@ class TalismanParser(object):
         """
         return "Import Talisman Scan findings in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         """
         Converts a Talisman JSON report to DefectDojo findings
         """

--- a/dojo/tools/tenable/csv_format.py
+++ b/dojo/tools/tenable/csv_format.py
@@ -8,7 +8,7 @@ import sys
 from cpe import CPE
 from cvss import CVSS3
 
-from dojo.models import Endpoint, Finding, Test
+from dojo.models import Endpoint, Finding
 
 LOGGER = logging.getLogger(__name__)
 

--- a/dojo/tools/tenable/csv_format.py
+++ b/dojo/tools/tenable/csv_format.py
@@ -63,7 +63,7 @@ class TenableCSVParser(object):
         cpe_match = re.findall(r"cpe:/[^\n\ ]+", val)
         return cpe_match if cpe_match else None
 
-    def get_findings(self, filename: str, test: Test):
+    def get_findings(self, filename: str, test, parser_custom_setting=None):
         # Read the CSV
         content = filename.read()
         if isinstance(content, bytes):

--- a/dojo/tools/tenable/csv_format.py
+++ b/dojo/tools/tenable/csv_format.py
@@ -8,7 +8,7 @@ import sys
 from cpe import CPE
 from cvss import CVSS3
 
-from dojo.models import Endpoint, Finding
+from dojo.models import Endpoint, Finding, Test
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +63,7 @@ class TenableCSVParser(object):
         cpe_match = re.findall(r"cpe:/[^\n\ ]+", val)
         return cpe_match if cpe_match else None
 
-    def get_findings(self, filename: str, test, parser_custom_setting=None):
+    def get_findings(self, filename: str, test:Test, parser_custom_setting=None):
         # Read the CSV
         content = filename.read()
         if isinstance(content, bytes):

--- a/dojo/tools/tenable/csv_format.py
+++ b/dojo/tools/tenable/csv_format.py
@@ -63,7 +63,7 @@ class TenableCSVParser(object):
         cpe_match = re.findall(r"cpe:/[^\n\ ]+", val)
         return cpe_match if cpe_match else None
 
-    def get_findings(self, filename: str, test:Test, parser_custom_setting=None):
+    def get_findings(self, filename: str, test: Test, parser_custom_setting=None):
         # Read the CSV
         content = filename.read()
         if isinstance(content, bytes):

--- a/dojo/tools/tenable/parser.py
+++ b/dojo/tools/tenable/parser.py
@@ -14,7 +14,7 @@ class TenableParser(object):
             "Reports can be imported as CSV or .nessus (XML) report formats."
         )
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename.name.lower().endswith(
             ".xml"
         ) or filename.name.lower().endswith(".nessus"):

--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -40,7 +40,7 @@ class TenableXMLParser(object):
                 return element_text or None
         return None
 
-    def get_findings(self, filename: str, test: Test) -> list:
+    def get_findings(self, filename: str, test, parser_custom_setting=None):
         # Read the XML
         nscan = ElementTree.parse(filename)
         root = nscan.getroot()

--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -5,7 +5,7 @@ from cvss import CVSS3
 from defusedxml import ElementTree
 from hyperlink._url import SCHEME_PORT_MAP
 
-from dojo.models import Endpoint, Finding, Test
+from dojo.models import Endpoint, Finding
 
 LOGGER = logging.getLogger(__name__)
 

--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -40,7 +40,7 @@ class TenableXMLParser(object):
                 return element_text or None
         return None
 
-    def get_findings(self, filename: str, test: Test, parser_custom_setting=None):
+    def get_findings(self, filename: str, test: Test, parser_custom_setting=None) -> list:
         # Read the XML
         nscan = ElementTree.parse(filename)
         root = nscan.getroot()

--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -5,7 +5,7 @@ from cvss import CVSS3
 from defusedxml import ElementTree
 from hyperlink._url import SCHEME_PORT_MAP
 
-from dojo.models import Endpoint, Finding
+from dojo.models import Endpoint, Finding, Test
 
 LOGGER = logging.getLogger(__name__)
 
@@ -40,7 +40,7 @@ class TenableXMLParser(object):
                 return element_text or None
         return None
 
-    def get_findings(self, filename: str, test, parser_custom_setting=None):
+    def get_findings(self, filename: str, test: Test, parser_custom_setting=None):
         # Read the XML
         nscan = ElementTree.parse(filename)
         root = nscan.getroot()

--- a/dojo/tools/terrascan/parser.py
+++ b/dojo/tools/terrascan/parser.py
@@ -24,7 +24,7 @@ class TerrascanParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON output for Terrascan scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = {}
         if "results" not in data and "violations" not in data.get("results"):

--- a/dojo/tools/testssl/parser.py
+++ b/dojo/tools/testssl/parser.py
@@ -15,7 +15,7 @@ class TestsslParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import CSV output of testssl scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8")

--- a/dojo/tools/tfsec/parser.py
+++ b/dojo/tools/tfsec/parser.py
@@ -28,7 +28,7 @@ class TFSecParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON output for TFSec scan report."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         dupes = {}
         if "results" not in data:

--- a/dojo/tools/threagile/parser.py
+++ b/dojo/tools/threagile/parser.py
@@ -65,7 +65,7 @@ class ThreagileParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Threagile Risks Report in JSON format (risks.json)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file is None:
             return None
 

--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -70,7 +70,7 @@ class TrivyParser:
             else:
                 return "Critical"
 
-    def get_findings(self, scan_file, test):
+    def get_findings(self, scan_file, test, parser_custom_setting=None):
         scan_data = scan_file.read()
 
         try:

--- a/dojo/tools/trivy_operator/parser.py
+++ b/dojo/tools/trivy_operator/parser.py
@@ -37,7 +37,7 @@ class TrivyOperatorParser:
     def get_description_for_scan_types(self, scan_type):
         return "Import trivy-operator JSON scan report."
 
-    def get_findings(self, scan_file, test):
+    def get_findings(self, scan_file, test, parser_custom_setting=None):
         scan_data = scan_file.read()
 
         try:

--- a/dojo/tools/trufflehog/parser.py
+++ b/dojo/tools/trufflehog/parser.py
@@ -14,7 +14,7 @@ class TruffleHogParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON Output of Trufflehog. Supports version 2 and 3 of https://github.com/trufflesecurity/trufflehog"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = filename.read()
         dict_strs = data.splitlines()
         if len(dict_strs) == 0:

--- a/dojo/tools/trufflehog3/parser.py
+++ b/dojo/tools/trufflehog3/parser.py
@@ -14,7 +14,7 @@ class TruffleHog3Parser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON Output of Trufflehog3, a fork of TruffleHog located at https://github.com/feeltheajf/truffleHog3"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
 
         dupes = dict()

--- a/dojo/tools/trustwave/parser.py
+++ b/dojo/tools/trustwave/parser.py
@@ -15,7 +15,7 @@ class TrustwaveParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "CSV output of Trustwave vulnerability scan."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         content = filename.read()
         if isinstance(content, bytes):
             content = content.decode("utf-8")

--- a/dojo/tools/trustwave_fusion_api/parser.py
+++ b/dojo/tools/trustwave_fusion_api/parser.py
@@ -21,7 +21,7 @@ class TrustwaveFusionAPIParser(object):
             "Trustwave Fusion API report file can be imported in JSON format"
         )
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = json.load(file)
         items = {}
 

--- a/dojo/tools/twistlock/parser.py
+++ b/dojo/tools/twistlock/parser.py
@@ -215,7 +215,7 @@ class TwistlockParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "JSON output of twistcli image scan or CSV."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return list()
 

--- a/dojo/tools/utils.py
+++ b/dojo/tools/utils.py
@@ -14,7 +14,7 @@ def get_npm_cwe(item_node):
     """
     cwe_node = item_node.get('cwe')
     if cwe_node:
-        if type(cwe_node) == list:
+        if type(cwe_node) is list:
             return int(cwe_node[0][4:])
         elif cwe_node.startswith('CWE-'):
             cwe_string = cwe_node[4:]

--- a/dojo/tools/vcg/parser.py
+++ b/dojo/tools/vcg/parser.py
@@ -211,7 +211,7 @@ class VCGParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "VCG output can be imported in CSV or Xml formats."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return list()
 

--- a/dojo/tools/veracode/json_parser.py
+++ b/dojo/tools/veracode/json_parser.py
@@ -50,7 +50,7 @@ class VeracodeJSONParser(object):
         4: ("High", "High-risk licenses are typically strong copyleft licenses that require you to preserve the copyright and license notices, and require distributors to make the source code of the component and any modifications under the same terms."),
     }
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         findings = []
         if json_output:
             json_data = json.load(json_output)

--- a/dojo/tools/veracode/parser.py
+++ b/dojo/tools/veracode/parser.py
@@ -14,7 +14,7 @@ class VeracodeParser(object):
             "Reports can be imported as JSON or XML report formats."
         )
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename.name.lower().endswith(".xml"):
             return VeracodeXMLParser().get_findings(filename, test)
         elif filename.name.lower().endswith(".json"):

--- a/dojo/tools/veracode/xml_parser.py
+++ b/dojo/tools/veracode/xml_parser.py
@@ -25,7 +25,7 @@ class VeracodeXMLParser(object):
         5: "Critical",
     }
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         root = ElementTree.parse(filename).getroot()
 
         app_id = root.attrib["app_id"]

--- a/dojo/tools/veracode_sca/parser.py
+++ b/dojo/tools/veracode_sca/parser.py
@@ -29,7 +29,7 @@ class VeracodeScaParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Veracode SourceClear CSV or JSON report format"
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file is None:
             return ()
 

--- a/dojo/tools/wapiti/parser.py
+++ b/dojo/tools/wapiti/parser.py
@@ -25,7 +25,7 @@ class WapitiParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import XML report"
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = parse(file)
         # get root of tree.
         root = tree.getroot()

--- a/dojo/tools/wazuh/parser.py
+++ b/dojo/tools/wazuh/parser.py
@@ -18,7 +18,7 @@ class WazuhParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Wazuh"
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
         # Detect duplications
         dupes = dict()

--- a/dojo/tools/wfuzz/parser.py
+++ b/dojo/tools/wfuzz/parser.py
@@ -28,7 +28,7 @@ class WFuzzParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import WFuzz findings in JSON format."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         data = json.load(filename)
 
         dupes = {}

--- a/dojo/tools/whispers/parser.py
+++ b/dojo/tools/whispers/parser.py
@@ -40,7 +40,7 @@ class WhispersParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Whispers report file can be imported in JSON format (option --json)."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = json.load(file)
         findings = []
         for vuln in tree:

--- a/dojo/tools/whitehat_sentinel/parser.py
+++ b/dojo/tools/whitehat_sentinel/parser.py
@@ -24,7 +24,7 @@ class WhiteHatSentinelParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "WhiteHat Sentinel output from api/vuln/query_site can be imported in JSON format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         findings_collection = json.load(file)
 
         if not findings_collection.keys():

--- a/dojo/tools/whitesource/parser.py
+++ b/dojo/tools/whitesource/parser.py
@@ -19,7 +19,7 @@ class WhitesourceParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import JSON report"
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         if file is None:
             return list()
 

--- a/dojo/tools/wpscan/parser.py
+++ b/dojo/tools/wpscan/parser.py
@@ -83,7 +83,7 @@ class WpscanParser(object):
             else:
                 dupes[dupe_key] = finding
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = json.load(file)
 
         report_date = None

--- a/dojo/tools/xanitizer/parser.py
+++ b/dojo/tools/xanitizer/parser.py
@@ -17,7 +17,7 @@ class XanitizerParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Import XML findings list report, preferably with parameter 'generateDetailsInFindingsListReport=true'."
 
-    def get_findings(self, filename, test):
+    def get_findings(self, filename, test, parser_custom_setting=None):
         if filename is None:
             return list()
 

--- a/dojo/tools/yarn_audit/parser.py
+++ b/dojo/tools/yarn_audit/parser.py
@@ -14,7 +14,7 @@ class YarnAuditParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "Yarn Audit Scan output file can be imported in JSON format."
 
-    def get_findings(self, json_output, test):
+    def get_findings(self, json_output, test, parser_custom_setting=None):
         if json_output is None:
             return list()
         tree = (json.loads(line) for line in json_output)

--- a/dojo/tools/zap/parser.py
+++ b/dojo/tools/zap/parser.py
@@ -25,7 +25,7 @@ class ZapParser(object):
     def get_description_for_scan_types(self, scan_type):
         return "ZAP XML report format."
 
-    def get_findings(self, file, test):
+    def get_findings(self, file, test, parser_custom_setting=None):
         tree = ET.parse(file)
         items = list()
         for node in tree.findall("site"):


### PR DESCRIPTION
see issue #9250

This additional field could help to customize / finetune some scanners directly when parsing the report.

Use cases:

- see my last comment in: https://github.com/DefectDojo/django-DefectDojo/pull/9275
- Harbor has a field which states if a finding has a fix available yet or not. This can be turned on or off within the parser: https://documentation.defectdojo.com/integrations/parsers/file/harbor_vulnerability/
- MSDefender findings could be filtered based on the additional field.
