### PR TITLE
sysdig_reports: migrate cve to unsaved_vulnerability_ids

### DIFF
--- a/dojo/tools/sysdig_reports/parser.py
+++ b/dojo/tools/sysdig_reports/parser.py
@@ -76,7 +76,6 @@ class SysdigReportsParser(object):
             description += "k8sWorkloadType: " + k8sWorkloadType + "\n"
             description += "k8sWorkloadName: " + k8sWorkloadName + "\n"
             description += "k8sPodContainerName: " + k8sPodContainerName + "\n"
-            description += "vulnName: " + vulnName + "\n"
             description += "vulnCvssVersion: " + vulnCvssVersion + "\n"
             description += "vulnCvssScore: " + str(vulnCvssScore) + "\n"
             description += "vulnCvssVector: " + vulnCvssVector + "\n"
@@ -98,12 +97,14 @@ class SysdigReportsParser(object):
                 description=description,
                 severity=vulnSeverity,
                 mitigation=mitigation,
-                cve=vulnName,
                 static_finding=True,
                 references=vulnLink,
                 component_name=packageName,
                 component_version=packageVersion,
             )
+            if vulnName != '':
+                find.unsaved_vulnerability_ids = list()
+                find.unsaved_vulnerability_ids.append(vulnName)
             findings.append(find)
         return findings
 
@@ -119,7 +120,8 @@ class SysdigReportsParser(object):
             else:
                 finding.title = f"{row.vulnerability_id} - {row.package_name}"
             finding.vuln_id_from_tool = row.vulnerability_id
-            finding.cve = row.vulnerability_id
+            finding.unsaved_vulnerability_ids = list()
+            finding.unsaved_vulnerability_ids.append(row.vulnerability_id)
             finding.severity = row.severity
             # Set Component Version
             finding.component_name = row.package_name

--- a/unittests/tools/test_sysdig_reports_parser.py
+++ b/unittests/tools/test_sysdig_reports_parser.py
@@ -23,7 +23,7 @@ class TestSysdigParser(TestCase):
         self.assertEqual(1, len(findings))
         self.assertEqual("com.fasterxml.jackson.core:jackson-databind", findings[0].component_name)
         self.assertEqual("2.9.7", findings[0].component_version)
-        self.assertEqual("CVE-2018-19360", findings[0].cve)
+        self.assertEqual("CVE-2018-19360", findings[0].unsaved_vulnerability_ids[0])
 
     def test_sysdig_parser_with_many_vuln_has_many_findings(self):
         testfile = open("unittests/scans/sysdig_reports/sysdig_reports_many_vul.csv")


### PR DESCRIPTION
This PR migrates sysdig_reports from cve to unsaved_vulnerability_ids. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612 