### PR TITLE
Remove handling of broken unittests

### DIFF
--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -51,13 +51,9 @@ EOF
     python3 manage.py spectacular > /dev/null
 }
 
-echo "Swagger Schema Tests - Broken"
-echo "------------------------------------------------------------"
-python3 manage.py test unittests -v 3 --keepdb --no-input --tag broken && true
-
 echo "Unit Tests"
 echo "------------------------------------------------------------"
-python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag broken
+python3 manage.py test unittests -v 3 --keepdb --no-input
 
 # you can select a single file to "test" unit tests
 # python3 manage.py test unittests.tools.test_npm_audit_scan_parser.TestNpmAuditParser --keepdb -v 3

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -77,10 +77,6 @@ python3 manage.py migrate
 # --parallel fails on GitHub Actions
 #python3 manage.py test unittests -v 3 --no-input --parallel
 
-echo "Swagger Schema Tests - Broken"
-echo "------------------------------------------------------------"
-python3 manage.py test unittests -v 3 --keepdb --no-input --tag broken && true
-
 echo "Unit Tests"
 echo "------------------------------------------------------------"
-python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag broken
+python3 manage.py test unittests -v 3 --keepdb --no-input


### PR DESCRIPTION
There are no broken unittests. It is not needed run these tests separately.