### PR TITLE
fix(docker): Bump versions (python 3.11, alpine 3.20)

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.11.3-alpine3.16@sha256:9efc6e155f287eb424ede74aeff198be75ae04504b1e42e87ec9f221e7410f2d as base
+FROM python:3.12.3-alpine3.20@sha256:ff11a2170938ae4e4f931435fd47f64b0f6efabd471aef37d20ad58f827ba19c as base
 FROM base as build
 WORKDIR /app
 RUN \

--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.12.3-alpine3.20@sha256:ff11a2170938ae4e4f931435fd47f64b0f6efabd471aef37d20ad58f827ba19c as base
+FROM python:3.11.9-alpine3.20@sha256:df44c0c0761ddbd6388f4549cab42d24d64d257c2a960ad5b276bb7dab9639c7 as base
 FROM base as build
 WORKDIR /app
 RUN \

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.11.4-slim-bullseye@sha256:40319d0a897896e746edf877783ef39685d44e90e1e6de8d964d0382df0d4952 as base
+FROM python:3.12.3-slim-bookworm@sha256:fd3817f3a855f6c2ada16ac9468e5ee93e361005bd226fd5a5ee1a504e038c84 as base
 FROM base as build
 WORKDIR /app
 RUN \

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.12.3-slim-bookworm@sha256:fd3817f3a855f6c2ada16ac9468e5ee93e361005bd226fd5a5ee1a504e038c84 as base
+FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as base
 FROM base as build
 WORKDIR /app
 RUN \

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -2,7 +2,7 @@
 # code: language=Dockerfile
 
 FROM openapitools/openapi-generator-cli:v7.5.0@sha256:cdf11948948de9c21c6035de47dd5fc73c1651c8ba2ea0a4b86a527608ef52a9 as openapitools
-FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as base
+FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as build
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -2,7 +2,7 @@
 # code: language=Dockerfile
 
 FROM openapitools/openapi-generator-cli:v7.5.0@sha256:cdf11948948de9c21c6035de47dd5fc73c1651c8ba2ea0a4b86a527608ef52a9 as openapitools
-FROM python:3.11.4-slim-bullseye@sha256:40319d0a897896e746edf877783ef39685d44e90e1e6de8d964d0382df0d4952 as build
+FROM python:3.12.3-slim-bookworm@sha256:fd3817f3a855f6c2ada16ac9468e5ee93e361005bd226fd5a5ee1a504e038c84 as base
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -2,7 +2,7 @@
 # code: language=Dockerfile
 
 FROM openapitools/openapi-generator-cli:v7.5.0@sha256:cdf11948948de9c21c6035de47dd5fc73c1651c8ba2ea0a4b86a527608ef52a9 as openapitools
-FROM python:3.12.3-slim-bookworm@sha256:fd3817f3a855f6c2ada16ac9468e5ee93e361005bd226fd5a5ee1a504e038c84 as base
+FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as base
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -5,7 +5,7 @@
 # Dockerfile.django-alpine to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.12.3-alpine3.20@sha256:ff11a2170938ae4e4f931435fd47f64b0f6efabd471aef37d20ad58f827ba19c as base
+FROM python:3.11.9-alpine3.20@sha256:df44c0c0761ddbd6388f4549cab42d24d64d257c2a960ad5b276bb7dab9639c7 as base
 FROM base as build
 WORKDIR /app
 RUN \

--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -5,7 +5,7 @@
 # Dockerfile.django-alpine to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.11.3-alpine3.16@sha256:9efc6e155f287eb424ede74aeff198be75ae04504b1e42e87ec9f221e7410f2d as base
+FROM python:3.12.3-alpine3.20@sha256:ff11a2170938ae4e4f931435fd47f64b0f6efabd471aef37d20ad58f827ba19c as base
 FROM base as build
 WORKDIR /app
 RUN \

--- a/Dockerfile.nginx-debian
+++ b/Dockerfile.nginx-debian
@@ -5,7 +5,7 @@
 # Dockerfile.django-debian to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.11.4-slim-bullseye@sha256:40319d0a897896e746edf877783ef39685d44e90e1e6de8d964d0382df0d4952 as base
+FROM python:3.12.3-slim-bookworm@sha256:fd3817f3a855f6c2ada16ac9468e5ee93e361005bd226fd5a5ee1a504e038c84 as base
 FROM base as build
 WORKDIR /app
 RUN \

--- a/Dockerfile.nginx-debian
+++ b/Dockerfile.nginx-debian
@@ -5,7 +5,7 @@
 # Dockerfile.django-debian to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.12.3-slim-bookworm@sha256:fd3817f3a855f6c2ada16ac9468e5ee93e361005bd226fd5a5ee1a504e038c84 as base
+FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as base
 FROM base as build
 WORKDIR /app
 RUN \


### PR DESCRIPTION
Looks like Renovate and/or Dependabot are not able to identify higher versions
- If Debian names are used
- If 2 versions are mentioned in the tag

This should be addressed somehow, for now, let's fix it by hand.

Fix for #10277