### PR TITLE
fix(doc): Disable markup.highlight.guessSyntax + enable mermaid

### DIFF
--- a/docs/config.dev.toml
+++ b/docs/config.dev.toml
@@ -85,7 +85,8 @@ weight = 1
       # See a complete list of available styles at https://xyproto.github.io/splash/docs/all.html
       style = "dracula"
       # Uncomment if you want your chosen highlight style used for code blocks without a specified language
-      guessSyntax = "true"
+      # Do not uncomment otherwise it breaks mermaid
+      # guessSyntax = "true"
 
 # Everything below this are Site Params
 
@@ -198,3 +199,6 @@ enable = false
 	url = "https://owasp.slack.com/archives/C014H3ZV9U6"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers"
+
+[params.mermaid]
+enable = true

--- a/docs/config.master.toml
+++ b/docs/config.master.toml
@@ -85,7 +85,8 @@ weight = 1
       # See a complete list of available styles at https://xyproto.github.io/splash/docs/all.html
       style = "dracula"
       # Uncomment if you want your chosen highlight style used for code blocks without a specified language
-      guessSyntax = "true"
+      # Do not uncomment otherwise it breaks mermaid
+      # guessSyntax = "true"
 
 # Everything below this are Site Params
 
@@ -198,3 +199,6 @@ enable = false
 	url = "https://owasp.slack.com/archives/C014H3ZV9U6"
 	icon = "fab fa-slack"
         desc = "Chat with other project developers"
+
+[params.mermaid]
+enable = true

--- a/docs/content/en/integrations/ldap-authentication.md
+++ b/docs/content/en/integrations/ldap-authentication.md
@@ -41,7 +41,7 @@ Please check for the latest version of these requirements at the time of impleme
 
 Otherwise add the following to requirements.txt:
 
-```
+```python
 python-ldap==3.4.2
 django-auth-ldap==4.1.0
 ```
@@ -119,7 +119,7 @@ Read the docs for Django Authentication with LDAP here: https://django-auth-ldap
 In order to pass the variables to the settings.dist.py file via docker, it's a good idea to add these to the docker-compose file.
 
 You can do this by adding the following variables to the environment section for the uwsgi image:
-```
+```yaml
 DD_LDAP_SERVER_URI: "${DD_LDAP_SERVER_URI:-ldap://ldap.example.com}"
 DD_LDAP_BIND_DN: "${DD_LDAP_BIND_DN:-}"
 DD_LDAP_BIND_PASSWORD: "${DD_LDAP_BIND_PASSWORD:-}"

--- a/docs/content/en/integrations/parsers/file/fortify.md
+++ b/docs/content/en/integrations/parsers/file/fortify.md
@@ -20,6 +20,6 @@ per category. To get all issues, copy the [DefaultReportDefinitionAllIssues.xml]
 
 Once this is complete, you can run the following command on your .fpr file to generate the
 required XML:
-```
+```bash
 ./path/to/ReportGenerator -format xml -f /path/to/output.xml -source /path/to/downloaded/artifact.fpr -template DefaultReportDefinitionAllIssues.xml
 ```

--- a/docs/content/en/integrations/parsers/file/veracode.md
+++ b/docs/content/en/integrations/parsers/file/veracode.md
@@ -14,7 +14,7 @@ Veracode reports can be ingested in either XML or JSON Format
       - Requires slight modification of the response returned from the API
       - Exmample of a request being: `url <endpoint> | jq "{findings}"`
       - Desired Format:
-        ```
+        ```json
         {
             "findings": [
                 {
@@ -28,7 +28,7 @@ Veracode reports can be ingested in either XML or JSON Format
       - This response can be saved directly to a file and uploaded
       - Not as ideal for crafting a refined report consisting of multiple requests
       - Desired Format:
-        ```
+        ```json
         {
             "_embedded": {
                 "findings": [

--- a/docs/content/en/integrations/social-authentication.md
+++ b/docs/content/en/integrations/social-authentication.md
@@ -312,7 +312,7 @@ Edit the settings (see [Configuration]({{< ref "/getting_started/configuration" 
  
 or, alternatively, for helm configuration, add this to the `extraConfig` section: 
 
-```
+```yaml
 DD_SESSION_COOKIE_SECURE: 'True'
 DD_CSRF_COOKIE_SECURE: 'True'
 DD_SECURE_SSL_REDIRECT: 'True'
@@ -453,7 +453,7 @@ Some Identity Providers are able to send list of groups to which should user bel
 
 You can bypass the login form if you are only using SSO/Social authentication for login in by enabling these two environment variables:
 
-```
+```yaml
 DD_SOCIAL_LOGIN_AUTO_REDIRECT: "true"
 DD_SOCIAL_AUTH_SHOW_LOGIN_FORM: "false"
 ```

--- a/docs/content/en/usage/productgrading.md
+++ b/docs/content/en/usage/productgrading.md
@@ -27,7 +27,7 @@ Note that the following abbreviations were used:
 - med: amount of medium findings within the product
 - low: amount of low findings within the product
 
-```
+```python
 health=100
 if crit > 0:
     health = 40


### PR DESCRIPTION
I found [`mermaid`](https://mermaid.js.org/) quite handy during the preparation of documentation for #7311.

Unfortunately, when `mermaid` is enabled `guessSyntax` has to be disabled otherwise graphs are not rendered (because `guessSyntax` marks `mermaid` snippets as `language-fallback` and they are not rendered at all).

I added languages to places where they have been probably guessed in the past. Now they do not need to be guessed.