### PR TITLE
The Jira environment is built using only existing endpoints

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -618,7 +618,13 @@ def jira_environment(obj):
     if isinstance(obj, Finding):
         return "\n".join([str(endpoint) for endpoint in obj.endpoints.all()])
     elif isinstance(obj, Finding_Group):
-        return "\n".join([jira_environment(finding) for finding in obj.findings.all()])
+        envs = [
+            jira_environment(finding)
+            for finding in obj.findings.all()
+        ]
+
+        jira_environments = [env for env in envs if env]
+        return "\n".join(jira_environments)
     else:
         return ''
 


### PR DESCRIPTION
**Description**
When DefectDojo processes groups of findings to generate the Jira environment, it sometimes adds unnecessary "\n" characters. This happens when multiple findings are grouped, even if their endpoints are empty. In contrast, single findings with unset endpoints do not add extra carriage returns.

This fix ensures the Jira environment is generated using existing endpoints only, maintaining consistency across both grouped and single findings.

**Test results**

I don't believe there are tests for this

**Documentation**

This is a minor bug fix that shouldn't need any documentation updates

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [X] Bugfixes should be submitted against the `bugfix` branch.
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is flake8 compliant.
- [X] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.


