### PR TITLE
RemoteUser: Hide from Swagger

### DIFF
--- a/dojo/remote_user.py
+++ b/dojo/remote_user.py
@@ -98,6 +98,9 @@ class RemoteUserScheme(OpenApiAuthenticationExtension):
     priority = 1
 
     def get_security_definition(self, auto_schema):
+        if not settings.AUTH_REMOTEUSER_VISIBLE_IN_SWAGGER:
+            return {}
+
         header_name = settings.AUTH_REMOTEUSER_USERNAME_HEADER
         if header_name.startswith('HTTP_'):
             header_name = header_name[5:]

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -180,6 +180,9 @@ env = environ.FileAwareEnv(
     DD_AUTH_REMOTEUSER_TRUSTED_PROXY=(list, ['127.0.0.1/32']),
     # REMOTE_USER will be processed only on login page. Check https://docs.djangoproject.com/en/3.2/howto/auth-remote-user/#using-remote-user-on-login-pages-only
     DD_AUTH_REMOTEUSER_LOGIN_ONLY=(bool, False),
+    # `RemoteUser` is usually used behind AuthN proxy and users should not know about this mechanism from Swagger because it is not usable by users.
+    # It should be hidden by default.
+    DD_AUTH_REMOTEUSER_VISIBLE_IN_SWAGGER=(bool, False),
     # if somebody is using own documentation how to use DefectDojo in his own company
     DD_DOCUMENTATION_URL=(str, 'https://documentation.defectdojo.com'),
     # merging findings doesn't always work well with dedupe and reimport etc.
@@ -1041,6 +1044,7 @@ AUTH_REMOTEUSER_FIRSTNAME_HEADER = env('DD_AUTH_REMOTEUSER_FIRSTNAME_HEADER')
 AUTH_REMOTEUSER_LASTNAME_HEADER = env('DD_AUTH_REMOTEUSER_LASTNAME_HEADER')
 AUTH_REMOTEUSER_GROUPS_HEADER = env('DD_AUTH_REMOTEUSER_GROUPS_HEADER')
 AUTH_REMOTEUSER_GROUPS_CLEANUP = env('DD_AUTH_REMOTEUSER_GROUPS_CLEANUP')
+AUTH_REMOTEUSER_VISIBLE_IN_SWAGGER = env('DD_AUTH_REMOTEUSER_VISIBLE_IN_SWAGGER')
 
 AUTH_REMOTEUSER_TRUSTED_PROXY = IPSet()
 for ip_range in env('DD_AUTH_REMOTEUSER_TRUSTED_PROXY'):

--- a/unittests/test_remote_user.py
+++ b/unittests/test_remote_user.py
@@ -198,11 +198,20 @@ class TestRemoteUser(DojoTestCase):
     @override_settings(
         AUTH_REMOTEUSER_ENABLED=True,
         AUTH_REMOTEUSER_USERNAME_HEADER="HTTP_OUR_REMOTE_USER",
+        AUTH_REMOTEUSER_VISIBLE_IN_SWAGGER=True,
     )
-    def test_api_schema(self):
+    def test_api_schema_visible(self):
         security_definition = RemoteUserScheme.get_security_definition(None, None)
         self.assertEqual(security_definition, {
             "type": "apiKey",
             "in": "header",
             "name": "Our-remote-user",
         })
+
+    @override_settings(
+        AUTH_REMOTEUSER_ENABLED=True,
+        AUTH_REMOTEUSER_VISIBLE_IN_SWAGGER=False,
+    )
+    def test_api_schema_hidden(self):
+        security_definition = RemoteUserScheme.get_security_definition(None, None)
+        self.assertEqual(security_definition, {})


### PR DESCRIPTION
`RemoteUser` is usually used behind AuthN proxy and users should not know about this mechanism from Swagger because it is not usable by users.
It should be hidden by default.