### PR TITLE
fix(helm): Unpin old HELM version

### DIFF
--- a/.github/workflows/release-x-manual-helm-chart.yml
+++ b/.github/workflows/release-x-manual-helm-chart.yml
@@ -46,10 +46,8 @@ jobs:
           git config --global user.name "${{ env.GIT_USERNAME }}"
           git config --global user.email "${{ env.GIT_EMAIL }}"
       
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.4.0
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
       
       - name: Configure HELM repos
         run: |-


### PR DESCRIPTION
The previous implementation used an old version of `helm`, which was pinned in `.github/workflows/release-x-manual-helm-chart.yml`. Renovate and Dependable ignored these values.

Version `v3.4.0` did not support `oci` protocol for pulling charts (support was added in `v3.5` as an experiment and from `v.3.8` by default; source: https://helm.sh/docs/topics/registries/). The current latest version is [`v3.16.3`
](https://github.com/helm/helm/releases/)

The issue has not been noticed because:
- dependency repo (psql) did not use `oci` as default
- linter and release used different method for setup `helm`

This change removes pinning in the "release" step. It uses exactly the same method as the `helm` linter https://github.com/DefectDojo/django-DefectDojo/blob/fc603485650db2e4b9ce532bacda5cfad4ec352b/.github/workflows/test-helm-chart.yml#L22-L23

Context: https://owasp.slack.com/archives/C2P5BA8MN/p1733236658398939

Failing step: https://github.com/DefectDojo/django-DefectDojo/actions/runs/12125529029/job/33855921016