### PR TITLE
fix(edit-prod): Add assigned PT to queryset

### DIFF
--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -321,6 +321,8 @@ class ProductForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["prod_type"].queryset = get_authorized_product_types(Permissions.Product_Type_Add_Product)
+        if prod_type_id := getattr(kwargs.get("instance", Product()), "prod_type_id"):  # we are editing existing instance
+            self.fields["prod_type"].queryset |= Product_Type.objects.filter(pk=prod_type_id)  # even if user does not have permission for any other ProdType we need to add at least assign ProdType to make form submittable (otherwise empty list was here which generated invalid form)
 
         # if this product has findings being asynchronously updated, disable the sla config field
         if self.instance.async_updating:


### PR DESCRIPTION
Until now, when a user has no permission to add Prod or edit ProdType (a.k.a `get_authorized_product_types(Permissions.Product_Type_Add_Product)` is empty) but the same user still has permission to edit product (Maintainer for that specific product), generated edit form for Product contained empty list for `Product Types`. So user wasn't able to edit this product.

![Screenshot 2024-09-02 at 16 36 47](https://github.com/user-attachments/assets/8a26bd2e-1654-41b3-af08-ae3709a140ca)

From now on, it does not matter which other permissions a user has, the list of product types contains at least ProdType which is already assigned - so it is possible to submit the form.

<img width="434" alt="Screenshot 2024-09-02 at 16 37 01" src="https://github.com/user-attachments/assets/a8fc861e-4da9-430c-abfe-96fc9a730e4e">
