### PR TITLE
Prefetching: Add swagger docs for models already supporting prefetching

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -297,7 +297,7 @@ class GlobalRoleViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
 class EndPointViewSet(
     PrefetchDojoModelViewSet,
 ):

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -185,7 +185,7 @@ def schema_with_prefetch() -> dict:
                 ),
             ],
         ),
-        "retrieve":extend_schema(
+        "retrieve": extend_schema(
             parameters=[
                 OpenApiParameter(
                     "prefetch",

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -172,6 +172,33 @@ from dojo.utils import (
 logger = logging.getLogger(__name__)
 
 
+def schema_with_prefetch() -> dict:
+    return {
+        "list": extend_schema(
+            parameters=[
+                OpenApiParameter(
+                    "prefetch",
+                    OpenApiTypes.STR,
+                    OpenApiParameter.QUERY,
+                    required=False,
+                    description="List of fields for which to prefetch model instances and add those to the response",
+                ),
+            ],
+        ),
+        "retrieve":extend_schema(
+            parameters=[
+                OpenApiParameter(
+                    "prefetch",
+                    OpenApiTypes.STR,
+                    OpenApiParameter.QUERY,
+                    required=False,
+                    description="List of fields for which to prefetch model instances and add those to the response",
+                ),
+            ],
+        ),
+    }
+
+
 class DojoOpenApiJsonRenderer(OpenApiJsonRenderer2):
     def get_indent(self, accepted_media_type, renderer_context):
         if accepted_media_type and "indent" in accepted_media_type:
@@ -211,30 +238,7 @@ class RoleViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class DojoGroupViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -252,30 +256,7 @@ class DojoGroupViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class DojoGroupMemberViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -301,6 +282,7 @@ class DojoGroupMemberViewSet(
 
 
 # Authorization: superuser
+@extend_schema_view(**schema_with_prefetch())
 class GlobalRoleViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -315,6 +297,7 @@ class GlobalRoleViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class EndPointViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -370,6 +353,7 @@ class EndPointViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class EndpointStatusViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -398,6 +382,7 @@ class EndpointStatusViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class EngagementViewSet(
     PrefetchDojoModelViewSet,
     ra_api.AcceptedRisksMixin,
@@ -651,6 +636,7 @@ class EngagementViewSet(
         return generate_file_response(file_object)
 
 
+@extend_schema_view(**schema_with_prefetch())
 class RiskAcceptanceViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -716,6 +702,7 @@ class RiskAcceptanceViewSet(
 
 # These are technologies in the UI and the API!
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class AppAnalysisViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -734,6 +721,7 @@ class AppAnalysisViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class CredentialsViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -747,6 +735,7 @@ class CredentialsViewSet(
 
 
 # Authorization: configuration
+@extend_schema_view(**schema_with_prefetch())
 class CredentialsMappingViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1486,6 +1475,7 @@ class JiraInstanceViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class JiraIssuesViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1511,6 +1501,7 @@ class JiraIssuesViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class JiraProjectViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1573,6 +1564,7 @@ class SonarqubeIssueTransitionViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class ProductAPIScanConfigurationViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1599,30 +1591,7 @@ class ProductAPIScanConfigurationViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class DojoMetaViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1646,30 +1615,7 @@ class DojoMetaViewSet(
         return get_authorized_dojo_meta(Permissions.Product_View)
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class ProductViewSet(
     prefetch.PrefetchListMixin,
     prefetch.PrefetchRetrieveMixin,
@@ -1745,30 +1691,7 @@ class ProductViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class ProductMemberViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1796,30 +1719,7 @@ class ProductMemberViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class ProductGroupViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1847,30 +1747,7 @@ class ProductGroupViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class ProductTypeViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1955,30 +1832,7 @@ class ProductTypeViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class ProductTypeMemberViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -2020,30 +1874,7 @@ class ProductTypeMemberViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class ProductTypeGroupViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -2071,6 +1902,7 @@ class ProductTypeGroupViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class StubFindingsViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -2109,6 +1941,7 @@ class DevelopmentEnvironmentViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class TestsViewSet(
     PrefetchDojoModelViewSet,
     ra_api.AcceptedRisksMixin,
@@ -2316,30 +2149,7 @@ class TestTypesViewSet(
         return Test_Type.objects.all().order_by("id")
 
 
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class TestImportViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -2398,6 +2208,7 @@ class TestImportViewSet(
 
 
 # Authorization: configurations
+@extend_schema_view(**schema_with_prefetch())
 class ToolConfigurationsViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -2418,6 +2229,7 @@ class ToolConfigurationsViewSet(
 
 
 # Authorization: object-based
+@extend_schema_view(**schema_with_prefetch())
 class ToolProductSettingsViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -2502,30 +2314,7 @@ class UsersViewSet(
 
 
 # Authorization: superuser
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class UserContactInfoViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -2680,30 +2469,7 @@ class LanguageTypeViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class LanguageViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -3147,30 +2913,7 @@ class SystemSettingsViewSet(
 
 
 # Authorization: superuser
-@extend_schema_view(
-    list=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-    retrieve=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                "prefetch",
-                OpenApiTypes.STR,
-                OpenApiParameter.QUERY,
-                required=False,
-                description="List of fields for which to prefetch model instances and add those to the response",
-            ),
-        ],
-    ),
-)
+@extend_schema_view(**schema_with_prefetch())
 class NotificationsViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -3184,6 +2927,7 @@ class NotificationsViewSet(
         return Notifications.objects.all().order_by("id")
 
 
+@extend_schema_view(**schema_with_prefetch())
 class EngagementPresetsViewset(
     PrefetchDojoModelViewSet,
 ):
@@ -3303,6 +3047,7 @@ class QuestionnaireEngagementSurveyViewSet(
         return Engagement_Survey.objects.all().order_by("id")
 
 
+@extend_schema_view(**schema_with_prefetch())
 class QuestionnaireAnsweredSurveyViewSet(
     prefetch.PrefetchListMixin,
     prefetch.PrefetchRetrieveMixin,


### PR DESCRIPTION
- The /api/v2/global_role endpoint does not support prefetching, but it really should
- I felt sorta icky copy pasting the whole drf-spectacular schema extension, so I added a function to generalize it, then add it to all of the viewsets that already supported prefetch via the `PrefetchDojoModelViewSet` mixin

[sc-7579]

