### PR TITLE
remove duplicated risk accepted

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -319,7 +319,6 @@ def get_finding_filterset_fields(metrics=False, similar=False):
                 'is_mitigated',
                 'out_of_scope',
                 'false_p',
-                'risk_accepted',
                 'has_component',
                 'has_notes',
                 'file_path',
@@ -584,7 +583,7 @@ class ReportRiskAcceptanceFilter(ChoiceFilter):
         None: (_('Either'), any),
         1: (_('Yes'), accepted),
         2: (_('No'), not_accepted),
-        3: (_('Was'), was_accepted),
+        3: (_('Expired'), was_accepted),
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## remove duplicated risk accepted
[sc-4046]
https://github.com/DefectDojo/django-DefectDojo/issues/9414
**Description**
Now the finding filters risk accepted was removed the duplicated

**Test results**
![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/d02879e3-8d58-45e0-8e29-49c8c6f512d4)

the remaining filter now shows `Expired` instead `Was`