### PR TITLE
feat(helm): Allow to keep initializer if requested

### DIFF
--- a/helm/defectdojo/templates/initializer-job.yaml
+++ b/helm/defectdojo/templates/initializer-job.yaml
@@ -15,7 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and (int .Values.initializer.keepSeconds) (gt (int .Values.initializer.keepSeconds) 0) }}
   ttlSecondsAfterFinished: {{ .Values.initializer.keepSeconds }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/helm/defectdojo/values.yaml
+++ b/helm/defectdojo/values.yaml
@@ -321,7 +321,7 @@ initializer:
   jobAnnotations: {}
   annotations: {}
   labels: {}
-  keepSeconds: 60
+  keepSeconds: 60  # A positive integer will keep this Job and Pod deployed for the specified number of seconds, after which they will be removed. For all other values, the Job and Pod will remain deployed.
   affinity: {}
   nodeSelector: {}
   resources:


### PR DESCRIPTION
If the user needed to keep the `initializer` in the stack, there was no way (only set an unreasonable large number).

Now, any value that is not a positive integer will keep the `initializer` there.

Tested with:
- `--set 'initializer.keepSeconds=[]'` - stayed
- `--set 'initializer.keepSeconds=null'` - stayed
- `--set 'initializer.keepSeconds=x'` - stayed
- `--set 'initializer.keepSeconds=-1'` - stayed
- `--set 'initializer.keepSeconds=0'` - stayed
- `--set 'initializer.keepSeconds=1'` - removed after 1s

Context: 