### PR TITLE
Disallow multiple single-use notes on a single object 

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -504,7 +504,7 @@ class EngagementViewSet(
                 )
 
             notes = engagement.notes.filter(note_type=note_type).first()
-            if notes and note_type.is_single:
+            if notes and note_type and note_type.is_single:
                 return Response("Only one instance of this note_type allowed on an engagement.", status=status.HTTP_400_BAD_REQUEST)
 
             author = request.user
@@ -1054,7 +1054,7 @@ class FindingViewSet(
 
             if finding.notes:
                 notes = finding.notes.filter(note_type=note_type).first()
-                if notes and note_type.is_single:
+                if notes and note_type and note_type.is_single:
                     return Response("Only one instance of this note_type allowed on a finding.", status=status.HTTP_400_BAD_REQUEST)
 
             author = request.user
@@ -2058,7 +2058,7 @@ class TestsViewSet(
                 )
 
             notes = test.notes.filter(note_type=note_type).first()
-            if notes and note_type.is_single:
+            if notes and note_type and note_type.is_single:
                 return Response("Only one instance of this note_type allowed on a test.", status=status.HTTP_400_BAD_REQUEST)
 
             author = request.user

--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -503,6 +503,10 @@ class EngagementViewSet(
                     new_note.errors, status=status.HTTP_400_BAD_REQUEST,
                 )
 
+            notes = engagement.notes.filter(note_type=note_type).first()
+            if notes and note_type.is_single:
+                return Response("Only one instance of this note_type allowed on an engagement.", status=status.HTTP_400_BAD_REQUEST)
+
             author = request.user
             note = Notes(
                 entry=entry,
@@ -1047,6 +1051,11 @@ class FindingViewSet(
                 return Response(
                     new_note.errors, status=status.HTTP_400_BAD_REQUEST,
                 )
+
+            if finding.notes:
+                notes = finding.notes.filter(note_type=note_type).first()
+                if notes and note_type.is_single:
+                    return Response("Only one instance of this note_type allowed on a finding.", status=status.HTTP_400_BAD_REQUEST)
 
             author = request.user
             note = Notes(
@@ -2047,6 +2056,10 @@ class TestsViewSet(
                 return Response(
                     new_note.errors, status=status.HTTP_400_BAD_REQUEST,
                 )
+
+            notes = test.notes.filter(note_type=note_type).first()
+            if notes and note_type.is_single:
+                return Response("Only one instance of this note_type allowed on a test.", status=status.HTTP_400_BAD_REQUEST)
 
             author = request.user
             note = Notes(


### PR DESCRIPTION
[sc-6050]

Returns a BAD_REQUEST status and an error message when attempting to POST a note with a Note Type of 'is_single' - if another Note with that Note Type already exists on the given object (finding, engagement, test).

