### PR TITLE
Add anonymous questionnaire to engagement

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -3556,7 +3556,7 @@ class ExistingEngagementForm(forms.Form):
         queryset=Engagement.objects.none(),
         required=True,
         widget=forms.widgets.Select(),
-        help_text="Select which Engagement to attach the Questionnaire")
+        help_text="Select which Engagement to link the Questionnaire to")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -31,6 +31,7 @@ from tagulous.forms import TagField
 import dojo.jira_link.helper as jira_helper
 from dojo.authorization.roles_permissions import Permissions
 from dojo.endpoint.utils import endpoint_filter, endpoint_get_or_create, validate_endpoints_to_add
+from dojo.engagement.queries import get_authorized_engagements
 from dojo.finding.queries import get_authorized_findings
 from dojo.group.queries import get_authorized_groups, get_group_member_roles
 from dojo.models import (
@@ -3548,6 +3549,18 @@ class AddEngagementForm(forms.Form):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["product"].queryset = get_authorized_products(Permissions.Engagement_Add)
+
+
+class ExistingEngagementForm(forms.Form):
+    engagement = forms.ModelChoiceField(
+        queryset=Engagement.objects.none(),
+        required=True,
+        widget=forms.widgets.Select(),
+        help_text="Select which Engagement to attach the Questionnaire")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["engagement"].queryset = get_authorized_engagements(Permissions.Engagement_Edit).order_by("-target_start")
 
 
 class ConfigurationPermissionsForm(forms.Form):

--- a/dojo/survey/urls.py
+++ b/dojo/survey/urls.py
@@ -77,4 +77,7 @@ urlpatterns = [
     re_path(r"^empty_questionnaire/(?P<esid>\d+)/new_engagement$",
         views.engagement_empty_survey,
         name="engagement_empty_survey"),
+    re_path(r"^empty_questionnaire/(?P<esid>\d+)/existing_engagement$",
+        views.ExistingEngagementEmptySurveyView.as_view(),
+        name="existing_engagement_empty_survey"),
 ]

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -910,7 +910,7 @@ class ExistingEngagementEmptySurveyView(View):
                 messages.SUCCESS,
                 "Questionnaire successfully linked to Engagement.",
                 extra_tags="alert-success")
-            return HttpResponseRedirect(reverse("edit_engagement", args=(engagement.id,)))
+            return HttpResponseRedirect(reverse("view_engagement", args=(engagement.id,)))
 
         messages.add_message(
             request,

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -874,7 +874,7 @@ class ExistingEngagementEmptySurveyView(View):
     def get(self, request, esid):
         survey = get_object_or_404(Answered_Survey, id=esid)
         if survey.engagement:
-            # If the questionnaire is already linked so a survey, ensure the user has permission edit it
+            # If the questionnaire is already linked to a survey, ensure the user has permission to edit it
             user_has_permission_or_403(request.user, survey.engagement, Permissions.Engagement_Edit)
             # Prepopulate the form with the current engagement
             form = self.get_form_class()({"engagement": survey.engagement})

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -877,7 +877,7 @@ class ExistingEngagementEmptySurveyView(View):
             # If the questionnaire is already linked so a survey, ensure the user has permission edit it
             user_has_permission_or_403(request.user, survey.engagement, Permissions.Engagement_Edit)
             # Prepopulate the form with the current engagement
-            form = self.get_form_class()({'engagement': survey.engagement})
+            form = self.get_form_class()({"engagement": survey.engagement})
         else:
             form = self.get_form_class()()
         self.add_breadcrumb(request)
@@ -885,7 +885,7 @@ class ExistingEngagementEmptySurveyView(View):
             request,
             self.get_template(),
             {
-                "form": form
+                "form": form,
              },
         )
 

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -881,13 +881,7 @@ class ExistingEngagementEmptySurveyView(View):
         else:
             form = self.get_form_class()()
         self.add_breadcrumb(request)
-        return render(
-            request,
-            self.get_template(),
-            {
-                "form": form,
-             },
-        )
+        return render(request, self.get_template(), {"form": form})
 
     def post(self, request, esid):
         survey = get_object_or_404(Answered_Survey, id=esid)

--- a/dojo/survey/views.py
+++ b/dojo/survey/views.py
@@ -879,7 +879,7 @@ class ExistingEngagementEmptySurveyView(View):
 
     def add_breadcrumb(self, request):
         add_breadcrumb(
-            title="Link Questionnaire to new Engagement",
+            title="Link Questionnaire to existing Engagement",
             top_level=False,
             request=request)
 
@@ -899,8 +899,10 @@ class ExistingEngagementEmptySurveyView(View):
         survey = get_object_or_404(Answered_Survey, id=esid)
         form = self.get_form_class()(request.POST)
         if form.is_valid():
+            # Validate perms
             engagement = form.cleaned_data.get("engagement")
             user_has_permission_or_403(request.user, engagement, Permissions.Engagement_Edit)
+            # Link and save
             survey.engagement = engagement
             survey.save()
             messages.add_message(

--- a/dojo/templates/defectDojo-engagement-survey/existing_engagement.html
+++ b/dojo/templates/defectDojo-engagement-survey/existing_engagement.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+    {{ block.super }}
+	<h3>Link Questionnaire to Existing Engagement</h3>
+    <br />
+	<form class="form-horizontal" method="post">
+		{% csrf_token %}
+		{% include "dojo/form_fields.html" with form=form %}
+		<div class="form-group">
+			<div class="col-sm-offset-2 col-sm-10">
+				<input class="btn btn-primary" type="submit" label="existing_engagement" name="existing_engagement" value="Link to Engagement"/>
+			</div>
+		</div>
+	</form>
+{% endblock %}

--- a/dojo/templates/defectDojo-engagement-survey/surveys.html
+++ b/dojo/templates/defectDojo-engagement-survey/surveys.html
@@ -40,6 +40,13 @@
                                         <i class="fa-solid fa-plus"></i> Assign User</a>
                                 </li>
                                 {% endif %}
+                                {% if survey.engagement|has_object_permission:"Engagement_Edit" %}
+                                <li role="presentation">
+                                    <a class="" href="/empty_questionnaire/{{ survey.id }}/existing_engagement">
+                                        <i class="fa-solid fa-link"></i> Link to a Different Engagement
+                                    </a>
+                                </li>
+                                {% endif %}
                                 <li>
                                     <a class="" data-toggle="modal"
                                     data-target="#shareQuestionnaireModal"

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -208,7 +208,7 @@
                                                         <a class="btn btn-sm btn-secondary"
                                                         href="/empty_questionnaire/{{ survey.id }}">{% trans "View Responses" %}</a>
                                                         <a class="btn btn-sm btn-success" href="/empty_questionnaire/{{ survey.id }}/new_engagement">{% trans "Create Engagement" %}</a>
-                                                        <a class="btn btn-sm btn-success" href="/empty_questionnaire/{{ survey.id }}/existing_engagement">{% trans "Add to Engagement" %}</a>
+                                                        <a class="btn btn-sm btn-success" href="/empty_questionnaire/{{ survey.id }}/existing_engagement">{% trans "Link to Existing Engagement" %}</a>
                                                         <button class="btn btn-sm btn-info" disabled
                                                         href="/engagement/{{ survey.engagement.id }}/questionnaire/{{ survey.id }}/assign">{% trans "Assign User" %}</button>
                                                     {% endif %}

--- a/dojo/templates/dojo/dashboard.html
+++ b/dojo/templates/dojo/dashboard.html
@@ -208,6 +208,7 @@
                                                         <a class="btn btn-sm btn-secondary"
                                                         href="/empty_questionnaire/{{ survey.id }}">{% trans "View Responses" %}</a>
                                                         <a class="btn btn-sm btn-success" href="/empty_questionnaire/{{ survey.id }}/new_engagement">{% trans "Create Engagement" %}</a>
+                                                        <a class="btn btn-sm btn-success" href="/empty_questionnaire/{{ survey.id }}/existing_engagement">{% trans "Add to Engagement" %}</a>
                                                         <button class="btn btn-sm btn-info" disabled
                                                         href="/engagement/{{ survey.engagement.id }}/questionnaire/{{ survey.id }}/assign">{% trans "Assign User" %}</button>
                                                     {% endif %}


### PR DESCRIPTION
**Description**

This patch adds the ability to link an anonymous questionnaire to an existing engagement. Previously, anon. qsnr. could only be added to an ad hoc-created engagement.

The dashboard listing of unassigned qsnrs. has been updated to include a button titled 'Link to Existing Engagement.' This takes the user to a new form that allows them to select an engagement (they have permission to) and link the two.

Additionally, the same page can be used to reassign/relink a qsnr. if necessary. A new entry in the context menu of qsnrs. listed on an engagement, titled "Link to a Different Engagement," has been added and takes the user to the same linking page, with the currently-linked engagement preselected. Permission checks (engagement edit) are done on both the 'source' and 'destination' engagements.

**Screenshots**
* New button:
![Screenshot 2024-08-09 at 12 06 39 PM](https://github.com/user-attachments/assets/9b16a2a8-77a8-47f2-8aa2-d60579c82615)
* New form:
![Screenshot 2024-08-09 at 12 06 44 PM](https://github.com/user-attachments/assets/38654bbe-bed8-46ed-9624-360fa4816eb7)
* New context menu entry:
![Screenshot 2024-08-09 at 12 14 03 PM](https://github.com/user-attachments/assets/125830cc-8cde-4736-bd8f-03765d27051a)
* New form when relinking (same as above, but prefilled):
![Screenshot 2024-08-09 at 12 06 54 PM](https://github.com/user-attachments/assets/8c4be559-d410-49cb-8263-d190cd465b42)

[sc-3538]