### PR TITLE
nancy: migrate from cve to unsaved_vulnerability_ids

### DIFF
--- a/dojo/tools/nancy/parser.py
+++ b/dojo/tools/nancy/parser.py
@@ -63,7 +63,6 @@ class NancyParser(object):
                         static_finding=True,
                         dynamic_finding=False,
                         vuln_id_from_tool=associated_vuln["Id"],
-                        cve=associated_vuln['Cve'],
                         references="\n".join(references),
                     )
 

--- a/unittests/tools/test_nancy_parser.py
+++ b/unittests/tools/test_nancy_parser.py
@@ -23,6 +23,8 @@ class TestNancyParser(DojoTestCase):
             self.assertEqual('Info', finding.severity)
             self.assertIsNotNone(finding.description)
             self.assertGreater(len(finding.description), 0)
+            self.assertEqual(None, finding.cve)
+            self.assertEqual("CVE-2017-1000070", finding.unsaved_vulnerability_ids[0])
             self.assertEqual("CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N", finding.cvssv3)
 
     def test_nancy_plus_parser_with_many_vuln_has_many_findings(self):


### PR DESCRIPTION
This PR removes cve from nancy and migrates to unsaved_vulnerability_ids. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612