### PR TITLE
Endpoint Status: Accommodate Risk Exceptions

### DIFF
--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -336,7 +336,7 @@ class FindingTest(BaseTestCase):
         # Select and click on the particular finding to edit
         driver.find_element(By.LINK_TEXT, "App Vulnerable to XSS").click()
         # Get the status of the current endpoint
-        pre_status = driver.find_element(By.XPATH, '//*[@id="vuln_endpoints"]/tbody/tr/td[3]').text
+        pre_status = driver.find_element(By.XPATH, '//*[@id="remd_endpoints"]/tbody/tr/td[3]').text
         # Click on the 'dropdownMenu1 button'
         driver.find_element(By.ID, "dropdownMenu1").click()
         # Click on `Close Finding`


### PR DESCRIPTION
When setting or removing a risk exception on a given finding, the endpoint statuses were not updated. With this PR, endpoint statuses on a finding that is being risk accepted will have a status of mitigated + risk accepted. When the risk exception expires or is removed, the endpoint statuses for a given finding will revert to active to match the finding

[sc-3960]