### PR TITLE
fix(helm): Longer wait for DB

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -53,7 +53,7 @@ spec:
         command:
         - '/bin/bash'
         - '-c'
-        - '/wait-for-it.sh ${DD_DATABASE_HOST:-postgres}:${DD_DATABASE_PORT:-5432} -t 30 -s -- /bin/echo Database is up'
+        - '/wait-for-it.sh ${DD_DATABASE_HOST:-postgres}:${DD_DATABASE_PORT:-5432} -t 300 -s -- /bin/echo Database is up'
         image: '{{ template "django.uwsgi.repository" . }}:{{ .Values.tag }}'
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         {{- if .Values.securityContext.enabled }}


### PR DESCRIPTION
During a couple of last PRs, I noticed that sometimes k8s are failing. Reason: The first run of the initializer fails while waiting on DB. The second run pass successfully.

I suppose 30 seconds might not be enough for DB, 5min should be an acceptable compromise.