### PR TITLE
Test_Import: Correct exception for multiple findings in the same object

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -261,7 +261,7 @@ class DefaultReImporter(BaseImporter):
         # following finding in the same report
         # this means untouched can have this finding inside it,
         # while it is in fact a new finding. So we subtract new_items
-        untouched = set(unchanged_items) - set(to_mitigate) - set(new_items)
+        untouched = set(unchanged_items) - set(to_mitigate) - set(new_items) - set(reactivated_items)
         # Process groups
         self.process_groups_for_all_findings(
             group_names_to_findings_dict,


### PR DESCRIPTION
When a vulnerability is present in  a report multiple times, but with different status, there is an opportunity for the following exception:
```
duplicate key value violates unique constraint "dojo_test_import_finding_test_import_id_finding_i_e6f366e5_uniq"
DETAIL:  Key (test_import_id, finding_id)=(4108, 948) already exists.
```