### PR TITLE
Ruff: Add checks that are fully solved

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,25 @@
  # Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
  # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
  # McCabe complexity (`C901`) by default.
- lint.select = ["E", "F", "UP", "FLY", "TRY004", "TRY2"]
+ lint.select = [
+   "F",
+   "E",
+   "W",
+   "UP",
+   "YTT",
+   "ASYNC",
+   "TRIO",
+   "ICN",
+   "LOG",
+   "SLOT",
+   "PD",
+   "PGH",
+   "TRY004",
+   "TRY2",
+   "FLY",
+   "NPY",
+   "AIR",
+]
  lint.ignore = ["E501", "E722", "F821"]
 
  # Allow autofix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
Add checks that are fully solved and do not need any fixes - as prevention for the future.

`lint.select` has been split into lines (for easier readability and adding new ones). They are ordered based on https://docs.astral.sh/ruff/rules