### PR TITLE
fix(k8s): run k8s test on the latest version of k8s and minikube

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.11.0
         with:
-          minikube version: 'v1.31.2'
+          minikube version: 'v1.33.1'
           kubernetes version: ${{ matrix.k8s }}
           driver: docker
           start args: '--addons=ingress --cni calico'

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -28,7 +28,7 @@ jobs:
           # are tested (https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions)
           - databases: pgsql
             brokers: redis
-            k8s: 'v1.26.11'
+            k8s: 'v1.30.3'
             os: debian
     steps:
       - name: Checkout


### PR DESCRIPTION
Run k8s on the latest version of k8s and minikube, as described in the comment.