### PR TITLE
fix(loc): Do not use _(...) in combination with format

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -127,11 +127,11 @@ def create_notification(event=None, **kwargs):
 def create_description(event, *args, **kwargs):
     if "description" not in kwargs.keys():
         if event == 'product_added':
-            kwargs["description"] = _('Product {title} has been created successfully.'.format(title=kwargs['title']))
+            kwargs["description"] = _('Product %s has been created successfully.') % kwargs['title']
         elif event == 'product_type_added':
-            kwargs["description"] = _('Product Type {title} has been created successfully.'.format(title=kwargs['title']))
+            kwargs["description"] = _('Product Type %s has been created successfully.') % kwargs['title']
         else:
-            kwargs["description"] = _('Event {event}  has occurred.'.format(event=str(event)))
+            kwargs["description"] = _('Event %s has occurred.') % str(event)
 
     return kwargs["description"]
 


### PR DESCRIPTION
For the correct handling of translations, in the strings that use string interpolation (placing variables to translated text), preparation steps need to be performed in the following order:
1. translate string with placeholders
2. replace placeholders with variables

If steps are executed in opposite order, it is not possible to perform translation.

Context: https://docs.djangoproject.com/en/5.0/topics/i18n/translation/#internationalization-in-python-code