### PR TITLE
Better separation of vulnerabilieties in tenable scan 

### DIFF
--- a/dojo/tools/tenable/csv_format.py
+++ b/dojo/tools/tenable/csv_format.py
@@ -104,12 +104,25 @@ class TenableCSVParser(object):
             mitigation = str(row.get("Solution", row.get("definition.solution", "N/A")))
             impact = row.get("Description", row.get("definition.description", "N/A"))
             references = row.get("See Also", row.get("definition.see_also", "N/A"))
+            # Endpoint related fields
+            host = row.get("Host", row.get("asset.host_name", ""))
+            if host == "":
+                host = row.get("DNS Name", "")
+            if host == "":
+                host = row.get("IP Address", "localhost")
+
+            protocol = row.get("Protocol", row.get("protocol", ""))
+            protocol = protocol.lower() if protocol != "" else None
+            port = str(row.get("Port", row.get("asset.port", "")))
+            if isinstance(port, str) and port in ["", "0"]:
+                port = None
+
             # Determine if the current row has already been processed
             dupe_key = (
                 severity
                 + title
-                + row.get("Host", row.get("asset.host_name", "No host"))
-                + str(row.get("Port", row.get("asset.port", "No port")))
+                + host
+                + str(port)
                 + row.get("Synopsis", row.get("definition.synopsis", "No synopsis"))
             )
             # Finding has not been detected in the current report. Proceed with
@@ -177,18 +190,7 @@ class TenableCSVParser(object):
                     find.unsaved_vulnerability_ids += detected_cve
                 else:
                     find.unsaved_vulnerability_ids.append(detected_cve)
-            # Endpoint related fields
-            host = row.get("Host", row.get("asset.host_name", ""))
-            if host == "":
-                host = row.get("DNS Name", "")
-            if host == "":
-                host = row.get("IP Address", "localhost")
 
-            protocol = row.get("Protocol", row.get("protocol", ""))
-            protocol = protocol.lower() if protocol != "" else None
-            port = str(row.get("Port", row.get("asset.port", "")))
-            if isinstance(port, str) and port in ["", "0"]:
-                port = None
             # Update the endpoints
             if "://" in host:
                 endpoint = Endpoint.from_uri(host)

--- a/unittests/tools/test_tenable_parser.py
+++ b/unittests/tools/test_tenable_parser.py
@@ -296,5 +296,5 @@ class TestTenableParser(DojoTestCase):
         for finding in findings:
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()
-        self.assertEqual(2, len(findings))
+        self.assertEqual(3, len(findings))
         self.assertEqual("Critical", findings[0].severity)


### PR DESCRIPTION
No longer aggregate different endpoints into single vulnerability because it complicates finding management and reporting. More info:
https://github.com/DefectDojo/django-DefectDojo/discussions/9669

(2nd PR approach because it appears that changes in xml_parser cause too many unittests failures and it have to be done separately)
