### PR TITLE
Mark UserProfile properties user_contact_info and global_role as optional

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2968,8 +2968,8 @@ class SLAConfigurationSerializer(serializers.ModelSerializer):
 
 class UserProfileSerializer(serializers.Serializer):
     user = UserSerializer(many=False)
-    user_contact_info = UserContactInfoSerializer(many=False)
-    global_role = GlobalRoleSerializer(many=False)
+    user_contact_info = UserContactInfoSerializer(many=False, required=False)
+    global_role = GlobalRoleSerializer(many=False, required=False)
     dojo_group_member = DojoGroupMemberSerializer(many=True)
     product_type_member = ProductTypeMemberSerializer(many=True)
     product_member = ProductMemberSerializer(many=True)


### PR DESCRIPTION
**Description**

Currently the openapi spec lists these properties as required in UserProfile objects:

```
        "required": [
          "dojo_group_member",
          "global_role",
          "product_member",
          "product_type_member",
          "user",
          "user_contact_info"
        ]
```

However, response may not included `global_role` or `user_contact_info`, if they are not set. With this change the required properties are:

```
        "required": [
          "dojo_group_member",
          "product_member",
          "product_type_member",
          "user"
        ]
```

This is useful for generating clients from the openapi spec.

**Test results**

I don't believe there are tests for this.

**Documentation**

This is just a change to the openapi spec.

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

