### PR TITLE
GHA Release: Update settings SHA when creating PR from master

### DIFF
--- a/.github/workflows/release-3-master-into-dev.yml
+++ b/.github/workflows/release-3-master-into-dev.yml
@@ -50,11 +50,15 @@ jobs:
           CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml | head -1)
           sed -ri "0,/version/s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')-dev/" helm/defectdojo/Chart.yaml
       
+      - name: Update settings SHA
+        run: sha256sum dojo/settings/settings.dist.py | cut -d ' ' -f1 > dojo/settings/.settings.dist.py.sha256sum
+
       - name: Check numbers
         run: |
           grep version dojo/__init__.py
           grep appVersion helm/defectdojo/Chart.yaml
           grep version components/package.json
+          cat dojo/settings/.settings.dist.py.sha256sum
 
       - name: Create upgrade notes to documentation
         run: |
@@ -132,11 +136,15 @@ jobs:
           CURRENT_CHART_VERSION=$(grep -oP 'version: (\K\S*)?' helm/defectdojo/Chart.yaml | head -1)
           sed -ri "0,/version/s/version: \S+/$(echo "version: $CURRENT_CHART_VERSION" | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{$NF=sprintf("%0*d", length($NF), ($NF+1)); print}')-dev/" helm/defectdojo/Chart.yaml
       
+      - name: Update settings SHA
+        run: sha256sum dojo/settings/settings.dist.py | cut -d ' ' -f1 > dojo/settings/.settings.dist.py.sha256sum
+
       - name: Check numbers
         run: |
           grep version dojo/__init__.py
           grep appVersion helm/defectdojo/Chart.yaml
           grep version components/package.json
+          cat dojo/settings/.settings.dist.py.sha256sum
       
       - name: Push version changes
         uses: stefanzweifel/git-auto-commit-action@v5.0.1


### PR DESCRIPTION
When doing a release that contains settings changes in the `bugfix` branch as well as the `dev` branch, it is inevitable that settings SHA will not be correct when merging master back into the dev branch. To accommodate this, we can regenerate the SHA with the contents of the two branches merge together. This _should_, in theory, reduce the chances of conflicts at release time, or remove them entirely