### PR TITLE
Endpoints: Remove "verified" query on listing pages

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -34,7 +34,6 @@ def process_endpoints_view(request, host_view=False, vulnerable=False):
     if vulnerable:
         endpoints = Endpoint.objects.filter(
             finding__active=True,
-            finding__verified=True,
             finding__out_of_scope=False,
             finding__mitigated__isnull=True,
             finding__false_p=False,
@@ -124,12 +123,12 @@ def process_endpoint_view(request, eid, host_view=False):
         endpoints = endpoint.host_endpoints()
         endpoint_metadata = None
         all_findings = endpoint.host_findings()
-        active_verified_findings = endpoint.host_active_verified_findings()
+        active_findings = endpoint.host_active_findings()
     else:
         endpoints = None
         endpoint_metadata = dict(endpoint.endpoint_meta.values_list('name', 'value'))
         all_findings = endpoint.findings.all()
-        active_verified_findings = endpoint.active_verified_findings()
+        active_findings = endpoint.active_findings()
 
     if all_findings:
         start_date = timezone.make_aware(datetime.combine(all_findings.last().date, datetime.min.time()))
@@ -148,12 +147,8 @@ def process_endpoint_view(request, eid, host_view=False):
     monthly_counts = get_period_counts(all_findings, closed_findings, None, months_between, start_date,
                                        relative_delta='months')
 
-    paged_findings = get_page_items(request, active_verified_findings, 25)
-
-    vulnerable = False
-
-    if active_verified_findings.count() != 0:
-        vulnerable = True
+    paged_findings = get_page_items(request, active_findings, 25)
+    vulnerable = active_findings.count() != 0
 
     product_tab = Product_Tab(endpoint.product, "Host" if host_view else "Endpoint", tab="endpoints")
     return render(request,

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -33,11 +33,6 @@ def process_endpoints_view(request, host_view=False, vulnerable=False):
 
     if vulnerable:
         endpoints = Endpoint.objects.filter(
-            finding__active=True,
-            finding__out_of_scope=False,
-            finding__mitigated__isnull=True,
-            finding__false_p=False,
-            finding__duplicate=False,
             status_endpoint__mitigated=False,
             status_endpoint__false_positive=False,
             status_endpoint__out_of_scope=False,

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1124,7 +1124,7 @@ class Product(models.Model):
         endpoints = getattr(self, 'active_endpoints', None)
         if endpoints:
             return len(self.active_endpoints)
-        return None
+        return 0
 
     def open_findings(self, start_date=None, end_date=None):
         if start_date is None or end_date is None:

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -112,8 +112,11 @@ def prefetch_for_product(prods):
         prefetched_prods = prefetched_prods.prefetch_related('members')
         prefetched_prods = prefetched_prods.prefetch_related('prod_type__members')
         active_endpoint_query = Endpoint.objects.filter(
-            finding__active=True,
-            finding__mitigated__isnull=True).distinct()
+            status_endpoint__mitigated=False,
+            status_endpoint__false_positive=False,
+            status_endpoint__out_of_scope=False,
+            status_endpoint__risk_accepted=False,
+        ).distinct()
         prefetched_prods = prefetched_prods.prefetch_related(
             Prefetch('endpoint_set', queryset=active_endpoint_query, to_attr='active_endpoints'))
         prefetched_prods = prefetched_prods.prefetch_related('tags')

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -765,10 +765,8 @@
                                             <a class="dropdown-toggle" data-toggle="dropdown" href="">
                                                 <span class="fa-solid fa-sitemap" aria-hidden="true"></span>
                                                 <span class="hidden-xs">
-                                                    {% trans "Endpoints" %}
-                                                    {% if product_tab.endpoints > 0 %}
-                                                        <span class="badge">{{ product_tab.endpoint_hosts }} / {{ product_tab.endpoints }}</span>
-                                                    {% endif %}
+                                                    {% trans "Hosts / Endpoints" %}
+                                                    <span class="badge">{{ product_tab.endpoint_hosts }} / {{ product_tab.endpoints }}</span>
                                                 </span>
                                                 <span class="caret"></span>
                                             </a>

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -87,7 +87,7 @@
                                 {% comment %} The display field is translated in the function. No need to translate here as well{% endcomment %}    
                                 <th>{% dojo_sort request 'Product' 'product' 'asc' %}</th>
                             {% endif %}
-							<th class="text-center" nowrap="nowrap">Active Verified Findings</th>
+							<th class="text-center" nowrap="nowrap">Active (Verified) Findings</th>
 							<th>Status</th>
                         </tr>
 
@@ -117,13 +117,10 @@
                                 {% endif %}
                                 <td class="text-center">
                                   {% if host_view %}
-                                      {{ e.host_active_verified_findings_count }}
+                                       {{ e.host_active_findings_count }} ({{ e.host_active_verified_findings_count }})
                                   {% else %}
-                                    {% if e.active_verified_findings_count > 0 %}
-                                      <a href="{% url 'verified_findings' %}?endpoints={{ e.id }}">{{ e.active_verified_findings_count }}</a>
-                                    {% else %}
-                                      0
-                                    {% endif %}
+                                      <a href="{% url 'open_findings' %}?endpoints={{ e.id }}">{{ e.active_findings_count }}</a>
+                                      <a href="{% url 'verified_findings' %}?endpoints={{ e.id }}">({{ e.active_verified_findings_count }})</a>
                                   {% endif %}
                                 </td>
                                 <td>
@@ -133,10 +130,10 @@
                                     {% if e.mitigated %}
                                       Mitigated
                                     {% else %}
-                                      {% if e.active_verified_findings_count > 0 %}
+                                      {% if e.active_findings_count > 0 %}
                                         Vulnerable
                                       {% else %}
-                                        No active verified findings
+                                        No active findings
                                       {% endif %}
                                     {% endif %}
                                   {% endif %}

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -248,12 +248,8 @@
                                     {% endif %}
                                 </td>
                                 <td class="text-center">
-                                  {% if prod.endpoint_count %}
                                     <a href="{% url 'vulnerable_endpoint_hosts' %}?product={{ prod.id }}"><b>{{ prod.endpoint_host_count }}</b></a> /
                                     <a href="{% url 'vulnerable_endpoints' %}?product={{ prod.id }}"><b>{{ prod.endpoint_count }}</b></a>
-                                    {% else %}
-                                      0
-                                  {% endif %}
                                 </td>
                                 <td>
                                   {% if prod.product_manager %}

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -248,7 +248,7 @@
 
     <div class="panel panel-default table-responsive">
         <div class="panel-heading">
-            <h4>Active Findings</h4>
+            <h4>Open Findings</h4>
         </div>
     {% if findings %}
     <div class="clearfix pagination-in-panel">

--- a/dojo/templates/dojo/view_endpoint.html
+++ b/dojo/templates/dojo/view_endpoint.html
@@ -103,7 +103,7 @@
                                 <div class="pull-right inline-block text-right">
                                     <span class=" fa-2x">&nbsp;</span>
                                     <span>
-                                        Finding Age ({{ all_findings|length|apnumber }} verified
+                                        Finding Age ({{ all_findings|length|apnumber }}
                                         finding{{ all_findings|length|pluralize }})
                                     </span>
                                 </div>
@@ -178,9 +178,9 @@
                                 <td>{% if item %}
                                       <a data-toggle="tooltip" data-placement="top" data-original-title="{{ item }}" href="{% url 'view_endpoint' item.id %}">
                                       {% if item.vulnerable %}
-                                        <span style="color:OrangeRed" class="fa-solid fa-thumbs-down"></span>
+                                        <span style="color:OrangeRed" class="fa-solid fa-xmark"></span>
                                       {% else %}
-                                        <span class="fa-solid fa-thumbs-up"></span>
+                                        <span style="color:LimeGreen" class="fa-solid fa-check"></span>
                                       {% endif %}
                                       &nbsp;{{ item|url_shortner }}{% if endpoint.is_broken %} <span data-toggle="tooltip" title="Endpoint is broken. Check documentation to look for fix process" >&#128681;</span>{% endif %}</a>
                                     {% endif %}
@@ -248,7 +248,7 @@
 
     <div class="panel panel-default table-responsive">
         <div class="panel-heading">
-            <h4>Active Verified Findings</h4>
+            <h4>Active Findings</h4>
         </div>
     {% if findings %}
     <div class="clearfix pagination-in-panel">

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1576,7 +1576,12 @@ class Product_Tab():
                                                           active=True,
                                                           mitigated__isnull=True).count()
         active_endpoints = Endpoint.objects.filter(
-            product=self.product, finding__active=True, finding__mitigated__isnull=True)
+            product=self.product,
+            status_endpoint__mitigated=False,
+            status_endpoint__false_positive=False,
+            status_endpoint__out_of_scope=False,
+            status_endpoint__risk_accepted=False,
+        )
         self.endpoints_count = active_endpoints.distinct().count()
         self.endpoint_hosts_count = active_endpoints.values('host').distinct().count()
         self.benchmark_type = Benchmark_Type.objects.filter(


### PR DESCRIPTION
When working with endpoints, I thought it was a little misleading that findings needed to be verified to be counted on a given endpoint/host. A finding being active seems like a more accurate representation. To maintain the previous behavior of counting verified findings, I kept the count and added a link to the query:
<img width="1363" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/46459665/6f8d2f3e-a1ab-49c5-9c45-927a1be83a90">

This PR also changes how endpoints are measured on a given product. Instead of counting vulnerable hosts / endpoints based on the status of findings, they will now be based on the status of an endpoint statuses. Fixes #9413 

[sc-4752]