### PR TITLE
fix(filters): prevent crashes when `start_date == date.min`

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2,7 +2,7 @@ import collections
 import decimal
 import logging
 import warnings
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import pytz
 import six
@@ -184,7 +184,10 @@ class FindingStatusFilter(ChoiceFilter):
             start_date = local_tz.localize(datetime.combine(
                 earliest_finding.date, datetime.min.time())
             )
-            self.start_date = _truncate(start_date - timedelta(days=1))
+            try:
+                self.start_date = _truncate(start_date - timedelta(days=1))
+            except OverflowError:  # this will fail when start_date is date.min
+                self.start_date = date.min
             self.end_date = _truncate(now() + timedelta(days=1))
         try:
             value = int(value)
@@ -772,7 +775,10 @@ class MetricsDateRangeFilter(ChoiceFilter):
             start_date = local_tz.localize(datetime.combine(
                 earliest_finding.date, datetime.min.time())
             )
-            self.start_date = _truncate(start_date - timedelta(days=1))
+            try:
+                self.start_date = _truncate(start_date - timedelta(days=1))
+            except OverflowError:  # this will fail when start_date is date.min
+                self.start_date = date.min
             self.end_date = _truncate(now() + timedelta(days=1))
             return qs.all()
 
@@ -840,7 +846,10 @@ class MetricsDateRangeFilter(ChoiceFilter):
             start_date = local_tz.localize(datetime.combine(
                 earliest_finding.date, datetime.min.time())
             )
-            self.start_date = _truncate(start_date - timedelta(days=1))
+            try:
+                self.start_date = _truncate(start_date - timedelta(days=1))
+            except OverflowError:  # this will fail when start_date is date.min
+                self.start_date = date.min
             self.end_date = _truncate(now() + timedelta(days=1))
         try:
             value = int(value)

--- a/unittests/scans/generic/generic_bad_date.json
+++ b/unittests/scans/generic/generic_bad_date.json
@@ -1,0 +1,16 @@
+{
+    "findings": [
+	{
+            "title": "test title",
+            "description": "Test description",
+            "active": true,
+            "verified": true,
+            "severity": "High",
+            "impact": "Some impact",
+            "date": "0001-01-01",
+            "tags": ["security", "network"],
+            "unique_id_from_tool": "0b5a8a8f-b3b0-4fe9-9b27-87d58631ac03",
+            "vuln_id_from_tool": "TEST_BAD_DATE"
+	}
+    ]
+}

--- a/unittests/tools/test_generic_parser.py
+++ b/unittests/tools/test_generic_parser.py
@@ -650,3 +650,11 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             with self.assertRaisesMessage(ValueError,
                     "Not allowed fields are present: ['invalid_field', 'last_status_update']"):
                 parser.get_findings(file, Test())
+
+    def test_parse_json_bad_date(self):
+        with open("unittests/scans/generic/generic_bad_date.json") as fdesc:
+            parser = GenericParser()
+            findings = parser.get_findings(fdesc, Test())
+            self.assertEqual(1, len(findings))
+            # test the filters
+            self.assertEqual(1, len(Finding.objects.filter(active=True)))


### PR DESCRIPTION
**Description**

Some reports may include bogus values for `start_date`, like the `date.min` value. In that situation, DefectDojo would crash; the bug is not really in DefectDojo, but a bit of defensive programming won't hurt, and we want to avoid a crash even with invalid data.

When that happen, we'll use `date.min` as `start_date` rather than `date.min - timedelta(days=1)` which cannot exist in Python.

**Test results**

We do have an (internal, home made) scanner that (used to) produce such invalid result, and this patch fixes the issue.

**Documentation**

N/A

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest ~~`dev`~~ `bugfix`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] Add the proper label to categorize your PR.
