### PR TITLE
StringAgg: use default Value('')

### DIFF
--- a/dojo/components/views.py
+++ b/dojo/components/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.db.models import Count, Q
+from django.db.models.expressions import Value
 from dojo.utils import add_breadcrumb, get_page_items
 from dojo.filters import ComponentFilter
 from dojo.components.sql_group_concat import Sql_GroupConcat
@@ -23,7 +24,7 @@ def components(request):
             .order_by("component_name")
             .annotate(
                 component_version=StringAgg(
-                    "component_version", delimiter=separator, distinct=True
+                    "component_version", delimiter=separator, distinct=True, default=Value('')
                 )
             )
         )

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -14,6 +14,7 @@ from django.contrib.admin.utils import NestedObjects
 from django.contrib.postgres.aggregates import StringAgg
 from django.db import DEFAULT_DB_ALIAS, connection
 from django.db.models import Sum, Count, Q, Max, Prefetch, F, OuterRef, Subquery
+from django.db.models.expressions import Value
 from django.db.models.query import QuerySet
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.http import HttpResponseRedirect, Http404, JsonResponse, HttpRequest
@@ -238,7 +239,7 @@ def view_product_components(request, pid):
     if connection.vendor == 'postgresql':
         component_query = Finding.objects.filter(test__engagement__product__id=pid).values("component_name").order_by(
             'component_name').annotate(
-            component_version=StringAgg('component_version', delimiter=separator, distinct=True))
+            component_version=StringAgg('component_version', delimiter=separator, distinct=True, default=Value('')))
     else:
         component_query = Finding.objects.filter(test__engagement__product__id=pid).values("component_name")
         component_query = component_query.annotate(


### PR DESCRIPTION
To avoid `RemovedInDjango50Warning - In Django 5.0, StringAgg() will return None instead of an empty string if there are no rows. Pass default=None to opt into the new behavior and silence this warning or default=Value('') to keep the previous behavior.`

Note: Discovered in #9503