### PR TITLE
osv_scanner: migrate from cve to unsaved_vulnerability_ids

### DIFF
--- a/dojo/tools/osv_scanner/parser.py
+++ b/dojo/tools/osv_scanner/parser.py
@@ -37,7 +37,7 @@ class OSVScannerParser(object):
                 package_version = package["package"]["version"]
                 package_ecosystem = package["package"]["ecosystem"]
                 for vulnerability in package["vulnerabilities"]:
-                    vulnerabilityid = vulnerability["id"]
+                    vulnerabilityid = vulnerability.get("id", "")
                     vulnerabilitysummary = vulnerability.get("summary", "")
                     vulnerabilitydetails = vulnerability["details"]
                     vulnerabilitypackagepurl = vulnerability["affected"][0].get("package", "")
@@ -65,9 +65,11 @@ class OSVScannerParser(object):
                         component_name=package_name,
                         component_version=package_version,
                         cwe=cwe,
-                        cve=vulnerabilityid,
                         file_path=source_path,
                         references=reference,
                     )
+                    if vulnerabilityid != "":
+                        finding.unsaved_vulnerability_ids = list()
+                        finding.unsaved_vulnerability_ids.append(vulnerabilityid)
                     findings.append(finding)
         return findings

--- a/unittests/tools/test_osv_scanner_parser.py
+++ b/unittests/tools/test_osv_scanner_parser.py
@@ -19,7 +19,8 @@ class TestOSVScannerParser(DojoTestCase):
             finding = findings[0]
             self.assertEqual(finding.cwe, "CWE-506")
             self.assertEqual(finding.title, "MAL-2023-1035_flot-axis")
-            self.assertEqual(finding.cve, "MAL-2023-1035")
+            self.assertEqual(finding.cve, None)
+            self.assertEqual(finding.unsaved_vulnerability_ids[0], "MAL-2023-1035")
             self.assertEqual(finding.severity, "Low")
 
     def test_many_findings(self):
@@ -29,7 +30,8 @@ class TestOSVScannerParser(DojoTestCase):
             self.assertEqual(66, len(findings))
             finding = findings[0]
             self.assertEqual(finding.title, "GHSA-25mq-v84q-4j7r_guzzlehttp/guzzle")
-            self.assertEqual(finding.cve, "GHSA-25mq-v84q-4j7r")
+            self.assertEqual(finding.cve, None)
+            self.assertEqual(finding.unsaved_vulnerability_ids[0], "GHSA-25mq-v84q-4j7r")
             self.assertEqual(finding.severity, "High")
             finding = findings[3]
             self.assertEqual(finding.static_finding, True)


### PR DESCRIPTION
This PR removes cve from osv_scanner and migrates to unsaved_vulnerability_ids. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612