### PR TITLE
Inline finding images on reports

### DIFF
--- a/dojo/templates/dojo/custom_html_report_endpoint_list.html
+++ b/dojo/templates/dojo/custom_html_report_endpoint_list.html
@@ -151,7 +151,7 @@
             <pre>{{ finding.references|markdown_render }}</pre>
             {% endif %}
             {% if include_finding_images %}
-                {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
+                {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="INLINE" %}
             {% endif %}
             {% if include_finding_notes %}
                 {% with notes=finding.notes.all|get_public_notes %}

--- a/dojo/templates/dojo/custom_html_report_finding_list.html
+++ b/dojo/templates/dojo/custom_html_report_finding_list.html
@@ -154,7 +154,7 @@
         {% endif %}
 
         {% if include_finding_images %}
-            {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="HTML" %}
+            {% include "dojo/snippets/file_images.html" with size='original' obj=finding format="INLINE" %}
         {% endif %}
         {% if include_finding_notes %}
             {% with notes=finding.notes.all|get_public_notes %}

--- a/dojo/templates/dojo/snippets/file_images.html
+++ b/dojo/templates/dojo/snippets/file_images.html
@@ -9,6 +9,15 @@
             <p class="text-center">No images found.</p>
         {% endfor %}
     {% endwith %}
+{% elif format == "INLINE" %}
+    {% with images=obj|file_images %}
+        <h6>Images</h6>
+        {% for pic in images %}
+            <p><img src="{{ pic|inline_image }}" style="max-width: 85%" alt="Finding Image"></p>
+        {% empty %}
+            <p class="text-center">No images found.</p>
+        {% endfor %}
+    {% endwith %}
 {% else %}
     {% with images=obj|file_images %}
         {% for pic in images %}

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -426,7 +426,7 @@ def pic_token(context, image, size):
 def inline_image(image_file):
     try:
         if img_type := mimetypes.guess_type(image_file.file.name)[0]:
-            if "image" in img_type:
+            if img_type.startswith("image/"):
                 img_data = base64.b64encode(image_file.file.read())
                 return f"data:{img_type};base64, {img_data.decode('utf-8')}"
     except:

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -1,5 +1,7 @@
+import base64
 import datetime
 import logging
+import mimetypes
 from itertools import chain
 
 import bleach
@@ -418,6 +420,18 @@ def pic_token(context, image, size):
     token = FileAccessToken(user=user, file=image, size=size)
     token.save()
     return reverse("download_finding_pic", args=[token.token])
+
+
+@register.filter
+def inline_image(image_file):
+    try:
+        if img_type := mimetypes.guess_type(image_file.file.name)[0]:
+            if "image" in img_type:
+                img_data = base64.b64encode(image_file.file.read())
+                return f"data:{img_type};base64, {img_data.decode('utf-8')}"
+    except:
+        pass
+    return ""
 
 
 @register.filter


### PR DESCRIPTION
**Description**

This patch extends file_images template to allow for inline-image generation. When called with format="INFLINE," instead of generating picture tokens and using those to retrieve images, images will be encoded as base64 and embedded directly into the report. It updates the Finding and Endpoint listing widgets to use inline images.

Looking for feedback on this implementation; the PR would target release 2.37.2 or later.

[sc-6857]