### PR TITLE
GHA Artifacts: Update to v4

### DIFF
--- a/.github/workflows/build-docker-images-for-testing.yml
+++ b/.github/workflows/build-docker-images-for-testing.yml
@@ -49,8 +49,8 @@ jobs:
       # export docker images to be used in next jobs below
       - name: Upload image ${{ matrix.docker-image }} as artifact
         timeout-minutes: 10
-        uses:  actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
-          name: ${{ matrix.docker-image }}
+          name: built-docker-image-${{ matrix.docker-image }}
           path: ${{ matrix.docker-image }}-${{ matrix.os }}_img
           retention-days: 1

--- a/.github/workflows/build-docker-images-for-testing.yml
+++ b/.github/workflows/build-docker-images-for-testing.yml
@@ -51,6 +51,6 @@ jobs:
         timeout-minutes: 10
         uses:  actions/upload-artifact@v4
         with:
-          name: built-docker-image-${{ matrix.docker-image }}
+          name: built-docker-image-${{ matrix.docker-image }}-${{ matrix.os }}
           path: ${{ matrix.docker-image }}-${{ matrix.os }}_img
           retention-days: 1

--- a/.github/workflows/fetch-oas.yml
+++ b/.github/workflows/fetch-oas.yml
@@ -51,7 +51,7 @@ jobs:
         run: docker compose down
 
       - name: Upload oas.${{ matrix.file-type }} as artifact
-        uses:  actions/upload-artifact@v3
+        uses:  actions/upload-artifact@v4
         with:
           name: oas-${{ matrix.file-type }}
           path: oas.${{ matrix.file-type }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,7 +45,11 @@ jobs:
 
       # load docker images from build jobs
       - name: Load images from artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          path: built-docker-image
+          pattern: built-docker-image-*
+          merge-multiple: true
 
       - name: Load docker images
         timeout-minutes: 10

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Load docker images
         timeout-minutes: 10
         run: |-
-             docker load -i nginx/nginx-${{ matrix.os }}_img
-             docker load -i django/django-${{ matrix.os }}_img
+             docker load -i nginx-${{ matrix.os }}_img
+             docker load -i django-${{ matrix.os }}_img
              docker load -i integration-tests/integration-tests-debian_img
              docker images
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,9 +54,9 @@ jobs:
       - name: Load docker images
         timeout-minutes: 10
         run: |-
-             docker load -i nginx-${{ matrix.os }}_img
-             docker load -i django-${{ matrix.os }}_img
-             docker load -i integration-tests/integration-tests-debian_img
+             docker load -i built-docker-image/nginx-${{ matrix.os }}_img
+             docker load -i built-docker-image/django-${{ matrix.os }}_img
+             docker load -i built-docker-image/integration-tests-debian_img
              docker images
 
       - name: Set integration-test mode

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -58,8 +58,8 @@ jobs:
         timeout-minutes: 10
         run: |-
              eval $(minikube docker-env)
-             docker load -i nginx/nginx-${{ matrix.os }}_img
-             docker load -i django/django-${{ matrix.os }}_img
+             docker load -i nginx-${{ matrix.os }}_img
+             docker load -i django-${{ matrix.os }}_img
              docker images
 
       - name: Configure HELM repos

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -58,8 +58,8 @@ jobs:
         timeout-minutes: 10
         run: |-
              eval $(minikube docker-env)
-             docker load -i nginx-${{ matrix.os }}_img
-             docker load -i django-${{ matrix.os }}_img
+             docker load -i built-docker-image/nginx-${{ matrix.os }}_img
+             docker load -i built-docker-image/django-${{ matrix.os }}_img
              docker images
 
       - name: Configure HELM repos

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -48,7 +48,11 @@ jobs:
           minikube status
 
       - name: Load images from artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          path: built-docker-image
+          pattern: built-docker-image-*
+          merge-multiple: true
 
       - name: Load docker images
         timeout-minutes: 10

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Load OAS files from artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: Upload Release Asset - OpenAPI Specification - YAML
         id: upload-release-asset-yaml

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Load docker images
         timeout-minutes: 10
         run: |-
-             docker load -i nginx-${{ matrix.os }}_img
-             docker load -i django-${{ matrix.os }}_img
+             docker load -i built-docker-image/nginx-${{ matrix.os }}_img
+             docker load -i built-docker-image/django-${{ matrix.os }}_img
              docker images
 
       # run tests with docker compose

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -29,8 +29,8 @@ jobs:
       - name: Load docker images
         timeout-minutes: 10
         run: |-
-             docker load -i nginx/nginx-${{ matrix.os }}_img
-             docker load -i django/django-${{ matrix.os }}_img
+             docker load -i nginx-${{ matrix.os }}_img
+             docker load -i django-${{ matrix.os }}_img
              docker images
 
       # run tests with docker compose

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -20,7 +20,11 @@ jobs:
 
       # load docker images from build jobs
       - name: Load images from artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          path: built-docker-image
+          pattern: built-docker-image-*
+          merge-multiple: true
 
       - name: Load docker images
         timeout-minutes: 10


### PR DESCRIPTION
With the upcoming deprecations of version 3 of `actions/upload-artifact` and `actions/download-artifact`, we must get to v4 by following the [migration guide](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)

[sc-8285]