### PR TITLE
Fix numerical sorting in the old UI for Active/Verified findings

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1182,6 +1182,7 @@ class ProductFilter(DojoFilter):
             ('origin', 'origin'),
             ('external_audience', 'external_audience'),
             ('internet_accessible', 'internet_accessible'),
+            ('findings_count', 'findings_count')
         ),
         field_labels={
             'name': 'Product Name',
@@ -1193,6 +1194,7 @@ class ProductFilter(DojoFilter):
             'origin': 'Origin ',
             'external_audience': 'External Audience ',
             'internet_accessible': 'Internet Accessible ',
+            'findings_count': 'Findings Count ',
         }
 
     )

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -68,6 +68,10 @@ def product(request):
     # see https://code.djangoproject.com/ticket/23771 and https://code.djangoproject.com/ticket/25375
     name_words = prods.values_list('name', flat=True)
 
+    prods = prods.annotate(
+        findings_count=Count('engagement__test__finding', filter=Q(engagement__test__finding__active=True))
+    )
+
     prod_filter = ProductFilter(request.GET, queryset=prods, user=request.user)
 
     prod_list = get_page_items(request, prod_filter.qs, 25)

--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -62,7 +62,7 @@
                             {% if system_settings.enable_github %}
                             <th class="text-center">GitHub</th>
                             {% endif %}
-                            <th class="text-center"> Active (Verified) Findings</th>
+                            <th class="text-center">{% dojo_sort request 'Active (Verified) Findings' 'findings_count' %}</th>
                             <th class="text-center"> Vulnerable Hosts / Endpoints</th>
                             <th> Contact</th>
                             {% comment %} The display field is translated in the function. No need to translate here as well{% endcomment %}


### PR DESCRIPTION
[sc-5627]

As #6629 describes, there are views where sorting is made "lexicographically." The main problem I found is that sorting is performed by the front end (the page doesn't reload on sorting). Tables that don't perform sorting on the backend, like the ones displayed at `/product/{pid}/engagements,` will need another approach.

For the `All products` view, using a filter for findings_count on the backend allows us to sort numerically and sort over the complete dataset instead of being limited by the rows shown on the current page.

By implementing this change, we directly address the issue outlined in #8127, providing a more efficient sorting and filtering mechanism for the displayed data.
