### PR TITLE
devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/go-postgres
+{
+	"name": "DefectDojo",
+	"dockerComposeFile": ["../docker-compose.yml", "../docker-compose.override.dev.yml", "docker-compose.override.dc.yml"],
+	"service": "uwsgi",
+	"workspaceFolder": "/app/",
+
+	// Configure tool-specific properties - https://containers.dev/supporting
+	"customizations": {
+		"extensions": ["ms-azuretools.vscode-docker", "ms-python.python", "ms-python.debugpy"]
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,12 @@
 
 	// Configure tool-specific properties - https://containers.dev/supporting
 	"customizations": {
-		"extensions": ["ms-azuretools.vscode-docker", "ms-python.python", "ms-python.debugpy"]
+		"vscode": {
+			"extensions": [
+				"ms-azuretools.vscode-docker",
+				"ms-python.python",
+				"ms-python.debugpy"
+			]
+		}
 	}
 }

--- a/.devcontainer/docker-compose.override.dc.yml
+++ b/.devcontainer/docker-compose.override.dc.yml
@@ -1,0 +1,27 @@
+---
+services:
+  uwsgi:
+    entrypoint: ['sleep', 'infinity']
+    ports:
+      - target: 8080
+        published: ${DD_PORT:-8080}
+        protocol: tcp
+        mode: host
+    build:
+      context: ./
+      dockerfile: "Dockerfile.django-debian"
+      target: devcontainer
+  node-static:
+    # yarn cleans node_modules, including .gitkeep - alternative to readding it is to configure autoclean/.yarnclean
+    command: sh -c "yarn; touch node_modules/.gitkeep"
+    working_dir: /app/components
+    volumes:
+      - '.:/app:z'
+    build:
+      context: ./
+      dockerfile: "Dockerfile.nginx-debian"
+      target: collectstatic
+  nginx:
+    deploy:
+      # disable nginx - serve static directly from Django
+      replicas: 0

--- a/Dockerfile.django-debian
+++ b/Dockerfile.django-debian
@@ -137,5 +137,18 @@ ENV \
   DD_UWSGI_NUM_OF_THREADS="2"
 ENTRYPOINT ["/entrypoint-uwsgi.sh"]
 
+FROM django AS devcontainer
+
+USER root
+RUN usermod -d /home/${appuser} -s /usr/bin/bash ${appuser} \
+ && mkdir /home/${appuser} \
+ && chown ${appuser}:${appuser} /home/${appuser}
+
+# do not clean cache as it can be useful in dev
+RUN apt update \
+ && apt install -y procps
+
+USER ${appuser}
+
 FROM django AS django-unittests
 COPY unittests/ ./unittests/


### PR DESCRIPTION
**Description**

This add devcontainer.json to the project: https://containers.dev/

If you're not familiar, this started off as a VSCode feature but spun off as a standard and currently implemented in many other IDEs.

The current plethora of compose overrides is ok but none of them cover the case for debugging.

One could fork the `dev` override, disable the `uwsgi` service and publish ports on all the others. Then it would be possible to set up a local_settings.py to use those services while running main django process in an IDE.
But devcontainers makes that easier (less files/changes) and cleaner, as it continues to run the main django process in a container.

**Usage**

In VSCode, when opening the project (without any prior configuration), pop up shows saying devcontainers were found and suggesting re-opening inside the container.

Accepting it kicks off the compose file and opens the project inside the `uwsgi` container and it's ready to use:
* Type `./manage.py runserver 0.0.0.0:8080` and Dojo is running
* Stop that and launch instead from the IDE and pydebugger will be attached and looking for those breakpoints!

**Changes**

Reasoning of each change:
* Dockerfile with a new very small target because the user running the process needs to have an homedir and shell for us to use the terminal
* Change uswgi service to use that new target and publish port 8080
* Disable nginx service to serve static files straight from django, so we can modify them and they're immeditaly used
* Run-once service `node-static` just to install the `components` - if those are changed, service needs to be re-executed
  * We can add inotify or alike to monitor package.json if that makes sense, but I assume they're rarely changed and this keeps things simpler
* New `dc` override that runs together with the `dev` one to be able to modify those services

**Note**

This makes it very easy to also use Github Codespace!