### PR TITLE
Groups/users labels text

### DIFF
--- a/dojo/templates/dojo/view_group.html
+++ b/dojo/templates/dojo/view_group.html
@@ -3,7 +3,7 @@
 {% load authorization_tags %}
 
 {% block content %}
-<h3 id="id_heading"> Group {{ group.name }}</h3>
+<h3 id="id_heading"> Group: {{ group.name }}</h3>
 <div class="row">
     <div id="tests" class="col-md-8">
         <div class="panel panel-default">
@@ -43,7 +43,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">Members</h4>
+                    <h4 class="pull-left">Members of this Group</h4>
                     &nbsp;
                     <a href="https://documentation.defectdojo.com/usage/permissions/#groups" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
@@ -72,7 +72,7 @@
                     <tr>
                         <th label="Actions"></th>
                         <th>User</th>
-                        <th>Group role</th>
+                        <th>Role in this Group</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -108,7 +108,7 @@
             </div>
             {% else %}
             <div class="panel-body">
-                <small class="text-muted"><em>No members found.</em></small>
+                <small class="text-muted"><em>This Group has no members.</em></small>
             </div>
             {% endif %}
         </div>
@@ -116,7 +116,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">Product Type Groups</h4>
+                    <h4 class="pull-left">Product Types this Group can access</h4>
                     &nbsp;
                     <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
@@ -182,7 +182,7 @@
             </div>
             {% else %}
             <div class="panel-body">
-                <small class="text-muted"><em>No product type groups found.</em></small>
+                <small class="text-muted"><em>This Group cannot access any Product Types.</em></small>
             </div>
             {% endif %}
         </div>
@@ -190,7 +190,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">Product Groups</h4>
+                    <h4 class="pull-left">Products this Group can access</h4>
                     &nbsp;
                     <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
@@ -256,7 +256,7 @@
             </div>
             {% else %}
             <div class="panel-body">
-                <small class="text-muted"><em>No product groups found.</em></small>
+                <small class="text-muted"><em>This Group cannot access any Products.</em></small>
             </div>
             {% endif %}
         </div>

--- a/dojo/templates/dojo/view_user.html
+++ b/dojo/templates/dojo/view_user.html
@@ -5,7 +5,7 @@
 
 {% block content %}
     {{ block.super }}
-<h3 id="id_heading">{% blocktrans with full_name=user.get_full_name %}User {{ full_name }}{% endblocktrans %}</h3>
+<h3 id="id_heading">{% blocktrans with full_name=user.get_full_name %}User: {{ full_name }}{% endblocktrans %}</h3>
 <div class="row">
     <div id="tests" class="col-md-8">
         <div class="panel panel-default">
@@ -104,7 +104,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">{% trans "Product Type Membership" %}</h4>
+                    <h4 class="pull-left">{% trans "Product Types this User can access" %}</h4>
                     &nbsp;
                     <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
@@ -170,14 +170,14 @@
             </div>
             {% else %}
             <div class="panel-body">
-                <small class="text-muted"><em>{% trans "No product type members found." %}</em></small>
+                <small class="text-muted"><em>{% trans "This User is not assigned to any Product Types." %}</em></small>
             </div>
             {% endif %}
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">{% trans "Product Membership" %}</h4>
+                    <h4 class="pull-left">{% trans "Products this User can access" %}</h4>
                     &nbsp;
                     <a href="https://documentation.defectdojo.com/usage/permissions/" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
@@ -243,7 +243,7 @@
             </div>
             {% else %}
             <div class="panel-body">
-                <small class="text-muted"><em>{% trans "No product members found." %}</em></small>
+                <small class="text-muted"><em>{% trans "This User is not assigned to any Products." %}</em></small>
             </div>
             {% endif %}
         </div>
@@ -251,7 +251,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <div class="clearfix">
-                    <h4 class="pull-left">{% trans "Group Membership" %}</h4>
+                    <h4 class="pull-left">{% trans "Groups this User is a member of" %}</h4>
                     &nbsp;
                     <a href="https://documentation.defectdojo.com/usage/permissions/#groups" target="_blank">
                         <i class="fa-solid fa-circle-question"></i></a>
@@ -280,7 +280,7 @@
                     <tr>
                         <th></th>
                         <th>{% trans "Group" %}</th>
-                        <th>{% trans "Group role" %}</th>
+                        <th>{% trans "Role in this Group" %}</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -317,7 +317,7 @@
             </div>
             {% else %}
             <div class="panel-body">
-                <small class="text-muted"><em>{% trans "No group members found." %}</em></small>
+                <small class="text-muted"><em>{% trans "This User is not a member of any Groups." %}</em></small>
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
**Description**

This patch updates some of the labels/wording on the Groups and Users view pages.

**Test results**

Viewing the pages yields updated text.

**Screenshots**

Group (with no associations):
![empty_groups](https://github.com/user-attachments/assets/106c4233-0385-4ae2-a585-bb1e9424acfb)
(If a Group was empty, it'd say "This Group has no members." in line with the other sections.)

Group (with associations):
![full_group](https://github.com/user-attachments/assets/20df14f7-ebcc-4d3f-97d1-4573b6972475)

User (without associations):
![empty_user](https://github.com/user-attachments/assets/1f14fc70-d061-4eb4-b7fe-24380a2d2cfc)

User (with associations):
![full_user](https://github.com/user-attachments/assets/51a9feea-7dc7-408f-b886-37725b1182a6)

[sc-3273]