### PR TITLE
Add product_scm_type field processing in auto_create_context for import-scan

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2076,7 +2076,6 @@ class ImportScanSerializer(serializers.Serializer):
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)
     product_scm_type = serializers.CharField(required=False)
-    scan_type = serializers.ChoiceField(choices=get_choices_sorted())
     engagement_name = serializers.CharField(required=False)
     engagement_end_date = serializers.DateField(
         required=False,

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2075,6 +2075,8 @@ class ImportScanSerializer(serializers.Serializer):
     file = serializers.FileField(allow_empty_file=True, required=False)
     product_type_name = serializers.CharField(required=False)
     product_name = serializers.CharField(required=False)
+    product_scm_type = serializers.CharField(required=False)
+    scan_type = serializers.ChoiceField(choices=get_choices_sorted())
     engagement_name = serializers.CharField(required=False)
     engagement_end_date = serializers.DateField(
         required=False,

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -2387,6 +2387,7 @@ class ImportScanView(mixins.CreateModelMixin, viewsets.GenericViewSet):
     - Provide `product_name`
     - Provide `engagement_name`
     - Optionally provide `product_type_name`
+    - Optionally provide `product_scm_type`
 
     In this scenario Defect Dojo will look up the Engagement by the provided details.
 

--- a/dojo/importers/auto_create_context.py
+++ b/dojo/importers/auto_create_context.py
@@ -8,12 +8,12 @@ from django.http.request import QueryDict
 from django.utils import timezone
 
 from dojo.models import (
+    DojoMeta,
     Engagement,
     Product,
     Product_Member,
     Product_Type,
     Product_Type_Member,
-    DojoMeta,
     Role,
     Test,
 )
@@ -278,7 +278,7 @@ class AutoCreateContextManager:
                 )
                 # Create scm-type for product
                 if product_scm_type:
-                    DojoMeta.objects.select_for_update().get_or_create(name='scm-type', value=product_scm_type, product=product)
+                    DojoMeta.objects.select_for_update().get_or_create(name="scm-type", value=product_scm_type, product=product)
         return product
 
     def get_or_create_engagement(

--- a/dojo/importers/auto_create_context.py
+++ b/dojo/importers/auto_create_context.py
@@ -13,6 +13,7 @@ from dojo.models import (
     Product_Member,
     Product_Type,
     Product_Type_Member,
+    DojoMeta,
     Role,
     Test,
 )
@@ -245,6 +246,7 @@ class AutoCreateContextManager:
         self,
         product_name: Optional[str] = None,
         product_type_name: Optional[str] = None,
+        product_scm_type: Optional[str] = None,
         *,
         auto_create_context: bool = False,
         **kwargs: dict,
@@ -272,7 +274,9 @@ class AutoCreateContextManager:
                     product=product,
                     role=Role.objects.get(is_owner=True),
                 )
-
+                # Create scm-type for product
+                if product_scm_type:
+                    DojoMeta.objects.select_for_update().get_or_create(name='scm-type', value=product_scm_type, product=product)
         return product
 
     def get_or_create_engagement(
@@ -281,6 +285,7 @@ class AutoCreateContextManager:
         engagement_name: Optional[str] = None,
         product_name: Optional[str] = None,
         product_type_name: Optional[str] = None,
+        product_scm_type: Optional[str] = None,
         *,
         auto_create_context: bool = False,
         deduplication_on_engagement: bool = False,
@@ -310,6 +315,7 @@ class AutoCreateContextManager:
         product = self.get_or_create_product(
             product_name=product_name,
             product_type_name=product_type_name,
+            product_scm_type=product_scm_type,
             auto_create_context=auto_create_context,
         )
         # Get the target start date in order

--- a/dojo/importers/auto_create_context.py
+++ b/dojo/importers/auto_create_context.py
@@ -102,6 +102,8 @@ class AutoCreateContextManager:
         self.process_object_name("product_type_name", data)
         # Validate the product_name
         self.process_object_name("product_name", data)
+        # Validate the product_scm_type
+        self.process_object_name("product_scm_type", data)
         # Validate the engagement_name
         self.process_object_name("engagement_name", data)
         # Validate the test_title


### PR DESCRIPTION
Hi guys!  Please consider to add additional field product_scm_type to api/v2/import-scan 

It works in tandem with auto_create_context and needed to be able to load scans for gitlab or other repos with only one request without setting it for new project in second request to api/v2/metadata/.

If fields product_scm_type and auto_create_context are set it just create new metavar for project.