### PR TITLE
dissallow already linked issue

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1287,6 +1287,12 @@ class JIRAIssueSerializer(serializers.ModelSerializer):
             msg = "Either engagement or finding or finding_group has to be set."
             raise serializers.ValidationError(msg)
 
+        if finding:
+            linked_finding = jira_helper.jira_already_linked(finding, data.get("jira_key"), data.get("jira_id"))
+            if linked_finding:
+                msg = "JIRA issue " + data.get("jira_key") + " already linked to " + reverse("view_finding", args=(linked_finding,))
+                raise serializers.ValidationError(msg)
+
         return data
 
 

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1426,6 +1426,17 @@ def add_simple_jira_comment(jira_instance, jira_issue, comment):
         return False
 
 
+def jira_already_linked(finding, jira_issue_key, jira_id):
+    jira_issues = JIRA_Issue.objects.filter(jira_id=jira_id, jira_key=jira_issue_key).exclude(engagement__isnull=False)
+    jira_issues = jira_issues.exclude(finding=finding)
+
+    result = 0
+    if len(jira_issues) > 0:
+        result = jira_issues[0].finding_id
+
+    return result
+
+
 def finding_link_jira(request, finding, new_jira_issue_key):
     logger.debug("linking existing jira issue %s for finding %i", new_jira_issue_key, finding.id)
 


### PR DESCRIPTION
[sc-5525]

Fixes #9930 

When using the jira_finding_mappings API endpoint, trying to update a finding's Jira mapping with a Jira issue that is already assigned to another finding will now raise a validation error.