### PR TITLE
Hide checkbox and action columns on Test view Findings listing

### DIFF
--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1682,6 +1682,10 @@
                         "targets": [0]
                     },
                     {
+                        targets: [0, 1],
+                        className: 'noVis'
+                    },
+                    {
                         targets: 'severity-sort',
                         orderDataType: 'severity-asc'
                     },


### PR DESCRIPTION
**Description**

This patch excludes the checkbox and action columns from the column visibility options on the Test view Findings listing.

Before:
![Screenshot 2024-04-19 at 4 56 13 PM](https://github.com/DefectDojo/django-DefectDojo/assets/19554266/a8f0ecf7-f29d-43fb-a2c1-f2aff1b46148)

After:
![Screenshot 2024-04-19 at 4 53 53 PM](https://github.com/DefectDojo/django-DefectDojo/assets/19554266/ab5f7a03-5558-4378-b03c-9a674ad05eb6)


**Test results**

Columns are hidden.

[sc-4284]