### PR TITLE
Prefetch: Disable on some viewsets due to payload size

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -298,6 +298,7 @@ class GlobalRoleViewSet(
 
 # Authorization: object-based
 # @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class EndPointViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -353,7 +354,8 @@ class EndPointViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class EndpointStatusViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -382,7 +384,8 @@ class EndpointStatusViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class EngagementViewSet(
     PrefetchDojoModelViewSet,
     ra_api.AcceptedRisksMixin,
@@ -636,7 +639,8 @@ class EngagementViewSet(
         return generate_file_response(file_object)
 
 
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class RiskAcceptanceViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -735,7 +739,8 @@ class CredentialsViewSet(
 
 
 # Authorization: configuration
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class CredentialsMappingViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1475,7 +1480,8 @@ class JiraInstanceViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class JiraIssuesViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1591,7 +1597,8 @@ class ProductAPIScanConfigurationViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class DojoMetaViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1902,7 +1909,8 @@ class ProductTypeGroupViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class StubFindingsViewSet(
     PrefetchDojoModelViewSet,
 ):
@@ -1941,7 +1949,8 @@ class DevelopmentEnvironmentViewSet(
 
 
 # Authorization: object-based
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class TestsViewSet(
     PrefetchDojoModelViewSet,
     ra_api.AcceptedRisksMixin,
@@ -2149,7 +2158,8 @@ class TestTypesViewSet(
         return Test_Type.objects.all().order_by("id")
 
 
-@extend_schema_view(**schema_with_prefetch())
+# @extend_schema_view(**schema_with_prefetch())
+# Nested models with prefetch make the response schema too long for Swagger UI
 class TestImportViewSet(
     PrefetchDojoModelViewSet,
 ):


### PR DESCRIPTION
Generating the response schema for some API endpoints with prefetching will break the Swagger UI:

<img width="686" alt="image" src="https://github.com/user-attachments/assets/81e6aa5e-5596-4dc0-a4e1-4280f9eba735">

[sc-7682]
