### PR TITLE
No Docker build checks in GHA

### DIFF
--- a/.github/workflows/build-docker-images-for-testing.yml
+++ b/.github/workflows/build-docker-images-for-testing.yml
@@ -37,6 +37,8 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v6
         timeout-minutes: 10
+        env:
+          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
         with:
           context: .
           push: false

--- a/.github/workflows/release-x-manual-docker-containers.yml
+++ b/.github/workflows/release-x-manual-docker-containers.yml
@@ -65,6 +65,7 @@ jobs:
         if: ${{ matrix.os  == 'debian' }}
         uses: docker/build-push-action@v6
         env:
+          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
           REPO_ORG: ${{ env.repoorg }}
           docker-image: ${{ matrix.docker-image }}
         with:
@@ -79,6 +80,7 @@ jobs:
         if: ${{ matrix.os  == 'alpine' }}
         uses: docker/build-push-action@v6
         env:
+          DOCKER_BUILD_CHECKS_ANNOTATIONS: false
           REPO_ORG: ${{ env.repoorg }}
           docker-image: ${{ matrix.docker-image }}
         with:


### PR DESCRIPTION
**Description**

This should disable the Docker build check summaries that are showing up on every PR regardless of whether the PR has anything to do with our Docker images ([ref](https://github.com/docker/build-push-action?tab=readme-ov-file#environment-variables)).

![Screenshot 2024-08-12 at 12 20 30](https://github.com/user-attachments/assets/ef535ecd-c0b1-4904-ae0e-e081608065f2)