### PR TITLE
msdefender: migrate cve to unsaved_vulnerability_ids

### DIFF
--- a/dojo/tools/ms_defender/parser.py
+++ b/dojo/tools/ms_defender/parser.py
@@ -80,7 +80,8 @@ class MSDefenderParser(object):
         if vulnerability['fixingKbId'] is not None:
             finding.mitigation = vulnerability['fixingKbId']
         if vulnerability['cveId'] is not None:
-            finding.cve = vulnerability['cveId']
+            finding.unsaved_vulnerability_ids = list()
+            finding.unsaved_vulnerability_ids.append(vulnerability['cveId'])
         self.findings.append(finding)
         finding.unsaved_endpoints = list()
 
@@ -130,7 +131,8 @@ class MSDefenderParser(object):
         if vulnerability['fixingKbId'] is not None:
             finding.mitigation = vulnerability['fixingKbId']
         if vulnerability['cveId'] is not None:
-            finding.cve = vulnerability['cveId']
+            finding.unsaved_vulnerability_ids = list()
+            finding.unsaved_vulnerability_ids.append(vulnerability['cveId'])
         self.findings.append(finding)
         finding.unsaved_endpoints = list()
         if machine['computerDnsName'] is not None:

--- a/unittests/tools/test_ms_defender_parser.py
+++ b/unittests/tools/test_ms_defender_parser.py
@@ -3,7 +3,7 @@ from dojo.tools.ms_defender.parser import MSDefenderParser
 from dojo.models import Test
 
 
-class TestSDefenderParser(DojoTestCase):
+class TestMSDefenderParser(DojoTestCase):
 
     def test_parse_many_findings(self):
         testfile = open("unittests/scans/ms_defender/report_many_vulns.json")
@@ -24,7 +24,7 @@ class TestSDefenderParser(DojoTestCase):
         finding = findings[0]
         self.assertEqual("Low", finding.severity)
         self.assertEqual("CVE-1234-5678_fjweoifjewiofjweoifjeowifjowei", finding.title)
-        self.assertEqual("CVE-1234-5678", finding.cve)
+        self.assertEqual("CVE-1234-5678", finding.unsaved_vulnerability_ids[0])
 
     def test_parse_no_finding(self):
         testfile = open("unittests/scans/ms_defender/report_no_vuln.json")


### PR DESCRIPTION
This PR removes cve from msdefender and migrates to unsaved_vulnerability_ids. See https://github.com/DefectDojo/django-DefectDojo/pull/9791#pullrequestreview-1958009612