### PR TITLE
Improve GitHub vulnerability adding affected version

### DIFF
--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -81,6 +81,9 @@ class GithubVulnerabilityParser(object):
                     "package"
                 ].get("name")
 
+            if "vulnerableVersionRange" in alert["securityVulnerability"]:
+                finding.component_version = alert["securityVulnerability"]["vulnerableVersionRange"]
+
             if "references" in alert["securityVulnerability"]["advisory"]:
                 finding.references = ""
                 for ref in alert["securityVulnerability"]["advisory"][


### PR DESCRIPTION
**Description**

Today component version field in GitHub Vulnerability import is not managed.
This PR will add the vulnerable range for the specific component that could be useful for developers.

**Test results**

I tested the import from GitHub to defectdojo.

**Documentation**

Examples inside the documentation already import the vulnerable range but the parser ignored it.

**Extra information**

Please clear everything below when submitting your pull request, it's here purely for your information.
