### PR TITLE
:tada: Importing EPSS score from AWS Inspector via AWS SecHub

### DIFF
--- a/dojo/tools/awssecurityhub/parser.py
+++ b/dojo/tools/awssecurityhub/parser.py
@@ -122,6 +122,9 @@ def get_item(finding: dict, test):
         references.append(remediation_rec_url)
     false_p = False
 
+    if finding.get("Vulnerabilities", []).get("EpssScore") is not None:
+        epss_score = float(finding.get("Vulnerabilities", []).get("EpssScore"))
+
     result = Finding(
         title=f"{title}{title_suffix}",
         test=test,
@@ -140,6 +143,10 @@ def get_item(finding: dict, test):
         dynamic_finding=False,
         component_name=component_name,
     )
+
+    if epss_score:
+        result.epss_score = epss_score
+
     # Add the unsaved vulnerability ids
     result.unsaved_vulnerability_ids = unsaved_vulnerability_ids
 

--- a/dojo/tools/awssecurityhub/parser.py
+++ b/dojo/tools/awssecurityhub/parser.py
@@ -47,6 +47,7 @@ def get_item(finding: dict, test):
     impact = []
     references = []
     unsaved_vulnerability_ids = []
+    epss_score = None
     if aws_scanner_type == "Inspector":
         description = f"This is an Inspector Finding\n{finding.get('Description', '')}"
         vulnerabilities = finding.get("Vulnerabilities", [])
@@ -66,6 +67,8 @@ def get_item(finding: dict, test):
             if vendor := vulnerability.get("Vendor"):
                 if vendor_url := vendor.get("Url"):
                     references.append(vendor_url)
+            if vulnerability.get("EpssScore") != None:
+                epss_score = vulnerability.get("EpssScore")
 
         if finding.get("ProductFields", {}).get("aws/inspector/FindingStatus", "ACTIVE") == "ACTIVE":
             mitigated = None
@@ -122,9 +125,6 @@ def get_item(finding: dict, test):
         references.append(remediation_rec_url)
     false_p = False
 
-    if finding.get("Vulnerabilities", []).get("EpssScore") is not None:
-        epss_score = float(finding.get("Vulnerabilities", []).get("EpssScore"))
-
     result = Finding(
         title=f"{title}{title_suffix}",
         test=test,
@@ -144,7 +144,7 @@ def get_item(finding: dict, test):
         component_name=component_name,
     )
 
-    if epss_score:
+    if epss_score != None:
         result.epss_score = epss_score
 
     # Add the unsaved vulnerability ids

--- a/dojo/tools/awssecurityhub/parser.py
+++ b/dojo/tools/awssecurityhub/parser.py
@@ -67,7 +67,7 @@ def get_item(finding: dict, test):
             if vendor := vulnerability.get("Vendor"):
                 if vendor_url := vendor.get("Url"):
                     references.append(vendor_url)
-            if vulnerability.get("EpssScore") != None:
+            if vulnerability.get("EpssScore") is not None:
                 epss_score = vulnerability.get("EpssScore")
 
         if finding.get("ProductFields", {}).get("aws/inspector/FindingStatus", "ACTIVE") == "ACTIVE":
@@ -144,7 +144,7 @@ def get_item(finding: dict, test):
         component_name=component_name,
     )
 
-    if epss_score != None:
+    if epss_score is not None:
         result.epss_score = epss_score
 
     # Add the unsaved vulnerability ids

--- a/unittests/tools/test_awssecurityhub_parser.py
+++ b/unittests/tools/test_awssecurityhub_parser.py
@@ -101,3 +101,4 @@ class TestAwsSecurityHubParser(DojoTestCase):
             self.assertEqual("CVE-2023-2650 - openssl - Image: repo-os/sha256:af965ef68c78374a5f987fce98c0ddfa45801df2395bf012c50b863e65978d74", finding.title)
             self.assertIn("repo-os/sha256:af965ef68c78374a5f987fce98c0ddfa45801df2395bf012c50b863e65978d74", finding.impact)
             self.assertIn("Repository: repo-os", finding.impact)
+            self.assertEqual(0.0014, finding.epss_score)


### PR DESCRIPTION
This PR should be merged after #9516.

It adds support for importing the EPSS score from AWS Inspector via AWS SecHub.