### PR TITLE
API Import/Reimport: Convert string tags to lists

### DIFF
--- a/docs/content/en/usage/features.md
+++ b/docs/content/en/usage/features.md
@@ -20,6 +20,9 @@ Here is an example with a product with two tags and four findings each with a si
 
 Tags can be formatted in any of the following ways:
 - StringWithNoSpaces
+- string-with-hyphens
+- string_with_underscores
+- colons:acceptable
 - "quoted string with spaces"
 - "quoted,comma,tag"
 - "quoted with spaces, and also commas!"

--- a/docs/content/en/usage/features.md
+++ b/docs/content/en/usage/features.md
@@ -16,6 +16,14 @@ Here is an example with a product with two tags and four findings each with a si
 
 ![High level example of usage with tags](../../images/tags-high-level-example.png)
 
+#### Format of tag
+
+Tags can be formatted in any of the following ways:
+- StringWithNoSpaces
+- "quoted string with spaces"
+- "quoted,comma,tag"
+- "quoted with spaces, and also commas!"
+
 ### Adding and Removing
 
 Tags can be managed in the following ways

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2217,7 +2217,7 @@ class ImportScanSerializer(serializers.Serializer):
             name=environment_name
         )
         tags = data.get("tags", None)
-        # Convert the tags to a list if needed. At this point, the 
+        # Convert the tags to a list if needed. At this point, the
         # TaggitListSerializer has already removed commas supplied
         # by the user, so this operation will consistently return
         # a list to be used by the importer
@@ -2499,7 +2499,7 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         service = data.get("service", None)
         lead = data.get("lead", None)
         tags = data.get("tags", None)
-        # Convert the tags to a list if needed. At this point, the 
+        # Convert the tags to a list if needed. At this point, the
         # TaggitListSerializer has already removed commas supplied
         # by the user, so this operation will consistently return
         # a list to be used by the importer

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -264,24 +264,24 @@ class TagListSerializerField(serializers.ListField):
         if not isinstance(data, list):
             self.fail("not_a_list", input_type=type(data).__name__)
 
-        # data_safe = []
+        data_safe = []
         for s in data:
+            # Ensure if the element in the list is  string
             if not isinstance(s, six.string_types):
                 self.fail("not_a_str")
-
+            # Run the children validation
             self.child.run_validation(s)
+            # Strip out any commas if they are present
+            if len(commas_removed := s.split(",")):
+                # Add any new items to the running list
+                data_safe += commas_removed
+            else:
+                # No commas here, so add the element as usual
+                data_safe.append(s)
 
-            # if ' ' in s or ',' in s:
-            #     s = '"%s"' % s
-
-            # data_safe.append(s)
-
-        # internal_value = ','.join(data_safe)
-
-        internal_value = tagulous.utils.render_tags(data)
+        internal_value = tagulous.utils.render_tags(data_safe)
 
         return internal_value
-        # return data
 
     def to_representation(self, value):
         if not isinstance(value, list):
@@ -2217,6 +2217,12 @@ class ImportScanSerializer(serializers.Serializer):
             name=environment_name
         )
         tags = data.get("tags", None)
+        # Convert the tags to a list if needed. At this point, the 
+        # TaggitListSerializer has already removed commas supplied
+        # by the user, so this operation will consistently return
+        # a list to be used by the importer
+        if isinstance(tags, str):
+            tags = tags.split(", ")
         lead = data.get("lead")
 
         scan = data.get("file", None)
@@ -2493,6 +2499,12 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         service = data.get("service", None)
         lead = data.get("lead", None)
         tags = data.get("tags", None)
+        # Convert the tags to a list if needed. At this point, the 
+        # TaggitListSerializer has already removed commas supplied
+        # by the user, so this operation will consistently return
+        # a list to be used by the importer
+        if isinstance(tags, str):
+            tags = tags.split(", ")
         environment_name = data.get("environment", "Development")
         environment = Development_Environment.objects.get(
             name=environment_name

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2643,6 +2643,8 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
                     service=service,
                     title=test_title,
                     create_finding_groups_for_all_findings=create_finding_groups_for_all_findings,
+                    apply_tags_to_findings=apply_tags_to_findings,
+                    apply_tags_to_endpoints=apply_tags_to_endpoints,
                 )
 
             else:

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1,3 +1,4 @@
+import re
 from dojo.finding.queries import get_authorized_findings
 from dojo.group.utils import get_auth_group_name
 from django.contrib.auth.models import Group
@@ -271,13 +272,8 @@ class TagListSerializerField(serializers.ListField):
                 self.fail("not_a_str")
             # Run the children validation
             self.child.run_validation(s)
-            # Strip out any commas if they are present
-            if len(commas_removed := s.split(",")):
-                # Add any new items to the running list
-                data_safe += commas_removed
-            else:
-                # No commas here, so add the element as usual
-                data_safe.append(s)
+            substrings = re.findall(r'(?:"[^"]*"|[^",]+)', s)
+            data_safe.extend(substrings)
 
         internal_value = tagulous.utils.render_tags(data_safe)
 

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1414,7 +1414,7 @@ class ProductTest(BaseClass.RESTEndpointTest):
             "prod_type": 1,
             "name": "Test Product",
             "description": "test product",
-            "tags": ["mytag, yourtag"]
+            "tags": ["mytag", "yourtag"]
         }
         self.update_fields = {'prod_type': 2}
         self.test_type = TestType.OBJECT_PERMISSIONS

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -161,7 +161,6 @@ class TagTests(DojoAPITestCase):
         response = self.get_finding_tags_api(finding_id)
 
         self.assertEqual(2, len(response.get('tags')))
-        # print("response['tags']:" + str(response['tags']))
         self.assertIn('one', str(response['tags']))
         self.assertIn('two', str(response['tags']))
 

--- a/unittests/test_tags.py
+++ b/unittests/test_tags.py
@@ -160,13 +160,7 @@ class TagTests(DojoAPITestCase):
         finding_id = self.create_finding_with_tags(tags)
         response = self.get_finding_tags_api(finding_id)
 
-        # the old django-tagging library was splitting this tag into 2 tags
-        # with djangotagulous the tag does no longer get split up and we cannot modify tagulous
-        # to keep doing the old behaviour. so this is a small incompatibility, but only for
-        # tags with commas, so should be minor trouble
-        #
-        # self.assertEqual(2, len(response.get('tags')))
-        self.assertEqual(1, len(response.get('tags')))
+        self.assertEqual(2, len(response.get('tags')))
         # print("response['tags']:" + str(response['tags']))
         self.assertIn('one', str(response['tags']))
         self.assertIn('two', str(response['tags']))


### PR DESCRIPTION
When supplying tags to the import and reimport endpoints through the swagger page, the resulting curl command on the tags form data looks like this:
 ```
...
  -F 'tags=one,two,three'
...
```
When the serializer processes this request, a single string with the value `one,two,three` will be applied to any objects requested to be tagged. This is misleading and incorrect. Instead, the string should be split with commas as the delimiters.

[sc-4993]