### PR TITLE
Rest Framework: Remove Parallel + Shuffle

### DIFF
--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -54,10 +54,11 @@ EOF
 echo "Unit Tests"
 echo "------------------------------------------------------------"
 
-python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --shuffle --parallel --exclude-tag="non-parallel" || {
+# Removing parallel and shufful for now to maintain stability
+python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
     exit 1; 
 }
-python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --shuffle --tag="non-parallel" || {
+python3 manage.py test unittests -v 3 --keepdb --no-input --tag="non-parallel" || {
     exit 1; 
 }
 

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -54,7 +54,7 @@ EOF
 echo "Unit Tests"
 echo "------------------------------------------------------------"
 
-# Removing parallel and shufful for now to maintain stability
+# Removing parallel and shuffle for now to maintain stability
 python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
     exit 1; 
 }

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -80,9 +80,10 @@ python3 manage.py migrate
 echo "Unit Tests"
 echo "------------------------------------------------------------"
 
-python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --shuffle --parallel --exclude-tag="non-parallel" || {
+# Removing parallel and shufful for now to maintain stability
+python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
     exit 1; 
 }
-python3 manage.py test unittests -v 3 --keepdb --no-input --failfast --shuffle --tag="non-parallel" || {
+python3 manage.py test unittests -v 3 --keepdb --no-input --tag="non-parallel" || {
     exit 1; 
 }

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -80,7 +80,7 @@ python3 manage.py migrate
 echo "Unit Tests"
 echo "------------------------------------------------------------"
 
-# Removing parallel and shufful for now to maintain stability
+# Removing parallel and shuffle for now to maintain stability
 python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
     exit 1; 
 }


### PR DESCRIPTION
The rest framework tests have been very flakey not that they are actually producing failures for GHAs (this part is a good thing)

To increase stability for these tests, we should revert the `--prallel` and `--shuffle` flags

[sc-7127]