### PR TITLE
Fix broken migration 0197

### DIFF
--- a/dojo/db_migrations/0187_nessus_to_tenable.py
+++ b/dojo/db_migrations/0187_nessus_to_tenable.py
@@ -34,7 +34,7 @@ def migrate_nessus_findings_to_tenable(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create Tenable Test Type and fetch the nessus and nessus WAS test types
-    tenable_test_type, _ = test_type_model.objects.get_or_create(name="Tenable Scan", defaults={active=True})
+    tenable_test_type, _ = test_type_model.objects.get_or_create(name="Tenable Scan", defaults={"active": True})
     nessus_test_type = test_type_model.objects.filter(name="Nessus Scan").first()
     nessus_was_test_type = test_type_model.objects.filter(name="Nessus WAS Scan").first()
     # Get all the findings found by Nessus and Nessus WAS

--- a/dojo/db_migrations/0187_nessus_to_tenable.py
+++ b/dojo/db_migrations/0187_nessus_to_tenable.py
@@ -34,7 +34,7 @@ def migrate_nessus_findings_to_tenable(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create Tenable Test Type and fetch the nessus and nessus WAS test types
-    tenable_test_type, _ = test_type_model.objects.get_or_create(name="Tenable Scan", active=True)
+    tenable_test_type, _ = test_type_model.objects.get_or_create(name="Tenable Scan", defaults={active=True})
     nessus_test_type = test_type_model.objects.filter(name="Nessus Scan").first()
     nessus_was_test_type = test_type_model.objects.filter(name="Nessus WAS Scan").first()
     # Get all the findings found by Nessus and Nessus WAS

--- a/dojo/db_migrations/0197_parser_merge.py
+++ b/dojo/db_migrations/0197_parser_merge.py
@@ -54,7 +54,7 @@ def migrate_openvas_parsers(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create OpenVAS Test Type and fetch the OpenVAS XML and OpenVAS CSV test types
-    openvas_test_type, _ = test_type_model.objects.get_or_create(name="OpenVAS Parser", active=True)
+    openvas_test_type, _ = test_type_model.objects.get_or_create(name="OpenVAS Parser", defaults={active=True})
     openvascsv_test_type = test_type_model.objects.filter(name="OpenVAS CSV").first()
     openvasxml_test_type = test_type_model.objects.filter(name="OpenVAS XML").first()
     # Get all the findings found by Nessus and Nessus WAS
@@ -73,7 +73,7 @@ def migrate_clairklar_parsers(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create Clair Scan Test Type and fetch the Clair Klar Scan test types
-    clair_test_type, _ = test_type_model.objects.get_or_create(name="Clair Scan", active=True)
+    clair_test_type, _ = test_type_model.objects.get_or_create(name="Clair Scan", , defaults={active=True})
     clairklar_test_type = test_type_model.objects.filter(name="Clair Klar Scan").first()
     # Get all the findings found by Clair Klar Scan
     findings = finding_model.objects.filter(test__scan_type__in=CLAIRKLAR_REFERENCES)

--- a/dojo/db_migrations/0197_parser_merge.py
+++ b/dojo/db_migrations/0197_parser_merge.py
@@ -73,7 +73,7 @@ def migrate_clairklar_parsers(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create Clair Scan Test Type and fetch the Clair Klar Scan test types
-    clair_test_type, _ = test_type_model.objects.get_or_create(name="Clair Scan", , defaults={active=True})
+    clair_test_type, _ = test_type_model.objects.get_or_create(name="Clair Scan", defaults={active=True})
     clairklar_test_type = test_type_model.objects.filter(name="Clair Klar Scan").first()
     # Get all the findings found by Clair Klar Scan
     findings = finding_model.objects.filter(test__scan_type__in=CLAIRKLAR_REFERENCES)

--- a/dojo/db_migrations/0197_parser_merge.py
+++ b/dojo/db_migrations/0197_parser_merge.py
@@ -54,7 +54,7 @@ def migrate_openvas_parsers(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create OpenVAS Test Type and fetch the OpenVAS XML and OpenVAS CSV test types
-    openvas_test_type, _ = test_type_model.objects.get_or_create(name="OpenVAS Parser", defaults={active=True})
+    openvas_test_type, _ = test_type_model.objects.get_or_create(name="OpenVAS Parser", defaults={"active": True})
     openvascsv_test_type = test_type_model.objects.filter(name="OpenVAS CSV").first()
     openvasxml_test_type = test_type_model.objects.filter(name="OpenVAS XML").first()
     # Get all the findings found by Nessus and Nessus WAS
@@ -73,7 +73,7 @@ def migrate_clairklar_parsers(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create Clair Scan Test Type and fetch the Clair Klar Scan test types
-    clair_test_type, _ = test_type_model.objects.get_or_create(name="Clair Scan", defaults={active=True})
+    clair_test_type, _ = test_type_model.objects.get_or_create(name="Clair Scan", defaults={"active": True})
     clairklar_test_type = test_type_model.objects.filter(name="Clair Klar Scan").first()
     # Get all the findings found by Clair Klar Scan
     findings = finding_model.objects.filter(test__scan_type__in=CLAIRKLAR_REFERENCES)

--- a/dojo/db_migrations/0199_whitesource_to_mend.py
+++ b/dojo/db_migrations/0199_whitesource_to_mend.py
@@ -34,7 +34,7 @@ def migrate_whitesource_findings_to_mend(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create Mend Test Type and fetch the whitesource test types
-    mend_test_type, _ = test_type_model.objects.get_or_create(name="Mend Scan", active=True)
+    mend_test_type, _ = test_type_model.objects.get_or_create(name="Mend Scan", defaults={active=True})
     whitesource_test_type = test_type_model.objects.filter(name="Whitesource Scan").first()
     # Get all the findings found by whitesource
     findings = finding_model.objects.filter(test__scan_type__in=WHITESOURCE_REFERENCES)

--- a/dojo/db_migrations/0199_whitesource_to_mend.py
+++ b/dojo/db_migrations/0199_whitesource_to_mend.py
@@ -34,7 +34,7 @@ def migrate_whitesource_findings_to_mend(apps, schema_editor):
     finding_model = apps.get_model('dojo', 'Finding')
     test_type_model = apps.get_model('dojo', 'Test_Type')
     # Get or create Mend Test Type and fetch the whitesource test types
-    mend_test_type, _ = test_type_model.objects.get_or_create(name="Mend Scan", defaults={active=True})
+    mend_test_type, _ = test_type_model.objects.get_or_create(name="Mend Scan", defaults={"active": True})
     whitesource_test_type = test_type_model.objects.filter(name="Whitesource Scan").first()
     # Get all the findings found by whitesource
     findings = finding_model.objects.filter(test__scan_type__in=WHITESOURCE_REFERENCES)


### PR DESCRIPTION
Fix #9600

If the user manually disabled TestType, it is not safe to run `get_or_create` with a static variable. It should be moved to `defaults`
