### PR TITLE
CVSS Override: Revert #9744

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1719,17 +1719,6 @@ class FindingSerializer(TaggitSerializer, serializers.ModelSerializer):
 
     # Overriding this to push add Push to JIRA functionality
     def update(self, instance, validated_data):
-        # cvssv3 handling cvssv3 vector takes precedence,
-        # then cvssv3_score and finally severity
-        if validated_data.get("cvssv3"):
-            validated_data["cvssv3_score"] = None
-            validated_data["severity"] = ""
-        elif validated_data.get("cvssv3_score"):
-            validated_data["severity"] = ""
-        elif validated_data.get("severity"):
-            validated_data["cvssv3"] = None
-            validated_data["cvssv3_score"] = None
-
         # remove tags from validated data and store them seperately
         to_be_tagged, validated_data = self._pop_tags(validated_data)
 


### PR DESCRIPTION
CVSS overrides are creating issues for reimport due to the calculation of hash codes. This functionality needs to be reverted for the time being

[sc-5098]