### PR TITLE
Setting status code on 400/500 errors

### DIFF
--- a/dojo/views.py
+++ b/dojo/views.py
@@ -27,11 +27,11 @@ logger = logging.getLogger(__name__)
 
 
 def custom_error_view(request, exception=None):
-    return render(request, "500.html", {})
+    return render(request, "500.html", {}, status=500)
 
 
 def custom_bad_request_view(request, exception=None):
-    return render(request, "400.html", {})
+    return render(request, "400.html", {}, status=400)
 
 
 def action_history(request, cid, oid):


### PR DESCRIPTION
**Description**

Because DefectDojo uses a custom error handler for 400/500 errors that does not set a status code, 200 status codes will be returned even when an exception is raised. This means that Django logs those exceptions at the INFO level rather than a more appropriate `WARNING` / `ERROR` level. This patch simply sets the status codes to 400/500.

**Test results**

In my testing, 500 status codes are now returned when exceptions are raised, and those requests are now logged at an `ERROR` level.

[sc-5912]