### PR TITLE
Questionnaires: Correct nested object deletions

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -27,6 +27,7 @@ from django.utils import timezone
 from django.utils.html import escape
 from pytz import all_timezones
 from polymorphic.models import PolymorphicModel
+from polymorphic.managers import PolymorphicManager
 from multiselectfield import MultiSelectField
 from django import forms
 from django.utils.translation import gettext as _
@@ -4355,6 +4356,8 @@ class Question(PolymorphicModel, TimeStampedModel):
         help_text=_("If selected, user doesn't have to answer this question"))
 
     text = models.TextField(blank=False, help_text=_('The question text'), default='')
+    objects = models.Manager()
+    polymorphic = PolymorphicManager()
 
     def __str__(self):
         return self.text
@@ -4364,6 +4367,7 @@ class TextQuestion(Question):
     '''
     Question with a text answer
     '''
+    objects = PolymorphicManager()
 
     def get_form(self):
         '''
@@ -4397,8 +4401,8 @@ class ChoiceQuestion(Question):
 
     multichoice = models.BooleanField(default=False,
                                       help_text=_("Select one or more"))
-
     choices = models.ManyToManyField(Choice)
+    objects = PolymorphicManager()
 
     def get_form(self):
         '''
@@ -4476,6 +4480,8 @@ class Answer(PolymorphicModel, TimeStampedModel):
                                         null=False,
                                         blank=False,
                                         on_delete=models.CASCADE)
+    objects = models.Manager()
+    polymorphic = PolymorphicManager()
 
 
 class TextAnswer(Answer):
@@ -4483,6 +4489,7 @@ class TextAnswer(Answer):
         blank=False,
         help_text=_('The answer text'),
         default='')
+    objects = PolymorphicManager()
 
     def __str__(self):
         return self.answer
@@ -4492,6 +4499,7 @@ class ChoiceAnswer(Answer):
     answer = models.ManyToManyField(
         Choice,
         help_text=_('The selected choices as the answer'))
+    objects = PolymorphicManager()
 
     def __str__(self):
         if len(self.answer.all()):

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -36,9 +36,9 @@ def delete_engagement_survey(request, eid, sid):
     if request.method == 'POST':
         form = Delete_Questionnaire_Form(request.POST, instance=survey)
         if form.is_valid():
-            answers = Answer.objects.filter(
+            answers = Answer.polymorphic.filter(
                 question__in=[
-                    question.id for question in survey.survey.questions.all()],
+                    question.id for question in Question.polymorphic.filter(engagement_survey=survey.survey)],
                 answered_survey=survey)
             for answer in answers:
                 answer.delete()
@@ -95,7 +95,7 @@ def answer_questionnaire(request, eid, sid):
                 prefix=str(q.id),
                 answered_survey=survey,
                 question=q, form_tag=False)
-            for q in survey.survey.questions.all()]
+            for q in Question.polymorphic.filter(engagement_survey=survey.survey)]
 
         questions_are_valid = []
 
@@ -184,7 +184,7 @@ def get_answered_questions(survey=None, read_only=False):
             answered_survey=survey,
             question=q,
             form_tag=False)
-        for q in survey.survey.questions.all()]
+        for q in Question.polymorphic.filter(engagement_survey=survey.survey)]
 
     if read_only:
         for question in questions:
@@ -416,7 +416,7 @@ def questionnaire(request):
 
 @user_is_configuration_authorized('dojo.view_question')
 def questions(request):
-    questions = Question.objects.all()
+    questions = Question.polymorphic.all()
     questions = QuestionFilter(request.GET, queryset=questions)
     paged_questions = get_page_items(request, questions.qs, 25)
     add_breadcrumb(title="Questions", top_level=False, request=request)
@@ -500,7 +500,10 @@ def create_question(request):
 
 @user_is_configuration_authorized('dojo.change_question')
 def edit_question(request, qid):
-    question = get_object_or_404(Question, id=qid)
+    try: 
+        question = Question.polymorphic.get(id=qid)
+    except Question.DoesNotExist:
+        return Http404()
     survey = Engagement_Survey.objects.filter(questions__in=[question])
     reverted = False
     answered = []
@@ -652,7 +655,7 @@ def delete_empty_questionnaire(request, esid):
         form = Delete_Questionnaire_Form(request.POST, instance=survey)
         if form.is_valid():
             answers = Answer.objects.filter(
-                question__in=[question.id for question in survey.survey.questions.all()],
+                question__in=[question.id for question in Question.polymorphic.filter(engagement_survey=survey.survey)],
                 answered_survey=survey)
             for answer in answers:
                 answer.delete()
@@ -740,7 +743,7 @@ def answer_empty_survey(request, esid):
             engagement_survey=engagement_survey,
             question=q,
             form_tag=False)
-        for q in engagement_survey.questions.all()
+        for q in Question.polymorphic.filter(engagement_survey=engagement_survey)
     ]
 
     if request.method == 'POST':
@@ -753,7 +756,7 @@ def answer_empty_survey(request, esid):
                 answered_survey=survey,
                 question=q,
                 form_tag=False)
-            for q in survey.survey.questions.all()
+            for q in Question.polymorphic.filter(engagement_survey=survey.survey)
         ]
 
         questions_are_valid = []

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -500,7 +500,7 @@ def create_question(request):
 
 @user_is_configuration_authorized('dojo.change_question')
 def edit_question(request, qid):
-    try: 
+    try:
         question = Question.polymorphic.get(id=qid)
     except Question.DoesNotExist:
         return Http404()


### PR DESCRIPTION
When using questionnaires, deleting an an engagement/product/product-type will result In the following errors:
Engagement
```
[14/Feb/2024 13:56:06] INFO [django.request:241] OK: /engagement/256/delete
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/db/backends/base/base.py", line 306, in _commit
    return self.connection.commit()
           ^^^^^^^^^^^^^^^^^^^^^^^^
psycopg2.errors.ForeignKeyViolation: update or delete on table "dojo_answer" violates foreign key constraint "dojo_choiceanswer_answer_ptr_id_e9da2254_fk_dojo_answer_id" on table "dojo_choiceanswer"
DETAIL:  Key (id)=(62) is still referenced from table "dojo_choiceanswer".
```
Product/ProductType
```
[16/Feb/2024 17:59:23] ERROR [django.request:241] Internal Server Error: /product/1/delete
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/authorization/authorization_decorators.py", line 35, in _wrapped
    return func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/product/views.py", line 979, in delete_product
    collector.collect([product])
  File "/usr/local/lib/python3.11/site-packages/django/contrib/admin/utils.py", line 186, in collect
    return super().collect(objs, source_attr=source_attr, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 345, in collect
    field.remote_field.on_delete(self, field, sub_objs, self.using)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 23, in CASCADE
    collector.collect(
  File "/usr/local/lib/python3.11/site-packages/django/contrib/admin/utils.py", line 186, in collect
    return super().collect(objs, source_attr=source_attr, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 345, in collect
    field.remote_field.on_delete(self, field, sub_objs, self.using)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 23, in CASCADE
    collector.collect(
  File "/usr/local/lib/python3.11/site-packages/django/contrib/admin/utils.py", line 186, in collect
    return super().collect(objs, source_attr=source_attr, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 345, in collect
    field.remote_field.on_delete(self, field, sub_objs, self.using)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 23, in CASCADE
    collector.collect(
  File "/usr/local/lib/python3.11/site-packages/django/contrib/admin/utils.py", line 186, in collect
    return super().collect(objs, source_attr=source_attr, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 323, in collect
    sub_objs = self.related_objects(related_model, [field], batch)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/contrib/admin/utils.py", line 193, in related_objects
    qs = super().related_objects(related_model, related_fields, objs)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/deletion.py", line 406, in related_objects
    return related_model._base_manager.using(self.using).filter(predicate)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 1421, in filter
    return self._filter_or_exclude(False, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 1439, in _filter_or_exclude
    clone._filter_or_exclude_inplace(negate, args, kwargs)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/query.py", line 1446, in _filter_or_exclude_inplace
    self._query.add_q(Q(*args, **kwargs))
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1532, in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1562, in _add_q
    child_clause, needed_inner = self.build_filter(
                                 ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1388, in build_filter
    return self._add_q(
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1562, in _add_q
    child_clause, needed_inner = self.build_filter(
                                 ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1445, in build_filter
    self.check_related_objects(join_info.final_field, value, join_info.opts)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1259, in check_related_objects
    self.check_query_object_type(v, opts, field)
  File "/usr/local/lib/python3.11/site-packages/django/db/models/sql/query.py", line 1233, in check_query_object_type
    raise ValueError(
ValueError: Cannot query "a": Must be "ChoiceAnswer" instance.
```

The reason for this error is the django does not support polymorphism out of the box. When determining the nested structure of an object tree, django will make some incorrect assumptions, and attempt to delete a parent object without deleting the children first. To solve this, we can tell django to use the default object manager instead of the polymorphic object manager. Along with some other accommodations that are handled in this PR, a consequence is that there is not a warning in the logs expressing that this behavior is not correct. I have not been able to suppress these warnings:
```
/app/dojo/models.py:4343: ManagerInheritanceWarning: PolymorphicModel: "Question.objects" manager is of type "Manager", but must be a subclass of PolymorphicManager. to support retrieving subclasses
  class Question(PolymorphicModel, TimeStampedModel):
/app/dojo/models.py:4474: ManagerInheritanceWarning: PolymorphicModel: "Answer.objects" manager is of type "Manager", but must be a subclass of PolymorphicManager. to support retrieving subclasses
  class Answer(PolymorphicModel, TimeStampedModel):
[17/Feb/2024 02:17:15] INFO [dojo.models:4513] enabling audit logging
/app/dojo/models.py:4343: ManagerInheritanceWarning: PolymorphicModel: "Question.objects" manager is of type "Manager", but must be a subclass of PolymorphicManager. to support retrieving subclasses
  class Question(PolymorphicModel, TimeStampedModel):
/app/dojo/models.py:4474: ManagerInheritanceWarning: PolymorphicModel: "Answer.objects" manager is of type "Manager", but must be a subclass of PolymorphicManager. to support retrieving subclasses
  class Answer(PolymorphicModel, TimeStampedModel):
```

Ref: https://github.com/jazzband/django-polymorphic/issues/229

[sc-4265]
