### PR TITLE
Manage Images: Do not display thumbnail for PDF

### DIFF
--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -69,10 +69,10 @@ finding_related_action_title_dict = {
     "mark_finding_duplicate": "Mark as duplicate",
 }
 
-supported_file_formats = [
+supported_thumbnail_file_formats = [
     "apng", "avif", "gif", "jpg",
     "jpeg", "jfif", "pjpeg", "pjp",
-    "png", "svg", "webp", "pdf",
+    "png", "svg", "webp",
 ]
 
 
@@ -860,7 +860,7 @@ def jira_change(obj):
 def get_thumbnail(file):
     from pathlib import Path
     file_format = Path(file.file.url).suffix[1:]
-    return file_format in supported_file_formats
+    return file_format in supported_thumbnail_file_formats
 
 
 @register.filter


### PR DESCRIPTION
When attaching files to a finding, images will have a thumbnail generated for quick glance viewing. Currently PDFs are part of the whitelist file extensions that allow a thumbnail to be generated, but that does not work, so we get a "cannot find image" icon

<img width="791" alt="image" src="https://github.com/user-attachments/assets/76309555-b360-4cca-a67a-8afc122bec01">

[sc-7547]