### PR TITLE
Finding Open/Close/Review: Enforce more status standardization

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -1812,7 +1812,7 @@ class ClearFindingReviewForm(forms.ModelForm):
 
     class Meta:
         model = Finding
-        fields = ['active', 'verified', 'false_p', 'out_of_scope', 'duplicate']
+        fields = ['active', 'verified', 'false_p', 'out_of_scope', 'duplicate', "is_mitigated"]
 
 
 class ReviewFindingForm(forms.Form):


### PR DESCRIPTION
- Allow for closing a finding when clearing a review
- Enforces the `under_review` flag is set to `False` when reopening or closing a finding

[sc-3366]