### PR TITLE
Fix for engagement_end_date not being used

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2258,6 +2258,13 @@ class CommonImportScanSerializer(serializers.Serializer):
             if context.get("scan_date")
             else None
         )
+
+        # engagement end date was not being used at all and so target_end would also turn into None
+        # in this case, do not want to change target_end unless engagement_end exists
+        eng_end_date = context.get("engagement_end_date", None)
+        if eng_end_date:
+            context["target_end"] = context.get("engagement_end_date")
+
         return context
 
 


### PR DESCRIPTION
When a scan was imported or reimported, the engagement_end_date was not being used and was defaulting to now + 365 days. This change sets the target_end appropriately for engagements.

[sc-8190]