### PR TITLE
Add CVSS vector string to JIRA description

### DIFF
--- a/dojo/templates/issue-trackers/jira_full/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-description.tpl
@@ -25,7 +25,7 @@
 {% endif %}
 
 {% if finding.cvssv3_score %}
-*CVSSv3 Score:* {{ finding.cvssv3_score }}
+*CVSSv3 Score:* {{ finding.cvssv3_score }} {% if finding.cvssv3 %}({{ finding.cvssv3 }}){% endif %}
 {% endif %}
 
 *Product/Engagement/Test:* [{{ finding.test.engagement.product.name }}|{{ product_url|full_url }}] / [{{ finding.test.engagement.name }}|{{ engagement_url|full_url }}] / [{{ finding.test }}|{{ test_url|full_url }}]


### PR DESCRIPTION
When pushing a finding to JIRA, the CVSS score is already being passed, but the vector string is equally important