### PR TITLE
Add uwsgi vars to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - uwsgi
     environment:
       NGINX_METRICS_ENABLED: "${NGINX_METRICS_ENABLED:-false}"
+      DD_UWSGI_HOST: "${DD_UWSGI_HOST:-uwsgi}"
+      DD_UWSGI_PORT: "${DD_UWSGI_PORT:-3031}"
     volumes:
       - defectdojo_media:/usr/share/nginx/html/media
     ports:


### PR DESCRIPTION
**Description**

Add variables for `nginx` service in `docker-compose.yml`.
Without them, nginx will create default `/run/defectdojo/usgi_server` which is
```
server uwsgi:3031;
```

Having these variables will give opportunity to change the name of the `uwsgi` service in `docker-compose.yml` and properly create  `/run/defectdojo/usgi_server`