### PR TITLE
Correct search queries containing colons

### DIFF
--- a/dojo/search/views.py
+++ b/dojo/search/views.py
@@ -410,7 +410,7 @@ def parse_search_query(clean_query):
 
     for query_part in query_parts:
         if ':' in query_part:
-            query_part_split = query_part.split(':')
+            query_part_split = query_part.split(':', 1)
 
             operator = query_part_split[0]
             parameter = query_part_split[1].strip()


### PR DESCRIPTION
When tagging objects in the formate of `metadata-key:metadata-value`, searching with the simple search operation will throw out the `metadata-value` portion due to the splitting of all colons in given search query. Splitting only on the first colon will correct this behavior

Before:
```
[25/Feb/2024 02:27:55] DEBUG [dojo.search.views:425] query:     tag:owner:someone product:prod
[25/Feb/2024 02:27:55] DEBUG [dojo.search.views:426] operators: {'tag': ['owner'], 'product': ['prod']}
[25/Feb/2024 02:27:55] DEBUG [dojo.search.views:427] keywords:  []
```
After:
``` 
[25/Feb/2024 02:28:24] DEBUG [dojo.search.views:425] query:     tag:owner:someone product:prod
[25/Feb/2024 02:28:24] DEBUG [dojo.search.views:426] operators: {'tag': ['owner:someone'], 'product': ['prod']}
[25/Feb/2024 02:28:24] DEBUG [dojo.search.views:427] keywords:  []
```

[sc-4492]