### PR TITLE
fix for Add Risk Acceptance on Finding List dropdown Not Working

### DIFF
--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1080,8 +1080,7 @@
                                                                 {% endif %}
                                                                 {% if finding.test.engagement.product.enable_full_risk_acceptance %}
                                                                     <li role="presentation">
-                                                                        <a href
-                                                                        {% url 'add_risk_acceptance' finding.test.engagement.id finding.id %}>
+                                                                        <a href="{% url 'add_risk_acceptance' finding.test.engagement.id finding.id %}?return_url={{ request.get_full_path|urlencode }}">
                                                                             <i class="fa-solid fa-circle-exclamation"></i> {% trans "Add Risk Acceptance..." %}
                                                                         </a>
                                                                     </li>


### PR DESCRIPTION
[sc-7768]

Fixes issue#11010

Update path for Full Risk Acceptance when clicking the ... and choosing Add Risk Acceptance... next to a finding in the finding list.
