### PR TITLE
Fix sarif parser location files processing

### DIFF
--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -274,7 +274,7 @@ def get_description(result, rule, location):
         )
         description += f"**Result message:** {message}\n"
     if get_snippet(location) is not None:
-        description += f"**Snippet:**\n```\n{get_snippet(result)}\n```\n"
+        description += f"**Snippet:**\n```\n{get_snippet(location)}\n```\n"
     if rule is not None:
         if "name" in rule:
             description += f"**{_('Rule name')}:** {rule.get('name')}\n"

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -62,7 +62,7 @@ class SarifParser:
         run_date = self.__get_last_invocation_date(run)
         for result in run.get("results", []):
             result_items = get_items_from_result(result, rules, artifacts, run_date)
-            if result_items :
+            if result_items:
                 items.extend(result_items)
         return items
 
@@ -388,7 +388,7 @@ def get_items_from_result(result, rules, artifacts, run_date):
                     else:
                         line = location["physicalLocation"]["region"]["startLine"]
 
-            files.append((file_path,line))
+            files.append((file_path, line))
 
     if not files:
         files.append((None, None))

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -61,9 +61,9 @@ class SarifParser:
         # get the timestamp of the run if possible
         run_date = self.__get_last_invocation_date(run)
         for result in run.get("results", []):
-            item = get_item(result, rules, artifacts, run_date)
-            if item is not None:
-                items.append(item)
+            result_items = get_items_from_result(result, rules, artifacts, run_date)
+            if result_items :
+                items.extend(result_items)
         return items
 
     def __get_last_invocation_date(self, data):
@@ -351,7 +351,7 @@ def get_severity(result, rule):
     return "Medium"
 
 
-def get_item(result, rules, artifacts, run_date):
+def get_items_from_result(result, rules, artifacts, run_date):
     # see
     # https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html
     # / 3.27.9
@@ -366,100 +366,117 @@ def get_item(result, rules, artifacts, run_date):
     if result.get("suppressions"):
         suppressed = True
 
-    # if there is a location get it
-    file_path = None
-    line = None
+    # if there is a location get all files into files list
+
+    files = []
+
     if "locations" in result:
-        location = result["locations"][0]
-        if "physicalLocation" in location:
-            file_path = location["physicalLocation"]["artifactLocation"]["uri"]
+        for location in result["locations"]:
 
-            # 'region' attribute is optionnal
-            if "region" in location["physicalLocation"]:
-                # https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html / 3.30.1
-                # need to check whether it is byteOffset
-                if "byteOffset" in location["physicalLocation"]["region"]:
-                    pass
-                else:
-                    line = location["physicalLocation"]["region"]["startLine"]
+            file_path = None
+            line = None
 
-    # test rule link
-    rule = rules.get(result.get("ruleId"))
+            if "physicalLocation" in location:
+                file_path = location["physicalLocation"]["artifactLocation"]["uri"]
 
-    finding = Finding(
-        title=get_title(result, rule),
-        severity=get_severity(result, rule),
-        description=get_description(result, rule),
-        static_finding=True,  # by definition
-        dynamic_finding=False,  # by definition
-        false_p=suppressed,
-        active=not suppressed,
-        file_path=file_path,
-        line=line,
-        references=get_references(rule),
-    )
+                # 'region' attribute is optionnal
+                if "region" in location["physicalLocation"]:
+                    # https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html / 3.30.1
+                    # need to check whether it is byteOffset
+                    if "byteOffset" in location["physicalLocation"]["region"]:
+                        pass
+                    else:
+                        line = location["physicalLocation"]["region"]["startLine"]
 
-    if "ruleId" in result:
-        finding.vuln_id_from_tool = result["ruleId"]
-        # for now we only support when the id of the rule is a CVE
-        if cve_try(result["ruleId"]):
-            finding.unsaved_vulnerability_ids = [cve_try(result["ruleId"])]
-    # some time the rule id is here but the tool doesn't define it
-    if rule is not None:
-        cwes_extracted = get_rule_cwes(rule)
-        if len(cwes_extracted) > 0:
-            finding.cwe = cwes_extracted[-1]
+            files.append((file_path,line))
 
-        # Some tools such as GitHub or Grype return the severity in properties
-        # instead
-        if "properties" in rule and "security-severity" in rule["properties"]:
-            try:
-                cvss = float(rule["properties"]["security-severity"])
-                severity = cvss_to_severity(cvss)
-                finding.cvssv3_score = cvss
-                finding.severity = severity
-            except ValueError:
-                if rule["properties"]["security-severity"].lower().capitalize() in ["Info", "Low", "Medium", "High", "Critical"]:
-                    finding.severity = rule["properties"]["security-severity"].lower().capitalize()
-                else:
-                    finding.severity = "Info"
+    if not files:
+        files.append((None, None))
 
-    # manage the case that some tools produce CWE as properties of the result
-    cwes_properties_extracted = get_result_cwes_properties(result)
-    if len(cwes_properties_extracted) > 0:
-        finding.cwe = cwes_properties_extracted[-1]
+    result_items = []
 
-    # manage fixes provided in the report
-    if "fixes" in result:
-        finding.mitigation = "\n".join(
-            [fix.get("description", {}).get("text") for fix in result["fixes"]],
+    for file_path, line in files:
+
+        # test rule link
+        rule = rules.get(result.get("ruleId"))
+
+        finding = Finding(
+            title=get_title(result, rule),
+            severity=get_severity(result, rule),
+            description=get_description(result, rule),
+            static_finding=True,  # by definition
+            dynamic_finding=False,  # by definition
+            false_p=suppressed,
+            active=not suppressed,
+            file_path=file_path,
+            line=line,
+            references=get_references(rule),
         )
 
-    if run_date:
-        finding.date = run_date
+        if "ruleId" in result:
+            finding.vuln_id_from_tool = result["ruleId"]
+            # for now we only support when the id of the rule is a CVE
+            if cve_try(result["ruleId"]):
+                finding.unsaved_vulnerability_ids = [cve_try(result["ruleId"])]
+        # some time the rule id is here but the tool doesn't define it
+        if rule is not None:
+            cwes_extracted = get_rule_cwes(rule)
+            if len(cwes_extracted) > 0:
+                finding.cwe = cwes_extracted[-1]
 
-    # manage tags provided in the report and rule and remove duplicated
-    tags = list(set(get_properties_tags(rule) + get_properties_tags(result)))
-    tags = [s.removeprefix("external/cwe/") for s in tags]
-    finding.tags = tags
+            # Some tools such as GitHub or Grype return the severity in properties
+            # instead
+            if "properties" in rule and "security-severity" in rule["properties"]:
+                try:
+                    cvss = float(rule["properties"]["security-severity"])
+                    severity = cvss_to_severity(cvss)
+                    finding.cvssv3_score = cvss
+                    finding.severity = severity
+                except ValueError:
+                    if rule["properties"]["security-severity"].lower().capitalize() in ["Info", "Low", "Medium", "High", "Critical"]:
+                        finding.severity = rule["properties"]["security-severity"].lower().capitalize()
+                    else:
+                        finding.severity = "Info"
 
-    # manage fingerprints
-    # fingerprinting in SARIF is more complete than in current implementation
-    # SARIF standard make it possible to have multiple version in the same report
-    # for now we just take the first one and keep the format to be able to
-    # compare it
-    if result.get("fingerprints"):
-        hashes = get_fingerprints_hashes(result["fingerprints"])
-        first_item = next(iter(hashes.items()))
-        finding.unique_id_from_tool = first_item[1]["value"]
-    elif result.get("partialFingerprints"):
-        # for this one we keep an order to have id that could be compared
-        hashes = get_fingerprints_hashes(result["partialFingerprints"])
-        sorted_hashes = sorted(hashes.keys())
-        finding.unique_id_from_tool = "|".join(
-            [f'{key}:{hashes[key]["value"]}' for key in sorted_hashes],
-        )
-    return finding
+        # manage the case that some tools produce CWE as properties of the result
+        cwes_properties_extracted = get_result_cwes_properties(result)
+        if len(cwes_properties_extracted) > 0:
+            finding.cwe = cwes_properties_extracted[-1]
+
+        # manage fixes provided in the report
+        if "fixes" in result:
+            finding.mitigation = "\n".join(
+                [fix.get("description", {}).get("text") for fix in result["fixes"]],
+            )
+
+        if run_date:
+            finding.date = run_date
+
+        # manage tags provided in the report and rule and remove duplicated
+        tags = list(set(get_properties_tags(rule) + get_properties_tags(result)))
+        tags = [s.removeprefix("external/cwe/") for s in tags]
+        finding.tags = tags
+
+        # manage fingerprints
+        # fingerprinting in SARIF is more complete than in current implementation
+        # SARIF standard make it possible to have multiple version in the same report
+        # for now we just take the first one and keep the format to be able to
+        # compare it
+        if result.get("fingerprints"):
+            hashes = get_fingerprints_hashes(result["fingerprints"])
+            first_item = next(iter(hashes.items()))
+            finding.unique_id_from_tool = first_item[1]["value"]
+        elif result.get("partialFingerprints"):
+            # for this one we keep an order to have id that could be compared
+            hashes = get_fingerprints_hashes(result["partialFingerprints"])
+            sorted_hashes = sorted(hashes.keys())
+            finding.unique_id_from_tool = "|".join(
+                [f'{key}:{hashes[key]["value"]}' for key in sorted_hashes],
+            )
+
+        result_items.append(finding)
+
+    return result_items
 
 
 def get_fingerprints_hashes(values):

--- a/unittests/tools/test_sarif_parser.py
+++ b/unittests/tools/test_sarif_parser.py
@@ -1,6 +1,5 @@
 import datetime
 from os import path
-from pathlib import Path
 
 from dojo.models import Finding, Test
 from dojo.tools.sarif.parser import SarifParser, get_fingerprints_hashes
@@ -30,7 +29,7 @@ class TestSarifParser(DojoTestCase):
 
     def test_suppression_report(self):
         """Test report file having different suppression definitions"""
-        with open(path.join(Path(__file__).parent, "../scans/sarif/suppression_test.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/suppression_test.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             for finding in findings:
@@ -42,7 +41,7 @@ class TestSarifParser(DojoTestCase):
                     self.assertEqual(True, finding.active)
 
     def test_example2_report(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -70,13 +69,13 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_k1_report(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k1.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k1.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(0, len(findings))
 
     def test_example_k2_report(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k2.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k2.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -91,7 +90,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_k3_report(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k3.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k3.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -101,7 +100,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_k4_report_mitigation(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k4.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k4.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -118,7 +117,7 @@ add_core(ptr, offset, val);
 
     def test_example_report_ms(self):
         """Report file come from Microsoft SARIF sdk on GitHub"""
-        with open(path.join(Path(__file__).parent, "../scans/sarif/SuppressionTestCurrent.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/SuppressionTestCurrent.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(4, len(findings))
@@ -128,7 +127,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_semgrep(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/semgrepowasp-benchmark-sample.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/semgrepowasp-benchmark-sample.sarif"), encoding="utf-8") as testfile:
             test = Test()
             parser = SarifParser()
             findings = parser.get_findings(testfile, test)
@@ -142,7 +141,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_scanlift_dependency_check(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/dependency_check.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/dependency_check.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(13, len(findings))
@@ -165,7 +164,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_scanlift_bash(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/bash-report.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/bash-report.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(27, len(findings))
@@ -194,7 +193,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_taint_python(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(11, len(findings))
@@ -236,7 +235,7 @@ add_core(ptr, offset, val);
 
     def test_njsscan(self):
         """Generated with opensecurity/njsscan (https://github.com/ajinabraham/njsscan)"""
-        with open(path.join(Path(__file__).parent, "../scans/sarif/njsscan.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/njsscan.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(3, len(findings))
@@ -263,7 +262,7 @@ add_core(ptr, offset, val);
 
     def test_dockle(self):
         """Generated with goodwithtech/dockle (https://github.com/goodwithtech/dockle)"""
-        with open(path.join(Path(__file__).parent, "../scans/sarif/dockle_0_3_15.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/dockle_0_3_15.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(4, len(findings))
@@ -311,16 +310,15 @@ add_core(ptr, offset, val);
                 )
 
     def test_mobsfscan(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/mobsfscan.json"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/mobsfscan.json"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(18, len(findings))
-
             for finding in findings:
                 self.common_checks(finding)
 
     def test_gitleaks(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/gitleaks_7.5.0.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/gitleaks_7.5.0.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(8, len(findings))
@@ -370,7 +368,7 @@ add_core(ptr, offset, val);
             self.assertEqual(37, finding.line)
 
     def test_flawfinder(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(53, len(findings))
@@ -446,7 +444,7 @@ add_core(ptr, offset, val);
                 self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
 
     def test_flawfinder_interfacev2(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             tests = parser.get_tests(parser.get_scan_types()[0], testfile)
             self.assertEqual(1, len(tests))
@@ -515,7 +513,7 @@ add_core(ptr, offset, val);
                 self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
 
     def test_appendix_k1_double_interfacev2(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k1_double.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k1_double.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             tests = parser.get_tests(parser.get_scan_types()[0], testfile)
             self.assertEqual(2, len(tests))
@@ -531,7 +529,7 @@ add_core(ptr, offset, val);
                 self.assertEqual(0, len(findings))
 
     def test_codeql_snippet_report(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/codeQL-output.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/codeQL-output.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(72, len(findings))
@@ -557,7 +555,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_severity_cvss_from_grype(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/cxf-3.4.6.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/cxf-3.4.6.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(22, len(findings))
@@ -586,14 +584,14 @@ add_core(ptr, offset, val);
         )
 
     def test_tags_from_result_properties(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             item = findings[0]
             self.assertEqual(["Scan"], item.tags)
 
     def test_severity_in_properties(self):
-        with open(path.join(Path(__file__).parent, "../scans/sarif/issue_10191.json"), encoding="utf-8") as testfile:
+        with open(path.join(path.dirname(__file__), "../scans/sarif/issue_10191.json"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(77, len(findings))

--- a/unittests/tools/test_sarif_parser.py
+++ b/unittests/tools/test_sarif_parser.py
@@ -1,5 +1,6 @@
 import datetime
 from os import path
+from pathlib import Path
 
 from dojo.models import Finding, Test
 from dojo.tools.sarif.parser import SarifParser, get_fingerprints_hashes
@@ -29,7 +30,7 @@ class TestSarifParser(DojoTestCase):
 
     def test_suppression_report(self):
         """Test report file having different suppression definitions"""
-        with open(path.join(path.dirname(__file__), "../scans/sarif/suppression_test.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/suppression_test.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             for finding in findings:
@@ -41,7 +42,7 @@ class TestSarifParser(DojoTestCase):
                     self.assertEqual(True, finding.active)
 
     def test_example2_report(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -69,13 +70,13 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_k1_report(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k1.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k1.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(0, len(findings))
 
     def test_example_k2_report(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k2.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k2.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -90,7 +91,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_k3_report(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k3.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k3.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -100,7 +101,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_k4_report_mitigation(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k4.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k4.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(1, len(findings))
@@ -117,7 +118,7 @@ add_core(ptr, offset, val);
 
     def test_example_report_ms(self):
         """Report file come from Microsoft SARIF sdk on GitHub"""
-        with open(path.join(path.dirname(__file__), "../scans/sarif/SuppressionTestCurrent.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/SuppressionTestCurrent.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(4, len(findings))
@@ -127,7 +128,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_semgrep(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/semgrepowasp-benchmark-sample.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/semgrepowasp-benchmark-sample.sarif"), encoding="utf-8") as testfile:
             test = Test()
             parser = SarifParser()
             findings = parser.get_findings(testfile, test)
@@ -141,7 +142,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_scanlift_dependency_check(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/dependency_check.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/dependency_check.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(13, len(findings))
@@ -164,7 +165,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_scanlift_bash(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/bash-report.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/bash-report.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(27, len(findings))
@@ -193,7 +194,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_example_report_taint_python(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(11, len(findings))
@@ -235,10 +236,10 @@ add_core(ptr, offset, val);
 
     def test_njsscan(self):
         """Generated with opensecurity/njsscan (https://github.com/ajinabraham/njsscan)"""
-        with open(path.join(path.dirname(__file__), "../scans/sarif/njsscan.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/njsscan.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
-            self.assertEqual(2, len(findings))
+            self.assertEqual(3, len(findings))
             # finding 0
             finding = findings[0]
             self.assertEqual(
@@ -262,7 +263,7 @@ add_core(ptr, offset, val);
 
     def test_dockle(self):
         """Generated with goodwithtech/dockle (https://github.com/goodwithtech/dockle)"""
-        with open(path.join(path.dirname(__file__), "../scans/sarif/dockle_0_3_15.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/dockle_0_3_15.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(4, len(findings))
@@ -310,15 +311,16 @@ add_core(ptr, offset, val);
                 )
 
     def test_mobsfscan(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/mobsfscan.json"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/mobsfscan.json"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
-            self.assertEqual(9, len(findings))
+            self.assertEqual(18, len(findings))
+
             for finding in findings:
                 self.common_checks(finding)
 
     def test_gitleaks(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/gitleaks_7.5.0.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/gitleaks_7.5.0.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(8, len(findings))
@@ -368,7 +370,7 @@ add_core(ptr, offset, val);
             self.assertEqual(37, finding.line)
 
     def test_flawfinder(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(53, len(findings))
@@ -444,7 +446,7 @@ add_core(ptr, offset, val);
                 self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
 
     def test_flawfinder_interfacev2(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/flawfinder.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             tests = parser.get_tests(parser.get_scan_types()[0], testfile)
             self.assertEqual(1, len(tests))
@@ -513,7 +515,7 @@ add_core(ptr, offset, val);
                 self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
 
     def test_appendix_k1_double_interfacev2(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/appendix_k1_double.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/appendix_k1_double.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             tests = parser.get_tests(parser.get_scan_types()[0], testfile)
             self.assertEqual(2, len(tests))
@@ -529,7 +531,7 @@ add_core(ptr, offset, val);
                 self.assertEqual(0, len(findings))
 
     def test_codeql_snippet_report(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/codeQL-output.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/codeQL-output.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(72, len(findings))
@@ -555,7 +557,7 @@ add_core(ptr, offset, val);
                 self.common_checks(finding)
 
     def test_severity_cvss_from_grype(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/cxf-3.4.6.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/cxf-3.4.6.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(22, len(findings))
@@ -584,14 +586,14 @@ add_core(ptr, offset, val);
         )
 
     def test_tags_from_result_properties(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/taint-python-report.sarif"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             item = findings[0]
             self.assertEqual(["Scan"], item.tags)
 
     def test_severity_in_properties(self):
-        with open(path.join(path.dirname(__file__), "../scans/sarif/issue_10191.json"), encoding="utf-8") as testfile:
+        with open(path.join(Path(__file__).parent, "../scans/sarif/issue_10191.json"), encoding="utf-8") as testfile:
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(77, len(findings))


### PR DESCRIPTION
**Description**

In sarif results -> locations provided list of files by sarif standart. In many scanners like semgrep each item in results contain one file in locations, but in some scanners like mobsfscan scanner reports contain multiple files for one item:

Example for located in tests mobsfscan [report](https://github.com/DefectDojo/django-DefectDojo/blob/master/unittests/scans/sarif/mobsfscan.json#L71):

```
      "results": [
        {
          "message": {
            "text": "The App logs information. Please ensure that sensitive information is never logged."
          },
          "level": "note",
          "locations": [
            {
              "physicalLocation": {
                "region": {
                  "snippet": {
                    "text": "            Log.d(\"Diva\", \"Error occurred while creating database: \" + e.getMessage());"
                  },
                  "endColumn": 88,
                  "endLine": 57,
                  "startColumn": 13,
                  "startLine": 57
                },
                "artifactLocation": {
                  "uri": "app/src/main/java/jakhar/aseem/diva/InsecureDataStorage2Activity.java"
                }
              }
            },
            {
              "physicalLocation": {
                "region": {
                  "snippet": {
                    "text": "            Log.d(\"Diva\", \"Error occurred while inserting into database: \" + e.getMessage());"
                  },
                  "endColumn": 94,
                  "endLine": 71,
                  "startColumn": 13,
                  "startLine": 71
                },
                "artifactLocation": {
                  "uri": "app/src/main/java/jakhar/aseem/diva/InsecureDataStorage2Activity.java"
                }
              }
            },

```
In old parser logic all files in one result except the first file are lost because `locations[0]` used for item filling.
In new logic information about scanner hit in each file saved in `files` list and after from this list created separate vuln items.

**Test results**

Fixed tests for mobsfscan and njsscan sarif reports.