### PR TITLE
Jira Server/DataCenter: Update meta methods

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1036,28 +1036,28 @@ def get_issuetype_fields(
 
         else:
             try:
-                issuetypes = jira.createmeta_issuetypes(project_key)
+                issuetypes = jira.project_issue_types(project_key)
             except JIRAError as e:
                 e.text = f"Jira API call 'createmeta/issuetypes' failed with status: {e.status_code} and message: {e.text}. Project misconfigured or no permissions in Jira ?"
                 raise e
 
             issuetype_id = None
-            for it in issuetypes['values']:
-                if it['name'] == issuetype_name:
-                    issuetype_id = it['id']
+            for it in issuetypes:
+                if it.name == issuetype_name:
+                    issuetype_id = it.id
                     break
 
             if not issuetype_id:
                 raise JIRAError("Issue type ID can not be matched. Misconfigured default issue type ?")
 
             try:
-                issuetype_fields = jira.createmeta_fieldtypes(project_key, issuetype_id)
+                issuetype_fields = jira.project_issue_fields(project_key, issuetype_id)
             except JIRAError as e:
                 e.text = f"Jira API call 'createmeta/fieldtypes' failed with status: {e.status_code} and message: {e.text}. Misconfigured project or default issue type ?"
                 raise e
 
             try:
-                issuetype_fields = [f['fieldId'] for f in issuetype_fields['values']]
+                issuetype_fields = [f.fieldId for f in issuetype_fields]
             except Exception:
                 raise JIRAError("Misconfigured default issue type ?")
 


### PR DESCRIPTION
With the recent upgrade from the python third party library for jira from version 3.5.2 to 3.6.0, two methods were renamed/repurposed that we were relying on. This PR updates this part of the code to restore functionality

fixes #9509

[sc-4203]