### PR TITLE
DojoMeta: Ability to create or update multiple objects in batch

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -417,6 +417,51 @@ class MetaSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
+class MetadataSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=120)
+    value = serializers.CharField(max_length=300)
+
+
+class MetaMainSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+
+    product = serializers.PrimaryKeyRelatedField(
+        queryset=Product.objects.all(),
+        required=False,
+        default=None,
+        allow_null=True,
+    )
+    endpoint = serializers.PrimaryKeyRelatedField(
+        queryset=Endpoint.objects.all(),
+        required=False,
+        default=None,
+        allow_null=True,
+    )
+    finding = serializers.PrimaryKeyRelatedField(
+        queryset=Finding.objects.all(),
+        required=False,
+        default=None,
+        allow_null=True,
+    )
+    metadata = MetadataSerializer(many=True)
+
+    def validate(self, data):
+        product_id = data.get("product", None)
+        endpoint_id = data.get("endpoint", None)
+        finding_id = data.get("finding", None)
+        metadata = data.get("metadata")
+
+        for item in metadata:
+            # this will only verify that one and only one of product, endpoint, or finding is passed...
+            DojoMeta(product=product_id,
+                     endpoint=endpoint_id,
+                     finding=finding_id,
+                     name=item.get("name"),
+                     value=item.get("value")).clean()
+
+        return data
+
+
 class ProductMetaSerializer(serializers.ModelSerializer):
     class Meta:
         model = DojoMeta

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1672,7 +1672,7 @@ class DojoMetaViewSet(
     def process_post(self: object, data: dict):
         product = Product.objects.filter(id=data.get("product")).first()
         finding = Finding.objects.filter(id=data.get("finding")).first()
-        endpoint = Finding.objects.filter(id=data.get("endpoint")).first()
+        endpoint = Endpoint.objects.filter(id=data.get("endpoint")).first()
         metalist = data.get("metadata")
         for metadata in metalist:
             try:

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1689,7 +1689,7 @@ class DojoMetaViewSet(
     def process_patch(self: object, data: dict):
         product = Product.objects.filter(id=data.get("product")).first()
         finding = Finding.objects.filter(id=data.get("finding")).first()
-        endpoint = Finding.objects.filter(id=data.get("endpoint")).first()
+        endpoint = Endpoint.objects.filter(id=data.get("endpoint")).first()
         metalist = data.get("metadata")
         for metadata in metalist:
             dojometa = DojoMeta.objects.filter(product=product, finding=finding, endpoint=endpoint, name=metadata.get("name"))

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -1705,6 +1705,7 @@ class DojoMetaViewSet(
                 msg = f"Metadata {metadata.get('name')} not found for object."
                 raise ValidationError(msg)
 
+
 @extend_schema_view(**schema_with_prefetch())
 class ProductViewSet(
     prefetch.PrefetchListMixin,


### PR DESCRIPTION
[sc-856]

Added 'batch' endpoint for metadata to create or update multiple metadata at once. The same constraints still apply: can only be added to a single product, finding, or endpoint at a time and the metadata must be unique across the parent object id and the name of the metadata.

