### PR TITLE
Feat(psql): Use psycopg3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ Markdown==3.6
 mysqlclient==2.1.1
 openpyxl==3.1.5
 Pillow==10.3.0  # required by django-imagekit
-psycopg2-binary==2.9.9
+psycopg[binary]==3.1.19
 cryptography==42.0.8
 python-dateutil==2.9.0.post0
 pytz==2024.1


### PR DESCRIPTION
Django 4.2 introduced support for Psycopg 3

> Psycopg 3 support[¶](https://docs.djangoproject.com/en/5.0/releases/4.2/#psycopg-3-support)
> Django now supports [psycopg](https://www.psycopg.org/psycopg3/) version 3.1.8 or higher. To update your code, install the [psycopg library](https://pypi.org/project/psycopg/), you don’t need to change the [ENGINE](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-DATABASE-ENGINE) as django.db.backends.postgresql supports both libraries.
> 
> Support for psycopg2 is likely to be deprecated and removed at some point in the future.
> Source: https://docs.djangoproject.com/en/5.0/releases/4.2/#psycopg-3-support

This PR is blocked by #9493