### PR TITLE
remove outdated skip_duplicates API reference from docs

### DIFF
--- a/docs/content/en/usage/features.md
+++ b/docs/content/en/usage/features.md
@@ -388,8 +388,6 @@ details about the deduplication process : switch
 
 ### Deduplication - APIv2 parameters
 
-- `skip_duplicates`: if true, duplicates are not
-    inserted at all
 - `close_old_findings` : if true, findings that are not
     duplicates and that were in the previous scan of the same type
     (example ZAP) for the same engagement (or product in case of


### PR DESCRIPTION
`skip_duplicates` has not been used in DefectDojo since deduplication was refactored in 2019: see PR https://github.com/DefectDojo/django-DefectDojo/pull/1395.  This commit removes the API reference from docs.

