### PR TITLE
Format cyclonedx_cwe.json unit test for legibility

### DIFF
--- a/unittests/scans/cyclonedx/cyclonedx_cwe.json
+++ b/unittests/scans/cyclonedx/cyclonedx_cwe.json
@@ -1,1 +1,71 @@
-{"bomFormat":"CycloneDX","specVersion":"1.4","version":"1","serialNumber":"fb206469-0178-4dec-9397-987f51f4d4e0","vulnerabilities":[{"id":"CVE-2018-10054","source":{"url":"https://www.exploit-db.com/exploits/44422/","name":"Vendor Disclosure"},"ratings":[{"score":6.5,"severity":"medium","method":"CVSSv2","vector":"AV:N/AC:L/Au:S/C:P/I:P/A:P"},{"score":8.8,"severity":"high","method":"CVSSv3","vector":"AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"}],"created":"2018-06-25T00:00:00.000+0000","published":"2018-03-29T00:00:00.000+0000","updated":"2022-06-17T00:00:00.000+0000","cwes":[20],"description":"Arbitrary Code Execution H2 Database Engine is vulnerable to arbitrary code execution.It allows an authorized user to inject arbitrary java code using H2 SQL ALIAS command `CREATE ALIAS`.","affects":[{"ref":"maven:com.h2database:h2:2.1.210:"}],"properties":[{"name":"Vulnerability Link","value":"https://www.exploit-db.com/exploits/44422/"},{"name":"Vulnerability Link","value":"https://mthbernardes.github.io/rce/2018/03/14/abusing-h2-database-alias.html"},{"name":"Vulnerability Link","value":"http://blog.datomic.com/2018/03/important-security-update.html"},{"name":"Vulnerability Link","value":"https://forum.datomic.com/t/important-security-update-0-9-5697/379"},{"name":"Vulnerability Link","value":"https://github.com/h2database/h2database/blob/f97a3dcc856c012b45112cea48d0f1e1bc5518b4/h2/src/main/org/h2/server/web/WebServer.java#L279-L280"},{"name":"Vulnerability Link","value":"https://github.com/h2database/h2database/blob/f97a3dcc856c012b45112cea48d0f1e1bc5518b4/h2/src/main/org/h2/server/web/WebServer.java#L267"},{"name":"Vulnerability Link","value":"https://lists.apache.org/thread.html/582d4165de6507b0be82d5a6f9a1ce392ec43a00c9fed32bacf7fe1e@%3Cuser.ignite.apache.org%3E"}]}]}
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": "1",
+  "serialNumber": "fb206469-0178-4dec-9397-987f51f4d4e0",
+  "vulnerabilities": [
+    {
+      "id": "CVE-2018-10054",
+      "source": {
+        "url": "https://www.exploit-db.com/exploits/44422/",
+        "name": "Vendor Disclosure"
+      },
+      "ratings": [
+        {
+          "score": 6.5,
+          "severity": "medium",
+          "method": "CVSSv2",
+          "vector": "AV:N/AC:L/Au:S/C:P/I:P/A:P"
+        },
+        {
+          "score": 8.8,
+          "severity": "high",
+          "method": "CVSSv3",
+          "vector": "AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
+        }
+      ],
+      "created": "2018-06-25T00:00:00.000+0000",
+      "published": "2018-03-29T00:00:00.000+0000",
+      "updated": "2022-06-17T00:00:00.000+0000",
+      "cwes": [
+        20
+      ],
+      "description": "Arbitrary Code Execution H2 Database Engine is vulnerable to arbitrary code execution.It allows an authorized user to inject arbitrary java code using H2 SQL ALIAS command `CREATE ALIAS`.",
+      "affects": [
+        {
+          "ref": "maven:com.h2database:h2:2.1.210:"
+        }
+      ],
+      "properties": [
+        {
+          "name": "Vulnerability Link",
+          "value": "https://www.exploit-db.com/exploits/44422/"
+        },
+        {
+          "name": "Vulnerability Link",
+          "value": "https://mthbernardes.github.io/rce/2018/03/14/abusing-h2-database-alias.html"
+        },
+        {
+          "name": "Vulnerability Link",
+          "value": "http://blog.datomic.com/2018/03/important-security-update.html"
+        },
+        {
+          "name": "Vulnerability Link",
+          "value": "https://forum.datomic.com/t/important-security-update-0-9-5697/379"
+        },
+        {
+          "name": "Vulnerability Link",
+          "value": "https://github.com/h2database/h2database/blob/f97a3dcc856c012b45112cea48d0f1e1bc5518b4/h2/src/main/org/h2/server/web/WebServer.java#L279-L280"
+        },
+        {
+          "name": "Vulnerability Link",
+          "value": "https://github.com/h2database/h2database/blob/f97a3dcc856c012b45112cea48d0f1e1bc5518b4/h2/src/main/org/h2/server/web/WebServer.java#L267"
+        },
+        {
+          "name": "Vulnerability Link",
+          "value": "https://lists.apache.org/thread.html/582d4165de6507b0be82d5a6f9a1ce392ec43a00c9fed32bacf7fe1e@%3Cuser.ignite.apache.org%3E"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Formatting the CycloneDX unit test using multiple lines, so that it's easier to reference and compare to other files.