### PR TITLE
Update Reported Finding Severity by Month on the dashboard to be by month instead of day.

### DIFF
--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -57,7 +57,8 @@ function homepage_pie_chart(critical, high, medium, low, info) {
 function homepage_severity_plot(critical, high, medium, low) {
     var options = {
         xaxes: [{
-            mode: 'time'
+            mode: 'time',
+            minTickSize: [1, "month"]
         }],
         yaxes: [{
             min: 0


### PR DESCRIPTION
[sc-8650]

Addresses #11254 

The graph on the dashboard for "Reported Finding Severity by Month" is currently displaying data in days, rather than months. And when there is only 1 data point (all findings are from the same day as it was in the demo case in the issue above) then the graph does not display correctly.

This changes the minimum data point to 1 and specifies that the data is by month. This should display accurate, if not visually appealing, data when there is only 1 month's worth of data. As time progresses, the chart will look better and will display up to 6 months of Reported Finding Severity by Month.