### PR TITLE
Fixing Spotbugs unit test error with new html2text version

### DIFF
--- a/unittests/tools/test_spotbugs_parser.py
+++ b/unittests/tools/test_spotbugs_parser.py
@@ -4,7 +4,6 @@ from dojo.models import Test
 
 
 class TestSpotbugsParser(DojoTestCase):
-
     def test_no_findings(self):
         parser = SpotbugsParser()
         findings = parser.get_findings(get_unit_tests_path() + "/scans/spotbugs/no_finding.xml", Test())
@@ -76,19 +75,15 @@ class TestSpotbugsParser(DojoTestCase):
         test_finding = findings[0]
         # Test if line 13 is correct
         self.assertEqual(
-            "At IdentityFunctionCommandInjection.kt:[lines 20-170]",
-            test_finding.description.splitlines()[12]
+            "At IdentityFunctionCommandInjection.kt:[lines 20-170]", test_finding.description.splitlines()[12]
         )
 
     def test_mitigation(self):
         parser = SpotbugsParser()
         findings = parser.get_findings(get_unit_tests_path() + "/scans/spotbugs/many_findings.xml", Test())
         test_finding = findings[0]
-        # Test if line 10 is correct
-        self.assertEqual(
-            "#### Example",
-            test_finding.mitigation.splitlines()[9]
-        )
+        # Test if line 8 is correct
+        self.assertEqual("#### Example", test_finding.mitigation.splitlines()[7])
 
     def test_references(self):
         parser = SpotbugsParser()
@@ -97,7 +92,7 @@ class TestSpotbugsParser(DojoTestCase):
         # Test if line 2 is correct
         self.assertEqual(
             "[OWASP: Top 10 2013-A1-Injection](https://www.owasp.org/index.php/Top_10_2013-A1-Injection)",
-            test_finding.references.splitlines()[1]
+            test_finding.references.splitlines()[1],
         )
 
     def test_version_4_4(self):


### PR DESCRIPTION
**Description**

The PR #9990 to upgrade `html2text` hit a unit test failure due to a whitespace issue. This should resolve it so we can merge the `html2text` upgrade PR.

**Test results**

Spotbugs test that was failing now passes:

```
System check identified no issues (0 silenced).
test_description (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_description) ... ok
test_file (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_file) ... ok
test_find_file_path (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_find_file_path) ... ok
test_find_sast_source_line (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_find_sast_source_line) ... ok
test_find_sast_source_path (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_find_sast_source_path) ... ok
test_find_source_line (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_find_source_line) ... ok
test_mitigation (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_mitigation) ... ok
test_no_findings (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_no_findings) ... ok
test_parse_many_finding (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_parse_many_finding) ... ok
test_references (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_references) ... ok
test_version_4_4 (unittests.tools.test_spotbugs_parser.TestSpotbugsParser.test_version_4_4)
There was a big difference between version < 4.4.x and after ... ok

----------------------------------------------------------------------
Ran 11 tests in 0.182s

OK
```