### PR TITLE
feat(unittests): Try to avoid assertTrue/False

### DIFF
--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -350,9 +350,9 @@ class BaseTestCase(unittest.TestCase):
             # save settings
             driver.find_element(By.CSS_SELECTOR, "input.btn.btn-primary").click()
             # check if it's enabled after reload
-            self.assertTrue(
-                driver.find_element(By.ID, "id_block_execution").is_selected()
-                == block_execution,
+            self.assertEqual(
+                driver.find_element(By.ID, "id_block_execution").is_selected(),
+                block_execution,
             )
         return driver
 

--- a/tests/close_old_findings_dedupe_test.py
+++ b/tests/close_old_findings_dedupe_test.py
@@ -90,9 +90,9 @@ class CloseOldDedupeTest(BaseTestCase):
         text = driver.find_element(By.ID, "no_findings").text
 
         self.assertIsNotNone(text)
-        self.assertTrue("No findings found." in text)
+        self.assertIn("No findings found.", text)
         # check that user was redirect back to url where it came from based on return_url
-        self.assertTrue(driver.current_url.endswith("page=1"))
+        self.assertTrue(driver.current_url.endswith("page=1"), driver.current_url)
 
 # --------------------------------------------------------------------------------------------------------
 # Same scanner deduplication - Deduplication on engagement

--- a/tests/close_old_findings_test.py
+++ b/tests/close_old_findings_test.py
@@ -50,9 +50,9 @@ class CloseOldTest(BaseTestCase):
         text = driver.find_element(By.ID, "no_findings").text
 
         self.assertIsNotNone(text)
-        self.assertTrue("No findings found." in text)
+        self.assertIn("No findings found.", text)
         # check that user was redirect back to url where it came from based on return_url
-        self.assertTrue(driver.current_url.endswith("page=1"))
+        self.assertTrue(driver.current_url.endswith("page=1"), driver.current_url)
 
 # --------------------------------------------------------------------------------------------------------
 # Same scanner import - Close Old Findings on engagement

--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -88,9 +88,9 @@ class DedupeTest(BaseTestCase):
         text = driver.find_element(By.ID, "no_findings").text
 
         self.assertIsNotNone(text)
-        self.assertTrue("No findings found." in text)
+        self.assertIn("No findings found.", text)
         # check that user was redirect back to url where it came from based on return_url
-        self.assertTrue(driver.current_url.endswith("page=1"))
+        self.assertTrue(driver.current_url.endswith("page=1"), driver.current_url)
 
 # --------------------------------------------------------------------------------------------------------
 # Same scanner deduplication - Deduplication on engagement

--- a/tests/finding_test.py
+++ b/tests/finding_test.py
@@ -280,7 +280,7 @@ class FindingTest(BaseTestCase):
         # This will throw exception if the test fails due to invalid xpath
         post_status = driver.find_element(By.XPATH, '//*[@id="remd_endpoints"]/tbody/tr/td[3]').text
         # Assert ot the query to dtermine status of failure
-        self.assertTrue(pre_status != post_status)
+        self.assertNotEqual(pre_status, post_status)
 
     def test_open_finding(self):
         driver = self.driver
@@ -303,7 +303,7 @@ class FindingTest(BaseTestCase):
         # This will throw exception if the test fails due to invalid xpath
         post_status = driver.find_element(By.XPATH, '//*[@id="vuln_endpoints"]/tbody/tr/td[3]').text
         # Assert ot the query to dtermine status of failure
-        self.assertTrue(pre_status != post_status)
+        self.assertNotEqual(pre_status, post_status)
 
     @on_exception_html_source_logger
     def test_simple_accept_finding(self):
@@ -328,7 +328,7 @@ class FindingTest(BaseTestCase):
         # This will throw exception if the test fails due to invalid xpath
         # TODO: risk acceptance doesn't mitigate endpoints currently
         # post_status = driver.find_element(By.XPATH, '//*[@id="remd_endpoints"]/tbody/tr/td[3]').text
-        # self.assertTrue(pre_status != post_status)
+        # self.assertNotEqual(pre_status, post_status)
 
     def test_unaccept_finding(self):
         driver = self.driver
@@ -352,7 +352,7 @@ class FindingTest(BaseTestCase):
         # This will throw exception if the test fails due to invalid xpath
         # TODO: risk acceptance doesn't mitigate endpoints currently
         # post_status = driver.find_element(By.XPATH, '//*[@id="remd_endpoints"]/tbody/tr/td[3]').text
-        # self.assertTrue(pre_status != post_status)
+        # self.assertNotEqual(pre_status, post_status)
 
     def test_make_finding_a_template(self):
         driver = self.driver

--- a/tests/notes_test.py
+++ b/tests/notes_test.py
@@ -34,10 +34,7 @@ class NoteTest(BaseTestCase):
         if not driver.find_element(By.ID, "add_note").is_displayed():
             self.uncollapse_all(driver)
         text = driver.find_element(By.TAG_NAME, "body").text
-        pass_test = "Test public note" in text
-        if not pass_test:
-            logger.info(f"Public note created at the {level} level")
-        self.assertTrue(pass_test)
+        self.assertIn("Test public note", text, f"Public note created at the {level} level")
 
     def create_private_note(self, driver, level):
         time.sleep(1)

--- a/tests/product_type_member_test.py
+++ b/tests/product_type_member_test.py
@@ -186,7 +186,7 @@ class ProductTypeMemberTest(BaseTestCase):
             # Assert the message to determine success status
             self.assertTrue(self.is_success_message_present(text="Product type member deleted successfully."))
             # Query the site to determine if the member has been deleted
-            self.assertTrue(len(driver.find_elements(By.NAME, "member_user")) == 1)
+            self.assertEqual(len(driver.find_elements(By.NAME, "member_user")), 1)
         else:
             logger.info("--------------------------------")
             logger.info("test_product_delete_product_member: Not executed because legacy authorization is active")

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -41,7 +41,7 @@ class ReportBuilderTest(BaseTestCase):
         Select(driver.find_element(By.ID, "id_report_type")).select_by_visible_text("HTML")
         driver.find_element(By.ID, "id_report_name").send_keys("Test Report")
         driver.find_element(By.CLASS_NAME, "run_report").click()
-        self.assertTrue(driver.current_url == self.base_url + "reports/custom")
+        self.assertEqual(driver.current_url, self.base_url + "reports/custom")
 
     def test_product_type_report(self):
         driver = self.driver

--- a/unittests/test_deduplication_logic.py
+++ b/unittests/test_deduplication_logic.py
@@ -1044,7 +1044,7 @@ class TestDuplicationLogic(DojoTestCase):
         self.assertEqual(finding_new.hash_code, None)
 
         finding_new.save()
-        self.assertTrue(finding_new.hash_code)  # True -> not None
+        self.assertIsNotNone(finding_new.hash_code)
         hash_code_at_creation = finding_new.hash_code
 
         finding_new.title = "new_title"
@@ -1111,17 +1111,17 @@ class TestDuplicationLogic(DojoTestCase):
         finding_new.save(dedupe_option=False)
 
         # save skips hash_code generation if dedupe_option==False
-        self.assertFalse(finding_new.hash_code)
+        self.assertIsNone(finding_new.hash_code)
 
         finding_new.save(dedupe_option=True)
 
-        self.assertTrue(finding_new.hash_code)
+        self.assertIsNotNone(finding_new.hash_code)
 
         finding_new, _finding_124 = self.copy_and_reset_finding(id=124)
         finding_new.save()
 
         # by default hash_code should be generated
-        self.assertTrue(finding_new.hash_code)
+        self.assertIsNotNone(finding_new.hash_code)
 
     # # utility methods
 
@@ -1248,11 +1248,11 @@ class TestDuplicationLogic(DojoTestCase):
 
         self.assertEqual(finding.duplicate, duplicate)
         if not duplicate:
-            self.assertFalse(finding.duplicate_finding)  # False -> None
+            self.assertIsNone(finding.duplicate_finding)
 
         if duplicate_finding_id:
             logger.debug("asserting that finding %i is a duplicate of %i", finding.id if finding.id is not None else "None", duplicate_finding_id if duplicate_finding_id is not None else "None")
-            self.assertTrue(finding.duplicate_finding)  # True -> not None
+            self.assertIsNotNone(finding.duplicate_finding)
             self.assertEqual(finding.duplicate_finding.id, duplicate_finding_id)
 
         if not_hash_code:

--- a/unittests/test_jira_config_product.py
+++ b/unittests/test_jira_config_product.py
@@ -85,7 +85,7 @@ class JIRAConfigProductTest(DojoTestCase):
         self.assertEqual(200, response.status_code)
         content = response.content.decode("utf-8")
         # debian throws 'Name or service not known' error and alpine 'Name does not resolve'
-        self.assertTrue(("Name or service not known" in content) or ("Name does not resolve" in content))
+        self.assertTrue(("Name or service not known" in content) or ("Name does not resolve" in content), content)
 
         # test raw connection error
         with self.assertRaises(requests.exceptions.RequestException):

--- a/unittests/test_parsers.py
+++ b/unittests/test_parsers.py
@@ -1,5 +1,4 @@
 import os
-import re
 from pathlib import Path
 
 from .dojo_test_case import DojoTestCase, get_unit_tests_path
@@ -33,17 +32,17 @@ class TestParsers(DojoTestCase):
                                     )
 
                     content = Path(doc_file).read_text(encoding="utf-8")
-                    self.assertTrue(re.search("title:", content),
+                    self.assertRegex(content, "title:",
                                     f"Documentation file '{doc_file}' does not contain a title",
                                     )
-                    self.assertTrue(re.search("toc_hide: true", content),
+                    self.assertRegex(content, "toc_hide: true",
                                     f"Documentation file '{doc_file}' does not contain toc_hide: true",
                                     )
                     if category == "file":
-                        self.assertTrue(re.search("### Sample Scan Data", content),
+                        self.assertRegex(content, "### Sample Scan Data",
                                         f"Documentation file '{doc_file}' does not contain ### Sample Scan Data",
                                         )
-                        self.assertTrue(re.search("https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans", content),
+                        self.assertRegex(content, "https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans",
                                         f"Documentation file '{doc_file}' does not contain https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans",
                                         )
 

--- a/unittests/tools/test_appcheck_web_application_scanner_parser.py
+++ b/unittests/tools/test_appcheck_web_application_scanner_parser.py
@@ -42,9 +42,10 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
                 finding.description.startswith(
                     "The remote host is running a FTP service that allows cleartext logins over\n  unencrypted connections.",
                 ),
+                finding.description,
             )
             for section in ["**Impact**:", "**Detection**:", "**Technical Details**:"]:
-                self.assertTrue(section in finding.description)
+                self.assertIn(section, finding.description)
 
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
@@ -77,10 +78,11 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
                 finding.description.startswith(
                     "The dedicated port scanner found open ports on this host, along with other\nhost-specific information, which can be viewed in Technical Details.",
                 ),
+                finding.description,
             )
-            self.assertTrue(
-                "Host: 0.0.0.1 (0.0.0.1)\nHost is up, received user-set (0.015s latency).\nScanned at 2020-01-29 15:44:46 UTC for 15763s\nNot shown: 65527 filtered ports, 4 closed ports\nReason: 65527 no-responses and 4 resets\nSome closed ports may be reported as filtered due to --defeat-rst-ratelimit\nPORT      STATE SERVICE     REASON          VERSION\n21/tcp    open  ftp         syn-ack ttl 116 Microsoft ftpd\n45000/tcp open  ssl/asmp?   syn-ack ttl 116\n45010/tcp open  unknown     syn-ack ttl 116\n60001/tcp open  ssl/unknown syn-ack ttl 116\n60011/tcp open  unknown     syn-ack ttl 116\nService Info: OS: Windows; CPE: cpe:/o:microsoft:windows"
-                in finding.description,
+            self.assertIn(
+                "Host: 0.0.0.1 (0.0.0.1)\nHost is up, received user-set (0.015s latency).\nScanned at 2020-01-29 15:44:46 UTC for 15763s\nNot shown: 65527 filtered ports, 4 closed ports\nReason: 65527 no-responses and 4 resets\nSome closed ports may be reported as filtered due to --defeat-rst-ratelimit\nPORT      STATE SERVICE     REASON          VERSION\n21/tcp    open  ftp         syn-ack ttl 116 Microsoft ftpd\n45000/tcp open  ssl/asmp?   syn-ack ttl 116\n45010/tcp open  unknown     syn-ack ttl 116\n60001/tcp open  ssl/unknown syn-ack ttl 116\n60011/tcp open  unknown     syn-ack ttl 116\nService Info: OS: Windows; CPE: cpe:/o:microsoft:windows",
+                finding.description,
             )
 
             expected_ports = [21, 45000, 45010, 60001, 60011]
@@ -106,9 +108,9 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
             self.assertEqual("8.0.32", finding.component_version)
             self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
             self.assertEqual("CVE-2016-6796", finding.unsaved_vulnerability_ids[0])
-            self.assertTrue(finding.description.startswith('**Product Background**\n\n**Apache Tomcat** is a free and open-source Java web application server. It provides a "pure Java" HTTP web server environment in which Java code can also run, implementing the Jakarta Servlet, Jakarta Expression Language, and WebSocket technologies. Tomcat is released with **Catalina** (a servlet and JSP Java Server Pages container), **Coyote** (an HTTP connector), **Coyote JK** (JK protocol proxy connector) and **Jasper** (a JSP engine). Tomcat can optionally be bundled with Java Enterprise Edition (Jakarta EE) as **Apache TomEE** to deliver a complete application server with enterprise features such as distributed computing and web services.\n\n**Vulnerability Summary**\n\nA malicious web application running on Apache Tomcat 9.0.0.M1 to 9.0.0.M9, 8.5.0 to 8.5.4, 8.0.0.RC1 to 8.0.36, 7.0.0 to 7.0.70 and 6.0.0 to 6.0.45 was able to bypass a configured SecurityManager via manipulation of the configuration parameters for the JSP Servlet.\n\n**References**\n\n* http://www.securitytracker.com/id/1038757\n\n* http://www.securitytracker.com/id/1037141\n\n* http://www.securityfocus.com/bid/93944\n\n* http://www.debian.org/security/2016/dsa-3720\n\n* https://access.redhat.com/errata/RHSA-2017:2247\n\n* https://access.redhat.com/errata/RHSA-2017:1552\n\n* https://access.redhat.com/errata/RHSA-2017:1550\n\n* https://access.redhat.com/errata/RHSA-2017:1549\n\n* https://access.redhat.com/errata/RHSA-2017:1548\n\n* https://access.redhat.com/errata/RHSA-2017:0456\n\n* https://access.redhat.com/errata/RHSA-2017:0455\n\n* http://rhn.redhat.com/errata/RHSA-2017-1551.html\n\n* http://rhn.redhat.com/errata/RHSA-2017-0457.html\n\n* https://security.netapp.com/advisory/ntap-20180605-0001/\n\n* https://usn.ubuntu.com/4557-1/\n\n* https://www.oracle.com/security-alerts/cpuoct2021.html\n\n'))
+            self.assertTrue(finding.description.startswith('**Product Background**\n\n**Apache Tomcat** is a free and open-source Java web application server. It provides a "pure Java" HTTP web server environment in which Java code can also run, implementing the Jakarta Servlet, Jakarta Expression Language, and WebSocket technologies. Tomcat is released with **Catalina** (a servlet and JSP Java Server Pages container), **Coyote** (an HTTP connector), **Coyote JK** (JK protocol proxy connector) and **Jasper** (a JSP engine). Tomcat can optionally be bundled with Java Enterprise Edition (Jakarta EE) as **Apache TomEE** to deliver a complete application server with enterprise features such as distributed computing and web services.\n\n**Vulnerability Summary**\n\nA malicious web application running on Apache Tomcat 9.0.0.M1 to 9.0.0.M9, 8.5.0 to 8.5.4, 8.0.0.RC1 to 8.0.36, 7.0.0 to 7.0.70 and 6.0.0 to 6.0.45 was able to bypass a configured SecurityManager via manipulation of the configuration parameters for the JSP Servlet.\n\n**References**\n\n* http://www.securitytracker.com/id/1038757\n\n* http://www.securitytracker.com/id/1037141\n\n* http://www.securityfocus.com/bid/93944\n\n* http://www.debian.org/security/2016/dsa-3720\n\n* https://access.redhat.com/errata/RHSA-2017:2247\n\n* https://access.redhat.com/errata/RHSA-2017:1552\n\n* https://access.redhat.com/errata/RHSA-2017:1550\n\n* https://access.redhat.com/errata/RHSA-2017:1549\n\n* https://access.redhat.com/errata/RHSA-2017:1548\n\n* https://access.redhat.com/errata/RHSA-2017:0456\n\n* https://access.redhat.com/errata/RHSA-2017:0455\n\n* http://rhn.redhat.com/errata/RHSA-2017-1551.html\n\n* http://rhn.redhat.com/errata/RHSA-2017-0457.html\n\n* https://security.netapp.com/advisory/ntap-20180605-0001/\n\n* https://usn.ubuntu.com/4557-1/\n\n* https://www.oracle.com/security-alerts/cpuoct2021.html\n\n'), finding.description)
             for section in ["**Technical Details**:", "**Classifications**:"]:
-                self.assertTrue(section in finding.description)
+                self.assertIn(section, finding.description)
 
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
@@ -134,9 +136,10 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
                 finding.description.startswith(
                     "This is simply a report of HTTP request methods supported by the web application.",
                 ),
+                finding.description,
             )
             for section in ["**Permitted HTTP Methods**:"]:
-                self.assertTrue(section in finding.description)
+                self.assertIn(section, finding.description)
 
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
@@ -171,9 +174,10 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
                 finding.description.startswith(
                     "This routine reports all SSL/TLS cipher suites accepted by a service   where attack vectors exists only on HTTPS services.\n\nThese rules are applied for the evaluation of the vulnerable cipher suites:\n\n- 64-bit block cipher 3DES vulnerable to the SWEET32 attack (CVE-2016-2183).",
                 ),
+                finding.description,
             )
             for section in ["**Technical Details**:", "**External Sources**"]:
-                self.assertTrue(section in finding.description)
+                self.assertIn(section, finding.description)
 
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
@@ -202,9 +206,10 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
                 finding.description.startswith(
                     "The server responded with a HTTP status code that may indicate that the remote server is experiencing technical\ndifficulties that are likely to affect the scan and may also be affecting other application users.",
                 ),
+                finding.description,
             )
             for section in ["**Technical Details**:"]:
-                self.assertTrue(section in finding.description)
+                self.assertIn(section, finding.description)
 
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
@@ -232,12 +237,12 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
             self.assertEqual("2024-08-06", finding.date)
             self.assertEqual("HTTP/2 Supported", finding.title)
             self.assertEqual(1, len(finding.unsaved_endpoints))
-            self.assertTrue("**Messages**" not in finding.description)
-            self.assertTrue("\x00" not in finding.description)
+            self.assertNotIn("**Messages**", finding.description)
+            self.assertNotIn("\x00", finding.description)
             self.assertIsNotNone(finding.unsaved_request)
-            self.assertTrue(finding.unsaved_request.startswith(":method  =   GET"))
+            self.assertTrue(finding.unsaved_request.startswith(":method  =   GET"), finding.unsaved_request)
             self.assertIsNotNone(finding.unsaved_response)
-            self.assertTrue(finding.unsaved_response.startswith(":status: 200"))
+            self.assertTrue(finding.unsaved_response.startswith(":status: 200"), finding.unsaved_response)
             endpoint = finding.unsaved_endpoints[0]
             endpoint.clean()
             self.assertEqual("www.xzzvwy.com", endpoint.host)
@@ -250,13 +255,13 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
             self.assertEqual("4e7c0b570ff6083376b99e1897102a87907effe2199dc8d4", finding.unique_id_from_tool)
             self.assertEqual("2024-08-06", finding.date)
             self.assertEqual("HTTP/2 Protocol: Transfer-Encoding Header Accepted", finding.title)
-            self.assertTrue("**Messages**" not in finding.description)
-            self.assertTrue("\x00" not in finding.description)
-            self.assertTrue("**HTTP2 Headers**" in finding.description)
+            self.assertNotIn("**Messages**", finding.description)
+            self.assertNotIn("\x00", finding.description)
+            self.assertIn("**HTTP2 Headers**", finding.description)
             self.assertIsNotNone(finding.unsaved_request)
-            self.assertTrue(finding.unsaved_request.startswith(":method  =   POST"))
+            self.assertTrue(finding.unsaved_request.startswith(":method  =   POST"), finding.unsaved_request)
             self.assertIsNotNone(finding.unsaved_response)
-            self.assertTrue(finding.unsaved_response.startswith(":status: 200"))
+            self.assertTrue(finding.unsaved_response.startswith(":status: 200"), finding.unsaved_response)
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
             endpoint.clean()
@@ -270,13 +275,13 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
             self.assertEqual("2f1fb384e6a866f9ee0c6f7550e3b607e8b1dd2b1ab0fd02", finding.unique_id_from_tool)
             self.assertEqual("2024-08-06", finding.date)
             self.assertEqual("HTTP/2 Protocol: Transfer-Encoding Header Accepted", finding.title)
-            self.assertTrue("**Messages**" not in finding.description)
-            self.assertTrue("**HTTP2 Headers**" in finding.description)
-            self.assertTrue("\x00" not in finding.description)
+            self.assertNotIn("**Messages**", finding.description)
+            self.assertIn("**HTTP2 Headers**", finding.description)
+            self.assertNotIn("\x00", finding.description)
             self.assertIsNotNone(finding.unsaved_request)
-            self.assertTrue(finding.unsaved_request.startswith(":method  =   POST"))
+            self.assertTrue(finding.unsaved_request.startswith(":method  =   POST"), finding.unsaved_request)
             self.assertIsNotNone(finding.unsaved_response)
-            self.assertTrue(finding.unsaved_response.startswith(":status: 200"))
+            self.assertTrue(finding.unsaved_response.startswith(":status: 200"), finding.unsaved_response)
             self.assertEqual(1, len(finding.unsaved_endpoints))
             endpoint = finding.unsaved_endpoints[0]
             endpoint.clean()
@@ -495,7 +500,7 @@ class TestAppCheckWebApplicationScannerParser(TestCase):
             self.assertIsNone(f.unsaved_response)
             # If the dict originally has a 'Messages' entry, it should remain there since no req/res was extracted
             if has_messages_entry:
-                self.assertTrue("Messages" in no_rr)
+                self.assertIn("Messages", no_rr)
 
         for template, test_data in {
             # HTTP/1

--- a/unittests/tools/test_asff_parser.py
+++ b/unittests/tools/test_asff_parser.py
@@ -31,7 +31,7 @@ class TestAsffParser(DojoTestCase):
             "IpV4Addresses"
         ]
         for endpoint in finding.unsaved_endpoints:
-            self.assertTrue(endpoint, expected_ipv4s)
+            self.assertIn(str(endpoint), expected_ipv4s)
             endpoint.clean()
 
     def test_asff_one_vuln(self):

--- a/unittests/tools/test_auditjs_parser.py
+++ b/unittests/tools/test_auditjs_parser.py
@@ -63,8 +63,8 @@ class TestAuditJSParser(DojoTestCase):
                 parser = AuditJSParser()
                 parser.get_findings(testfile, Test())
 
-        self.assertTrue(
-            "Invalid JSON format. Are you sure you used --json option ?" in str(context.exception),
+        self.assertIn(
+            "Invalid JSON format. Are you sure you used --json option ?", str(context.exception),
         )
 
     def test_auditjs_parser_with_package_name_has_namespace(self):

--- a/unittests/tools/test_chefinspect_parser.py
+++ b/unittests/tools/test_chefinspect_parser.py
@@ -21,4 +21,4 @@ class TestChefInspectParser(DojoTestCase):
         with open("unittests/scans/chefinspect/many_findings.log", encoding="utf-8") as testfile:
             parser = ChefInspectParser()
             findings = parser.get_findings(testfile, Test())
-            self.assertTrue(10, len(findings))
+            self.assertEqual(10, len(findings))

--- a/unittests/tools/test_meterian_parser.py
+++ b/unittests/tools/test_meterian_parser.py
@@ -52,7 +52,7 @@ class TestMeterianParser(DojoTestCase):
             self.assertEqual(1, len(finding.unsaved_vulnerability_ids))
             self.assertEqual("CVE-2020-26289", finding.unsaved_vulnerability_ids[0])
             self.assertEqual(400, finding.cwe)
-            self.assertTrue(finding.mitigation.startswith("## Remediation"))
+            self.assertTrue(finding.mitigation.startswith("## Remediation"), finding.mitigation)
             self.assertIn("Upgrade date-and-time to version 0.14.2 or higher.", finding.mitigation)
             self.assertIn("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-26289", finding.references, "found " + finding.references)
             self.assertIn("https://nvd.nist.gov/vuln/detail/CVE-2020-26289", finding.references, "found " + finding.references)
@@ -68,7 +68,7 @@ class TestMeterianParser(DojoTestCase):
             findings = parser.get_findings(testfile, Test())
 
             finding = findings[0]
-            self.assertTrue(finding.mitigation.startswith("We were not able to provide a safe version for this library."))
+            self.assertTrue(finding.mitigation.startswith("We were not able to provide a safe version for this library."), finding.mitigation)
             self.assertIn("You should consider replacing this component as it could be an "
                 + "issue for the safety of your application.", finding.mitigation)
 

--- a/unittests/tools/test_noseyparker_parser.py
+++ b/unittests/tools/test_noseyparker_parser.py
@@ -39,7 +39,7 @@ class TestNoseyParkerParser(TestCase):
                 findings = parser.get_findings(testfile, Test())
                 testfile.close()
                 self.assertEqual(0, len(findings))
-                self.assertTrue(
-                    "Invalid Nosey Parker data, make sure to use Nosey Parker v0.16.0" in str(context.exception),
+                self.assertIn(
+                    "Invalid Nosey Parker data, make sure to use Nosey Parker v0.16.0", str(context.exception),
                 )
-                self.assertTrue("ECONNREFUSED" in str(context.exception))
+                self.assertIn("ECONNREFUSED", str(context.exception))

--- a/unittests/tools/test_yarn_audit_parser.py
+++ b/unittests/tools/test_yarn_audit_parser.py
@@ -67,10 +67,10 @@ class TestYarnAuditParser(DojoTestCase):
             with open("unittests/scans/yarn_audit/empty_with_error.json", encoding="utf-8") as testfile:
                 parser = YarnAuditParser()
                 parser.get_findings(testfile, self.get_test())
-                self.assertTrue(
-                    "yarn audit report contains errors:" in str(context.exception),
+                self.assertIn(
+                    "yarn audit report contains errors:", str(context.exception),
                 )
-                self.assertTrue("ECONNREFUSED" in str(context.exception))
+                self.assertIn("ECONNREFUSED", str(context.exception))
 
     def test_yarn_audit_parser_issue_6495(self):
         with open("unittests/scans/yarn_audit/issue_6495.json", encoding="utf-8") as testfile:


### PR DESCRIPTION
Python supports many useful checkers in unittests which (if a test does not pass) are able to provide useful information about the context (why it is not going through, on which position).

It might be good to prefer these `assert*`. And it is not possible to add context as an additional parameter for faster troubleshooting.