### PR TITLE
add engagement closed MS teams, Email, Alert, and Slack  template

### DIFF
--- a/dojo/templates/notifications/alert/engagement_closed.tpl
+++ b/dojo/templates/notifications/alert/engagement_closed.tpl
@@ -1,0 +1,3 @@
+{% load i18n %}{% blocktranslate trimmed with eng_name=engagement.name eng_product=engagement.product %}
+The engagement "{{ eng_name }}" has been closed in the product "{{ eng_product }}".
+{% endblocktranslate %}

--- a/dojo/templates/notifications/mail/engagement_closed.tpl
+++ b/dojo/templates/notifications/mail/engagement_closed.tpl
@@ -1,0 +1,41 @@
+{% load i18n %}
+{% load navigation_tags %}
+{% load display_tags %}
+{% url 'view_product' engagement.product.id as product_url %}
+{% url 'view_engagement' engagement.id as engagement_url %}
+<html>
+    <body>
+        {% autoescape on %}
+            <p>
+                {% trans "Hello" %},
+            </p>
+            <p>
+              {% blocktranslate trimmed with engagement_name=engagement.name engagement_product=engagement.product prod_url=product_url|full_url eng_url=engagement_url|full_url%}
+                The engagement "{{ engagement_name }}" has been closed in the product "{{ engagement_product }}". It can be viewed here: <a href="{{prod_url}}">{{product}}</a> / <a href="{{eng_url}}">{{ engagement_name }}</a>
+              {% endblocktranslate %}
+            </p>
+            <br/>
+            <br/>
+                {% trans "Kind regards" %},<br/>
+            <br/>
+                {% if system_settings.team_name %}
+                    {{ system_settings.team_name }}
+                {% else %}
+                    Defect Dojo
+                {% endif %}
+            <br/>
+            <br/>
+            <p>
+                {% url 'notifications' as notification_url %}
+                {% trans "You can manage your notification settings here" %}: <a href="{{ notification_url|full_url }}">{{ notification_url|full_url }}</a>
+            </p>
+            {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
+                <br/>
+                <div style="background-color:#DADCE2; border:1px #003333; padding:.8em; ">
+                    <span style="font-size:16pt;  font-family: 'Cambria','times new roman','garamond',serif; color:#ff0000;">{% trans "Disclaimer" %}</span><br/>
+                    <p style="font-size:11pt; line-height:10pt; font-family: 'Cambria','times roman',serif;">{{ system_settings.disclaimer }}</p>
+                </div>
+            {% endif %}
+        {% endautoescape %}
+    </body>
+</html>

--- a/dojo/templates/notifications/msteams/engagement_closed.tpl
+++ b/dojo/templates/notifications/msteams/engagement_closed.tpl
@@ -1,0 +1,44 @@
+{% load i18n %}
+{% load display_tags %}
+{
+    "@context": "https://schema.org/extensions",
+    "@type": "MessageCard",
+    "title": "{% trans "Engagement closed" %}",
+    "summary": "{% trans "Engagement closed" %}",
+    "sections": [
+        {
+            "activityTitle": "DefectDojo",
+            "activityImage": "https://raw.githubusercontent.com/DefectDojo/django-DefectDojo/master/dojo/static/dojo/img/chop.png",
+            "text": "{% trans "An engagement has been closed" %}.",
+            "facts": [
+                {
+                    "name": "{% trans "Product" %}:",
+                    "value": "{{ engagement.product.name }}"
+                },
+                {
+                    "name": "{% trans "Engagement" %}:",
+                    "value": "{{ engagement.name }}"
+                }
+            ]
+        }
+        {% if system_settings.disclaimer and system_settings.disclaimer.strip %}
+            ,{
+                "activityTitle": "{% trans "Disclaimer" %}",
+                "text": "{{ system_settings.disclaimer }}"
+            }
+        {% endif %}
+        
+    ],
+    "potentialAction": [
+        {
+            "@type": "OpenUri",
+            "name": "{% trans "View Engagement" %}",
+            "targets": [
+                {
+                    "os": "default",
+                    "uri": "{{ url|full_url }}"
+                }
+            ]
+        }
+    ]
+}

--- a/dojo/templates/notifications/slack/engagement_closed.tpl
+++ b/dojo/templates/notifications/slack/engagement_closed.tpl
@@ -1,0 +1,10 @@
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with name=engagement.name eng_product=engagement.product eng_url=url|full_url %}
+The engagement "{{ name }}" has been closed in the product "{{ eng_product }}". It can be viewed here: {{ eng_url }}
+{% endblocktranslate %}
+{% if system_settings.disclaimer and system_settings.disclaimer.strip %}
+    
+    {% trans "Disclaimer" %}:
+    {{ system_settings.disclaimer }}
+{% endif %}


### PR DESCRIPTION
Add a MS Teams, Email, Alert, and Slack template for engagement closed.
[sc-6170]