### PR TITLE
Engagement Surveys: Add missing leading slash

### DIFF
--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -207,7 +207,7 @@
                                                     {% else %}
                                                         <a class="btn btn-sm btn-secondary"
                                                         href="/empty_questionnaire/{{ survey.id }}">{% trans "View Responses" %}</a>
-                                                        <a class="btn btn-sm btn-success" href="empty_questionnaire/{{ survey.id }}/new_engagement">{% trans "Create Engagement" %}</a>
+                                                        <a class="btn btn-sm btn-success" href="/empty_questionnaire/{{ survey.id }}/new_engagement">{% trans "Create Engagement" %}</a>
                                                         <button class="btn btn-sm btn-info" disabled
                                                         href="/engagement/{{ survey.engagement.id }}/questionnaire/{{ survey.id }}/assign">{% trans "Assign User" %}</button>
                                                     {% endif %}


### PR DESCRIPTION
URL redirects were behaving strangely without this leading slash. it seems it was missed when all the others were added

[sc-4182]