### PR TITLE
advance notifications.md with expanded slack guide

### DIFF
--- a/docs/content/en/integrations/notifications.md
+++ b/docs/content/en/integrations/notifications.md
@@ -29,10 +29,6 @@ report has finished generating.
 
 Users can define notifications on a product level as well, and these settings will be applied only for selected products.
 
-Microsoft Teams does not provide an easy way to send messages to a personal
-channel. Therefore, DefectDojo can only send system scope notifications
-to Microsoft Teams.
-
 In order to identify and notify you about things like upcoming
 engagements, DefectDojo runs scheduled tasks for this purpose. These
 tasks are scheduled and run using Celery beat, so this needs to run for
@@ -42,25 +38,78 @@ DefectDojo allows `template` to be used, administrator can use this feature to d
 
 ### Slack
 
+#### Basic Integration
+This method will allow DefectDojo to send Global notifications to a Slack channel.  It can also send Personal notifications to an individual user's Slackbot.
+
+To configure Slack messaging, you will first need to create a new Slack app at https://api.slack.com/apps.  
+
+This app can be created from scratch, or from a JSON manifest which includes all necessary scopes and bot functionality.  This manifest can be copied and pasted into the Slack App wizard when you select 'Build From Manifest'.
+
+<details>
+    <summary>JSON Manifest</summary>
+
+~~~
+{
+  "_metadata": {
+    "major_version": 1,
+    "minor_version": 1
+  },
+  "display_information": {
+    "name": "DefectDojo",
+    "description": "Notifications from DefectDojo",
+    "background_color": "#0000AA"
+  },
+  "features": {
+    "bot_user": {
+      "display_name": "DefectDojo Notifications"
+    }
+  },
+  "oauth_config": {
+    "scopes": {
+      "bot": [
+        "chat:write",
+        "chat:write.customize",
+        "chat:write.public",
+        "incoming-webhook",
+        "users:read",
+        "users:read.email"
+      ]
+    },
+    "redirect_urls": [
+      "https://slack.com/oauth/v2/authorize"
+    ]
+  }
+}
+~~~
+
+</details>
+
+Choose the channel where you want to post Global notifications during the 'Create From Manifest' process.  Personal notifications will appear in a user's Slackbot if they have their Slack Email Address specified on their user profile.
+
 #### Scopes
 
-The following scopes have to be granted.
+The following scopes have to be granted to your Slack App.  If the App was created from the JSON Manifest above, these permission scopes will already be set correctly.
 
 ![Slack OAuth scopes](../../images/slack_scopes.png)
 
 #### Token
 
-The bot token has to be chosen and put in your System Settings
+The Slack Bot Token needs to be pasted in the DefectDojo System Settings, nested underneath the 'Enable slack notifications' checkbox.  This token can be found in the Features / OAuth & Permissions section on the Slack App settings.
 
 ![Slack token](../../images/slack_tokens.png)
 
-#### What it generally looks like
+#### Examples of Slack notifications
 
 ![Add Product](../../images/slack_add_product.png)
 
 ![Import Scan](../../images/slack_import_scan.png)
 
+
 ### Microsoft Teams
+
+Microsoft Teams does not provide an easy way to send messages to a personal
+channel. Therefore, DefectDojo can only send system scope notifications
+to Microsoft Teams.
 
 To activate notifications to Microsoft Teams, you have to:
 - Configure an Incoming Webhook in a Teams channel and copy the URL of the webhook to the clipboard


### PR DESCRIPTION
1. This PR updates the Notifications documentation page with more info on how to create a Slack app, as well as a JSON app manifest to quickly configure the necessary permissions and bot settings.

For users looking to add a Slack integration to Dojo, using this manifest creates a bot with all required OAuth permissions as listed in docs. These are steps a user already has to take to get the Slack integration working, so using this manifest allows them to skip manual configuration and speeds this up.

User will still have to locate the OAuth Bot Access token and add it to DefectDojo to complete integration.

2. Also moved the Microsoft-teams paragraph to the correct heading.