### PR TITLE
Fix typo of github username in DryRun Security config

### DIFF
--- a/.dryrunsecurity.yaml
+++ b/.dryrunsecurity.yaml
@@ -62,7 +62,7 @@ allowedAuthors:
     - grendel513
     - cneill
     - Maffooch
-    - blakeowens
+    - blakeaowens
     - kiblik
     - dsever
     - dogboat


### PR DESCRIPTION
**Description**

Minor PR to fix typo in GH usename in DryRun Security config
