### PR TITLE
Parsers: Specify lists rather than `dict.values()`

### DIFF
--- a/dojo/tools/blackduck/parser.py
+++ b/dojo/tools/blackduck/parser.py
@@ -78,7 +78,7 @@ class BlackduckParser:
 
                 dupes[dupe_key] = finding
 
-        return dupes.values()
+        return list(dupes.values())
 
     def format_title(self, i):
         if i.channel_version_origin_id is not None:

--- a/dojo/tools/blackduck_binary_analysis/parser.py
+++ b/dojo/tools/blackduck_binary_analysis/parser.py
@@ -104,7 +104,7 @@ class BlackduckBinaryAnalysisParser:
 
                 findings[unique_finding_key] = finding
 
-        return findings.values()
+        return list(findings.values())
 
     def format_title(self, i):
         title = f"{i.object_name}: {i.component} {i.version} Vulnerable"

--- a/dojo/tools/h1/parser.py
+++ b/dojo/tools/h1/parser.py
@@ -100,7 +100,7 @@ class HackerOneVulnerabilityDisclosureProgram:
                 )
                 finding.unsaved_endpoints = []
                 dupes[dupe_key] = finding
-        return dupes.values()
+        return list(dupes.values())
 
     def build_description(self, content):
         date = content["attributes"]["created_at"]

--- a/dojo/tools/intsights/parser.py
+++ b/dojo/tools/intsights/parser.py
@@ -71,4 +71,4 @@ class IntSightsParser:
             duplicates[dupe_key] = alert
             if dupe_key not in duplicates:
                 duplicates[dupe_key] = True
-        return duplicates.values()
+        return list(duplicates.values())

--- a/dojo/tools/mend/parser.py
+++ b/dojo/tools/mend/parser.py
@@ -161,4 +161,4 @@ class MendParser:
             if dupe_key not in dupes:
                 dupes[dupe_key] = finding
 
-        return dupes.values()
+        return list(dupes.values())

--- a/dojo/tools/qualys_webapp/parser.py
+++ b/dojo/tools/qualys_webapp/parser.py
@@ -462,7 +462,7 @@ def qualys_webapp_parser(qualys_xml_file, test, unique, enable_weakness=False):
             ).values(),
         )
 
-    return items
+    return list(items)
 
 
 class QualysWebAppParser:

--- a/dojo/tools/sslscan/parser.py
+++ b/dojo/tools/sslscan/parser.py
@@ -93,4 +93,4 @@ class SslscanParser:
                             else:
                                 endpoint = Endpoint(host=host, port=port)
                             finding.unsaved_endpoints.append(endpoint)
-        return dupes.values()
+        return list(dupes.values())

--- a/dojo/tools/sslyze/parser_xml.py
+++ b/dojo/tools/sslyze/parser_xml.py
@@ -161,4 +161,4 @@ class SSLyzeXMLParser:
                                     host=host, port=port, protocol=protocol,
                                 ),
                             )
-        return dupes.values()
+        return list(dupes.values())

--- a/dojo/tools/whitehat_sentinel/parser.py
+++ b/dojo/tools/whitehat_sentinel/parser.py
@@ -268,4 +268,4 @@ class WhiteHatSentinelParser:
                 finding.unsaved_endpoints = endpoints
                 dupes[dupe_key] = finding
 
-        return dupes.values()
+        return list(dupes.values())


### PR DESCRIPTION
A few parsers do not pass a list of findings, but rather an another type of iterable. This PR will correct these parsers to make the return type more explicit