### PR TITLE
creds-notes-fixes Some updates to creds/cred-related notes

### DIFF
--- a/dojo/cred/views.py
+++ b/dojo/cred/views.py
@@ -112,7 +112,8 @@ def view_cred_details(request, ttid):
         'cred': cred,
         'form': form,
         'notes': notes,
-        'cred_products': cred_products
+        'cred_products': cred_products,
+        'person': request.user.username,
     })
 
 
@@ -650,7 +651,7 @@ def delete_cred_controller(request, destination_url, id, ttid):
     if id:
         product = None
         if destination_url == "all_cred_product":
-            product = get_object_or_404(Product, id)
+            product = get_object_or_404(Product, id=id)
         elif destination_url == "view_engagement":
             engagement = get_object_or_404(Engagement, id=id)
             product = engagement.product
@@ -669,7 +670,7 @@ def delete_cred_controller(request, destination_url, id, ttid):
 
 @user_is_authorized(Cred_User, Permissions.Credential_Delete, 'ttid')
 def delete_cred(request, ttid):
-    return delete_cred_controller(request, "cred", 0, ttid)
+    return delete_cred_controller(request, "cred", 0, ttid=ttid)
 
 
 @user_is_authorized(Product, Permissions.Product_Edit, 'pid')

--- a/dojo/notes/views.py
+++ b/dojo/notes/views.py
@@ -15,7 +15,7 @@ from dojo.authorization.roles_permissions import Permissions
 
 # Local application/library imports
 from dojo.forms import DeleteNoteForm, NoteForm, TypedNoteForm
-from dojo.models import Engagement, Finding, Note_Type, NoteHistory, Notes, Test
+from dojo.models import Cred_User, Engagement, Finding, Note_Type, NoteHistory, Notes, Test
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +37,11 @@ def delete_note(request, id, page, objid):
         object = get_object_or_404(Finding, id=objid)
         object_id = object.id
         reverse_url = "view_finding"
+    elif page == "cred":
+        object = get_object_or_404(Cred_User, id=objid)
+        object_id = object.id
+        reverse_url = "view_cred_details"
+
     form = DeleteNoteForm(request.POST, instance=note)
 
     if page is None:
@@ -53,7 +58,7 @@ def delete_note(request, id, page, objid):
     else:
         messages.add_message(request,
                              messages.SUCCESS,
-                             _('Note was not succesfully deleted.'),
+                             _('Note was not successfully deleted.'),
                              extra_tags='alert-danger')
 
     return HttpResponseRedirect(reverse(reverse_url, args=(object_id, )))

--- a/dojo/templates/dojo/view_cred_details.html
+++ b/dojo/templates/dojo/view_cred_details.html
@@ -99,11 +99,7 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
-            <div class="clearfix">
-              <div class="panel-heading">
-                  <h4>Associated Products</h4>
-              </div>
-            </div>
+            <h4>Associated Products</h4>
         </div>
         <div class="table-responsive">
             {% if cred_products %}
@@ -142,56 +138,58 @@
         <div class="panel-heading">
             <h3>Notes</h3>
         </div>
-        {% if notes %}
-            <table id="notes" class="table-striped table table-condensed table-hover">
-                <thead>
-                <tr>
-                    <th>User</th>
-                    <th>Date</th>
-                    <th>Note</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for note in notes %}
+        <div class="panel-body">
+            {% if notes %}
+                <table id="notes" class="table-striped table table-condensed table-hover">
+                    <thead>
                     <tr>
-                        <td>
-                            {{ note.author.username }}
-                        </td>
-                        <td>
-                            {{ note.date }}
-                        </td>
-                        <td>
-                            {{ note }}
-                            {% if person == note.author.username %}
-                                <a href="{% url 'delete_test_note' test.id note.id %}" class="btn btn-danger btn-xs"
-                                   title="Delete">
-                                    <i class="fa-solid fa-trash" aria-hidden="true"></i>
-                                </a>
-                            {% endif %}
-                        </td>
+                        <th>User</th>
+                        <th>Date</th>
+                        <th>Note</th>
                     </tr>
-                {% endfor %}
-
-                </tbody>
-            </table>
-        {% else %}
-
-            <p class="text-center">No notes found.</p>
-        {% endif %}
-        <hr/>
-
-        <form class="form-horizontal" id="add_notes" action="{% url 'view_cred_details' cred.id %}"
-              method="post">{% csrf_token %}
-            {% include "dojo/form_fields.html" with form=form %}
-            <div class="form-group">
-                <div class="col-sm-offset-2 col-sm-10">
-                    <input class="btn btn-primary" type="submit" value="Add Note"/>
-
+                    </thead>
+                    <tbody>
+                    {% for note in notes %}
+                        <tr>
+                            <td>
+                                {{ note.author.username }}
+                            </td>
+                            <td>
+                                {{ note.date }}
+                            </td>
+                            <td>
+                                {{ note }}
+                                {% if person == note.author.username %}
+                                    <div class="pull-right">
+                                        <form method="post" action="{% url 'delete_note' note.id 'cred' cred.id %}">
+                                            {% csrf_token %}
+                                            <input type="hidden" aria-label="id" name="id" value="{{note.id}}"
+                                                   id="id_id" />
+                                            <button type="submit" aria-label="Delete Note" class="btn-delete">
+                                              <i class="fa-solid fa-trash"></i>
+                                            </button>
+                                        </form>
+                                    </div>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <p class="text-center">No notes found.</p>
+            {% endif %}
+            <hr/>
+            <form class="form-horizontal" id="add_notes" action="{% url 'view_cred_details' cred.id %}"
+                  method="post">{% csrf_token %}
+                {% include "dojo/form_fields.html" with form=form %}
+                <div class="form-group">
+                    <div class="col-sm-offset-2 col-sm-10">
+                        <input class="btn btn-secondary" type="submit" value="Add Note"/>
+                    </div>
                 </div>
-            </div>
-        </form>
-        <br/>
-        <br/>
+            </form>
+        </div>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
**Description**

Some updates to things I noticed while doing the 'cascading notes deletes' patch.

Changes included:
* Display the "Add Note" button on the credentials view page; it's there, but was invisible.
* Show the 'delete note' button for note creator and fix note deletion.
* Update the "Associated Products" header to have less spacing around it;
* Fix credential deletion to work

**Test results**

Things delete and show up differently now. Some before/after pictures:

"Add Note" before:
![add_note_before](https://github.com/user-attachments/assets/387e3a1d-e38f-4502-a85c-66833516adab)
"Add Note" after:
![add_note_after](https://github.com/user-attachments/assets/cc3f1de8-cf66-45f7-9aca-85e537db2038)

"Delete Note" before:
![delete_before](https://github.com/user-attachments/assets/e2634319-aeba-4378-bdbb-9bad24708a80)
"Delete Note" after:
![delete_note_after](https://github.com/user-attachments/assets/756231dc-09df-4191-986d-4667ce620f99)

"Associated Products Header" before:
![header_before](https://github.com/user-attachments/assets/ae06e81d-71c1-4b50-95d0-5426e3a57a26)

"Associated Products Header" after:
![haeder_after](https://github.com/user-attachments/assets/807eed3b-eacb-4b46-a5f2-67e84e1bfe6c)
