### PR TITLE
Downgrade uwsgi to 2.0.26

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ redis==5.1.0
 requests==2.32.3
 sqlalchemy==2.0.35  # Required by Celery broker transport
 urllib3==1.26.18
-uWSGI==2.0.27
+uWSGI==2.0.26
 vobject==0.9.8
 whitenoise==5.2.0
 titlecase==2.4.1


### PR DESCRIPTION
Hot reloading appears to be broken in. 2.0.27. The linked GitHub issue is the same behavior that I am seeing

https://github.com/unbit/uwsgi/issues/2681
