### PR TITLE
fix(docker): Bump versions (python 3.11, debian bookworm)

### DIFF
--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -5,7 +5,7 @@
 # Dockerfile.nginx to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as base
+FROM python:3.11.9-slim-bookworm@sha256:8c1036ec919826052306dfb5286e4753ffd9d5f6c24fbc352a5399c3b405b57e as base
 FROM base as build
 WORKDIR /app
 RUN \
@@ -43,10 +43,10 @@ RUN \
   # ugly fix to install postgresql-client without errors
   mkdir -p /usr/share/man/man1 /usr/share/man/man7 && \
   apt-get -y install --no-install-recommends \
-    # libopenjp2-7 libjpeg62 libtiff5 are required by the pillow package
+    # libopenjp2-7 libjpeg62 libtiff are required by the pillow package
     libopenjp2-7 \
     libjpeg62 \
-    libtiff5 \
+    libtiff6 \
     dnsutils \
     default-mysql-client \
     libmariadb3 \

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -2,7 +2,7 @@
 # code: language=Dockerfile
 
 FROM openapitools/openapi-generator-cli:v7.5.0@sha256:cdf11948948de9c21c6035de47dd5fc73c1651c8ba2ea0a4b86a527608ef52a9 as openapitools
-FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as build
+FROM python:3.11.9-slim-bookworm@sha256:8c1036ec919826052306dfb5286e4753ffd9d5f6c24fbc352a5399c3b405b57e as build
 WORKDIR /app
 RUN \
   apt-get -y update && \

--- a/Dockerfile.nginx-debian
+++ b/Dockerfile.nginx-debian
@@ -5,7 +5,7 @@
 # Dockerfile.django-debian to use the caching mechanism of Docker.
 
 # Ref: https://devguide.python.org/#branchstatus
-FROM python:3.11.9-slim-bullseye@sha256:03b84f686938d82255f6e784e8c9222c1fad1ba4a9e609d79efed56da69b025b as base
+FROM python:3.11.9-slim-bookworm@sha256:8c1036ec919826052306dfb5286e4753ffd9d5f6c24fbc352a5399c3b405b57e as base
 FROM base as build
 WORKDIR /app
 RUN \


### PR DESCRIPTION
Same as #10280 but for Debian