### PR TITLE
Be strict about Warnings during testing

### DIFF
--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -29,6 +29,9 @@ export CHROMEDRIVER
 CHROME_PATH=/opt/chrome/chrome
 export CHROME_PATH
 
+# We are strict about Warnings during testing
+export PYTHONWARNINGS=error
+
 # Run available unittests with a simple setup
 # All available Integrationtest Scripts are activated below
 # If successsful, A successs message is printed and the script continues

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -15,6 +15,9 @@ unset DD_DATABASE_URL
 # Unset the celery broker URL so that we can force the other DD_CELERY_BROKER settings
 unset DD_CELERY_BROKER_URL
 
+# We are strict about Warnings during testing
+export PYTHONWARNINGS=error
+
 python3 manage.py makemigrations dojo
 python3 manage.py migrate
 

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -16,6 +16,9 @@ unset DD_DATABASE_URL
 # Unset the celery broker URL so that we can force the other DD_CELERY_BROKER settings
 unset DD_CELERY_BROKER_URL
 
+# We are strict about Warnings during testing
+export PYTHONWARNINGS=error
+
 # TARGET_SETTINGS_FILE=dojo/settings/settings.py
 # if [ ! -f ${TARGET_SETTINGS_FILE} ]; then
 #   echo "Creating settings.py"

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1722,3 +1722,5 @@ if DEBUG:
     warnings.filterwarnings("ignore", category=RemovedInDjango50Warning)
     warnings.filterwarnings("ignore", message="invalid escape sequence.*")
     warnings.filterwarnings("ignore", message="'cgi' is deprecated and slated for removal in Python 3\\.13")
+    warnings.filterwarnings("ignore", message="DateTimeField .+ received a naive datetime .+ while time zone support is active\\.")
+    warnings.filterwarnings("ignore", message="unclosed file .+")

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -7,6 +7,7 @@ import environ
 from netaddr import IPNetwork, IPSet
 import json
 import logging
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -1714,3 +1715,10 @@ CREATE_CLOUD_BANNER = env('DD_CREATE_CLOUD_BANNER')
 AUDITLOG_FLUSH_RETENTION_PERIOD = env('DD_AUDITLOG_FLUSH_RETENTION_PERIOD')
 ENABLE_AUDITLOG = env('DD_ENABLE_AUDITLOG')
 USE_FIRST_SEEN = env('DD_USE_FIRST_SEEN')
+
+# TODO - these warnings needs to be removed
+if DEBUG:
+    from django.utils.deprecation import RemovedInDjango50Warning
+    warnings.filterwarnings("ignore", category=RemovedInDjango50Warning)
+    warnings.filterwarnings("ignore", message="invalid escape sequence.*")
+    warnings.filterwarnings("ignore", message="'cgi' is deprecated and slated for removal in Python 3\\.13")

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -94,6 +94,8 @@ class BaseTestCase(unittest.TestCase):
             # TODO - this filter needs to be removed
             import warnings
             warnings.filterwarnings("ignore", message="executable_path has been deprecated, please pass in a Service object")
+            warnings.filterwarnings("ignore", message="use options instead of chrome_options")
+            warnings.filterwarnings("ignore", message="desired_capabilities has been deprecated, please pass in a Service object")
 
             dd_driver = webdriver.Chrome(
                 os.environ["CHROMEDRIVER"],

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -90,6 +90,11 @@ class BaseTestCase(unittest.TestCase):
             print(
                 "starting chromedriver with options: ", vars(dd_driver_options), desired
             )
+
+            # TODO - this filter needs to be removed
+            import warnings
+            warnings.filterwarnings("ignore", message="executable_path has been deprecated, please pass in a Service object")
+
             dd_driver = webdriver.Chrome(
                 os.environ["CHROMEDRIVER"],
                 chrome_options=dd_driver_options,

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -96,6 +96,7 @@ class BaseTestCase(unittest.TestCase):
             warnings.filterwarnings("ignore", message="executable_path has been deprecated, please pass in a Service object")
             warnings.filterwarnings("ignore", message="use options instead of chrome_options")
             warnings.filterwarnings("ignore", message="desired_capabilities has been deprecated, please pass in a Service object")
+            warnings.filterwarnings("ignore", message="It is deprecated to return a value that is not None from a test case")
 
             dd_driver = webdriver.Chrome(
                 os.environ["CHROMEDRIVER"],


### PR DESCRIPTION
This PR sets more strict rules for test environments to be motivated to fix issues as soon we know about them.
It also adds some exceptions (`filterwarnings`) that need to be solved - they should be solved one by one to avoid large PR.

- `RemovedInDjango50Warning` - Fixed in https://github.com/DefectDojo/django-DefectDojo/pull/9491
- `invalid escape sequence.*`
- `'cgi' is deprecated and slated for removal in Python 3.13` - Fixed in https://github.com/DefectDojo/django-DefectDojo/pull/9108
- `DateTimeField .+ received a naive datetime .+ while time zone support is active.`
- `unclosed file .+`

For integration tests:
- `executable_path has been deprecated, please pass in a Service object`
- `use options instead of chrome_options`
- `desired_capabilities has been deprecated, please pass in a Service object`
- `It is deprecated to return a value that is not None from a test case`