### PR TITLE
Ruff Linter: Resolve deprecation notice

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -33,4 +33,4 @@ jobs:
         run: pip install -r requirements-lint.txt
 
       - name: Run Ruff Linter
-        run: ruff .
+        run: ruff check .


### PR DESCRIPTION
There are some warnings on the ruff linter action related to the deprecated default `check` action. The action must be explicitly set now

[sc-4736]
