### PR TITLE
openapi fix: allow last_login to be null

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -427,7 +427,7 @@ class ProductMetaSerializer(serializers.ModelSerializer):
 
 class UserSerializer(serializers.ModelSerializer):
     date_joined = serializers.DateTimeField(read_only=True)
-    last_login = serializers.DateTimeField(read_only=True)
+    last_login = serializers.DateTimeField(read_only=True, allow_null=True)
     password = serializers.CharField(
         write_only=True,
         style={"input_type": "password"},


### PR DESCRIPTION
**Description**

When using a tool such as openapi-python-client to generate a library based on Defectdojo's OpenAPI, the resulting library will crash when using the 'user_profile/' endpoint if the user never logged in. This may happen when a token was generated straight from the API, instead of the webUI.

This patch fixes the serializers to make last_login nullable.

To reproduce:
1) create a new user but DO NOT LOGIN
2) generate a token for that user
3) retrieve Defectdojo's OpenApi, and generate a library using openapi-python-client (do not use v.0.20.0, it fails)
4) using the library, access `user_profile/` for that user.

**Checklist**

This checklist is for your information.

- [✔️ ] Make sure to rebase your PR against the very latest `dev`.
- [N/A ] Features/Changes should be submitted against the `dev`.
- [ ✔️] Bugfixes should be submitted against the `bugfix` branch.
- [✔️ ] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [ ✔️] Your code is flake8 compliant.
- [✔️ ] Your code is python 3.11 compliant.
- [N/A ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [N/A ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [N/A ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.



