### PR TITLE
Ruff: Add C90

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -28,13 +28,11 @@ exclude = [
 ]
 
 [lint]
-# Enable the pycodestyle (`E`) and Pyflakes (`F`) rules by default.
-# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
-# McCabe complexity (`C901`) by default.
 select = [
    "F",
    "E",
    "W",
+   "C90",
    "I",
    "D3",
    "UP",
@@ -98,3 +96,6 @@ per-file-ignores = {}
 
 [lint.flake8-boolean-trap]
 extend-allowed-calls = ["dojo.utils.get_system_setting"]
+
+[lint.mccabe]
+max-complexity = 70  # value is far from perfect (recommended default is 10). But we will try to decrease it over the time.


### PR DESCRIPTION
This PR was created based on https://github.com/DefectDojo/django-DefectDojo/pull/10111#pullrequestreview-2264320904

Context:
- https://docs.astral.sh/ruff/rules/#mccabe-c90
- https://docs.astral.sh/ruff/rules/complex-structure/
- https://docs.astral.sh/ruff/settings/#lintmccabe

It is far from "perfect" but let's start with adding this rule and we will see how we will be able to improve it over time.

Just some small statistic:
```python
  count complexity 
     28 11 
     29 12 
     16 13 
     15 14 
      9 15 
      8 16 
     15 17 
      7 18 
      6 19 
      3 20 
      3 21 
      3 22 
      1 23 
      7 24 
      4 25 
      2 26 
      1 27 
      5 28 
      1 29 
      2 30 
      2 31 
      1 32 
      1 33 
      2 36 
      1 37 
      1 38 
      1 40 
      1 42 
      1 46 
      1 48 
      1 57 
      2 69 
```