### PR TITLE
yarn_audit: migrate from cve to unsaved_vulnerability_ids

### DIFF
--- a/dojo/tools/yarn_audit/parser.py
+++ b/dojo/tools/yarn_audit/parser.py
@@ -85,7 +85,6 @@ class YarnAuditParser(object):
                 test=test,
                 severity=self.severitytranslator(severity=tree.get("advisories").get(element).get("severity")),
                 description=description,
-                cve=tree.get("advisories").get(element).get("cves")[0],
                 mitigation=tree.get("advisories").get(element).get("recommendation"),
                 references=url + "\n" + references,
                 component_name=tree.get("advisories").get(element).get("module_name"),
@@ -98,6 +97,10 @@ class YarnAuditParser(object):
                 static_finding=True,
                 dynamic_finding=False,
             )
+            if tree.get("advisories").get(element).get("cves") != []:
+                dojo_finding.unsaved_vulnerability_ids = list()
+                for cve in tree.get("advisories").get(element).get("cves"):
+                    dojo_finding.unsaved_vulnerability_ids.append(cve)
             if tree.get("advisories").get(element).get("cwe") != []:
                 dojo_finding.cwe = tree.get("advisories").get(element).get("cwe")[0].strip("CWE-")
             items.append(dojo_finding)

--- a/unittests/tools/test_yarn_audit_parser.py
+++ b/unittests/tools/test_yarn_audit_parser.py
@@ -64,6 +64,8 @@ class TestYarnAuditParser(DojoTestCase):
         self.assertEqual(2, len(findings))
         self.assertEqual(findings[0].cwe, 918)
         self.assertEqual(findings[1].cwe, 1035)
+        self.assertEqual(findings[1].cve, None)
+        self.assertEqual(findings[1].unsaved_vulnerability_ids[0], "CVE-2021-3807")
 
     def test_yarn_audit_parser_empty_with_error(self):
         with self.assertRaises(ValueError) as context:
@@ -83,3 +85,5 @@ class TestYarnAuditParser(DojoTestCase):
         testfile.close()
         self.assertEqual(3, len(findings))
         self.assertEqual(findings[0].cwe, "1321")
+        self.assertEqual(findings[1].unsaved_vulnerability_ids[0], "CVE-2022-25851")
+        self.assertEqual(findings[1].cve, None)


### PR DESCRIPTION
This PR removes cve from yarn_audit and migrates to unsaved_vulnerability_ids. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612