### PR TITLE
feat(helm): Add support for staticName for initializer

### DIFF
--- a/helm/defectdojo/templates/_helpers.tpl
+++ b/helm/defectdojo/templates/_helpers.tpl
@@ -102,7 +102,11 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{- define "initializer.jobname" -}}
+{{- if .Values.initializer.staticName -}}
+{{ .Release.Name }}-initializer
+{{- else -}}
 {{ .Release.Name }}-initializer-{{- printf "%s" now | date "2006-01-02-15-04" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -365,6 +365,11 @@ initializer:
   # @type: array<map>
   extraVolumes: []
 
+  # staticName defines whether name of the job will be the same (e.g., "defectdojo-initializer")
+  # or different every time - generated based on current time (e.g., "defectdojo-initializer-2024-11-11-18-57")
+  # This might be handy for ArgoCD deployments
+  staticName: false
+
 postgresql:
   enabled: true
   auth:


### PR DESCRIPTION
This PR
- enables a static name for the Initializer job
- do not change the default behavior
- was already mentioned [here](https://github.com/DefectDojo/django-DefectDojo/pull/11016#issuecomment-2443930306) as enabled
- might be useful for systems that use HELM only to generate templates (like ArgoCD).
