### PR TITLE
Object File Uploads: Add validations and download functionality

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import re
 from datetime import datetime
 from typing import List
@@ -796,6 +797,24 @@ class FileSerializer(serializers.ModelSerializer):
     class Meta:
         model = FileUpload
         fields = "__all__"
+
+    def validate(self, data):
+        if file := data.get("file"):
+            ext = os.path.splitext(file.name)[1]  # [0] returns path+filename
+            valid_extensions = settings.FILE_UPLOAD_TYPES
+            if ext.lower() not in valid_extensions:
+                if accepted_extensions := f"{', '.join(valid_extensions)}":
+                    msg = (
+                        "Unsupported extension. Supported extensions are as "
+                        f"follows: {accepted_extensions}"
+                    )
+                else:
+                    msg = (
+                        "File uploads are prohibited due to the list of acceptable "
+                        "file extensions being empty"
+                    )
+                raise ValidationError(msg)
+            return data
 
 
 class RawFileSerializer(serializers.ModelSerializer):

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -850,13 +850,22 @@ class BaseManageFileFormSet(forms.BaseModelFormSet):
             # Don't bother validating the formset unless each form is valid on its own
             return
         for form in self.forms:
-            print(dir(form))
             file = form.cleaned_data.get('file', None)
             if file:
                 ext = os.path.splitext(file.name)[1]  # [0] returns path+filename
                 valid_extensions = settings.FILE_UPLOAD_TYPES
                 if ext.lower() not in valid_extensions:
-                    form.add_error('file', 'Unsupported file extension.')
+                    if accepted_extensions := f"{', '.join(valid_extensions)}":
+                        msg = (
+                            "Unsupported extension. Supported extensions are as "
+                            f"follows: {accepted_extensions}"
+                        )
+                    else:
+                        msg = (
+                            "File uploads are prohibited due to the list of acceptable "
+                            "file extensions being empty"
+                        )
+                    form.add_error('file', msg)
 
 
 ManageFileFormSet = modelformset_factory(FileUpload, extra=3, max_num=10, fields=['title', 'file'], can_delete=True, formset=BaseManageFileFormSet)

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -691,7 +691,7 @@
                                 <div class="col-md-2" style="text-align: center">
                                     <div class="row">
                                         {% url 'access_file' fid=file.id oid=eng.id obj_type='Engagement' as image_url %}
-                                        <a href="{{ image_url }}" target="_blank">
+                                        <a href="{{ image_url }}" target="_blank" download>
                                             {% if file|get_thumbnail %}
                                                 <img src="{{ image_url }}" alt="thumbnail" style="width:150px">
                                             {% else %}

--- a/dojo/templates/dojo/view_finding.html
+++ b/dojo/templates/dojo/view_finding.html
@@ -943,7 +943,7 @@
                             <div class="col-md-2" style="text-align: center">
                                 <div class="row">
                                     {% url 'access_file' fid=file.id oid=finding.id obj_type='Finding' as image_url %}
-                                    <a href="{{ image_url }}" target="_blank">
+                                    <a href="{{ image_url }}" target="_blank" download>
                                         {% if file|get_thumbnail %}
                                             <img src="{{ image_url }}" alt="thumbnail" style="width:150px">
                                         {% else %}

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1551,7 +1551,7 @@
                         <div class="col-md-2" style="text-align: center">
                             <div class="row">
                                 {% url 'access_file' fid=file.id oid=test.id obj_type='Test' as image_url %}
-                                <a href="{{ image_url }}" target="_blank">
+                                <a href="{{ image_url }}" target="_blank" download>
                                     {% if file|get_thumbnail %}
                                         <img src="{{ image_url }}" alt="thumbnail" style="width:150px">
                                     {% else %}


### PR DESCRIPTION
When using the API to upload files, it was noticed that `FILE_UPLOAD_TYPES` settings was not being enforced. This PR adds enforcement of this setting. Additionally, these files should be downloaded to disk rather than being rendered by the browser

[sc-5953]