### PR TITLE
Introducing DefectDojo Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
                 <a href="https://github.com/DefectDojo/django-DefectDojo/releases/latest"><img src="https://img.shields.io/github/release/DefectDojo/django-DefectDojo.svg" alt="GitHub release"></a>
                 <a href="https://www.youtube.com/channel/UCWw9qzqptiIvTqSqhOFuCuQ"><img src="https://img.shields.io/badge/youtube-subscribe-%23c4302b.svg" alt="YouTube Subscribe"></a>
                 <a href="https://twitter.com/defectdojo/"><img src="https://img.shields.io/twitter/follow/defectdojo.svg?style=social&amp;label=Follow" alt="Twitter Follow"></a>
+                <a href="https://gurubase.io/g/defectdojo"><img src="https://img.shields.io/badge/Gurubase-Ask%20DefectDojo%20Guru-006BFF" alt="Gurubase"></a>
             </p>
             <p>
                 <a href="https://github.com/DefectDojo/django-DefectDojo/actions"><img src="https://github.com/DefectDojo/django-DefectDojo/actions/workflows/unit-tests.yml/badge.svg?branch=master" alt="Unit Tests"></a>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [DefectDojo Guru](https://gurubase.io/g/defectdojo) to Gurubase. DefectDojo Guru uses the data from this repo and data from the [docs](https://documentation.defectdojo.com/) to answer questions by leveraging the LLM.

In this PR, I showcased the "DefectDojo Guru", which highlights that DefectDojo now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable DefectDojo Guru in Gurubase, just let me know that's totally fine.
