### PR TITLE
if severity not enforced do not notify

### DIFF
--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1966,6 +1966,8 @@ def sla_compute_and_notify(*args, **kwargs):
                 total_count += 1
                 sla_age = finding.sla_days_remaining()
 
+                # get the sla enforcement for the severity and, if the severity setting is not enforced, do not notify
+                # resolves an issue where notifications are always sent for the severity of SLA that is not enforced
                 severity, enforce = finding.get_sla_period()
                 if not enforce:
                     logger.debug(f"SLA is not enforced for Finding {finding.id} of {severity} severity, skipping notification.")

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -1965,6 +1965,12 @@ def sla_compute_and_notify(*args, **kwargs):
             for finding in findings:
                 total_count += 1
                 sla_age = finding.sla_days_remaining()
+
+                severity, enforce = finding.get_sla_period()
+                if not enforce:
+                    logger.debug(f"SLA is not enforced for Finding {finding.id} of {severity} severity, skipping notification.")
+                    continue
+
                 # if SLA is set to 0 in settings, it's a null. And setting at 0 means no SLA apparently.
                 if sla_age is None:
                     sla_age = 0


### PR DESCRIPTION
[sc-7211]

Notifications were being sent for findings even if the SLA severity was 'not enforced' per settings. This checks for enforcement of the finding severity and, if not enforced, skips notification.

Tested with python manage.py sla_notifications.