### PR TITLE
view-finding-footer-fix Close a div so footer displays properly

### DIFF
--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -1167,6 +1167,7 @@
     <div class="protip">
        <i class="fa-solid fa-lightbulb"></i> <strong>ProTip!</strong> Type <kbd>e</kbd> to edit any finding, <kbd>p</kbd> and <kbd>n</kbd> to navigate to the previous or next finding.
     </div>
+</div>
 {% endblock %}
 {% block postscript %}
     {{ block.super }}


### PR DESCRIPTION
**Description**

This patch closes a div on the "view finding" page so the footer shows up properly.

Before:
<img width="489" alt="Screenshot 2024-04-19 at 2 29 15 PM" src="https://github.com/DefectDojo/django-DefectDojo/assets/19554266/9a859787-1327-4aca-bbe1-31d2a7fcb93b">


After:
![Screenshot 2024-04-19 at 2 28 26 PM](https://github.com/DefectDojo/django-DefectDojo/assets/19554266/2e0dc937-e31e-48e0-b342-6b38023b13b8)


**Test results**

It looks correct now.

[sc-3353]