### PR TITLE
switch to mysql 8.4.0 which has support both intel and applie silicon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
   mysql:
-    image: mysql:5.7.44@sha256:4bc6bc963e6d8443453676cae56536f4b8156d78bae03c0145cbe47c2aad73bb
+    image: mysql:8.4.0
     profiles:
       - mysql-rabbitmq
       - mysql-redis


### PR DESCRIPTION

**Description**
This PR allows doing a POC of DefectDojo on an Apple Silicon laptop.

Running "dc-up.sh mysql-redis" or "dc-up.sh mysql-rabbitmq" on an apple silicon cpu will display the following error
```
✖  ./dc-up.sh mysql-redis
Checking docker compose version
Supported docker compose version
Starting docker compose with profile mysql-redis in the foreground ...
[+] Running 0/1
 ⠼ mysql Pulling                                                                                                                                                    1.3s
no matching manifest for linux/arm64/v8 in the manifest list entries
```

However running "dc-up.sh postgres-redis" and "dc-up.sh postgres-rabbitmq" on apple silicon cpu works fine.

mysql5.7 docker hub page that shows only one platform is supported
https://hub.docker.com/_/mysql/tags?page=&page_size=&ordering=&name=5.7

mysql8.4 docker hub page that show both platforms are supported
https://hub.docker.com/_/mysql/tags?page=&page_size=&ordering=&name=8.4

**Test results**
Ran both "dc-up.sh mysql-redis" or "dc-up.sh mysql-rabbitmq" and verify the containers are up and able to login through the GUI


