### PR TITLE
Making EPSS float formatting consistent in 'view Finding'

### DIFF
--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -433,11 +433,11 @@
                         </td>
                         {% if finding.epss_score != None or finding.epss_percentile != None %}
                                 {% if finding.epss_score != None and finding.epss_percentile != None %}
-                                    <td>{{ finding.epss_score|multiply:100|floatformat:"3" }}% / {{ finding.epss_percentile|multiply:100|floatformat:"3" }}%</td>
+                                    <td>{{ finding.epss_score|multiply:100|floatformat:"2" }}% / {{ finding.epss_percentile|multiply:100|floatformat:"2" }}%</td>
                                 {% elif finding.epss_score != None and finding.epss_percentile == None %}
-                                    <td>{{ finding.epss_score|multiply:100|floatformat:"3" }}%</td>
+                                    <td>{{ finding.epss_score|multiply:100|floatformat:"2" }}%</td>
                                 {% elif finding.epss_score == None and finding.epss_percentile != None %}
-                                    <td>{{ finding.epss_percentile|multiply:100|floatformat:"3" }}%</td>
+                                    <td>{{ finding.epss_percentile|multiply:100|floatformat:"2" }}%</td>
                                 {% endif %}
                         {% endif %}
                         <td>


### PR DESCRIPTION
**Description**

This updates the EPSS score to display 2 decimal places of precision instead of 3 in the "view Finding" view to be consistent with its presentation in the "list Findings" view. Displaying 3 decimal places seems like overkill even if EPSS can go out to many decimal places, since it's technically **5** decimal places with the multiplication by 100 to get a percentage. I just forgot to post a comment about this on the original PR #9516 before it was merged.

![Screenshot 2024-02-20 at 12 48 54](https://github.com/DefectDojo/django-DefectDojo/assets/1749665/fab1e4a4-8b80-4250-aee3-7bb4940b8d54)
