### PR TITLE
Correct Endpoint "Hosts" views when the host field is `None`

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -92,7 +92,7 @@ def get_endpoint_ids(endpoints):
     hosts = []
     ids = []
     for e in endpoints:
-        key = e.host + '-' + str(e.product.id)
+        key = f"{e.host}-{e.product.id}"
         if key in hosts:
             continue
         else:

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1601,13 +1601,6 @@ class Endpoint(models.Model):
             models.Index(fields=['product']),
         ]
 
-    def save(self, *args, **kwargs):
-        # clean() is not called when an object is saved, so we should do it here to prevent
-        # the endpoint from getting into an inrecoverable state
-        # https://docs.djangoproject.com/en/5.0/ref/models/instances/#django.db.models.Model.clean
-        self.clean()
-        super(Endpoint, self).save(*args, **kwargs)
-
     def clean(self):
         errors = []
         null_char_list = ["0x00", "\x00"]
@@ -1914,7 +1907,7 @@ class Endpoint(models.Model):
         query = query_string[:1000] if query_string is not None and query_string != '' else None
         fragment = url.fragment[:500] if url.fragment is not None and url.fragment != '' else None
 
-        endpoint = Endpoint(
+        return Endpoint(
             protocol=protocol,
             userinfo=userinfo,
             host=host,
@@ -1923,11 +1916,6 @@ class Endpoint(models.Model):
             query=query,
             fragment=fragment,
         )
-        # Ensure the parsed endpoint is actually clean. In the event of a validation error, it will be caught
-        # here rather than when findings have already been saved
-        endpoint.clean()
-
-        return endpoint
 
     def get_absolute_url(self):
         from django.urls import reverse


### PR DESCRIPTION
When visiting the "All Hosts" view, I was encountered with a 500 error page for the following exception:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sentry_sdk/integrations/django/views.py", line 84, in sentry_wrapped_callback
    return callback(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/endpoint/views.py", line 109, in all_endpoint_hosts
    return process_endpoints_view(request, host_view=True, vulnerable=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/endpoint/views.py", line 53, in process_endpoints_view
    ids = get_endpoint_ids(EndpointFilter(request.GET, queryset=endpoints, user=request.user).qs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/endpoint/views.py", line 95, in get_endpoint_ids
    key = e.host + '-' + str(e.product.id)
          ~~~~~~~^~~~~
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
I am still not sure how there is an endpoint without a host as there are multiple places where the `clean` function on an endpoint is ran to ensure there is a host. I learned that [on model saves, the `clean` function is actually not executed](https://docs.djangoproject.com/en/5.0/ref/models/instances/#django.db.models.Model.clean). To ensure the database does not get into an unrecoverable state again, the `clean` function is now explicitly called when saving an endpoint. 

[sc-4260]