### PR TITLE
Fix "Overdue" tag still visible with closed issues

### DIFF
--- a/dojo/templates/dojo/engagement.html
+++ b/dojo/templates/dojo/engagement.html
@@ -151,7 +151,7 @@
                                     </div>
                                 </td>
                                 <td> {{ e.target_start }} - {{ e.target_end }}
-                                     {% if e.is_overdue %}
+                                     {% if e.is_overdue and e.status != 'Completed' %}
                                         <span class="tag-label warning-color">
                                              {{ e.target_end|overdue }} overdue
                                          </span>

--- a/dojo/templates/dojo/engagements_all.html
+++ b/dojo/templates/dojo/engagements_all.html
@@ -141,7 +141,7 @@
                                     {% endif %}
                                     <td> {{ e.status }} </td>
                                     <td> {{ e.target_start }} - {{ e.target_end }}
-                                        {% if e.is_overdue and e.active %}
+                                        {% if e.is_overdue and e.active and e.status != 'Completed' %}
                                         <sup><div class="tag-label warning-color">{{ e.target_end|overdue }} overdue</div></sup>
                                         {% endif %}
                                     </td>

--- a/dojo/templates/dojo/snippets/engagement_list.html
+++ b/dojo/templates/dojo/snippets/engagement_list.html
@@ -179,7 +179,7 @@
                     </td>
                     <td class="text-left" class="nowrap">{{ eng.target_start|datediff_time:eng.target_end }}
                       {% if status == "open" %}
-                        {% if eng.is_overdue %}
+                        {% if eng.is_overdue and eng.status != 'Completed' %}
                         <sup>
                           <div class="tag-label warning-color">
                             {{ eng.target_end|overdue }} overdue


### PR DESCRIPTION
## Fix "Overdue" tag still visible with closed issues
[sc-2740]

**Description**
This bugfix removes the overdue tag in the completed engagements that before showed it.

![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/d81ffc3a-93a1-41e2-9f0a-384b47ac2f4d)
