### PR TITLE
feat(initContainer): Tune start-up process

### DIFF
--- a/helm/defectdojo/templates/celery-beat-deployment.yaml
+++ b/helm/defectdojo/templates/celery-beat-deployment.yaml
@@ -66,6 +66,12 @@ spec:
           path: {{ .hostPath }}
           {{- end }}
       {{- end }}
+      {{- if .Values.dbMigrationChecker.enabled }}
+      initContainers:
+      {{$data := dict "fullName" $fullName }}
+      {{- $newContext := merge . (dict "fullName" $fullName) }}
+      {{- include "dbMigrationChecker" $newContext | nindent 6 }}
+      {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy

--- a/helm/defectdojo/templates/celery-worker-deployment.yaml
+++ b/helm/defectdojo/templates/celery-worker-deployment.yaml
@@ -64,6 +64,12 @@ spec:
           path: {{ .hostPath }}
           {{- end }}
       {{- end }}
+      {{- if .Values.dbMigrationChecker.enabled }}
+      initContainers:
+      {{$data := dict "fullName" $fullName }}
+      {{- $newContext := merge . (dict "fullName" $fullName) }}
+      {{- include "dbMigrationChecker" $newContext | nindent 6 }}
+      {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy

--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -82,6 +82,12 @@ spec:
         emptyDir: {}
         {{- end }}
       {{- end }}
+      {{- if .Values.dbMigrationChecker.enabled }}
+      initContainers:
+      {{$data := dict "fullName" $fullName }}
+      {{- $newContext := merge . (dict "fullName" $fullName) }}
+      {{- include "dbMigrationChecker" $newContext | nindent 6 }}
+      {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -79,6 +79,9 @@ securityContext:
     # nginx dockerfile sets USER=1001
     runAsUser: 1001
 
+dbMigrationChecker:
+  enabled: true
+
 tests:
   unitTests:
     resources:
@@ -219,7 +222,7 @@ django:
       # Enable liveness checks on uwsgi container. Those values are use on nginx readiness checks as well.
       enabled: true
       failureThreshold: 6
-      initialDelaySeconds: 120
+      initialDelaySeconds: 3
       periodSeconds: 10
       successThreshold: 1
       timeoutSeconds: 5


### PR DESCRIPTION
Previous implementation used `initialDelaySeconds` set to `120s` which might be fine for standard (default resource allocation), first-time starting (with empty database) instances. Mentioned fact is problematic for:
- instances that are "under-resourced" and start-ups might be longer and `120s` might not be enough
- instances that are "over-resourced" and start-ups might be much shorter and `120s` might be wasting of time (to wait until the instance is marked as `Ready`)
- instances that are already deployed and just need upgrade (with no or only just a couple of migrations). In this case, it  is wasting of time again.
- instances with multiple replicas when each replica needs to wait 2 minutes without the reason. Waisting of time again.

This solution does not solve #10197 but at least do not silently allow full rollout until the database is fully migrated.

This solution might be solved as well #10141