### PR TITLE
Fix SARIF parser with CodeQL rules

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -77,7 +77,10 @@ class SarifParser(object):
 
 def get_rules(run):
     rules = {}
-    for item in run["tool"]["driver"].get("rules", []):
+    rules_array = run["tool"]["driver"].get("rules", [])
+    if len(rules_array) == 0:
+        rules_array = run["tool"]["extensions"][0].get("rules", [])
+    for item in rules_array:
         rules[item["id"]] = item
     return rules
 

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -78,7 +78,7 @@ class SarifParser(object):
 def get_rules(run):
     rules = {}
     rules_array = run["tool"]["driver"].get("rules", [])
-    if len(rules_array) == 0 and run["tool"].get("extensions") != None:
+    if len(rules_array) == 0 and run["tool"].get("extensions") is not None:
         rules_array = run["tool"]["extensions"][0].get("rules", [])
     for item in rules_array:
         rules[item["id"]] = item

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -78,7 +78,7 @@ class SarifParser(object):
 def get_rules(run):
     rules = {}
     rules_array = run["tool"]["driver"].get("rules", [])
-    if len(rules_array) == 0:
+    if len(rules_array) == 0 and run["tool"].get("extensions") != None:
         rules_array = run["tool"]["extensions"][0].get("rules", [])
     for item in rules_array:
         rules[item["id"]] = item


### PR DESCRIPTION
**Description**

Currently SARIF parser looking for list of rules in `run["tool"]["driver"]` object.
Although SARIF report generated by https://github.com/github/codeql-action lists rules under `run["tool"]["extensions"]` object. This results in finding's CWE, Severity and Description not being populated with information according to the rule.

**Test results**

Now parser checks for driver object as usual but then also checks for extensions object ([link](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790782) to the SARIF specification). This way i was able to populate CWE, Severity and Description fields from the report of my CodeQL action. This is also may be useful for other scanners that populates extensions instead of driver
