### PR TITLE
:bug: fix sonarqube missing CWE for deduplication

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1186,7 +1186,7 @@ HASHCODE_FIELDS_PER_SCANNER = {
     'Checkmarx Scan': ['cwe', 'severity', 'file_path'],
     'Checkmarx OSA': ['vulnerability_ids', 'component_name'],
     'Cloudsploit Scan': ['title', 'description'],
-    'SonarQube Scan': ['cwe', 'severity', 'file_path'],
+    'SonarQube Scan': ['severity', 'file_path', 'vuln_id_from_tool'],
     'SonarQube API Import': ['title', 'file_path', 'line'],
     'Sonatype Application Scan': ['title', 'cwe', 'file_path', 'component_name', 'component_version', 'vulnerability_ids'],
     'Dependency Check Scan': ['title', 'cwe', 'file_path'],

--- a/dojo/tools/sonarqube/sonarqube_restapi_json.py
+++ b/dojo/tools/sonarqube/sonarqube_restapi_json.py
@@ -55,7 +55,7 @@ class SonarQubeRESTAPIJSON:
                         tags=tags,
                     )
                     if line != "None":
-                        item.line=line
+                        item.line = line
                 elif issue.get("type") == "VULNERABILITY":
                     key = issue.get("key")
                     rule = issue.get("rule")
@@ -126,7 +126,7 @@ class SonarQubeRESTAPIJSON:
                         tags=tags,
                     )
                     if line != "None":
-                        item.line=line
+                        item.line = line
                     vulnids = []
                     if "Reference: CVE" in message:
                         cve_pattern = r'Reference: CVE-\d{4}-\d{4,7}'
@@ -198,7 +198,7 @@ class SonarQubeRESTAPIJSON:
                         tags=tags,
                     )
                     if line != "None":
-                        item.line=line
+                        item.line = line
                 items.append(item)
         if json_content.get("hotspots"):
             for hotspot in json_content.get("hotspots"):
@@ -243,7 +243,7 @@ class SonarQubeRESTAPIJSON:
                     tags=["hotspot"],
                 )
                 if line != "None":
-                    item.line=line
+                    item.line = line
                 items.append(item)
         return items
 

--- a/unittests/tools/test_sonarqube_parser.py
+++ b/unittests/tools/test_sonarqube_parser.py
@@ -579,11 +579,14 @@ class TestSonarQubeParser(DojoTestCase):
         self.assertEqual("6.4", item.cvssv3_score)
         self.assertEqual("package", item.component_name)
         self.assertEqual("1.1.2", item.component_version)
+        self.assertEqual(["cve", "cwe", "cwe-937", "owasp-a9", "vulnerability"], item.tags)
         item = findings[1]
         self.assertEqual("Web:TableWithoutCaptionCheck_asdfwfewfwefewf", item.title)
         self.assertEqual("Low", item.severity)
         self.assertEqual(0, item.cwe)
         self.assertIsNone(item.cvssv3_score)
+        self.assertEqual(59, int(item.line))
+        self.assertEqual("testapplication:src/app/pages/fjiowefjewio/fjwieof/fjiwoe/details.html", item.file_path)
         item = findings[2]
         self.assertEqual("typescript:S1533_fjoiewfjoweifjoihugu-", item.title)
         self.assertEqual("Low", item.severity)


### PR DESCRIPTION
During the import of Sonarqube findings I got aware of an issue related with the deduplication on the parser. For some kind of findings a cwe is not provided but is mandatory for the deduplication algorithm by settings.dist.py. The deduplication then falls back to the legacy dedupe hash model and the import takes longer than usual.
```
defectdojo-uwsgi-1  | [10/May/2024 07:38:28] WARNING [dojo.specific-loggers.deduplication:2746] Cannot compute hash_code based on configured fields because cwe is 0 for finding of title 'java:S3415_AYK2F0bHUOabgueBfBvD' found in file 'None'. Fallback to legacy mode for this finding.
```
I removed the cwe from the dedupe hash code and added other suitable values by extending the parser.