### PR TITLE
report-builder-sort-fixes Fix report builder finding and endpoints widgets

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2896,6 +2896,17 @@ class ReportFindingFilterHelper(FilterSet):
     outside_of_sla = FindingSLAFilter(label="Outside of SLA")
     file_path = CharFilter(lookup_expr='icontains')
 
+    o = OrderingFilter(
+        fields=(
+            ('title', 'title'),
+            ('date', 'date'),
+            ('numerical_severity', 'numerical_severity'),
+            ('epss_score', 'epss_score'),
+            ('epss_percentile', 'epss_percentile'),
+            ('test__engagement__product__name', 'test__engagement__product__name'),
+        ),
+    )
+
     class Meta:
         model = Finding
         # exclude sonarqube issue as by default it will show all without checking permissions

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -175,7 +175,7 @@ def report_findings(request):
     title_words = get_words_for_field(Finding, 'title')
     component_words = get_words_for_field(Finding, 'component_name')
 
-    paged_findings = get_page_items(request, findings.qs.distinct().order_by('numerical_severity'), 25)
+    paged_findings = get_page_items(request, findings.qs.distinct(), 25)
 
     return render(request,
                   'dojo/report_findings.html',

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -304,18 +304,11 @@
                 retrieveReportData("{% url 'report_findings' %}", $a.closest('li.finding-list'));
             });
 
-            // Sort/order columns
-            $(document).on('click', 'li.finding-list th a', function (event) {
+            // Sort/order columns and Pagination
+            $(document).on('click', 'li.finding-list th a, div.finding-pagination a', function (event) {
                 const $a = $(this);
                 event.preventDefault();
                 retrieveReportData("{% url 'report_findings' %}" + $a.attr('href'), $a.closest('li.finding-list'));
-            });
-
-            // Pagination
-            $(document).on('click', 'div.finding-pagination a', function (event) {
-                const $a = $(this);
-                event.preventDefault();
-                retrieveReportData("{% url 'report_findings' %}" + $a.attr('href'),  $a.closest('li.finding-list'));
             });
 
             /// --------

--- a/dojo/templates/dojo/report_builder.html
+++ b/dojo/templates/dojo/report_builder.html
@@ -272,51 +272,79 @@
                     .selectpicker('render');
             }
 
+            // Retrieves (report) data at the given url and inserts it as HTMl into $targetEl, and configures filters
+            // on the returned data.
+            function retrieveReportData(url, $targetEl) {
+                $.get(url).done(function (data) {
+                    filterFieldInit(
+                        $targetEl.html(data)
+                    );
+                    setUpFindingFilters();
+                });
+            }
+
+            // --------
+            // Findings
+            // --------
+
+            // "Apply Filters"
             $(document).on('submit', 'form.finding-list', function (event) {
-                var form = this;
-                $.get("{% url 'report_findings' %}?" + $(this).serialize()).done(function (data) {
-                    filterFieldInit(
-                        $(form).closest('li.finding-list').html(data)
-                    );
-                    setUpFindingFilters();
-                });
-
+                const $form = $(this);
                 event.preventDefault();
+                retrieveReportData(
+                    "{% url 'report_findings' %}?" + $form.serialize(),
+                    $form.closest('li.finding-list')
+                );
             });
 
-            $(document).on('click', 'form.finding-list a.clear.centered, div.finding-pagination a', function (event) {
-                $.get("{% url 'report_findings' %}").done(function (data) {
-                    filterFieldInit(
-                        $('div.in-use-widgets li.finding-list').html(data)
-                    );
-                    setUpFindingFilters();
-                });
-
+            // "Clear filters"
+            $(document).on('click', 'form.finding-list a.clear.centered', function (event) {
+                const $a = $(this);
                 event.preventDefault();
+                retrieveReportData("{% url 'report_findings' %}", $a.closest('li.finding-list'));
             });
 
+            // Sort/order columns
+            $(document).on('click', 'li.finding-list th a', function (event) {
+                const $a = $(this);
+                event.preventDefault();
+                retrieveReportData("{% url 'report_findings' %}" + $a.attr('href'), $a.closest('li.finding-list'));
+            });
+
+            // Pagination
+            $(document).on('click', 'div.finding-pagination a', function (event) {
+                const $a = $(this);
+                event.preventDefault();
+                retrieveReportData("{% url 'report_findings' %}" + $a.attr('href'),  $a.closest('li.finding-list'));
+            });
+
+            /// --------
+            // Endpoints
+            // ---------
+
+            // "Apply filters"
             $(document).on('submit', 'form.endpoint-list', function (event) {
-                var form = this;
-                $.get("{% url 'report_endpoints' %}?" + $(this).serialize()).done(function (data) {
-                    filterFieldInit(
-                        $(form).closest('li.endpoint-list').html(data)
-                    );
-                    setUpFindingFilters();
-                });
-
+                const $form = $(this);
                 event.preventDefault();
+                retrieveReportData(
+                    "{% url 'report_endpoints' %}?" + $form.serialize(),
+                    $form.closest('li.endpoint-list')
+                );
             });
 
-            $(document).on('click', 'form.endpoint-list a.clear.centered, div.endpoint-pagination a', function (event) {
-                $.get("{% url 'report_endpoints' %}").done(function (data) {
-                    filterFieldInit(
-                        $('div.in-use-widgets li.endpoint-list').html(data)
-                    );
-                    setUpFindingFilters();
-                });
-
+            // "Clear filters"
+            $(document).on('click', 'form.endpoint-list a.clear.centered', function (event) {
+                const $a = $(this);
                 event.preventDefault();
+                retrieveReportData("{% url 'report_endpoints' %}", $a.closest('li.endpoint-list'));
             });
+
+            // Pagination
+            $(document).on('click', 'div.endpoint-pagination a', function (event) {
+                const $a = $(this);
+                event.preventDefault();
+                retrieveReportData("{% url 'report_endpoints' %}" + $a.attr('href'), $a.closest('li.endpoint-list'));
+            })
 
             $('[data-toggle="tooltip"]').tooltip()
 

--- a/dojo/templates/dojo/report_endpoints.html
+++ b/dojo/templates/dojo/report_endpoints.html
@@ -47,8 +47,8 @@
                     </tbody>
                 </table>
             </div>
-            <div class="clearfix">
-                {% include "dojo/paging_snippet.html" with page=findings page_size=False %}
+            <div class="clearfix endpoint-pagination">
+                {% include "dojo/paging_snippet.html" with page=endpoints page_size=False %}
             </div>
 
         {% endif %}

--- a/dojo/templates/dojo/report_findings.html
+++ b/dojo/templates/dojo/report_findings.html
@@ -62,7 +62,7 @@
                     </tbody>
                 </table>
             </div>
-            <div class="clearfix">
+            <div class="clearfix finding-pagination">
                 {% include "dojo/paging_snippet.html" with page=findings page_size=False %}
             </div>
 


### PR DESCRIPTION
**Description**

This patch updates the Findings and Vulnerable Endpoints widgets in the Report Builder to properly handle pagination and (in the case of the former) column sorting. Previously, clicking a column caused a page refresh (losing work), and pagination didn't work at all.

**Test results**

Manual testing of the widgets in OS and Pro successfully performed.

[sc-6965]