### PR TITLE
Fixing bug in Excel Exporter

### DIFF
--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -948,6 +948,7 @@ class ExcelExportView(View):
                     except Exception as exc:
                         logger.error("Error in attribute: " + str(exc))
                         cell = worksheet.cell(row=row_num, column=col_num, value=key)
+                        col_num += 1
                         continue
                 cell = worksheet.cell(row=row_num, column=col_num, value="found_by")
                 cell.font = font_bold
@@ -999,6 +1000,7 @@ class ExcelExportView(View):
                     except Exception as exc:
                         logger.error("Error in attribute: " + str(exc))
                         worksheet.cell(row=row_num, column=col_num, value="Value not supported")
+                        col_num += 1
                         continue
                 worksheet.cell(row=row_num, column=col_num, value=finding.test.test_type.name)
                 col_num += 1


### PR DESCRIPTION
**Description**

This PR is aimed to fix an bug when exporting excel reports for findings that has the finding_group field set, causing the Excel file to have displaced columns to the left starting from the finding_group one. This is caused because when trying to add that key from the Finding Ojbject, it is raising an Exception, and it should display the string `"Value not supported"`, line 1002.

The problem is that when this situation happens, it is not increasing the column number value and when the next iteration is processed, the next key is overwriting the values of the column mentioned above, causing this way the displacement of the rest of the columns.

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [ ] Add the proper label to categorize your PR.
