### PR TITLE
Fix metrics aggregation

### DIFF
--- a/dojo/metrics/utils.py
+++ b/dojo/metrics/utils.py
@@ -500,7 +500,7 @@ def aggregate_counts_by_period(
         )
         desired_values += ("closed",)
 
-    return severities_by_period.order_by('grouped_date').values(*desired_values)
+    return severities_by_period.order_by("grouped_date").values(*desired_values)
 
 
 def findings_by_product(

--- a/dojo/metrics/utils.py
+++ b/dojo/metrics/utils.py
@@ -500,7 +500,7 @@ def aggregate_counts_by_period(
         )
         desired_values += ("closed",)
 
-    return severities_by_period.values(*desired_values)
+    return severities_by_period.order_by('grouped_date').values(*desired_values)
 
 
 def findings_by_product(


### PR DESCRIPTION
**Description**

This patch fixes an issue with metrics aggregation by explicitly specifying the order_by() clause on the aggregate_counts_by_period() method. Not explicitly specifying it caused additional aggregation when the passed-in QuerySet had an ordering.

**Test results**

Tests need to be adjusted to check for this case but I'll add a followup soon.