### PR TITLE
Ruff: Solve F821

### DIFF
--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -21,6 +21,7 @@ from django.http import FileResponse, HttpRequest, HttpResponse, HttpResponseRed
 from django.shortcuts import get_object_or_404, render
 from django.urls import Resolver404, reverse
 from django.utils import timezone
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -13,6 +13,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
+from django.utils.translation import gettext as _
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST

--- a/dojo/management/commands/jira_async_updates.py
+++ b/dojo/management/commands/jira_async_updates.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 from django.utils import timezone
 from jira.exceptions import JIRAError
 
+import dojo.jira_link.helper as jira_helper
 from dojo.models import Dojo_User, Finding, Notes, User
 
 """

--- a/dojo/management/commands/rename_mend_findings.py
+++ b/dojo/management/commands/rename_mend_findings.py
@@ -1,7 +1,14 @@
+import logging
+import re
+
 from django.core.management.base import BaseCommand
 from pytz import timezone
 
 from dojo.celery import app
+from dojo.models import Finding, Test_Type
+from dojo.utils import get_system_setting
+
+logger = logging.getLogger(__name__)
 
 locale = timezone(get_system_setting("time_zone"))
 

--- a/dojo/management/commands/test_celery_decorator.py
+++ b/dojo/management/commands/test_celery_decorator.py
@@ -4,8 +4,10 @@ from functools import wraps
 
 from django.core.management.base import BaseCommand
 
-# from dojo.utils import get_system_setting, do_dedupe_finding, dojo_async_task
 from dojo.celery import app
+
+# from dojo.utils import get_system_setting, do_dedupe_finding, dojo_async_task
+from dojo.decorators import dojo_async_task, dojo_model_from_id, dojo_model_to_id
 from dojo.models import Finding, Notes
 from dojo.utils import test_valentijn
 

--- a/dojo/settings/settings.py
+++ b/dojo/settings/settings.py
@@ -12,7 +12,7 @@ include(
     optional("local_settings.py"),
 )
 
-if not (DEBUG or ("collectstatic" in sys.argv)):
+if not (DEBUG or ("collectstatic" in sys.argv)):  # noqa: F821 - not declared DEBUG is acceptable because we are sure it will be loaded from 'include'
     with (Path(__file__).parent / "settings.dist.py").open("rb") as file:
         real_hash = hashlib.sha256(file.read()).hexdigest()
     with (Path(__file__).parent / ".settings.dist.py.sha256sum").open("rb") as file:

--- a/dojo/tools/qualys/csv_parser.py
+++ b/dojo/tools/qualys/csv_parser.py
@@ -4,6 +4,7 @@ import logging
 import re
 from datetime import datetime
 
+from dateutil import parser
 from django.conf import settings
 
 from dojo.models import Endpoint, Finding

--- a/dojo/tools/qualys_webapp/parser.py
+++ b/dojo/tools/qualys_webapp/parser.py
@@ -1,6 +1,7 @@
 import base64
 import re
 from datetime import datetime
+from urllib.parse import urlparse
 
 from defusedxml import ElementTree
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -66,7 +66,7 @@ select = [
    "NPY",
    "AIR",
 ]
-ignore = ["E501", "E722", "F821"]
+ignore = ["E501", "E722"]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/Import_scanner_test.py
+++ b/tests/Import_scanner_test.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F821
 import logging
 import os
 import re
@@ -10,6 +11,8 @@ from base_test_class import BaseTestCase
 from product_test import ProductTest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import Select
+
+dir_path = os.path.dirname(os.path.realpath(__file__))
 
 logger = logging.getLogger(__name__)
 
@@ -52,33 +55,6 @@ class ScannerTest(BaseTestCase):
             for test in missing_tests:
                 logger.info(test)
         assert len(missing_tests) == 0
-
-    def test_check_for_doc(self):
-        driver = self.driver
-        driver.get("https://documentation.defectdojo.com/integrations/import/")
-        integration_index = integration_text.index("Integrations") + len("Integrations") + 1
-        usage_index = integration_text.index("Usage Examples") - len("Models") - 2
-        integration_text = integration_text[integration_index:usage_index].lower()
-        integration_text = integration_text.replace("_", " ").replace("-", " ").replace(".", "").split("\n")
-        acronyms = []
-        for words in integration_text:
-            acronyms += ["".join(word[0] for word in words.split())]
-
-        missing_docs = []
-        for tool in self.tools:
-            reg = re.compile(".*" + tool.replace("_", " ") + ".*")
-            if len(list(filter(reg.search, integration_text))) < 1:
-                if len(list(filter(reg.search, acronyms))) < 1:
-                    missing_docs += [tool]
-
-        if len(missing_docs) > 0:
-            logger.info("The following scanners are missing documentation")
-            logger.info("Names must match those listed in /dojo/tools")
-            logger.info("Documentation can be added here:")
-            logger.info("https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs\n")
-            for tool in missing_docs:
-                logger.info(tool)
-        assert len(missing_docs) == 0
 
     def test_check_for_forms(self):
         forms_path = dir_path[:-5] + "dojo/forms.py"

--- a/tests/zap.py
+++ b/tests/zap.py
@@ -3,6 +3,7 @@ import collections
 import logging
 import re
 import socket
+import sys
 import time
 from urllib.parse import urlparse
 
@@ -56,7 +57,7 @@ class Main:
         loginUrl = "http://os.environ['DD_BASE_URL']/login"
         # loginUrlregex = "\Q" + loginUrl + "\E.*"
         # The above line is flake8 violation as \Q and \E are not supported by python
-        loginURLregex = re.escape(loginURL)
+        loginURLregex = re.escape(loginUrl)
         result = zap.context.exclude_from_context(contextname, ".*logout.*", apikey)
         result = zap.context.exclude_from_context(contextname, ".*/static/.*", apikey)
 

--- a/unittests/test_parsers.py
+++ b/unittests/test_parsers.py
@@ -84,6 +84,7 @@ class TestParsers(DojoTestCase):
                     f = os.path.join(basedir, "dojo", "tools", parser_dir.name, file.name)
                     read_true = False
                     with open(f) as f:
+                        i = 0
                         for line in f.readlines():
                             if read_true is True:
                                 if ('"utf-8"' in str(line) or "'utf-8'" in str(line) or '"utf-8-sig"' in str(line) or "'utf-8-sig'" in str(line)) and i <= 4:

--- a/unittests/tools/test_api_sonarqube_parser.py
+++ b/unittests/tools/test_api_sonarqube_parser.py
@@ -11,7 +11,7 @@ from dojo.models import (
     Tool_Type,
 )
 from dojo.tools.api_sonarqube.parser import ApiSonarQubeParser
-from unittests.dojo_test_case import DojoTestCase
+from unittests.dojo_test_case import DojoTestCase, get_unit_tests_path
 
 
 def dummy_product(self, *args, **kwargs):


### PR DESCRIPTION
Remove F821 from `lint.ignore` and fix the findings.

This excluded quite critical parts. I'm quite surprised, that there have not been any failing unittests or complaining users.