### PR TITLE
cleanup(helm): Drop support for TCP/3000

### DIFF
--- a/helm/defectdojo/templates/django-deployment.yaml
+++ b/helm/defectdojo/templates/django-deployment.yaml
@@ -155,11 +155,6 @@ spec:
         - name: http-uwsgi
           protocol: TCP
           containerPort: 8081
-        {{- if .Values.django.uwsgi.enableDebug }}
-        - name: debug
-          protocol: TCP
-          containerPort: 3000
-        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ $fullName }}


### PR DESCRIPTION
Support for debug port `tcp/3000` was dropped in #10692
This is not needed anymore