### PR TITLE
AWS Security Hub: Accommodate for reports with missing AccountID

### DIFF
--- a/dojo/tools/awssecurityhub/parser.py
+++ b/dojo/tools/awssecurityhub/parser.py
@@ -28,7 +28,7 @@ class AwsSecurityHubParser:
         aws_acc = []
         for finding in findings:
             prod.append(finding.get("ProductName", "AWS Security Hub Ruleset"))
-            aws_acc.append(finding.get("AwsAccountId"))
+            aws_acc.append(finding.get("AwsAccountId", "No Account Found"))
         report_date = data.get("createdAt")
         test = ParserTest(
             name=self.ID, type=self.ID, version="",

--- a/unittests/scans/awssecurityhub/missing_account_id.json
+++ b/unittests/scans/awssecurityhub/missing_account_id.json
@@ -1,0 +1,112 @@
+{
+    "findings": [
+      {
+        "EpssScore": "0.00239",
+        "SchemaVersion": "2018-10-08",
+        "Id": "arn:aws:inspector2:us-east-1:1234567:finding/12344bc",
+        "ProductArn": "arn:aws:securityhub:us-east-1::product/aws/inspector",
+        "ProductName": "Inspector",
+        "CompanyName": "Amazon",
+        "Region": "us-east-1",
+        "GeneratorId": "AWSInspector",
+        "Types": [
+          "Software and Configuration Checks/Vulnerabilities/CVE"
+        ],
+        "FirstObservedAt": "2024-07-30T12:17:32.646Z",
+        "LastObservedAt": "2024-09-18T05:16:44.106Z",
+        "CreatedAt": "2024-07-30T12:17:32.646Z",
+        "UpdatedAt": "2024-09-18T05:16:44.106Z",
+        "Severity": {
+          "Label": "MEDIUM",
+          "Normalized": 50
+        },
+        "Title": "CVE-2024-123 - fdd",
+        "Description": "A vulnerability was found in sdd.",
+        "Remediation": {
+          "Recommendation": {
+            "Text": "None Provided"
+          }
+        },
+        "ProductFields": {
+          "aws/inspector/FindingStatus": "ACTIVE",
+          "aws/inspector/inspectorScore": "5.1",
+          "aws/inspector/resources/1/resourceDetails/awsEc2InstanceDetails/platform": "AMAZON_LINUX_2023",
+          "aws/inspector/ProductVersion": "1",
+          "aws/inspector/instanceId": "i-1234xxyy",
+          "aws/securityhub/FindingId": "arn:aws:inspector2:us-east-1:1234567:finding/addfss",
+          "aws/securityhub/ProductName": "Inspector",
+          "aws/securityhub/CompanyName": "Amazon"
+        },
+        "Resources": [
+          {
+            "Type": "AwsEc2Instance",
+            "Id": "i-1234xxyy",
+            "Partition": "aws",
+            "Region": "us-east-1",
+            "Tags": {
+              "Name": "Name:xx-123-yy"
+            },
+            "Details": {
+              "AwsEc2Instance": {
+                "Type": "tt",
+                "ImageId": "ami-1234",
+                "IpV4Addresses": [
+                  "0.0.0.0"
+                ],
+                "IamInstanceProfileArn": "arn:aws:iam::1234567:instance-profile/something",
+                "VpcId": "vpc-1234",
+                "SubnetId": "subnet-xxxxxxx",
+                "LaunchedAt": "2024-09-18T05:16:44.106Z"
+              }
+            }
+          }
+        ],
+        "WorkflowState": "NEW",
+        "Workflow": {
+          "Status": "NEW"
+        },
+        "RecordState": "ACTIVE",
+        "Vulnerabilities": [
+          {
+            "Id": "CVE-2024-1234",
+            "VulnerablePackages": [
+              {
+                "Name": "aa",
+                "Version": "1.2.0",
+                "Architecture": "X86_64]",
+                "PackageManager": "OS",
+                "FixedInVersion": "abc[2.0]"
+              }
+            ],
+            "Cvss": [
+              {
+                "Version": "3.1",
+                "BaseScore": "7.5",
+                "BaseVector": "CVSS:9.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N",
+                "Source": "NVD"
+              }
+            ],
+            "Vendor": {
+              "Name": "AMAZON_CVE",
+              "Url": "https://alas.aws.amazon.com/cve/json/v1/CVE-2024-1234.json",
+              "VendorSeverity": "Medium",
+              "VendorCreatedAt": "2024-01-16T00:00:00Z",
+              "VendorUpdatedAt": "2024-09-18T05:16:44.106Z"
+            },
+            "ReferenceUrls": [
+              "https://alas.aws.amazon.com"
+            ],
+            "FixAvailable": "YES"
+          }
+        ],
+        "FindingProviderFields": {
+          "Severity": {
+            "Label": "MEDIUM"
+          },
+          "Types": [
+            "Software and Configuration Checks/Vulnerabilities/CVE"
+          ]
+        }
+      }
+    ]
+  }

--- a/unittests/tools/test_awssecurityhub_parser.py
+++ b/unittests/tools/test_awssecurityhub_parser.py
@@ -134,3 +134,9 @@ class TestAwsSecurityHubParser(DojoTestCase):
             self.assertEqual(1, len(findings))
             finding = findings[0]
             self.assertEqual("0.00239", finding.epss_score)
+
+    def test_missing_account_id(self):
+        with open(get_unit_tests_path() + sample_path("missing_account_id.json"), encoding="utf-8") as test_file:
+            parser = AwsSecurityHubParser()
+            findings = parser.get_findings(test_file, Test())
+            self.assertEqual(1, len(findings))


### PR DESCRIPTION
The following issues was encountered on an AWS Security Hub Scan due to the `AccountID` field being missing in the report:
```
  File "/app/dojo/importers/default_importer.py", line 312, in parse_findings
    self.parsed_findings = self.parse_findings_dynamic_test_type(scan, parser)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/importers/default_importer.py", line 344, in parse_findings_dynamic_test_type
    tests = self.parse_dynamic_test_type_tests(scan, parser)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/importers/base_importer.py", line 174, in parse_dynamic_test_type_tests
    return parser.get_tests(self.scan_type, scan)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/tools/awssecurityhub/parser.py", line 36, in get_tests
    test.description = "**AWS Accounts:** " + ", ".join(set(aws_acc)) + "\n"
                                              ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: sequence item 0: expected str instance, NoneType found
```

Sets do cannot process a NoneType, so we must place a default string in the event a None would occur to circumvent that exception.