### PR TITLE
SLA Config: Add new config that does not enforce SLA

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -154,7 +154,7 @@ EOD
    echo "Importing fixtures all at once"
    python3 manage.py loaddata system_settings initial_banner_conf product_type test_type \
        development_environment benchmark_type benchmark_category benchmark_requirement \
-       language_type objects_review regulation initial_surveys role
+       language_type objects_review regulation initial_surveys role sla_configurations
 
   echo "UPDATE dojo_system_settings SET jira_webhook_secret='$DD_JIRA_WEBHOOK_SECRET'" | python manage.py dbshell
 

--- a/dojo/fixtures/sla_configurations.json
+++ b/dojo/fixtures/sla_configurations.json
@@ -18,7 +18,6 @@
     },
     {
         "model": "dojo.sla_configuration",
-        "pk": 100,
         "fields": {
             "name": "No SLA Enforced",
             "description": "No SLA is enforced for a product which uses this SLA configuration.",

--- a/dojo/fixtures/sla_configurations.json
+++ b/dojo/fixtures/sla_configurations.json
@@ -1,0 +1,36 @@
+[
+    {
+        "model": "dojo.sla_configuration",
+        "pk": 1,
+        "fields": {
+            "name": "Default",
+            "description": "The Default SLA Configuration. Products not using an explicit SLA Configuration will use this one.",
+            "critical": 7,
+            "enforce_critical": true,
+            "high": 30,
+            "enforce_high": true,
+            "medium": 90,
+            "enforce_medium": true,
+            "low": 120,
+            "enforce_low": true,
+            "async_updating": false
+        }
+    },
+    {
+        "model": "dojo.sla_configuration",
+        "pk": 100,
+        "fields": {
+            "name": "No SLA Enforced",
+            "description": "No SLA is enforced for a product which uses this SLA configuration.",
+            "critical": 7,
+            "enforce_critical": false,
+            "high": 30,
+            "enforce_high": false,
+            "medium": 90,
+            "enforce_medium": false,
+            "low": 120,
+            "enforce_low": false,
+            "async_updating": false
+        }
+    }
+]


### PR DESCRIPTION
It would be nice ship dojo with an SLA config that easily omits SLA configs on a per product basis

[sc-7952]