### PR TITLE
Deprecate merge_sets_safe in dojo/utils.py

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -4029,24 +4029,23 @@ class Notifications(models.Model):
                 result = notifications
                 # result.pk = None # detach from db
             else:
-                result.product_type_added = [*result.product_type_added, *notifications.product_type_added]
-                result.product_added = [*result.product_added, *notifications.product_added]
-                result.engagement_added = [*result.engagement_added, *notifications.engagement_added]
-                result.test_added = [*result.test_added, *notifications.test_added]
-                result.scan_added = [*result.scan_added, *notifications.scan_added]
-                result.jira_update = [*result.jira_update, *notifications.jira_update]
-                result.upcoming_engagement = [*result.upcoming_engagement, *notifications.upcoming_engagement]
-                result.stale_engagement = [*result.stale_engagement, *notifications.stale_engagement]
-                result.auto_close_engagement = [*result.auto_close_engagement, *notifications.auto_close_engagement]
-                result.close_engagement = [*result.close_engagement, *notifications.close_engagement]
-                result.user_mentioned = [*result.user_mentioned, *notifications.user_mentioned]
-                result.code_review = [*result.code_review, *notifications.code_review]
-                result.review_requested = [*result.review_requested, *notifications.review_requested]
-                result.other = [*result.other, *notifications.other]
-                result.sla_breach = [*result.sla_breach, *notifications.sla_breach]
-                result.sla_breach_combined = [*result.sla_breach_combined, *notifications.sla_breach_combined]
-                result.risk_acceptance_expiration = [*result.risk_acceptance_expiration, *notifications.risk_acceptance_expiration]
-
+                result.product_type_added = {*result.product_type_added, *notifications.product_type_added}
+                result.product_added = {*result.product_added, *notifications.product_added}
+                result.engagement_added = {*result.engagement_added, *notifications.engagement_added}
+                result.test_added = {*result.test_added, *notifications.test_added}
+                result.scan_added = {*result.scan_added, *notifications.scan_added}
+                result.jira_update = {*result.jira_update, *notifications.jira_update}
+                result.upcoming_engagement = {*result.upcoming_engagement, *notifications.upcoming_engagement}
+                result.stale_engagement = {*result.stale_engagement, *notifications.stale_engagement}
+                result.auto_close_engagement = {*result.auto_close_engagement, *notifications.auto_close_engagement}
+                result.close_engagement = {*result.close_engagement, *notifications.close_engagement}
+                result.user_mentioned = {*result.user_mentioned, *notifications.user_mentioned}
+                result.code_review = {*result.code_review, *notifications.code_review}
+                result.review_requested = {*result.review_requested, *notifications.review_requested}
+                result.other = {*result.other, *notifications.other}
+                result.sla_breach = {*result.sla_breach, *notifications.sla_breach}
+                result.sla_breach_combined = {*result.sla_breach_combined, *notifications.sla_breach_combined}
+                result.risk_acceptance_expiration = {*result.risk_acceptance_expiration, *notifications.risk_acceptance_expiration}
         return result
 
     def __str__(self):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -4029,26 +4029,23 @@ class Notifications(models.Model):
                 result = notifications
                 # result.pk = None # detach from db
             else:
-                # TODO This concat looks  better, but requires Python 3.6+
-                # result.scan_added = [*result.scan_added, *notifications.scan_added]
-                from dojo.utils import merge_sets_safe
-                result.product_type_added = merge_sets_safe(result.product_type_added, notifications.product_type_added)
-                result.product_added = merge_sets_safe(result.product_added, notifications.product_added)
-                result.engagement_added = merge_sets_safe(result.engagement_added, notifications.engagement_added)
-                result.test_added = merge_sets_safe(result.test_added, notifications.test_added)
-                result.scan_added = merge_sets_safe(result.scan_added, notifications.scan_added)
-                result.jira_update = merge_sets_safe(result.jira_update, notifications.jira_update)
-                result.upcoming_engagement = merge_sets_safe(result.upcoming_engagement, notifications.upcoming_engagement)
-                result.stale_engagement = merge_sets_safe(result.stale_engagement, notifications.stale_engagement)
-                result.auto_close_engagement = merge_sets_safe(result.auto_close_engagement, notifications.auto_close_engagement)
-                result.close_engagement = merge_sets_safe(result.close_engagement, notifications.close_engagement)
-                result.user_mentioned = merge_sets_safe(result.user_mentioned, notifications.user_mentioned)
-                result.code_review = merge_sets_safe(result.code_review, notifications.code_review)
-                result.review_requested = merge_sets_safe(result.review_requested, notifications.review_requested)
-                result.other = merge_sets_safe(result.other, notifications.other)
-                result.sla_breach = merge_sets_safe(result.sla_breach, notifications.sla_breach)
-                result.sla_breach_combined = merge_sets_safe(result.sla_breach_combined, notifications.sla_breach_combined)
-                result.risk_acceptance_expiration = merge_sets_safe(result.risk_acceptance_expiration, notifications.risk_acceptance_expiration)
+                result.product_type_added = [*result.product_type_added, *notifications.product_type_added]
+                result.product_added = [*result.product_added, *notifications.product_added]
+                result.engagement_added = [*result.engagement_added, *notifications.engagement_added]
+                result.test_added = [*result.test_added, *notifications.test_added]
+                result.scan_added = [*result.scan_added, *notifications.scan_added]
+                result.jira_update = [*result.jira_update, *notifications.jira_update]
+                result.upcoming_engagement = [*result.upcoming_engagement, *notifications.upcoming_engagement]
+                result.stale_engagement = [*result.stale_engagement, *notifications.stale_engagement]
+                result.auto_close_engagement = [*result.auto_close_engagement, *notifications.auto_close_engagement]
+                result.close_engagement = [*result.close_engagement, *notifications.close_engagement]
+                result.user_mentioned = [*result.user_mentioned, *notifications.user_mentioned]
+                result.code_review = [*result.code_review, *notifications.code_review]
+                result.review_requested = [*result.review_requested, *notifications.review_requested]
+                result.other = [*result.other, *notifications.other]
+                result.sla_breach = [*result.sla_breach, *notifications.sla_breach]
+                result.sla_breach_combined = [*result.sla_breach_combined, *notifications.sla_breach_combined]
+                result.risk_acceptance_expiration = [*result.risk_acceptance_expiration, *notifications.risk_acceptance_expiration]
 
         return result
 

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1784,12 +1784,6 @@ def engagement_post_Save(sender, instance, created, **kwargs):
                             url=reverse('view_engagement', args=(engagement.id,)))
 
 
-def merge_sets_safe(set1, set2):
-    return set(itertools.chain(set1 or [], set2 or []))
-    # This concat looks  better, but requires Python 3.6+
-    # return {*set1, *set2}
-
-
 def is_safe_url(url):
     try:
         # available in django 3+

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -32,7 +32,6 @@ from dojo.models import Finding, Engagement, Finding_Group, Finding_Template, Pr
 from asteval import Interpreter
 from dojo.notifications.helper import create_notification
 import logging
-import itertools
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 import crum

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -32,6 +32,7 @@ from dojo.models import Finding, Engagement, Finding_Group, Finding_Template, Pr
 from asteval import Interpreter
 from dojo.notifications.helper import create_notification
 import logging
+import itertools
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 import crum
@@ -1781,6 +1782,12 @@ def engagement_post_Save(sender, instance, created, **kwargs):
         title = 'Engagement created for ' + str(engagement.product) + ': ' + str(engagement.name)
         create_notification(event='engagement_added', title=title, engagement=engagement, product=engagement.product,
                             url=reverse('view_engagement', args=(engagement.id,)))
+
+
+def merge_sets_safe(set1, set2):
+    return set(itertools.chain(set1 or [], set2 or []))
+    # This concat looks  better, but requires Python 3.6+
+    # return {*set1, *set2}
 
 
 def is_safe_url(url):

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -32,7 +32,6 @@ from dojo.models import Finding, Engagement, Finding_Group, Finding_Template, Pr
 from asteval import Interpreter
 from dojo.notifications.helper import create_notification
 import logging
-import itertools
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 import crum
@@ -1782,12 +1781,6 @@ def engagement_post_Save(sender, instance, created, **kwargs):
         title = 'Engagement created for ' + str(engagement.product) + ': ' + str(engagement.name)
         create_notification(event='engagement_added', title=title, engagement=engagement, product=engagement.product,
                             url=reverse('view_engagement', args=(engagement.id,)))
-
-
-def merge_sets_safe(set1, set2):
-    return set(itertools.chain(set1 or [], set2 or []))
-    # This concat looks  better, but requires Python 3.6+
-    # return {*set1, *set2}
 
 
 def is_safe_url(url):

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -54,3 +54,4 @@ class TestNotifications(DojoTestCase):
         self.assertEqual('mail' in merged_notifications.other, True)
         self.assertEqual('slack' in merged_notifications.other, True)  # default alert from global
         self.assertEqual(len(merged_notifications.other), 3)
+        self.assertEqual(merged_notifications.other, {'alert', 'mail', 'slack'})

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -53,4 +53,4 @@ class TestNotifications(DojoTestCase):
         self.assertEqual('alert' in merged_notifications.other, True)
         self.assertEqual('mail' in merged_notifications.other, True)
         self.assertEqual('slack' in merged_notifications.other, True)  # default alert from global
-        self.assertEqual(len(merged_notifications.other), 4)
+        self.assertEqual(len(merged_notifications.other), 3)

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -53,4 +53,4 @@ class TestNotifications(DojoTestCase):
         self.assertEqual('alert' in merged_notifications.other, True)
         self.assertEqual('mail' in merged_notifications.other, True)
         self.assertEqual('slack' in merged_notifications.other, True)  # default alert from global
-        self.assertEqual(len(merged_notifications.other), 3)
+        self.assertEqual(len(merged_notifications.other), 4)


### PR DESCRIPTION
This PR uses python functionality which was added in newer python versions (3.6+) and thus deprecates method merge_sets_safe in utils.py. Furthermore, itertools is not needed anymore in utils.py. Thus, we don't need to import itertools. 