### PR TITLE
Fix create notification execution for group of findings

### DIFF
--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -244,7 +244,7 @@ def check_for_and_create_comment(parsed_json):
         findings = jissue.finding_group.findings.all()
         first_finding_group = findings.first()
         if first_finding_group:
-            create_notification(event='jira_comment', title=f'JIRA incoming comment - {first_finding_group}', finding=first_finding_group, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
+            create_notification(event='jira_comment', title=f'JIRA incoming comment - {jissue.finding_group}', finding=first_finding_group, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
     elif jissue.engagement:
         return webhook_responser_handler("debug", "Comment for engagement ignored")
     else:

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -241,8 +241,9 @@ def check_for_and_create_comment(parsed_json):
         findings = [jissue.finding]
         create_notification(event='jira_comment', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding", args=(jissue.finding.id,)), icon='check')
     elif jissue.finding_group:
-        findings = [jissue.finding_group.findings.all()]
-        create_notification(event='jira_comment', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
+        findings = jissue.finding_group.findings.all()
+        first_finding_group = findings.first()
+        create_notification(event='jira_comment', title=f'JIRA incoming comment - {first_finding_group}', finding=first_finding_group, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
     elif jissue.engagement:
         return webhook_responser_handler("debug", "Comment for engagement ignored")
     else:

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -243,7 +243,8 @@ def check_for_and_create_comment(parsed_json):
     elif jissue.finding_group:
         findings = jissue.finding_group.findings.all()
         first_finding_group = findings.first()
-        create_notification(event='jira_comment', title=f'JIRA incoming comment - {first_finding_group}', finding=first_finding_group, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
+        if first_finding_group:
+            create_notification(event='jira_comment', title=f'JIRA incoming comment - {first_finding_group}', finding=first_finding_group, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
     elif jissue.engagement:
         return webhook_responser_handler("debug", "Comment for engagement ignored")
     else:


### PR DESCRIPTION
**Description**

DefectDojo fails to process comments when closing a Jira issue associated with a group of findings, if the issue is closed with a comment. The error occurs because `jissue.finding` is not set when the Jira issue is associated with a group of findings. However, it is passed as a parameter to the `create_notification` function, which then fails when trying to get the product from it.

The proposed fix is to pass the first finding from the group, if it exists. This finding can be used as a parameter for the `create_notification` function, as the function uses it to retrieve notification parameters from the product configuration associated with the finding. Since all findings in the same group share the same product, using the first finding should work.

Additionally, I have updated the `findings` variable. It was previously created as a list with a `Queryset`, which is already an iterable object, so it does not need to be inside a list.

**Test results**

I don't believe there are tests for this

**Documentation**

This is a minor bug fix that shouldn't need any documentation updates

**Checklist**

This checklist is for your information.

- [ ] Make sure to rebase your PR against the very latest `dev`.
- [ ] Features/Changes should be submitted against the `dev`.
- [X] Bugfixes should be submitted against the `bugfix` branch.
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is flake8 compliant.
- [X] Your code is python 3.11 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [ ] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.

**Extra information**

The following example demonstrates the error that occurs when closing a Jira issue associated with a group of findings, if the issue is closed with a comment:

```python
[18/Jun/2024 13:04:08] ERROR [dojo.jira_link.views:124] 'NoneType' object has no attribute 'test'
Traceback (most recent call last):
  File "/app/dojo/jira_link/views.py", line 109, in webhook
    if (error_response := check_for_and_create_comment(parsed)) is not None:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/jira_link/views.py", line 214, in check_for_and_create_comment
    create_notification(event='other', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
  File "/app/dojo/notifications/helper.py", line 64, in create_notification
    product = kwargs['finding'].test.engagement.product
              ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'test'
[18/Jun/2024 13:04:08] INFO [django.request:241] OK: /jira/webhook/....
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 55, in wrapped_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/decorators/http.py", line 43, in inner
    return func(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/jira_link/views.py", line 109, in webhook
    if (error_response := check_for_and_create_comment(parsed)) is not None:
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/jira_link/views.py", line 214, in check_for_and_create_comment
    create_notification(event='other', title=f'JIRA incoming comment - {jissue.finding}', finding=jissue.finding, url=reverse("view_finding_group", args=(jissue.finding_group.id,)), icon='check')
  File "/app/dojo/notifications/helper.py", line 64, in create_notification
    product = kwargs['finding'].test.engagement.product
              ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'test'
 
```