### PR TITLE
feat(email notif): Scan_added - put findings to `<details>`

### DIFF
--- a/dojo/templates/notifications/mail/scan_added.tpl
+++ b/dojo/templates/notifications/mail/scan_added.tpl
@@ -16,40 +16,48 @@
                 {% blocktranslate %}{{ finding_count }} findings have been updated for while a scan was uploaded{% endblocktranslate %}:
                 <a href="{{product_url|full_url}}">{{product}}</a> / <a href="{{engagement_url|full_url}}">{{ engagement.name }}</a> / <a href="{{ test_url|full_url }}">{{ test }}</a><br/>
                 <br/>
-                {% blocktranslate %}New findings{% endblocktranslate %}:<br/>
+                <details>
+                <summary>{% blocktranslate %}New findings{% endblocktranslate %} ({{ findings_new | length }})</summary><br/>
                 {% for finding in findings_new %}
                     {% url 'view_finding' finding.id as finding_url %}
                     <a href="{{ finding_url|full_url }}">{{ finding.title }}</a> ({{ finding.severity }})<br/>
                 {% empty %}
                     {% trans "None" %}<br/>
                 {% endfor %}
+                </details>
             </p>
             <p>
-                {% blocktranslate %}Reactivated findings{% endblocktranslate %}:<br/>
+                <details>
+                <summary>{% blocktranslate %}Reactivated findings{% endblocktranslate %} ({{ findings_reactivated | length }})</summary><br/>
                 {% for finding in findings_reactivated %}
                     {% url 'view_finding' finding.id as finding_url %}
                     <a href="{{ finding_url|full_url }}">{{ finding.title }}</a> ({{ finding.severity }})<br/>
                 {% empty %}
                     {% trans "None" %}<br/>
                 {% endfor %}
+                </details>
             </p>
             <p>
-                {% blocktranslate %}Closed findings{% endblocktranslate %}:<br/>
+                <details>
+                <summary>{% blocktranslate %}Closed findings{% endblocktranslate %} ({{ findings_mitigated | length }})</summary><br/>
                 {% for finding in findings_mitigated %}
                     {% url 'view_finding' finding.id as finding_url %}
                     <a href="{{ finding_url|full_url }}">{{ finding.title }}</a> ({{ finding.severity }})<br/>
                 {% empty %}
                     {% trans "None" %}<br/>
                 {% endfor %}
+                </details>
             </p>
             <p>
-                {% blocktranslate %}Untouched findings{% endblocktranslate %}:<br/>
+                <details>
+                <summary>{% blocktranslate %}Untouched findings{% endblocktranslate %} ({{ findings_untouched | length }})</summary><br/>
                 {% for finding in findings_untouched %}
                     {% url 'view_finding' finding.id as finding_url %}
                     <a href="{{ finding_url|full_url }}">{{ finding.title }}</a> ({{ finding.severity }})<br/>
                 {% empty %}
                     {% trans "None" %}<br/>
                 {% endfor %}
+                </details>
             </p>
             <br/><br/>
                 {% trans "Kind regards" %},


### PR DESCRIPTION
This PR makes the "scan added" email notification easier to read.
If there is a long list of findings, it might be harder to read it. From now on, notifications are "collapsed" into detail section and only the number of findings is visible. Users can click on the name of the category and see the full list.

Before:
![Screenshot 2024-05-22 at 16 57 50](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/8ea78287-8a65-4841-8634-55906dbc5896)

After:
![Screenshot 2024-05-22 at 17 02 56](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/f9f19008-5045-42d9-a940-15b4580afd5b)

After, when you open 2 groups:
![Screenshot 2024-05-22 at 17 03 15](https://github.com/DefectDojo/django-DefectDojo/assets/5609770/91486a7c-42e6-404a-8250-f8336c8c630c)

No hard magic 🪄 , only simple HTML tags.