### PR TITLE
Delete Preview: Expand on missed objects

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -28,6 +28,7 @@ from dojo.utils import (
     calculate_grade,
     get_page_items,
     get_period_counts,
+    get_setting,
     get_system_setting,
     is_scan_file_too_large,
     redirect,
@@ -223,9 +224,12 @@ def delete_endpoint(request, eid):
                                      extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('view_product', args=(product.id,)))
 
-    collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-    collector.collect([endpoint])
-    rels = collector.nested()
+    rels = ["Previewing the relationships has been disabled.", ""]
+    display_preview = get_setting("DELETE_PREVIEW")
+    if display_preview:
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([endpoint])
+        rels = collector.nested()
 
     product_tab = Product_Tab(endpoint.product, "Delete Endpoint", tab="endpoints")
 

--- a/dojo/finding_group/views.py
+++ b/dojo/finding_group/views.py
@@ -16,7 +16,7 @@ from dojo.filters import FindingFilter, FindingFilterWithoutObjectLookups
 from dojo.finding.views import prefetch_for_findings
 from dojo.forms import DeleteFindingGroupForm, EditFindingGroupForm, FindingBulkUpdateForm
 from dojo.models import Engagement, Finding, Finding_Group, GITHUB_PKey, Product
-from dojo.utils import Product_Tab, add_breadcrumb, get_page_items, get_system_setting, get_words_for_field
+from dojo.utils import Product_Tab, add_breadcrumb, get_page_items, get_setting, get_system_setting, get_words_for_field
 
 logger = logging.getLogger(__name__)
 
@@ -121,9 +121,12 @@ def delete_finding_group(request, fgid):
                                      extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('view_test', args=(finding_group.test.id,)))
 
-    collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-    collector.collect([finding_group])
-    rels = collector.nested()
+    rels = ["Previewing the relationships has been disabled.", ""]
+    display_preview = get_setting("DELETE_PREVIEW")
+    if display_preview:
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([finding_group])
+        rels = collector.nested()
     product_tab = Product_Tab(finding_group.test.engagement.product, title="Product", tab="settings")
 
     return render(request, 'dojo/delete_finding_group.html', {

--- a/dojo/github_issue_link/views.py
+++ b/dojo/github_issue_link/views.py
@@ -16,7 +16,7 @@ from dojo.authorization.authorization_decorators import user_is_configuration_au
 # Local application/library imports
 from dojo.forms import DeleteGITHUBConfForm, GITHUBForm
 from dojo.models import GITHUB_Conf
-from dojo.utils import add_breadcrumb
+from dojo.utils import add_breadcrumb, get_setting
 
 logger = logging.getLogger(__name__)
 
@@ -87,9 +87,12 @@ def delete_github(request, tid):
                                      extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('github'))
 
-    collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-    collector.collect([github_instance])
-    rels = collector.nested()
+    rels = ["Previewing the relationships has been disabled.", ""]
+    display_preview = get_setting("DELETE_PREVIEW")
+    if display_preview:
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([github_instance])
+        rels = collector.nested()
 
     add_breadcrumb(title="Delete", top_level=False, request=request)
     return render(request, 'dojo/delete_github.html',

--- a/dojo/group/views.py
+++ b/dojo/group/views.py
@@ -40,7 +40,13 @@ from dojo.group.queries import (
 )
 from dojo.group.utils import get_auth_group_name
 from dojo.models import Dojo_Group, Dojo_Group_Member, Global_Role, Product_Group, Product_Type_Group
-from dojo.utils import add_breadcrumb, get_page_items, is_title_in_breadcrumbs, redirect_to_return_url_or_else
+from dojo.utils import (
+    add_breadcrumb,
+    get_page_items,
+    get_setting,
+    is_title_in_breadcrumbs,
+    redirect_to_return_url_or_else,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -239,12 +245,16 @@ class DeleteGroup(View):
 
     def get_initial_context(self, request: HttpRequest, group: Dojo_Group):
         # Add the related objects to the delete page
-        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-        collector.collect([group])
+        rels = ["Previewing the relationships has been disabled.", ""]
+        display_preview = get_setting("DELETE_PREVIEW")
+        if display_preview:
+            collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+            collector.collect([group])
+            rels = collector.nested()
         return {
             "form": self.get_group_form(request, group),
             "to_delete": group,
-            "rels": collector.nested()
+            "rels": rels,
         }
 
     def process_forms(self, request: HttpRequest, group: Dojo_Group, context: dict):

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -24,7 +24,7 @@ from dojo.authorization.authorization import user_has_configuration_permission
 from dojo.forms import DeleteJIRAInstanceForm, ExpressJIRAForm, JIRAForm
 from dojo.models import JIRA_Instance, JIRA_Issue, Notes, System_Settings, User
 from dojo.notifications.helper import create_notification
-from dojo.utils import add_breadcrumb, add_error_message_to_response
+from dojo.utils import add_breadcrumb, add_error_message_to_response, get_setting
 
 logger = logging.getLogger(__name__)
 
@@ -515,9 +515,12 @@ class DeleteJiraView(View):
             raise PermissionDenied
         jira_instance = get_object_or_404(JIRA_Instance, pk=tid)
         form = self.get_form_class()(instance=jira_instance)
-        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-        collector.collect([jira_instance])
-        rels = collector.nested()
+        rels = ["Previewing the relationships has been disabled.", ""]
+        display_preview = get_setting("DELETE_PREVIEW")
+        if display_preview:
+            collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+            collector.collect([jira_instance])
+            rels = collector.nested()
 
         add_breadcrumb(title="Delete", top_level=False, request=request)
         return render(request, self.get_template(), {
@@ -549,9 +552,13 @@ class DeleteJiraView(View):
                     return HttpResponseRedirect(reverse('jira'))
                 except Exception as e:
                     add_error_message_to_response(f'Unable to delete JIRA Instance, probably because it is used by JIRA Issues: {str(e)}')
-        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-        collector.collect([jira_instance])
-        rels = collector.nested()
+
+        rels = ["Previewing the relationships has been disabled.", ""]
+        display_preview = get_setting("DELETE_PREVIEW")
+        if display_preview:
+            collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+            collector.collect([jira_instance])
+            rels = collector.nested()
 
         add_breadcrumb(title="Delete", top_level=False, request=request)
         return render(request, self.get_template(), {

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -1625,9 +1625,12 @@ def delete_engagement_presets(request, pid, eid):
                                      extra_tags='alert-success')
                 return HttpResponseRedirect(reverse('engagement_presets', args=(pid,)))
 
-    collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-    collector.collect([preset])
-    rels = collector.nested()
+    rels = ["Previewing the relationships has been disabled.", ""]
+    display_preview = get_setting("DELETE_PREVIEW")
+    if display_preview:
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([preset])
+        rels = collector.nested()
 
     product_tab = Product_Tab(prod, title=_("Delete Engagement Preset"), tab="settings")
     return render(request, 'dojo/delete_presets.html',

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -49,7 +49,7 @@ from dojo.models import (
     System_Settings,
     TextQuestion,
 )
-from dojo.utils import add_breadcrumb, get_page_items
+from dojo.utils import add_breadcrumb, get_page_items, get_setting
 
 
 @user_is_authorized(Engagement, Permissions.Engagement_Edit, 'eid')
@@ -315,9 +315,12 @@ def edit_questionnaire(request, sid):
 def delete_questionnaire(request, sid):
     survey = get_object_or_404(Engagement_Survey, id=sid)
     form = Delete_Eng_Survey_Form(instance=survey)
-    collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-    collector.collect([survey])
-    rels = collector.nested()
+    rels = ["Previewing the relationships has been disabled.", ""]
+    display_preview = get_setting("DELETE_PREVIEW")
+    if display_preview:
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([survey])
+        rels = collector.nested()
 
     if request.method == 'POST':
         if 'id' in request.POST and str(survey.id) == request.POST['id']:

--- a/dojo/templates/dojo/delete_alerts.html
+++ b/dojo/templates/dojo/delete_alerts.html
@@ -8,15 +8,20 @@
         <div class="panel-heading">
             <h3>{% trans "Danger Zone" %}</h3>
         </div>
-
-        <div>
-            <h4>{% trans "The following alerts will be deleted" %}</h4>
-        </div>
-        {% for alert in alerts %}
-            <tr>
-                <td>{% if alert.url %}<a href="{{ alert.url }}">{% endif %}{{ alert.title|linebreaks }}{% if alert.url %}</a>{% endif %}</td>
-            </tr>
-        {% endfor %}
+        {% if delete_preview%}
+            <div>
+                <h4>{% trans "The following alerts will be deleted" %}</h4>
+            </div>
+            {% for alert in alerts %}
+                <tr>
+                    <td>{% if alert.url %}<a href="{{ alert.url }}">{% endif %}{{ alert.title|linebreaks }}{% if alert.url %}</a>{% endif %}</td>
+                </tr>
+            {% endfor %}
+        {% else %}
+            <div>
+                <h4>{% trans "Previewing the relationships has been disabled." %}</h4>
+            </div>
+        {% endif %}
         <form class="form-horizontal" method="post">
             {% csrf_token %}
             {{ form }}

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -49,7 +49,7 @@ from dojo.group.queries import get_authorized_group_members_for_user
 from dojo.models import Alerts, Dojo_Group_Member, Dojo_User, Product_Member, Product_Type_Member
 from dojo.product.queries import get_authorized_product_members_for_user
 from dojo.product_type.queries import get_authorized_product_type_members_for_user
-from dojo.utils import add_breadcrumb, get_page_items, get_system_setting
+from dojo.utils import add_breadcrumb, get_page_items, get_setting, get_system_setting
 
 logger = logging.getLogger(__name__)
 
@@ -199,9 +199,10 @@ def delete_alerts(request):
             extra_tags='alert-success')
         return HttpResponseRedirect('alerts')
 
-    return render(request,
-                    'dojo/delete_alerts.html',
-                    {'alerts': alerts})
+    return render(request, 'dojo/delete_alerts.html', {
+        "alerts": alerts,
+        "delete_preview": get_setting('DELETE_PREVIEW'),
+    })
 
 
 @login_required
@@ -493,9 +494,12 @@ def delete_user(request, uid):
                                             extra_tags='alert-warning')
                     return HttpResponseRedirect(reverse('users'))
 
-    collector = NestedObjects(using=DEFAULT_DB_ALIAS)
-    collector.collect([user])
-    rels = collector.nested()
+    rels = ["Previewing the relationships has been disabled.", ""]
+    display_preview = get_setting("DELETE_PREVIEW")
+    if display_preview:
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([user])
+        rels = collector.nested()
 
     add_breadcrumb(title=_("Delete User"), top_level=False, request=request)
     return render(request, 'dojo/delete_user.html',


### PR DESCRIPTION
There are a few objects that were missed in the addition of the `DELETE_PREVIEW` setting to prevent the full chain of associated objects from being expanded into memory. The list is as follows:
- Alerts
- Jira Instance
- Endpoints
- Questionnaires
- Github Links
- Engagement Presets
- Finding Groups
- Groups (users)
- User

Fixes #10532 

[sc-6873]