### PR TITLE
Upgrade Django to 4.2.13

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
           "tests/tool_config.py",
           "openapi-validatator",
         ]
-        profile: ["mysql-rabbitmq", "postgres-redis"]
+        profile: ["postgres-rabbitmq", "postgres-redis"]
         os: [alpine, debian]
       fail-fast: false
 
@@ -58,10 +58,10 @@ jobs:
       - name: Set integration-test mode
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
 
-      # phased startup with MySQL and RabbitMQ so we can use the exit code from integrationtest container
-      - name: Start Dojo MySQL + RabbitMQ
-        if: matrix.profile == 'mysql-rabbitmq'
-        run: docker compose --profile ${{ matrix.profile }} --env-file ./docker/environments/${{ matrix.profile }}.env up --no-deps -d mysql nginx celerybeat celeryworker mailhog uwsgi rabbitmq
+      # phased startup with PostgreSQL and RabbitMQ so we can use the exit code from integrationtest container
+      - name: Start Dojo PostgreSQL + RabbitMQ
+        if: matrix.profile == 'postgres-rabbitmq'
+        run: docker compose --profile ${{ matrix.profile }} --env-file ./docker/environments/${{ matrix.profile }}.env up --no-deps -d postgres nginx celerybeat celeryworker mailhog uwsgi rabbitmq
         env:
           DJANGO_VERSION: ${{ matrix.os }}
           NGINX_VERSION: ${{ matrix.os }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ django-slack==5.19.0
 git+https://github.com/DefectDojo/django-tagging@develop#egg=django-tagging
 django-watson==1.6.3
 django-prometheus==2.3.1
-Django==4.1.13
+Django==4.2.10
 djangorestframework==3.14.0
 html2text==2024.2.26
 humanize==4.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ django-slack==5.19.0
 git+https://github.com/DefectDojo/django-tagging@develop#egg=django-tagging
 django-watson==1.6.3
 django-prometheus==2.3.1
-Django==4.2.11
+Django==4.2.13
 djangorestframework==3.14.0
 html2text==2024.2.26
 humanize==4.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,8 +24,7 @@ django-slack==5.19.0
 git+https://github.com/DefectDojo/django-tagging@develop#egg=django-tagging
 django-watson==1.6.3
 django-prometheus==2.3.1
-# Django==4.2.11 # TODO
-Django==4.2.10
+Django==4.2.11
 djangorestframework==3.14.0
 html2text==2024.2.26
 humanize==4.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ django-slack==5.19.0
 git+https://github.com/DefectDojo/django-tagging@develop#egg=django-tagging
 django-watson==1.6.3
 django-prometheus==2.3.1
+# Django==4.2.11 # TODO
 Django==4.2.10
 djangorestframework==3.14.0
 html2text==2024.2.26

--- a/unittests/test_remote_user.py
+++ b/unittests/test_remote_user.py
@@ -33,12 +33,9 @@ class TestRemoteUser(DojoTestCase):
     )
     def test_basic(self):
         resp = self.client1.get('/profile',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                # headers={
-                                #     "Remote-User": self.user.username
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
 
@@ -51,18 +48,12 @@ class TestRemoteUser(DojoTestCase):
     )
     def test_update_user(self):
         resp = self.client1.get('/profile',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                HTTP_REMOTE_FIRSTNAME="new_first",
-                                HTTP_REMOTE_LASTNAME="new_last",
-                                HTTP_REMOTE_EMAIL="new@mail.com",
-                                # headers = {
-                                #     "Remote-User": self.user.username,
-                                #     "Remote-Firstname": "new_first",
-                                #     "Remote-Lastname": "new_last",
-                                #     "Remote-Email": "new@mail.com",
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username,
+                                    "Remote-Firstname": "new_first",
+                                    "Remote-Lastname": "new_last",
+                                    "Remote-Email": "new@mail.com",
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
         updated_user = User.objects.get(pk=self.user.pk)
@@ -78,14 +69,10 @@ class TestRemoteUser(DojoTestCase):
     )
     def test_update_groups_cleanup(self):
         resp = self.client1.get('/profile',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                HTTP_REMOTE_GROUPS=self.group1.name,
-                                # headers = {
-                                #     "Remote-User": self.user.username,
-                                #     "Remote-Groups": self.group1.name,
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username,
+                                    "Remote-Groups": self.group1.name,
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
         dgms = Dojo_Group_Member.objects.filter(user=self.user)
@@ -93,14 +80,10 @@ class TestRemoteUser(DojoTestCase):
         self.assertEqual(dgms.first().group.name, self.group1.name)
 
         resp = self.client2.get('/profile',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                HTTP_REMOTE_GROUPS=self.group2.name,
-                                # headers = {
-                                #     "Remote-User": self.user.username,
-                                #     "Remote-Groups": self.group2.name,
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username,
+                                    "Remote-Groups": self.group2.name,
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
         dgms = Dojo_Group_Member.objects.all().filter(user=self.user)
@@ -115,14 +98,10 @@ class TestRemoteUser(DojoTestCase):
     )
     def test_update_multiple_groups_cleanup(self):
         resp = self.client1.get('/profile',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                HTTP_REMOTE_GROUPS=f"{self.group1.name},{self.group2.name}",
-                                # headers = {
-                                #     "Remote-User": self.user.username,
-                                #     "Remote-Groups": f"{self.group1.name},{self.group2.name}",
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username,
+                                    "Remote-Groups": f"{self.group1.name},{self.group2.name}",
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
         dgms = Dojo_Group_Member.objects.filter(user=self.user)
@@ -136,26 +115,18 @@ class TestRemoteUser(DojoTestCase):
     )
     def test_update_groups_no_cleanup(self):
         resp = self.client1.get('/profile',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                HTTP_REMOTE_GROUPS=self.group1.name,
-                                # headers = {
-                                #     "Remote-User": self.user.username,
-                                #     "Remote-Groups": self.group1.name,
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username,
+                                    "Remote-Groups": self.group1.name,
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
 
         resp = self.client2.get('/profile',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                HTTP_REMOTE_GROUPS=self.group2.name,
-                                # headers = {
-                                #     "Remote-User": self.user.username,
-                                #     "Remote-Groups": self.group2.name,
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username,
+                                    "Remote-Groups": self.group2.name,
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
         dgms = Dojo_Group_Member.objects.filter(user=self.user)
@@ -169,12 +140,9 @@ class TestRemoteUser(DojoTestCase):
     def test_trusted_proxy(self):
         resp = self.client1.get('/profile',
                                 REMOTE_ADDR='192.168.0.42',
-                                # TODO - This can be replaced by following lines in the future
-                                # Using of "headers" is supported since Django 4.2
-                                HTTP_REMOTE_USER=self.user.username,
-                                # headers = {
-                                #     "Remote-User": self.user.username,
-                                # }
+                                headers={
+                                    "Remote-User": self.user.username,
+                                }
                                 )
         self.assertEqual(resp.status_code, 200)
 
@@ -187,12 +155,9 @@ class TestRemoteUser(DojoTestCase):
         with self.assertLogs('dojo.remote_user', level='DEBUG') as cm:
             resp = self.client1.get('/profile',
                                     REMOTE_ADDR='192.168.1.42',
-                                    # TODO - This can be replaced by following lines in the future
-                                    # Using of "headers" is supported since Django 4.2
-                                    HTTP_REMOTE_USER=self.user.username,
-                                    # headers = {
-                                    #     "Remote-User": self.user.username,
-                                    # }
+                                    headers={
+                                        "Remote-User": self.user.username,
+                                    }
                                     )
         self.assertEqual(resp.status_code, 302)
         self.assertIn('Requested came from untrusted proxy', cm.output[0])

--- a/unittests/test_user_queries.py
+++ b/unittests/test_user_queries.py
@@ -59,21 +59,21 @@ class TestUserQueries(DojoTestCase):
     def test_user_none(self, mock_current_user):
         mock_current_user.return_value = None
 
-        self.assertQuerysetEqual(Dojo_User.objects.none(), get_authorized_users(Permissions.Product_View))
+        self.assertQuerySetEqual(Dojo_User.objects.none(), get_authorized_users(Permissions.Product_View))
 
     @patch('dojo.user.queries.get_current_user')
     def test_user_admin(self, mock_current_user):
         mock_current_user.return_value = self.admin_user
 
         users = Dojo_User.objects.all().order_by('first_name', 'last_name', 'username')
-        self.assertQuerysetEqual(users, get_authorized_users(Permissions.Product_View))
+        self.assertQuerySetEqual(users, get_authorized_users(Permissions.Product_View))
 
     @patch('dojo.user.queries.get_current_user')
     def test_user_global_permission(self, mock_current_user):
         mock_current_user.return_value = self.global_permission_user
 
         users = Dojo_User.objects.all().order_by('first_name', 'last_name', 'username')
-        self.assertQuerysetEqual(users, get_authorized_users(Permissions.Product_View))
+        self.assertQuerySetEqual(users, get_authorized_users(Permissions.Product_View))
 
     @patch('dojo.user.queries.get_current_user')
     @patch('dojo.product.queries.get_current_user')
@@ -82,4 +82,4 @@ class TestUserQueries(DojoTestCase):
         mock_current_user_2.return_value = self.regular_user
 
         users = Dojo_User.objects.exclude(username='invisible_user').order_by('first_name', 'last_name', 'username')
-        self.assertQuerysetEqual(users, get_authorized_users(Permissions.Product_View))
+        self.assertQuerySetEqual(users, get_authorized_users(Permissions.Product_View))


### PR DESCRIPTION
Upgrade to Django 5.x https://github.com/DefectDojo/django-DefectDojo/pull/9258 might be quite complated but we need to go to at least 4.2.13 because 4.1.x is not supported anymore (check https://www.djangoproject.com/download/)

Needs to be checked/considered:
- [ ] https://docs.djangoproject.com/en/4.2/howto/upgrade-version/#deployment
- [ ] https://docs.djangoproject.com/en/5.0/releases/4.2/
       - Might be handy: _[CharField.max_length](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.CharField.max_length) is no longer required to be set on PostgreSQL, which supports unlimited VARCHAR columns._
       - We might need to change some lines for `makemigrations`: _The [makemigrations --check](https://docs.djangoproject.com/en/5.0/ref/django-admin/#cmdoption-makemigrations-check) option no longer creates missing migration files._