### PR TITLE
Test Types: Return support for disabling test types via the `active` flag

### DIFF
--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -48,7 +48,12 @@ def get_parser(scan_type):
 
 
 def get_inactive_test_types():
-    return Test_Type.objects.filter(active=False).values_list("name", flat=True)
+    try:
+        return list(Test_Type.objects.filter(active=False).values_list("name", flat=True))
+    except Exception:
+        # This exception is reached in the event of loading fixtures in to an empty database
+        # prior to migrations runnings
+        return []
 
 
 def get_scan_types_sorted():

--- a/dojo/tools/factory.py
+++ b/dojo/tools/factory.py
@@ -39,7 +39,7 @@ def get_parser(scan_type):
         raise ValueError(msg)
     rg = re.compile(settings.PARSER_EXCLUDE)
     if not rg.match(scan_type) or settings.PARSER_EXCLUDE.strip() == "":
-        # update DB dynamicaly
+        # update DB dynamically
         test_type, _ = Test_Type.objects.get_or_create(name=scan_type)
         if test_type.active:
             return PARSERS[scan_type]
@@ -47,17 +47,25 @@ def get_parser(scan_type):
     raise ValueError(msg)
 
 
+def get_inactive_test_types():
+    return Test_Type.objects.filter(active=False).values_list("name", flat=True)
+
+
 def get_scan_types_sorted():
     res = []
+    inactive_test_types = get_inactive_test_types()
     for key in PARSERS:
-        res.append((key, PARSERS[key].get_description_for_scan_types(key)))
+        if key not in inactive_test_types:
+            res.append((key, PARSERS[key].get_description_for_scan_types(key)))
     return sorted(res, key=lambda x: x[0].lower())
 
 
 def get_choices_sorted():
     res = []
+    inactive_test_types = get_inactive_test_types()
     for key in PARSERS:
-        res.append((key, key))
+        if key not in inactive_test_types:
+            res.append((key, key))
     return sorted(res, key=lambda x: x[1].lower())
 
 
@@ -74,8 +82,9 @@ def requires_file(scan_type):
 
 def get_api_scan_configuration_hints():
     res = []
+    inactive_test_types = get_inactive_test_types()
     for name, parser in PARSERS.items():
-        if hasattr(parser, "api_scan_configuration_hint"):
+        if name not in inactive_test_types and hasattr(parser, "api_scan_configuration_hint"):
             scan_types = parser.get_scan_types()
             for scan_type in scan_types:
                 tool_type = parser.requires_tool_type(scan_type)


### PR DESCRIPTION
Return the ability to remove a given test type from being used, but without deleting the test type. This change has the following impacts for test types with a False `active` status:
- Import forms will not list inactive test types
- Creating/editing a test will not allow for an inactive test type to be selected

There is a slight caveat to this such that the API swagger schema does not appear to be calling the function to generate the list of test types each time the schema is loaded. The test type list is updated on uwsgi reload. My best guess is the schema is being cached on the server somehow. 

[sc-6869]