### PR TITLE
Flake8: Remove useless ignores

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -12,10 +12,6 @@ ignore =
     C901
     # Bare except
     E722
-    # May be undefined
-    F405
-    # list comprehension redefines
-    F812
     E126
     E128
     # Line break occurred before a binary operator (conflicting with black)
@@ -23,20 +19,7 @@ ignore =
     # undefined file name excpetion
     F821
 
-
-exclude =
-    # No need to traverse our git directory
-    .git,
-    # Exclude unittests
-    dojo/unittests,
-    # There's no value in checking cache directories
-    __pycache__,
-    # This contains of branch that we don't want to check
-    # dev
-
 # We should not touch migrations that are already used, but check new migrations 
 per-file-ignores =
     dojo/db_migrations/00*:F841
     dojo/db_migrations/01*:F841
-
-max-complexity = 10


### PR DESCRIPTION
Remove `F405` and `F812`. Violations that are not in the code anymore.

`exclude` section can be removed because `dojo/unittests` and `['.git', '__pycache__']` is default for this parameter.

`max-complexity` can be removed because ignore for `C901` (Function is too complex) is already in place.