### PR TITLE
feat(members): List global role members in Prod and ProdType

### DIFF
--- a/dojo/product/queries.py
+++ b/dojo/product/queries.py
@@ -13,6 +13,7 @@ from dojo.models import (
     App_Analysis,
     DojoMeta,
     Engagement_Presets,
+    Global_Role,
     Languages,
     Product,
     Product_API_Scan_Configuration,
@@ -71,8 +72,15 @@ def get_authorized_members_for_product(product, permission):
 
     if user.is_superuser or user_has_permission(user, product, permission):
         return Product_Member.objects.filter(product=product).order_by("user__first_name", "user__last_name").select_related("role", "user")
-    else:
-        return None
+    return Product_Member.objects.none()
+
+
+def get_authorized_global_members_for_product(product, permission):
+    user = get_current_user()
+
+    if user.is_superuser or user_has_permission(user, product, permission):
+        return Global_Role.objects.filter(group=None, role__isnull=False).order_by("user__first_name", "user__last_name").select_related("role", "user")
+    return Global_Role.objects.none()
 
 
 def get_authorized_groups_for_product(product, permission):
@@ -81,8 +89,15 @@ def get_authorized_groups_for_product(product, permission):
     if user.is_superuser or user_has_permission(user, product, permission):
         authorized_groups = get_authorized_groups(Permissions.Group_View)
         return Product_Group.objects.filter(product=product, group__in=authorized_groups).order_by("group__name").select_related("role")
-    else:
-        return None
+    return Product_Group.objects.none()
+
+
+def get_authorized_global_groups_for_product(product, permission):
+    user = get_current_user()
+
+    if user.is_superuser or user_has_permission(user, product, permission):
+        return Global_Role.objects.filter(user=None, role__isnull=False).order_by("group__name").select_related("role")
+    return Global_Role.objects.none()
 
 
 def get_authorized_product_members(permission):

--- a/dojo/product/views.py
+++ b/dojo/product/views.py
@@ -92,6 +92,8 @@ from dojo.models import (
     Test_Type,
 )
 from dojo.product.queries import (
+    get_authorized_global_groups_for_product,
+    get_authorized_global_members_for_product,
     get_authorized_groups_for_product,
     get_authorized_members_for_product,
     get_authorized_products,
@@ -213,8 +215,10 @@ def view_product(request, pid):
                                       .prefetch_related("prod_type__members")
     prod = get_object_or_404(prod_query, id=pid)
     product_members = get_authorized_members_for_product(prod, Permissions.Product_View)
+    global_product_members = get_authorized_global_members_for_product(prod, Permissions.Product_View)
     product_type_members = get_authorized_members_for_product_type(prod.prod_type, Permissions.Product_Type_View)
     product_groups = get_authorized_groups_for_product(prod, Permissions.Product_View)
+    global_product_groups = get_authorized_global_groups_for_product(prod, Permissions.Product_View)
     product_type_groups = get_authorized_groups_for_product_type(prod.prod_type, Permissions.Product_Type_View)
     personal_notifications_form = ProductNotificationsForm(
         instance=Notifications.objects.filter(user=request.user).filter(product=prod).first())
@@ -291,8 +295,10 @@ def view_product(request, pid):
         "benchmarks_percents": benchAndPercent,
         "benchmarks": benchmarks,
         "product_members": product_members,
+        "global_product_members": global_product_members,
         "product_type_members": product_type_members,
         "product_groups": product_groups,
+        "global_product_groups": global_product_groups,
         "product_type_groups": product_type_groups,
         "personal_notifications_form": personal_notifications_form,
         "enabled_notifications": get_enabled_notifications_list(),

--- a/dojo/product_type/queries.py
+++ b/dojo/product_type/queries.py
@@ -9,7 +9,7 @@ from dojo.authorization.authorization import (
 )
 from dojo.authorization.roles_permissions import Permissions
 from dojo.group.queries import get_authorized_groups
-from dojo.models import Product_Type, Product_Type_Group, Product_Type_Member
+from dojo.models import Global_Role, Product_Type, Product_Type_Group, Product_Type_Member
 
 
 def get_authorized_product_types(permission):
@@ -45,8 +45,15 @@ def get_authorized_members_for_product_type(product_type, permission):
 
     if user.is_superuser or user_has_permission(user, product_type, permission):
         return Product_Type_Member.objects.filter(product_type=product_type).order_by("user__first_name", "user__last_name").select_related("role", "product_type", "user")
-    else:
-        return None
+    return Product_Type_Member.objects.none()
+
+
+def get_authorized_global_members_for_product_type(product_type, permission):
+    user = get_current_user()
+
+    if user.is_superuser or user_has_permission(user, product_type, permission):
+        return Global_Role.objects.filter(group=None, role__isnull=False).order_by("user__first_name", "user__last_name").select_related("role", "user")
+    return Global_Role.objects.none()
 
 
 def get_authorized_groups_for_product_type(product_type, permission):
@@ -55,8 +62,15 @@ def get_authorized_groups_for_product_type(product_type, permission):
     if user.is_superuser or user_has_permission(user, product_type, permission):
         authorized_groups = get_authorized_groups(Permissions.Group_View)
         return Product_Type_Group.objects.filter(product_type=product_type, group__in=authorized_groups).order_by("group__name").select_related("role", "group")
-    else:
-        return None
+    return Product_Type_Group.objects.none()
+
+
+def get_authorized_global_groups_for_product_type(product_type, permission):
+    user = get_current_user()
+
+    if user.is_superuser or user_has_permission(user, product_type, permission):
+        return Global_Role.objects.filter(user=None, role__isnull=False).order_by("group__name").select_related("role", "group")
+    return Global_Role.objects.none()
 
 
 def get_authorized_product_type_members(permission):

--- a/dojo/product_type/views.py
+++ b/dojo/product_type/views.py
@@ -27,6 +27,8 @@ from dojo.forms import (
 from dojo.models import Product_Type, Product_Type_Group, Product_Type_Member, Role
 from dojo.product.queries import get_authorized_products
 from dojo.product_type.queries import (
+    get_authorized_global_groups_for_product_type,
+    get_authorized_global_members_for_product_type,
     get_authorized_groups_for_product_type,
     get_authorized_members_for_product_type,
     get_authorized_product_types,
@@ -117,7 +119,9 @@ def view_product_type(request, ptid):
     page_name = _("View Product Type")
     pt = get_object_or_404(Product_Type, pk=ptid)
     members = get_authorized_members_for_product_type(pt, Permissions.Product_Type_View)
+    global_members = get_authorized_global_members_for_product_type(pt, Permissions.Product_Type_View)
     groups = get_authorized_groups_for_product_type(pt, Permissions.Product_Type_View)
+    global_groups = get_authorized_global_groups_for_product_type(pt, Permissions.Product_Type_View)
     products = get_authorized_products(Permissions.Product_View).filter(prod_type=pt)
     products = get_page_items(request, products, 25)
     add_breadcrumb(title=page_name, top_level=False, request=request)
@@ -126,7 +130,10 @@ def view_product_type(request, ptid):
         "pt": pt,
         "products": products,
         "groups": groups,
-        "members": members})
+        "members": members,
+        "global_groups": global_groups,
+        "global_members": global_members,
+    })
 
 
 @user_is_authorized(Product_Type, Permissions.Product_Type_Delete, "ptid")

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -295,7 +295,7 @@
                 {% endif %}
             </div>
         </div>
-        {% if product_members or product_type_members %}
+        {% if product_members or product_type_members or global_product_members %}
             <div class="table-responsive">
                 <table class="tablesorter-bootstrap table table-condensed table-striped">
                     <thead>
@@ -348,6 +348,15 @@
                             <td>{{ member.role }}</td>
                         </tr>
                     {% endfor %}
+                    {% for member in global_product_members %}
+                        <tr>
+                            <td>
+                            </td>
+                            <td>{{ member.user.get_full_name }}</td>
+                            <td>Global role</td>
+                            <td>{{ member.role }}</td>
+                        </tr>
+                    {% endfor %}
                     </tbody>
                 </table>
             </div>
@@ -383,7 +392,7 @@
                   {% endif %}
               </div>
           </div>
-          {% if product_groups or product_type_groups %}
+          {% if product_groups or product_type_groups or global_product_groups %}
           <div class="table-responsive">
               <table class="tablesorter-bootstrap table table-condensed table-striped">
                   <thead>
@@ -432,6 +441,14 @@
                               {{ type_group.product_type }}
                           </a>
                       </td>
+                      <td>{{ type_group.role }}</td>
+                  </tr>
+                  {% endfor %}
+                  {% for type_group in global_product_groups %}
+                  <tr>
+                      <td></td>
+                      <td>{{ type_group.group.name }}</td>
+                      <td>Global role</td>
                       <td>{{ type_group.role }}</td>
                   </tr>
                   {% endfor %}

--- a/dojo/templates/dojo/view_product_type.html
+++ b/dojo/templates/dojo/view_product_type.html
@@ -151,7 +151,7 @@
                             {% endif %}
                         </div>
                     </div>
-                    {% if members %}
+                    {% if members or global_members %}
                         <div class="table-responsive">
                             <table class="tablesorter-bootstrap table table-condensed table-striped">
                                 <thead>
@@ -189,6 +189,14 @@
                                         <td name="member_role">{{ member.role }}</td>
                                     </tr>
                                 {% endfor %}
+                                {% for member in global_members %}
+                                    <tr>
+                                        <td>
+                                        </td>
+                                        <td name="member_global_user">{{ member.user.get_full_name }}</td>
+                                        <td name="member_global_role">{{ member.role }} (Global role)</td>
+                                    </tr>
+                                {% endfor %}
                                 </tbody>
                             </table>
                         </div>
@@ -224,7 +232,7 @@
                         {% endif %}
                     </div>
                 </div>
-                {% if groups %}
+                {% if groups or global_groups %}
                 <div class="table-responsive">
                     <table class="tablesorter-bootstrap table table-condensed table-striped">
                         <thead>
@@ -260,6 +268,14 @@
                             </td>
                             <td name="product_type_group_group">{{ group.group.name }}</td>
                             <td name="product_type_group_role">{{ group.role }}</td>
+                        </tr>
+                        {% endfor %}
+                        {% for group in global_groups %}
+                        <tr>
+                            <td>
+                            </td>
+                            <td name="product_type_group_global_group">{{ group.group.name }}</td>
+                            <td name="product_type_group_global_role">{{ group.role }} (Global role)</td>
                         </tr>
                         {% endfor %}
                         </tbody>


### PR DESCRIPTION
Until now, UI listed only regular members of Prod or ProdType. From now on, owners of Prods are transparently informed that also `Global_Role` members also have access to their data.

In ProdType:
<img width="888" alt="image" src="https://github.com/user-attachments/assets/19387edc-5f5b-43f6-87f2-6ef0bf5a06e5">

In Prod:
<img width="857" alt="image" src="https://github.com/user-attachments/assets/dbf19749-0bb7-4143-b3fd-815c6bf20f54">
