### PR TITLE
Jira Finding Group Templates: Correct object links

### DIFF
--- a/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
@@ -1,9 +1,9 @@
 {% load navigation_tags %}
 {% load display_tags %}
 {% url 'view_finding_group' finding_group.id as finding_group_url %}
-{% url 'view_product' finding.test.engagement.product.id as product_url %}
-{% url 'view_engagement' finding.test.engagement.id as engagement_url %}
-{% url 'view_test' finding.test.id as test_url %}
+{% url 'view_product' finding_group.test.engagement.product.id as product_url %}
+{% url 'view_engagement' finding_group.test.engagement.id as engagement_url %}
+{% url 'view_test' finding_group.test.id as test_url %}
 
 A group of Findings has been pushed to JIRA to be investigated and fixed:
 
@@ -12,7 +12,7 @@ h2. Group
 
 
 || Severity || CVE || CWE || Component || Version || Title || Status ||{% for finding in finding_group.findings.all %}
-| {{finding.severity}} | {% if finding.cve %}[{{finding.cve}}|{{finding.cve|vulnerability_url}}]{% else %}None{% endif %} | [{{finding.cwe}}|{{finding.cwe|cwe_url}}] | {{finding.component_name|jiraencode_component}} | {{finding.component_version}} | [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}] | {{ finding.status }} |{% endfor %}
+| {{finding.severity}} | {% if finding.cve %}[{{finding.cve}}|{{finding.cve|vulnerability_url}}]{% else %}None{% endif %} | [{{finding.cwe}}|{{finding.cwe|cwe_url}}] | {{finding.component_name|jiraencode_component}} | {{finding.component_version}} | {% url 'view_finding' finding.id as finding_url %}[{{ finding.title|jiraencode}}|{{ finding_url|full_url }}] | {{ finding.status }} |{% endfor %}
 
 *Severity:* {{ finding_group.severity }}
 

--- a/dojo/templates/issue-trackers/jira_limited/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_limited/jira-finding-group-description.tpl
@@ -1,9 +1,9 @@
 {% load navigation_tags %}
 {% load display_tags %}
 {% url 'view_finding_group' finding_group.id as finding_group_url %}
-{% url 'view_product' finding.test.engagement.product.id as product_url %}
-{% url 'view_engagement' finding.test.engagement.id as engagement_url %}
-{% url 'view_test' finding.test.id as test_url %}
+{% url 'view_product' finding_group.test.engagement.product.id as product_url %}
+{% url 'view_engagement' finding_group.test.engagement.id as engagement_url %}
+{% url 'view_test' finding_group.test.id as test_url %}
 
 A group of Findings has been pushed to JIRA to be investigated and fixed:
 
@@ -11,6 +11,7 @@ A group of Findings has been pushed to JIRA to be investigated and fixed:
 
 Findings:
 {% for finding in finding_group.findings.all %}
+{% url 'view_finding' finding.id as finding_url %}
 - [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]{% endfor %}
 
 {% if finding_group.test.engagement.branch_tag %}


### PR DESCRIPTION
When findings groups are pushed to Jira, the URLs to represent the product, engagement, test, and even findings, are not functioning correctly. The reason for this is because the variable used to define the URL for each of the objects above is not actually in scope:
```
{% url 'view_finding_group' finding_group.id as finding_group_url %}
{% url 'view_product' finding.test.engagement.product.id as product_url %}
{% url 'view_engagement' finding.test.engagement.id as engagement_url %}
{% url 'view_test' finding.test.id as test_url %}
```
`finding_group` is present, and that links works, but `finding` is not in scope, and therefore does not produce the correct URLs

[sc-6434]