### PR TITLE
feat(user): Show date of user creation

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -424,6 +424,7 @@ class ProductMetaSerializer(serializers.ModelSerializer):
 
 
 class UserSerializer(serializers.ModelSerializer):
+    date_joined = serializers.DateTimeField(read_only=True)
     last_login = serializers.DateTimeField(read_only=True)
     password = serializers.CharField(
         write_only=True,
@@ -449,6 +450,7 @@ class UserSerializer(serializers.ModelSerializer):
             "first_name",
             "last_name",
             "email",
+            "date_joined",
             "last_login",
             "is_active",
             "is_superuser",

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2974,6 +2974,7 @@ class UserFilter(DojoFilter):
             ('email', 'email'),
             ('is_active', 'is_active'),
             ('is_superuser', 'is_superuser'),
+            ('date_joined', 'date_joined'),
             ('last_login', 'last_login'),
         ),
         field_labels={

--- a/dojo/templates/dojo/users.html
+++ b/dojo/templates/dojo/users.html
@@ -67,6 +67,7 @@
                                     {% comment %} The display field is translated in the function. No need to translate here as well{% endcomment %}
                                     <th class="nowrap, text-center">{% dojo_sort request superuser 'is_superuser' %}</th>
                                     <th class="nowrap">{% trans "Global Role" %}</th>
+                                    <th class="nowrap">{% trans "Date Joined" %}</th>
                                     <th class="nowrap">{% trans "Last Login" %}</th>
                                     {% block users_table_extra_header_rows %}
                                     {% endblock users_table_extra_header_rows %}
@@ -124,6 +125,7 @@
                                             <i class="text-success fa-solid fa-check"></i>{% else %}
                                             <i class="text-danger fa-solid fa-xmark"></i>{% endif %}</td>
                                         <td>{% if u.global_role.role %} {{ u.global_role.role }} {% endif %}</td>
+                                        <td>{{ u.date_joined }}</td>
                                         <td>{% if u.last_login %}{{ u.last_login }}{% else %}{% trans "Never" %}{% endif %}</td>
                                         {% block users_table_extra_data_rows %}
                                         {% endblock users_table_extra_data_rows %}

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -367,6 +367,10 @@
                             <td>{% if user.global_role.role %} {{ user.global_role.role }} {% endif %}</td>
                         </tr>
                         <tr>
+                            <td style="width: 200px;"><strong>{% trans "Date Joined" %}</strong></td>
+                            <td>{{ user.date_joined }}</td>
+                        </tr>
+                        <tr>
                             <td style="width: 200px;"><strong>{% trans "Last Login" %}</strong></td>
                             <td>{% if user.last_login %} {{ user.last_login }} {% else %} {% trans "Never" %} {% endif %}</td>
                         </tr>


### PR DESCRIPTION
I bumped into a situation when we were investigating when the user was created. I found it useful to add it to some of the views. Before it was only in the user's personal profile.
Now, it is in
- API response
- List of users
- It is useable for sorting
- User's profile (available by admins)


![Screenshot 2024-05-06 at 13 44 01](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/40ee1a1b-7b12-405e-af1d-577683b580c6)
![Screenshot 2024-05-06 at 13 43 17](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/c71ee9ee-5f0a-48d5-99ea-dddd55ea050c)
![Screenshot 2024-05-06 at 13 42 59](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/022a7c5b-c2af-43d4-b072-516752718677)
![Screenshot 2024-05-06 at 13 38 00](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/00773b93-a5cb-4468-8807-cfbe010f4104)
