### PR TITLE
Direct Renovate to ignore MySQL and RabbitMQ packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,10 @@
   "dependencyDashboardApproval": false,
   "baseBranches": ["dev"],
   "rebaseWhen": "conflicted",
+  "ignoreDeps": [
+    "mysql",
+    "rabbitmq"
+  ],
   "ignorePaths": ["requirements.txt", "components/package.json", "components/package-lock.json", "dojo/components/yarn.lock", "dojo/components/package.json", "Dockerfile**"],
   "packageRules": [{
     "packagePatterns": ["*"],


### PR DESCRIPTION
**Description**

Since we have [deprecated MySQL and RabbitMQ as of v2.36.0](https://github.com/DefectDojo/django-DefectDojo/discussions/9690), this PR will remove them from the list of packages for which Renovate will open PRs for every version bump (as seen with e.g. #10502 #10510). This is part of our gradual removal of these packages now that they are no longer supported.

This PR should be reverted once these packages are totally removed.

**Test results**

N/A

**Documentation**

N/A