### PR TITLE
sonarqube: cve to vulnerability_ids

### DIFF
--- a/dojo/tools/sonarqube/sonarqube_restapi_json.py
+++ b/dojo/tools/sonarqube/sonarqube_restapi_json.py
@@ -53,27 +53,6 @@ class SonarQubeRESTAPIJSON:
                     flows = str(issue.get("flows"))
                     status = issue.get("status")
                     message = issue.get("message")
-                    cve = None
-                    if "Reference: CVE" in message:
-                        cve_pattern = r'Reference: CVE-\d{4}-\d{4,7}'
-                        cves = re.findall(cve_pattern, message)
-                        if cves:
-                            cve = cves[0].split("Reference: ")[1]
-                    elif "References: CVE" in message:
-                        cve_pattern = r'References: CVE-\d{4}-\d{4,7}'
-                        cves = re.findall(cve_pattern, message)
-                        if cves:
-                            cve = cves[0].split("References: ")[1]
-                    elif "Reference: GHSA" in message and cve is None:
-                        cve_pattern = r'Reference: GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}'
-                        cves = re.findall(cve_pattern, message)
-                        if cves:
-                            cve = cves[0].split("Reference: ")[1]
-                    elif "References: GHSA" in message and cve is None:
-                        cve_pattern = r'References: GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}'
-                        cves = re.findall(cve_pattern, message)
-                        if cves:
-                            cve = cves[0].split("References: ")[1]
                     cwe = None
                     if "Category: CWE-" in message:
                         cwe_pattern = r'Category: CWE-\d{1,5}'
@@ -124,11 +103,34 @@ class SonarQubeRESTAPIJSON:
                         dynamic_finding=False,
                         component_name=component_name,
                         component_version=component_version,
-                        cve=cve,
                         cwe=cwe,
                         cvssv3_score=cvss,
                         tags=["vulnerability"],
                     )
+                    vulnids = list()
+                    if "Reference: CVE" in message:
+                        cve_pattern = r'Reference: CVE-\d{4}-\d{4,7}'
+                        cves = re.findall(cve_pattern, message)
+                        for cve in cves:
+                            vulnids.append(cve.split("Reference: ")[1])
+                    if "References: CVE" in message:
+                        cve_pattern = r'References: CVE-\d{4}-\d{4,7}'
+                        cves = re.findall(cve_pattern, message)
+                        for cve in cves:
+                            vulnids.append(cve.split("References: ")[1])
+                    if "Reference: GHSA" in message:
+                        cve_pattern = r'Reference: GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}'
+                        cves = re.findall(cve_pattern, message)
+                        for cve in cves:
+                            vulnids.append(cve.split("Reference: ")[1])
+                    if "References: GHSA" in message:
+                        cve_pattern = r'References: GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}'
+                        cves = re.findall(cve_pattern, message)
+                        for cve in cves:
+                            vulnids.append(cve.split("References: ")[1])
+                    item.unsaved_vulnerability_ids = list()
+                    for vulnid in vulnids:
+                        item.unsaved_vulnerability_ids.append(vulnid)
                 elif issue.get("type") == "CODE_SMELL":
                     key = issue.get("key")
                     rule = issue.get("rule")

--- a/unittests/tools/test_sonarqube_parser.py
+++ b/unittests/tools/test_sonarqube_parser.py
@@ -559,7 +559,7 @@ class TestSonarQubeParser(DojoTestCase):
         self.assertEqual(str, type(item.description))
         self.assertEqual("OWASP:UsingComponentWithKnownVulnerability_fjioefjwoefijo", item.title)
         self.assertEqual("Medium", item.severity)
-        self.assertEqual("CVE-2024-2529", item.cve)
+        self.assertEqual("CVE-2024-2529", item.unsaved_vulnerability_ids[0])
         self.assertEqual("120", item.cwe)
         self.assertEqual("6.4", item.cvssv3_score)
         self.assertEqual("package", item.component_name)
@@ -567,16 +567,15 @@ class TestSonarQubeParser(DojoTestCase):
         item = findings[1]
         self.assertEqual("Web:TableWithoutCaptionCheck_asdfwfewfwefewf", item.title)
         self.assertEqual("Low", item.severity)
-        self.assertIsNone(item.cve)
         self.assertEqual(0, item.cwe)
         self.assertIsNone(item.cvssv3_score)
         item = findings[2]
         self.assertEqual("typescript:S1533_fjoiewfjoweifjoihugu-", item.title)
         self.assertEqual("Low", item.severity)
         item = findings[3]
-        self.assertEqual("GHSA-frr2-c345-p7c2", item.cve)
+        self.assertEqual("GHSA-frr2-c345-p7c2", item.unsaved_vulnerability_ids[0])
         item = findings[4]
-        self.assertEqual("CVE-2023-52428", item.cve)
+        self.assertEqual("CVE-2023-52428", item.unsaved_vulnerability_ids[0])
         self.assertEqual("nimbus-jose-jwt-9.24.4.jar", item.component_name)
         self.assertIsNone(item.component_version)
 


### PR DESCRIPTION
This PR removes cve from sonarqube and migrates to unsaved_vulnerability_ids. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612