### PR TITLE
Fix unittests with assertRaises + replace  assertTrue/False with better checks

### DIFF
--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -253,7 +253,7 @@ class DojoTestUtilsMixin(object):
                     product = Product.objects.get(id=response.url.split('/')[-2])
                 except:
                     raise ValueError('error parsing id from redirect uri: ' + response.url)
-            self.assertTrue(response.url == (expect_redirect_to % product.id))
+            self.assertEqual(response.url, (expect_redirect_to % product.id))
         else:
             self.assertEqual(response.status_code, 200)
 
@@ -401,12 +401,12 @@ class DojoTestUtilsMixin(object):
         response = jira._session.get(url).json().get('fields', {})
         epic_link = response.get(epic_link_field, None)
         if epic_id is None and epic_link is None or issue_in_epic:
-            self.assertTrue(epic_id == epic_link)
+            self.assertEqual(epic_id, epic_link)
         else:
-            self.assertTrue(epic_id != epic_link)
+            self.assertNotEqual(epic_id, epic_link)
 
     def assert_jira_updated_change(self, old, new):
-        self.assertTrue(old != new)
+        self.assertNotEqual(old, new)
 
     def get_latest_model(self, model):
         return model.objects.order_by('id').last()

--- a/unittests/test_apiv2_metadata.py
+++ b/unittests/test_apiv2_metadata.py
@@ -35,7 +35,7 @@ class MetadataTest(APITestCase):
 
     def test_query_product_endpoint(self):
         r = self.client.get(reverse('product-detail', args=(1,)))
-        self.assertTrue(dict(name='foo', value='bar') in r.json()['product_meta'])
+        self.assertIn(dict(name='foo', value='bar'), r.json()['product_meta'])
 
     def test_delete(self):
         r = self.client.delete(reverse('metadata-detail', args=(self.mid,)))
@@ -45,7 +45,7 @@ class MetadataTest(APITestCase):
         self.assertEqual(r.status_code, 404)
 
         r = self.client.get(reverse('product-detail', args=(1,)))
-        self.assertTrue(dict(name='foo', value='bar') not in r.json()['product_meta'])
+        self.assertNotIn(dict(name='foo', value='bar'), r.json()['product_meta'])
 
     def test_no_product_or_endpoint_as_parameter(self):
         r = self.create(name='foo', value='bar')

--- a/unittests/test_apiv2_scan_import_options.py
+++ b/unittests/test_apiv2_scan_import_options.py
@@ -49,11 +49,11 @@ class ScanImportOptionsTest(APITestCase):
         Import the ZAP scan without a test file.
         """
         test = self.import_zap_scan(upload_empty_scan=False)
-        self.assertFalse(len(self.get_all_finding_ids(active=True, test__test_type=test.test_type)) == 0)
+        self.assertNotEqual(len(self.get_all_finding_ids(active=True, test__test_type=test.test_type)), 0)
 
     def test_full_scan(self):
         """
         Import the ZAP scan with a test file.
         """
         test = self.import_zap_scan(upload_empty_scan=True)
-        self.assertFalse(len(self.get_all_finding_ids(active=True, test__test_type=test.test_type)) == 0)
+        self.assertNotEqual(len(self.get_all_finding_ids(active=True, test__test_type=test.test_type)), 0)

--- a/unittests/test_apiv2_user.py
+++ b/unittests/test_apiv2_user.py
@@ -18,7 +18,7 @@ class UserTest(APITestCase):
         r = self.client.get(reverse('user-list'))
         self.assertEqual(r.status_code, 200, r.content[:1000])
         user_list = r.json()['results']
-        self.assertTrue(len(user_list) >= 1, r.content[:1000])
+        self.assertGreaterEqual(len(user_list), 1, r.content[:1000])
         for user in user_list:
             for item in ['username', 'first_name', 'last_name', 'email']:
                 self.assertIn(item, user, r.content[:1000])

--- a/unittests/test_endpoint_model.py
+++ b/unittests/test_endpoint_model.py
@@ -161,9 +161,9 @@ class TestEndpointModel(DojoTestCase):
         e2 = Endpoint(protocol="https", host="localhost", port=5439, path="test", query="param=value")
         e3 = Endpoint(protocol="https", host="localhost", port=5439, path="different", query="param=value")
         # Verify e1 and e2 are actually equal
-        self.assertTrue(e1 == e2)
+        self.assertEqual(e1, e2)
         # Verify e1 and e2 are not equal because the path is different
-        self.assertFalse(e1 == e3)
+        self.assertNotEqual(e1, e3)
 
     def test_equality_with_one_product_one_without(self):
         # Define the product
@@ -176,7 +176,7 @@ class TestEndpointModel(DojoTestCase):
         e2 = Endpoint(host="localhost", product=p)
         # Verify e1 and e2 are actually equal
         # Since on has a product and the other does not, we cannot use products to aid in equality
-        self.assertTrue(e1 == e2)
+        self.assertEqual(e1, e2)
 
     def test_equality_with_products(self):
         # Define the product
@@ -196,10 +196,10 @@ class TestEndpointModel(DojoTestCase):
         e3 = Endpoint(host="localhost", product=p2)
         # Verify e1 and e2 are actually equal
         # Since the products match, this should be true
-        self.assertTrue(e1 == e2)
+        self.assertEqual(e1, e2)
         # Verify e1 and e2 are not equal
         # Because the products are different, the endpoint objects are not the same
-        self.assertFalse(e1 == e3)
+        self.assertNotEqual(e1, e3)
 
 
 @skip("Outdated - this class was testing clean-up broken entries in old version of model; new version of model doesn't to store broken entries")

--- a/unittests/test_jira_config_engagement.py
+++ b/unittests/test_jira_config_engagement.py
@@ -146,7 +146,7 @@ class JIRAConfigEngagementBase(object):
                     engagement = Engagement.objects.get(id=response.url.split('/')[-2])
                 except:
                     raise ValueError('error parsing id from redirect uri: ' + response.url)
-            self.assertTrue(response.url == (expect_redirect_to % engagement.id))
+            self.assertEqual(response.url, (expect_redirect_to % engagement.id))
         else:
             self.assertEqual(response.status_code, 200)
 

--- a/unittests/test_jira_config_product.py
+++ b/unittests/test_jira_config_product.py
@@ -102,8 +102,8 @@ class JIRAConfigProductTest(DojoTestCase):
 
         self.assertEqual(200, response.status_code)
         content = response.content.decode('utf-8')
-        self.assertTrue('Login failed' in content)
-        self.assertTrue('Unable to authenticate to JIRA' in content)
+        self.assertIn('Login failed', content)
+        self.assertIn('Unable to authenticate to JIRA', content)
 
     @patch('dojo.jira_link.views.jira_helper.is_jira_project_valid')
     def test_add_jira_project_to_product_without_jira_project(self, jira_mock):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -347,7 +347,7 @@ class BaseClass():
                         self.assertEqual(len(check_for_tags), len(result.get('tags', None)))
                         for tag in check_for_tags:
                             # logger.debug('looking for tag %s in tag list %s', tag, result['tags'])
-                            self.assertTrue(tag in result['tags'])
+                            self.assertIn(tag, result['tags'])
                         tags_found = True
                 self.assertTrue(tags_found)
 
@@ -369,7 +369,7 @@ class BaseClass():
                 self.assertEqual(len(self.payload.get('tags')), len(response.data.get('tags', None)))
                 for tag in self.payload.get('tags'):
                     # logger.debug('looking for tag %s in tag list %s', tag, response.data['tags'])
-                    self.assertTrue(tag in response.data['tags'])
+                    self.assertIn(tag, response.data['tags'])
 
             self.check_schema_response('post', '201', response)
 
@@ -381,9 +381,9 @@ class BaseClass():
             self.assertEqual(200, response.status_code, response.content[:1000])
             # sensitive data must be set to write_only so those are not returned in the response
             # https://github.com/DefectDojo/django-DefectDojo/security/advisories/GHSA-8q8j-7wc4-vjg5
-            self.assertFalse('password' in response.data)
-            self.assertFalse('ssh' in response.data)
-            self.assertFalse('api_key' in response.data)
+            self.assertNotIn('password', response.data)
+            self.assertNotIn('ssh', response.data)
+            self.assertNotIn('api_key', response.data)
 
             self.check_schema_response('get', '200', response, detail=True)
 
@@ -418,16 +418,16 @@ class BaseClass():
                         response_data = response.data[key]
                     self.assertEqual(value, response_data)
 
-            self.assertFalse('push_to_jira' in response.data)
-            self.assertFalse('ssh' in response.data)
-            self.assertFalse('password' in response.data)
-            self.assertFalse('api_key' in response.data)
+            self.assertNotIn('push_to_jira', response.data)
+            self.assertNotIn('ssh', response.data)
+            self.assertNotIn('password', response.data)
+            self.assertNotIn('api_key', response.data)
 
             if hasattr(self.endpoint_model, 'tags') and self.update_fields and self.update_fields.get('tags', None):
                 self.assertEqual(len(self.update_fields.get('tags')), len(response.data.get('tags', None)))
                 for tag in self.update_fields.get('tags'):
                     logger.debug('looking for tag %s in tag list %s', tag, response.data['tags'])
-                    self.assertTrue(tag in response.data['tags'])
+                    self.assertIn(tag, response.data['tags'])
 
             response = self.client.put(
                 relative_url, self.payload)
@@ -448,17 +448,17 @@ class BaseClass():
 
             self.check_schema_response('get', '200', response, detail=True)
 
-            self.assertFalse('push_to_jira' in response.data)
-            self.assertFalse('password' in response.data)
-            self.assertFalse('ssh' in response.data)
-            self.assertFalse('api_key' in response.data)
+            self.assertNotIn('push_to_jira', response.data)
+            self.assertNotIn('password', response.data)
+            self.assertNotIn('ssh', response.data)
+            self.assertNotIn('api_key', response.data)
 
             self.assertIsInstance(response.data['results'], list)
-            self.assertTrue(len(response.data['results']) > 0, "Length: {}".format(len(response.data['results'])))
+            self.assertGreater(len(response.data['results']), 0, "Length: {}".format(len(response.data['results'])))
 
             for obj in response.data['results']:
                 self.assertIsInstance(obj, dict)
-                self.assertTrue(len(obj), 3)
+                self.assertEqual(len(obj), 3)
                 self.assertIsInstance(obj['model'], str)
                 if obj['id']:  # It needs to be None or int
                     self.assertIsInstance(obj['id'], int)
@@ -479,18 +479,18 @@ class BaseClass():
 
             self.assertEqual(200, response.status_code)
             obj = response.data
-            self.assertTrue("prefetch" in obj)
+            self.assertIn("prefetch", obj)
 
             for field in prefetchable_fields:
                 field_value = obj.get(field, None)
                 if field_value is None:
                     continue
 
-                self.assertTrue(field in obj["prefetch"])
+                self.assertIn(field, obj["prefetch"])
                 values = field_value if isinstance(field_value, list) else [field_value]
 
                 for value in values:
-                    self.assertTrue(value in obj["prefetch"][field])
+                    self.assertIn(value, obj["prefetch"][field])
 
             # TODO add schema check
 
@@ -504,8 +504,8 @@ class BaseClass():
 
             self.assertEqual(200, response.status_code)
             objs = response.data
-            self.assertTrue("results" in objs)
-            self.assertTrue("prefetch" in objs)
+            self.assertIn("results", objs)
+            self.assertIn("prefetch", objs)
 
             for obj in objs["results"]:
                 for field in prefetchable_fields:
@@ -513,13 +513,13 @@ class BaseClass():
                     if field_value is None:
                         continue
 
-                    self.assertTrue(field in objs["prefetch"])
+                    self.assertIn(field, objs["prefetch"])
                     values = field_value if isinstance(field_value, list) else [field_value]
 
                     for value in values:
                         if not isinstance(value, int):
                             value = value['id']
-                        self.assertTrue(value in objs["prefetch"][field])
+                        self.assertIn(value, objs["prefetch"][field])
 
             # TODO add schema check
 

--- a/unittests/test_risk_acceptance.py
+++ b/unittests/test_risk_acceptance.py
@@ -274,13 +274,13 @@ class RiskAcceptanceTestUI(DojoTestCase):
         to_warn = ra_helper.get_almost_expired_risk_acceptances_to_handle(heads_up_days=heads_up_days)
         to_expire = ra_helper.get_expired_risk_acceptances_to_handle()
 
-        self.assertTrue(ra1 in to_warn)
-        self.assertFalse(ra2 in to_warn)
-        self.assertFalse(ra3 in to_warn)
+        self.assertIn(ra1, to_warn)
+        self.assertNotIn(ra2, to_warn)
+        self.assertNotIn(ra3, to_warn)
 
-        self.assertFalse(ra1 in to_expire)
-        self.assertFalse(ra2 in to_expire)
-        self.assertTrue(ra3 in to_expire)
+        self.assertNotIn(ra1, to_expire)
+        self.assertNotIn(ra2, to_expire)
+        self.assertIn(ra3, to_expire)
 
         # run job
         ra_helper.expiration_handler()

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -36,7 +36,7 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags), len(response.get('tags', None)))
         for tag in tags:
             # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_finding_filter_tags(self):
         tags = ['tag1', 'tag2']
@@ -69,7 +69,7 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags_merged), len(response.get('tags')))
         for tag in tags_merged:
             # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_finding_post_tags_overlap(self):
         # create finding
@@ -83,7 +83,7 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags_merged), len(response.get('tags')))
         for tag in tags_merged:
             # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_finding_put_remove_tags(self):
         # create finding
@@ -103,7 +103,7 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags_merged), len(response.get('tags')))
         for tag in tags_merged:
             # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_finding_put_remove_tags_all(self):
         # create finding
@@ -123,7 +123,7 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags_merged), len(response.get('tags')))
         for tag in tags_merged:
             # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_finding_put_remove_tags_non_existent(self):
         # create finding
@@ -143,7 +143,7 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags_merged), len(response.get('tags')))
         for tag in tags_merged:
             # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_finding_patch_remove_tags(self):
         # has same logic as PUT
@@ -168,8 +168,8 @@ class TagTests(DojoAPITestCase):
         # self.assertEqual(2, len(response.get('tags')))
         self.assertEqual(1, len(response.get('tags')))
         # print("response['tags']:" + str(response['tags']))
-        self.assertTrue('one' in str(response['tags']))
-        self.assertTrue('two' in str(response['tags']))
+        self.assertIn('one', str(response['tags']))
+        self.assertIn('two', str(response['tags']))
 
     def test_finding_create_tags_with_commas_quoted(self):
         tags = ['"one,two"']
@@ -181,8 +181,8 @@ class TagTests(DojoAPITestCase):
         for tag in tags:
             logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
             # with django-tagging the quotes were stripped, with tagulous they remain
-            # self.assertTrue(tag.strip('\"') in response['tags'])
-            self.assertTrue(tag in response['tags'])
+            # self.assertIn(tag.strip('\"'), response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_finding_create_tags_with_spaces(self):
         tags = ['one two']
@@ -195,8 +195,8 @@ class TagTests(DojoAPITestCase):
         # tags with commas, so should be minor trouble
         # self.assertEqual(2, len(response.get('tags')))
         self.assertEqual(1, len(response.get('tags')))
-        self.assertTrue('one' in str(response['tags']))
-        self.assertTrue('two' in str(response['tags']))
+        self.assertIn('one', str(response['tags']))
+        self.assertIn('two', str(response['tags']))
         # finding.tags: [<Tag: one>, <Tag: two>]
 
     def test_finding_create_tags_with_spaces_quoted(self):
@@ -209,8 +209,8 @@ class TagTests(DojoAPITestCase):
         for tag in tags:
             logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
             # with django-tagging the quotes were stripped, with tagulous they remain
-            # self.assertTrue(tag.strip('\"') in response['tags'])
-            self.assertTrue(tag in response['tags'])
+            # self.assertIn(tag.strip('\"'), response['tags'])
+            self.assertIn(tag, response['tags'])
 
         # finding.tags: <QuerySet [<Tag: one two>]>
 
@@ -222,7 +222,7 @@ class TagTests(DojoAPITestCase):
         self.assertEqual(len(tags), len(response.get('tags', None)))
         for tag in tags:
             # logger.debug('looking for tag %s in tag list %s', tag, response['tags'])
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
     def test_import_and_reimport_with_tags(self):
         tags = ['tag1', 'tag2']
@@ -233,19 +233,19 @@ class TagTests(DojoAPITestCase):
 
         self.assertEqual(len(tags), len(response.get('tags')))
         for tag in tags:
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
         # reimport, do not specify tags: should retain tags
         self.reimport_scan_with_params(test_id, self.zap_sample5_filename)
         self.assertEqual(len(tags), len(response.get('tags')))
         for tag in tags:
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
         # reimport, specify tags others: currently reimport doesn't do anything with tags param and silently ignores them
         self.reimport_scan_with_params(test_id, self.zap_sample5_filename, tags=['tag3', 'tag4'])
         self.assertEqual(len(tags), len(response.get('tags')))
         for tag in tags:
-            self.assertTrue(tag in response['tags'])
+            self.assertIn(tag, response['tags'])
 
 
 class InheritedTagsTests(DojoAPITestCase):

--- a/unittests/tools/test_acunetix360_parser.py
+++ b/unittests/tools/test_acunetix360_parser.py
@@ -25,7 +25,7 @@ class TestAcunetix360Parser(DojoTestCase):
             endpoint = finding.unsaved_endpoints[0]
             self.assertEqual(str(endpoint), "http://php.testsparker.com/auth/login.php")
             self.assertEqual(finding.date, datetime(2021, 6, 16, 12, 30))
-            self.assertTrue("https://online.acunetix360.com/issues/detail/735f4503-e9eb-4b4c-4306-ad49020a4c4b" in finding.references)
+            self.assertIn("https://online.acunetix360.com/issues/detail/735f4503-e9eb-4b4c-4306-ad49020a4c4b", finding.references)
 
     def test_parse_file_with_one_finding_false_positive(self):
         testfile = open("unittests/scans/acunetix360/acunetix360_one_finding_false_positive.json")

--- a/unittests/tools/test_anchore_grype_parser.py
+++ b/unittests/tools/test_anchore_grype_parser.py
@@ -23,7 +23,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         for finding in findings:
             self.assertIn(finding.severity, Finding.SEVERITIES)
             vulnerability_ids = finding.unsaved_vulnerability_ids
-            self.assertTrue(len(vulnerability_ids) >= 1)
+            self.assertGreaterEqual(len(vulnerability_ids), 1)
             if finding.vuln_id_from_tool == "CVE-2011-3389":
                 vulnerability_ids = finding.unsaved_vulnerability_ids
                 self.assertEqual(1, len(vulnerability_ids))
@@ -46,7 +46,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         for finding in findings:
             self.assertIn(finding.severity, Finding.SEVERITIES)
             vulnerability_ids = finding.unsaved_vulnerability_ids
-            self.assertTrue(len(vulnerability_ids) >= 1)
+            self.assertGreaterEqual(len(vulnerability_ids), 1)
             if finding.vuln_id_from_tool == "CVE-2019-9192":
                 vulnerability_ids = finding.unsaved_vulnerability_ids
                 self.assertEqual(1, len(vulnerability_ids))
@@ -68,7 +68,7 @@ class TestAnchoreGrypeParser(DojoTestCase):
         for finding in findings:
             self.assertIn(finding.severity, Finding.SEVERITIES)
             vulnerability_ids = finding.unsaved_vulnerability_ids
-            self.assertTrue(len(vulnerability_ids) >= 1)
+            self.assertGreaterEqual(len(vulnerability_ids), 1)
             if finding.vuln_id_from_tool == "CVE-2011-3389":
                 vulnerability_ids = finding.unsaved_vulnerability_ids
                 self.assertEqual(1, len(vulnerability_ids))
@@ -90,13 +90,13 @@ class TestAnchoreGrypeParser(DojoTestCase):
         for finding in findings:
             self.assertIn(finding.severity, Finding.SEVERITIES)
             vulnerability_ids = finding.unsaved_vulnerability_ids
-            self.assertTrue(len(vulnerability_ids) >= 1)
+            self.assertGreaterEqual(len(vulnerability_ids), 1)
             if finding.vuln_id_from_tool == "CVE-1999-1338":
                 vulnerability_ids = finding.unsaved_vulnerability_ids
                 self.assertEqual(1, len(vulnerability_ids))
                 self.assertEqual('CVE-1999-1338', vulnerability_ids[0])
                 self.assertEqual("Medium", finding.severity)
-                self.assertTrue("javascript-matcher" in finding.description)
+                self.assertIn("javascript-matcher", finding.description)
                 self.assertEqual("delegate", finding.component_name)
                 self.assertEqual("3.2.0", finding.component_version)
                 found = True

--- a/unittests/tools/test_api_bugcrowd_parser.py
+++ b/unittests/tools/test_api_bugcrowd_parser.py
@@ -42,9 +42,9 @@ class TestApiBugcrowdParser(TestCase):
             self.assertEqual(
                 finding.unique_id_from_tool, "a4201d47-62e1-4287-9ff6-30807ae9d36a"
             )
-            self.assertTrue(
-                "/submissions/a4201d47-62e1-4287-9ff6-30807ae9d36a"
-                in finding.references
+            self.assertIn(
+                "/submissions/a4201d47-62e1-4287-9ff6-30807ae9d36a",
+                finding.references
             )
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()

--- a/unittests/tools/test_auditjs_parser.py
+++ b/unittests/tools/test_auditjs_parser.py
@@ -65,9 +65,9 @@ class TestAuditJSParser(DojoTestCase):
             parser = AuditJSParser()
             parser.get_findings(testfile, Test())
             testfile.close()
-            self.assertTrue(
-                "Invalid JSON format. Are you sure you used --json option ?" in str(context.exception)
-            )
+        self.assertTrue(
+            "Invalid JSON format. Are you sure you used --json option ?" in str(context.exception)
+        )
 
     def test_auditjs_parser_with_package_name_has_namespace(self):
         testfile = open("unittests/scans/auditjs/auditjs_with_package_namespace.json")

--- a/unittests/tools/test_checkmarx_osa_parser.py
+++ b/unittests/tools/test_checkmarx_osa_parser.py
@@ -188,6 +188,6 @@ class TestCheckmarxOsaParser(DojoTestCase):
             parser = CheckmarxOsaParser()
             parser.get_findings(my_file_handle, test)
             self.teardown(my_file_handle)
-        self.assertTrue(
-            "Invalid format: missing mandatory field libraryId:" in str(context.exception)
+        self.assertEqual(
+            "Invalid format: missing mandatory field libraryId", str(context.exception)
         )

--- a/unittests/tools/test_checkmarx_osa_parser.py
+++ b/unittests/tools/test_checkmarx_osa_parser.py
@@ -188,6 +188,6 @@ class TestCheckmarxOsaParser(DojoTestCase):
             parser = CheckmarxOsaParser()
             parser.get_findings(my_file_handle, test)
             self.teardown(my_file_handle)
-            self.assertTrue(
-                "Invalid format: missing mandatory field libraryId:" in str(context.exception)
-            )
+        self.assertTrue(
+            "Invalid format: missing mandatory field libraryId:" in str(context.exception)
+        )

--- a/unittests/tools/test_checkov_parser.py
+++ b/unittests/tools/test_checkov_parser.py
@@ -27,7 +27,7 @@ class TestCheckovParser(DojoTestCase):
         testfile = open("unittests/scans/checkov/checkov-report-many-vuln.json")
         parser = CheckovParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) > 2)
+        self.assertGreater(len(findings), 2)
 
     def test_parse_file_with_multiple_check_type_has_multiple_check_type(self):
         testfile = open("unittests/scans/checkov/checkov-report-multiple-check_type.json")

--- a/unittests/tools/test_codechecker_parser.py
+++ b/unittests/tools/test_codechecker_parser.py
@@ -37,14 +37,14 @@ class TestCodeCheckerParser(DojoTestCase):
         )
         parser = CodeCheckerParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(94 == len(findings), str(len(findings)))
+        self.assertEqual(94, len(findings), str(len(findings)))
 
-        self.assertTrue(sum(1 for f in findings if f.duplicate) == 0)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'HIGH') == 20)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'INFO') == 6)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'CRITICAL') == 0)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'LOW') == 5)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'MEDIUM') == 63)
+        self.assertEqual(sum(1 for f in findings if f.duplicate), 0)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'HIGH'), 20)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'INFO'), 6)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'CRITICAL'), 0)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'LOW'), 5)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'MEDIUM'), 63)
 
         finding = findings[0]
         self.assertEqual("clang-diagnostic-sign-compare", finding.title)
@@ -64,7 +64,7 @@ class TestCodeCheckerParser(DojoTestCase):
         )
         parser = CodeCheckerParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) == 4)
+        self.assertEqual(len(findings), 4)
 
         finding = findings[0]
         self.assertTrue(finding.active)

--- a/unittests/tools/test_dependency_track_parser.py
+++ b/unittests/tools/test_dependency_track_parser.py
@@ -84,7 +84,7 @@ class TestDependencyTrackParser(DojoTestCase):
         self.assertEqual(12, len(findings))
         self.assertTrue(all(item.file_path is not None for item in findings))
         self.assertTrue(all(item.vuln_id_from_tool is not None for item in findings))
-        self.assertTrue('CVE-2022-42004' in findings[0].unsaved_vulnerability_ids)
+        self.assertIn('CVE-2022-42004', findings[0].unsaved_vulnerability_ids)
 
     def test_dependency_track_parser_findings_with_empty_alias(self):
         testfile = open(
@@ -95,7 +95,7 @@ class TestDependencyTrackParser(DojoTestCase):
         testfile.close()
 
         self.assertEqual(12, len(findings))
-        self.assertTrue('CVE-2022-2053' in findings[11].unsaved_vulnerability_ids)
+        self.assertIn('CVE-2022-2053', findings[11].unsaved_vulnerability_ids)
 
     def test_dependency_track_parser_findings_with_cvssV3_score(self):
         with open(f"{get_unit_tests_path()}/scans/dependency_track/many_findings_with_cvssV3_score.json") as testfile:
@@ -104,5 +104,5 @@ class TestDependencyTrackParser(DojoTestCase):
         self.assertEqual(12, len(findings))
         self.assertTrue(all(item.file_path is not None for item in findings))
         self.assertTrue(all(item.vuln_id_from_tool is not None for item in findings))
-        self.assertTrue('CVE-2022-42004' in findings[0].unsaved_vulnerability_ids)
+        self.assertIn('CVE-2022-42004', findings[0].unsaved_vulnerability_ids)
         self.assertEqual(8.3, findings[0].cvssv3_score)

--- a/unittests/tools/test_dockerbench_parser.py
+++ b/unittests/tools/test_dockerbench_parser.py
@@ -35,11 +35,11 @@ class TestDockerBenchParser(DojoTestCase):
         )
         parser = DockerBenchParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) == 50)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'CRITICAL') == 0)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'HIGH') == 32)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'LOW') == 16)
-        self.assertTrue(sum(1 for f in findings if f.severity.upper() == 'INFO') == 2)
+        self.assertEqual(len(findings), 50)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'CRITICAL'), 0)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'HIGH'), 32)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'LOW'), 16)
+        self.assertEqual(sum(1 for f in findings if f.severity.upper() == 'INFO'), 2)
 
         finding = findings[3]
         self.assertEqual("High", finding.severity)

--- a/unittests/tools/test_gcloud_artifact_scan_parser.py
+++ b/unittests/tools/test_gcloud_artifact_scan_parser.py
@@ -8,7 +8,7 @@ class TestGCloudArtifactScanParser(DojoTestCase):
         with open(f"{get_unit_tests_path()}/scans/gcloud_artifact_scan/many_vulns.json") as testfile:
             parser = GCloudArtifactScanParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertTrue(7, len(findings))
+        self.assertEqual(7, len(findings))
         finding = findings[0]
         self.assertEqual("projects/goog-vulnz/notes/CVE-2023-29405", finding.title)
         self.assertEqual("Critical", finding.severity)

--- a/unittests/tools/test_gitlab_dast_parser.py
+++ b/unittests/tools/test_gitlab_dast_parser.py
@@ -82,7 +82,7 @@ class TestGitlabDastParser(DojoTestCase):
         finding = findings[1]
         # must-have fields
         self.assertEqual(3, finding.scanner_confidence)
-        self.assertTrue("Content Security Policy (CSP)" in finding.description)
+        self.assertIn("Content Security Policy (CSP)", finding.description)
         self.assertEqual(False, finding.static_finding)
         self.assertEqual(True, finding.dynamic_finding)
 
@@ -95,14 +95,14 @@ class TestGitlabDastParser(DojoTestCase):
         # vulnerability does not have a name: fallback to using id as a title
         self.assertEqual(finding.unique_id_from_tool, finding.title)
         self.assertEqual(16, finding.cwe)
-        self.assertTrue("http://www.w3.org/TR/CSP/" in finding.references)
+        self.assertIn("http://www.w3.org/TR/CSP/", finding.references)
         self.assertEqual("Medium", finding.severity)
         endpoint = finding.unsaved_endpoints[0]
         self.assertEqual(str(endpoint), "http://api-server/v1/tree/10")
         self.assertEqual(endpoint.host, "api-server")  # host port path
         self.assertEqual(endpoint.port, 80)
         self.assertEqual(endpoint.path, "v1/tree/10")
-        self.assertTrue("Ensure that your web server," in finding.mitigation)
+        self.assertEqual("Ensure that your web server,", finding.mitigation)
 
     def test_parse_file_with_multiple_vuln_has_multiple_findings_v15(self):
         testfile = open("unittests/scans/gitlab_dast/gitlab_dast_many_vul_v15.json")
@@ -120,7 +120,7 @@ class TestGitlabDastParser(DojoTestCase):
         finding = findings[1]
         # must-have fields
         self.assertEqual(None, finding.scanner_confidence)
-        self.assertTrue("Content Security Policy (CSP)" in finding.description)
+        self.assertIn("Content Security Policy (CSP)", finding.description)
         self.assertEqual(False, finding.static_finding)
         self.assertEqual(True, finding.dynamic_finding)
 
@@ -133,11 +133,11 @@ class TestGitlabDastParser(DojoTestCase):
         # vulnerability does not have a name: fallback to using id as a title
         self.assertEqual(finding.unique_id_from_tool, finding.title)
         self.assertEqual(16, finding.cwe)
-        self.assertTrue("http://www.w3.org/TR/CSP/" in finding.references)
+        self.assertIn("http://www.w3.org/TR/CSP/", finding.references)
         self.assertEqual("Medium", finding.severity)
         endpoint = finding.unsaved_endpoints[0]
         self.assertEqual(str(endpoint), "http://api-server/v1/tree/10")
         self.assertEqual(endpoint.host, "api-server")  # host port path
         self.assertEqual(endpoint.port, 80)
         self.assertEqual(endpoint.path, "v1/tree/10")
-        self.assertTrue("Ensure that your web server," in finding.mitigation)
+        self.assertIn("Ensure that your web server,", finding.mitigation)

--- a/unittests/tools/test_gitlab_dast_parser.py
+++ b/unittests/tools/test_gitlab_dast_parser.py
@@ -102,7 +102,7 @@ class TestGitlabDastParser(DojoTestCase):
         self.assertEqual(endpoint.host, "api-server")  # host port path
         self.assertEqual(endpoint.port, 80)
         self.assertEqual(endpoint.path, "v1/tree/10")
-        self.assertEqual("Ensure that your web server,", finding.mitigation)
+        self.assertIn("Ensure that your web server,", finding.mitigation)
 
     def test_parse_file_with_multiple_vuln_has_multiple_findings_v15(self):
         testfile = open("unittests/scans/gitlab_dast/gitlab_dast_many_vul_v15.json")

--- a/unittests/tools/test_gitlab_dep_scan_parser.py
+++ b/unittests/tools/test_gitlab_dep_scan_parser.py
@@ -63,7 +63,7 @@ class TestGitlabDepScanParser(DojoTestCase):
         )
         parser = GitlabDepScanParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) > 2)
+        self.assertGreater(len(findings), 2)
 
         self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
         self.assertEqual("CVE-2020-29652", findings[0].unsaved_vulnerability_ids[0])
@@ -74,7 +74,7 @@ class TestGitlabDepScanParser(DojoTestCase):
         )
         parser = GitlabDepScanParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) > 2)
+        self.assertGreater(len(findings), 2)
 
         self.assertEqual(1, len(findings[0].unsaved_vulnerability_ids))
         self.assertEqual("CVE-2020-29652", findings[0].unsaved_vulnerability_ids[0])

--- a/unittests/tools/test_gitlab_sast_parser.py
+++ b/unittests/tools/test_gitlab_sast_parser.py
@@ -33,7 +33,7 @@ class TestGitlabSastParser(DojoTestCase):
         with open(f"{get_unit_tests_path()}/scans/gitlab_sast/gl-sast-report-many-vuln_v14.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertTrue(3, len(findings))
+        self.assertEqual(3, len(findings))
         finding = findings[0]
         self.assertEqual("Password in URL", finding.title)
         self.assertEqual("Critical", finding.severity)
@@ -48,7 +48,7 @@ class TestGitlabSastParser(DojoTestCase):
         with open(f"{get_unit_tests_path()}/scans/gitlab_sast/gl-sast-report-many-vuln_v15.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertTrue(3, len(findings))
+        self.assertEqual(3, len(findings))
         finding = findings[0]
         self.assertEqual("Password in URL", finding.title)
         self.assertEqual("Critical", finding.severity)
@@ -63,9 +63,10 @@ class TestGitlabSastParser(DojoTestCase):
         with open(f"{get_unit_tests_path()}/scans/gitlab_sast/gl-sast-report-confidence_v14.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) == 8)
+        self.assertEqual(len(findings), 8)
         for item in findings:
-            self.assertTrue(item.cwe is None or isinstance(item.cwe, int))
+            if item.cwe:
+                self.assertIsInstance(item.cwe, int)
         finding = findings[3]
         self.assertEqual("Tentative", finding.get_scanner_confidence_text())
         finding = findings[4]
@@ -81,9 +82,10 @@ class TestGitlabSastParser(DojoTestCase):
         with open(f"{get_unit_tests_path()}/scans/gitlab_sast/gl-sast-report-confidence_v15.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) == 8)
+        self.assertEqual(len(findings), 8)
         for item in findings:
-            self.assertTrue(item.cwe is None or isinstance(item.cwe, int))
+            if item.cwe:
+                self.assertIsInstance(item.cwe, int)
         finding = findings[3]
         self.assertEqual("", finding.get_scanner_confidence_text())
         finding = findings[4]
@@ -99,7 +101,7 @@ class TestGitlabSastParser(DojoTestCase):
         with open("unittests/scans/gitlab_sast/gl-sast-report-cwe_v14.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) == 3)
+        self.assertEqual(len(findings), 3)
         self.assertEqual(79, findings[0].cwe)
         self.assertEqual(89, findings[1].cwe)
         self.assertEqual(None, findings[2].cwe)
@@ -108,7 +110,7 @@ class TestGitlabSastParser(DojoTestCase):
         with open("unittests/scans/gitlab_sast/gl-sast-report-cwe_v15.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) == 3)
+        self.assertEqual(len(findings), 3)
         self.assertEqual(79, findings[0].cwe)
         self.assertEqual(89, findings[1].cwe)
         self.assertEqual(None, findings[2].cwe)

--- a/unittests/tools/test_gitlab_sast_parser.py
+++ b/unittests/tools/test_gitlab_sast_parser.py
@@ -33,7 +33,7 @@ class TestGitlabSastParser(DojoTestCase):
         with open(f"{get_unit_tests_path()}/scans/gitlab_sast/gl-sast-report-many-vuln_v14.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertEqual(3, len(findings))
+        self.assertEqual(219, len(findings))
         finding = findings[0]
         self.assertEqual("Password in URL", finding.title)
         self.assertEqual("Critical", finding.severity)
@@ -48,7 +48,7 @@ class TestGitlabSastParser(DojoTestCase):
         with open(f"{get_unit_tests_path()}/scans/gitlab_sast/gl-sast-report-many-vuln_v15.json") as testfile:
             parser = GitlabSastParser()
             findings = parser.get_findings(testfile, Test())
-        self.assertEqual(3, len(findings))
+        self.assertEqual(219, len(findings))
         finding = findings[0]
         self.assertEqual("Password in URL", finding.title)
         self.assertEqual("Critical", finding.severity)

--- a/unittests/tools/test_govulncheck_parser.py
+++ b/unittests/tools/test_govulncheck_parser.py
@@ -10,9 +10,9 @@ class TestGovulncheckParser(DojoTestCase):
             testfile = open("unittests/scans/govulncheck/empty.json")
             parser = GovulncheckParser()
             parser.get_findings(testfile, Test())
-            self.assertTrue(
-                "Invalid JSON format" in str(exp.exception)
-            )
+        self.assertTrue(
+            "Invalid JSON format" in str(exp.exception)
+        )
 
     def test_parse_no_findings(self):
         testfile = open("unittests/scans/govulncheck/no_vulns.json")

--- a/unittests/tools/test_govulncheck_parser.py
+++ b/unittests/tools/test_govulncheck_parser.py
@@ -10,8 +10,8 @@ class TestGovulncheckParser(DojoTestCase):
             testfile = open("unittests/scans/govulncheck/empty.json")
             parser = GovulncheckParser()
             parser.get_findings(testfile, Test())
-        self.assertTrue(
-            "Invalid JSON format" in str(exp.exception)
+        self.assertIn(
+            "Invalid JSON format", str(exp.exception)
         )
 
     def test_parse_no_findings(self):

--- a/unittests/tools/test_immuniweb_parser.py
+++ b/unittests/tools/test_immuniweb_parser.py
@@ -27,4 +27,4 @@ class TestImmuniwebParser(DojoTestCase):
         for finding in findings:
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()
-        self.assertTrue(len(findings) > 2)
+        self.assertGreater(len(findings), 2)

--- a/unittests/tools/test_kubebench_parser.py
+++ b/unittests/tools/test_kubebench_parser.py
@@ -27,7 +27,7 @@ class TestKubeBenchParser(DojoTestCase):
         )
         parser = KubeBenchParser()
         findings = parser.get_findings(testfile, Test())
-        self.assertTrue(len(findings) == 4)
+        self.assertEqual(len(findings), 4)
 
     def test_parse_file_with_controls_tag(self):
 

--- a/unittests/tools/test_kubehunter_parser.py
+++ b/unittests/tools/test_kubehunter_parser.py
@@ -43,10 +43,10 @@ class TestKubeHunterParser(TestCase):
             parser.get_findings(testfile, Test())
             testfile.close()
 
-            self.assertTrue(
-                "KubeHunter report contains errors:" in str(context.exception)
-            )
-            self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertTrue(
+            "KubeHunter report contains errors:" in str(context.exception)
+        )
+        self.assertTrue("ECONNREFUSED" in str(context.exception))
 
     def test_kubehunter_parser_dupe(self):
         testfile = open("unittests/scans/kubehunter/dupe.json")

--- a/unittests/tools/test_kubehunter_parser.py
+++ b/unittests/tools/test_kubehunter_parser.py
@@ -43,10 +43,9 @@ class TestKubeHunterParser(TestCase):
             parser.get_findings(testfile, Test())
             testfile.close()
 
-        self.assertIn(
-            "KubeHunter report contains errors:", str(context.exception)
+        self.assertEqual(
+            "Expecting value: line 1 column 1 (char 0)", str(context.exception)
         )
-        self.assertIn("ECONNREFUSED", str(context.exception))
 
     def test_kubehunter_parser_dupe(self):
         testfile = open("unittests/scans/kubehunter/dupe.json")

--- a/unittests/tools/test_kubehunter_parser.py
+++ b/unittests/tools/test_kubehunter_parser.py
@@ -43,10 +43,10 @@ class TestKubeHunterParser(TestCase):
             parser.get_findings(testfile, Test())
             testfile.close()
 
-        self.assertTrue(
-            "KubeHunter report contains errors:" in str(context.exception)
+        self.assertIn(
+            "KubeHunter report contains errors:", str(context.exception)
         )
-        self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertIn("ECONNREFUSED", str(context.exception))
 
     def test_kubehunter_parser_dupe(self):
         testfile = open("unittests/scans/kubehunter/dupe.json")

--- a/unittests/tools/test_meterian_parser.py
+++ b/unittests/tools/test_meterian_parser.py
@@ -61,13 +61,13 @@ class TestMeterianParser(DojoTestCase):
         self.assertEqual("CVE-2020-26289", finding.unsaved_vulnerability_ids[0])
         self.assertEqual(400, finding.cwe)
         self.assertTrue(finding.mitigation.startswith("## Remediation"))
-        self.assertTrue("Upgrade date-and-time to version 0.14.2 or higher." in finding.mitigation)
-        self.assertTrue("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26289" in finding.references, "found " + finding.references)
-        self.assertTrue("https://nvd.nist.gov/vuln/detail/CVE-2020-26289" in finding.references, "found " + finding.references)
-        self.assertTrue("https://www.npmjs.com/package/date-and-time" in finding.references, "found " + finding.references)
-        self.assertTrue("https://github.com/knowledgecode/date-and-time/security/advisories/GHSA-r92x-f52r-x54g" in finding.references, "found " + finding.references)
-        self.assertTrue("https://github.com/knowledgecode/date-and-time/commit/9e4b501eacddccc8b1f559fb414f48472ee17c2a" in finding.references, "found " + finding.references)
-        self.assertTrue("Manifest file", finding.file_path)
+        self.assertIn("Upgrade date-and-time to version 0.14.2 or higher.", finding.mitigation)
+        self.assertIn("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26289", finding.references, "found " + finding.references)
+        self.assertIn("https://nvd.nist.gov/vuln/detail/CVE-2020-26289", finding.references, "found " + finding.references)
+        self.assertIn("https://www.npmjs.com/package/date-and-time", finding.references, "found " + finding.references)
+        self.assertIn("https://github.com/knowledgecode/date-and-time/security/advisories/GHSA-r92x-f52r-x54g", finding.references, "found " + finding.references)
+        self.assertIn("https://github.com/knowledgecode/date-and-time/commit/9e4b501eacddccc8b1f559fb414f48472ee17c2a", finding.references, "found " + finding.references)
+        self.assertIn("Manifest file", finding.file_path)
         self.assertEqual(["nodejs"], finding.tags)
 
     def test_meterianParser_finding_has_no_remediation(self):
@@ -79,8 +79,8 @@ class TestMeterianParser(DojoTestCase):
 
         finding = findings[0]
         self.assertTrue(finding.mitigation.startswith("We were not able to provide a safe version for this library."))
-        self.assertTrue("You should consider replacing this component as it could be an " +
-            "issue for the safety of your application." in finding.mitigation)
+        self.assertIn("You should consider replacing this component as it could be an " +
+            "issue for the safety of your application.", finding.mitigation)
 
     def test_meterianParser_dual_language_report_has_two_findins(self):
         testfile = open("unittests/scans/meterian/report_multi_language.json")

--- a/unittests/tools/test_nikto_parser.py
+++ b/unittests/tools/test_nikto_parser.py
@@ -48,7 +48,7 @@ class TestNiktoParser(DojoTestCase):
         for finding in findings:
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()
-        self.assertTrue(len(findings) == 10)
+        self.assertEqual(len(findings), 10)
 
     def test_parse_file_json_with_multiple_vuln_has_multiple_findings(self):
         testfile = open("unittests/scans/nikto/juice-shop.json")

--- a/unittests/tools/test_npm_audit_parser.py
+++ b/unittests/tools/test_npm_audit_parser.py
@@ -76,8 +76,8 @@ class TestNpmAuditParser(DojoTestCase):
             parser = NpmAuditParser()
             parser.get_findings(testfile, Test())
             testfile.close()
-            self.assertTrue("npm audit report contains errors:" in str(context.exception))
-            self.assertTrue("ENOAUDIT" in str(context.exception))
+        self.assertTrue("npm audit report contains errors:" in str(context.exception))
+        self.assertTrue("ENOAUDIT" in str(context.exception))
 
     def test_npm_audit_parser_many_vuln_npm7(self):
         with self.assertRaises(ValueError) as context:
@@ -85,8 +85,8 @@ class TestNpmAuditParser(DojoTestCase):
             parser = NpmAuditParser()
             findings = parser.get_findings(testfile, Test())
             testfile.close()
-            self.assertTrue("npm7 with auditReportVersion 2 or higher not yet supported" in str(context.exception))
-            self.assertEqual(findings, None)
+        self.assertTrue("npm7 with auditReportVersion 2 or higher not yet supported" in str(context.exception))
+        self.assertEqual(findings, None)
 
     def test_npm_audit_censored_hash(self):
         path = "77d76e075ae87483063c4c74885422f98300f9fc0ecbd3b8dfb60152a36e5269>axios"

--- a/unittests/tools/test_npm_audit_parser.py
+++ b/unittests/tools/test_npm_audit_parser.py
@@ -76,8 +76,8 @@ class TestNpmAuditParser(DojoTestCase):
             parser = NpmAuditParser()
             parser.get_findings(testfile, Test())
             testfile.close()
-        self.assertTrue("npm audit report contains errors:" in str(context.exception))
-        self.assertTrue("ENOAUDIT" in str(context.exception))
+        self.assertIn("npm audit report contains errors:", str(context.exception))
+        self.assertIn("ENOAUDIT", str(context.exception))
 
     def test_npm_audit_parser_many_vuln_npm7(self):
         with self.assertRaises(ValueError) as context:
@@ -85,7 +85,7 @@ class TestNpmAuditParser(DojoTestCase):
             parser = NpmAuditParser()
             findings = parser.get_findings(testfile, Test())
             testfile.close()
-        self.assertTrue("npm7 with auditReportVersion 2 or higher not yet supported" in str(context.exception))
+        self.assertIn("npm7 with auditReportVersion 2 or higher not yet supported", str(context.exception))
         self.assertEqual(findings, None)
 
     def test_npm_audit_censored_hash(self):

--- a/unittests/tools/test_npm_audit_parser.py
+++ b/unittests/tools/test_npm_audit_parser.py
@@ -83,10 +83,9 @@ class TestNpmAuditParser(DojoTestCase):
         with self.assertRaises(ValueError) as context:
             testfile = open(path.join(path.dirname(__file__), "../scans/npm_audit/many_vuln_npm7.json"))
             parser = NpmAuditParser()
-            findings = parser.get_findings(testfile, Test())
+            parser.get_findings(testfile, Test())
             testfile.close()
         self.assertIn("npm7 with auditReportVersion 2 or higher not yet supported", str(context.exception))
-        self.assertEqual(findings, None)
 
     def test_npm_audit_censored_hash(self):
         path = "77d76e075ae87483063c4c74885422f98300f9fc0ecbd3b8dfb60152a36e5269>axios"

--- a/unittests/tools/test_nsp_parser.py
+++ b/unittests/tools/test_nsp_parser.py
@@ -27,12 +27,12 @@ class TestNspParser(DojoTestCase):
                 codeExec += 1
             elif finding.title.startswith("Regular Expression Denial of Service"):
                 self.assertEqual(findings[0].severity, "High")
-                self.assertTrue(
-                    finding.references == "https://nodesecurity.io/advisories/106" or
-                    finding.references == "https://nodesecurity.io/advisories/526" or
-                    finding.references == "https://nodesecurity.io/advisories/534" or
-                    finding.references == "https://nodesecurity.io/advisories/535"
-                )
+                self.assertIn(finding.references, [
+                    "https://nodesecurity.io/advisories/106",
+                    "https://nodesecurity.io/advisories/526",
+                    "https://nodesecurity.io/advisories/534",
+                    "https://nodesecurity.io/advisories/535",
+                ])
                 dos += 1
             else:
                 self.fail("Unexpected NSP finding.")

--- a/unittests/tools/test_ossindex_devaudit_parser.py
+++ b/unittests/tools/test_ossindex_devaudit_parser.py
@@ -30,7 +30,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         parser = OssIndexDevauditParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertTrue(len(findings) > 1)
+        self.assertGreater(len(findings), 1)
 
     def test_ossindex_devaudit_parser_with_no_cve_returns_info_severity(self):
         testfile = open(
@@ -39,7 +39,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         parser = OssIndexDevauditParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
-        self.assertTrue(len(findings) == 1)
+        self.assertEqual(len(findings), 1)
 
     def test_ossindex_devaudit_parser_with_reference_shows_reference(self):
         testfile = open(
@@ -51,7 +51,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
 
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.references != "")
+                self.assertNotEqual(item.references, "")
 
     def test_ossindex_devaudit_parser_with_empty_reference_shows_empty_reference(self):
         testfile = open(
@@ -62,7 +62,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.references == "")
+                self.assertEqual(item.references, "")
 
     def test_ossindex_devaudit_parser_with_missing_reference_shows_empty(self):
         testfile = open(
@@ -73,7 +73,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.references == "")
+                self.assertEqual(item.references, "")
 
     def test_ossindex_devaudit_parser_with_missing_cwe_shows_1035(self):
         testfile = open(
@@ -84,7 +84,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.cwe == 1035)
+                self.assertEqual(item.cwe, 1035)
 
     def test_ossindex_devaudit_parser_with_null_cwe_shows_1035(self):
         testfile = open(
@@ -95,7 +95,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.cwe == 1035)
+                self.assertEqual(item.cwe, 1035)
 
     def test_ossindex_devaudit_parser_with_empty_cwe_shows_1035(self):
         testfile = open(
@@ -106,7 +106,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.cwe == 1035)
+                self.assertEqual(item.cwe, 1035)
 
     def test_ossindex_devaudit_parser_get_severity_shows_info(self):
         testfile = open(
@@ -117,7 +117,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.severity == "Info")
+                self.assertEqual(item.severity, "Info")
 
     def test_ossindex_devaudit_parser_get_severity_shows_critical(self):
         testfile = open(
@@ -128,7 +128,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.severity == "Critical")
+                self.assertEqual(item.severity, "Critical")
 
     def test_ossindex_devaudit_parser_get_severity_shows_high(self):
         testfile = open(
@@ -139,7 +139,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.severity == "High")
+                self.assertEqual(item.severity, "High")
 
     def test_ossindex_devaudit_parser_get_severity_shows_medium(self):
         testfile = open(
@@ -150,7 +150,7 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.severity == "Medium")
+                self.assertEqual(item.severity, "Medium")
 
     def test_ossindex_devaudit_parser_get_severity_shows_low(self):
         testfile = open(
@@ -161,4 +161,4 @@ class TestOssIndexDevauditParser(DojoTestCase):
         testfile.close()
         if len(findings) > 0:
             for item in findings:
-                self.assertTrue(item.severity == "Low")
+                self.assertEqual(item.severity, "Low")

--- a/unittests/tools/test_ssl_labs_parser.py
+++ b/unittests/tools/test_ssl_labs_parser.py
@@ -22,7 +22,7 @@ class TestSslLabsParser(DojoTestCase):
         self.assertEqual(findings[0].unsaved_endpoints[0].host, "defectdojo.mevitae.com")
         self.assertEqual(findings[0].cwe, 310)
         self.assertEqual(findings[0].severity, "Info")
-        self.assertTrue("TLS" in findings[0].description)
+        self.assertIn("TLS", findings[0].description)
 
     def test_parse_dh1024(self):
         parser = SslLabsParser()
@@ -37,7 +37,7 @@ class TestSslLabsParser(DojoTestCase):
         self.assertEqual(findings[0].unsaved_endpoints[0].host, "dh1024.badssl.com")
         self.assertEqual(findings[0].cwe, 310)
         self.assertEqual(findings[0].severity, "Medium")
-        self.assertTrue("TLS" in findings[0].description)
+        self.assertIn("TLS", findings[0].description)
 
     def test_parse_3des(self):
         parser = SslLabsParser()
@@ -52,7 +52,7 @@ class TestSslLabsParser(DojoTestCase):
         self.assertEqual(findings[0].unsaved_endpoints[0].host, "3des.badssl.com")
         self.assertEqual(findings[0].cwe, 310)
         self.assertEqual(findings[0].severity, "High")
-        self.assertTrue("TLS" in findings[0].description)
+        self.assertIn("TLS", findings[0].description)
 
     def test_parse_revoked(self):
         parser = SslLabsParser()
@@ -67,7 +67,7 @@ class TestSslLabsParser(DojoTestCase):
         self.assertEqual(findings[0].unsaved_endpoints[0].host, "revoked.badssl.com")
         self.assertEqual(findings[0].cwe, 310)
         self.assertEqual(findings[0].severity, "Critical")
-        self.assertTrue("TLS" in findings[0].description)
+        self.assertIn("TLS", findings[0].description)
 
     def test_parse_multiple(self):
         parser = SslLabsParser()
@@ -84,7 +84,7 @@ class TestSslLabsParser(DojoTestCase):
         foundCritical = False
 
         for finding in findings:
-            self.assertTrue("TLS" in finding.description)
+            self.assertIn("TLS", finding.description)
             self.assertEqual(finding.cwe, 310)
             if finding.severity == "Info":
                 self.assertEqual(finding.title, "TLS Grade 'A+' for defectdojo.mevitae.com")

--- a/unittests/tools/test_sysdig_reports_parser.py
+++ b/unittests/tools/test_sysdig_reports_parser.py
@@ -44,10 +44,10 @@ class TestSysdigParser(TestCase):
             for finding in findings:
                 for endpoint in finding.unsaved_endpoints:
                     endpoint.clean()
-            self.assertTrue(
-                "sysdig report contains errors:" in str(context.exception)
-            )
-            self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertTrue(
+            "sysdig report contains errors:" in str(context.exception)
+        )
+        self.assertTrue("ECONNREFUSED" in str(context.exception))
 
     def test_sysdig_parser_missing_cve_field_not_starting_with_cve(self):
         with self.assertRaises(ValueError) as context:
@@ -58,10 +58,10 @@ class TestSysdigParser(TestCase):
             for finding in findings:
                 for endpoint in finding.unsaved_endpoints:
                     endpoint.clean()
-            self.assertTrue(
-                "sysdig report contains errors:" in str(context.exception)
-            )
-            self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertTrue(
+            "sysdig report contains errors:" in str(context.exception)
+        )
+        self.assertTrue("ECONNREFUSED" in str(context.exception))
 
     def test_sysdig_parser_json_with_many_findings(self):
         testfile = open("unittests/scans/sysdig_reports/sysdig.json")

--- a/unittests/tools/test_sysdig_reports_parser.py
+++ b/unittests/tools/test_sysdig_reports_parser.py
@@ -44,10 +44,10 @@ class TestSysdigParser(TestCase):
             for finding in findings:
                 for endpoint in finding.unsaved_endpoints:
                     endpoint.clean()
-        self.assertTrue(
-            "sysdig report contains errors:" in str(context.exception)
+        self.assertIn(
+            "sysdig report contains errors:", str(context.exception)
         )
-        self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertIn("ECONNREFUSED", str(context.exception))
 
     def test_sysdig_parser_missing_cve_field_not_starting_with_cve(self):
         with self.assertRaises(ValueError) as context:
@@ -58,10 +58,10 @@ class TestSysdigParser(TestCase):
             for finding in findings:
                 for endpoint in finding.unsaved_endpoints:
                     endpoint.clean()
-        self.assertTrue(
-            "sysdig report contains errors:" in str(context.exception)
+        self.assertIn(
+            "sysdig report contains errors:", str(context.exception)
         )
-        self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertIn("ECONNREFUSED", str(context.exception))
 
     def test_sysdig_parser_json_with_many_findings(self):
         testfile = open("unittests/scans/sysdig_reports/sysdig.json")

--- a/unittests/tools/test_sysdig_reports_parser.py
+++ b/unittests/tools/test_sysdig_reports_parser.py
@@ -44,10 +44,9 @@ class TestSysdigParser(TestCase):
             for finding in findings:
                 for endpoint in finding.unsaved_endpoints:
                     endpoint.clean()
-        self.assertIn(
-            "sysdig report contains errors:", str(context.exception)
+        self.assertEqual(
+            "Number of fields in row (22) does not match number of headers (21)", str(context.exception)
         )
-        self.assertIn("ECONNREFUSED", str(context.exception))
 
     def test_sysdig_parser_missing_cve_field_not_starting_with_cve(self):
         with self.assertRaises(ValueError) as context:
@@ -58,10 +57,9 @@ class TestSysdigParser(TestCase):
             for finding in findings:
                 for endpoint in finding.unsaved_endpoints:
                     endpoint.clean()
-        self.assertIn(
-            "sysdig report contains errors:", str(context.exception)
+        self.assertEqual(
+            "Number of fields in row (22) does not match number of headers (21)", str(context.exception)
         )
-        self.assertIn("ECONNREFUSED", str(context.exception))
 
     def test_sysdig_parser_json_with_many_findings(self):
         testfile = open("unittests/scans/sysdig_reports/sysdig.json")

--- a/unittests/tools/test_tenable_parser.py
+++ b/unittests/tools/test_tenable_parser.py
@@ -70,7 +70,7 @@ class TestTenableParser(DojoTestCase):
         finding = findings[0]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Info", finding.severity)
-        self.assertFalse(finding.unsaved_vulnerability_ids)
+        self.assertEqual(0, len(finding.unsaved_vulnerability_ids))
         self.assertEqual(0, finding.cwe)
         self.assertEqual("HTTP Server Type and Version", finding.title)
         finding = findings[25]
@@ -92,7 +92,7 @@ class TestTenableParser(DojoTestCase):
         finding = findings[0]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Info", finding.severity)
-        self.assertFalse(finding.unsaved_vulnerability_ids)
+        self.assertEqual(0, len(finding.unsaved_vulnerability_ids))
         self.assertEqual(0, finding.cwe)
         self.assertEqual("HTTP Server Type and Version", finding.title)
         finding = findings[25]
@@ -136,14 +136,14 @@ class TestTenableParser(DojoTestCase):
         finding = findings[0]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Info", finding.severity)
-        self.assertFalse(finding.unsaved_vulnerability_ids)
+        self.assertEqual(0, len(finding.unsaved_vulnerability_ids))
         self.assertEqual("Nessus Scan Information", finding.title)
 
         finding = findings[25]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual("Nessus SYN scanner", finding.title)
         self.assertEqual("Info", finding.severity)
-        self.assertFalse(finding.unsaved_vulnerability_ids)
+        self.assertEqual(0, len(finding.unsaved_vulnerability_ids))
         endpoint = finding.unsaved_endpoints[26]
         self.assertEqual("http", endpoint.protocol)
         endpoint = finding.unsaved_endpoints[37]
@@ -221,7 +221,7 @@ class TestTenableParser(DojoTestCase):
             finding = findings[i]
             self.assertIn(finding.severity, Finding.SEVERITIES)
             self.assertEqual('google.com', finding.unsaved_endpoints[0].host)
-            self.assertFalse(finding.unsaved_vulnerability_ids)
+            self.assertEqual(0, len(finding.unsaved_vulnerability_ids))
         finding = findings[0]
         self.assertEqual('7.1', finding.cvssv3_score)
         self.assertEqual('High', finding.severity)
@@ -238,7 +238,7 @@ class TestTenableParser(DojoTestCase):
         finding = findings[0]
         self.assertIn(finding.severity, Finding.SEVERITIES)
         self.assertEqual('google.com', finding.unsaved_endpoints[0].host)
-        self.assertFalse(finding.unsaved_vulnerability_ids)
+        self.assertEqual(0, len(finding.unsaved_vulnerability_ids))
         self.assertEqual('7.1', finding.cvssv3_score)
         self.assertEqual('High', finding.severity)
         self.assertEqual('http', finding.unsaved_endpoints[0].protocol)

--- a/unittests/tools/test_threagile_parser.py
+++ b/unittests/tools/test_threagile_parser.py
@@ -9,8 +9,8 @@ class TestThreAgileParser(DojoTestCase):
             parser = ThreagileParser()
             with self.assertRaises(ValueError) as exc_context:
                 parser.get_findings(testfile, Test())
-            exc = exc_context.exception
-            self.assertEqual("Invalid ThreAgile risks file", str(exc))
+        exc = exc_context.exception
+        self.assertEqual("Invalid ThreAgile risks file", str(exc))
 
     def test_empty_file_returns_no_findings(self):
         with open("unittests/scans/threagile/empty_file_no_risks.json") as testfile:

--- a/unittests/tools/test_yarn_audit_parser.py
+++ b/unittests/tools/test_yarn_audit_parser.py
@@ -71,7 +71,7 @@ class TestYarnAuditParser(DojoTestCase):
             parser = YarnAuditParser()
             parser.get_findings(testfile, self.get_test())
             testfile.close()
-            self.assertTrue(
-                "yarn audit report contains errors:" in str(context.exception)
-            )
-            self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertTrue(
+            "yarn audit report contains errors:" in str(context.exception)
+        )
+        self.assertTrue("ECONNREFUSED" in str(context.exception))

--- a/unittests/tools/test_yarn_audit_parser.py
+++ b/unittests/tools/test_yarn_audit_parser.py
@@ -71,7 +71,7 @@ class TestYarnAuditParser(DojoTestCase):
             parser = YarnAuditParser()
             parser.get_findings(testfile, self.get_test())
             testfile.close()
-        self.assertTrue(
-            "yarn audit report contains errors:" in str(context.exception)
+        self.assertIn(
+            "yarn audit report contains errors:", str(context.exception)
         )
-        self.assertTrue("ECONNREFUSED" in str(context.exception))
+        self.assertIn("ECONNREFUSED", str(context.exception))


### PR DESCRIPTION
Some `assert*` are skipped because they are evaluated in `with self.assertRaises(...)`. These asserts should be outside of these blocks.

Some unittests have been hard to troubleshoot if they use only `assertTrue` or `assertFalse`