### PR TITLE
Jira: Append labels and respect priority on update

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -863,9 +863,10 @@ def update_jira_issue(obj, *args, **kwargs):
             summary=jira_summary(obj),
             description=jira_description(obj),
             component_name=jira_project.component if not issue.fields.components else None,
-            labels=labels,
+            labels=labels + issue.fields.labels,
             environment=jira_environment(obj),
-            priority_name=jira_priority(obj),
+            # Do not update the priority in jira after creation as this could have changed in jira, but should not change in dojo
+            # priority_name=jira_priority(obj),
             issuetype_fields=issuetype_fields)
 
         logger.debug('sending fields to JIRA: %s', fields)
@@ -873,7 +874,8 @@ def update_jira_issue(obj, *args, **kwargs):
         issue.update(
             summary=fields['summary'],
             description=fields['description'],
-            priority=fields['priority'],
+            # Do not update the priority in jira after creation as this could have changed in jira, but should not change in dojo
+            # priority=fields['priority'],
             fields=fields)
 
         push_status_to_jira(obj, jira_instance, jira, issue)


### PR DESCRIPTION
A couple fields are overwritten by DefectDojo when findings are pushed to an existing jira ticket. This can be destructive for developers in the following ways:
- Priority: This field often reflects the timeline a particular issue may be fixed. Developers may have more specific context for why a vulnerability may not be as severe as initially thought.
- Labels: Labels could be used to sort issues in a given queue to determine who works on a given ticket. When a finding is pushed to jira again after creation, these new labels should not be overwritten

These fields should be respected to avoid stomping on any changes/process set by developers

[sc-4264]