### PR TITLE
bundleraudit: remove cves

### DIFF
--- a/dojo/tools/bundler_audit/parser.py
+++ b/dojo/tools/bundler_audit/parser.py
@@ -92,7 +92,6 @@ class BundlerAuditParser(object):
                     dynamic_finding=False,
                     component_name=gem_name,
                     component_version=gem_version,
-                    cve=advisory_id,
                 )
                 if advisory_id:
                     find.unsaved_vulnerability_ids = [advisory_id]

--- a/unittests/tools/test_bundler_audit_parser.py
+++ b/unittests/tools/test_bundler_audit_parser.py
@@ -38,7 +38,6 @@ class TestBundlerAuditParser(DojoTestCase):
                 self.assertEqual("Medium", finding.severity)
                 self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
                 self.assertEqual("CVE-2020-8161", finding.unsaved_vulnerability_ids[0])
-                self.assertEqual("CVE-2020-8161", finding.cve)
                 self.assertEqual("rack", finding.component_name)
                 self.assertEqual("1.6.13", finding.component_version)
             with self.subTest(i=1):
@@ -47,7 +46,6 @@ class TestBundlerAuditParser(DojoTestCase):
                 self.assertEqual("Medium", finding.severity)
                 self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
                 self.assertEqual("CVE-2020-8184", finding.unsaved_vulnerability_ids[0])
-                self.assertEqual("CVE-2020-8184", finding.cve)
                 self.assertEqual("rack", finding.component_name)
                 self.assertEqual("1.6.13", finding.component_version)
             with self.subTest(i=2):
@@ -56,7 +54,6 @@ class TestBundlerAuditParser(DojoTestCase):
                 self.assertEqual("Medium", finding.severity)
                 self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
                 self.assertEqual("CVE-2018-3760", finding.unsaved_vulnerability_ids[0])
-                self.assertEqual("CVE-2018-3760", finding.cve)
                 self.assertEqual("sprockets", finding.component_name)
                 self.assertEqual("2.2.3", finding.component_version)
             with self.subTest(i=3):
@@ -65,6 +62,5 @@ class TestBundlerAuditParser(DojoTestCase):
                 self.assertEqual("Medium", finding.severity)
                 self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
                 self.assertEqual("GHSA-xc9x-jj77-9p9j", finding.unsaved_vulnerability_ids[0])
-                self.assertEqual("GHSA-xc9x-jj77-9p9j", finding.cve)
                 self.assertEqual("nokogiri", finding.component_name)
                 self.assertEqual("1.15.2", finding.component_version)


### PR DESCRIPTION
This PR removes cve from bundler, but unsaved_vulnerability_ids already exists. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612