### PR TITLE
fix(deps): build psycopg3 instead of using pre-build binary

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -16,13 +16,15 @@ RUN \
     bind-tools \
     mysql-client \
     mariadb-dev \
-    postgresql14-client \
+    postgresql16-client \
     xmlsec \
     git \
     util-linux \
     curl-dev \
     openssl \
     libffi-dev \
+    python3-dev \
+    libpq-dev \
     && \
     rm -rf /var/cache/apk/* && \
   true
@@ -49,7 +51,7 @@ RUN \
     xmlsec \
     git \
     util-linux \
-    postgresql14-client \
+    postgresql16-client \
     curl-dev \
     openssl \
     # needed for integration-tests

--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -16,13 +16,15 @@ RUN \
     bind-tools \
     mysql-client \
     mariadb-dev \
-    postgresql14-client \
+    postgresql16-client \
     xmlsec \
     git \
     util-linux \
     curl-dev \
     openssl \
     libffi-dev \
+    python3-dev \
+    libpq-dev \
     && \
     rm -rf /var/cache/apk/* && \
   true

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ Markdown==3.6
 mysqlclient==2.1.1
 openpyxl==3.1.5
 Pillow==10.4.0  # required by django-imagekit
-psycopg[binary]==3.2.1
+psycopg[c]==3.2.1
 cryptography==42.0.8
 python-dateutil==2.9.0.post0
 pytz==2024.1


### PR DESCRIPTION
**Description**

Since the update of the base python docker image from alpine:3.16 to 3.20 we've had segmentation faults while connecting to aws rds postgres databases. With the debug environment variable from the psycopg2 dependency we found connection issues while connecting to our database (see logs below).

Building the psycopg3 postgresql adapter instead of using the pre-build dependency as it's described in the [psycopg3 installation documentation](https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation) the connection could be established again as expected.

Also see the [slack thread](https://owasp.slack.com/messages/C2P5BA8MN/p1717509947946239) on this issue.

**Test results**

I've locally build and tested both the alpine and debian django +nginx dockerimages and tested them against the bitnami and aws rds postgres database.

**Extra information**

Additional logs:

Debug logs with the alpine image containing the psycopg2-binary 2.9.9 dependency:
```
[19] psyco_connect: dsn = 'dbname=dd client_encoding=UTF8 user=aws_admin password=bla host=defectdojo-rds-dev port=5432', async = 0
[19] connection_setup: init connection object at 0x7f18ab9af240, async 0, refcnt = [1] connection_setup: init connection object at 0x7f18ab9af240, async 0, refcnt = 11
[19] con_connect: connecting in SYNC mode
[19] conn_connect: new PG connection at 0x7f18aaf8d4b0
[19] conn_connect: PQconnectdb(dbname=dd client_encoding=UTF8 user=aws_admin password=bla host=defectdojo-rds-dev port=5432) returned BAD
[19] connection_init: FAILED
!!! uWSGI process 19 got Segmentation Fault !!!
```

Debug logs with the alpine image containing the self-build psycopg2 2.9.9 dependency:
```
[19] psyco_connect: dsn = 'dbname=dd client_encoding=UTF8 user=aws_admin password=bla host=defectdojo-rds-dev port=5432', async = 0
[19] connection_setup: init connection object at 0x7f87c53e3240, async 0, refcnt = 1
[19] con_connect: connecting in SYNC mode
[19] conn_connect: new PG connection at 0x7f87c49248a0
[19] conn_connect: server standard_conforming_strings parameter: on
[19] conn_connect: server requires E'' quotes: NO
[19] conn_connect: using protocol 3
[19] conn_connect: client encoding: UTF8
[19] clear_encoding_name: UTF8 -> UTF8
[19] conn_set_fast_codec: encoding=UTF8
[19] conn_set_fast_codec: PyUnicode_DecodeUTF8
[19] conn_connect: DateStyle ISO, MDY
[19] connection_setup: good connection object at 0x7f87c53e3240, refcnt = 1
```