### PR TITLE
Simpler nginx dockerfile

### DIFF
--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -31,113 +31,33 @@ COPY requirements.txt ./
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
 RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
+FROM node:20.11.0@sha256:7bf4a586b423aac858176b3f683e35f08575c84500fbcfd1d433ad8568972ec6 AS yarn
+
+WORKDIR /app
+
+# yarn already installed but we want to reproduce with exact version
+RUN npm -g --force i yarn@1.22.19
+
+COPY components/ ./components/
+RUN \
+  cd components && \
+  yarn
+
 FROM build AS collectstatic
 
-# Node installation from https://github.com/nodejs/docker-node
-ENV NODE_VERSION=20.11.0
+USER root
 
-RUN addgroup -g 1000 node \
-    && adduser -u 1000 -G node -s /bin/sh -D node \
-    && apk add --no-cache \
-        libstdc++ \
-    && apk add --no-cache --virtual .build-deps \
-        curl \
-    && ARCH= && alpineArch="$(apk --print-arch)" \
-      && case "${alpineArch##*-}" in \
-        x86_64) \
-          ARCH='x64' \
-          CHECKSUM=$(curl -sSL --compressed "https://unofficial-builds.nodejs.org/download/release/v${NODE_VERSION}/SHASUMS256.txt" | grep "node-v${NODE_VERSION}-linux-x64-musl.tar.xz" | cut -d' ' -f1) \
-          ;; \
-        *) ;; \
-      esac \
-  && if [ -n "${CHECKSUM}" ]; then \
-    set -eu; \
-    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
-    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
-      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
-  else \
-    echo "Building from source" \
-    # backup build
-    && apk add --no-cache --virtual .build-deps-full \
-        binutils-gold \
-        g++ \
-        gcc \
-        gnupg \
-        libgcc \
-        linux-headers \
-        make \
-        python3 \
-    # gpg keys listed at https://github.com/nodejs/node#release-keys
-    && for key in \
-      4ED778F539E3634C779C87C6D7062848A1AB005C \
-      141F07595B7B3FFE74309A937405533BE57C7D57 \
-      74F12602B6F1C4E913FAA37AD3A89613643B6201 \
-      61FC681DFB92A079F1685E77973F295594EC4689 \
-      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-      890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4 \
-      C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C \
-      108F52B48DB57BB0CC439B2997B01419BD92F80A \
-    ; do \
-      gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-      gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-    done \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
-    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-    && tar -xf "node-v$NODE_VERSION.tar.xz" \
-    && cd "node-v$NODE_VERSION" \
-    && ./configure \
-    && make -j$(getconf _NPROCESSORS_ONLN) V= \
-    && make install \
-    && apk del .build-deps-full \
-    && cd .. \
-    && rm -Rf "node-v$NODE_VERSION" \
-    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
-  fi \
-  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
-  && apk del .build-deps \
-  # smoke tests
-  && node --version \
-  && npm --version
-
-ENV YARN_VERSION=1.22.19
-
-RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" ; \
-  done \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && apk del .build-deps-yarn \
-  # smoke test
-  && yarn --version
-
-# installing DefectDojo packages
 RUN pip3 install \
 	--no-cache-dir \
 	--no-index \
   --find-links=/tmp/wheels \
 	-r ./requirements.txt
 
-# generate static files
-COPY components/ ./components/
-RUN \
-  cd components && \
-  yarn
+COPY --from=yarn /app/components/ ./components/
+
 COPY manage.py ./
 COPY dojo/ ./dojo/
+
 RUN env DD_SECRET_KEY='.' python3 manage.py collectstatic --noinput && true
 
 FROM nginx:1.27.2-alpine@sha256:2140dad235c130ac861018a4e13a6bc8aea3a35f3a40e20c1b060d51a7efd250

--- a/Dockerfile.nginx-debian
+++ b/Dockerfile.nginx-debian
@@ -30,32 +30,21 @@ COPY requirements.txt ./
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
 RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
+FROM node:20.11.0@sha256:7bf4a586b423aac858176b3f683e35f08575c84500fbcfd1d433ad8568972ec6 AS yarn
+
+WORKDIR /app
+
+# yarn already installed but we want to reproduce with exact version
+RUN npm -g --force i yarn@1.22.19
+
+COPY components/ ./components/
+RUN \
+  cd components && \
+  yarn
 
 FROM build AS collectstatic
 
 USER root
-ENV \
-  # This will point yarn to whatever version of node you decide to use
-  # due to the use of nodejs instead of node name in some distros
-  node="nodejs"
-RUN \
-  apt-get -y update && \
-  apt-get -y install --no-install-recommends apt-transport-https ca-certificates curl wget gnupg && \
-  curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add --no-tty - && \
-  echo 'deb https://deb.nodesource.com/node_20.x bullseye main' > /etc/apt/sources.list.d/nodesource.list && \
-  echo 'deb-src https://deb.nodesource.com/node_20.x bullseye main' >> /etc/apt/sources.list.d/nodesource.list && \
-  apt-get update -y -o Dir::Etc::sourcelist="sources.list.d/nodesource.list" \
-  -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" && \
-  curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-  wget https://github.com/yarnpkg/yarn/releases/download/v1.22.10/yarn_1.22.10_all.deb && \
-  dpkg -i yarn_1.22.10_all.deb && \
-  echo "$(yarn --version)" && \
-  apt-get -y install --no-install-recommends nodejs && \
-  echo "$(node --version)" && \
-  apt-get clean && \
-  rm yarn_1.22.10_all.deb && \
-  rm -rf /var/lib/apt/lists && \
-  true
 
 RUN pip3 install \
 	--no-cache-dir \
@@ -63,10 +52,7 @@ RUN pip3 install \
   --find-links=/tmp/wheels \
 	-r ./requirements.txt
 
-COPY components/ ./components/
-RUN \
-  cd components && \
-  yarn
+COPY --from=yarn /app/components/ ./components/
 
 COPY manage.py ./
 COPY dojo/ ./dojo/


### PR DESCRIPTION
Instead of complex node installation on top of the build base image, this uses separate stage just for yarn and then collectstatic copies the components from it.

I've pinned the same node and yarn versions that were used - but it can always use just `node:20.11` to pick up on latest patches

**NOTE** I've opened another PR with an alternative that I believe to be even better but a bigger change - https://github.com/DefectDojo/django-DefectDojo/pull/11182