### PR TITLE
fix(helm-celery): Drop unused variable logLevel

### DIFF
--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -131,7 +131,6 @@ celery:
   worker:
     annotations: {}
     affinity: {}
-    logLevel: INFO
     nodeSelector: {}
     replicas: 1
     resources:


### PR DESCRIPTION
In the whole helm template `logLevel` is used only in ConfigMap
https://github.com/DefectDojo/django-DefectDojo/blob/81c123e8d92024b965ddd3c985640e2fe398007b/helm/defectdojo/templates/configmap.yaml#L24
However, mentioned `logLevel` is used from `.Values.celery.logLevel` (not from `.Values.celery.worker.logLevel`) so the definition of `.Values.celery.worker.logLevel` is obsolete. 