### PR TITLE
Replacing deprecated netaddr 'is_private' call

### DIFF
--- a/dojo/tools/asff/parser.py
+++ b/dojo/tools/asff/parser.py
@@ -56,7 +56,7 @@ class AsffParser:
                     if resource["Type"] == "AwsEc2Instance" and "Details" in resource:
                         details = resource["Details"]["AwsEc2Instance"]
                         for ip in details.get("IpV4Addresses", []):
-                            # Adding only private IP addresses as endpoints:
+                            # Adding only non-"global" IP addresses as endpoints:
                             #
                             # 1. **Stability**: In AWS, the private IP address of an EC2 instance remains consistent
                             #    unless the instance is terminated. In contrast, public IP addresses in AWS are separate
@@ -68,7 +68,12 @@ class AsffParser:
                             #
                             # By limiting our endpoints to private IP addresses, we're ensuring that the data remains
                             # relevant even if the AWS resources undergo changes, and we also ensure a cleaner representation.
-                            if IPAddress(ip).is_private():
+                            #
+                            # netaddr deprecated the "is_private" method previously used here, so the logic has been
+                            # flipped to exclude "global" addresses.
+                            #
+                            # Ref: https://netaddr.readthedocs.io/en/latest/api.html#netaddr.IPAddress.is_global
+                            if not IPAddress(ip).is_global():
                                 endpoints.append(Endpoint(host=ip))
                 finding.unsaved_endpoints = endpoints
 


### PR DESCRIPTION
**Description**

Resolving the issue with the deprecated netaddr `is_private` method by replacing with `not is_global` ([ref](https://netaddr.readthedocs.io/en/latest/api.html#netaddr.IPAddress.is_global))

**Test results**

ASFF tests now pass, but I haven't added a separate test to confirm that this still behaves exactly the same as `is_private` did.