### PR TITLE
fix(api-notif): Fix order of validators

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2951,6 +2951,7 @@ class NotificationsSerializer(serializers.ModelSerializer):
     def validate(self, data):
         user = None
         product = None
+        template = False
 
         if self.instance is not None:
             user = self.instance.user
@@ -2960,25 +2961,26 @@ class NotificationsSerializer(serializers.ModelSerializer):
             user = data.get("user")
         if "product" in data:
             product = data.get("product")
+        if "template" in data:
+            template = data.get("template")
 
+        if (
+            template
+            and Notifications.objects.filter(template=True).count() > 0
+        ):
+            msg = "Notification template already exists"
+            raise ValidationError(msg)
         if (
             self.instance is None
             or user != self.instance.user
             or product != self.instance.product
         ):
             notifications = Notifications.objects.filter(
-                user=user, product=product, template=False
+                user=user, product=product, template=template
             ).count()
             if notifications > 0:
                 msg = "Notification for user and product already exists"
                 raise ValidationError(msg)
-        if (
-            data.get("template")
-            and Notifications.objects.filter(template=True).count() > 0
-        ):
-            msg = "Notification template already exists"
-            raise ValidationError(msg)
-
         return data
 
 

--- a/unittests/test_apiv2_notifications.py
+++ b/unittests/test_apiv2_notifications.py
@@ -21,7 +21,7 @@ class NotificationsTest(DojoAPITestCase):
             scan_added=['alert', 'slack']
         )
         self.creation_id = r.json()["id"]
-        self.assertEqual(r.status_code, 201)
+        self.assertEqual(r.status_code, 201, r.data)
 
     def tearDown(self):
         self.client.delete(f"{reverse('notifications-list')}/{self.creation_id}")


### PR DESCRIPTION
During the implementation of #7311, I noticed specific edge cases that the implemented `validate` function did not handle correctly.

If there is an existing System Notification (user=None, product=None, template=false), it is not possible to add a Notification Template. It failed with `Notification for user and product already exists` even though it wasn't true. So I add a `template` flag to the checking query. However, I also needed to reorder checkers because "existing template" would fail with `Notification for user and product already exists` so a reorder was needed.