### PR TITLE
API: Fix typed-enum from spectral/limeflight

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -164,14 +164,14 @@ class FindingStatusFilter(ChoiceFilter):
 
     options = {
         None: (_("Any"), any),
-        0: (_("Open"), open),
-        1: (_("Verified"), verified),
-        2: (_("Out Of Scope"), out_of_scope),
-        3: (_("False Positive"), false_positive),
-        4: (_("Inactive"), inactive),
-        5: (_("Risk Accepted"), risk_accepted),
-        6: (_("Closed"), closed),
-        7: (_("Under Review"), under_review),
+        "0": (_("Open"), open),
+        "1": (_("Verified"), verified),
+        "2": (_("Out Of Scope"), out_of_scope),
+        "3": (_("False Positive"), false_positive),
+        "4": (_("Inactive"), inactive),
+        "5": (_("Risk Accepted"), risk_accepted),
+        "6": (_("Closed"), closed),
+        "7": (_("Under Review"), under_review),
     }
 
     def __init__(self, *args, **kwargs):
@@ -218,8 +218,8 @@ class FindingSLAFilter(ChoiceFilter):
 
     options = {
         None: (_("Any"), any),
-        0: (_("False"), sla_satisfied),
-        1: (_("True"), sla_violated),
+        "0": (_("False"), sla_satisfied),
+        "1": (_("True"), sla_violated),
     }
 
     def __init__(self, *args, **kwargs):
@@ -253,8 +253,8 @@ class ProductSLAFilter(ChoiceFilter):
 
     options = {
         None: (_("Any"), any),
-        0: (_("False"), sla_satisifed),
-        1: (_("True"), sla_violated),
+        "0": (_("False"), sla_satisifed),
+        "1": (_("True"), sla_violated),
     }
 
     def __init__(self, *args, **kwargs):
@@ -606,31 +606,31 @@ class FindingTagStringFilter(FilterSet):
 class DateRangeFilter(ChoiceFilter):
     options = {
         None: (_("Any date"), lambda qs, name: qs.all()),
-        1: (_("Today"), lambda qs, name: qs.filter(**{
+        "1": (_("Today"), lambda qs, name: qs.filter(**{
             f"{name}__year": now().year,
             f"{name}__month": now().month,
             f"{name}__day": now().day,
         })),
-        2: (_("Past 7 days"), lambda qs, name: qs.filter(**{
+        "2": (_("Past 7 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=7)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
-        3: (_("Past 30 days"), lambda qs, name: qs.filter(**{
+        "3": (_("Past 30 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=30)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
-        4: (_("Past 90 days"), lambda qs, name: qs.filter(**{
+        "4": (_("Past 90 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=90)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
-        5: (_("Current month"), lambda qs, name: qs.filter(**{
+        "5": (_("Current month"), lambda qs, name: qs.filter(**{
             f"{name}__year": now().year,
             f"{name}__month": now().month,
         })),
-        6: (_("Current year"), lambda qs, name: qs.filter(**{
+        "6": (_("Current year"), lambda qs, name: qs.filter(**{
             f"{name}__year": now().year,
         })),
-        7: (_("Past year"), lambda qs, name: qs.filter(**{
+        "7": (_("Past year"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=365)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
@@ -652,47 +652,47 @@ class DateRangeFilter(ChoiceFilter):
 class DateRangeOmniFilter(ChoiceFilter):
     options = {
         None: (_("Any date"), lambda qs, name: qs.all()),
-        1: (_("Today"), lambda qs, name: qs.filter(**{
+        "1": (_("Today"), lambda qs, name: qs.filter(**{
             f"{name}__year": now().year,
             f"{name}__month": now().month,
             f"{name}__day": now().day,
         })),
-        2: (_("Next 7 days"), lambda qs, name: qs.filter(**{
+        "2": (_("Next 7 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() + timedelta(days=1)),
             f"{name}__lt": _truncate(now() + timedelta(days=7)),
         })),
-        3: (_("Next 30 days"), lambda qs, name: qs.filter(**{
+        "3": (_("Next 30 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() + timedelta(days=1)),
             f"{name}__lt": _truncate(now() + timedelta(days=30)),
         })),
-        4: (_("Next 90 days"), lambda qs, name: qs.filter(**{
+        "4": (_("Next 90 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() + timedelta(days=1)),
             f"{name}__lt": _truncate(now() + timedelta(days=90)),
         })),
-        5: (_("Past 7 days"), lambda qs, name: qs.filter(**{
+        "5": (_("Past 7 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=7)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
-        6: (_("Past 30 days"), lambda qs, name: qs.filter(**{
+        "6": (_("Past 30 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=30)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
-        7: (_("Past 90 days"), lambda qs, name: qs.filter(**{
+        "7": (_("Past 90 days"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=90)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
-        8: (_("Current month"), lambda qs, name: qs.filter(**{
+        "8": (_("Current month"), lambda qs, name: qs.filter(**{
             f"{name}__year": now().year,
             f"{name}__month": now().month,
         })),
-        9: (_("Past year"), lambda qs, name: qs.filter(**{
+        "9": (_("Past year"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() - timedelta(days=365)),
             f"{name}__lt": _truncate(now() + timedelta(days=1)),
         })),
-        10: (_("Current year"), lambda qs, name: qs.filter(**{
+        "10": (_("Current year"), lambda qs, name: qs.filter(**{
             f"{name}__year": now().year,
         })),
-        11: (_("Next year"), lambda qs, name: qs.filter(**{
+        "11": (_("Next year"), lambda qs, name: qs.filter(**{
             f"{name}__gte": _truncate(now() + timedelta(days=1)),
             f"{name}__lt": _truncate(now() + timedelta(days=365)),
         })),
@@ -714,10 +714,10 @@ class DateRangeOmniFilter(ChoiceFilter):
 class ReportBooleanFilter(ChoiceFilter):
     options = {
         None: (_("Either"), lambda qs, name: qs.all()),
-        1: (_("Yes"), lambda qs, name: qs.filter(**{
+        "1": (_("Yes"), lambda qs, name: qs.filter(**{
             f"{name}": True,
         })),
-        2: (_("No"), lambda qs, name: qs.filter(**{
+        "2": (_("No"), lambda qs, name: qs.filter(**{
             f"{name}": False,
         })),
     }
@@ -752,9 +752,9 @@ class ReportRiskAcceptanceFilter(ChoiceFilter):
 
     options = {
         None: (_("Either"), any),
-        1: (_("Yes"), accepted),
-        2: (_("No"), not_accepted),
-        3: (_("Expired"), was_accepted),
+        "1": (_("Yes"), accepted),
+        "2": (_("No"), not_accepted),
+        "3": (_("Expired"), was_accepted),
     }
 
     def __init__(self, *args, **kwargs):
@@ -823,13 +823,13 @@ class MetricsDateRangeFilter(ChoiceFilter):
 
     options = {
         None: (_("Past 30 days"), past_thirty_days),
-        1: (_("Past 7 days"), past_seven_days),
-        2: (_("Past 90 days"), past_ninety_days),
-        3: (_("Current month"), current_month),
-        4: (_("Current year"), current_year),
-        5: (_("Past 6 Months"), past_six_months),
-        6: (_("Past year"), past_year),
-        7: (_("Any date"), any),
+        "1": (_("Past 7 days"), past_seven_days),
+        "2": (_("Past 90 days"), past_ninety_days),
+        "3": (_("Current month"), current_month),
+        "4": (_("Current year"), current_year),
+        "5": (_("Past 6 Months"), past_six_months),
+        "6": (_("Past year"), past_year),
+        "7": (_("Any date"), any),
     }
 
     def __init__(self, *args, **kwargs):
@@ -3330,8 +3330,8 @@ class QuestionTypeFilter(ChoiceFilter):
 
     options = {
         None: (_("Any"), any),
-        1: (_("Text Question"), text_question),
-        2: (_("Choice Question"), choice_question),
+        "1": (_("Text Question"), text_question),
+        "2": (_("Choice Question"), choice_question),
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
During add #9441 I bumped into the error which needed to be fixed.

OAS defines for some fields option to choose (ChoiceFilter). Parameters are defined in OAS as nullable strings but options are integers.

This will transfer definitions to
```yaml
  - '1'
  - '2'
  - ...
```
and still keep compatibility with existing systems.