### PR TITLE
extend _index.md with link to Knowledge Base

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -17,8 +17,6 @@ cascade:
 
 ![image](images/dashboard.png)
 
-## About DefectDojo
-
 ### What is DefectDojo?
 
 DefectDojo is a DevSecOps platform. DefectDojo streamlines DevSecOps by serving as an aggregator and single pane of glass for your security tools. DefectDojo has smart features to enhance and tune the results from your security tools including the ability to merge findings, remember false positives, and distill duplicates. DefectDojo also integrates with JIRA, provides metrics / reports, and can also be used for traditional pen test management.
@@ -36,10 +34,7 @@ Product:Engagement model, enables traceability among multiple projects
 2. [Usage]({{< ref "/usage" >}}) covers how to use DefectDojo to manage vulnerabilities.
 3. We support a large amount of [integrations]({{< ref "/integrations" >}}) to help fit DefectDojo in your DevSecOps program.
 
-
 ### Where to find DefectDojo?
-
-Proprietary editions that include [additional features](https://documentation.defectdojo.com/proprietary_plugins/) and support can be purchased through [defectdojo.com](https://www.defectdojo.com/).
 
 The open-source edition is [available on
 GitHub](https://github.com/DefectDojo/django-DefectDojo).
@@ -48,6 +43,16 @@ A running example is available on [our demo server](https://demo.defectdojo.org)
 using the credentials `admin` / `defectdojo@demo#appsec`. Note: The demo
 server is refreshed regularly and provisioned with some sample data.
 
-Follow us on [LinkedIn](https://www.linkedin.com/company/33245534) for updates.
-To get in touch with us, please reach out to info@defectdojo.com
+### DefectDojo Pro and Enterprise
 
+DefectDojo Inc. hosts a commercial edition of this software, which includes: 
+- additional features, smart features and UI improvements 
+- cloud hosting, with regular backups, updates and maintenance
+- premium support and implementation guidance
+
+For more information, please visit [defectdojo.com](https://www.defectdojo.com/).
+
+DefectDojo Inc. also maintains an updated Knowledge Base at [https://support.defectdojo.com](https://support.defectdojo.com/en/). The Knowledge Base is written to support DefectDojo's Pro and Enterprise releases, but the tutorials and guides can also be applied to the open-source edition.
+
+Follow DefectDojo Inc. on [LinkedIn](https://www.linkedin.com/company/33245534) for updates.
+To get in touch with us, please reach out to info@defectdojo.com

--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -52,7 +52,7 @@ DefectDojo Inc. hosts a commercial edition of this software, which includes:
 
 For more information, please visit [defectdojo.com](https://www.defectdojo.com/).
 
-DefectDojo Inc. also maintains an updated Knowledge Base at [https://support.defectdojo.com](https://support.defectdojo.com/en/). The Knowledge Base is written to support DefectDojo's Pro and Enterprise releases, but the tutorials and guides can also be applied to the open-source edition.
+DefectDojo Inc. also maintains an updated Knowledge Base at [https://support.defectdojo.com](https://support.defectdojo.com/en/). The Knowledge Base is written to support DefectDojo's Pro and Enterprise releases, but the tutorials and guides may also be applied to the open-source edition.
 
 Follow DefectDojo Inc. on [LinkedIn](https://www.linkedin.com/company/33245534) for updates.
 To get in touch with us, please reach out to info@defectdojo.com


### PR DESCRIPTION
This PR is mainly related to the  https://documentation.defectdojo.com/ deployment, in order to consolidate all references to the commercial offering onto this single page.

The change is mainly to ensure that DefectDojo Open Source docs and DefectDojo Inc's Knowledge Base are differentiated and identified in both locations.