### PR TITLE
add Knowledge Base link to docs sidebar element

### DIFF
--- a/docs/content/en/link_knowledge-base.md
+++ b/docs/content/en/link_knowledge-base.md
@@ -1,0 +1,9 @@
+---
+title: "Knowledge Base"
+manualLink: "https://support.defectdojo.com"
+manualLinkTitle: "Open the DefectDojo Knowledge Base"
+icon: fas fa-atlas
+date: 2021-02-02T20:46:29+01:00
+weight: 1
+chapter: true
+---


### PR DESCRIPTION
Add a link to the DefectDojo Knowledge Base on the documentation sidebar with a book icon.  Along the same lines as my previous PR: https://github.com/DefectDojo/django-DefectDojo/pull/10002

The change is mainly to ensure that DefectDojo Open Source docs and DefectDojo Inc's Knowledge Base are differentiated and identified in both locations.