### PR TITLE
Move PYTHONWARNINGS to EnvVar

### DIFF
--- a/docker-compose.override.debug.yml
+++ b/docker-compose.override.debug.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - '.:/app:z'
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during debugging
       DD_DEBUG: 'True'
       DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
       DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
@@ -19,14 +20,18 @@ services:
     volumes:
       - '.:/app:z'
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during debugging
       DD_EMAIL_URL: "smtp://mailhog:1025"
   celerybeat:
+    environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during debugging
     volumes:
       - '.:/app:z'
   initializer:
     volumes:
       - '.:/app:z'
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during debugging
       DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
       DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
   nginx:

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - '.:/app:z'
     environment:
+      PYTHONWARNINGS: always  # We are strict during development so Warnings needs to be more verbose
       DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
       DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
       DD_EMAIL_URL: "smtp://mailhog:1025"
@@ -13,14 +14,18 @@ services:
     volumes:
       - '.:/app:z'
     environment:
+      PYTHONWARNINGS: always  # We are strict during development so Warnings needs to be more verbose
       DD_EMAIL_URL: "smtp://mailhog:1025"
   celerybeat:
     volumes:
       - '.:/app:z'
+    environment:
+      PYTHONWARNINGS: always  # We are strict during development so Warnings needs to be more verbose
   initializer:
     volumes:
       - '.:/app:z'
     environment:
+      PYTHONWARNINGS: always  # We are strict during development so Warnings needs to be more verbose
       DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
       DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-admin}"
   nginx:

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -19,6 +19,7 @@ services:
       - '.:/app:z'
       - "defectdojo_media_integration_tests:${DD_MEDIA_ROOT:-/app/media}"
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during testing
       DD_BASE_URL: 'http://nginx:8080/'
       DD_SECURE_CROSS_ORIGIN_OPENER_POLICY: 'None'
       DD_ADMIN_USER: "${DD_ADMIN_USER:-admin}"
@@ -33,6 +34,7 @@ services:
       - '.:/app:z'
       - defectdojo_media_integration_tests:${DD_MEDIA_ROOT:-/app/media}
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during testing
       DD_DEBUG: 'True'
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL}
       DD_SECURE_CROSS_ORIGIN_OPENER_POLICY: 'None'
@@ -46,6 +48,7 @@ services:
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL}
   initializer:
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during testing
       DD_INITIALIZE: 'true'
       DD_DATABASE_URL: ${DD_TEST_DATABASE_URL}
       DD_ADMIN_PASSWORD: "${DD_ADMIN_PASSWORD:-AdminsLoveIntegrationtests!}"

--- a/docker-compose.override.unit_tests.yml
+++ b/docker-compose.override.unit_tests.yml
@@ -14,6 +14,7 @@ services:
       - '.:/app:z'
       - "defectdojo_media_unit_tests:${DD_MEDIA_ROOT:-/app/media}"
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during testing
       DD_DEBUG: 'True'
       DD_TEST_DATABASE_NAME: ${DD_TEST_DATABASE_NAME}
       DD_DATABASE_NAME: ${DD_TEST_DATABASE_NAME}

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -14,6 +14,7 @@ services:
       - '.:/app:z'
       - "defectdojo_media_unit_tests:${DD_MEDIA_ROOT:-/app/media}"
     environment:
+      PYTHONWARNINGS: error  # We are strict about Warnings during testing
       DD_DEBUG: 'True'
       DD_TEST_DATABASE_NAME: ${DD_TEST_DATABASE_NAME}
       DD_DATABASE_NAME: ${DD_TEST_DATABASE_NAME}

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -29,9 +29,6 @@ export CHROMEDRIVER
 CHROME_PATH=/opt/chrome/chrome
 export CHROME_PATH
 
-# We are strict about Warnings during testing
-export PYTHONWARNINGS=error
-
 # Run available unittests with a simple setup
 # All available Integrationtest Scripts are activated below
 # If successsful, A successs message is printed and the script continues

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -15,9 +15,6 @@ unset DD_DATABASE_URL
 # Unset the celery broker URL so that we can force the other DD_CELERY_BROKER settings
 unset DD_CELERY_BROKER_URL
 
-# We are strict about Warnings during testing
-export PYTHONWARNINGS=error
-
 python3 manage.py makemigrations dojo
 python3 manage.py migrate
 

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -16,9 +16,6 @@ unset DD_DATABASE_URL
 # Unset the celery broker URL so that we can force the other DD_CELERY_BROKER settings
 unset DD_CELERY_BROKER_URL
 
-# We are strict about Warnings during testing
-export PYTHONWARNINGS=error
-
 # TARGET_SETTINGS_FILE=dojo/settings/settings.py
 # if [ ! -f ${TARGET_SETTINGS_FILE} ]; then
 #   echo "Creating settings.py"


### PR DESCRIPTION
- Move PYTHONWARNINGS to EnvVar
- Be strict in debug as well
- Do not fail but be more verbose in dev