### PR TITLE
User: Make email required at all times, password required for new users

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -429,6 +429,7 @@ class ProductMetaSerializer(serializers.ModelSerializer):
 class UserSerializer(serializers.ModelSerializer):
     date_joined = serializers.DateTimeField(read_only=True)
     last_login = serializers.DateTimeField(read_only=True, allow_null=True)
+    email = serializers.EmailField(required=True)
     password = serializers.CharField(
         write_only=True,
         style={"input_type": "password"},
@@ -549,11 +550,11 @@ class UserSerializer(serializers.ModelSerializer):
             msg = "Only superusers are allowed to add or edit superusers."
             raise ValidationError(msg)
 
-        if (
-            self.context["request"].method in ["PATCH", "PUT"]
-            and "password" in data
-        ):
+        if self.context["request"].method in ["PATCH", "PUT"] and "password" in data:
             msg = "Update of password though API is not allowed"
+            raise ValidationError(msg)
+        if self.context["request"].method == "POST" and "password" not in data:
+            msg = "Passwords must be supplied for new users"
             raise ValidationError(msg)
         else:
             return super().validate(data)

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -2168,8 +2168,9 @@ class ChangePasswordForm(forms.Form):
 
 
 class AddDojoUserForm(forms.ModelForm):
+    email = forms.EmailField(required=True)
     password = forms.CharField(widget=forms.PasswordInput,
-        required=False,
+        required=True,
         validators=[validate_password],
         help_text="")
 
@@ -2186,6 +2187,7 @@ class AddDojoUserForm(forms.ModelForm):
 
 
 class EditDojoUserForm(forms.ModelForm):
+    email = forms.EmailField(required=True)
 
     class Meta:
         model = Dojo_User

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -59,6 +59,9 @@ class UserTest(BaseTestCase):
         # username
         driver.find_element(By.ID, "id_username").clear()
         driver.find_element(By.ID, "id_username").send_keys("userWriter")
+        # password
+        driver.find_element(By.ID, "id_password").clear()
+        driver.find_element(By.ID, "id_password").send_keys("Def3ctD0jo&")
         # First Name
         driver.find_element(By.ID, "id_first_name").clear()
         driver.find_element(By.ID, "id_first_name").send_keys("Writer")

--- a/unittests/test_apiv2_notifications.py
+++ b/unittests/test_apiv2_notifications.py
@@ -33,6 +33,7 @@ class NotificationsTest(DojoAPITestCase):
         password = "testTEST1234!@#$"
         r = self.client.post(reverse("user-list"), {
             "username": "api-user-notification",
+            "email": "admin@dojo.com",
             "password": password,
         }, format="json")
         return r.json()["id"]

--- a/unittests/test_apiv2_user.py
+++ b/unittests/test_apiv2_user.py
@@ -26,16 +26,11 @@ class UserTest(APITestCase):
                 self.assertNotIn(item, user, r.content[:1000])
 
     def test_user_add(self):
-        # simple user without password
-        r = self.client.post(reverse("user-list"), {
-            "username": "api-user-1",
-        }, format="json")
-        self.assertEqual(r.status_code, 201, r.content[:1000])
-
         # user with good password
         password = "testTEST1234!@#$"
         r = self.client.post(reverse("user-list"), {
             "username": "api-user-2",
+            "email": "admin@dojo.com",
             "password": password,
         }, format="json")
         self.assertEqual(r.status_code, 201, r.content[:1000])
@@ -50,6 +45,7 @@ class UserTest(APITestCase):
         # user with weak password
         r = self.client.post(reverse("user-list"), {
             "username": "api-user-3",
+            "email": "admin@dojo.com",
             "password": "weakPassword",
         }, format="json")
         self.assertEqual(r.status_code, 400, r.content[:1000])
@@ -59,6 +55,8 @@ class UserTest(APITestCase):
         # some user
         r = self.client.post(reverse("user-list"), {
             "username": "api-user-4",
+            "email": "admin@dojo.com",
+            "password": "testTEST1234!@#$",
         }, format="json")
         self.assertEqual(r.status_code, 201, r.content[:1000])
         user_id = r.json()["id"]
@@ -66,16 +64,19 @@ class UserTest(APITestCase):
         r = self.client.put("{}{}/".format(reverse("user-list"), user_id), {
             "username": "api-user-4",
             "first_name": "first",
+            "email": "admin@dojo.com",
         }, format="json")
         self.assertEqual(r.status_code, 200, r.content[:1000])
 
         r = self.client.patch("{}{}/".format(reverse("user-list"), user_id), {
             "last_name": "last",
+            "email": "admin@dojo.com",
         }, format="json")
         self.assertEqual(r.status_code, 200, r.content[:1000])
 
         r = self.client.put("{}{}/".format(reverse("user-list"), user_id), {
             "username": "api-user-4",
+            "email": "admin@dojo.com",
             "password": "testTEST1234!@#$",
         }, format="json")
         self.assertEqual(r.status_code, 400, r.content[:1000])
@@ -83,6 +84,7 @@ class UserTest(APITestCase):
 
         r = self.client.patch("{}{}/".format(reverse("user-list"), user_id), {
             "password": "testTEST1234!@#$",
+            "email": "admin@dojo.com",
         }, format="json")
         self.assertEqual(r.status_code, 400, r.content[:1000])
         self.assertIn("Update of password though API is not allowed", r.content.decode("utf-8"))

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1709,7 +1709,9 @@ class UsersTest(BaseClass.BaseClassTest):
         self.assertEqual(self.endpoint_model.objects.count(), length + 1)
 
     def test_create_user_with_non_configuration_permissions(self):
-        payload = self.payload.copy()
+        payload = self.payload.copy() | {
+            "password": "testTEST1234!@#$",
+        }
         payload["configuration_permissions"] = [25, 26]  # these permissions exist but user can not assign them becaause they are not "configuration_permissions"
         response = self.client.post(self.url, payload)
         self.assertEqual(response.status_code, 400)

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1699,6 +1699,15 @@ class UsersTest(BaseClass.BaseClassTest):
         self.deleted_objects = 25
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
+    def test_create(self):
+        payload = self.payload.copy() | {
+            "password": "testTEST1234!@#$",
+        }
+        length = self.endpoint_model.objects.count()
+        response = self.client.post(self.url, payload)
+        self.assertEqual(201, response.status_code, response.content[:1000])
+        self.assertEqual(self.endpoint_model.objects.count(), length + 1)
+
     def test_create_user_with_non_configuration_permissions(self):
         payload = self.payload.copy()
         payload["configuration_permissions"] = [25, 26]  # these permissions exist but user can not assign them becaause they are not "configuration_permissions"


### PR DESCRIPTION
Creating local users is not the best experience. To accommodate a flow that supports sending temporary passwords to user, and forcing them to login again, we need to make the password field and email field required attributes for new users

[sc-7616]