### PR TITLE
Update Dockerfile.django* to use gid 4242

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -34,7 +34,7 @@ RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 FROM base AS django-alpine
 WORKDIR /app
 ARG uid=1001
-ARG gid=1337
+ARG gid=4242
 ARG appuser=defectdojo
 ENV appuser=${appuser}
 RUN \

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -33,7 +33,7 @@ RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 FROM base AS django
 WORKDIR /app
 ARG uid=1001
-ARG gid=1337
+ARG gid=4242
 ARG appuser=defectdojo
 ENV appuser=${appuser}
 RUN \


### PR DESCRIPTION
The gid set for the image is currently 1337.
This collides with istio, a popular k8s traffic
management, telemetry, and security tool, which
also uses gid 1337 to rewrite iptables so that
it can do its magic.

This results in DefectDojo's initializer being
unable to connect to postgresql.

Original bug issue:
[github.com/DefectDojo/django-DefectDojo/issues/7532
](https://github.com/DefectDojo/django-DefectDojo/issues/7532)
**Test results**

No test updates required, I don't believe.  I did not see any that validated or made use of the current gid.

Manual testing:
Brought up DefectDojo within a cluster that makes use of istio.
Fails to connect to postgresql before gid change.
Succeeds in its connection after gid update.
