### PR TITLE
Finding Reports: Support string based filtering

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -3012,8 +3012,8 @@ class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, Finding
     review_requested_by = CharFilter(
         field_name="review_requested_by__username",
         lookup_expr="iexact",
-        label="Review Request By Username",
-        help_text="Search for Review Request By names that are an exact match")
+        label="Review Requested By Username",
+        help_text="Search for Review Requested By names that are an exact match")
     review_requested_by_contains = CharFilter(
         field_name="review_requested_by__username",
         lookup_expr="icontains",

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -3118,7 +3118,7 @@ class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, Finding
             self.delete_tags_from_form(product_refs)
             self.delete_tags_from_form(engagement_refs)
             self.delete_tags_from_form(test_refs)
-        if self.engagement:
+        elif self.engagement:
             self.delete_tags_from_form(product_type_refs)
             self.delete_tags_from_form(product_refs)
             self.delete_tags_from_form(engagement_refs)

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -3017,8 +3017,8 @@ class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, Finding
     review_requested_by_contains = CharFilter(
         field_name="review_requested_by__username",
         lookup_expr="icontains",
-        label="Review Request By Username Contains",
-        help_text="Search for Review Request By usernames that contain a given pattern")
+        label="Review Requested By Username Contains",
+        help_text="Search for Review Requested By usernames that contain a given pattern")
     mitigated_by = CharFilter(
         field_name="mitigated_by__username",
         lookup_expr="iexact",

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -3058,7 +3058,7 @@ class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, Finding
         field_name="test__engagement__product__name",
         lookup_expr="icontains",
         label="Product name Contains",
-        help_text="Search for Product Typ names that contain a given pattern")
+        help_text="Search for Product names that contain a given pattern")
     test__engagement__name = CharFilter(
         field_name="test__engagement__name",
         lookup_expr="iexact",

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2896,8 +2896,8 @@ class ReportFindingFilterHelper(FilterSet):
         model = Finding
         # exclude sonarqube issue as by default it will show all without checking permissions
         exclude = ['date', 'cwe', 'url', 'description', 'mitigation', 'impact',
-                   'references', 'sonarqube_issue',
-                   'thread_id', 'notes',
+                   'references', 'sonarqube_issue', 'duplicate_finding',
+                   'thread_id', 'notes', 'inherited_tags', 'endpoints',
                    'numerical_severity', 'reporter', 'last_reviewed',
                    'jira_creation', 'jira_change', 'files']
 
@@ -2970,11 +2970,67 @@ class ReportFindingFilter(ReportFindingFilterHelper, FindingTagFilter):
 
 
 class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, FindingTagStringFilter):
-    test__engagement__product__prod_type = NumberFilter(widget=HiddenInput())
-    test__engagement__product = NumberFilter(widget=HiddenInput())
-    test__engagement = NumberFilter(widget=HiddenInput())
-    duplicate_finding = NumberFilter(widget=HiddenInput())
-    test__engagement__product__prod_type__name = CharFilter(
+    reporter = CharFilter(
+        field_name="reporter__username",
+        lookup_expr="iexact",
+        label="Reporter Username",
+        help_text="Search for Reporter names that are an exact match")
+    reporter_contains = CharFilter(
+        field_name="reporter__username",
+        lookup_expr="icontains",
+        label="Reporter Username Contains",
+        help_text="Search for Reporter names that contain a given pattern")
+    reviewers = CharFilter(
+        field_name="reviewers__username",
+        lookup_expr="iexact",
+        label="Reviewer Username",
+        help_text="Search for Reviewer names that are an exact match")
+    reviewers_contains = CharFilter(
+        field_name="reviewers__username",
+        lookup_expr="icontains",
+        label="Reviewer Username Contains",
+        help_text="Search for Reviewer usernames that contain a given pattern")
+    last_reviewed_by = CharFilter(
+        field_name="last_reviewed_by__username",
+        lookup_expr="iexact",
+        label="Last Reviewed By Username",
+        help_text="Search for Last Reviewed By names that are an exact match")
+    last_reviewed_by_contains = CharFilter(
+        field_name="last_reviewed_by__username",
+        lookup_expr="icontains",
+        label="Last Reviewed By Username Contains",
+        help_text="Search for Last Reviewed By usernames that contain a given pattern")
+    review_requested_by = CharFilter(
+        field_name="review_requested_by__username",
+        lookup_expr="iexact",
+        label="Review Request By Username",
+        help_text="Search for Review Request By names that are an exact match")
+    review_requested_by_contains = CharFilter(
+        field_name="review_requested_by__username",
+        lookup_expr="icontains",
+        label="Review Request By Username Contains",
+        help_text="Search for Review Request By usernames that contain a given pattern")
+    mitigated_by = CharFilter(
+        field_name="mitigated_by__username",
+        lookup_expr="iexact",
+        label="Mitigator Username",
+        help_text="Search for Mitigator names that are an exact match")
+    mitigated_by_contains = CharFilter(
+        field_name="mitigated_by__username",
+        lookup_expr="icontains",
+        label="Mitigator Username Contains",
+        help_text="Search for Mitigator usernames that contain a given pattern")
+    defect_review_requested_by = CharFilter(
+        field_name="defect_review_requested_by__username",
+        lookup_expr="iexact",
+        label="Requester of Defect Review Username",
+        help_text="Search for Requester of Defect Review names that are an exact match")
+    defect_review_requested_by_contains = CharFilter(
+        field_name="defect_review_requested_by__username",
+        lookup_expr="icontains",
+        label="Requester of Defect Review Username Contains",
+        help_text="Search for Requester of Defect Review usernames that contain a given pattern")
+    test__engagement__product__prod_type = CharFilter(
         field_name="test__engagement__product__prod_type__name",
         lookup_expr="iexact",
         label="Product Type Name",
@@ -2984,7 +3040,7 @@ class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, Finding
         lookup_expr="icontains",
         label="Product Type Name Contains",
         help_text="Search for Product Type names that contain a given pattern")
-    test__engagement__product__name = CharFilter(
+    test__engagement__product = CharFilter(
         field_name="test__engagement__product__name",
         lookup_expr="iexact",
         label="Product Name",
@@ -2994,7 +3050,7 @@ class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, Finding
         lookup_expr="icontains",
         label="Product name Contains",
         help_text="Search for Product Typ names that contain a given pattern")
-    test__engagement__name = CharFilter(
+    test__engagement = CharFilter(
         field_name="test__engagement__name",
         lookup_expr="iexact",
         label="Engagement Name",
@@ -3004,7 +3060,7 @@ class ReportFindingFilterWithoutObjectLookups(ReportFindingFilterHelper, Finding
         lookup_expr="icontains",
         label="Engagement name Contains",
         help_text="Search for Engagement names that contain a given pattern")
-    test__name = CharFilter(
+    test = CharFilter(
         field_name="test__engagement__name",
         lookup_expr="iexact",
         label="Test Name",

--- a/dojo/reports/widgets.py
+++ b/dojo/reports/widgets.py
@@ -11,7 +11,12 @@ from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
-from dojo.filters import EndpointFilter, EndpointFilterWithoutObjectLookups, ReportFindingFilter
+from dojo.filters import (
+    EndpointFilter,
+    EndpointFilterWithoutObjectLookups,
+    ReportFindingFilter,
+    ReportFindingFilterWithoutObjectLookups,
+)
 from dojo.forms import CustomReportOptionsForm
 from dojo.models import Endpoint, Finding
 from dojo.utils import get_page_items, get_system_setting, get_words_for_field
@@ -427,8 +432,9 @@ def report_widget_factory(json_data=None, request=None, user=None, finding_notes
                     d.appendlist(item['name'], item['value'])
                 else:
                     d[item['name']] = item['value']
-
-            findings = ReportFindingFilter(d, queryset=findings)
+            filter_string_matching = get_system_setting("filter_string_matching", False)
+            filter_class = ReportFindingFilterWithoutObjectLookups if filter_string_matching else ReportFindingFilter
+            findings = filter_class(d, queryset=findings)
             user_id = user.id if user is not None else None
             selected_widgets[list(widget.keys())[0] + '-' + str(idx)] = FindingList(request=request, findings=findings,
                                                                               finding_notes=finding_notes,

--- a/dojo/templates/dojo/report_filter_snippet.html
+++ b/dojo/templates/dojo/report_filter_snippet.html
@@ -5,7 +5,10 @@
 {% endblock %}
 <div class="filter-set report-filter-set">
     <form id="{{ title|slugify }}" method="get" class="{{ title|slugify }} {{ request.path|slugify }}-filters form-inline dojo-filter-set">
-        {% for field in form %}
+        {% for field in form.hidden_fields %}
+            {{ field }}
+        {% endfor %}
+        {% for field in form.visible_fields %}
             <div class="form-group">
                 {{ field.errors }}
                 {{ field.label_tag }} {{ field }}


### PR DESCRIPTION
This PR extends the string based filtering to the finding report filter. Currently, all of the following objects the user has access to are fetched on each page load:
- Product types
- Products
- Endpoints
- Engagements
- Tests
- Test Types
- Users,
- Tags (for each of the models)

On instances with large amounts of data, rendering this filter is as follows for my server 40k findings
- Object based filtering: ~15 seconds
- String based filtering: ~1.5 seconds

[sc-6622]