### PR TITLE
Risk Exceptions: Add/Remove notes when finding is added/removed from risk exception

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1467,7 +1467,7 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         instance = super().create(validated_data)
-        user = self.context.get("request", {}).get("user", None)
+        user = getattr(self.context.get("request", None), "user", None)
         add_findings_to_risk_acceptance(user, instance, instance.accepted_findings.all())
         return instance
 
@@ -1482,7 +1482,7 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
         findings_to_remove = Finding.objects.filter(id__in=[x.id for x in findings_to_remove])
         # Make the update in the database
         instance = super().update(instance, validated_data)
-        user = self.context.get("request", {}).get("user", None)
+        user = getattr(self.context.get("request", None), "user", None)
         # Add the new findings
         add_findings_to_risk_acceptance(user, instance, findings_to_add)
         # Remove the ones that were not present in the payload

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1467,7 +1467,8 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         instance = super().create(validated_data)
-        add_findings_to_risk_acceptance(instance, instance.accepted_findings.all())
+        user = self.context.get("request", {}).get("user", None)
+        add_findings_to_risk_acceptance(user, instance, instance.accepted_findings.all())
         return instance
 
     def update(self, instance, validated_data):
@@ -1481,11 +1482,12 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
         findings_to_remove = Finding.objects.filter(id__in=[x.id for x in findings_to_remove])
         # Make the update in the database
         instance = super().update(instance, validated_data)
+        user = self.context.get("request", {}).get("user", None)
         # Add the new findings
-        add_findings_to_risk_acceptance(instance, findings_to_add)
+        add_findings_to_risk_acceptance(user, instance, findings_to_add)
         # Remove the ones that were not present in the payload
         for finding in findings_to_remove:
-            remove_finding_from_risk_acceptance(instance, finding)
+            remove_finding_from_risk_acceptance(user, instance, finding)
         return instance
 
     @extend_schema_field(serializers.CharField())

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -668,7 +668,7 @@ class RiskAcceptanceViewSet(
         instance = self.get_object()
         # Remove any findings on the risk acceptance
         for finding in instance.accepted_findings.all():
-            remove_finding_from_risk_acceptance(instance, finding)
+            remove_finding_from_risk_acceptance(request.user, instance, finding)
         # return the response of the object being deleted
         return super().destroy(request, pk=pk)
 

--- a/dojo/engagement/views.py
+++ b/dojo/engagement/views.py
@@ -1250,7 +1250,7 @@ def add_risk_acceptance(request, eid, fid=None):
 
             findings = form.cleaned_data["accepted_findings"]
 
-            risk_acceptance = ra_helper.add_findings_to_risk_acceptance(risk_acceptance, findings)
+            risk_acceptance = ra_helper.add_findings_to_risk_acceptance(request.user, risk_acceptance, findings)
 
             messages.add_message(
                 request,
@@ -1360,7 +1360,7 @@ def view_edit_risk_acceptance(request, eid, raid, edit_mode=False):
             finding = get_object_or_404(
                 Finding, pk=request.POST["remove_finding_id"])
 
-            ra_helper.remove_finding_from_risk_acceptance(risk_acceptance, finding)
+            ra_helper.remove_finding_from_risk_acceptance(request.user, risk_acceptance, finding)
 
             messages.add_message(
                 request,
@@ -1391,7 +1391,7 @@ def view_edit_risk_acceptance(request, eid, raid, edit_mode=False):
             if not errors:
                 findings = add_findings_form.cleaned_data["accepted_findings"]
 
-                ra_helper.add_findings_to_risk_acceptance(risk_acceptance, findings)
+                ra_helper.add_findings_to_risk_acceptance(request.user, risk_acceptance, findings)
 
                 messages.add_message(
                     request,

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1623,7 +1623,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
                     owner=finding.reporter,
                 )
                 finding.test.engagement.risk_acceptance.add(ra)
-                ra_helper.add_findings_to_risk_acceptance(None, ra, [finding])
+                ra_helper.add_findings_to_risk_acceptance(User.objects.get_or_create(username="JIRA")[0], ra, [finding])
                 status_changed = True
         elif jira_instance and resolution_name in jira_instance.false_positive_resolutions:
             if not finding.false_p:
@@ -1633,7 +1633,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
                 finding.mitigated = None
                 finding.is_mitigated = False
                 finding.false_p = True
-                ra_helper.risk_unaccept(None, finding)
+                ra_helper.risk_unaccept(User.objects.get_or_create(username="JIRA")[0], finding)
                 status_changed = True
         else:
             # Mitigated by default as before
@@ -1645,7 +1645,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
                 finding.mitigated_by, _created = User.objects.get_or_create(username="JIRA")
                 finding.endpoints.clear()
                 finding.false_p = False
-                ra_helper.risk_unaccept(None, finding)
+                ra_helper.risk_unaccept(User.objects.get_or_create(username="JIRA")[0], finding)
                 status_changed = True
     else:
         if not finding.active:
@@ -1655,7 +1655,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
             finding.mitigated = None
             finding.is_mitigated = False
             finding.false_p = False
-            ra_helper.risk_unaccept(None, finding)
+            ra_helper.risk_unaccept(User.objects.get_or_create(username="JIRA")[0], finding)
             status_changed = True
 
     # for findings in a group, there is no jira_issue attached to the finding

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1623,7 +1623,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
                     owner=finding.reporter,
                 )
                 finding.test.engagement.risk_acceptance.add(ra)
-                ra_helper.add_findings_to_risk_acceptance(ra, [finding])
+                ra_helper.add_findings_to_risk_acceptance(None, ra, [finding])
                 status_changed = True
         elif jira_instance and resolution_name in jira_instance.false_positive_resolutions:
             if not finding.false_p:
@@ -1633,7 +1633,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
                 finding.mitigated = None
                 finding.is_mitigated = False
                 finding.false_p = True
-                ra_helper.risk_unaccept(finding)
+                ra_helper.risk_unaccept(None, finding)
                 status_changed = True
         else:
             # Mitigated by default as before
@@ -1645,7 +1645,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
                 finding.mitigated_by, _created = User.objects.get_or_create(username="JIRA")
                 finding.endpoints.clear()
                 finding.false_p = False
-                ra_helper.risk_unaccept(finding)
+                ra_helper.risk_unaccept(None, finding)
                 status_changed = True
     else:
         if not finding.active:
@@ -1655,7 +1655,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
             finding.mitigated = None
             finding.is_mitigated = False
             finding.false_p = False
-            ra_helper.risk_unaccept(finding)
+            ra_helper.risk_unaccept(None, finding)
             status_changed = True
 
     # for findings in a group, there is no jira_issue attached to the finding

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -117,7 +117,7 @@ def remove_finding_from_risk_acceptance(user: Dojo_User, risk_acceptance: Risk_A
     if user is not None:
         finding.notes.add(Notes.objects.create(
             entry=(
-                f"{Dojo_User.generate_full_name(user)} removed this finding from the risk acceptance: "
+                f"{Dojo_User.generate_full_name(user)} ({user.id}) removed this finding from the risk acceptance: "
                 f'"{risk_acceptance.name}" ({get_view_risk_acceptance(risk_acceptance)})'
             ),
             author=user,
@@ -139,7 +139,7 @@ def add_findings_to_risk_acceptance(user: Dojo_User, risk_acceptance: Risk_Accep
         if user is not None:
             finding.notes.add(Notes.objects.create(
                 entry=(
-                    f"{Dojo_User.generate_full_name(user)} added this finding to the risk acceptance: "
+                    f"{Dojo_User.generate_full_name(user)} ({user.id}) added this finding to the risk acceptance: "
                     f'"{risk_acceptance.name}" ({get_view_risk_acceptance(risk_acceptance)})'
                 ),
                 author=user,
@@ -317,7 +317,7 @@ def simple_risk_accept(user: Dojo_User, finding: Finding, perform_save=True) -> 
     # Add a note to reflect that the finding was removed from the risk acceptance
     if user is not None:
         finding.notes.add(Notes.objects.create(
-            entry=(f"{Dojo_User.generate_full_name(user)} has risk accepted this finding"),
+            entry=(f"{Dojo_User.generate_full_name(user)} ({user.id}) has risk accepted this finding"),
             author=user,
         ))
 
@@ -343,7 +343,7 @@ def risk_unaccept(user: Dojo_User, finding: Finding, perform_save=True) -> None:
         # Add a note to reflect that the finding was removed from the risk acceptance
         if user is not None:
             finding.notes.add(Notes.objects.create(
-                entry=(f"{Dojo_User.generate_full_name(user)} removed a risk exception from this finding"),
+                entry=(f"{Dojo_User.generate_full_name(user)} ({user.id}) removed a risk exception from this finding"),
                 author=user,
             ))
 

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 import dojo.jira_link.helper as jira_helper
 from dojo.celery import app
 from dojo.jira_link.helper import escape_for_jira
-from dojo.models import Finding, Risk_Acceptance, System_Settings
+from dojo.models import Finding, Risk_Acceptance, System_Settings, Notes, Dojo_User
 from dojo.notifications.helper import create_notification
 from dojo.utils import get_full_url, get_system_setting
 
@@ -102,7 +102,7 @@ def delete(eng, risk_acceptance):
     risk_acceptance.delete()
 
 
-def remove_finding_from_risk_acceptance(risk_acceptance, finding):
+def remove_finding_from_risk_acceptance(user: Dojo_User, risk_acceptance: Risk_Acceptance, finding: Finding) -> None:
     logger.debug("removing finding %i from risk acceptance %i", finding.id, risk_acceptance.id)
     risk_acceptance.accepted_findings.remove(finding)
     finding.active = True
@@ -112,9 +112,20 @@ def remove_finding_from_risk_acceptance(risk_acceptance, finding):
     finding.save(dedupe_option=False)
     # best effort jira integration, no status changes
     post_jira_comments(risk_acceptance, [finding], unaccepted_message_creator)
+    # Add a note to reflect that the finding was removed from the risk acceptance
+    if user is not None:
+        finding.notes.add(Notes.objects.create(
+            entry=(
+                f"{Dojo_User.generate_full_name(user)} removed this finding from the risk acceptance: "
+                f'"{risk_acceptance.name}" ({get_view_risk_acceptance(risk_acceptance)})'
+            ),
+            author=user,
+        ))
+
+    return None
 
 
-def add_findings_to_risk_acceptance(risk_acceptance, findings):
+def add_findings_to_risk_acceptance(user: Dojo_User, risk_acceptance: Risk_Acceptance, findings: list[Finding]) -> None:
     for finding in findings:
         if not finding.duplicate or finding.risk_accepted:
             finding.active = False
@@ -124,9 +135,19 @@ def add_findings_to_risk_acceptance(risk_acceptance, findings):
             update_endpoint_statuses(finding, accept_risk=True)
             risk_acceptance.accepted_findings.add(finding)
     risk_acceptance.save()
-
     # best effort jira integration, no status changes
     post_jira_comments(risk_acceptance, findings, accepted_message_creator)
+    # Add a note to reflect that the finding was removed from the risk acceptance
+    if user is not None:
+        finding.notes.add(Notes.objects.create(
+            entry=(
+                f"{Dojo_User.generate_full_name(user)} added this finding to the risk acceptance: "
+                f'"{risk_acceptance.name}" ({get_view_risk_acceptance(risk_acceptance)})'
+            ),
+            author=user,
+        ))
+
+    return None
 
 
 @app.task
@@ -172,6 +193,13 @@ def expiration_handler(*args, **kwargs):
 
             risk_acceptance.expiration_date_warned = timezone.now()
             risk_acceptance.save()
+
+
+def get_view_risk_acceptance(risk_acceptance: Risk_Acceptance) -> str:
+    """Return the full qualified URL of the view risk acceptance page."""
+    return get_full_url(
+        reverse("view_risk_acceptance", args=(risk_acceptance.engagement.id, risk_acceptance.id)),
+    )
 
 
 def expiration_message_creator(risk_acceptance, heads_up_days=0):
@@ -267,7 +295,7 @@ def prefetch_for_expiration(risk_acceptances):
                                              )
 
 
-def simple_risk_accept(finding, perform_save=True):
+def simple_risk_accept(user: Dojo_User, finding: Finding, perform_save=True) -> None:
     if not finding.test.engagement.product.enable_simple_risk_acceptance:
         raise PermissionDenied
 
@@ -282,9 +310,15 @@ def simple_risk_accept(finding, perform_save=True):
     # post_jira_comment might reload from database so see unaccepted finding. but the comment
     # only contains some text so that's ok
     post_jira_comment(finding, accepted_message_creator)
+    # Add a note to reflect that the finding was removed from the risk acceptance
+    if user is not None:
+        finding.notes.add(Notes.objects.create(
+            entry=(f"{Dojo_User.generate_full_name(user)} has risk accepted this finding"),
+            author=user,
+        ))
 
 
-def risk_unaccept(finding, perform_save=True):
+def risk_unaccept(user: Dojo_User, finding: Finding, perform_save=True) -> None:
     logger.debug("unaccepting finding %i:%s if it is currently risk accepted", finding.id, finding)
     if finding.risk_accepted:
         logger.debug("unaccepting finding %i:%s", finding.id, finding)
@@ -302,6 +336,12 @@ def risk_unaccept(finding, perform_save=True):
         # post_jira_comment might reload from database so see unaccepted finding. but the comment
         # only contains some text so that's ok
         post_jira_comment(finding, unaccepted_message_creator)
+        # Add a note to reflect that the finding was removed from the risk acceptance
+        if user is not None:
+            finding.notes.add(Notes.objects.create(
+                entry=(f"{Dojo_User.generate_full_name(user)} removed a risk exception from this finding"),
+                author=user,
+            ))
 
 
 def remove_from_any_risk_acceptance(finding):

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 import dojo.jira_link.helper as jira_helper
 from dojo.celery import app
 from dojo.jira_link.helper import escape_for_jira
-from dojo.models import Finding, Risk_Acceptance, System_Settings, Notes, Dojo_User
+from dojo.models import Dojo_User, Finding, Notes, Risk_Acceptance, System_Settings
 from dojo.notifications.helper import create_notification
 from dojo.utils import get_full_url, get_system_setting
 


### PR DESCRIPTION
When managing risk exceptions, it would very nice to have record on the finding when the finding is added/removed from a risk exception object, or when a simple risk exception is set via the boolean flag. This can achieved but adding a note on the finding

This PR does not address:
- Setting/Unsetting simple risk exception in the edit finding form
- Setting/Unsetting simple risk exception vie the API
- Setting/Unsetting simple risk exception during bulk edit

[sc-7544]