### PR TITLE
feat(api - user contact): Add all user data

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -559,6 +559,8 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class UserContactInfoSerializer(serializers.ModelSerializer):
+    user_profile = UserSerializer(many=False, source="user", read_only=True)
+
     class Meta:
         model = UserContactInfo
         fields = "__all__"


### PR DESCRIPTION
This PR adds more metadata about the user to `/api/v2/user_contact_infos/` endpoint.

Before:
```json
{
  "id": 1,
  "title": null,
  "phone_number": "",
  "cell_number": "",
  "twitter_username": null,
  "github_username": null,
  "slack_username": "lalal",
  "slack_user_id": null,
  "block_execution": true,
  "force_password_reset": false,
  "user": 1
}
```

After:
```json
{
  "id": 1,
  "user_profile": {
    "id": 1,
    "username": "admin",
    "first_name": "Admin",
    "last_name": "User",
    "email": "admin@defectdojo.local",
    "date_joined": "2024-06-14T08:35:49.750327Z",
    "last_login": "2024-06-14T14:53:57.859457Z",
    "is_active": true,
    "is_superuser": true,
    "configuration_permissions": []
  },
  "title": null,
  "phone_number": "",
  "cell_number": "",
  "twitter_username": null,
  "github_username": null,
  "slack_username": "lalal",
  "slack_user_id": null,
  "block_execution": true,
  "force_password_reset": false,
  "user": 1
}
```

Why this? `?prefetch=user` is able to provide metadata, however not all of them:
```json
  "prefetch": {
    "user": {
      "1": {
        "id": 1,
        "username": "admin",
        "first_name": "Admin",
        "last_name": "User"
      }
    }
  }
```

Why not just adjust Serializer for `prefetch`? Because all endpoints that are able to use `?prefetch=user` would receive much more data about the user (including possibly sensitive data that should only admin see).

Summary:
```shell
$ oasdiff changelog old.yaml new.yaml
6 changes: 0 error, 0 warning, 6 info
info	[response-required-property-added] at new.yaml
	in API GET /api/v2/user_contact_infos/
		added the required property 'results/items/user_profile' to the response with the '200' status

info	[response-required-property-added] at new.yaml
	in API POST /api/v2/user_contact_infos/
		added the required property 'user_profile' to the response with the '201' status

info	[response-required-property-added] at new.yaml
	in API GET /api/v2/user_contact_infos/{id}/
		added the required property 'user_profile' to the response with the '200' status

info	[response-required-property-added] at new.yaml
	in API PATCH /api/v2/user_contact_infos/{id}/
		added the required property 'user_profile' to the response with the '200' status

info	[response-required-property-added] at new.yaml
	in API PUT /api/v2/user_contact_infos/{id}/
		added the required property 'user_profile' to the response with the '200' status

info	[response-required-property-added] at new.yaml
	in API GET /api/v2/user_profile/
		added the required property 'user_contact_info/user_profile' to the response with the '200' status
```