### PR TITLE
Disallow duplicate tool types

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1134,11 +1134,11 @@ class ToolTypeSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
     def validate(self, data):
-        name = data.get("name")
-        # Make sure this will not create a duplicate test type
-        if Tool_Type.objects.filter(name=name).count() > 0:
-            raise serializers.ValidationError('A Tool Type with the name already exists')
-
+        if self.context["request"].method == "POST":
+            name = data.get("name")
+            # Make sure this will not create a duplicate test type
+            if Tool_Type.objects.filter(name=name).count() > 0:
+                raise serializers.ValidationError('A Tool Type with the name already exists')
         return data
 
 

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1133,6 +1133,14 @@ class ToolTypeSerializer(serializers.ModelSerializer):
         model = Tool_Type
         fields = "__all__"
 
+    def validate(self, data):
+        name = data.get("name")
+        # Make sure this will not create a duplicate test type
+        if Tool_Type.objects.filter(name=name).count() > 0:
+            raise serializers.ValidationError('A Tool Type with the name already exists')
+
+        return data
+
 
 class RegulationSerializer(serializers.ModelSerializer):
     class Meta:

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2395,7 +2395,7 @@ class ToolTypeForm(forms.ModelForm):
         if Tool_Type.objects.filter(name=name).count() > 0:
             raise forms.ValidationError('A Tool Type with the name already exists')
 
-        return form_data 
+        return form_data
 
 
 class RegulationForm(forms.ModelForm):

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2388,12 +2388,20 @@ class ToolTypeForm(forms.ModelForm):
         model = Tool_Type
         exclude = ['product']
 
+    def __init__(self, *args, **kwargs):
+        instance = kwargs.get('instance', None)
+        self.newly_created = True
+        if instance is not None:
+            self.newly_created = instance.pk is None
+        super().__init__(*args, **kwargs)
+
     def clean(self):
         form_data = self.cleaned_data
-        name = form_data.get("name")
-        # Make sure this will not create a duplicate test type
-        if Tool_Type.objects.filter(name=name).count() > 0:
-            raise forms.ValidationError('A Tool Type with the name already exists')
+        if self.newly_created:
+            name = form_data.get("name")
+            # Make sure this will not create a duplicate test type
+            if Tool_Type.objects.filter(name=name).count() > 0:
+                raise forms.ValidationError('A Tool Type with the name already exists')
 
         return form_data
 

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2388,6 +2388,15 @@ class ToolTypeForm(forms.ModelForm):
         model = Tool_Type
         exclude = ['product']
 
+    def clean(self):
+        form_data = self.cleaned_data
+        name = form_data.get("name")
+        # Make sure this will not create a duplicate test type
+        if Tool_Type.objects.filter(name=name).count() > 0:
+            raise forms.ValidationError('A Tool Type with the name already exists')
+
+        return form_data 
+
 
 class RegulationForm(forms.ModelForm):
     class Meta:

--- a/unittests/test_swagger_schema.py
+++ b/unittests/test_swagger_schema.py
@@ -785,6 +785,9 @@ class ToolTypeTest(BaseClass.SchemaTest):
         self.viewset = ToolTypesViewSet
         self.model = Tool_Type
         self.serializer = ToolTypeSerializer
+        self.field_transformers = {
+            "name": lambda v: v + "_new"
+        }
 
 
 class UserTest(BaseClass.SchemaTest):


### PR DESCRIPTION
Disallow the possibility of duplicate tool types
UI:
<img width="1190" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/46459665/72bc348f-c9db-4708-a8b4-f004b53519af">

API:
```
{
  "non_field_errors": [
    "A Tool Type with the name already exists"
  ],
  "message": "{'non_field_errors': [ErrorDetail(string='A Tool Type with the name already exists', code='invalid')]}"
}
```

[sc-4239]