### PR TITLE
Allow sorting endpoints by ID

### DIFF
--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -2393,6 +2393,7 @@ class EndpointFilterHelper(FilterSet):
         fields=(
             ("product", "product"),
             ("host", "host"),
+            ("id", "id"),
         ),
     )
 
@@ -2630,6 +2631,7 @@ class ApiEndpointFilter(DojoFilter):
         fields=(
             ("host", "host"),
             ("product", "product"),
+            ("id", "id"),
         ),
     )
 

--- a/dojo/templates/dojo/endpoints.html
+++ b/dojo/templates/dojo/endpoints.html
@@ -109,7 +109,7 @@
                                 {% endif %}
                                   {% include "dojo/snippets/tags.html" with tags=e.tags.all %}
                                 </td>
-                                {% if not product_tab %}
+                                {% if not product_tab and e.product %}
                                   <td>
                                     <a href="{% url 'view_product' e.product.id %}">{{ e.product }}</a>
                                     {% include "dojo/snippets/tags.html" with tags=e.product.tags.all %}


### PR DESCRIPTION
This allows sorting endpoints by ID, both in UI and API.

The UI doesn't have any ID column, so it's not click-accessible, however advanced user can still make use of it via `o=` in the URL.

Motivation is that we do not have a "created" date field in endpoints, in order to find the latest additions.

Sorting by ID (descending in this use case) is a good alternative and less impactful than adding a new date field to the model.

Also adding a small fix in the endpoint list template: when endpoints lose the "product" (not sure how it happens but it did), we're not even able to "see" them as the app would break. Even if there are many more templates that also break, this is the one that lists the endpoints and it already flags "broken" endpoints anyway (though it was not possible to see that flag before this small change).
Let me know if should remove this latest change from this PR.


