### PR TITLE
fix(docs): Typo in "Release Notes" link

### DIFF
--- a/docs/content/en/getting_started/upgrading/2.37.md
+++ b/docs/content/en/getting_started/upgrading/2.37.md
@@ -14,4 +14,4 @@ MySQL and RabbitMQ have been removed from the following places:
 - Helm Chart
 - Unit/Integration CI/CD Tests
 
-There are no other special instructions for upgrading to 2.37.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.36.0) for the contents of the release.
+There are no other special instructions for upgrading to 2.37.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.37.0) for the contents of the release.


### PR DESCRIPTION
Fix typo (probably from copy-pasting)