### PR TITLE
Finding: refactor set hash_code

### DIFF
--- a/docs/content/en/getting_started/upgrading/2.36.md
+++ b/docs/content/en/getting_started/upgrading/2.36.md
@@ -1,7 +1,0 @@
----
-title: 'Upgrading to DefectDojo Version 2.36.x'
-toc_hide: true
-weight: -20240603
-description: No special instructions.
----
-There are no special instructions for upgrading to 2.36.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.36.0) for the contents of the release.

--- a/docs/content/en/getting_started/upgrading/2.36.md
+++ b/docs/content/en/getting_started/upgrading/2.36.md
@@ -1,0 +1,7 @@
+---
+title: 'Upgrading to DefectDojo Version 2.36.x'
+toc_hide: true
+weight: -20240603
+description: No special instructions.
+---
+There are no special instructions for upgrading to 2.36.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.36.0) for the contents of the release.

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2609,16 +2609,6 @@ class Finding(models.Model):
     def __str__(self):
         return self.title
 
-    def set_hash_code(self, dedupe_option):
-        # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
-        # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
-        if dedupe_option:
-            if self.hash_code is not None:
-                deduplicationLogger.debug("Hash_code already computed for finding")
-            else:
-                self.hash_code = self.compute_hash_code()
-                deduplicationLogger.debug("Hash_code computed for finding: %s", self.hash_code)
-
     def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,
              issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):
 
@@ -3345,6 +3335,16 @@ class Finding(models.Model):
     @property
     def violates_sla(self):
         return (self.sla_expiration_date and self.sla_expiration_date < timezone.now().date())
+
+    def set_hash_code(self, dedupe_option):
+        # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
+        # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
+        if dedupe_option:
+            if self.hash_code is not None:
+                deduplicationLogger.debug("Hash_code already computed for finding")
+            else:
+                self.hash_code = self.compute_hash_code()
+                deduplicationLogger.debug("Hash_code computed for finding: %s", self.hash_code)
 
 
 class FindingAdmin(admin.ModelAdmin):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2609,12 +2609,15 @@ class Finding(models.Model):
     def __str__(self):
         return self.title
 
-    def _set_hash_code(self):
-        if (self.hash_code is not None):
-            deduplicationLogger.debug("Hash_code already computed for finding")
-        else:
-            self.hash_code = self.compute_hash_code()
-            deduplicationLogger.debug("Hash_code computed for finding: %s", self.hash_code)
+    def set_hash_code(self, dedupe_option):
+        # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
+        # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
+        if dedupe_option:
+            if self.hash_code is not None:
+                deduplicationLogger.debug("Hash_code already computed for finding")
+            else:
+                self.hash_code = self.compute_hash_code()
+                deduplicationLogger.debug("Hash_code computed for finding: %s", self.hash_code)
 
     def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,
              issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):
@@ -2642,10 +2645,7 @@ class Finding(models.Model):
             except Exception as ex:
                 logger.error("Can't compute cvssv3 score for finding id %i. Invalid cvssv3 vector found: '%s'. Exception: %s", self.id, self.cvssv3, ex)
 
-        # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
-        # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
-        if dedupe_option:
-            self._set_hash_code()
+        self.set_hash_code(dedupe_option)
 
         if self.pk is None:
             # We enter here during the first call from serializers.py

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -2609,6 +2609,13 @@ class Finding(models.Model):
     def __str__(self):
         return self.title
 
+    def _set_hash_code(self):
+        if (self.hash_code is not None):
+            deduplicationLogger.debug("Hash_code already computed for finding")
+        else:
+            self.hash_code = self.compute_hash_code()
+            deduplicationLogger.debug("Hash_code computed for finding: %s", self.hash_code)
+
     def save(self, dedupe_option=True, rules_option=True, product_grading_option=True,
              issue_updater_option=True, push_to_jira=False, user=None, *args, **kwargs):
 
@@ -2638,11 +2645,7 @@ class Finding(models.Model):
         # Finding.save is called once from serializers.py with dedupe_option=False because the finding is not ready yet, for example the endpoints are not built
         # It is then called a second time with dedupe_option defaulted to true; now we can compute the hash_code and run the deduplication
         if dedupe_option:
-            if (self.hash_code is not None):
-                deduplicationLogger.debug("Hash_code already computed for finding")
-            else:
-                self.hash_code = self.compute_hash_code()
-                deduplicationLogger.debug("Hash_code computed for finding: %s", self.hash_code)
+            self._set_hash_code()
 
         if self.pk is None:
             # We enter here during the first call from serializers.py


### PR DESCRIPTION
**Description**

This patch refactors the setting of a Finding's hash code into its own method that is called from Finding#save(). No logic is changed, just moving the logic for setting the hash_code attribute to its own method.

**Test results**

Findings still save as expected.