### PR TITLE
Reimport: Set Vulnerability ID from incoming finding

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -704,6 +704,8 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             finding.unsaved_files = finding_from_report.unsaved_files
         self.process_files(finding)
         # Process vulnerability IDs
+        if finding_from_report.unsaved_vulnerability_ids:
+            finding.unsaved_vulnerability_ids = finding_from_report.unsaved_vulnerability_ids
         finding = self.process_vulnerability_ids(finding)
 
         return finding


### PR DESCRIPTION
When reimporting, findings that previously had multiple vulnerability IDs will suddenly only have a single vulnerability ID (the primary one, or the first one that was created). Two things are occurring here:
- **Where are the vulnerability IDs going?**: When reimports occur, the current finding that exists in the database has its vulnerability IDs are processed, which includes removing all of them before hand. The step that is missing is that the existing finding does not have any `unsaved_vulnerability_ids`. The incoming finding does though. The solution is to set the existing findings `unsaved_vulnerability_ids` to what is set by the incoming finding. That way, if there are any differences between the two (such as the a CVE no longer applying to a vulnerability, or one gets added) then it will be reflected on the existing finding.
- **Why is the first vulnerability ID never erased?**: The primary vulnerability ID is also saved in the `cve` field, which is then translated over to a vulnerability ID. It is sort of like having an unintended redundancy policy

[sc-7384] 