### PR TITLE
Nosey Parker description fixes

### DIFF
--- a/dojo/tools/noseyparker/parser.py
+++ b/dojo/tools/noseyparker/parser.py
@@ -61,9 +61,8 @@ class NoseyParkerParser(object):
                                   f"Committer Name: {json_path['commit_provenance']['commit_metadata']['committer_name']}  \n" \
                                   f"Committer Email: {json_path['commit_provenance']['commit_metadata']['committer_email']} \n" \
                                   f"Commit ID: {json_path['commit_provenance']['commit_metadata']['commit_id']}  \n" \
-                                  f"Location: {filepath} line #{line_num} \n " \
-                                  f"Line #{line_num} \n " \
-                                  f"Code Snippet Containing Secret: {match['snippet']['before']}***SECRET***{match['snippet']['after']} \n"
+                                  f"Location: {filepath} line #{line_num} \n" \
+                                  f"Line #{line_num} \n"
 
                     # Internal de-duplication
                     key = hashlib.md5((filepath + "|" + secret + "|" + str(line_num)).encode("utf-8")).hexdigest()


### PR DESCRIPTION
**Current issue with the Nosey Parker parser:**

The parser currently grabs a code snippet for the secret found in source code. This code snippet is taken directly from the Nosey Parker JSONL output. However, in some cases, secrets are printed out in Defect Dojo (in plaintext) if they are in the line before and after the matching secret. 

<img width="256" alt="image" src="https://github.com/DefectDojo/django-DefectDojo/assets/32806320/2a4f7992-1ec1-4a22-87f3-105572cf3efe">



**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [ ] Your code is python 3.11 compliant.

