### PR TITLE
Clean up and make setting page more organized and easier to use/read

### DIFF
--- a/dojo/system_settings/views.py
+++ b/dojo/system_settings/views.py
@@ -16,6 +16,62 @@ logger = logging.getLogger(__name__)
 @user_passes_test(lambda u: u.is_superuser)
 def system_settings(request):
     system_settings_obj = System_Settings.objects.get(no_cache=True)
+    form = SystemSettingsForm(instance=system_settings_obj)
+
+    sections = [
+        {
+            'name': 'Deduplication and Finding Settings',
+            'fields': {'enable_deduplication', 'delete_duplicates', 'max_dupes', 'false_positive_history',
+                       'retroactive_false_positive_history', 'risk_acceptance_form_default_days',
+                       'risk_acceptance_notify_before_expiration', 'enable_finding_groups',
+                       'enable_endpoint_metadata_import', 'enable_template_match'}
+        },
+        {
+            'name': 'Finding Service Level Agreement (SLA) Settings',
+            'fields': {'enable_finding_sla', 'enable_notify_sla_active', 'enable_notify_sla_active_verified',
+                       'enable_notify_sla_jira_only', 'enable_notify_sla_exponential_backoff',
+                       'enable_similar_findings'}
+        },
+        {
+            'name': 'Jira Integration Settings',
+            'fields': {'enable_jira', 'jira_labels', 'add_vulnerability_id_to_jira_label', 'enable_jira_web_hook',
+                       'disable_jira_webhook_secret', 'jira_webhook_secret', 'jira_minimum_severity'}
+        },
+        {
+            'name': 'Integration Settings',
+            'fields': {'enable_github', 'enable_slack_notifications', 'slack_channel', 'slack_token', 'slack_username',
+                       'enable_msteams_notifications', 'msteams_url', 'email_from', 'enable_mail_notifications',
+                       'mail_notifications_to'}
+        },
+        {
+            'name': 'Product Settings',
+            'fields': {'enable_product_grade', 'product_grade_a', 'product_grade_b', 'product_grade_c',
+                       'product_grade_d', 'product_grade_e', 'product_grade_f', 'enable_benchmark',
+                       'enable_product_tag_inheritance', 'enable_product_tracking_files'}
+        },
+        {
+            'name': 'Engagement Settings',
+            'fields': {'engagement_auto_close', 'engagement_auto_close_days'}
+        },
+        {
+            'name': 'Application Settings',
+            'fields': {'enable_credentials', 'credentials', 'disclaimer', 'url_prefix', 'team_name', 'time_zone',
+                       'allow_anonymous_survey_repsonse', 'enable_questionnaires', 'enable_checklists',
+                       'enable_calendar', 'enable_user_profile_editable', 'default_group', 'default_group_role',
+                       'default_group_email_pattern'}
+        },
+        {
+            'name': 'Password Settings',
+            'fields': {'minimum_password_length', 'maximum_password_length', 'number_character_required',
+                       'special_character_required', 'lowercase_character_required', 'uppercase_character_required',
+                       'non_common_password_required'}
+        }
+    ]
+
+    all_fields = {field.name for field in form.visible_fields()}
+    fields_with_section = {field for section in sections for field in section['fields']}
+    fields_without_section = all_fields - fields_with_section
+    sections.append({'name': 'Other', 'fields': fields_without_section})
 
     """
     **** To be Finished JIRA Status info ****
@@ -46,7 +102,7 @@ def system_settings(request):
                                  extra_tags='alert-danger')
 
     """
-    form = SystemSettingsForm(instance=system_settings_obj)
+
     if request.method == 'POST':
         form = SystemSettingsForm(request.POST, instance=system_settings_obj)
         if form.is_valid():
@@ -77,7 +133,7 @@ def system_settings(request):
                                     messages.SUCCESS,
                                     'Settings saved.',
                                     extra_tags='alert-success')
-        return render(request, 'dojo/system_settings.html', {'form': form})
+        return render(request, 'dojo/system_settings.html', {'form': form, 'sections': sections})
 
     else:
         # Celery needs to be set with the setting: CELERY_RESULT_BACKEND = 'db+sqlite:///dojo.celeryresults.sqlite'
@@ -94,11 +150,12 @@ def system_settings(request):
         else:
             celery_bool = False
             celery_msg = "Celery needs to have the setting CELERY_RESULT_BACKEND = 'db+sqlite:///dojo.celeryresults.sqlite' set in settings.py."
-            celery_status = "Unkown"
+            celery_status = "Unknown"
 
     add_breadcrumb(title="Application settings", top_level=False, request=request)
     return render(request, 'dojo/system_settings.html',
                   {'form': form,
+                    'sections': sections,
                    'celery_bool': celery_bool,
                    'celery_msg': celery_msg,
                    'celery_status': celery_status})

--- a/dojo/templates/dojo/form_fields_with_sections.html
+++ b/dojo/templates/dojo/form_fields_with_sections.html
@@ -1,0 +1,104 @@
+{% load event_tags %}
+{% block css %}
+    {{ form.media.css }}
+{% endblock %}
+{% block js %}
+    {{ form.media.js }}
+{% endblock %}
+{% if form.non_field_errors %}
+    <div class="alert alert-danger alert-dismissible" role="alert">
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span
+          aria-hidden="true">&times;</span></button>
+        {{ form.non_field_errors }}
+    </div>
+{% endif %}
+{% for field in form.hidden_fields %}
+    {{ field }}
+{% endfor %}
+{% for section in sections %}
+    {% if section.fields %}
+        <div class="row">
+            <h3 style="margin-top: 4rem; margin-bottom: 2rem"> {{ section.name }} </h3>
+            {% for field in form.visible_fields %}
+                {% if field.name in section.fields %}
+                    <div class="form-group{% if field.errors %} has-error{% endif %}">
+                        {% if field|is_checkbox %}
+                            <div class="col-sm-offset-2 col-sm-10 {{ classes.single_value }}">
+                                <div class="checkbox">
+                                    {% if field.auto_id %}
+                                        <label
+                                          {% if field.field.required and form.required_css_class %}class="col-sm-2 control-label"{% endif %}>
+                                            {{ field }} <span>{{ field.label }}{% if field.field.required %}
+                                            <sup>*</sup>{% endif %}</span>
+                                        </label>
+                                    {% endif %}
+                                    {% if field.help_text %}
+                                        <i class="fa-solid fa-circle-question has-popover" data-trigger="hover"
+                                           data-content="{{ field.help_text }}" data-placement="right"
+                                           data-container="body">
+                                        </i>
+                                    {% endif %}
+                                    {% for error in field.errors %}
+                                        <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+                                    {% endfor %}
+
+                                </div>
+                            </div>
+                        {% elif field|is_radio %}
+                            {% if field.auto_id %}
+                                <label class="col-sm-2 control-label
+                        {% if field.field.required %}{{ form.required_css_class }}{% endif %}">
+                                    {{ field.label }}{% if field.field.required %}<sup>*</sup>{% endif %}</label>
+                            {% endif %}
+                            <div class="col-sm-10 {{ classes.value }}">
+                                {% for choice in field %}
+                                    <div class="radio">
+                                        <label>
+                                            {{ choice.tag }}
+                                            {{ choice.choice_label }}
+                                        </label>
+                                    </div>
+                                {% endfor %}
+
+                                {% for error in field.errors %}
+                                    <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+                                {% endfor %}
+
+                                {% if field.help_text %}
+                                    <i class="fa-solid fa-circle-question has-popover" data-trigger="hover"
+                                       data-content="{{ field.help_text }}" data-placement="right"
+                                       data-container="body">
+                                    </i>
+                                {% endif %}
+                            </div>
+                        {% else %}
+                            {% if field.auto_id %}
+                                <label class="col-sm-2 control-label
+                        {% if field.field.required %}{{ form.required_css_class }}{% endif %}"
+                                       for="{{ field.auto_id }}">
+                                    {{ field.label }}{% if field.field.required %}<sup>*</sup>{% endif %}
+                                    {% if field.help_text %}
+                                        <i class="fa-solid fa-circle-question has-popover" data-trigger="hover"
+                                           data-content="{{ field.help_text }}" data-placement="right"
+                                           data-container="body">
+                                        </i>
+                                    {% endif %}
+                                </label>
+                            {% endif %}
+                            <div
+                              class="col-sm-10 {{ classes.value }} {% if field|is_multiple_checkbox %}multiple-checkbox{% endif %}">
+                                {{ field|addcss:"class:form-control" }}
+                                <p
+                                  style="width: 70%; font-style: italic; margin-bottom: 0px;">{{ field.field.widget.attrs.message }}</p>
+                                {% for error in field.errors %}
+                                    <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </div>
+                {% endif %}
+            {% endfor %}
+        </div>
+        <hr>
+    {% endif %}
+{% endfor %}

--- a/dojo/templates/dojo/system_settings.html
+++ b/dojo/templates/dojo/system_settings.html
@@ -29,17 +29,14 @@
             </div>
 </div>
 <hr>
-    <div class="row">
-    <h3> System Settings </h3>
-   <form class="form-horizontal" method="post">{% csrf_token %}
-        {% include "dojo/form_fields.html" with form=form %}
-        <div class="form-group">
-            <div class="col-sm-offset-2 col-sm-10">
-                <input class="btn btn-primary" type="submit" name="edit_settings" value="Submit"/>
-            </div>
+<form class="form-horizontal" method="post">{% csrf_token %}
+    {% include "dojo/form_fields_with_sections.html" with form=form sections=sections %}
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+            <input class="btn btn-primary" type="submit" name="edit_settings" value="Submit"/>
         </div>
-    </form>
     </div>
+</form>
 {% endblock %}
 {comment}
 Django forms are very rigid so without crispy-forms we're forced to use javascript to add some flavour...
@@ -65,12 +62,12 @@ Django forms are very rigid so without crispy-forms we're forced to use javascri
         $(function () {
             var jira_url = $('<span style="display: inline-block;height: 34px;padding-top: 7px;">'+ absolutePath('/jira/webhook/') + '</span>')
             $(jira_url).css('padding-right', '1px')
-            $(jira_url).parent().height('34px')            
+            $(jira_url).parent().height('34px')
             $('#id_jira_webhook_secret').before(jira_url);
 
             var generate_secret = $('<i id="id_generate_secret" class="fa-solid fa-arrows-rotate has-popover" data-trigger="hover" data-content="Click to generate a new secret" data-placement="right" data-container="body" data-original-title="" title=""></i>')
             $('#id_jira_webhook_secret').css('display', 'inline-block');
-            $('#id_jira_webhook_secret').width('25%')            
+            $('#id_jira_webhook_secret').width('25%')
             $('#id_jira_webhook_secret').after(generate_secret);
             $(generate_secret).css('padding-left', '5px')
             $(generate_secret).popover()


### PR DESCRIPTION
[sc-4957]

The idea is to define an array of sections with a list of fields belonging to each section. If a field doesn't belong to any section, it will be added to the "Other" section automatically. Thus, in case a new setting is added in the SystemSettings model/form, the section list will not need to be updated to show the new field.

Finally, this PR adds a new Django template to iterate over the sections and render all their fields, preserving their actual functionality.
