### PR TITLE
Fix for Findings count in Dashboard based on wrong date

### DIFF
--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -33,7 +33,7 @@ def dashboard(request: HttpRequest) -> HttpResponse:
 
     date_range = [today - timedelta(days=6), today]  # 7 days (6 days plus today)
     finding_count = findings\
-        .filter(date__date__range=date_range)\
+        .filter(date__range=date_range)\
         .count()
     mitigated_count = findings\
         .filter(mitigated__date__range=date_range)\

--- a/dojo/home/views.py
+++ b/dojo/home/views.py
@@ -33,7 +33,7 @@ def dashboard(request: HttpRequest) -> HttpResponse:
 
     date_range = [today - timedelta(days=6), today]  # 7 days (6 days plus today)
     finding_count = findings\
-        .filter(created__date__range=date_range)\
+        .filter(date__date__range=date_range)\
         .count()
     mitigated_count = findings\
         .filter(mitigated__date__range=date_range)\


### PR DESCRIPTION
[sc-7804]

Resolves issue 11000

The number of active findings in the last 7 days now uses the correct date instead of the created date.

 
