### PR TITLE
Manage not defined metadata in mitigations and add assumptions comments

### DIFF
--- a/unittests/scans/threat_composer/threat_composer_many_threats.json
+++ b/unittests/scans/threat_composer/threat_composer_many_threats.json
@@ -94,13 +94,8 @@
         "tags": [
           "lorem ipsum"
         ],
-        "metadata": [
-          {
-            "key": "Comments",
-            "value": "lorem ipsum"
-          }
-        ],
-        "displayOrder": 21
+        "displayOrder": 21,
+        "status": "mitigationResolved"
       },
       {
         "id": "11fb1c71-42f0-4004-89a7-09d8bf6f8b11",


### PR DESCRIPTION
**Description**

Threat Composer has different behavior for _metadata_ depending on whether it is a threat or a mitigation. In the case of the threat, the 'metadata' key always exists even if no data has been included. However, in mitigation that key may not exist. A fix has been included to validate the 'metadata' key in the mitigation, including an empty list if it does not exist. In addition, comments of the assumptions have been included.
