### PR TITLE
Ruff: Move F403

### DIFF
--- a/dojo/settings/unittest.py
+++ b/dojo/settings/unittest.py
@@ -2,7 +2,7 @@
 # first;
 # Do so by copying the file dojo/settings/settings.dist.py to
 # dojo/settings/settings.py; Otherwise, the following import will not work
-from .settings import *
+from .settings import *  # noqa: F401,F403
 
 DEBUG = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
  # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
  # McCabe complexity (`C901`) by default.
  lint.select = ["E", "F"]
- lint.ignore = ["E501", "E722", "E402", "F821", "F601", "F403"]
+ lint.ignore = ["E501", "E722", "E402", "F821", "F601"]
 
  # Allow autofix for all enabled rules (when `--fix`) is provided.
  lint.fixable = ["ALL"]


### PR DESCRIPTION
Move F403 from `lint.ignore` to the related line (not to exclude the whole project)