### PR TITLE
Fix(django): Upgrade of 4.2.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ django-slack==5.19.0
 git+https://github.com/DefectDojo/django-tagging@develop#egg=django-tagging
 django-watson==1.6.3
 django-prometheus==2.3.1
-Django==4.2.13
+Django==4.2.14
 djangorestframework==3.15.2
 html2text==2024.2.26
 humanize==4.10.0


### PR DESCRIPTION
While waiting for the acceptance of #10409, it might be a good idea to upgrade Django at least to `4.2.14` to mitigate known issues: https://docs.djangoproject.com/en/5.0/releases/4.2.14/

This change is not offered by `dependabot` because it is monitoring only the latest versions (in running configuration).