### PR TITLE
Fix Nuclei parser

### DIFF
--- a/dojo/tools/nuclei/parser.py
+++ b/dojo/tools/nuclei/parser.py
@@ -151,7 +151,7 @@ class NucleiParser(object):
             )
 
             dupe_key = hashlib.sha256(
-                (template_id + item_type + matcher + endpoint.host).encode(
+                (template_id + item_type + matcher + host).encode(
                     "utf-8"
                 )
             ).hexdigest()


### PR DESCRIPTION
Fix Nuclei JSON parser

**Description**

Current Nuclei parser does not work due to a mistake on line 154. It's trying to access endpoint.host, which is undefined. Upon replacing with just 'host', the parser works as intended.

**Test results**

After changing the line 154, I rebuilded my local DefectDojo installation and Nuclei parser started working.