### PR TITLE
Remove flot-axis JS library

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -21,7 +21,6 @@
     "drmonty-datatables-responsive": "^1.0.0",
     "easymde": "^2.18.0",
     "flot": "flot/flot#~0.8.3",
-    "flot-axis": "markrcote/flot-axislabels#*",
     "font-awesome": "^4.0.0",
     "fullcalendar": "^3.10.2",
     "google-code-prettify": "^1.0.0",

--- a/dojo/templates/dojo/dashboard-metrics.html
+++ b/dojo/templates/dojo/dashboard-metrics.html
@@ -176,7 +176,6 @@
     <script src="{% static "jquery.flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
     <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
     <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
-    <script src="{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     {% if punchcard %}
         <script src="{% static "JUMFlot/javascripts/JUMFlot.min.js" %}"></script>
         <script src="{% static "JUMFlot/javascripts/jquery.flot.mouse.js" %}"></script>

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -279,7 +279,6 @@
     <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -404,7 +404,6 @@
     <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -255,7 +255,6 @@
     <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -327,7 +327,6 @@
     <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
-    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     {% if punchcard %}
         <script src="{{ host }}{% static "jquery.flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
         <script src="{{ host }}{% static "JUMFlot/javascripts/JUMFlot.min.js" %}"></script>

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -489,7 +489,6 @@
     <script src="{% static "flot/jquery.flot.pie.js" %}"></script>
     <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
     <script src="{% static "flot/jquery.flot.categories.js" %}"></script>
-    <script src="{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     {% include "dojo/filter_js_snippet.html" %}
     {% if punchcard %}
         <script src="{% static "JUMFlot/javascripts/JUMFlot.min.js" %}"></script>

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -383,7 +383,6 @@
     <script src="{{ host }}{% static "flot/excanvas.min.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
-    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     {% if punchcard %}
         <script src="{{ host }}{% static "jquery.flot.tooltip/js/jquery.flot.tooltip.min.js" %}"></script>
         <script src="{{ host }}{% static "JUMFlot/javascripts/JUMFlot.min.js" %}"></script>

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -314,7 +314,6 @@
     <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
         $(function () {

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -419,7 +419,6 @@
     <script src="{{ host }}{% static "flot/jquery.flot.resize.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{{ host }}{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{{ host }}{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     <script src="{{ host }}{% static "dojo/js/metrics.js" %}"></script>
     <script type="text/javascript">
         {% if include_executive_summary %}

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -308,7 +308,6 @@
     <script src="{% static "flot/jquery.flot.resize.js" %}"></script>
     <script src="{% static "flot/jquery.flot.time.js" %}"></script>
     <script src="{% static "flot/jquery.flot.stack.js" %}"></script>
-    <script src="{% static "flot-axis/jquery.flot.axislabels.js" %}"></script>
     {% block metrics %}
         <script src="{% static "dojo/js/metrics.js" %}"></script>
     {% endblock metrics %}


### PR DESCRIPTION
## Remove `flot-axis` JS library 
[sc-2602]

**Description**
Since this library will no longer be maintained, it has been removed to make the app be secure and without vulnerabilities.
