### PR TITLE
Endpoint get or create: Do not raise warning when there is an existing endpoint

### DIFF
--- a/dojo/endpoint/utils.py
+++ b/dojo/endpoint/utils.py
@@ -79,6 +79,8 @@ def endpoint_get_or_create(**kwargs):
         count = qs.count()
         if count == 0:
             return Endpoint.objects.get_or_create(**kwargs)
+        elif count == 1:
+            return qs.order_by("id").first(), False
         else:
             logger.warning(
                 f"Endpoints in your database are broken. "


### PR DESCRIPTION
When a single endpoints is found in the endpoint get or create helper method, we do not want to raise a warning
