### PR TITLE
Fix engagement/view if import fail

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -768,7 +768,7 @@ class ImportScanResultsView(View):
                 return HttpResponseRedirect(
                     reverse('view_test', args=(test.id, )))
 
-        return HttpResponseRedirect(reverse('view_test', args=(test.id, )))
+        return HttpResponseRedirect(reverse('import_scan_results', args=(engagement.id, )))
 
 
 @user_is_authorized(Engagement, Permissions.Engagement_Edit, 'eid')


### PR DESCRIPTION
If `import_scan` fails in the following block, `test` is not set. The user should be redirected to where he/she/they came from.

https://github.com/DefectDojo/django-DefectDojo/blob/d698a7a1ff2a914754a541140b236dd3092d7e8e/dojo/engagement/views.py#L732-L752

I suppose the user should be redirected to the mentioned place with the prefilled form (to avoid the necessity to refill it again). I need to know how to do it here.