### PR TITLE
Extend APIv2 Findings endpoint and UI filters to accept new date filters

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1506,7 +1506,6 @@ class FindingFilter(FindingFilterWithTags):
         self.form.fields['before'].widget = date_input_widget
         self.form.fields['after'].widget = date_input_widget
 
-
         # Don't show the product filter on the product finding view
         if self.pid:
             del self.form.fields['test__engagement__product']

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1213,6 +1213,9 @@ class ApiFindingFilter(DojoFilter):
     # DateRangeFilter
     created = DateRangeFilter()
     date = DateRangeFilter()
+    on = DateFilter(field_name='date', lookup_expr='exact')
+    before = DateFilter(field_name='date', lookup_expr='lt')
+    after = DateFilter(field_name='date', lookup_expr='gt')
     jira_creation = DateRangeFilter(field_name='jira_issue__jira_creation')
     jira_change = DateRangeFilter(field_name='jira_issue__jira_change')
     last_reviewed = DateRangeFilter()
@@ -1305,9 +1308,11 @@ class ApiFindingFilter(DojoFilter):
 
 class FindingFilter(FindingFilterWithTags):
     # tag = CharFilter(field_name='tags__name', lookup_expr='icontains', label='Tag name contains')
-
     title = CharFilter(lookup_expr='icontains')
     date = DateRangeFilter()
+    on = DateFilter(field_name='date', lookup_expr='exact', label='On')
+    before = DateFilter(field_name='date', lookup_expr='lt', label='Before')
+    after = DateFilter(field_name='date', lookup_expr='gt', label='After')
     last_reviewed = DateRangeFilter()
     last_status_update = DateRangeFilter()
     cwe = MultipleChoiceFilter(choices=[])
@@ -1496,6 +1501,11 @@ class FindingFilter(FindingFilterWithTags):
         super().__init__(*args, **kwargs)
 
         self.form.fields['cwe'].choices = cwe_options(self.queryset)
+        date_input_widget = forms.DateInput(attrs={'class': 'datepicker', 'placeholder': 'YYYY-MM-DD'}, format="%Y-%m-%d")
+        self.form.fields['on'].widget = date_input_widget
+        self.form.fields['before'].widget = date_input_widget
+        self.form.fields['after'].widget = date_input_widget
+
 
         # Don't show the product filter on the product finding view
         if self.pid:


### PR DESCRIPTION
## Extend APIv2 Findings endpoint and UI filters to accept new date filters
[sc-3125]


**Description**

With this feature, the user will be able to filter the finding objects with three new filters:

- On -  return only the findings reported on the given date.
- Before - return only the findings reported before the given date
- After - return only the findings reported after the given date

This filters were added to UI and API endpoints.

**Test results**

- API
![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/2d279b13-0f74-41e4-9084-49e691c78324)

- UI
![image](https://github.com/DefectDojo/django-DefectDojo/assets/7889626/49736523-00a5-44bf-8417-f78fb6d0e517)
