### PR TITLE
fix(helm): add missing env config on job

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -67,8 +67,8 @@ spec:
             name: {{ $fullName }}
             optional: true
         env:
-        {{- if .Values.extraEnv }}
-        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
@@ -122,8 +122,8 @@ spec:
               name: {{ .Values.postgresqlha.postgresql.existingSecret }}
               key: postgresql-postgres-password
               {{- end }}
-        {{- if .Values.extraEnv }}
-        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         resources:
           {{- toYaml .Values.initializer.resources | nindent 10 }}

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -66,6 +66,20 @@ spec:
         - secretRef:
             name: {{ $fullName }}
             optional: true
+        env:
+        - name: DD_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              {{- if eq .Values.database "postgresql" }}
+              name: {{ .Values.postgresql.auth.existingSecret }}
+              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
+              {{- else if eq .Values.database "postgresqlha" }}
+              name: {{ .Values.postgresqlha.postgresql.existingSecret }}
+              key: postgresql-postgres-password
+              {{- end }}
+        {{- if .Values.extraEnv }}
+        {{- toYaml .Values.extraEnv | nindent 8 }}
+        {{- end }}
       containers:
       {{- if .Values.cloudsql.enabled  }}
       - name: cloudsql-proxy

--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -67,16 +67,6 @@ spec:
             name: {{ $fullName }}
             optional: true
         env:
-        - name: DD_DATABASE_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              {{- if eq .Values.database "postgresql" }}
-              name: {{ .Values.postgresql.auth.existingSecret }}
-              key: {{ .Values.postgresql.auth.secretKeys.userPasswordKey }}
-              {{- else if eq .Values.database "postgresqlha" }}
-              name: {{ .Values.postgresqlha.postgresql.existingSecret }}
-              key: postgresql-postgres-password
-              {{- end }}
         {{- if .Values.extraEnv }}
         {{- toYaml .Values.extraEnv | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
The job isn't working well when using an external database because the init container checking if the database is accessible isn't taking the same env values as the container that is initializing the database config

I propose to fix this little issue by simply uniformizing the env provided on the initContainer and the container.

The fix is minor, if you need more information, feel free to ask.