### PR TITLE
fix(multiselectfield): Use original repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,7 @@ django-dbbackup==4.1.0
 django-environ==0.11.2
 django-filter==24.2
 django-imagekit==5.0.0
-# This library is very outdated, but is a pillar of DefectDojo
-# django-multiselectfield==0.1.12
-git+https://github.com/DefectDojo/django-multiselectfield@master#egg=django-multiselectfield
+django-multiselectfield==0.1.13
 django-polymorphic==3.1.0
 django-crispy-forms==2.2
 django_extensions==3.2.3


### PR DESCRIPTION
https://github.com/goinnn/django-multiselectfield looks like alive again (https://github.com/goinnn/django-multiselectfield/issues/141) with more fixes (including Django 5 support - needed for #10409) than https://github.com/DefectDojo/django-multiselectfield.

`django-multiselectfield` in version `0.1.13` was released and it is pinned in `requirements.txt` now