### PR TITLE
Fix finding filter in API `not_test__tags'

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1258,7 +1258,7 @@ class ApiFindingFilter(DojoFilter):
     not_tag = CharFilter(field_name='tags__name', lookup_expr='icontains', help_text='Not Tag name contains', exclude='True')
     not_tags = CharFieldInFilter(field_name='tags__name', lookup_expr='in',
                                  help_text='Comma separated list of exact tags not present on model', exclude='True')
-    not_test__tags = CharFieldInFilter(field_name='test__tags__name', lookup_expr='in', help_text='Comma separated list of exact tags present on test')
+    not_test__tags = CharFieldInFilter(field_name='test__tags__name', lookup_expr='in', exclude='True', help_text='Comma separated list of exact tags present on test')
     not_test__engagement__tags = CharFieldInFilter(field_name='test__engagement__tags__name', lookup_expr='in',
                                                    help_text='Comma separated list of exact tags not present on engagement',
                                                    exclude='True')


### PR DESCRIPTION
## Fix finding filter in API `not_test__tags'
[sc-4929]

The Finding filters `not_test__tags` and `test_tags` was returning the same dataset when used on a GET /finding/ request.

**Test results**

The `exclude='True'` was missing in the `not_test__tags` field in API Finding filter. The exclude parameter was added.
Now the filter works properly.