### PR TITLE
Fixing "'WSGIRequest' object has no attribute 'user'" errors

### DIFF
--- a/dojo/context_processors.py
+++ b/dojo/context_processors.py
@@ -4,48 +4,54 @@ from django.conf import settings
 
 def globalize_vars(request):
     # return the value you want as a dictionnary. you may add multiple values in there.
-    return {'SHOW_LOGIN_FORM': settings.SHOW_LOGIN_FORM,
-            'FORGOT_PASSWORD': settings.FORGOT_PASSWORD,
-            'FORGOT_USERNAME': settings.FORGOT_USERNAME,
-            'CLASSIC_AUTH_ENABLED': settings.CLASSIC_AUTH_ENABLED,
-            'AUTH0_ENABLED': settings.AUTH0_OAUTH2_ENABLED,
-            'GOOGLE_ENABLED': settings.GOOGLE_OAUTH_ENABLED,
-            'OKTA_ENABLED': settings.OKTA_OAUTH_ENABLED,
-            'GITLAB_ENABLED': settings.GITLAB_OAUTH2_ENABLED,
-            'AZUREAD_TENANT_OAUTH2_ENABLED': settings.AZUREAD_TENANT_OAUTH2_ENABLED,
-            'AZUREAD_TENANT_OAUTH2_GET_GROUPS': settings.AZUREAD_TENANT_OAUTH2_GET_GROUPS,
-            'AZUREAD_TENANT_OAUTH2_GROUPS_FILTER': settings.AZUREAD_TENANT_OAUTH2_GROUPS_FILTER,
-            'AZUREAD_TENANT_OAUTH2_CLEANUP_GROUPS': settings.AZUREAD_TENANT_OAUTH2_CLEANUP_GROUPS,
-            'KEYCLOAK_ENABLED': settings.KEYCLOAK_OAUTH2_ENABLED,
-            'SOCIAL_AUTH_KEYCLOAK_LOGIN_BUTTON_TEXT': settings.SOCIAL_AUTH_KEYCLOAK_LOGIN_BUTTON_TEXT,
-            'GITHUB_ENTERPRISE_ENABLED': settings.GITHUB_ENTERPRISE_OAUTH2_ENABLED,
-            'SAML2_ENABLED': settings.SAML2_ENABLED,
-            'SAML2_LOGIN_BUTTON_TEXT': settings.SAML2_LOGIN_BUTTON_TEXT,
-            'SAML2_LOGOUT_URL': settings.SAML2_LOGOUT_URL,
-            'DOCUMENTATION_URL': settings.DOCUMENTATION_URL,
-            'API_TOKENS_ENABLED': settings.API_TOKENS_ENABLED,
-            }
+    return {
+        "SHOW_LOGIN_FORM": settings.SHOW_LOGIN_FORM,
+        "FORGOT_PASSWORD": settings.FORGOT_PASSWORD,
+        "FORGOT_USERNAME": settings.FORGOT_USERNAME,
+        "CLASSIC_AUTH_ENABLED": settings.CLASSIC_AUTH_ENABLED,
+        "AUTH0_ENABLED": settings.AUTH0_OAUTH2_ENABLED,
+        "GOOGLE_ENABLED": settings.GOOGLE_OAUTH_ENABLED,
+        "OKTA_ENABLED": settings.OKTA_OAUTH_ENABLED,
+        "GITLAB_ENABLED": settings.GITLAB_OAUTH2_ENABLED,
+        "AZUREAD_TENANT_OAUTH2_ENABLED": settings.AZUREAD_TENANT_OAUTH2_ENABLED,
+        "AZUREAD_TENANT_OAUTH2_GET_GROUPS": settings.AZUREAD_TENANT_OAUTH2_GET_GROUPS,
+        "AZUREAD_TENANT_OAUTH2_GROUPS_FILTER": settings.AZUREAD_TENANT_OAUTH2_GROUPS_FILTER,
+        "AZUREAD_TENANT_OAUTH2_CLEANUP_GROUPS": settings.AZUREAD_TENANT_OAUTH2_CLEANUP_GROUPS,
+        "KEYCLOAK_ENABLED": settings.KEYCLOAK_OAUTH2_ENABLED,
+        "SOCIAL_AUTH_KEYCLOAK_LOGIN_BUTTON_TEXT": settings.SOCIAL_AUTH_KEYCLOAK_LOGIN_BUTTON_TEXT,
+        "GITHUB_ENTERPRISE_ENABLED": settings.GITHUB_ENTERPRISE_OAUTH2_ENABLED,
+        "SAML2_ENABLED": settings.SAML2_ENABLED,
+        "SAML2_LOGIN_BUTTON_TEXT": settings.SAML2_LOGIN_BUTTON_TEXT,
+        "SAML2_LOGOUT_URL": settings.SAML2_LOGOUT_URL,
+        "DOCUMENTATION_URL": settings.DOCUMENTATION_URL,
+        "API_TOKENS_ENABLED": settings.API_TOKENS_ENABLED,
+    }
 
 
 def bind_system_settings(request):
     from dojo.models import System_Settings
-    return {'system_settings': System_Settings.objects.get()}
+
+    return {"system_settings": System_Settings.objects.get()}
 
 
 def bind_alert_count(request):
     if not settings.DISABLE_ALERT_COUNTER:
         from dojo.models import Alerts
-        if request.user.is_authenticated:
-            return {'alert_count': Alerts.objects.filter(user_id=request.user).count()}
+
+        if hasattr(request, "user") and request.user.is_authenticated:
+            return {"alert_count": Alerts.objects.filter(user_id=request.user).count()}
     return {}
 
 
 def bind_announcement(request):
     from dojo.models import UserAnnouncement
+
     try:
         if request.user.is_authenticated:
-            user_announcement = UserAnnouncement.objects.select_related('announcement').get(user=request.user)
-            return {'announcement': user_announcement.announcement}
+            user_announcement = UserAnnouncement.objects.select_related(
+                "announcement"
+            ).get(user=request.user)
+            return {"announcement": user_announcement.announcement}
         return {}
     except Exception:
         return {}


### PR DESCRIPTION
**Description**

This fixes an error that occurs in addition to the invalid host header error raised by Django when a user requests e.g. `/favicon.ico` via a non-allowed host. 

```
django-defectdojo-uwsgi-1         |   File "/app/dojo/context_processors.py", line 38, in bind_alert_count
django-defectdojo-uwsgi-1         |     if request.user.is_authenticated:
django-defectdojo-uwsgi-1         |        ^^^^^^^^^^^^
django-defectdojo-uwsgi-1         | AttributeError: 'WSGIRequest' object has no attribute 'user'
django-defectdojo-uwsgi-1         | [pid: 14|app: -|req: -/-] 192.168.65.1 (-) {50 vars in 847 bytes} [Fri Jan 19 17:40:13 2024] GET /favicon.ico => generated 0 bytes in 554 msecs (HTTP/1.1 500) 0 headers in 0 bytes (0 switches on core 0)
```

**Test results**

Setting `DD_ALLOWED_HOSTS=localhost` when calling `./dc-up-d.sh` and making a request to `http://127.0.0.1:8080/favicon.ico`, now raises the invalid host header exception as expected, but it doesn't produce a 500 error from the missing `user` attribute on the `request` object.

After fix:

```
django-defectdojo-uwsgi-1         | [19/Jan/2024 17:46:46] ERROR [django.security.DisallowedHost:125] Invalid HTTP_HOST header: '127.0.0.1:8080'. You may need to add '127.0.0.1' to ALLOWED_HOSTS.
django-defectdojo-uwsgi-1         | Traceback (most recent call last):
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
django-defectdojo-uwsgi-1         |     response = get_response(request)
django-defectdojo-uwsgi-1         |                ^^^^^^^^^^^^^^^^^^^^^
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/django/utils/deprecation.py", line 135, in __call__
django-defectdojo-uwsgi-1         |     response = self.process_request(request)
django-defectdojo-uwsgi-1         |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/django/middleware/common.py", line 48, in process_request
django-defectdojo-uwsgi-1         |     host = request.get_host()
django-defectdojo-uwsgi-1         |            ^^^^^^^^^^^^^^^^^^
django-defectdojo-uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/django/http/request.py", line 152, in get_host
django-defectdojo-uwsgi-1         |     raise DisallowedHost(msg)
django-defectdojo-uwsgi-1         | django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: '127.0.0.1:8080'. You may need to add '127.0.0.1' to ALLOWED_HOSTS.
django-defectdojo-uwsgi-1         | [pid: 15|app: -|req: -/-] 192.168.65.1 (-) {50 vars in 847 bytes} [Fri Jan 19 17:46:46 2024] GET /favicon.ico => generated 13233 bytes in 778 msecs (HTTP/1.1 200) 1 headers in 59 bytes (1 switches on core 0)
```

[sc-3996]