### PR TITLE
WIP for sorting endpoints by active findings

### DIFF
--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -49,8 +49,9 @@ def process_endpoints_view(request, host_view=False, vulnerable=False):
     else:
         endpoints = Endpoint.objects.all()
 
-    endpoints = endpoints.prefetch_related("product", "product__tags", "tags").distinct()
+    endpoints = endpoints.prefetch_related("product", "product__tags", "tags", "findings").distinct()
     endpoints = get_authorized_endpoints(Permissions.Endpoint_View, endpoints, request.user)
+    endpoints = endpoints.annotate(findings_count=Count("findings", filter=Q(findings__active=True)))
     filter_string_matching = get_system_setting("filter_string_matching", False)
     filter_class = EndpointFilterWithoutObjectLookups if filter_string_matching else EndpointFilter
     if host_view:

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2396,8 +2396,8 @@ class EndpointFilterHelper(FilterSet):
             ("findings_count", "findings_count"),
         ),
         field_labels={
-            "findings_count": "Findings Count ",
-        }
+            "findings_count": "Active Findings Count ",
+        },
     )
 
 

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2393,7 +2393,11 @@ class EndpointFilterHelper(FilterSet):
         fields=(
             ("product", "product"),
             ("host", "host"),
+            ("findings_count", "findings_count"),
         ),
+        field_labels={
+            "findings_count": "Findings Count ",
+        }
     )
 
 

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1839,9 +1839,15 @@ class Endpoint(models.Model):
             risk_accepted=False,
         ).count() > 0
 
-    @property
+    @cached_property
     def findings_count(self):
-        return self.findings.all().count()
+        try: 
+            # If prefetched/annotated (used for ordering based on active findings count)
+            return self.active_finding_count
+        except AttributeError:
+            self.active_finding_count = self.findings.all().count()
+            return self.active_finding_count
+
 
     def active_findings(self):
         return self.findings.filter(
@@ -1868,9 +1874,13 @@ class Endpoint(models.Model):
             status_finding__risk_accepted=False,
         ).order_by("numerical_severity")
 
-    @property
+    @cached_property
     def active_findings_count(self):
-        return self.active_findings().count()
+        try: 
+            return self.active_finding_count
+        except AttributeError:
+            self.active_finding_count = self.active_findings().count()
+            return self.active_finding_count
 
     @property
     def active_verified_findings_count(self):

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -87,7 +87,7 @@
                                 {% comment %} The display field is translated in the function. No need to translate here as well{% endcomment %}    
                                 <th>{% dojo_sort request 'Product' 'product' 'asc' %}</th>
                             {% endif %}
-							<th class="text-center" nowrap="nowrap">Active (Verified) Findings</th>
+              <th class="text-center" nowrap="nowrap">{% dojo_sort request 'Active (Verified) Findings' 'findings_count' %}</th>
 							<th>Status</th>
                         </tr>
 


### PR DESCRIPTION
This PR implements the ordering of endpoints by the count of active findings on the endpoints views.

Closes issue #10540 