### PR TITLE
Fix: Broken Swagger when Remote User enabled

### DIFF
--- a/dojo/remote_user.py
+++ b/dojo/remote_user.py
@@ -98,4 +98,13 @@ class RemoteUserScheme(OpenApiAuthenticationExtension):
     priority = 1
 
     def get_security_definition(self, auto_schema):
-        return settings.SWAGGER_SETTINGS['SECURITY_DEFINITIONS']['remoteUserAuth']
+        header_name = settings.AUTH_REMOTEUSER_USERNAME_HEADER
+        if header_name.startswith('HTTP_'):
+            header_name = header_name[5:]
+        header_name = header_name.replace('_', '-').capitalize()
+
+        return {
+            'type': 'apiKey',
+            'in': 'header',
+            'name': header_name,
+        }

--- a/unittests/test_remote_user.py
+++ b/unittests/test_remote_user.py
@@ -1,6 +1,7 @@
 from django.test import Client, override_settings
 from netaddr import IPSet
 from dojo.models import User, Dojo_Group, Dojo_Group_Member
+from dojo.remote_user import RemoteUserScheme
 from .dojo_test_case import DojoTestCase
 
 
@@ -193,3 +194,15 @@ class TestRemoteUser(DojoTestCase):
                                     )
         self.assertEqual(resp.status_code, 302)
         self.assertIn('Requested came from untrusted proxy', cm.output[0])
+
+    @override_settings(
+        AUTH_REMOTEUSER_ENABLED=True,
+        AUTH_REMOTEUSER_USERNAME_HEADER="HTTP_OUR_REMOTE_USER",
+    )
+    def test_api_schema(self):
+        security_definition = RemoteUserScheme.get_security_definition(None, None)
+        self.assertEqual(security_definition, {
+            "type": "apiKey",
+            "in": "header",
+            "name": "Our-remote-user",
+        })


### PR DESCRIPTION
Combination of https://github.com/DefectDojo/django-DefectDojo/pull/9108/ and enabled `DD_AUTH_REMOTEUSER_ENABLED` was breaking API Swagger because of removed `settings.SWAGGER_SETTINGS`. 

![image](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/6f9c7380-54b2-47b5-af70-f5bd27bba707)

```python

uwsgi-1         | [18/Apr/2024 12:50:56] ERROR [dojo.api_v2.exception_handler:41] 'Settings' object has no attribute 'SWAGGER_SETTINGS'
uwsgi-1         | Traceback (most recent call last):
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
uwsgi-1         |     response = handler(request, *args, **kwargs)
uwsgi-1         |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/drf_spectacular/views.py", line 84, in get
uwsgi-1         |     return self._get_schema_response(request)
uwsgi-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/drf_spectacular/views.py", line 92, in _get_schema_response
uwsgi-1         |     data=generator.get_schema(request=request, public=self.serve_public),
uwsgi-1         |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/drf_spectacular/generators.py", line 281, in get_schema
uwsgi-1         |     paths=self.parse(request, public),
uwsgi-1         |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/drf_spectacular/generators.py", line 252, in parse
uwsgi-1         |     operation = view.schema.get_operation(
uwsgi-1         |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/drf_spectacular/openapi.py", line 103, in get_operation
uwsgi-1         |     auth = self.get_auth()
uwsgi-1         |            ^^^^^^^^^^^^^^^
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/drf_spectacular/openapi.py", line 342, in get_auth
uwsgi-1         |     names, definitions = [scheme.name], [scheme.get_security_definition(self)]
uwsgi-1         |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         |   File "/app/dojo/remote_user.py", line 108, in get_security_definition
uwsgi-1         |     return settings.SWAGGER_SETTINGS['SECURITY_DEFINITIONS']['remoteUserAuth']
uwsgi-1         |            ^^^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         |   File "/usr/local/lib/python3.11/site-packages/django/conf/__init__.py", line 94, in __getattr__
uwsgi-1         |     val = getattr(_wrapped, name)
uwsgi-1         |           ^^^^^^^^^^^^^^^^^^^^^^^
uwsgi-1         | AttributeError: 'Settings' object has no attribute 'SWAGGER_SETTINGS'
uwsgi-1         | [18/Apr/2024 12:50:56] ERROR [django.request:241] Internal Server Error: /api/v2/oa3/schema/
```

Unittest added as well.
Now it should work fine.

![image](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/95af4e98-98f7-4b87-b4e0-88b8bfad87b5)
