### PR TITLE
fix(notification): Use site_url in notification contexts

### DIFF
--- a/dojo/templates/dojo/notifications.html
+++ b/dojo/templates/dojo/notifications.html
@@ -162,7 +162,7 @@
             $(".chosen-select").chosen({disable_search_threshold: 10});
             $('#notification-scope').val('{{ scope }}');
             $('.chosen-select').trigger('chosen:updated');
-            $('#notification-scope').change(function() { window.location = '/notifications/' + $(this).val(); });
+            $('#notification-scope').change(function() { window.location = '{% url 'notifications' %}/' + $(this).val(); });
         });
     </script>
 {% endblock postscript %}


### PR DESCRIPTION
Dojo was using a static URL while changing the context in the notification menu.

Now, URL is generated from SITE_URL

Reported on https://owasp.slack.com/archives/C2P5BA8MN/p1729065595314239