### PR TITLE
Importers: Force tags to lowercase

### DIFF
--- a/dojo/importers/options.py
+++ b/dojo/importers/options.py
@@ -530,13 +530,15 @@ class ImporterOptions:
         *args: list,
         **kwargs: dict,
     ) -> list:
-        return self.validate(
+        tags = self.validate(
             "tags",
             expected_types=[list],
             required=False,
             default=[],
             **kwargs,
         )
+        # Force all tags to be lowercase
+        return [tag.lower() for tag in tags]
 
     def validate_test(
         self,


### PR DESCRIPTION
When adding tags on a model object through the UI or API, the tag is forced to lowercase. Here is an example of the finding model with this requirement:

https://github.com/DefectDojo/django-DefectDojo/blob/fafe5c3cc5f1287963e4681979095b8b8064575f/dojo/models.py#L2571

The issue is that when doing imports, something is bypassed in the way that tags are being added to the model. They are being added like any other many to may relationship, but the `force_lowercase` flag is not being respected for some reason. Instead, we can just force the tags to be lowercased ourselves when the importer processes the tags

[sc-8280]