### PR TITLE
Parse GitHub vulnerability version

### DIFF
--- a/dojo/tools/github_vulnerability/parser.py
+++ b/dojo/tools/github_vulnerability/parser.py
@@ -66,6 +66,9 @@ class GithubVulnerabilityParser(object):
             if "vulnerableManifestPath" in alert:
                 finding.file_path = alert["vulnerableManifestPath"]
 
+            if "vulnerableRequirements" in alert and alert["vulnerableRequirements"].startswith("= "):
+                finding.component_version = alert["vulnerableRequirements"][2:]
+
             if "createdAt" in alert:
                 finding.date = dateutil.parser.parse(alert["createdAt"])
 

--- a/unittests/scans/github_vulnerability/github-vuln-version.json
+++ b/unittests/scans/github_vulnerability/github-vuln-version.json
@@ -1,0 +1,106 @@
+{
+  "data": {
+    "repository": {
+      "vulnerabilityAlerts": {
+        "nodes": [
+          {
+            "id": "RVA_kwDOLJyUo88AAAABQUWapw",
+            "createdAt": "2024-01-26T02:42:32Z",
+            "vulnerableManifestPath": "sompath/pom.xml",
+            "securityVulnerability": {
+              "severity": "CRITICAL",
+              "updatedAt": "2022-12-09T22:02:22Z",
+              "package": {
+                "name": "org.springframework:spring-web",
+                "ecosystem": "MAVEN"
+              },
+              "firstPatchedVersion": {
+                "identifier": "6.0.0"
+              },
+              "vulnerableVersionRange": "< 6.0.0",
+              "advisory": {
+                "description": "Pivotal Spring Framework before 6.0.0 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and authentication may be required.\n\nMaintainers recommend investigating alternative components or a potential mitigating control. Version 4.2.6 and 3.2.17 contain [enhanced documentation](https://github.com/spring-projects/spring-framework/commit/5cbe90b2cd91b866a5a9586e460f311860e11cfa) advising users to take precautions against unsafe Java deserialization, version 5.3.0 [deprecate the impacted classes](https://github.com/spring-projects/spring-framework/issues/25379) and version 6.0.0 [removed it entirely](https://github.com/spring-projects/spring-framework/issues/27422).",
+                "summary": "Pivotal Spring Framework contains unsafe Java deserialization methods",
+                "identifiers": [
+                  {
+                    "value": "GHSA-4wrc-f8pq-fpqp",
+                    "type": "GHSA"
+                  },
+                  {
+                    "value": "CVE-2016-1000027",
+                    "type": "CVE"
+                  }
+                ],
+                "references": [
+                  {
+                    "url": "https://nvd.nist.gov/vuln/detail/CVE-2016-1000027"
+                  },
+                  {
+                    "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2016-1000027"
+                  },
+                  {
+                    "url": "https://security-tracker.debian.org/tracker/CVE-2016-1000027"
+                  },
+                  {
+                    "url": "https://www.tenable.com/security/research/tra-2016-20"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/issues/24434"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-1231625331"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/commit/5cbe90b2cd91b866a5a9586e460f311860e11cfa"
+                  },
+                  {
+                    "url": "https://support.contrastsecurity.com/hc/en-us/articles/4402400830612-Spring-web-Java-Deserialization-CVE-2016-1000027"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/issues/21680"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/commit/2b051b8b321768a4cfef83077db65c6328ffd60f"
+                  },
+                  {
+                    "url": "https://jira.spring.io/browse/SPR-17143?redirect=false"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-579669626"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-582313417"
+                  },
+                  {
+                    "url": "https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-744519525"
+                  },
+                  {
+                    "url": "https://security.netapp.com/advisory/ntap-20230420-0009/"
+                  },
+                  {
+                    "url": "https://spring.io/blog/2022/05/11/spring-framework-5-3-20-and-5-2-22-available-now"
+                  },
+                  {
+                    "url": "https://github.com/advisories/GHSA-4wrc-f8pq-fpqp"
+                  }
+                ],
+                "cvss": {
+                  "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                }
+              }
+            },
+            "state": "OPEN",
+            "vulnerableManifestFilename": "pom.xml",
+            "vulnerableRequirements": "= 5.3.29",
+            "number": 1,
+            "dependencyScope": "RUNTIME",
+            "dismissComment": null,
+            "dismissReason": null,
+            "dismissedAt": null,
+            "fixedAt": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/unittests/tools/test_github_vulnerability_parser.py
+++ b/unittests/tools/test_github_vulnerability_parser.py
@@ -251,3 +251,18 @@ class TestGithubVulnerabilityParser(DojoTestCase):
             self.assertEqual(finding.file_path, "apache/cxf/cxf-shiro/pom.xml")
             self.assertEqual(finding.active, False)
             self.assertEqual(finding.is_mitigated, True)
+
+    def test_parser_version(self):
+        testfile = open("unittests/scans/github_vulnerability/github-vuln-version.json")
+        parser = GithubVulnerabilityParser()
+        findings = parser.get_findings(testfile, Test())
+        self.assertEqual(1, len(findings))
+        for finding in findings:
+            finding.clean()
+
+        with self.subTest(i=0):
+            finding = findings[0]
+            self.assertEqual(finding.title, "Pivotal Spring Framework contains unsafe Java deserialization methods")
+            self.assertEqual(finding.severity, "Critical")
+            self.assertEqual(finding.component_name, "org.springframework:spring-web")
+            self.assertEqual(finding.component_version, "5.3.29")


### PR DESCRIPTION
**Description**

The affected version from GitHub is not imported by the parser. I think this change is better than the one proposed in https://github.com/DefectDojo/django-DefectDojo/pull/9457 which just adds the range of impacted versions, and not the range of the vulnerable version detected.

**Test results**

Test added.
