### PR TITLE
Metrics: Status unification

### DIFF
--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -32,6 +32,7 @@ from dojo.authorization.roles_permissions import Permissions
 from dojo.product.queries import get_authorized_products
 from dojo.product_type.queries import get_authorized_product_types
 from dojo.finding.queries import get_authorized_findings
+from dojo.finding.helper import ACCEPTED_FINDINGS_QUERY, CLOSED_FINDINGS_QUERY
 from dojo.endpoint.queries import get_authorized_endpoint_status
 from dojo.authorization.authorization import user_has_permission_or_403
 from django.utils.translation import gettext as _
@@ -126,9 +127,10 @@ def identify_view(request):
 
 
 def finding_querys(prod_type, request):
-    findings_query = Finding.objects.filter(
-        verified=True,
-        severity__in=('Critical', 'High', 'Medium', 'Low', 'Info')
+    # Get the initial list of findings th use is authorized to see
+    findings_query = get_authorized_findings(
+        Permissions.Finding_View,
+        request.user
     ).select_related(
         'reporter',
         'test',
@@ -139,50 +141,35 @@ def finding_querys(prod_type, request):
         'test__engagement__risk_acceptance',
         'test__test_type',
     )
-
-    findings_query = get_authorized_findings(Permissions.Finding_View, findings_query, request.user)
-
     findings = MetricsFindingFilter(request.GET, queryset=findings_query)
     findings_qs = queryset_check(findings)
-
+    # Quick check to determine if the filters were too tight and filtered everything away
     if not findings_qs and not findings_query:
         findings = findings_query
         findings_qs = findings if isinstance(findings, QuerySet) else findings.qs
-        messages.add_message(request,
-                                     messages.ERROR,
-                                     _('All objects have been filtered away. Displaying all objects'),
-                                     extra_tags='alert-danger')
-
+        messages.add_message(
+            request,
+            messages.ERROR,
+            _('All objects have been filtered away. Displaying all objects'),
+            extra_tags='alert-danger')
+    # Attempt to parser the date ranges
     try:
         start_date, end_date = get_date_range(findings_qs)
     except:
         start_date = timezone.now()
         end_date = timezone.now()
-
+    # Filter by the date ranges supplied
+    findings_query  = findings_query.filter(date__range=[start_date, end_date])
+    # Get the list of closed and risk accepted findings
+    findings_closed = findings_query.filter(CLOSED_FINDINGS_QUERY)
+    accepted_findings = findings_query.filter(ACCEPTED_FINDINGS_QUERY)
+    # filter by product type if applicable 
     if len(prod_type) > 0:
-        findings_closed = Finding.objects.filter(mitigated__date__range=[start_date, end_date],
-                                                 test__engagement__product__prod_type__in=prod_type).prefetch_related(
-            'test__engagement__product')
-        # capture the accepted findings in period
-        accepted_findings = Finding.objects.filter(risk_accepted=True, date__range=[start_date, end_date],
-                                                   test__engagement__product__prod_type__in=prod_type). \
-            prefetch_related('test__engagement__product')
-        accepted_findings_counts = Finding.objects.filter(risk_accepted=True, date__range=[start_date, end_date],
-                                                          test__engagement__product__prod_type__in=prod_type). \
-            prefetch_related('test__engagement__product')
-    else:
-        findings_closed = Finding.objects.filter(mitigated__date__range=[start_date, end_date]).prefetch_related(
-            'test__engagement__product')
-        accepted_findings = Finding.objects.filter(risk_accepted=True, date__range=[start_date, end_date]). \
-            prefetch_related('test__engagement__product')
-        accepted_findings_counts = Finding.objects.filter(risk_accepted=True, date__range=[start_date, end_date]). \
-            prefetch_related('test__engagement__product')
-
-    findings_closed = get_authorized_findings(Permissions.Finding_View, findings_closed, request.user)
-    accepted_findings = get_authorized_findings(Permissions.Finding_View, accepted_findings, request.user)
-    accepted_findings_counts = get_authorized_findings(Permissions.Finding_View, accepted_findings_counts, request.user)
-    accepted_findings_counts = severity_count(accepted_findings_counts, 'aggregate', 'severity')
-
+        findings_closed = findings_closed(test__engagement__product__prod_type__in=prod_type)
+        accepted_findings = Finding.objects.filter(test__engagement__product__prod_type__in=prod_type)
+    # Get the severity counts of risk accepted findings
+    accepted_findings_counts = severity_count(accepted_findings, 'aggregate', 'severity')
+    
     r = relativedelta(end_date, start_date)
     months_between = (r.years * 12) + r.months
     # include current month

--- a/dojo/metrics/views.py
+++ b/dojo/metrics/views.py
@@ -130,7 +130,7 @@ def finding_querys(prod_type, request):
     # Get the initial list of findings th use is authorized to see
     findings_query = get_authorized_findings(
         Permissions.Finding_View,
-        request.user
+        user=request.user,
     ).select_related(
         'reporter',
         'test',
@@ -159,17 +159,17 @@ def finding_querys(prod_type, request):
         start_date = timezone.now()
         end_date = timezone.now()
     # Filter by the date ranges supplied
-    findings_query  = findings_query.filter(date__range=[start_date, end_date])
+    findings_query = findings_query.filter(date__range=[start_date, end_date])
     # Get the list of closed and risk accepted findings
     findings_closed = findings_query.filter(CLOSED_FINDINGS_QUERY)
     accepted_findings = findings_query.filter(ACCEPTED_FINDINGS_QUERY)
-    # filter by product type if applicable 
+    # filter by product type if applicable
     if len(prod_type) > 0:
-        findings_closed = findings_closed(test__engagement__product__prod_type__in=prod_type)
-        accepted_findings = Finding.objects.filter(test__engagement__product__prod_type__in=prod_type)
+        findings_closed = findings_closed.filter(test__engagement__product__prod_type__in=prod_type)
+        accepted_findings = accepted_findings.filter(test__engagement__product__prod_type__in=prod_type)
     # Get the severity counts of risk accepted findings
     accepted_findings_counts = severity_count(accepted_findings, 'aggregate', 'severity')
-    
+
     r = relativedelta(end_date, start_date)
     months_between = (r.years * 12) + r.months
     # include current month

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -303,7 +303,6 @@ def finding_querys(request, prod):
     findings = MetricsFindingFilter(request.GET, queryset=findings_query, pid=prod)
     findings_qs = queryset_check(findings)
     filters['form'] = findings.form
-    week = end_date - timedelta(days=7)  # seven days and /newer are considered "new"
 
     try:
         # logger.debug(findings_qs.query)
@@ -321,9 +320,10 @@ def finding_querys(request, prod):
         logger.debug(e)
         start_date = timezone.now()
         end_date = timezone.now()
+    week = end_date - timedelta(days=7)  # seven days and /newer are considered "new"
 
     filters['accepted'] = findings_qs.filter(finding_helper.ACCEPTED_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
-    filters['verified'] = findings_qs.filter(finding_helper.VERIFIED_FINDINGS_QUERY).filter(date__range=[start_date, end_date])).order_by("date")
+    filters['verified'] = findings_qs.filter(finding_helper.VERIFIED_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
     filters['new_verified'] = findings_qs.filter(finding_helper.VERIFIED_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
     filters['open'] = findings_qs.filter(finding_helper.OPEN_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
     filters['inactive'] = findings_qs.filter(finding_helper.INACTIVE_FINDINGS_QUERY).filter(date__range=[start_date, end_date])

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -290,10 +290,7 @@ def identify_view(request):
 
 def finding_querys(request, prod):
     filters = dict()
-
-    findings_query = Finding.objects.filter(test__engagement__product=prod,
-                                            severity__in=('Critical', 'High', 'Medium', 'Low', 'Info'))
-
+    findings_query = Finding.objects.filter(test__engagement__product=prod)
     # prefetch only what's needed to avoid lots of repeated queries
     findings_query = findings_query.prefetch_related(
         # 'test__engagement',
@@ -306,82 +303,35 @@ def finding_querys(request, prod):
     findings = MetricsFindingFilter(request.GET, queryset=findings_query, pid=prod)
     findings_qs = queryset_check(findings)
     filters['form'] = findings.form
-
-    # dead code:
-    # if not findings_qs and not findings_query:
-    #     # logger.debug('all filtered')
-    #     findings = findings_query
-    #     findings_qs = queryset_check(findings)
-    #     messages.add_message(request,
-    #                                  messages.ERROR,
-    #                                  'All objects have been filtered away. Displaying all objects',
-    #                                  extra_tags='alert-danger')
+    week = end_date - timedelta(days=7)  # seven days and /newer are considered "new"
 
     try:
         # logger.debug(findings_qs.query)
         start_date = findings_qs.earliest('date').date
-        start_date = datetime(start_date.year,
-                              start_date.month, start_date.day,
-                              tzinfo=timezone.get_current_timezone())
+        start_date = datetime(
+            start_date.year,
+            start_date.month, start_date.day,
+            tzinfo=timezone.get_current_timezone())
         end_date = findings_qs.latest('date').date
-        end_date = datetime(end_date.year,
-                            end_date.month, end_date.day,
-                            tzinfo=timezone.get_current_timezone())
+        end_date = datetime(
+            end_date.year,
+            end_date.month, end_date.day,
+            tzinfo=timezone.get_current_timezone())
     except Exception as e:
         logger.debug(e)
         start_date = timezone.now()
         end_date = timezone.now()
-    week = end_date - timedelta(days=7)  # seven days and /newnewer are considered "new"
 
-    # risk_acceptances = Risk_Acceptance.objects.filter(engagement__in=Engagement.objects.filter(product=prod)).prefetch_related('accepted_findings')
-    # filters['accepted'] = [finding for ra in risk_acceptances for finding in ra.accepted_findings.all()]
-
-    from dojo.finding.helper import ACCEPTED_FINDINGS_QUERY
-    filters['accepted'] = findings_qs.filter(ACCEPTED_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
-    filters['verified'] = findings_qs.filter(date__range=[start_date, end_date],
-                                             false_p=False,
-                                             active=True,
-                                             verified=True,
-                                             duplicate=False,
-                                             out_of_scope=False).order_by("date")
-    filters['new_verified'] = findings_qs.filter(date__range=[week, end_date],
-                                                 false_p=False,
-                                                 verified=True,
-                                                 active=True,
-                                                 duplicate=False,
-                                                 out_of_scope=False).order_by("date")
-    filters['open'] = findings_qs.filter(date__range=[start_date, end_date],
-                                         false_p=False,
-                                         duplicate=False,
-                                         out_of_scope=False,
-                                         active=True,
-                                         is_mitigated=False)
-    filters['inactive'] = findings_qs.filter(date__range=[start_date, end_date],
-                                             duplicate=False,
-                                             out_of_scope=False,
-                                             active=False,
-                                             is_mitigated=False)
-    filters['closed'] = findings_qs.filter(date__range=[start_date, end_date],
-                                           false_p=False,
-                                           duplicate=False,
-                                           out_of_scope=False,
-                                           active=False,
-                                           is_mitigated=True)
-    filters['false_positive'] = findings_qs.filter(date__range=[start_date, end_date],
-                                                   false_p=True,
-                                                   duplicate=False,
-                                                   out_of_scope=False)
-    filters['out_of_scope'] = findings_qs.filter(date__range=[start_date, end_date],
-                                                 false_p=False,
-                                                 duplicate=False,
-                                                 out_of_scope=True)
+    filters['accepted'] = findings_qs.filter(finding_helper.ACCEPTED_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
+    filters['verified'] = findings_qs.filter(finding_helper.VERIFIED_FINDINGS_QUERY).filter(date__range=[start_date, end_date])).order_by("date")
+    filters['new_verified'] = findings_qs.filter(finding_helper.VERIFIED_FINDINGS_QUERY).filter(date__range=[start_date, end_date]).order_by("date")
+    filters['open'] = findings_qs.filter(finding_helper.OPEN_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
+    filters['inactive'] = findings_qs.filter(finding_helper.INACTIVE_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
+    filters['closed'] = findings_qs.filter(finding_helper.CLOSED_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
+    filters['false_positive'] = findings_qs.filter(finding_helper.FALSE_POSITIVE_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
+    filters['out_of_scope'] = findings_qs.filter(finding_helper.OUT_OF_SCOPE_FINDINGS_QUERY).filter(date__range=[start_date, end_date])
     filters['all'] = findings_qs
-    filters['open_vulns'] = findings_qs.filter(
-        false_p=False,
-        duplicate=False,
-        out_of_scope=False,
-        active=True,
-        mitigated__isnull=True,
+    filters['open_vulns'] = findings_qs.filter(finding_helper.OPEN_FINDINGS_QUERY).filter(
         cwe__isnull=False,
     ).order_by('cwe').values(
         'cwe'

--- a/dojo/templates/dojo/product_metrics.html
+++ b/dojo/templates/dojo/product_metrics.html
@@ -313,7 +313,7 @@
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
-                        Open, Closed, and Accepted Week to Week
+                        Open, Closed, and Risk Accepted Week to Week
                         <i title="Weeks are only displayed if findings are available."
                            class="text-info fa-solid fa-circle-info"></i>
                     </div>

--- a/unittests/test_metrics_queries.py
+++ b/unittests/test_metrics_queries.py
@@ -49,7 +49,7 @@ class FindingQueriesTest(DojoTestCase):
         mock_timezone.return_value = mock_datetime
 
         # Queries over Finding and Risk_Acceptance
-        with self.assertNumQueries(27):
+        with self.assertNumQueries(24):
             product_types = []
             finding_queries = views.finding_querys(
                 product_types,


### PR DESCRIPTION
There was some disparity regarding the flags that consist of a given status. A prime example is product type metrics only measuring verified findings while most of defectdojo does not. Unification of these queries to those in `dojo.finding.helper` not only makes status of a given finding more consistent from page to page, but it also will make any future changes to a status a much smaller lift, and reduce the chances of creating bugs

[sc-4459]