### PR TITLE
:bug: fix Nonetype in Acunetix, #10370

### DIFF
--- a/dojo/tools/acunetix/parse_acunetix360_json.py
+++ b/dojo/tools/acunetix/parse_acunetix360_json.py
@@ -19,7 +19,7 @@ class AcunetixJSONParser:
         for item in data["Vulnerabilities"]:
             title = item["Name"]
             findingdetail = text_maker.handle(item.get("Description", ""))
-            if "Cwe" in item["Classification"]:
+            if item["Classification"] is not None and "Cwe" in item["Classification"]:
                 try:
                     cwe = int(item["Classification"]["Cwe"].split(",")[0])
                 except BaseException:

--- a/unittests/scans/acunetix/issue_10370.json
+++ b/unittests/scans/acunetix/issue_10370.json
@@ -1,0 +1,57 @@
+{
+  "Generated": "25/06/2021 09:59 AM",
+  "Target": {
+    "Duration": "00:00:41.3968969",
+    "Initiated": "25/06/2021 09:53 AM",
+    "ScanId": "663eb6e88d9e4f4d9e00ad52017aa66d",
+    "Url": "http://php.testsparker.com/"
+  },
+  "Vulnerabilities": [
+    {
+      "Certainty": 100,
+      "Classification": null,
+      "Confirmed": true,
+      "Description": "<p>Acunetix360 identified a cookie not marked as HTTPOnly.</p>\n<p>HTTPOnly cookies cannot be read by client-side scripts, therefore marking a cookie as HTTPOnly can provide an additional layer of protection against cross-site scripting attacks.</p>",
+      "ExploitationSkills": "",
+      "ExternalReferences": "<div><ul><li><a target='_blank' href='https://www.acunetix.com/security-cookies-whitepaper/#httpOnlyFlag'><i class='icon-external-link'></i>Acunetix - Security Cookies - HTTPOnly Flag</a></li><li><a target='_blank' href='https://wiki.owasp.org/index.php/HttpOnly'><i class='icon-external-link'></i>OWASP HTTPOnly Cookies</a></li><li><a target='_blank' href='https://msdn.microsoft.com/en-us/library/system.web.httpcookie.httponly%28VS.80%29.aspx'><i class='icon-external-link'></i>MSDN - ASP.NET HTTPOnly Cookies</a></li></ul></div>",
+      "ExtraInformation": [
+        {
+          "Name": "Identified Cookie(s)",
+          "Value": "PHPSESSID"
+        },
+        {
+          "Name": "Cookie Source",
+          "Value": "HTTP Header"
+        },
+        {
+          "Name": "Page Type",
+          "Value": "Login"
+        }
+      ],
+      "FirstSeenDate": "16/06/2021 12:30 PM",
+      "HttpRequest": {
+        "Content": "GET /auth/login.php HTTP/1.1\r\nHost: php.testsparker.com\r\nAccept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8\r\nAccept-Language: en-us,en;q=0.5\r\nCache-Control: no-cache\r\nReferer: http://php.testsparker.com/auth/\r\nUser-Agent: Mozilla/5.0 (Windows NT 10.0; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.0 Safari/537.36\r\nX-Scanner: Acunetix360\r\n\r\n",
+        "Method": "GET",
+        "Parameters": []
+      },
+      "HttpResponse": {
+        "Content": "HTTP/1.1 200 OK\r\nSet-Cookie: PHPSESSID=e52a07f0fe53c0294ae211bc4481332d; path=/\r\nServer: Apache/2.2.8 (Win32) PHP/5.2.6\r\nContent-Length: 3061\r\nX-Powered-By: PHP/5.2.6\r\nPragma: no-cache\r\nExpires: Thu, 19 Nov 1981 08:52:00 GMT<!-- end #footer -->\n</body>\n</html>\n",
+        "Duration": 41.4849,
+        "StatusCode": 200
+      },
+      "LookupId": "735f4503-e9eb-4b4c-4306-ad49020a4c4b",
+      "Impact": "<div>During a cross-site scripting attack, an attacker might easily access cookies and hijack the victim's session.</div>",
+      "KnownVulnerabilities": [],
+      "LastSeenDate": "25/06/2021 01:52 AM",
+      "Name": "Cookie Not Marked as HttpOnly",
+      "ProofOfConcept": "",
+      "RemedialActions": "<div>\n<ol>\n<li>See the remedy for solution.</li>\n<li>Consider marking all of the cookies used by the application as HTTPOnly. (<em>After these changes javascript code will not be able to read cookies.</em>)</li>\n</ol>\n</div>",
+      "RemedialProcedure": "<div>Mark the cookie as HTTPOnly. This will be an extra layer of defense against XSS. However this is not a silver bullet and will not protect the system against cross-site scripting attacks. An attacker can use a tool such as <a href=\"https://labs.portcullis.co.uk/tools/xss-tunnel/\">XSS Tunnel</a> to bypass HTTPOnly protection.</div>",
+      "RemedyReferences": "",
+      "Severity": "Medium",
+      "State": "Present",
+      "Type": "CookieNotMarkedAsHttpOnly",
+      "Url": "http://php.testsparker.com/auth/login.php"
+    }
+  ]
+}

--- a/unittests/tools/test_acunetix_parser.py
+++ b/unittests/tools/test_acunetix_parser.py
@@ -324,3 +324,9 @@ class TestAcunetixParser(DojoTestCase):
                 self.assertEqual(1, len(finding.unsaved_endpoints))
                 endpoint = finding.unsaved_endpoints[0]
                 self.assertEqual(str(endpoint), "http://php.testsparker.com/auth/login.php")
+
+    def test_parse_file_issue_10370(self):
+        with open("unittests/scans/acunetix/issue_10370.json") as testfile:
+            parser = AcunetixParser()
+            findings = parser.get_findings(testfile, Test())
+            self.assertEqual(1, len(findings))


### PR DESCRIPTION
In automated reports from Acunetix 360 to be imported into defect dojo. One vulnerability make the import crash due to no classification provided by Acunetix

#10370 