### PR TITLE
Edit wording on "Add group members" pages

### DIFF
--- a/dojo/templates/dojo/new_group_member.html
+++ b/dojo/templates/dojo/new_group_member.html
@@ -5,7 +5,7 @@ width: 70% !important;
 }
 {% endblock %}
 {% block content %}
-<h3> Add Some Group Members </h3>
+<h3> Add Group Members </h3>
 <form class="form-horizontal" action="{%  url 'add_group_member' group.id %}" method="post">{% csrf_token %}
   {% include "dojo/form_fields.html" with form=form %}
   <div class="form-group">

--- a/dojo/templates/dojo/new_group_member_user.html
+++ b/dojo/templates/dojo/new_group_member_user.html
@@ -6,7 +6,7 @@ width: 70% !important;
 }
 {% endblock %}
 {% block content %}
-<h3>{% trans "Add Some Group Members" %}</h3>
+<h3>{% trans "Add Group Members" %}</h3>
 <form class="form-horizontal" action="{%  url 'add_group_member_user' user.id %}" method="post">{% csrf_token %}
   {% include "dojo/form_fields.html" with form=form %}
   <div class="form-group">


### PR DESCRIPTION
**Description**

This PR updates the wording of the titles on the "Add Group Members" pages to remove the word "Some" so it sounds more formal. Previously it said "Add Some Group Members," now it says "Add Group Members." This change is in two places -- from the view accessed through the group views, and the view accessed through the user view.

**Test results**

Text shows up as expected in both places.

[sc-3271]