### PR TITLE
dojo/importers/importer/importer.py - Change "None" string to "Info" from cvss module when a CVSS vector string should evaluate to "Info"

### DIFF
--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -81,7 +81,7 @@ class DojoDefaultImporter(object):
             # _and_ given a CVSS vector string such as:
             # cvss_vector_str = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N',
             # the following severity calculation returns the
-            # string values of, "None" instead of the expected string values 
+            # string values of, "None" instead of the expected string values
             # of "Info":
             # ```
             # cvss_obj = CVSS3(cvss_vector_str)

--- a/dojo/importers/importer/importer.py
+++ b/dojo/importers/importer/importer.py
@@ -76,7 +76,24 @@ class DojoDefaultImporter(object):
 
         for item in items:
             # FIXME hack to remove when all parsers have unit tests for this attribute
-            if item.severity.lower().startswith('info') and item.severity != 'Info':
+            # Importing the cvss module via:
+            # `from cvss import CVSS3`
+            # _and_ given a CVSS vector string such as:
+            # cvss_vector_str = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N',
+            # the following severity calculation returns the
+            # string values of, "None" instead of the expected string values 
+            # of "Info":
+            # ```
+            # cvss_obj = CVSS3(cvss_vector_str)
+            # severities = cvss_obj.severities()
+            # print(severities)
+            # ('None', 'None', 'None')
+            # print(severities[0])
+            # 'None'
+            # print(type(severities[0]))
+            # <class 'str'>
+            # ```
+            if (item.severity.lower().startswith('info') or item.severity.lower() == 'none') and item.severity != 'Info':
                 item.severity = 'Info'
 
             item.numerical_severity = Finding.get_numerical_severity(item.severity)


### PR DESCRIPTION
**Description**

Importing the cvss module via:
```
from cvss import CVSS3
```
_and_ given a CVSS vector string such as:
```
cvss_vector_str = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N'
```

the following severity calculation returns string values of, "None" instead of the expected string values of "Info":
```
            cvss_obj = CVSS3(cvss_vector_str)
            severities = cvss_obj.severities()
            print(severities)
             ('None', 'None', 'None')
            print(severities[0])
            'None'
            print(type(severities[0]))
            <class 'str'>
```
 
**Test results**

This is quite a small change, however, if you want me to update `unittests/test_importers_importer.py`, please provide recommendations on the preferred approach.

**Checklist**

This checklist is for your information.

- [X ] Make sure to rebase your PR against the very latest `dev`.
- [ X] Features/Changes should be submitted against the `dev`.
- [ X] Bugfixes should be submitted against the `bugfix` branch.
- [ X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X ] Your code is flake8 compliant.
- [ X] Your code is python 3.11 compliant.
- [X ] Add the proper label to categorize your PR.