### PR TITLE
Entrypoint Scripts: Add container level breakouts to prevent doom loopings

### DIFF
--- a/.github/workflows/build-docker-images-for-testing.yml
+++ b/.github/workflows/build-docker-images-for-testing.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v5
+        timeout-minutes: 10
         with:
           context: .
           push: false
@@ -47,6 +48,7 @@ jobs:
   
       # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact
+        timeout-minutes: 10
         uses:  actions/upload-artifact@v3
         with:
           name: ${{ matrix.docker-image }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/download-artifact@v3
 
       - name: Load docker images
+        timeout-minutes: 10
         run: |-
              docker load -i nginx/nginx-${{ matrix.os }}_img
              docker load -i django/django-${{ matrix.os }}_img
@@ -74,12 +75,14 @@ jobs:
           NGINX_VERSION: ${{ matrix.os }}
 
       - name: Initialize
+        timeout-minutes: 10
         run: docker compose --profile ${{ matrix.profile }} --env-file ./docker/environments/${{ matrix.profile }}.env up --no-deps --exit-code-from initializer initializer
         env:
           DJANGO_VERSION: ${{ matrix.os }}
           NGINX_VERSION: ${{ matrix.os }}
 
       - name: Integration tests
+        timeout-minutes: 10
         run: docker compose --profile ${{ matrix.profile }} --env-file ./docker/environments/${{ matrix.profile }}.env up --no-deps --exit-code-from integration-tests integration-tests
         env:
           DD_INTEGRATION_TEST_FILENAME: ${{ matrix.test-case }}

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/download-artifact@v3
 
       - name: Load docker images
+        timeout-minutes: 10
         run: |-
              eval $(minikube docker-env)
              docker load -i nginx/nginx-${{ matrix.os }}_img
@@ -103,6 +104,7 @@ jobs:
               echo "rabbit=${{ env.HELM_RABBIT_BROKER_SETTINGS }}" >> $GITHUB_ENV
 
       - name: Deploying Djano application with ${{ matrix.databases }} ${{ matrix.brokers }}
+        timeout-minutes: 10 
         run: |-
              helm install \
                --timeout 800s \
@@ -123,6 +125,7 @@ jobs:
              kubectl get services
 
       - name: Check Application
+        timeout-minutes: 10
         run: |-
              to_complete () {
                kubectl wait --for=$1 $2 --timeout=500s --selector=$3 2>/tmp/test || true

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/download-artifact@v3
 
       - name: Load docker images
+        timeout-minutes: 10
         run: |-
              docker load -i nginx/nginx-${{ matrix.os }}_img
              docker load -i django/django-${{ matrix.os }}_img
@@ -38,6 +39,7 @@ jobs:
 
       # no celery or initializer needed for unit tests
       - name: Unit tests
+        timeout-minutes: 10
         run: docker compose --profile mysql-redis --env-file ./docker/environments/mysql-redis.env up --no-deps --exit-code-from uwsgi uwsgi
         env:
           DJANGO_VERSION: ${{ matrix.os }}

--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -76,6 +76,7 @@ COPY \
   docker/entrypoint-unit-tests-devDocker.sh \
   docker/wait-for-it.sh \
   docker/secret-file-loader.sh \
+  docker/reach_database.sh \
   docker/certs/* \
   /
 COPY wsgi.py manage.py docker/unit-tests.sh ./

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -81,6 +81,7 @@ COPY \
   docker/entrypoint-unit-tests-devDocker.sh \
   docker/wait-for-it.sh \
   docker/secret-file-loader.sh \
+  docker/reach_database.sh \
   docker/certs/* \
   /
 COPY wsgi.py manage.py docker/unit-tests.sh ./

--- a/Dockerfile.integration-tests-debian
+++ b/Dockerfile.integration-tests-debian
@@ -62,6 +62,7 @@ COPY --from=openapitools /opt/openapi-generator/modules/openapi-generator-cli/ta
 
 COPY docker/wait-for-it.sh \
   docker/secret-file-loader.sh \
+  docker/reach_database.sh \
   docker/entrypoint-integration-tests.sh \
   /
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       DD_CELERY_BROKER_URL: ${DD_CELERY_BROKER_URL}
       DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
       DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
+      DD_DATABASE_READINESS_TIMEOUT: "${DD_DATABASE_READINESS_TIMEOUT:-30}"
     volumes:
         - type: bind
           source: ./docker/extra_settings
@@ -75,6 +76,7 @@ services:
       DD_CELERY_BROKER_URL: ${DD_CELERY_BROKER_URL}
       DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
       DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
+      DD_DATABASE_READINESS_TIMEOUT: "${DD_DATABASE_READINESS_TIMEOUT:-30}"
     volumes:
         - type: bind
           source: ./docker/extra_settings
@@ -95,6 +97,7 @@ services:
       DD_CELERY_BROKER_URL: ${DD_CELERY_BROKER_URL}
       DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
       DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
+      DD_DATABASE_READINESS_TIMEOUT: "${DD_DATABASE_READINESS_TIMEOUT:-30}"
     volumes:
         - type: bind
           source: ./docker/extra_settings
@@ -119,6 +122,7 @@ services:
       DD_INITIALIZE: "${DD_INITIALIZE:-true}"
       DD_SECRET_KEY: "${DD_SECRET_KEY:-hhZCp@D28z!n@NED*yB!ROMt+WzsY*iq}"
       DD_CREDENTIAL_AES_256_KEY: "${DD_CREDENTIAL_AES_256_KEY:-&91a*agLqesc*0DJ+2*bAbsUZfR*4nLw}"
+      DD_DATABASE_READINESS_TIMEOUT: "${DD_DATABASE_READINESS_TIMEOUT:-30}"
     volumes:
         - type: bind
           source: ./docker/extra_settings

--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /reach_database.sh
+. /reach_database.sh
 
 umask 0002
 

--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source /reach_database.sh
+
 umask 0002
 
 id
@@ -16,12 +19,7 @@ if [ "$NUM_FILES" -gt 0 ]; then
     rm -f /app/dojo/settings/README.md
 fi
 
-echo -n "Waiting for database to be reachable "
-until echo "select 1;" | python3 manage.py dbshell > /dev/null
-do
-  echo -n "."
-  sleep 1
-done
+wait_for_database_to_be_reachable
 echo
 
 # do the check with Django stack

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -4,6 +4,7 @@ umask 0002
 id
 
 . /secret-file-loader.sh
+source /reach_database.sh
 
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
@@ -18,12 +19,7 @@ if [ "$NUM_FILES" -gt 0 ]; then
     rm -f /app/dojo/settings/README.md
 fi
 
-echo -n "Waiting for database to be reachable "
-until echo "select 1;" | python3 manage.py dbshell > /dev/null
-do
-  echo -n "."
-  sleep 1
-done
+wait_for_database_to_be_reachable
 echo
 
 if [ "${DD_CELERY_WORKER_POOL_TYPE}" = "prefork" ]; then

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -4,7 +4,7 @@ umask 0002
 id
 
 . /secret-file-loader.sh
-source /reach_database.sh
+. /reach_database.sh
 
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 . /secret-file-loader.sh
+source /reach_database.sh
 
 initialize_data()
 {
@@ -60,12 +61,7 @@ then
 fi
 echo "Initializing."
 
-echo -n "Waiting for database to be reachable "
-until echo "select 1;" | python3 manage.py dbshell > /dev/null
-do
-  echo -n "."
-  sleep 1
-done
+wait_for_database_to_be_reachable
 echo
 
 echo "Checking ENABLE_AUDITLOG"

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 . /secret-file-loader.sh
-source /reach_database.sh
+. /reach_database.sh
 
 initialize_data()
 {

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -7,6 +7,7 @@ set -e
 set -v
 
 . /secret-file-loader.sh
+source /reach_database.sh
 
 cd /app
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)
@@ -14,6 +15,8 @@ unset DD_DATABASE_URL
 
 # Unset the celery broker URL so that we can force the other DD_CELERY_BROKER settings
 unset DD_CELERY_BROKER_URL
+
+wait_for_database_to_be_reachable
 
 python3 manage.py makemigrations dojo
 python3 manage.py migrate

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -7,7 +7,7 @@ set -e
 set -v
 
 . /secret-file-loader.sh
-source /reach_database.sh
+. /reach_database.sh
 
 cd /app
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -8,6 +8,7 @@
 
 
 . /secret-file-loader.sh
+source /reach_database.sh
 
 cd /app || exit
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)
@@ -21,6 +22,8 @@ unset DD_CELERY_BROKER_URL
 #   echo "Creating settings.py"
 #   cp dojo/settings/settings.dist.py dojo/settings/settings.py
 # fi
+
+wait_for_database_to_be_reachable
 
 python3 manage.py spectacular --fail-on-warn > /dev/null || {
     cat <<-EOF

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -8,7 +8,7 @@
 
 
 . /secret-file-loader.sh
-source /reach_database.sh
+. /reach_database.sh
 
 cd /app || exit
 # Unset the database URL so that we can force the DD_TEST_DATABASE_NAME (see django "DATABASES" configuration in settings.dist.py)

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 function wait_for_database_to_be_reachable {
     echo -n "Waiting for database to be reachable "
     failure_count=0

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -3,13 +3,12 @@
 wait_for_database_to_be_reachable() {
     echo -n "Waiting for database to be reachable "
     failure_count=0
-    exit_on_count=30
     until echo "select 1;" | python3 manage.py dbshell > /dev/null
     do 
     echo -n "."
     failure_count=$((failure_count + 1)) 
     sleep 1
-    if [ $exit_on_count = $failure_count ]; then
+    if [ $DD_DATABASE_READINESS_TIMEOUT = $failure_count ]; then
         exit 1
     fi
     done

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -3,7 +3,7 @@
 wait_for_database_to_be_reachable() {
     echo -n "Waiting for database to be reachable "
     failure_count=0
-    exit_on_count=10
+    exit_on_count=30
     until echo "select 1;" | python3 manage.py dbshell > /dev/null
     do 
     echo -n "."

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 wait_for_database_to_be_reachable() {
     echo -n "Waiting for database to be reachable "

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-function wait_for_database_to_be_reachable {
+wait_for_database_to_be_reachable() {
     echo -n "Waiting for database to be reachable "
     failure_count=0
     exit_on_count=10

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -1,0 +1,14 @@
+function wait_for_database_to_be_reachable {
+    echo -n "Waiting for database to be reachable "
+    failure_count=0
+    exit_on_count=10
+    until echo "select 1;" | python3 manage.py dbshell > /dev/null
+    do 
+    echo -n "."
+    failure_count=$((failure_count + 1)) 
+    sleep 1
+    if [ $exit_on_count = $failure_count ]; then
+        exit 1
+    fi
+    done
+}

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -3,6 +3,7 @@
 wait_for_database_to_be_reachable() {
     echo -n "Waiting for database to be reachable "
     failure_count=0
+    DD_DATABASE_READINESS_TIMEOUT=${DD_DATABASE_READINESS_TIMEOUT:-30}
     until echo "select 1;" | python3 manage.py dbshell > /dev/null
     do 
     echo -n "."

--- a/dojo/settings/settings.py
+++ b/dojo/settings/settings.py
@@ -21,4 +21,4 @@ if not (DEBUG or ('collectstatic' in sys.argv)):
         msg = "Change of 'settings.dist.py' file was detected. It is not allowed to edit this file. " \
             "Any customization of variables need to be done via environmental variables or in 'local_settings.py'. " \
             "For more information check https://documentation.defectdojo.com/getting_started/configuration/ "
-        raise ValueError(msg)
+        sys.exit(msg)


### PR DESCRIPTION
In cases where the `settings.dist.py` hash is incorrect in incoming PRs, containers will boot loop during unit tests until they timeout. By default this timeout is 360 minutes, or 6 hours. This prevents units tests from actually running for all other PRs

This PR adds a breakout condition after 10 seconds of not being able to query the database through Django's `db_shell` to allow unit tests to exit quicker. In addition, I also added some timeouts for GHA action jobs just in case we run into a similar situation down the road

[sc-6360]