### PR TITLE
Force to use DjangoDivFormRenderer

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1700,3 +1700,12 @@ USE_FIRST_SEEN = env('DD_USE_FIRST_SEEN')
 # Reference issue: https://github.com/jazzband/django-polymorphic/issues/229
 warnings.filterwarnings("ignore", message="polymorphic.base.ManagerInheritanceWarning.*")
 warnings.filterwarnings("ignore", message="PolymorphicModelBase._default_manager.*")
+
+# This setting is here to override default renderer of forms (use div-based, instred of table-based).
+# It has effect only on templates that use "{{ form }}" in the body. Only "Delete forms" now.
+# The setting is here to avoid RemovedInDjango50Warning. It is here only for transition period.
+# TODO - Remove this setting in Django 5.0 because DjangoDivFormRenderer will become deprecated and the same class will be used by default DjangoTemplates.
+# More info:
+# - https://docs.djangoproject.com/en/4.1/ref/forms/renderers/#django.forms.renderers.DjangoTemplates
+# - https://docs.djangoproject.com/en/5.0/ref/forms/renderers/#django.forms.renderers.DjangoTemplates
+FORM_RENDERER = "django.forms.renderers.DjangoDivFormRenderer"


### PR DESCRIPTION
This setting is here to override default renderer of forms (use div-based, instred of table-based).
It has effect only on templates that use "{{ form }}" in the body. Only "Delete forms" now.
The setting is here to avoid RemovedInDjango50Warning.

More info:
- https://docs.djangoproject.com/en/4.1/ref/forms/renderers/#django.forms.renderers.DjangoTemplates
- https://docs.djangoproject.com/en/5.0/ref/forms/renderers/#django.forms.renderers.DjangoTemplates

Notes:
 - Remove this setting in Django 5.0 because DjangoDivFormRenderer will become deprecated and the same class will be used by default DjangoTemplates.
 - Discovered during debugging #9503

Btw, there is no visual difference.

Before:
<img width="1085" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/5609770/a3c7fc84-42c2-49c1-85bb-34288c6bcc96">

After:
<img width="1091" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/5609770/eb1dc588-ff3a-4fec-a938-2cdd136bd48c">

