### PR TITLE
redhatsatellite: migrate cve to unsaved_vulnerability_ids

### DIFF
--- a/dojo/tools/redhatsatellite/parser.py
+++ b/dojo/tools/redhatsatellite/parser.py
@@ -69,9 +69,11 @@ class RedHatSatelliteParser(object):
                 description=description,
                 severity=self.severity_mapping(input=severity),
                 mitigation=solution,
-                cve=errata_id,
                 component_name=packages,
                 dynamic_finding=True,
             )
+            if errata_id is not None:
+                find.unsaved_vulnerability_ids = list()
+                find.unsaved_vulnerability_ids.append(errata_id)
             findings.append(find)
         return findings

--- a/unittests/tools/test_redhatsatellite_parser.py
+++ b/unittests/tools/test_redhatsatellite_parser.py
@@ -22,3 +22,4 @@ class TestRedHatSatelliteParser(DojoTestCase):
         parser = RedHatSatelliteParser()
         findings = parser.get_findings(testfile, Test())
         self.assertEqual(3, len(findings))
+        self.assertEqual("RHSA-1966:12313", findings[0].unsaved_vulnerability_ids[0])


### PR DESCRIPTION
This PR removes cve from redhatsatellite and migrates to unsaved_vulnerability_ids. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612