### PR TITLE
API: Engagement update jira epic

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2710,6 +2710,11 @@ class ReportGenerateSerializer(serializers.Serializer):
     )
 
 
+class EngagementUpdateJiraEpicSerializer(serializers.Serializer):
+    epic_name = serializers.CharField(required=False, max_length=200)
+    epic_priority = serializers.CharField(required=False, allow_null=True)
+
+
 class TagSerializer(serializers.Serializer):
     tags = TagListSerializerField(required=True)
 

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -639,6 +639,36 @@ class EngagementViewSet(
         # send file
         return generate_file_response(file_object)
 
+    @extend_schema(
+        request=serializers.EngagementUpdateJiraEpicSerializer,
+        responses={status.HTTP_200_OK: serializers.EngagementUpdateJiraEpicSerializer},
+    )
+    @action(
+        detail=True, methods=["post"], permission_classes=[IsAuthenticated],
+    )
+    def update_jira_epic(self, request, pk=None):
+        engagement = self.get_object()
+        try:
+
+            if engagement.has_jira_issue:
+                jira_helper.update_epic(engagement, **request.data)
+                response = Response(
+                    {"info": "Jira Epic update query sent"},
+                    status=status.HTTP_200_OK,
+                )
+            else:
+                jira_helper.add_epic(engagement, **request.data)
+                response = Response(
+                    {"info": "Jira Epic create query sent"},
+                    status=status.HTTP_200_OK,
+                )
+            return response
+        except ValidationError:
+            return Response(
+                {"error": "Bad Request!"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
 
 # @extend_schema_view(**schema_with_prefetch())
 # Nested models with prefetch make the response schema too long for Swagger UI

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1289,7 +1289,14 @@ def update_epic(engagement, **kwargs):
             if not epic_name:
                 epic_name = engagement.name
 
-            issue.update(summary=epic_name, description=epic_name)
+            epic_priority = kwargs.get("epic_priority", None)
+
+            jira_issue_update_kwargs = {
+                "summary": epic_name,
+                "description": epic_name,
+                "priority": {"name": epic_priority},
+            }
+            issue.update(**jira_issue_update_kwargs)
             return True
         except JIRAError as e:
             logger.exception(e)


### PR DESCRIPTION
**Title:** Update Jira Epic Engagement in API v2

**Description:**
This pull request includes updates to the Jira Epic engagement functionality in the API v2. The changes aim to improve the integration and handling of Jira Epics within the DefectDojo application.

**Changes:**
- Updated the API v2 engagment endpoint to handle Jira related epic.

**Engagment Edit view**

![Edit Engagement DefectDojo](https://github.com/user-attachments/assets/702d4b47-310b-492a-8dc3-c670bb26d096)

**API v2 Engagment endpint**
![Defect Dojo API v2](https://github.com/user-attachments/assets/c1c463a5-7ed3-47f6-b02e-948fd734cf9f)

**Jira Epic Update**
- Title
- Priority
![Testing - Jira Epic](https://github.com/user-attachments/assets/fe79e2ab-d652-4703-81a0-9166be538b99)
