### PR TITLE
Disallow spaces in tags from the API

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -234,6 +234,7 @@ class TagListSerializerField(serializers.ListField):
             " form must be valid json."
         ),
         "not_a_str": _("All list items must be of string type."),
+        "spaces_in_tag": _("Spaces are prohibited within a given tag: {value}"),
     }
     order_by = None
 
@@ -266,6 +267,9 @@ class TagListSerializerField(serializers.ListField):
         for s in data:
             if not isinstance(s, six.string_types):
                 self.fail("not_a_str")
+
+            if " " in s:
+                self.fail("spaces_in_tag", value=s)
 
             self.child.run_validation(s)
 


### PR DESCRIPTION
When adding tags to an object vie the UI, it is not possible to add spaces to a tag. However, the same is not true for the API. This PR will make the use case consistent

Request
```
curl -X 'POST'   'http://localhost:8080/api/v2/findings/'   -H 'accept: application/json'   -H 'Authorization: Token XXX'   -H 'Content-Type: application/json'   -d '{
    "test": 1,
    "title": "test",
    "description": "test",
    "severity": "Medium",
    "numerical_severity": 2,
    "found_by": [1],
    "active": true,
    "verified": true,
    "tags": ["tag with spaces"]
}'
```
Response:
```
{
  "tags": [
    "Spaces are prohibited within a given tag: tag with spaces"
  ],
  "message": "{'tags': [ErrorDetail(string='Spaces are prohibited within a given tag: tag with spaces', code='spaces_in_tag')]}"
}
```