### PR TITLE
fix(helm-psql): Drop pinning of old version of postgresql

### DIFF
--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -367,8 +367,6 @@ mysql:
 
 postgresql:
   enabled: true
-  image:
-    tag: 11.22.0-debian-11-r4
   auth:
     username: defectdojo
     password: ""


### PR DESCRIPTION
Fix #10490