### PR TITLE
FindingGroupSerializer: not break schemas when JIRAIssue not available

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1394,7 +1394,7 @@ class DevelopmentEnvironmentSerializer(serializers.ModelSerializer):
 
 
 class FindingGroupSerializer(serializers.ModelSerializer):
-    jira_issue = JIRAIssueSerializer(read_only=True)
+    jira_issue = JIRAIssueSerializer(read_only=True, allow_null=True)
 
     class Meta:
         model = Finding_Group


### PR DESCRIPTION
Fix #9643

There is still an open question: Is this the only place with this kind of bug?
Check analysis in https://github.com/DefectDojo/django-DefectDojo/issues/9643#issuecomment-1971291731