### PR TITLE
Remove 'version' from docker-compose

### DIFF
--- a/docker-compose.override.debug.yml
+++ b/docker-compose.override.debug.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   uwsgi:
     entrypoint: ['/wait-for-it.sh', '${DD_DATABASE_HOST}:${DD_DATABASE_PORT}', '-t', '30', '--', '/entrypoint-uwsgi-dev.sh']

--- a/docker-compose.override.dev.yml
+++ b/docker-compose.override.dev.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   uwsgi:
     entrypoint: ['/wait-for-it.sh', '${DD_DATABASE_HOST}:${DD_DATABASE_PORT}', '-t', '30', '--', '/entrypoint-uwsgi-dev.sh']

--- a/docker-compose.override.https.yml
+++ b/docker-compose.override.https.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   nginx:
     environment:

--- a/docker-compose.override.integration_tests.yml
+++ b/docker-compose.override.integration_tests.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   integration-tests:
     build:

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.8'
 services:
   nginx:
     image: busybox:1.36.1-musl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@
 # docker-compose.yml file is not intended for production use without first
 # customizing it to your particular situation.
 ---
-version: '3.8'
 services:
   nginx:
     build:


### PR DESCRIPTION
Solve Warning
```bash
WARN[0000] .../django-DefectDojo/docker-compose.yml: `version` is obsolete 
WARN[0000] .../django-DefectDojo/docker-compose.override.yml: `version` is obsolete
```

More info:
> The top-level `version` property is defined by the Compose Specification for backward compatibility. It is only informative.
> 
> Compose doesn't use `version` to select an exact schema to validate the Compose file, but prefers the most recent schema when it's implemented.

From https://github.com/compose-spec/compose-spec/blob/master/04-version-and-name.md
