### PR TITLE
remove non-working links from social-authentication.md

### DIFF
--- a/docs/content/en/integrations/social-authentication.md
+++ b/docs/content/en/integrations/social-authentication.md
@@ -15,7 +15,7 @@ leverage Auth0 to authenticate users on DefectDojo.
 2.  On the new application set the following fields:
     -   Name: "Defectdojo"
     -   Allowed Callback URLs:
-        [https://the_hostname_you_have_dojo_deployed:your_server_port/complete/auth0/](https://the_hostname_you_have_dojo_deployed:your_server_port/complete/auth0/)
+        **https://the_hostname_you_have_dojo_deployed:your_server_port/complete/auth0/**
 3.  Copy the following info from the application:
     -   Domain
     -   Client ID
@@ -175,7 +175,7 @@ user, such as 'superuser'.
 
     -   <http://localhost:8080/complete/azuread-tenant-oauth2/>
     -   **OR**
-    -   [https://the_hostname_you_have_dojo_deployed:your_server_port/complete/azuread-tenant-oauth2/](https://the_hostname_you_have_dojo_deployed:your_server_port/complete/azuread-tenant-oauth2/)
+    -   **https://the_hostname_you_have_dojo_deployed:your_server_port/complete/azuread-tenant-oauth2/**
 
 4.  Edit the settings (see [Configuration]({{< ref "/getting_started/configuration" >}})) with the following
     information:
@@ -236,13 +236,13 @@ Follow along below.
 
     -   <https://gitlab.com/profile/applications>
     -   **OR**
-    -   [https://the_hostname_you_have_gitlab_deployed:your_gitlab_port/profile/applications](https://the_hostname_you_have_gitlab_deployed:your_gitlab_port/profile/applications)
+    -   **https://the_hostname_you_have_gitlab_deployed:your_gitlab_port/profile/applications**
 
 2. Choose a name for your application
 3. For the Redirect URI, enter the DefectDojo URL with the following
     format
 
-    -   [https://the_hostname_you_have_dojo_deployed:your_server_port/complete/gitlab/](https://the_hostname_you_have_dojo_deployed:your_server_port/complete/gitlab/)
+    -   **https://the_hostname_you_have_dojo_deployed:your_server_port/complete/gitlab/**
 
 4. Edit the settings (see [Configuration]({{< ref "/getting_started/configuration" >}})) with the following
     information:
@@ -331,7 +331,7 @@ Optionally, you *can* set `DD_SOCIAL_AUTH_KEYCLOAK_LOGIN_BUTTON_TEXT` in order t
 2. Choose a name for your application
 3. For the Redirect URI, enter the DefectDojo URL with the following
     format
-    -   [https://the_hostname_you_have_dojo_deployed:your_server_port/complete/github-enterprise/](https://the_hostname_you_have_dojo_deployed:your_server_port/complete/github-enterprise/)
+    -   **https://the_hostname_you_have_dojo_deployed:your_server_port/complete/github-enterprise/**
 4. Edit the settings (see [Configuration]({{< ref "/getting_started/configuration" >}})) with the following
     information:
     {{< highlight python >}}  


### PR DESCRIPTION
Using certain markdown links prevents the docs from building correctly locally, as 'https://the_hostname_you_have_gitlab_deployed:your_gitlab_port/profile/applications' etc are not real URLs. 

Although this problem might be due to my own Hugo settings/version, I think it would be less problematic to remove the non-existent URL from the docs altogether, so that readers understand that this is an example url and not intended to be a functioning link.