### PR TITLE
Trivy Operator additionalVulnerabilityReportFields

### DIFF
--- a/dojo/tools/trivy_operator/parser.py
+++ b/dojo/tools/trivy_operator/parser.py
@@ -78,6 +78,36 @@ class TrivyOperatorParser:
                 package_name = vulnerability.get("resource")
                 package_version = vulnerability.get("installedVersion")
                 cvssv3_score = vulnerability.get("score")
+
+                finding_tags = list()
+                target_target = None
+                target_class = None
+                package_path = None
+
+                if vulnerability.get("packageType"):
+                    package_type = vulnerability.get("packageType")
+                    finding_tags.append(package_type)
+
+                if vulnerability.get("class"):
+                    target_class = vulnerability.get("class")
+                    finding_tags.append(target_class)
+
+                if vulnerability.get("packagePath"):
+                    package_path = vulnerability.get("packagePath")
+
+                if vulnerability.get("target"):
+                    target_target = vulnerability.get("target")
+
+                if target_class == "os-pkgs" or target_class == "lang-pkgs":
+                    if package_path:
+                        file_path = package_path
+                    elif target_target:
+                        file_path = target_target
+                    else:
+                        file_path = None
+                else:
+                    file_path = None
+
                 description = DESCRIPTION_TEMPLATE.format(
                     title=vulnerability.get("title"), fixed_version=mitigation
                 )
@@ -101,6 +131,8 @@ class TrivyOperatorParser:
                     static_finding=True,
                     dynamic_finding=False,
                     service=service,
+                    file_path=file_path,
+                    tags=finding_tags,
                 )
                 if vuln_id:
                     finding.unsaved_vulnerability_ids = [vuln_id]

--- a/unittests/scans/trivy_operator/vulnerabilityreport_extended.json
+++ b/unittests/scans/trivy_operator/vulnerabilityreport_extended.json
@@ -1,0 +1,206 @@
+{
+  "kind": "VulnerabilityReport",
+  "apiVersion": "aquasecurity.github.io/v1alpha1",
+  "metadata": {
+    "name": "pod-ubuntu-ubuntu",
+    "namespace": "lbc",
+    "uid": "e2c1fa59-051b-479d-ab47-f7bf6e7f858d",
+    "resourceVersion": "26700784781",
+    "generation": 1,
+    "creationTimestamp": "2024-01-23T13:43:55Z",
+    "labels": {
+      "resource-spec-hash": "666674544b",
+      "trivy-operator.container.name": "ubuntu",
+      "trivy-operator.resource.kind": "Pod",
+      "trivy-operator.resource.name": "ubuntu",
+      "trivy-operator.resource.namespace": "lbc"
+    },
+    "annotations": {
+      "trivy-operator.aquasecurity.github.io/report-ttl": "24h0m0s"
+    },
+    "ownerReferences": [
+      {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "name": "ubuntu",
+        "uid": "aa8d6ec8-5417-4190-93e9-6d4d78dc8da9",
+        "controller": true,
+        "blockOwnerDeletion": false
+      }
+    ],
+    "managedFields": [
+      {
+        "manager": "trivy-operator",
+        "operation": "Update",
+        "apiVersion": "aquasecurity.github.io/v1alpha1",
+        "time": "2024-01-23T13:43:55Z",
+        "fieldsType": "FieldsV1",
+        "fieldsV1": {
+          "f:metadata": {
+            "f:annotations": {
+              ".": {},
+              "f:trivy-operator.aquasecurity.github.io/report-ttl": {}
+            },
+            "f:labels": {
+              ".": {},
+              "f:resource-spec-hash": {},
+              "f:trivy-operator.container.name": {},
+              "f:trivy-operator.resource.kind": {},
+              "f:trivy-operator.resource.name": {},
+              "f:trivy-operator.resource.namespace": {}
+            },
+            "f:ownerReferences": {
+              ".": {},
+              "k:{\"uid\":\"aa8d6ec8-5417-4190-93e9-6d4d78dc8da9\"}": {}
+            }
+          },
+          "f:report": {
+            ".": {},
+            "f:artifact": {
+              ".": {},
+              "f:digest": {},
+              "f:repository": {},
+              "f:tag": {}
+            },
+            "f:os": {
+              ".": {},
+              "f:family": {},
+              "f:name": {}
+            },
+            "f:registry": {
+              ".": {},
+              "f:server": {}
+            },
+            "f:scanner": {
+              ".": {},
+              "f:name": {},
+              "f:vendor": {},
+              "f:version": {}
+            },
+            "f:summary": {
+              ".": {},
+              "f:criticalCount": {},
+              "f:highCount": {},
+              "f:lowCount": {},
+              "f:mediumCount": {},
+              "f:noneCount": {},
+              "f:unknownCount": {}
+            },
+            "f:updateTimestamp": {},
+            "f:vulnerabilities": {}
+          }
+        }
+      }
+    ]
+  },
+  "report": {
+    "updateTimestamp": "2024-01-23T13:43:55Z",
+    "scanner": {
+      "name": "Trivy",
+      "vendor": "Aqua Security",
+      "version": "0.48.3"
+    },
+    "registry": {
+      "server": "index.docker.io"
+    },
+    "artifact": {
+      "repository": "library/ubuntu",
+      "digest": "sha256:f78909c2b360d866b3220655c0b079838258b8891a12ac25fc670f0cbb54229f",
+      "tag": "20.04"
+    },
+    "os": {
+      "family": "ubuntu",
+      "name": "20.04"
+    },
+    "summary": {
+      "criticalCount": 0,
+      "highCount": 0,
+      "mediumCount": 5,
+      "lowCount": 0,
+      "unknownCount": 0,
+      "noneCount": 0
+    },
+    "vulnerabilities": [
+      {
+        "vulnerabilityID": "CVE-2024-0553",
+        "resource": "libgnutls30",
+        "installedVersion": "3.6.13-2ubuntu1.9",
+        "fixedVersion": "3.6.13-2ubuntu1.10",
+        "publishedDate": "2024-01-16T12:15:45Z",
+        "lastModifiedDate": "2024-01-19T21:15:08Z",
+        "severity": "MEDIUM",
+        "title": "gnutls: incomplete fix for CVE-2023-5981",
+        "primaryLink": "https://avd.aquasec.com/nvd/cve-2024-0553",
+        "links": [],
+        "score": 5.9,
+        "target": "ubuntu:20.04 (ubuntu 20.04)",
+        "class": "os-pkgs",
+        "packageType": "ubuntu"
+      },
+      {
+        "vulnerabilityID": "CVE-2024-22365",
+        "resource": "libpam-modules",
+        "installedVersion": "1.3.1-5ubuntu4.6",
+        "fixedVersion": "1.3.1-5ubuntu4.7",
+        "publishedDate": "",
+        "lastModifiedDate": "",
+        "severity": "MEDIUM",
+        "title": "pam: allowing unpriledged user to block another user namespace",
+        "primaryLink": "https://avd.aquasec.com/nvd/cve-2024-22365",
+        "links": [],
+        "score": 5.5,
+        "target": "ubuntu:20.04 (ubuntu 20.04)",
+        "class": "os-pkgs",
+        "packageType": "ubuntu"
+      },
+      {
+        "vulnerabilityID": "CVE-2024-22365",
+        "resource": "libpam-modules-bin",
+        "installedVersion": "1.3.1-5ubuntu4.6",
+        "fixedVersion": "1.3.1-5ubuntu4.7",
+        "publishedDate": "",
+        "lastModifiedDate": "",
+        "severity": "MEDIUM",
+        "title": "pam: allowing unpriledged user to block another user namespace",
+        "primaryLink": "https://avd.aquasec.com/nvd/cve-2024-22365",
+        "links": [],
+        "score": 5.5,
+        "target": "ubuntu:20.04 (ubuntu 20.04)",
+        "class": "os-pkgs",
+        "packageType": "ubuntu"
+      },
+      {
+        "vulnerabilityID": "CVE-2024-22365",
+        "resource": "libpam-runtime",
+        "installedVersion": "1.3.1-5ubuntu4.6",
+        "fixedVersion": "1.3.1-5ubuntu4.7",
+        "publishedDate": "",
+        "lastModifiedDate": "",
+        "severity": "MEDIUM",
+        "title": "pam: allowing unpriledged user to block another user namespace",
+        "primaryLink": "https://avd.aquasec.com/nvd/cve-2024-22365",
+        "links": [],
+        "score": 5.5,
+        "target": "ubuntu:20.04 (ubuntu 20.04)",
+        "class": "os-pkgs",
+        "packageType": "ubuntu"
+      },
+      {
+        "vulnerabilityID": "CVE-2024-22365",
+        "resource": "libpam0g",
+        "installedVersion": "1.3.1-5ubuntu4.6",
+        "fixedVersion": "1.3.1-5ubuntu4.7",
+        "publishedDate": "",
+        "lastModifiedDate": "",
+        "severity": "MEDIUM",
+        "title": "pam: allowing unpriledged user to block another user namespace",
+        "primaryLink": "https://avd.aquasec.com/nvd/cve-2024-22365",
+        "links": [],
+        "score": 5.5,
+        "target": "ubuntu:20.04 (ubuntu 20.04)",
+        "class": "os-pkgs",
+        "packageType": "ubuntu"
+      }
+    ]
+  }
+}

--- a/unittests/tools/test_trivy_operator_parser.py
+++ b/unittests/tools/test_trivy_operator_parser.py
@@ -4,6 +4,7 @@ from ..dojo_test_case import DojoTestCase, get_unit_tests_path
 from dojo.tools.trivy_operator.parser import TrivyOperatorParser
 from dojo.models import Test
 
+import logging
 
 def sample_path(file_name):
     return os.path.join(get_unit_tests_path() + "/scans/trivy_operator", file_name)
@@ -121,3 +122,18 @@ class TestTrivyOperatorParser(DojoTestCase):
         self.assertEqual("github-pat", finding.references)
         self.assertEqual("root/github_secret.txt", finding.file_path)
         self.assertEqual("Secret detected in root/github_secret.txt - GitHub Personal Access Token", finding.title)
+
+    def test_vulnerabilityreport_extended(self):
+        test_file = open(sample_path("vulnerabilityreport_extended.json"))
+        parser = TrivyOperatorParser()
+        findings = parser.get_findings(test_file, Test())
+        self.assertEqual(len(findings), 5)
+        finding = findings[0]
+        self.assertEqual("Medium", finding.severity)
+        self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
+        self.assertEqual("CVE-2024-0553", finding.unsaved_vulnerability_ids[0])
+        self.assertEqual("CVE-2024-0553 libgnutls30 3.6.13-2ubuntu1.9", finding.title)
+        self.assertEqual("3.6.13-2ubuntu1.10", finding.mitigation)
+        self.assertEqual(5.9, finding.cvssv3_score)
+        self.assertEqual("ubuntu:20.04 (ubuntu 20.04)", finding.file_path)
+        self.assertEqual("os-pkgs, ubuntu", str(finding.tags))


### PR DESCRIPTION
This feature allows adding Target, Class, PackagePath and PackageType already managed in trivy reports

related to:
trivy-operator [additionalVulnerabilityReportFields](https://github.com/aquasecurity/trivy-operator/blob/main/deploy/helm/values.yaml#L315C1-L317C42)

  # -- additionalVulnerabilityReportFields is a comma separated list of additional fields which
  # can be added to the VulnerabilityReport. Supported parameters: Description, Links, CVSS, Target, Class, PackagePath and PackageType
  additionalVulnerabilityReportFields: ""