### PR TITLE
feat(unittests): Avoid run 'dojo_async_task' in async mode (during te…

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from functools import wraps
 
 from django.conf import settings
@@ -26,6 +27,12 @@ def we_want_async(*args, func=None, **kwargs):
 
     if Dojo_User.wants_block_execution(user):
         logger.debug('dojo_async_task %s: running task in the foreground as block_execution is set to True for %s', func, user)
+        return False
+
+    # if a function is running as part of unittest, it should not be performed in async mode:
+    # - to be able to test functions decorated with `dojo_async_task`
+    # - to test that the task will not fail in the background in celery
+    if sys.argv[:2] == ['manage.py', 'test']:
         return False
 
     logger.debug('dojo_async_task %s: no current user, running task in the background', func)

--- a/unittests/test_utils_deduplication_reopen.py
+++ b/unittests/test_utils_deduplication_reopen.py
@@ -22,13 +22,13 @@ class TestDuplicationReopen(DojoTestCase):
         self.finding_a.false_p = True
         self.finding_a.active = False
         self.finding_a.duplicate_finding = None
-        self.finding_a.save()
+        self.finding_a.save(dedupe_option=False)
         self.finding_b = Finding.objects.get(id=3)
         self.finding_b.pk = None
         self.finding_a.active = True
         self.finding_b.duplicate = False
         self.finding_b.duplicate_finding = None
-        self.finding_b.save()
+        self.finding_b.save(dedupe_option=False)
 
         self.finding_c = Finding.objects.get(id=4)
         self.finding_c.duplicate = False
@@ -37,13 +37,13 @@ class TestDuplicationReopen(DojoTestCase):
         self.finding_c.duplicate_finding = None
         self.finding_c.pk = None
         logger.debug('creating finding_c')
-        self.finding_c.save()
+        self.finding_c.save(dedupe_option=False)
         self.finding_d = Finding.objects.get(id=5)
         self.finding_d.duplicate = False
         self.finding_d.duplicate_finding = None
         self.finding_d.pk = None
         logger.debug('creating finding_d')
-        self.finding_d.save()
+        self.finding_d.save(dedupe_option=False)
 
     def tearDown(self):
         if self.finding_a.id:


### PR DESCRIPTION
if a function is running as part of unittest, it should not be performed in async mode:
- to be able to test functions decorated with `dojo_async_task`
- to test that the task will not fail in the background in celery

`dedupe_option=False` is needed in `unittests/test_utils_deduplication_reopen.py` to avoid triggering dedup at that moment.