### PR TITLE
Importer: Correct logic bug for empty scan reports

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -214,7 +214,7 @@ class BaseImporter(ImporterOptions):
         `get_tests` function on the parser object
         """
         # Attempt any preprocessing before generating findings
-        if len(self.parsed_findings) == 0 or self.test is None:
+        if len(self.parsed_findings) == 0 and self.test is None:
             scan = self.process_scan_file(scan)
             if hasattr(parser, 'get_tests'):
                 self.parsed_findings = self.parse_findings_dynamic_test_type(scan, parser)

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -212,15 +212,12 @@ class BaseImporter(ImporterOptions):
         """
         Determine how to parse the findings based on the presence of the
         `get_tests` function on the parser object
+
+        This function will vary by importer, so it is marked as
+        abstract with a prohibitive exception raised if the
+        method is attempted to to be used by the BaseImporter class
         """
-        # Attempt any preprocessing before generating findings
-        if len(self.parsed_findings) == 0 and self.test is None:
-            scan = self.process_scan_file(scan)
-            if hasattr(parser, 'get_tests'):
-                self.parsed_findings = self.parse_findings_dynamic_test_type(scan, parser)
-            else:
-                self.parsed_findings = self.parse_findings_static_test_type(scan, parser)
-        return self.parsed_findings
+        self.check_child_implementation_exception()
 
     def sync_process_findings(
         self,

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -293,6 +293,24 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
 
         return old_findings
 
+    def parse_findings(
+        self,
+        scan: TemporaryUploadedFile,
+        parser: Parser,
+    ) -> List[Finding]:
+        """
+        Determine how to parse the findings based on the presence of the
+        `get_tests` function on the parser object
+        """
+        # Attempt any preprocessing before generating findings
+        if len(self.parsed_findings) == 0 and self.test is None:
+            scan = self.process_scan_file(scan)
+            if hasattr(parser, 'get_tests'):
+                self.parsed_findings = self.parse_findings_dynamic_test_type(scan, parser)
+            else:
+                self.parsed_findings = self.parse_findings_static_test_type(scan, parser)
+        return self.parsed_findings
+
     def parse_findings_static_test_type(
         self,
         scan: TemporaryUploadedFile,

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -277,6 +277,24 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
 
         return mitigated_findings
 
+    def parse_findings(
+        self,
+        scan: TemporaryUploadedFile,
+        parser: Parser,
+    ) -> List[Finding]:
+        """
+        Determine how to parse the findings based on the presence of the
+        `get_tests` function on the parser object
+        """
+        # Attempt any preprocessing before generating findings
+        if len(self.parsed_findings) == 0 or self.test is None:
+            scan = self.process_scan_file(scan)
+            if hasattr(parser, 'get_tests'):
+                self.parsed_findings = self.parse_findings_dynamic_test_type(scan, parser)
+            else:
+                self.parsed_findings = self.parse_findings_static_test_type(scan, parser)
+        return self.parsed_findings
+
     def parse_findings_static_test_type(
         self,
         scan: TemporaryUploadedFile,


### PR DESCRIPTION
When importing an empty scan report through the import endpoint, it is possible for two tests to be created during a single request

