### PR TITLE
Ruff: Add and fix S108

### DIFF
--- a/dojo/decorators.py
+++ b/dojo/decorators.py
@@ -144,22 +144,6 @@ def get_parameter_froms_args_kwargs(args, kwargs, parameter):
     return model_or_id
 
 
-def on_exception_log_kwarg(func):
-    def wrapper(self, *args, **kwargs):
-        try:
-            return func(self, *args, **kwargs)
-
-        except Exception:
-            logger.info(f"exception occured at url: {self.driver.current_url}")
-            logger.info(f"page source: {self.driver.page_source}")
-            f = open("/tmp/selenium_page_source.html", "w", encoding="utf-8")
-            f.writelines(self.driver.page_source)
-            # time.sleep(30)
-            raise
-
-    return wrapper
-
-
 def dojo_ratelimit(key="ip", rate=None, method=UNSAFE, block=False):
     def decorator(fn):
         @wraps(fn)

--- a/ruff.toml
+++ b/ruff.toml
@@ -41,7 +41,7 @@ select = [
    "UP",
    "YTT",
    "ASYNC",
-   "S2", "S5", "S7", "S101", "S104", "S105", "S112", "S311",
+   "S2", "S5", "S7", "S101", "S104", "S105", "S108", "S112", "S311",
    "FBT001", "FBT003",
    "A003", "A004", "A006",
    "COM",
@@ -102,6 +102,7 @@ preview = true
 [lint.per-file-ignores]
 "unittests/**" = [
     "S105",  # hardcoded passwords in tests are fine
+    "S108",  # tmp paths mentioned in tests are fine
 ]
 
 [lint.flake8-boolean-trap]


### PR DESCRIPTION
Add S108 https://docs.astral.sh/ruff/rules/hardcoded-temp-file/ and fix it.

- In unittests, they are compared to files from findings - they are not used for writing of content - so it is safe
- `on_exception_log_kwarg` from `dojo/decorators.py` is used nowhere in the project. It looks like it is a leftover from previous testing.