### PR TITLE
Update audit log with actual requested reviewers

### DIFF
--- a/dojo/models.py
+++ b/dojo/models.py
@@ -4613,7 +4613,7 @@ if settings.ENABLE_AUDITLOG:
     auditlog.register(Dojo_User, exclude_fields=["password"])
     auditlog.register(Endpoint)
     auditlog.register(Engagement)
-    auditlog.register(Finding)
+    auditlog.register(Finding, m2m_fields={"reviewers"})
     auditlog.register(Finding_Group)
     auditlog.register(Product_Type)
     auditlog.register(Product)
@@ -4622,6 +4622,7 @@ if settings.ENABLE_AUDITLOG:
     auditlog.register(Finding_Template)
     auditlog.register(Cred_User, exclude_fields=["password"])
     auditlog.register(Notification_Webhooks, exclude_fields=["header_name", "header_value"])
+
 
 from dojo.utils import calculate_grade, to_str_typed  # noqa: E402  # there is issue due to a circular import
 

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -328,7 +328,10 @@ def action_log_entry(value, autoescape=None):
     history = json.loads(value)
     text = ""
     for k in history.keys():
-        text += k.capitalize() + ' changed from "' + \
+        if isinstance(history[k], dict):
+            text += k.capitalize() + " operation: " + history[k].get("operation", "unknown") + ": " + str(history[k].get("objects", "unknown"))
+        else:
+            text += k.capitalize() + ' changed from "' + \
                 history[k][0] + '" to "' + history[k][1] + '"\n'
     return text
 


### PR DESCRIPTION
[sc-2885]

When a user requests a review of a Finding, there is a record of who requested a review but nothing about who was requested to review it.

This PR adds this record.
