### PR TITLE
fix for multi vuln ids when reimporting scans

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -650,7 +650,8 @@ def save_vulnerability_ids(finding, vulnerability_ids):
     Vulnerability_Id.objects.filter(finding=finding).delete()
 
     # Save new vulnerability ids
-    Vulnerability_Id.objects.bulk_create([Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id) for vulnerability_id in finding.unsaved_vulnerability_ids])
+    if finding.unsaved_vulnerability_ids:
+        Vulnerability_Id.objects.bulk_create([Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id) for vulnerability_id in finding.unsaved_vulnerability_ids])
 
     # Set CVE
     if vulnerability_ids:

--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -650,8 +650,7 @@ def save_vulnerability_ids(finding, vulnerability_ids):
     Vulnerability_Id.objects.filter(finding=finding).delete()
 
     # Save new vulnerability ids
-    for vulnerability_id in vulnerability_ids:
-        Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id).save()
+    Vulnerability_Id.objects.bulk_create([Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id) for vulnerability_id in finding.unsaved_vulnerability_ids])
 
     # Set CVE
     if vulnerability_ids:

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -38,6 +38,8 @@ from dojo.models import (
     Test_Import_Finding_Action,
     Test_Type,
     Tool_Configuration,
+    # noqa: F401
+    Vulnerability_Id,
 )
 from dojo.tools.factory import get_parser
 from dojo.utils import get_current_user, is_finding_groups_enabled, max_safe

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -880,12 +880,12 @@ class BaseImporter(ABC, DefaultReImporterEndpointManager):
         if finding.unsaved_vulnerability_ids:
             # Remove duplicates
             finding.unsaved_vulnerability_ids = list(dict.fromkeys(finding.unsaved_vulnerability_ids))
-            # Add all vulnerability ids to the database
+            # Remove old vulnerability ids
+            Vulnerability_Id.objects.filter(finding=finding).delete()
+
+            # Save new vulnerability ids
             for vulnerability_id in finding.unsaved_vulnerability_ids:
-                Vulnerability_Id(
-                    vulnerability_id=vulnerability_id,
-                    finding=finding,
-                ).save()
+                Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id).save()
 
         return finding
 

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -864,29 +864,8 @@ class BaseImporter(ABC, DefaultReImporterEndpointManager):
         Parse the `unsaved_vulnerability_ids` field from findings after they are parsed
         to create `Vulnerability_Id` objects with the finding associated correctly
         """
-        # Synchronize the cve field with the unsaved_vulnerability_ids
-        # We do this to be as flexible as possible to handle the fields until
-        # the cve field is not needed anymore and can be removed.
-        if finding.unsaved_vulnerability_ids and finding.cve:
-            # Make sure the first entry of the list is the value of the cve field
-            finding.unsaved_vulnerability_ids.insert(0, finding.cve)
-        elif finding.unsaved_vulnerability_ids and not finding.cve:
-            # If the cve field is not set, use the first entry of the list to set it
-            finding.cve = finding.unsaved_vulnerability_ids[0]
-        elif not finding.unsaved_vulnerability_ids and finding.cve:
-            # If there is no list, make one with the value of the cve field
-            finding.unsaved_vulnerability_ids = [finding.cve]
-
         if finding.unsaved_vulnerability_ids:
-            # Remove duplicates
-            finding.unsaved_vulnerability_ids = list(dict.fromkeys(finding.unsaved_vulnerability_ids))
-            # Remove old vulnerability ids
-            Vulnerability_Id.objects.filter(finding=finding).delete()
-
-            # Save new vulnerability ids
-            # for vulnerability_id in finding.unsaved_vulnerability_ids:
-            #     Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id).save()
-            Vulnerability_Id.objects. bulk_create([Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id) for vulnerability_id in finding.unsaved_vulnerability_ids])
+            finding_helper.save_vulnerability_ids(finding, finding.unsaved_vulnerability_ids)
 
         return finding
 

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -864,6 +864,7 @@ class BaseImporter(ABC, DefaultReImporterEndpointManager):
         Parse the `unsaved_vulnerability_ids` field from findings after they are parsed
         to create `Vulnerability_Id` objects with the finding associated correctly
         """
+
         if finding.unsaved_vulnerability_ids:
             finding_helper.save_vulnerability_ids(finding, finding.unsaved_vulnerability_ids)
 

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -884,8 +884,9 @@ class BaseImporter(ABC, DefaultReImporterEndpointManager):
             Vulnerability_Id.objects.filter(finding=finding).delete()
 
             # Save new vulnerability ids
-            for vulnerability_id in finding.unsaved_vulnerability_ids:
-                Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id).save()
+            # for vulnerability_id in finding.unsaved_vulnerability_ids:
+            #     Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id).save()
+            Vulnerability_Id.objects. bulk_create([Vulnerability_Id(finding=finding, vulnerability_id=vulnerability_id) for vulnerability_id in finding.unsaved_vulnerability_ids])
 
         return finding
 

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -38,7 +38,6 @@ from dojo.models import (
     Test_Import_Finding_Action,
     Test_Type,
     Tool_Configuration,
-    Vulnerability_Id,
 )
 from dojo.tools.factory import get_parser
 from dojo.utils import get_current_user, is_finding_groups_enabled, max_safe

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -38,8 +38,7 @@ from dojo.models import (
     Test_Import_Finding_Action,
     Test_Type,
     Tool_Configuration,
-    # noqa: F401
-    Vulnerability_Id,
+    Vulnerability_Id,  # noqa: F401
 )
 from dojo.tools.factory import get_parser
 from dojo.utils import get_current_user, is_finding_groups_enabled, max_safe

--- a/unittests/test_finding_helper.py
+++ b/unittests/test_finding_helper.py
@@ -228,7 +228,6 @@ class TestSaveVulnerabilityIds(DojoTestCase):
 
         filter_mock.assert_called_with(finding=finding)
         delete_mock.assert_called_once()
-        self.assertEqual(save_mock.call_count, 2)
         self.assertEqual('REF-1', finding.cve)
 
     @patch('dojo.finding.helper.Vulnerability_Id_Template.objects.filter')
@@ -243,5 +242,4 @@ class TestSaveVulnerabilityIds(DojoTestCase):
 
         filter_mock.assert_called_with(finding_template=finding_template)
         delete_mock.assert_called_once()
-        self.assertEqual(save_mock.call_count, 2)
         self.assertEqual('REF-1', finding_template.cve)

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -7,7 +7,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
 from dojo.importers.default_importer import DefaultImporter
-from dojo.models import Development_Environment, Engagement, Finding, Product, Product_Type, Test, User
+from dojo.models import Development_Environment, Engagement, Finding, Product, Product_Type, Test, Test_Type, User
 from dojo.tools.gitlab_sast.parser import GitlabSastParser
 from dojo.tools.sarif.parser import SarifParser
 from dojo.utils import get_object_or_none
@@ -517,62 +517,81 @@ class FlexibleReimportTestAPI(DojoAPITestCase):
 
 
 class TestImporterUtils(DojoAPITestCase):
+
+    def setUp(self):
+        self.testuser, _ = User.objects.get_or_create(username="admin", is_superuser=True)
+        token, _ = Token.objects.get_or_create(user=self.testuser)
+        self.client = APIClient(raise_request_exception=True)
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token.key)
+        self.client.force_authenticate(user=self.testuser, token=token)
+        self.create_default_data()
+
+    def create_default_data(self):
+        # creating is much faster compare to using a fixture
+        logger.debug('creating default product + engagement')
+        Development_Environment.objects.get_or_create(name='Development')
+        self.product_type = self.create_product_type(PRODUCT_TYPE_NAME_DEFAULT)
+        self.product = self.create_product(PRODUCT_NAME_DEFAULT)
+        self.engagement = self.create_engagement(ENGAGEMENT_NAME_DEFAULT, product=self.product)
+        self.test = self.create_test(engagement=self.engagement, scan_type=NPM_AUDIT_SCAN_TYPE, title=TEST_TITLE_DEFAULT)        
+        self.test_last_by_title = self.create_test(engagement=self.engagement, scan_type=NPM_AUDIT_SCAN_TYPE, title=TEST_TITLE_DEFAULT)
+        self.test_with_title = self.create_test(engagement=self.engagement, scan_type=NPM_AUDIT_SCAN_TYPE, title=TEST_TITLE_ALTERNATE)
+        self.test_last_by_scan_type = self.create_test(engagement=self.engagement, scan_type=NPM_AUDIT_SCAN_TYPE)
+
     @patch('dojo.importers.base_importer.Vulnerability_Id', autospec=True)
     def test_handle_vulnerability_ids_references_and_cve(self, mock):
+        # Why doesn't this test use the test db and query for one?
+        vulnerability_ids = ['CVE', 'REF-1', 'REF-2']
         finding = Finding()
-        finding.cve = 'CVE'
-        finding.unsaved_vulnerability_ids = ['REF-1', 'REF-2']
-
+        finding.unsaved_vulnerability_ids = vulnerability_ids
+        finding.test = self.test
+        finding.reporter = self.testuser
+        finding.save()
         DefaultImporter().process_vulnerability_ids(finding)
 
-        vulnerability_ids = ['CVE', 'REF-1', 'REF-2']
-
-        self.assertEqual(6, len(mock.mock_calls))
-        self.assertEqual('CVE', mock.mock_calls[2].kwargs['vulnerability_id'])
-        self.assertEqual('CVE', mock.mock_calls[2].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[0].kwargs['finding'].unsaved_vulnerability_ids)
-        self.assertEqual('REF-1', mock.mock_calls[3].kwargs['vulnerability_id'])
-        self.assertEqual('CVE', mock.mock_calls[3].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
-        self.assertEqual('REF-2', mock.mock_calls[4].kwargs['vulnerability_id'])
-        self.assertEqual('CVE', mock.mock_calls[4].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
+        self.assertEqual('CVE', finding.vulnerability_ids[0])
+        self.assertEqual('CVE', finding.cve)
+        self.assertEqual(vulnerability_ids, finding.unsaved_vulnerability_ids)
+        self.assertEqual('REF-1', finding.vulnerability_ids[1])
+        self.assertEqual('REF-2', finding.vulnerability_ids[2])
 
     @patch('dojo.importers.base_importer.Vulnerability_Id', autospec=True)
     def test_handle_no_vulnerability_ids_references_and_cve(self, mock):
+        vulnerability_ids = ['CVE']
         finding = Finding()
-        finding.cve = 'CVE'
+        finding.test = self.test
+        finding.reporter = self.testuser
+        finding.save()
+        finding.unsaved_vulnerability_ids = vulnerability_ids
 
         DefaultImporter().process_vulnerability_ids(finding)
 
-        vulnerability_ids = ['CVE']
-
-        self.assertEqual(4, len(mock.mock_calls))
-        self.assertEqual('CVE', mock.mock_calls[2].kwargs['vulnerability_id'])
-        self.assertEqual('CVE', mock.mock_calls[2].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[0].kwargs['finding'].unsaved_vulnerability_ids)
+        self.assertEqual('CVE', finding.vulnerability_ids[0])
+        self.assertEqual('CVE', finding.cve)
+        self.assertEqual(vulnerability_ids, finding.unsaved_vulnerability_ids)
 
     @patch('dojo.importers.base_importer.Vulnerability_Id', autospec=True)
     def test_handle_vulnerability_ids_references_and_no_cve(self, mock):
+        vulnerability_ids = ['REF-1', 'REF-2']
         finding = Finding()
-        finding.unsaved_vulnerability_ids = ['REF-1', 'REF-2']
-
+        finding.test = self.test
+        finding.reporter = self.testuser
+        finding.save()
+        finding.unsaved_vulnerability_ids = vulnerability_ids
         DefaultImporter().process_vulnerability_ids(finding)
 
-        vulnerability_ids = ['REF-1', 'REF-2']
-
-        self.assertEqual(5, len(mock.mock_calls))
-        self.assertEqual('REF-1', mock.mock_calls[2].kwargs['vulnerability_id'])
-        self.assertEqual('REF-1', mock.mock_calls[2].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
-        self.assertEqual('REF-2', mock.mock_calls[3].kwargs['vulnerability_id'])
-        self.assertEqual('REF-1', mock.mock_calls[3].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
+        self.assertEqual('REF-1', finding.vulnerability_ids[0])
+        self.assertEqual('REF-1', finding.cve)
+        self.assertEqual(vulnerability_ids, finding.unsaved_vulnerability_ids)
+        self.assertEqual('REF-2', finding.vulnerability_ids[1])
 
     @patch('dojo.importers.base_importer.Vulnerability_Id', autospec=True)
     def test_no_handle_vulnerability_ids_references_and_no_cve(self, mock):
         finding = Finding()
-
+        finding.test = self.test
+        finding.reporter = self.testuser
+        finding.save()
         DefaultImporter().process_vulnerability_ids(finding)
-
-        mock.assert_not_called()
+        self.assertEqual(finding.cve, None)
+        self.assertEqual(finding.unsaved_vulnerability_ids, None)
+        self.assertEqual(finding.vulnerability_ids, [])

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -528,11 +528,11 @@ class TestImporterUtils(DojoAPITestCase):
         vulnerability_ids = ['CVE', 'REF-1', 'REF-2']
 
         self.assertEqual(6, len(mock.mock_calls))
-        self.assertEqual('CVE', mock.mock_calls[0].kwargs['vulnerability_id'])
-        self.assertEqual('CVE', mock.mock_calls[0].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[0].kwargs['finding'].unsaved_vulnerability_ids)
-        self.assertEqual('REF-1', mock.mock_calls[2].kwargs['vulnerability_id'])
+        self.assertEqual('CVE', mock.mock_calls[2].kwargs['vulnerability_id'])
         self.assertEqual('CVE', mock.mock_calls[2].kwargs['finding'].cve)
+        self.assertEqual(vulnerability_ids, mock.mock_calls[0].kwargs['finding'].unsaved_vulnerability_ids)
+        self.assertEqual('REF-1', mock.mock_calls[3].kwargs['vulnerability_id'])
+        self.assertEqual('CVE', mock.mock_calls[3].kwargs['finding'].cve)
         self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
         self.assertEqual('REF-2', mock.mock_calls[4].kwargs['vulnerability_id'])
         self.assertEqual('CVE', mock.mock_calls[4].kwargs['finding'].cve)
@@ -547,9 +547,9 @@ class TestImporterUtils(DojoAPITestCase):
 
         vulnerability_ids = ['CVE']
 
-        self.assertEqual(2, len(mock.mock_calls))
-        self.assertEqual('CVE', mock.mock_calls[0].kwargs['vulnerability_id'])
-        self.assertEqual('CVE', mock.mock_calls[0].kwargs['finding'].cve)
+        self.assertEqual(4, len(mock.mock_calls))
+        self.assertEqual('CVE', mock.mock_calls[2].kwargs['vulnerability_id'])
+        self.assertEqual('CVE', mock.mock_calls[2].kwargs['finding'].cve)
         self.assertEqual(vulnerability_ids, mock.mock_calls[0].kwargs['finding'].unsaved_vulnerability_ids)
 
     @patch('dojo.importers.base_importer.Vulnerability_Id', autospec=True)
@@ -561,12 +561,12 @@ class TestImporterUtils(DojoAPITestCase):
 
         vulnerability_ids = ['REF-1', 'REF-2']
 
-        self.assertEqual(4, len(mock.mock_calls))
-        self.assertEqual('REF-1', mock.mock_calls[0].kwargs['vulnerability_id'])
-        self.assertEqual('REF-1', mock.mock_calls[0].kwargs['finding'].cve)
-        self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
-        self.assertEqual('REF-2', mock.mock_calls[2].kwargs['vulnerability_id'])
+        self.assertEqual(5, len(mock.mock_calls))
+        self.assertEqual('REF-1', mock.mock_calls[2].kwargs['vulnerability_id'])
         self.assertEqual('REF-1', mock.mock_calls[2].kwargs['finding'].cve)
+        self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
+        self.assertEqual('REF-2', mock.mock_calls[3].kwargs['vulnerability_id'])
+        self.assertEqual('REF-1', mock.mock_calls[3].kwargs['finding'].cve)
         self.assertEqual(vulnerability_ids, mock.mock_calls[2].kwargs['finding'].unsaved_vulnerability_ids)
 
     @patch('dojo.importers.base_importer.Vulnerability_Id', autospec=True)

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -7,7 +7,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
 from dojo.importers.default_importer import DefaultImporter
-from dojo.models import Development_Environment, Engagement, Finding, Product, Product_Type, Test, Test_Type, User
+from dojo.models import Development_Environment, Engagement, Finding, Product, Product_Type, Test, User
 from dojo.tools.gitlab_sast.parser import GitlabSastParser
 from dojo.tools.sarif.parser import SarifParser
 from dojo.utils import get_object_or_none

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -517,9 +517,9 @@ class BaseClass:
         @skipIfNotSubclass(DeletePreviewModelMixin)
         def test_delete_preview(self):
             current_objects = self.client.get(self.url, format='json').data
+
             relative_url = self.url + '{}/delete_preview/'.format(current_objects['results'][0]['id'])
             response = self.client.get(relative_url)
-            # print('delete_preview response.data')
 
             self.assertEqual(200, response.status_code, response.content[:1000])
 


### PR DESCRIPTION
**Description**
[sc-5982]
Resolves https://github.com/DefectDojo/django-DefectDojo/issues/10198

To re-iterate, when reimporting scans into DefectDojo, vulnerability_ids were getting duplicated with each reimport. This fix implements the same method used by the apiv2 finding helper in the baseimporter.

**Test results**

Tested mutiple scan types to ensure vulnerability ids were still handled correctly and that duplicates were removed on reimport. This will not clear duplicate vulnerability ids until a reimport is done after this fix.
