### PR TITLE
Update dojo_sort template tag to properly handle querystrings with keys with multiple values

### DIFF
--- a/dojo/templatetags/navigation_tags.py
+++ b/dojo/templatetags/navigation_tags.py
@@ -64,7 +64,7 @@ def dojo_sort(request, display='Name', value='title', default=None):
     icon += ' dd-sort"></i>'
     dict_ = request.GET.copy()
     dict_[field] = value
-    # QueryDict.urlencode() should be used here properly handle multiple values for a single key
+    # QueryDict.urlencode() used here to properly handle cases when keys have multiple values
     link = f'<a title="{title}" href="?{escape(dict_.urlencode())}">{_(display)}&nbsp;{icon}</a>'
     return safe(link)
 

--- a/dojo/templatetags/navigation_tags.py
+++ b/dojo/templatetags/navigation_tags.py
@@ -1,7 +1,6 @@
 from django import template
 from django.utils.safestring import mark_safe as safe
 from django.utils.html import escape
-from urllib.parse import urlencode
 from django.utils.translation import gettext as _
 
 from dojo.authorization.roles_permissions import Permissions
@@ -65,7 +64,8 @@ def dojo_sort(request, display='Name', value='title', default=None):
     icon += ' dd-sort"></i>'
     dict_ = request.GET.copy()
     dict_[field] = value
-    link = f'<a title="{title}" href="?{escape(urlencode(dict_))}">{_(display)}&nbsp;{icon}</a>'
+    # QueryDict.urlencode() should be used here properly handle multiple values for a single key
+    link = f'<a title="{title}" href="?{escape(dict_.urlencode())}">{_(display)}&nbsp;{icon}</a>'
     return safe(link)
 
 


### PR DESCRIPTION
**Description**

This patch updates the dojo_sort template tag to use QueryDict.urlencode() rather than urllib.parse.urlencode to properly generate links from querystrings that have instances of keys with multiple values. Previously, if a key had multiple values, only one of them appeared in the generated links. Now all appear, as expected.

For URL:
![Screenshot 2024-04-19 at 3 55 52 PM](https://github.com/DefectDojo/django-DefectDojo/assets/19554266/468aa59c-ca34-4853-8e87-a2c31f869a4a)

Generated links before:

![Screenshot 2024-04-19 at 3 49 19 PM](https://github.com/DefectDojo/django-DefectDojo/assets/19554266/7f014f4e-084f-4c40-92a8-4e4f37692416)

Generated links after:

![Screenshot 2024-04-19 at 3 48 43 PM](https://github.com/DefectDojo/django-DefectDojo/assets/19554266/a55506f0-06aa-409a-8b10-2338e05fd84b)

**Test results**

Links are generated properly now.

[sc-3832]

edit: fixed first picture of url