### PR TITLE
Prefetch Serialization: Add a preference during mapping

### DIFF
--- a/dojo/api_v2/prefetch/prefetcher.py
+++ b/dojo/api_v2/prefetch/prefetcher.py
@@ -3,10 +3,16 @@ import sys
 
 from rest_framework.serializers import ModelSerializer
 
+from dojo.models import FileUpload
+
 from . import utils
 
 # Reduce the scope of search for serializers.
 SERIALIZER_DEFS_MODULE = "dojo.api_v2.serializers"
+
+preferred_serializers = {
+    FileUpload: "FileSerializer",
+}
 
 
 class _Prefetcher:
@@ -31,7 +37,11 @@ class _Prefetcher:
 
         for _, serializer in available_serializers:
             model = serializer.Meta.model
-            serializers[model] = serializer
+            if model in preferred_serializers:
+                if serializer.__name__ == preferred_serializers[model]:
+                    serializers[model] = serializer
+            else:
+                serializers[model] = serializer
         # We add object->None to have a more uniform processing later on
         serializers[object] = None
 


### PR DESCRIPTION
When prefetching via the API, the serializer to user is dynamically fetched. There are cases where there is more than one `ModelSerializer` on defined, and the wrong one is selected. This PR adds a dict to specify the preferred serializer to user a per model basis

The motivation for this PR is when prefetching a finding with files. Before this PR, a 500 error would be generated

[sc-6061]