### PR TITLE
JIRA Finding Groups: Accommodate status function inconsistency

### DIFF
--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -162,7 +162,7 @@ def can_be_pushed_to_jira(obj, form=None):
         # Accommodating a strange behavior where a finding group sometimes prefers `obj.status` rather than `obj.status()`
         try:
             not_active = "Active" not in obj.status()
-        except TypeError: # TypeError: 'str' object is not callable
+        except TypeError:  # TypeError: 'str' object is not callable
             not_active = "Active" not in obj.status
         # Determine if the finding group is not active
         if not_active:

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -159,7 +159,13 @@ def can_be_pushed_to_jira(obj, form=None):
     elif isinstance(obj, Finding_Group):
         if not obj.findings.all():
             return False, f"{to_str_typed(obj)} cannot be pushed to jira as it is empty.", "error_empty"
-        if "Active" not in obj.status():
+        # Accommodating a strange behavior where a finding group sometimes prefers `obj.status` rather than `obj.status()`
+        try:
+            not_active = "Active" not in obj.status()
+        except TypeError: # TypeError: 'str' object is not callable
+            not_active = "Active" not in obj.status
+        # Determine if the finding group is not active
+        if not_active:
             return False, f"{to_str_typed(obj)} cannot be pushed to jira as it is not active.", "error_inactive"
 
     else:


### PR DESCRIPTION
Accommodating a strange behavior where a finding group sometimes prefers `obj.status` rather than `obj.status()`

```
Traceback (most recent call last):
  File "/app/dojo/jira_link/helper.py", line 666, in push_to_jira
    return add_jira_issue_for_finding_group(group, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/decorators.py", line 73, in __wrapper__
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/decorators.py", line 46, in __wrapper__
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/celery/local.py", line 182, in __call__
    return self._get_current_object()(*a, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/celery/app/task.py", line 411, in __call__
    return self.run(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/decorators.py", line 117, in __wrapper__
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/jira_link/helper.py", line 697, in add_jira_issue_for_finding_group
    return add_jira_issue(finding_group, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/jira_link/helper.py", line 769, in add_jira_issue
    obj_can_be_pushed_to_jira, error_message, _error_code = can_be_pushed_to_jira(obj)
                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/dojo/jira_link/helper.py", line 162, in can_be_pushed_to_jira
    if "Active" not in obj.status():
                       ^^^^^^^^^^^^
TypeError: 'str' object is not callable
```
[sc-8016][sc-8017]