### PR TITLE
Endpoints: Redefine vulnerable definition

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1769,7 +1769,13 @@ class Endpoint(models.Model):
 
     @property
     def vulnerable(self):
-        return self.active_findings_count > 0
+        return Endpoint_Status.objects.filter(
+            endpoint=self,
+            mitigated=False,
+            false_positive=False,
+            out_of_scope=False,
+            risk_accepted=False
+        ).count() > 0
 
     @property
     def findings_count(self):

--- a/unittests/test_endpoint_model.py
+++ b/unittests/test_endpoint_model.py
@@ -329,8 +329,8 @@ class TestEndpointStatusModel(DojoTestCase):
         with self.subTest('Endpoint with vulnerabilities but all of them are mitigated because of different reasons'):
             self.assertEqual(ep2.findings_count, 4, ep2.findings.all())
             self.assertEqual(ep2.active_findings_count, 1, ep2.active_findings)
-            self.assertTrue(ep2.vulnerable, ep2.active_findings_count)
-            self.assertFalse(ep2.mitigated, ep2.active_findings_count)
+            self.assertFalse(ep2.vulnerable, ep2.active_findings_count)
+            self.assertTrue(ep2.mitigated, ep2.active_findings_count)
 
         with self.subTest('Host without vulnerabilities'):
             self.assertEqual(ep1.host_endpoints_count, 2, ep1.host_endpoints)
@@ -345,8 +345,8 @@ class TestEndpointStatusModel(DojoTestCase):
         with self.subTest('Endpoint with one vulnerabilitiy but EPS is mitigated'):
             self.assertEqual(ep3.findings_count, 1, ep3.findings.all())
             self.assertEqual(ep3.active_findings_count, 1, ep3.active_findings)
-            self.assertTrue(ep3.vulnerable, ep3.active_findings_count)
-            self.assertFalse(ep3.mitigated, ep3.active_findings_count)
+            self.assertFalse(ep3.vulnerable, ep3.active_findings_count)
+            self.assertTrue(ep3.mitigated, ep3.active_findings_count)
 
         with self.subTest('Endpoint with one vulnerability'):
             self.assertEqual(ep4.findings_count, 1, ep4.findings.all())
@@ -357,8 +357,8 @@ class TestEndpointStatusModel(DojoTestCase):
         with self.subTest('Endpoint with one vulnerability but finding is mitigated'):
             self.assertEqual(ep5.findings_count, 1, ep5.findings.all())
             self.assertEqual(ep5.active_findings_count, 0, ep5.active_findings)
-            self.assertFalse(ep5.vulnerable, ep5.active_findings_count)
-            self.assertTrue(ep5.mitigated, ep5.active_findings_count)
+            self.assertTrue(ep5.vulnerable, ep5.active_findings_count)
+            self.assertFalse(ep5.mitigated, ep5.active_findings_count)
 
         with self.subTest('Host with vulnerabilities'):
             self.assertEqual(ep3.host_endpoints_count, 3, ep3.host_endpoints)


### PR DESCRIPTION
Redefine the vulnerability status of an endpoint to consider endpoint statuses rather than findings. An endpoint can only be considered mitigated when all endpoint statuses are marked as mitigated. This aligns with the behavior exhibited by the bulk mitigate feature on the view endpoint page