### PR TITLE
GH-action: Detect Merge Conflicts - update v3

### DIFF
--- a/.github/workflows/detect-merge-conflicts.yaml
+++ b/.github/workflows/detect-merge-conflicts.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: check if prs are conflicted
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v3
         with:
           dirtyLabel: "conflicts-detected"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Solve Node v16 vs v20 warning.

https://github.com/eps1lon/actions-label-merge-conflict/releases/tag/v3.0.0

Not detected by renovate/dependabot because of change of naming convention.