### PR TITLE
Import: leverage the minimum severity flag

### DIFF
--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -159,7 +159,7 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
             # make sure the severity is something is digestible
             unsaved_finding = self.sanitize_severity(unsaved_finding)
             # Filter on minimum severity if applicable
-            if (minimum_severity := kwargs.get("minimum_severity")) and (Finding.SEVERITIES[unsaved_finding.severity] > Finding.SEVERITIES[minimum_severity]):
+            if Finding.SEVERITIES[unsaved_finding.severity] > Finding.SEVERITIES[self.minimum_severity]:
                 # finding's severity is below the configured threshold : ignoring the finding
                 continue
 

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -175,7 +175,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             # make sure the severity is something is digestible
             unsaved_finding = self.sanitize_severity(unsaved_finding)
             # Filter on minimum severity if applicable
-            if (minimum_severity := kwargs.get("minimum_severity")) and (Finding.SEVERITIES[unsaved_finding.severity] > Finding.SEVERITIES[minimum_severity]):
+            if Finding.SEVERITIES[unsaved_finding.severity] > Finding.SEVERITIES[self.minimum_severity]:
                 # finding's severity is below the configured threshold : ignoring the finding
                 continue
             # Some parsers provide "mitigated" field but do not set timezone (because they are probably not available in the report)

--- a/unittests/dojo_test_case.py
+++ b/unittests/dojo_test_case.py
@@ -648,7 +648,7 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
     def assert_finding_count_json(self, count, findings_content_json):
         self.assertEqual(findings_content_json['count'], count)
 
-    def get_test_findings_api(self, test_id, active=None, verified=None, is_mitigated=None, component_name=None, component_version=None):
+    def get_test_findings_api(self, test_id, active=None, verified=None, is_mitigated=None, component_name=None, component_version=None, severity=None):
         payload = {'test': test_id}
         if active is not None:
             payload['active'] = active
@@ -660,6 +660,8 @@ class DojoAPITestCase(APITestCase, DojoTestUtilsMixin):
             payload['component_name'] = component_name
         if component_version is not None:
             payload['component_version'] = component_version
+        if severity is not None:
+            payload['severity'] = severity
 
         response = self.client.get(reverse('finding-list'), payload, format='json')
         self.assertEqual(200, response.status_code, response.content[:1000])

--- a/unittests/test_import_reimport.py
+++ b/unittests/test_import_reimport.py
@@ -513,6 +513,29 @@ class ImportReimportMixin:
         # reimporting the exact same scan shouldn't create any notes
         self.assertEqual(notes_count_before, self.db_notes_count())
 
+    # Test the minimum severity flag
+    def test_import_sonar1_measure_minimum_severity_counts(self):
+        # Critical
+        response_json = self.import_scan_with_params(self.sonarqube_file_name1, scan_type=self.scan_type_sonarqube_detailed, minimum_severity="Critical")
+        test_id = response_json['test']
+        # Count all findings
+        self.assert_finding_count_json(3, self.get_test_findings_api(test_id))
+        self.assert_finding_count_json(3, self.get_test_findings_api(test_id, severity="Critical"))
+
+        # High
+        response_json = self.import_scan_with_params(self.sonarqube_file_name1, scan_type=self.scan_type_sonarqube_detailed, minimum_severity="High")
+        test_id = response_json['test']
+        # Count all findings
+        self.assert_finding_count_json(4, self.get_test_findings_api(test_id))
+        self.assert_finding_count_json(1, self.get_test_findings_api(test_id, severity="High"))
+
+        # Low
+        response_json = self.import_scan_with_params(self.sonarqube_file_name1, scan_type=self.scan_type_sonarqube_detailed, minimum_severity="Low")
+        test_id = response_json['test']
+        # Count all findings
+        self.assert_finding_count_json(6, self.get_test_findings_api(test_id))
+        self.assert_finding_count_json(2, self.get_test_findings_api(test_id, severity="Low"))
+
     # Test re-import with unique_id_from_tool_or_hash_code algorithm
     # import veracode_many_findings and then reimport veracode_many_findings again with verified is false
     # - reimport, findings stay the same, stay active


### PR DESCRIPTION
The `minimum_seveirty` flag was parsed and managed by the `ImporterOptions` class, but was never actually used by the Importers. This PR corrects that and adds a unit test to ensure the flag is working as expected.

[sc-6837]