### PR TITLE
Product API scan config: Display view scan configs button for all products

### DIFF
--- a/dojo/templates/dojo/product.html
+++ b/dojo/templates/dojo/product.html
@@ -122,18 +122,20 @@
                                               <i class="fa-solid fa-pen-to-square"></i> Edit Custom Fields
                                             </a>
                                           </li>
-                                          <li role="separator" class="divider"></li>
+                                        {% endif %}
+                                        <li role="separator" class="divider"></li>
+                                        {% if prod|has_object_permission:"Product_API_Scan_Configuration_Edit" %}  
                                           <li role="presentation">
-                                              <a class="" href="{% url 'add_api_scan_configuration' prod.id %}">
-                                                  <i class="fa-solid fa-rectangle-list"></i> Add Scan API Configuration
-                                              </a>
-                                          </li>
-                                          <li role="presentation">
-                                              <a title="View API Scan configurations" href="{% url 'view_api_scan_configurations' prod.id %}">
-                                                <i class="fa-solid fa-clock-rotate-left"></i> View Scan API Configurations
-                                              </a>
+                                            <a class="" href="{% url 'add_api_scan_configuration' prod.id %}">
+                                              <i class="fa-solid fa-rectangle-list"></i> Add Scan API Configuration
+                                            </a>
                                           </li>
                                         {% endif %}
+                                        <li role="presentation">
+                                            <a title="View API Scan configurations" href="{% url 'view_api_scan_configurations' prod.id %}">
+                                              <i class="fa-solid fa-clock-rotate-left"></i> View Scan API Configurations
+                                            </a>
+                                        </li>
                                         {% if system_settings.enable_product_tracking_files %}
                                           <li role="separator" class="divider"></li>
                                           {% if prod|has_object_permission:"Product_Tracking_Files_Add" %}

--- a/dojo/templates/dojo/view_product_details.html
+++ b/dojo/templates/dojo/view_product_details.html
@@ -41,19 +41,21 @@
                         <i class="fa-solid fa-pen-to-square"></i>{% trans "Edit Custom Fields" %}
                     </a>
                   </li>
-                  <li role="separator" class="divider"></li>
+                {% endif %}
+                <li role="separator" class="divider"></li>
+                {% if prod|has_object_permission:"Product_API_Scan_Configuration_Add" %}
                   <li role="presentation">
-                      <a class="" href="{% url 'add_api_scan_configuration' prod.id %}">
-                          <i class="fa-solid fa-plus"></i>{% trans "Add API Scan Configuration" %}
-                      </a>
-                  </li>
-                  <li role="presentation">
-                      <a title="View API Scan Configurations"
-                         href="{% url 'view_api_scan_configurations' prod.id %}">
-                          <i class="fa-solid fa-rectangle-list"></i>{% trans "View API Scan Configurations" %}
-                      </a>
+                    <a class="" href="{% url 'add_api_scan_configuration' prod.id %}">
+                      <i class="fa-solid fa-plus"></i>{% trans "Add API Scan Configuration" %}
+                    </a>
                   </li>
                 {% endif %}
+                <li role="presentation">
+                    <a title="View API Scan Configurations"
+                        href="{% url 'view_api_scan_configurations' prod.id %}">
+                        <i class="fa-solid fa-rectangle-list"></i>{% trans "View API Scan Configurations" %}
+                    </a>
+                </li>
                 {% if system_settings.enable_product_tracking_files %}
                   <li role="separator" class="divider"></li>
                   {% if prod|has_object_permission:"Product_Tracking_Files_Add" %}


### PR DESCRIPTION
Viewing a product's API scan config is permissible if the product can be viewed. However, the UI would only display the "View API Scan Config" button if the user had permission to at least edit a product. This PR corrects the permission checks in the UI to display the button when a user has permission to view a product

[sc-7458]