### PR TITLE
Make endpoint names visible in reports

### DIFF
--- a/dojo/templates/dojo/custom_html_report_endpoint_list.html
+++ b/dojo/templates/dojo/custom_html_report_endpoint_list.html
@@ -17,7 +17,7 @@
 
 <div id="endpoint_content">
     {% for endpoint in endpoints %}
-        <div class="panel panel-warning">
+        <div class="panel panel-default panel-warning">
             <div class="panel-heading">
                 <h4>
                     Endpoint: {{ endpoint }} with {{ endpoint.active_findings|length|apnumber }}

--- a/helm/defectdojo/Chart.lock
+++ b/helm/defectdojo/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 9.19.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.2.13
+  version: 15.2.7
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 9.4.11
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 14.1.5
+  version: 14.1.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 19.1.5
-digest: sha256:ad543edf2f36ae912453b3b075f5db27c464d90d8035d5977ac434bc3fc63b69
-generated: "2024-05-20T14:55:05.297896821Z"
+digest: sha256:489bde31da1ba28130baef3c49292e052a50bbc3726de037b3778bdb091c7cad
+generated: "2024-04-30T12:26:32.131451724Z"

--- a/helm/defectdojo/Chart.lock
+++ b/helm/defectdojo/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 9.19.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.2.7
+  version: 15.2.13
 - name: postgresql-ha
   repository: https://charts.bitnami.com/bitnami
   version: 9.4.11
 - name: rabbitmq
   repository: https://charts.bitnami.com/bitnami
-  version: 14.1.0
+  version: 14.1.5
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 19.1.5
-digest: sha256:489bde31da1ba28130baef3c49292e052a50bbc3726de037b3778bdb091c7cad
-generated: "2024-04-30T12:26:32.131451724Z"
+digest: sha256:ad543edf2f36ae912453b3b075f5db27c464d90d8035d5977ac434bc3fc63b69
+generated: "2024-05-20T14:55:05.297896821Z"


### PR DESCRIPTION
**Description**

This patch adds a class to the endpoint name entry on a report so it can be seen; previously the white text was invisible on the white background, this adds the panel color so it can be seen.

**Test results**

Before (highlighted for visibility):

<img width="810" alt="Screenshot 2024-05-20 at 10 04 44 AM" src="https://github.com/DefectDojo/django-DefectDojo/assets/19554266/5ec6cf53-5163-4315-846d-253b1fe45033">

After:

<img width="979" alt="Screenshot 2024-05-20 at 9 45 27 AM" src="https://github.com/DefectDojo/django-DefectDojo/assets/19554266/2e111a90-77cd-46dc-843c-a6af426d5455">

[sc-6083]