### PR TITLE
Parser: Fix Qualys Parser Mitigation Date Issue 

### DIFF
--- a/dojo/tools/qualys/parser.py
+++ b/dojo/tools/qualys/parser.py
@@ -173,7 +173,7 @@ def parse_finding(host, tree):
             if last_fixed is not None:
                 _temp["mitigation_date"] = datetime.datetime.strptime(
                     last_fixed, "%Y-%m-%dT%H:%M:%SZ"
-                ).date()
+                )
             else:
                 _temp["mitigation_date"] = None
         # read cvss value if present


### PR DESCRIPTION

## :warning: Note on feature completeness :warning:

We are narrowing the scope of acceptable enhancements to DefectDojo in preparation for v3. Learn more here:
https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/CONTRIBUTING.md

**Description**

The Parser used a Date Field for the mitigation_date, however… the Finding-Model requires a DateTime Field which is not compatible and imports are getting canceled. The fix is simply to remove the "to_date" conversion, because we do not want to change the Finding Model

**Test results**

Ideally you extend the test suite in `tests/` and `dojo/unittests` to cover the changed in this PR.
Alternatively, describe what you have and haven't tested.

**Documentation**

Please update any documentation when needed in the [documentation folder](https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs))

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

