### PR TITLE
fix(exit in bash): Fix handling exit in initializer

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e  # needed to handle "exit" correctly
+
 . /secret-file-loader.sh
 . /reach_database.sh
 


### PR DESCRIPTION
The original `exit` (e.g. from #9002) worked correctly in `sh`.
However, by adding `shellcheck`, #9147 changed `sh` to `bash` which handles these situations differently.
Linter introduced an error that nobody noticed. 
Issue discovered during investigation of #10490