### PR TITLE
Fix(api-sq): Doc: typo in multi branch scanning

### DIFF
--- a/docs/content/en/integrations/parsers/api/sonarqube.md
+++ b/docs/content/en/integrations/parsers/api/sonarqube.md
@@ -37,7 +37,7 @@ only one defined or the SonarQube `Tool Configuration` if there is only one.
 ## Multi Branch Scanning
 
 If using a version of SonarQube with multi branch scanning, the branch tha be scanned can
-be supplied in the `branch tag` fieild at import/re-import time. If the branch does not exist,
+be supplied in the `branch_tag` fieild at import/re-import time. If the branch does not exist,
 a notification will be generated in the alerts table indicating that branch to be imported
 does not exist. If a branch name is not supplied during import/re-import, the default branch
 of the SonarQube project will be used.


### PR DESCRIPTION
Typo in documentation mentioned in Slack: https://owasp.slack.com/archives/C2P5BA8MN/p1715589858425459?thread_ts=1715347782.044819&cid=C2P5BA8MN