### PR TITLE
Revert "Update Helm release postgresql-ha from 9.4.11 to v13 (helm/defectdojo/Chart.yaml)"

### DIFF
--- a/helm/defectdojo/Chart.lock
+++ b/helm/defectdojo/Chart.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 11.9.13
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
-  version: 13.2.4
+  version: 9.4.11
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
   version: 11.16.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:e33a1f5fbe1601251363f38e2cc639074ef7b85c4d4e69d04967dfcdf5d1d70e
-generated: "2024-02-16T04:41:43.560933367Z"
+digest: sha256:50d07c49c1fb199a70fafd032712a1d5509a0352f090bfddd2e8a22b35be0961
+generated: "2024-02-15T20:24:24.560785941Z"

--- a/helm/defectdojo/Chart.yaml
+++ b/helm/defectdojo/Chart.yaml
@@ -18,7 +18,7 @@ dependencies:
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled
   - name: postgresql-ha
-    version: ~13.2.0
+    version: ~9.4.0
     repository: "https://charts.bitnami.com/bitnami"
     alias: postgresqlha
     condition: postgresqlha.enabled


### PR DESCRIPTION
Reverts DefectDojo/django-DefectDojo#9553

This should be reverted, The next move would be to configure renovate not to go with the big bang in case of the helm, but rather to work on minor and patch versions. 