### PR TITLE
Ruff: Enable and fix RUF010

### DIFF
--- a/dojo/endpoint/utils.py
+++ b/dojo/endpoint/utils.py
@@ -208,8 +208,8 @@ def clean_hosts_run(apps, change):
                     to_be_deleted.update(ep_ids[1:])
                     if change:
                         message = "Merging Endpoints {} into '{}'".format(
-                            [f"{str(x)} (id={x.pk})" for x in ep[1:]],
-                            f"{str(ep[0])} (id={ep[0].pk})")
+                            [f"{x} (id={x.pk})" for x in ep[1:]],
+                            f"{ep[0]} (id={ep[0].pk})")
                         html_log.append(message)
                         logger.info(message)
                         Endpoint_Status_model.objects\

--- a/dojo/endpoint/views.py
+++ b/dojo/endpoint/views.py
@@ -503,7 +503,7 @@ def import_endpoint_meta(request, pid):
                 endpoint_meta_import(file, product, create_endpoints, create_tags, create_dojo_meta, origin="UI", request=request)
             except Exception as e:
                 logger.exception(e)
-                add_error_message_to_response(f"An exception error occurred during the report import:{str(e)}")
+                add_error_message_to_response(f"An exception error occurred during the report import:{e}")
             return HttpResponseRedirect(reverse("endpoint") + "?product=" + pid)
 
     add_breadcrumb(title="Endpoint Meta Importer", top_level=False, request=request)

--- a/dojo/jira_link/views.py
+++ b/dojo/jira_link/views.py
@@ -552,7 +552,7 @@ class DeleteJiraView(View):
                         url=request.build_absolute_uri(reverse("jira")))
                     return HttpResponseRedirect(reverse("jira"))
                 except Exception as e:
-                    add_error_message_to_response(f"Unable to delete JIRA Instance, probably because it is used by JIRA Issues: {str(e)}")
+                    add_error_message_to_response(f"Unable to delete JIRA Instance, probably because it is used by JIRA Issues: {e}")
 
         rels = ["Previewing the relationships has been disabled.", ""]
         display_preview = get_setting("DELETE_PREVIEW")

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -1619,7 +1619,7 @@ class Endpoint_Status(models.Model):
         ]
 
     def __str__(self):
-        return f"'{str(self.finding)}' on '{str(self.endpoint)}'"
+        return f"'{self.finding}' on '{self.endpoint}'"
 
     def copy(self, finding=None):
         copy = self

--- a/dojo/product/helpers.py
+++ b/dojo/product/helpers.py
@@ -54,5 +54,5 @@ def propagate_tags_on_product_sync(product):
 def propagate_tags_on_object_list(object_list):
     for obj in object_list:
         if obj and obj.id is not None:
-            logger.debug(f"\tPropagating tags to {str(type(obj))} - {str(obj)}")
+            logger.debug(f"\tPropagating tags to {type(obj)} - {obj}")
             obj.save()

--- a/dojo/reports/views.py
+++ b/dojo/reports/views.py
@@ -876,7 +876,7 @@ class CSVExportView(View):
                 num_endpoints = 0
                 for endpoint in finding.endpoints.all():
                     num_endpoints += 1
-                    endpoint_value += f"{str(endpoint)}; "
+                    endpoint_value += f"{endpoint}; "
                 endpoint_value = endpoint_value.removesuffix("; ")
                 if len(endpoint_value) > EXCEL_CHAR_LIMIT:
                     endpoint_value = endpoint_value[:EXCEL_CHAR_LIMIT - 3] + "..."
@@ -889,7 +889,7 @@ class CSVExportView(View):
                     if num_vulnerability_ids > 5:
                         vulnerability_ids_value += "..."
                         break
-                    vulnerability_ids_value += f"{str(vulnerability_id)}; "
+                    vulnerability_ids_value += f"{vulnerability_id}; "
                 if finding.cve and vulnerability_ids_value.find(finding.cve) < 0:
                     vulnerability_ids_value += finding.cve
                 vulnerability_ids_value = vulnerability_ids_value.removesuffix("; ")
@@ -902,7 +902,7 @@ class CSVExportView(View):
                     if num_tags > 5:
                         tags_value += "..."
                         break
-                    tags_value += f"{str(tag)}; "
+                    tags_value += f"{tag}; "
                 tags_value = tags_value.removesuffix("; ")
                 fields.append(tags_value)
 
@@ -1025,7 +1025,7 @@ class ExcelExportView(View):
                 num_endpoints = 0
                 for endpoint in finding.endpoints.all():
                     num_endpoints += 1
-                    endpoint_value += f"{str(endpoint)}; \n"
+                    endpoint_value += f"{endpoint}; \n"
                 endpoint_value = endpoint_value.removesuffix("; \n")
                 if len(endpoint_value) > EXCEL_CHAR_LIMIT:
                     endpoint_value = endpoint_value[:EXCEL_CHAR_LIMIT - 3] + "..."
@@ -1039,7 +1039,7 @@ class ExcelExportView(View):
                     if num_vulnerability_ids > 5:
                         vulnerability_ids_value += "..."
                         break
-                    vulnerability_ids_value += f"{str(vulnerability_id)}; \n"
+                    vulnerability_ids_value += f"{vulnerability_id}; \n"
                 if finding.cve and vulnerability_ids_value.find(finding.cve) < 0:
                     vulnerability_ids_value += finding.cve
                 vulnerability_ids_value = vulnerability_ids_value.removesuffix("; \n")
@@ -1048,7 +1048,7 @@ class ExcelExportView(View):
                 # tags
                 tags_value = ""
                 for tag in finding.tags.all():
-                    tags_value += f"{str(tag)}; \n"
+                    tags_value += f"{tag}; \n"
                 tags_value = tags_value.removesuffix("; \n")
                 worksheet.cell(row=row_num, column=col_num, value=tags_value)
                 col_num += 1

--- a/dojo/tools/api_bugcrowd/importer.py
+++ b/dojo/tools/api_bugcrowd/importer.py
@@ -16,7 +16,7 @@ class BugcrowdApiImporter:
     def get_findings(self, test):
         client, config = self.prepare_client(test)
         logger.debug(
-            f"Fetching submissions program {str(config.service_key_1)} and target {str(config.service_key_2)}",
+            f"Fetching submissions program {config.service_key_1} and target {config.service_key_2}",
         )
 
         submissions_paged = client.get_findings(

--- a/dojo/tools/api_bugcrowd/parser.py
+++ b/dojo/tools/api_bugcrowd/parser.py
@@ -155,7 +155,7 @@ class ApiBugcrowdParser:
                         finding.unsaved_endpoints = [bug_endpoint]
                     except Exception as e:
                         logger.error(
-                            f"{str(bug_endpoint)} bug url from bugcrowd failed to parse to endpoint, error= {e}",
+                            f"{bug_endpoint} bug url from bugcrowd failed to parse to endpoint, error= {e}",
                         )
                 except ValidationError:
                     logger.error(

--- a/dojo/tools/blackduck/parser.py
+++ b/dojo/tools/blackduck/parser.py
@@ -89,10 +89,10 @@ class BlackduckParser:
         return f"{i.vuln_id} - {component_title}"
 
     def format_description(self, i):
-        description = f"Published on: {str(i.published_date)}\n\n"
-        description += f"Updated on: {str(i.updated_date)}\n\n"
-        description += f"Base score: {str(i.base_score)}\n\n"
-        description += f"Exploitability: {str(i.exploitability)}\n\n"
+        description = f"Published on: {i.published_date}\n\n"
+        description += f"Updated on: {i.updated_date}\n\n"
+        description += f"Base score: {i.base_score}\n\n"
+        description += f"Exploitability: {i.exploitability}\n\n"
         description += f"Description: {i.description}\n"
 
         return description

--- a/dojo/tools/blackduck_binary_analysis/parser.py
+++ b/dojo/tools/blackduck_binary_analysis/parser.py
@@ -115,30 +115,30 @@ class BlackduckBinaryAnalysisParser:
         return title
 
     def format_description(self, i):
-        description = f"CSV Result: {str(i.report_name)}\n"
-        description += f"Vulnerable Component: {str(i.component)}\n"
-        description += f"Vulnerable Component Version in Use: {str(i.version)}\n"
-        description += f"Vulnerable Component Latest Version: {str(i.latest_version)}\n"
-        description += f"Matching Type: {str(i.matching_type)}\n"
-        description += f"Object Name: {str(i.object_name)}\n"
-        description += f"Object Extraction Path: {str(i.object_full_path)}\n"
-        description += f"Object Compilation Date: {str(i.object_compilation_date)}\n"
-        description += f"Object SHA1: {str(i.object_sha1)}\n"
-        description += f"CVE: {str(i.cve)}\n"
-        description += f"CVE Publication Date: {str(i.cve_publication_date)}\n"
-        description += f"Distribution Package: {str(i.distribution_package)}\n"
-        description += f"Missing Exploit Mitigations: {str(i.missing_exploit_mitigations)}\n"
-        description += f"BDSA: {str(i.bdsa)}\n"
-        description += f"Summary:\n{str(i.summary)}\n"
-        description += f"Note Type:\n{str(i.note_type)}\n"
-        description += f"Note Reason:\n{str(i.note_reason)}\n"
-        description += f"Triage Vectors:\n{str(i.triage_vectors)}\n"
-        description += f"Unresolving Triage Vectors:\n{str(i.triage_vectors)}\n"
+        description = f"CSV Result: {i.report_name}\n"
+        description += f"Vulnerable Component: {i.component}\n"
+        description += f"Vulnerable Component Version in Use: {i.version}\n"
+        description += f"Vulnerable Component Latest Version: {i.latest_version}\n"
+        description += f"Matching Type: {i.matching_type}\n"
+        description += f"Object Name: {i.object_name}\n"
+        description += f"Object Extraction Path: {i.object_full_path}\n"
+        description += f"Object Compilation Date: {i.object_compilation_date}\n"
+        description += f"Object SHA1: {i.object_sha1}\n"
+        description += f"CVE: {i.cve}\n"
+        description += f"CVE Publication Date: {i.cve_publication_date}\n"
+        description += f"Distribution Package: {i.distribution_package}\n"
+        description += f"Missing Exploit Mitigations: {i.missing_exploit_mitigations}\n"
+        description += f"BDSA: {i.bdsa}\n"
+        description += f"Summary:\n{i.summary}\n"
+        description += f"Note Type:\n{i.note_type}\n"
+        description += f"Note Reason:\n{i.note_reason}\n"
+        description += f"Triage Vectors:\n{i.triage_vectors}\n"
+        description += f"Unresolving Triage Vectors:\n{i.triage_vectors}\n"
 
         return description
 
     def format_mitigation(self, i):
-        return f"Upgrade {str(i.component)} to latest version: {str(i.latest_version)}.\n"
+        return f"Upgrade {i.component} to latest version: {i.latest_version}.\n"
 
     def format_impact(self, i):
         impact = "The use of vulnerable third-party open source software in applications can have numerous negative impacts:\n\n"
@@ -150,7 +150,7 @@ class BlackduckBinaryAnalysisParser:
         return impact
 
     def format_references(self, i):
-        references = f"BDSA: {str(i.bdsa)}\n"
-        references += f"NIST CVE Details: {str(i.vulnerability_url)}\n"
+        references = f"BDSA: {i.bdsa}\n"
+        references += f"NIST CVE Details: {i.vulnerability_url}\n"
 
         return references

--- a/dojo/tools/cyclonedx/xml_parser.py
+++ b/dojo/tools/cyclonedx/xml_parser.py
@@ -104,7 +104,7 @@ class CycloneDXXMLParser:
                 [
                     f"**Ref:** {ref}",
                     f"**Id:** {vuln_id}",
-                    f"**Severity:** {str(severity)}",
+                    f"**Severity:** {severity}",
                 ],
             )
         if component_name is None:

--- a/dojo/tools/gosec/parser.py
+++ b/dojo/tools/gosec/parser.py
@@ -34,7 +34,7 @@ class GosecParser:
 
             #           Finding details information
             findingdetail += f"Filename: {filename}\n\n"
-            findingdetail += f"Line number: {str(line)}\n\n"
+            findingdetail += f"Line number: {line}\n\n"
             findingdetail += f"Issue Confidence: {scanner_confidence}\n\n"
             findingdetail += "Code:\n\n"
             findingdetail += "```{}```".format(item["code"])

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -240,10 +240,10 @@ def get_codeFlowsDescription(codeFlows):
                 snippet = ""
 
                 if "startLine" in region:
-                    start_line = f":L{str(region.get('startLine'))}"
+                    start_line = f":L{region.get('startLine')}"
 
                 if "startColumn" in region:
-                    start_column = f":C{str(region.get('startColumn'))}"
+                    start_column = f":C{region.get('startColumn')}"
 
                 if "snippet" in region:
                     snippet = f"\t-\t{region.get('snippet').get('text')}"

--- a/dojo/tools/tenable/xml_format.py
+++ b/dojo/tools/tenable/xml_format.py
@@ -112,8 +112,8 @@ class TenableXMLParser:
                         item.find("plugin_output"),
                     )
                     if plugin_output_element_text is not None:
-                        plugin_output = f"Plugin Output: {ip}{str(f':{port}' if port is not None else '')}"
-                        plugin_output += f"\n```\n{str(plugin_output_element_text)}\n```\n\n"
+                        plugin_output = f"Plugin Output: {ip}{f':{port}' if port is not None else ''}"
+                        plugin_output += f"\n```\n{plugin_output_element_text}\n```\n\n"
                         description += plugin_output
 
                     # Determine the severity

--- a/dojo/tools/veracode/json_parser.py
+++ b/dojo/tools/veracode/json_parser.py
@@ -129,7 +129,7 @@ class VeracodeJSONParser:
                 if uncleaned_cvss.startswith(("CVSS:3.1/", "CVSS:3.0/")):
                     finding.cvssv3 = CVSS3(str(uncleaned_cvss)).clean_vector(output_prefix=True)
                 elif not uncleaned_cvss.startswith("CVSS"):
-                    finding.cvssv3 = CVSS3(f"CVSS:3.1/{str(uncleaned_cvss)}").clean_vector(output_prefix=True)
+                    finding.cvssv3 = CVSS3(f"CVSS:3.1/{uncleaned_cvss}").clean_vector(output_prefix=True)
             elif isinstance(uncleaned_cvss, float | int):
                 finding.cvssv3_score = float(uncleaned_cvss)
         # Fill in extra info based on the scan type
@@ -238,7 +238,7 @@ class VeracodeJSONParser:
             # See if the CVSS has already been set. If not, use the one here
             if not finding.cvssv3:
                 if cvss_vector := cve_dict.get("cvss3", {}).get("vector"):
-                    finding.cvssv3 = CVSS3(f"CVSS:3.1/{str(cvss_vector)}").clean_vector(output_prefix=True)
+                    finding.cvssv3 = CVSS3(f"CVSS:3.1/{cvss_vector}").clean_vector(output_prefix=True)
         # Put the product ID in the metadata
         if product_id := finding_details.get("product_id"):
             finding.description += f"**Product ID**: {product_id}\n"

--- a/dojo/user/views.py
+++ b/dojo/user/views.py
@@ -647,7 +647,7 @@ class DojoPasswordResetForm(PasswordResetForm):
                 connection.open()
                 connection.close()
         except Exception as e:
-            logger.error(f"SMTP Server Connection Failure: {str(e)}")
+            logger.error(f"SMTP Server Connection Failure: {e}")
             msg = "SMTP server is not configured correctly..."
             raise ValidationError(msg)
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -93,7 +93,6 @@ ignore = [
     "SIM115",
     "SIM116",
     "SIM117",
-    "RUF010",
     "RUF012",
     "RUF015",
     "RUF027",

--- a/tests/base_test_class.py
+++ b/tests/base_test_class.py
@@ -338,7 +338,7 @@ class BaseTestCase(unittest.TestCase):
     def set_block_execution(self, block_execution=True):
         # we set the admin user (ourselves) to have block_execution checked
         # this will force dedupe to happen synchronously, among other things like notifications, rules, ...
-        logger.info(f"setting block execution to: {str(block_execution)}")
+        logger.info(f"setting block execution to: {block_execution}")
         driver = self.driver
         driver.get(self.base_url + "profile")
         if (

--- a/unittests/test_deduplication_logic.py
+++ b/unittests/test_deduplication_logic.py
@@ -1158,12 +1158,12 @@ class TestDuplicationLogic(DojoTestCase):
         else:
             logger.debug("\t\t" + "findings:")
             for finding in findings:
-                logger.debug(f"\t\t\t{str(finding.id):4.4}" + ': "' + f"{finding.title:20.20}" + '": ' + f"{finding.severity:5.5}" + ": act: " + f"{str(finding.active):5.5}"
-                        + ": ver: " + f"{str(finding.verified):5.5}" + ": mit: " + f"{str(finding.is_mitigated):5.5}"
-                        + ": dup: " + f"{str(finding.duplicate):5.5}" + ": dup_id: "
-                        + (f"{str(finding.duplicate_finding.id):4.4}" if finding.duplicate_finding else "None") + ": hash_code: " + str(finding.hash_code)
+                logger.debug(f"\t\t\t{finding.id!s:4.4}" + ': "' + f"{finding.title:20.20}" + '": ' + f"{finding.severity:5.5}" + ": act: " + f"{finding.active!s:5.5}"
+                        + ": ver: " + f"{finding.verified!s:5.5}" + ": mit: " + f"{finding.is_mitigated!s:5.5}"
+                        + ": dup: " + f"{finding.duplicate!s:5.5}" + ": dup_id: "
+                        + (f"{finding.duplicate_finding.id!s:4.4}" if finding.duplicate_finding else "None") + ": hash_code: " + str(finding.hash_code)
                         + ": eps: " + str(finding.endpoints.count()) + ": notes: " + str([n.id for n in finding.notes.all()])
-                        + ": uid: " + f"{str(finding.unique_id_from_tool):5.5}" + (" fp" if finding.false_p else ""),
+                        + ": uid: " + f"{finding.unique_id_from_tool!s:5.5}" + (" fp" if finding.false_p else ""),
                         )
 
         logger.debug("\t\tendpoints")

--- a/unittests/test_false_positive_history_logic.py
+++ b/unittests/test_false_positive_history_logic.py
@@ -1678,12 +1678,12 @@ class TestFalsePositiveHistoryLogic(DojoTestCase):
         else:
             logger.debug("\t\t" + "findings:")
             for finding in findings:
-                logger.debug(f"\t\t\t{str(finding.id):4.4}" + ': "' + f"{finding.title:20.20}" + '": ' + f"{finding.severity:5.5}" + ": act: " + f"{str(finding.active):5.5}"
-                        + ": ver: " + f"{str(finding.verified):5.5}" + ": mit: " + f"{str(finding.is_mitigated):5.5}"
-                        + ": dup: " + f"{str(finding.duplicate):5.5}" + ": dup_id: "
-                        + (f"{str(finding.duplicate_finding.id):4.4}" if finding.duplicate_finding else "None") + ": hash_code: " + str(finding.hash_code)
+                logger.debug(f"\t\t\t{finding.id!s:4.4}" + ': "' + f"{finding.title:20.20}" + '": ' + f"{finding.severity:5.5}" + ": act: " + f"{finding.active!s:5.5}"
+                        + ": ver: " + f"{finding.verified!s:5.5}" + ": mit: " + f"{finding.is_mitigated!s:5.5}"
+                        + ": dup: " + f"{finding.duplicate!s:5.5}" + ": dup_id: "
+                        + (f"{finding.duplicate_finding.id!s:4.4}" if finding.duplicate_finding else "None") + ": hash_code: " + str(finding.hash_code)
                         + ": eps: " + str(finding.endpoints.count()) + ": notes: " + str([n.id for n in finding.notes.all()])
-                        + ": uid: " + f"{str(finding.unique_id_from_tool):5.5}" + (" fp" if finding.false_p else ""),
+                        + ": uid: " + f"{finding.unique_id_from_tool!s:5.5}" + (" fp" if finding.false_p else ""),
                         )
 
         logger.debug("\t\tendpoints")

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1119,7 +1119,7 @@ class FilesTest(DojoAPITestCase):
         # Test the creation
         for level in self.url_levels:
             length = FileUpload.objects.count()
-            with open(f"{str(self.path)}/scans/acunetix/one_finding.xml", encoding="utf-8") as testfile:
+            with open(f"{self.path}/scans/acunetix/one_finding.xml", encoding="utf-8") as testfile:
                 payload = {
                     "title": level,
                     "file": testfile,
@@ -1131,7 +1131,7 @@ class FilesTest(DojoAPITestCase):
                 self.url_levels[level] = response.data.get("id")
 
         #  Test the download
-        file_data = Path(f"{str(self.path)}/scans/acunetix/one_finding.xml").read_text(encoding="utf-8")
+        file_data = Path(f"{self.path}/scans/acunetix/one_finding.xml").read_text(encoding="utf-8")
         for level, file_id in self.url_levels.items():
             response = self.client.get(f"/api/v2/{level}/files/download/{file_id}/")
             self.assertEqual(200, response.status_code)


### PR DESCRIPTION
Remove "RUF010" from ignored and fix it.
https://docs.astral.sh/ruff/rules/explicit-f-string-type-conversion/

I see no reason to use `str(...)` in combination with `f"{...}`.

Ruff recommended `f{...!s}` but I believe this is easier and sufficient.