### PR TITLE
feat(parser: generic): Allow epss_* parameters

### DIFF
--- a/dojo/tools/generic/json_parser.py
+++ b/dojo/tools/generic/json_parser.py
@@ -45,6 +45,8 @@ class GenericJSONParser:
                 "date",
                 "cwe",
                 "cve",
+                "epss_score",
+                "epss_percentile",
                 "cvssv3",
                 "cvssv3_score",
                 "mitigation",


### PR DESCRIPTION
When the users are using "Generic Findings Import", it does not allow them to set `epss_score` and `epss_percentile`. This is only because of the historical reason (limitation of allowed fields has been implemented before `epss_*` was added to `Findings`.

Context: https://owasp.slack.com/archives/C2P5BA8MN/p1732001998945879