### PR TITLE
feat(helm): Use `--wait` during tests

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -75,6 +75,7 @@ jobs:
         run: |-
              helm install \
                --timeout 800s \
+               --wait \
                defectdojo \
                ./helm/defectdojo \
                --set django.ingress.enabled=true \

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -70,12 +70,13 @@ jobs:
               echo "pgsql=${{ env.HELM_PG_DATABASE_SETTINGS }}" >> $GITHUB_ENV
               echo "redis=${{ env.HELM_REDIS_BROKER_SETTINGS }}" >> $GITHUB_ENV
 
-      - name: Deploying Djano application with ${{ matrix.databases }} ${{ matrix.brokers }}
-        timeout-minutes: 10 
+      - name: Deploying Django application with ${{ matrix.databases }} ${{ matrix.brokers }}
+        timeout-minutes: 15 
         run: |-
              helm install \
                --timeout 800s \
                --wait \
+               --wait-for-jobs \
                defectdojo \
                ./helm/defectdojo \
                --set django.ingress.enabled=true \
@@ -83,14 +84,14 @@ jobs:
                ${{ env[matrix.databases] }} \
                ${{ env[matrix.brokers] }} \
                --set createSecret=true \
-               --set tag=${{ matrix.os }} \
-               # --set imagePullSecrets=defectdojoregistrykey
+               --set tag=${{ matrix.os }}
 
       - name: Check deployment status
+        if: always()
         run: |-
-             kubectl get pods
-             kubectl get ingress
-             kubectl get services
+             kubectl get all,ingress  # all = pods, services, deployments, replicasets, statefulsets, jobs
+             helm status defectdojo
+             helm history defectdojo
 
       - name: Check Application
         timeout-minutes: 10

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -48,6 +48,24 @@ spec:
           path: {{ .hostPath }}
           {{- end }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        command:
+        - '/bin/bash'
+        - '-c'
+        - '/wait-for-it.sh ${DD_DATABASE_HOST:-postgres}:${DD_DATABASE_PORT:-5432} -t 30 -s -- /bin/echo Database is up'
+        image: '{{ template "django.uwsgi.repository" . }}:{{ .Values.tag }}'
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if .Values.securityContext.enabled }}
+        securityContext:
+          {{- toYaml .Values.securityContext.djangoSecurityContext | nindent 10 }}
+        {{- end }}
+        envFrom:
+        - configMapRef:
+            name: {{ $fullName }}
+        - secretRef:
+            name: {{ $fullName }}
+            optional: true
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -298,9 +298,7 @@ django:
 
 initializer:
   run: true
-  jobAnnotations: {
-    helm.sh/hook: "post-install,post-upgrade"
-  }
+  jobAnnotations: {}
   annotations: {}
   labels: {}
   keepSeconds: 60


### PR DESCRIPTION
This PR adds `--wait` and `--wait-for-jobs` to `helm install` to test that there is not some circular dependency or other bug disabling deployment.

Also some additional debug outputs were added.