### PR TITLE
Fix tag creation bug in FindingTemplateSerializer (letters instead of full tags)

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1939,6 +1939,8 @@ class FindingTemplateSerializer(TaggitSerializer, serializers.ModelSerializer):
         exclude = ("cve",)
 
     def create(self, validated_data):
+        to_be_tagged, validated_data = self._pop_tags(validated_data)
+
         # Save vulnerability ids and pop them
         if "vulnerability_id_template_set" in validated_data:
             vulnerability_id_set = validated_data.pop(
@@ -1961,6 +1963,7 @@ class FindingTemplateSerializer(TaggitSerializer, serializers.ModelSerializer):
             )
             new_finding_template.save()
 
+        self._save_tags(new_finding_template, to_be_tagged)
         return new_finding_template
 
     def update(self, instance, validated_data):


### PR DESCRIPTION
Fixes a bug that caused tags in finding templates created via the API to be split into single-letter tags instead of preserving the intended full tags.

Example of correctly and wrongly created tags for the tag "string":

![grafik](https://github.com/user-attachments/assets/3b286d62-8439-496f-b582-2e3edd953dc4)

