### PR TITLE
Update format_epss display tag to try/catch formatting errors

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -191,9 +191,10 @@ def percentage(fraction, value):
 
 @register.filter
 def format_epss(value):
-    if value is None:
+    try:
+        return f'{value:.2%}'
+    except (ValueError, TypeError):
         return 'N.A.'
-    return f'{value:.2%}'
 
 
 def asvs_calc_level(benchmark_score):


### PR DESCRIPTION
**Description**

This patch updates the format_epss display tag to try/catch the formatted value it returns; users have experienced situations where the metrics page throws a 500 due to the passed-in value being a string (rather than float|None); now just return "N.A." for these invalid values.