### PR TITLE
set Dynamic finding to false by default in add finding manually to test

### DIFF
--- a/dojo/test/views.py
+++ b/dojo/test/views.py
@@ -447,7 +447,7 @@ class AddFindingView(View):
         args = [request.POST] if request.method == "POST" else []
         # Set the initial form args
         kwargs = {
-            "initial": {'date': timezone.now().date(), 'verified': True},
+            "initial": {'date': timezone.now().date(), 'verified': True, 'dynamic_finding': False},
             "req_resp": None,
             "product": test.engagement.product,
         }


### PR DESCRIPTION
## set Dynamic finding (DAST) to false by default in add finding manually to test
[sc-3143]

**Description**

The initial data for the form in Add finding manually for test, now changes DAST field to false by default, the current value is set to True.

**Test results**

Now the default value is False.
<img width="1437" alt="Screenshot 2024-03-20 at 7 31 42 a m" src="https://github.com/DefectDojo/django-DefectDojo/assets/7889626/5cf46950-ab2a-4520-b7c9-4517ccf4c1f2">


**Documentation**

No docs provided
