### PR TITLE
:bug: fix kics, #7966

### DIFF
--- a/dojo/tools/kics/parser.py
+++ b/dojo/tools/kics/parser.py
@@ -62,6 +62,7 @@ class KICSParser(object):
                         + category
                         + issue_type
                         + file_name
+                        + expected_value
                         + str(line_number)
                     ).encode("utf-8")
                 ).hexdigest()


### PR DESCRIPTION
See issue #7966 

--> I noticed that a couple of findings which are almost the same are deduplicated because of dupe_key being to unspecific

compare: https://github.com/DefectDojo/django-DefectDojo/blob/d698a7a1ff2a914754a541140b236dd3092d7e8e/unittests/scans/kics/many_findings.json#L303 with: https://github.com/DefectDojo/django-DefectDojo/blob/d698a7a1ff2a914754a541140b236dd3092d7e8e/unittests/scans/kics/many_findings.json#L314

Now, the number of findings is also correct:
https://github.com/DefectDojo/django-DefectDojo/blob/d698a7a1ff2a914754a541140b236dd3092d7e8e/unittests/scans/kics/many_findings.json#L380