### PR TITLE
Importer: Correct `add_findings_to_auto_group` args

### DIFF
--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -215,7 +215,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
                 group_name,
                 findings,
                 self.group_by,
-                self.create_finding_groups_for_all_findings,
+                create_finding_groups_for_all_findings=self.create_finding_groups_for_all_findings,
                 **kwargs
             )
             if self.push_to_jira:

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -688,6 +688,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             finding_helper.add_findings_to_auto_group(
                 group_name,
                 findings,
+                self.group_by,
+                create_finding_groups_for_all_findings=self.create_finding_groups_for_all_findings,
                 **kwargs
             )
             if self.push_to_jira:


### PR DESCRIPTION
In the importer and reimporter, correct arguments passed to `add_findings_to_auto_group` 

[sc-6289]