### PR TITLE
Set Finding date if nothing is set from the parser

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2993,11 +2993,12 @@ class Finding(models.Model):
         if not user:
             from dojo.utils import get_current_user
             user = get_current_user()
-
         # Title Casing
         from titlecase import titlecase
         self.title = titlecase(self.title[:511])
-
+        # Set the date of the finding if nothing is supplied
+        if self.date is None:
+            self.date = timezone.now()
         # Assign the numerical severity for correct sorting order
         self.numerical_severity = Finding.get_numerical_severity(self.severity)
 


### PR DESCRIPTION
For parser that do not supply a date, or the scan completion date is not set, the finding will not be saved correctly. This PR sets the current timezone aware date on the finding before it is saved to the database in the event that a date is not already supplied

Fixes #9712, #9724