### PR TITLE
GHA: Remove Docker Caches

### DIFF
--- a/.github/workflows/build-docker-images-for-testing.yml
+++ b/.github/workflows/build-docker-images-for-testing.yml
@@ -45,9 +45,7 @@ jobs:
           tags: defectdojo/defectdojo-${{ matrix.docker-image }}:${{ matrix.os }}
           file: Dockerfile.${{ matrix.docker-image }}-${{ matrix.os }}
           outputs: type=docker,dest=${{ matrix.docker-image }}-${{ matrix.os }}_img
-          cache-from: type=gha,scope=${{ matrix.docker-image }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.docker-image }}
-  
+
       # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact
         timeout-minutes: 10

--- a/.github/workflows/release-x-manual-docker-containers.yml
+++ b/.github/workflows/release-x-manual-docker-containers.yml
@@ -49,18 +49,6 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        env:
-          docker-image: ${{ matrix.docker-image }}
-        with:
-          path: /tmp/.buildx-cache-${{ env.docker-image }}
-          key: ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-${{ env.workflow_name }}-${{ github.sha }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-${{ env.workflow_name}}-${{ github.sha }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-${{ env.workflow_name }}
-            ${{ runner.os }}-buildx-${{ env.docker-image }}-${{ matrix.os }}-
-
       - name: Build and push images with debian
         if: ${{ matrix.os  == 'debian' }}
         uses: docker/build-push-action@v6
@@ -73,8 +61,6 @@ jobs:
           tags: ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}-${{ matrix.os }}, ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}, ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:latest
           file: ./Dockerfile.${{ env.docker-image }}-${{ matrix.os }}
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
 
       - name: Build and push images with alpine
         if: ${{ matrix.os  == 'alpine' }}
@@ -88,9 +74,3 @@ jobs:
           tags: ${{ env.REPO_ORG }}/defectdojo-${{ env.docker-image}}:${{ github.event.inputs.release_number }}-${{ matrix.os }}
           file: ./Dockerfile.${{ env.docker-image }}-${{ matrix.os }}
           context: .
-          cache-from: type=local,src=/tmp/.buildx-cache-${{ env.docker-image }}
-          cache-to: type=local,dest=/tmp/.buildx-cache-${{ env.docker-image }}
-#           platforms: ${{ matrix.platform }}
-
-      - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
The docker caches in this repo are filling up pretty often. This is in part due to so many unique PRs coming through and using the caches to store their docker layers. It is so awesome to see such engagement, but the cache issues are causing sporadic failures when the cache gets full. To mitigate these cache fills, a cron has been running to periodically empty the caches. This begs the question: "if we are clearing the cache so often, are we really benefitting from having It"

[sc-7396]