### PR TITLE
fix(Qualys parser): wrong handling enable_weakness

### DIFF
--- a/dojo/tools/qualys_webapp/parser.py
+++ b/dojo/tools/qualys_webapp/parser.py
@@ -355,7 +355,7 @@ def get_unique_items(
         if qid in g_qid_list:
             index = g_qid_list.index(qid)
             findings[unique_id] = get_glossary_item(
-                glossary[index], finding, enable_weakness
+                glossary[index], finding, enable_weakness=enable_weakness
             )
     for unique_id, finding in get_unique_vulnerabilities(
         info_gathered, test, True, is_app_report
@@ -364,7 +364,7 @@ def get_unique_items(
         if qid in g_qid_list:
             index = g_qid_list.index(qid)
             finding = get_glossary_item(
-                glossary[index], finding, True, enable_weakness
+                glossary[index], finding, True, enable_weakness=enable_weakness
             )
         if qid in ig_qid_list:
             index = ig_qid_list.index(qid)
@@ -393,7 +393,7 @@ def get_items(
         if qid in g_qid_list:
             index = g_qid_list.index(qid)
             findings[qid] = get_glossary_item(
-                glossary[index], finding, enable_weakness
+                glossary[index], finding, enable_weakness=enable_weakness
             )
     for qid, finding in get_vulnerabilities(
         info_gathered, test, True, is_app_report
@@ -401,7 +401,7 @@ def get_items(
         if qid in g_qid_list:
             index = g_qid_list.index(qid)
             finding = get_glossary_item(
-                glossary[index], finding, True, enable_weakness
+                glossary[index], finding, True, enable_weakness=enable_weakness
             )
         if qid in ig_qid_list:
             index = ig_qid_list.index(qid)

--- a/unittests/tools/test_qualys_webapp_parser.py
+++ b/unittests/tools/test_qualys_webapp_parser.py
@@ -54,6 +54,6 @@ class TestQualysWebAppParser(DojoTestCase):
         for finding in findings:
             for endpoint in finding.unsaved_endpoints:
                 endpoint.clean()
-        # 18 non-info findings, 21 total
-        self.assertEqual(18, len([x for x in findings if x.severity != "Info"]))
+        # 21 non-info findings, 21 total
+        self.assertEqual(21, len([x for x in findings if x.severity != "Info"]))
         self.assertEqual(21, len(findings))


### PR DESCRIPTION
This PR fixes the wrong passing of parameter `enable_weakness` in the Qualys Webapp parser.

It was identified during the preparation of https://github.com/DefectDojo/django-DefectDojo/pull/10085

@iwalton3, I noticed, you have been implementing this functionality in https://github.com/DefectDojo/django-DefectDojo/pull/3427. Can you confirm, that it was a bug and that this is the correct behavior?

Problematic are lines 358 and 396 where `enable_weakness` is passed into `is_info`, not into `enable_weakness`