### PR TITLE
Fix items not found in scout suite findings

### DIFF
--- a/dojo/tools/scout_suite/parser.py
+++ b/dojo/tools/scout_suite/parser.py
@@ -106,7 +106,7 @@ class ScoutSuiteParser(object):
             service_item = data["services"][service_name]
             for finding_name in service_item.get("findings", []):
                 finding = service_item["findings"][finding_name]
-                for name in finding["items"]:
+                for name in finding.get("items", []):
                     description_text = (
                         finding.get("rationale", "")
                         + "\n**Location:** "


### PR DESCRIPTION
**Description**

Some Scout Suite findings do not include `items`. If this is the case, Defect Dojo will fail when importing a scan.

**Test results**

I imported a scan where 2 of the findings (`vpc-subnet-with-allow-all-egress-acls` and `vpc-subnet-with-allow-all-ingress-acls` were missing `items`. The scan imported successfully.

Tested using Docker on Windows 11 and Amazon ECS.