### PR TITLE
Display reviewers on finding pages.

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -135,6 +135,9 @@ def prefetch_for_findings(findings, prefetch_type="all", exclude_untouched=True)
     if isinstance(
         findings, QuerySet,
     ):  # old code can arrive here with prods being a list because the query was already executed
+        prefetched_findings = prefetched_findings.prefetch_related(
+            "reviewers",
+        )
         prefetched_findings = prefetched_findings.prefetch_related("reporter")
         prefetched_findings = prefetched_findings.prefetch_related(
             "jira_issue__jira_project__jira_instance",

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -384,6 +384,11 @@
                                     <th>
                                         {% trans "Planned Remediation" %}
                                     </th>
+                                    {% if filter_name != 'Closed' %}
+                                        <th>
+                                            {% trans "Reviewers" %}
+                                        </th>
+                                    {% endif %}
                                 {% endblock header %}
                             </tr>
                         </thead>
@@ -699,6 +704,16 @@
                                         <td class="nowrap">
                                             {% if finding.planned_remediation_date %}{{ finding.planned_remediation_date }}{% endif %}
                                         </td>
+                                        {% if filter_name != 'Closed' %}
+                                            <td class="nowrap">
+                                                {% if finding.reviewers %}
+                                                    {% for reviewer in finding.reviewers.all %}
+                                                        {{reviewer.get_full_name}}
+                                                        {% if not forloop.last %}<br>{% endif %}
+                                                    {% endfor %}
+                                                {% endif %}
+                                            </td>
+                                        {% endif %}
                                     {% endblock body %}
                                 </tr>
                             {% endfor %}
@@ -779,6 +794,9 @@
                 {% endif %}
                 { "data": "service" },
                 { "data": "planned_remediation_date" },
+                {% if filter_name != 'Closed' %}
+                    { "data": "reviewers" },
+                {% endif %}
             ];
         {% endblock datatables_columns %}
     </script>


### PR DESCRIPTION
**Description**

This PR adds a list of reviewers (assigned with the "request peer review" feature) to the UI in the finding pages.
I believe this would make for better finding visualization, and this is something that some users might miss, as noted in issue #10434's discussion.

**Test results**

I have tested (manually) all of the finding listing pages. Except when the findings are filtered by closed, all of the assigned reviewers should be displayed in the rightmost column.  

**Disclaimer**

Please, note that this is my first open source contribution PR ever, so, explaining stuff assuming I know very little about open source might be a good call. 

![eli5](https://github.com/user-attachments/assets/8b412212-dd15-40f8-aa40-66b9b1ef749d)

I'm open to any feedback and to implement any changes that might be necessary. Although I read the contribution guidelines, it's likely that I might have done some things wrong here, and I realize that this feature ideally should've gone through a pre-approval, but, since implementing it was fairly straightforward after I got (kind of :sweat_smile: ) used to the codebase and I wouldn't lose a lot of work if the PR is denied, I thought I'd give it a shot.