### PR TITLE
Allow setting --max-fd argument to uwsgi to stop it from getting OOMKilled in Kubernetes

### DIFF
--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -32,5 +32,5 @@ exec uwsgi \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
   --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
   --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
-  --max-fd "${DD_UWSGI_MAX_FD:-1048576}
+  --max-fd "${DD_UWSGI_MAX_FD:-1048576}"
   # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -22,15 +22,31 @@ python3 manage.py check
 
 DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
-exec uwsgi \
-  "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
-  --protocol uwsgi \
-  --enable-threads \
-  --processes "${DD_UWSGI_NUM_OF_PROCESSES:-2}" \
-  --threads "${DD_UWSGI_NUM_OF_THREADS:-2}" \
-  --wsgi dojo.wsgi:application \
-  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
-  --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
-  --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
-  --max-fd "${DD_UWSGI_MAX_FD:-1048576}"
-  # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.
+args=()
+
+args+=("--${DD_UWSGI_MODE}")
+args+=("${DD_UWSGI_ENDPOINT}")
+args+=("--protocol")
+args+=("uwsgi")
+args+=("--enable-threads")
+args+=("--processes")
+args+=("${DD_UWSGI_NUM_OF_PROCESSES:-2}")
+args+=("--threads")
+args+=("${DD_UWSGI_NUM_OF_THREADS:-2}")
+args+=("--wsgi")
+args+=("dojo.wsgi:application")
+args+=("--buffer-size")
+args+=("${DD_UWSGI_BUFFER_SIZE:-8192}")
+args+=("--http")
+args+=("0.0.0.0:8081")
+args+=("--http-to")
+args+=("${DD_UWSGI_ENDPOINT}")
+args+=("--logformat")
+args+=("${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}")
+
+if [ -n "${DD_UWSGI_MAX_FD}" ]; then
+    args+=("--max-fd")
+    args+=("${DD_UWSGI_MAX_FD}")
+fi
+
+exec uwsgi "${args[@]}"

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -20,22 +20,22 @@ umask 0002
 # do the check with Django stack
 python3 manage.py check
 
-DD_UWSGI_LOGFORMAT_DEFAULT="'[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'"
+DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
-args="--${DD_UWSGI_MODE} ${DD_UWSGI_ENDPOINT} \
---protocol uwsgi \
---enable-threads \
---processes ${DD_UWSGI_NUM_OF_PROCESSES:-2} \
---threads ${DD_UWSGI_NUM_OF_THREADS:-2} \
---wsgi dojo.wsgi:application \
---buffer-size ${DD_UWSGI_BUFFER_SIZE:-8192} \
---http 0.0.0.0:8081 \
---http-to ${DD_UWSGI_ENDPOINT} \
---logformat ${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}"
-# HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.
-
+EXTRA_ARGS=""
 if [ -n "${DD_UWSGI_MAX_FD}" ]; then
-    args="${args} --max-fd ${DD_UWSGI_MAX_FD}"
+    EXTRA_ARGS="${EXTRA_ARGS} --max-fd ${DD_UWSGI_MAX_FD}"
 fi
 
-exec uwsgi $args
+exec uwsgi \
+    "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
+    --protocol uwsgi \
+    --enable-threads \
+    --processes "${DD_UWSGI_NUM_OF_PROCESSES:-2}" \
+    --threads "${DD_UWSGI_NUM_OF_THREADS:-2}" \
+    --wsgi dojo.wsgi:application \
+    --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
+    --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
+    --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
+    $EXTRA_ARGS
+# HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -31,5 +31,6 @@ exec uwsgi \
   --wsgi dojo.wsgi:application \
   --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
   --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
-  --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}"
+  --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
+  --max-fd "${DD_UWSGI_MAX_FD:-1048576}
   # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -28,14 +28,14 @@ if [ -n "${DD_UWSGI_MAX_FD}" ]; then
 fi
 
 exec uwsgi \
-    "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
-    --protocol uwsgi \
-    --enable-threads \
-    --processes "${DD_UWSGI_NUM_OF_PROCESSES:-2}" \
-    --threads "${DD_UWSGI_NUM_OF_THREADS:-2}" \
-    --wsgi dojo.wsgi:application \
-    --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
-    --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
-    --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
-    $EXTRA_ARGS
-# HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.
+  "--${DD_UWSGI_MODE}" "${DD_UWSGI_ENDPOINT}" \
+  --protocol uwsgi \
+  --enable-threads \
+  --processes "${DD_UWSGI_NUM_OF_PROCESSES:-2}" \
+  --threads "${DD_UWSGI_NUM_OF_THREADS:-2}" \
+  --wsgi dojo.wsgi:application \
+  --buffer-size="${DD_UWSGI_BUFFER_SIZE:-8192}" \
+  --http 0.0.0.0:8081 --http-to "${DD_UWSGI_ENDPOINT}" \
+  --logformat "${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}" \
+  $EXTRA_ARGS
+  # HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -22,31 +22,19 @@ python3 manage.py check
 
 DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
 
-args=()
-
-args+=("--${DD_UWSGI_MODE}")
-args+=("${DD_UWSGI_ENDPOINT}")
-args+=("--protocol")
-args+=("uwsgi")
-args+=("--enable-threads")
-args+=("--processes")
-args+=("${DD_UWSGI_NUM_OF_PROCESSES:-2}")
-args+=("--threads")
-args+=("${DD_UWSGI_NUM_OF_THREADS:-2}")
-args+=("--wsgi")
-args+=("dojo.wsgi:application")
-args+=("--buffer-size")
-args+=("${DD_UWSGI_BUFFER_SIZE:-8192}")
-args+=("--http")
-args+=("0.0.0.0:8081")
-args+=("--http-to")
-args+=("${DD_UWSGI_ENDPOINT}")
-args+=("--logformat")
-args+=("${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}")
+args="--${DD_UWSGI_MODE} ${DD_UWSGI_ENDPOINT} \
+--protocol uwsgi \
+--enable-threads \
+--processes ${DD_UWSGI_NUM_OF_PROCESSES:-2} \
+--threads ${DD_UWSGI_NUM_OF_THREADS:-2} \
+--wsgi dojo.wsgi:application \
+--buffer-size ${DD_UWSGI_BUFFER_SIZE:-8192} \
+--http 0.0.0.0:8081 \
+--http-to ${DD_UWSGI_ENDPOINT} \
+--logformat ${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}"
 
 if [ -n "${DD_UWSGI_MAX_FD}" ]; then
-    args+=("--max-fd")
-    args+=("${DD_UWSGI_MAX_FD}")
+    args="${args} --max-fd ${DD_UWSGI_MAX_FD}"
 fi
 
-exec uwsgi "${args[@]}"
+exec uwsgi $args

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -20,7 +20,7 @@ umask 0002
 # do the check with Django stack
 python3 manage.py check
 
-DD_UWSGI_LOGFORMAT_DEFAULT='[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'
+DD_UWSGI_LOGFORMAT_DEFAULT="'[pid: %(pid)|app: -|req: -/-] %(addr) (%(dd_user)) {%(vars) vars in %(pktsize) bytes} [%(ctime)] %(method) %(uri) => generated %(rsize) bytes in %(msecs) msecs (%(proto) %(status)) %(headers) headers in %(hsize) bytes (%(switches) switches on core %(core))'"
 
 args="--${DD_UWSGI_MODE} ${DD_UWSGI_ENDPOINT} \
 --protocol uwsgi \
@@ -32,6 +32,7 @@ args="--${DD_UWSGI_MODE} ${DD_UWSGI_ENDPOINT} \
 --http 0.0.0.0:8081 \
 --http-to ${DD_UWSGI_ENDPOINT} \
 --logformat ${DD_UWSGI_LOGFORMAT:-$DD_UWSGI_LOGFORMAT_DEFAULT}"
+# HTTP endpoint is enabled for Kubernetes liveness checks. It should not be exposed as a service.
 
 if [ -n "${DD_UWSGI_MAX_FD}" ]; then
     args="${args} --max-fd ${DD_UWSGI_MAX_FD}"

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -38,6 +38,7 @@ data:
   DD_UWSGI_PASS: unix:///run/defectdojo/uwsgi.sock
   DD_UWSGI_NUM_OF_PROCESSES: '{{ .Values.django.uwsgi.app_settings.processes | default 2 }}'
   DD_UWSGI_NUM_OF_THREADS: '{{ .Values.django.uwsgi.app_settings.threads | default 2 }}'
+  DD_UWSGI_MAX_FD: '{{ .Values.django.uwsgi.app_settings.max_fd | default 1048576 }}'
   DD_DJANGO_METRICS_ENABLED: '{{ .Values.monitoring.enabled }}'
   NGINX_METRICS_ENABLED: '{{ .Values.monitoring.enabled }}'
   METRICS_HTTP_AUTH_USER: {{ .Values.monitoring.user | default "monitoring" }}

--- a/helm/defectdojo/templates/configmap.yaml
+++ b/helm/defectdojo/templates/configmap.yaml
@@ -38,7 +38,7 @@ data:
   DD_UWSGI_PASS: unix:///run/defectdojo/uwsgi.sock
   DD_UWSGI_NUM_OF_PROCESSES: '{{ .Values.django.uwsgi.app_settings.processes | default 2 }}'
   DD_UWSGI_NUM_OF_THREADS: '{{ .Values.django.uwsgi.app_settings.threads | default 2 }}'
-  DD_UWSGI_MAX_FD: '{{ .Values.django.uwsgi.app_settings.max_fd | default 1048576 }}'
+  DD_UWSGI_MAX_FD: '{{ .Values.django.uwsgi.app_settings.max_fd }}'
   DD_DJANGO_METRICS_ENABLED: '{{ .Values.monitoring.enabled }}'
   NGINX_METRICS_ENABLED: '{{ .Values.monitoring.enabled }}'
   METRICS_HTTP_AUTH_USER: {{ .Values.monitoring.user | default "monitoring" }}


### PR DESCRIPTION
**Description**

Reopening https://github.com/DefectDojo/django-DefectDojo/pull/9564

This PR fixes the issue described in issue https://github.com/DefectDojo/django-DefectDojo/issues/9562 regarding uWSGI that under some circumstances will take up an unnecessary amount of resources on a kubernetes node leading to the pod getting OOMKilled.

We introduce the possibility to set the --max-fd argument when starting up uWSGI to mitigate this issue.

**Test results**

I have tested the fix on a kubernetes cluster where it prevented the pod from getting OOMKilled. For more information see https://github.com/DefectDojo/django-DefectDojo/issues/9562.

**Documentation**

It is not clear to me where the documentation should be updated.