### PR TITLE
String Filtering: Support ID matching for links on listing pages

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -1663,6 +1663,8 @@ class FindingFilterHelper(FilterSet):
 
 
 class FindingFilterWithoutObjectLookups(FindingFilterHelper, FindingTagStringFilter):
+    test__engagement__product__prod_type = NumberFilter(widget=HiddenInput())
+    test__engagement__product = NumberFilter(widget=HiddenInput())
     reporter = CharFilter(
         field_name="reporter__username",
         lookup_expr="iexact",
@@ -2471,6 +2473,7 @@ class EndpointFilter(EndpointFilterHelper, DojoFilter):
 
 
 class EndpointFilterWithoutObjectLookups(EndpointFilterHelper):
+    product = NumberFilter(widget=HiddenInput())
     product__name = CharFilter(
         field_name="product__name",
         lookup_expr="iexact",


### PR DESCRIPTION
With the "Filter String Matching Optimization" mode enabled in system settings, a few links within the UI have been broken:
- Product Type list - clicking on finding counts returns all findings a user has access to
- Product Endpoints - Clicking on hosts or endpoints returns all hosts or endpoints a user has access to

Adding a hidden filter that is not renderable on the page will support the object based filtering without fetching all of the objects at the time of request

[sc-6296]