### PR TITLE
CSV/Excel Report: Correct date/datetime comparison error

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3297,7 +3297,7 @@ class Finding(models.Model):
 
     @property
     def violates_sla(self):
-        return (self.sla_expiration_date and self.sla_expiration_date < timezone.now())
+        return (self.sla_expiration_date and self.sla_expiration_date < timezone.now().date())
 
 
 class FindingAdmin(admin.ModelAdmin):


### PR DESCRIPTION
When attempting to export findings to a CSV/Excel report,  the following error is produced:
```
[20/Feb/2024 20:09:06] ERROR [dojo.reports.views:965] Error in attribute: can't compare datetime.datetime to datetime.date
[20/Feb/2024 20:09:06] INFO [django.request:241] OK: /reports/csv_export
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/reports/views.py", line 985, in csv_export
    and (not callable(getattr(finding, key)) or key in allowed_attributes)
                      ^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/models.py", line 3297, in violates_sla
    return (self.sla_expiration_date and self.sla_expiration_date < timezone.now())
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: can't compare datetime.datetime to datetime.date
```

[sc-4443]