### PR TITLE
Rest Framework Tests: Disable shuffle

### DIFF
--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -54,10 +54,10 @@ EOF
 echo "Unit Tests"
 echo "------------------------------------------------------------"
 
-python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --shuffle --parallel --exclude-tag="non-parallel" || {
+python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --parallel --exclude-tag="non-parallel" || {
     exit 1; 
 }
-python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --shuffle --tag="non-parallel" || {
+python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --tag="non-parallel" || {
     exit 1; 
 }
 

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -172,7 +172,58 @@
   },
   {
     "model": "auditlog.logentry",
-    "pk": 3,
+    "pk": 800,
+    "fields": {
+        "content_type": 22,
+        "object_pk": "1",
+        "object_id": 1,
+        "object_repr": "Research and Development",
+        "serialized_data": null,
+        "action": 0,
+        "changes": "{\"prod_type\": [\"None\", \"dojo.Product.None\"], \"id\": [\"None\", \"1\"], \"name\": [\"None\", \"Research and Development\"], \"critical_product\": [\"None\", \"False\"], \"key_product\": [\"None\", \"False\"]}",
+        "actor": null,
+        "remote_addr": null,
+        "timestamp": "2021-10-22T01:24:54.919Z",
+        "additional_data": null
+    }
+  },
+  {
+    "model": "auditlog.logentry",
+    "pk": 801,
+    "fields": {
+        "content_type": 22,
+        "object_pk": "2",
+        "object_id": 2,
+        "object_repr": "Commerce",
+        "serialized_data": null,
+        "action": 0,
+        "changes": "{\"prod_type\": [\"None\", \"dojo.Product.None\"], \"id\": [\"None\", \"2\"], \"name\": [\"None\", \"Commerce\"], \"critical_product\": [\"None\", \"True\"], \"key_product\": [\"None\", \"False\"], \"updated\": [\"None\", \"2018-08-16 17:05:29.277000\"]}",
+        "actor": null,
+        "remote_addr": null,
+        "timestamp": "2021-10-22T01:24:54.920Z",
+        "additional_data": null
+    }
+  },
+  {
+    "model": "auditlog.logentry",
+    "pk": 802,
+    "fields": {
+      "content_type": 22,
+      "object_pk": "3",
+      "object_id": 3,
+      "object_repr": "Billing",
+      "serialized_data": null,
+      "action": 0,
+      "changes": "{\"prod_type\": [\"None\", \"dojo.Product.None\"], \"id\": [\"None\", \"3\"], \"name\": [\"None\", \"Billing\"], \"critical_product\": [\"None\", \"False\"], \"key_product\": [\"None\", \"True\"], \"updated\": [\"None\", \"2018-08-16 17:05:42.193000\"]}",
+      "actor": null,
+      "remote_addr": null,
+      "timestamp": "2021-10-22T01:24:54.921Z",
+      "additional_data": null
+    }
+  },
+  {
+    "model": "auditlog.logentry",
+    "pk": 803,
     "fields": {
       "content_type": 28,
       "object_pk": "1",
@@ -188,7 +239,7 @@
     },
     {
       "model": "auditlog.logentry",
-      "pk": 4,
+      "pk": 804,
       "fields": {
         "content_type": 28,
         "object_pk": "2",
@@ -204,7 +255,7 @@
     },
     {
       "model": "auditlog.logentry",
-      "pk": 5,
+      "pk": 805,
       "fields": {
         "content_type": 28,
         "object_pk": "3",

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -172,7 +172,7 @@
   },
   {
     "model": "auditlog.logentry",
-    "pk": 800,
+    "pk": 400,
     "fields": {
         "content_type": 22,
         "object_pk": "1",
@@ -189,7 +189,7 @@
   },
   {
     "model": "auditlog.logentry",
-    "pk": 801,
+    "pk": 401,
     "fields": {
         "content_type": 22,
         "object_pk": "2",
@@ -206,7 +206,7 @@
   },
   {
     "model": "auditlog.logentry",
-    "pk": 802,
+    "pk": 402,
     "fields": {
       "content_type": 22,
       "object_pk": "3",
@@ -223,7 +223,7 @@
   },
   {
     "model": "auditlog.logentry",
-    "pk": 803,
+    "pk": 403,
     "fields": {
       "content_type": 28,
       "object_pk": "1",
@@ -239,7 +239,7 @@
     },
     {
       "model": "auditlog.logentry",
-      "pk": 804,
+      "pk": 404,
       "fields": {
         "content_type": 28,
         "object_pk": "2",
@@ -255,7 +255,7 @@
     },
     {
       "model": "auditlog.logentry",
-      "pk": 805,
+      "pk": 405,
       "fields": {
         "content_type": 28,
         "object_pk": "3",

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -172,7 +172,7 @@
   },
   {
     "model": "auditlog.logentry",
-    "pk": 803,
+    "pk": 3,
     "fields": {
       "content_type": 28,
       "object_pk": "1",
@@ -188,7 +188,7 @@
     },
     {
       "model": "auditlog.logentry",
-      "pk": 804,
+      "pk": 4,
       "fields": {
         "content_type": 28,
         "object_pk": "2",
@@ -204,7 +204,7 @@
     },
     {
       "model": "auditlog.logentry",
-      "pk": 805,
+      "pk": 5,
       "fields": {
         "content_type": 28,
         "object_pk": "3",

--- a/unittests/test_sample_data.py
+++ b/unittests/test_sample_data.py
@@ -1,8 +1,10 @@
 from django.core.management import call_command
+from django.test import tag as test_tag
 
 from .dojo_test_case import DojoTestCase
 
 
+@test_tag("non-parallel")
 class TestSampleData(DojoTestCase):
     def test_loaddata(self):
         try:

--- a/unittests/test_sample_data.py
+++ b/unittests/test_sample_data.py
@@ -6,9 +6,10 @@ from .dojo_test_case import DojoTestCase
 
 @test_tag("non-parallel")
 class TestSampleData(DojoTestCase):
+
+    fixtures = ["defect_dojo_sample_data"]
+
     def test_loaddata(self):
-        try:
-            call_command("loaddata", "dojo/fixtures/defect_dojo_sample_data", verbosity=0)
-        except Exception as e:
-            self.assertEqual(False, True, e)
+        # this test running at all is indicative of the test passing
+        # We will just assert True, and move on
         self.assertEqual(True, True)

--- a/unittests/test_sample_data.py
+++ b/unittests/test_sample_data.py
@@ -1,4 +1,3 @@
-from django.core.management import call_command
 from django.test import tag as test_tag
 
 from .dojo_test_case import DojoTestCase


### PR DESCRIPTION
After ensuring that failed unit tests actually fail the GHAs, we notice that that rest framework tests are increasingly fickle around the following tests (that I have observed, but may not be an exhaustive list):
- [Sample Data](https://github.com/DefectDojo/django-DefectDojo/blob/master/unittests/test_sample_data.py)
- [Notifications](https://github.com/DefectDojo/django-DefectDojo/blob/master/unittests/test_notifications.py)
- [Metrics](https://github.com/DefectDojo/django-DefectDojo/blob/master/unittests/test_metrics_queries.py)

Removing the `--shuffle` flag _appears_ to be a quick fix, but we shall see