### PR TITLE
feat(db-checker): Extension of "db reachable"

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e  # needed to handle "exit" correctly
+
 . /secret-file-loader.sh
 . /reach_database.sh
 

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -13,4 +13,11 @@ wait_for_database_to_be_reachable() {
         exit 1
     fi
     done
+    cat <<EOD | python manage.py shell
+from django.db import connections
+from django.db.utils import OperationalError
+db_conn = connections['default']
+c = db_conn.cursor()
+EOD
+    exit $?
 }


### PR DESCRIPTION
Extend `wait_for_database_to_be_reachable`. Not only for simple operation but check that DB is compatible.

Added based on https://github.com/DefectDojo/django-DefectDojo/issues/10490