### PR TITLE
Update JIRA for Finding Group When Risk Acceptance Expires

### DIFF
--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1438,25 +1438,7 @@ def reopen_finding(request, fid):
         status.save()
     # Clear the risk acceptance, if present
     ra_helper.risk_unaccept(request.user, finding)
-
-    # Manage the jira status changes
-    push_to_jira = False
-    # Determine if the finding is in a group. if so, not push to jira
-    finding_in_group = finding.has_finding_group
-    # Check if there is a jira issue that needs to be updated
-    jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
-    # Only push if the finding is not in a group
-    if jira_issue_exists:
-        # Determine if any automatic sync should occur
-        push_to_jira = jira_helper.is_push_all_issues(finding) \
-            or jira_helper.get_jira_instance(finding).finding_jira_sync
-    # Save the finding
-    finding.save(push_to_jira=(push_to_jira and not finding_in_group))
-
-    # we only push the group after saving the finding to make sure
-    # the updated data of the finding is pushed as part of the group
-    if push_to_jira and finding_in_group:
-        jira_helper.push_to_jira(finding.finding_group)
+    ra_helper.update_risk_acceptance_jira(finding)
 
     reopen_external_issue(finding, "re-opened by defectdojo", "github")
 

--- a/dojo/finding/views.py
+++ b/dojo/finding/views.py
@@ -1438,7 +1438,7 @@ def reopen_finding(request, fid):
         status.save()
     # Clear the risk acceptance, if present
     ra_helper.risk_unaccept(request.user, finding)
-    ra_helper.update_risk_acceptance_jira(finding)
+    jira_helper.save_and_push_to_jira(finding)
 
     reopen_external_issue(finding, "re-opened by defectdojo", "github")
 

--- a/dojo/fixtures/dojo_testdata.json
+++ b/dojo/fixtures/dojo_testdata.json
@@ -2158,8 +2158,8 @@
     "fields": {
       "configuration_name": "Happy little JIRA 2",
       "url": "https://defectdojo.atlassian.net/",
-      "username": "YOUR USERNAME",
-      "password": "YOU API TOKEN",
+      "username": "[YOUR USERNAME]",
+      "password": "[YOUR API TOKEN]",
       "default_issue_type": "Task",
       "epic_name_id": 10011,
       "open_status_key": 11,
@@ -2253,7 +2253,7 @@
       "component": "",
       "enable_engagement_epic_mapping": true,
       "jira_instance": 2,
-      "project_key": "key1"
+      "project_key": "NTEST"
     }
   },
   {

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -785,7 +785,7 @@ def add_jira_issue(obj, *args, **kwargs):
         JIRAError.log_to_tempfile = False
         jira = get_jira_connection(jira_instance)
     except Exception as e:
-        message = f"The following jira instance could not be connected: {jira_instance} - {e.text}"
+        message = f"The following jira instance could not be connected: {jira_instance} - {e}"
         return failure_to_add_message(message, e, obj)
     # Set the list of labels to set on the jira issue
     labels = get_labels(obj) + get_tags(obj)
@@ -793,6 +793,7 @@ def add_jira_issue(obj, *args, **kwargs):
         labels = list(dict.fromkeys(labels))  # de-dup
     # Determine what due date to set on the jira issue
     duedate = None
+
     if System_Settings.objects.get().enable_finding_sla:
         duedate = obj.sla_deadline()
     # Set the fields that will compose the jira issue
@@ -1104,6 +1105,7 @@ def get_issuetype_fields(
 
     issuetype_fields = None
     use_cloud_api = jira.deploymentType.lower() == "cloud" or jira._version < (9, 0, 0)
+
     try:
         if use_cloud_api:
             try:

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1706,3 +1706,24 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
     if status_changed:
         finding.save()
     return status_changed
+
+
+def save_and_push_to_jira(finding):
+    # Manage the jira status changes
+    push_to_jira = False
+    # Determine if the finding is in a group. if so, not push to jira yet
+    finding_in_group = finding.has_finding_group
+    # Check if there is a jira issue that needs to be updated
+    jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
+    # Only push if the finding is not in a group
+    if jira_issue_exists:
+        # Determine if any automatic sync should occur
+        push_to_jira = is_push_all_issues(finding) \
+            or get_jira_instance(finding).finding_jira_sync
+    # Save the finding
+    finding.save(push_to_jira=(push_to_jira and not finding_in_group))
+
+    # we only push the group after saving the finding to make sure
+    # the updated data of the finding is pushed as part of the group
+    if push_to_jira and finding_in_group:
+        push_to_jira(finding.finding_group)

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -26,11 +26,13 @@ def expire_now(risk_acceptance):
                 logger.debug("%i:%s: unaccepting/reactivating finding.", finding.id, finding)
 
                 # Update any endpoint statuses on each of the findings
-                # update_endpoint_statuses(finding, accept_risk=False)
+                update_endpoint_statuses(finding, accept_risk=False)
+                risk_unaccept(None, finding, post_comments=False)  # comments will be posted at end
 
                 if risk_acceptance.restart_sla_expired:
                     finding.sla_start_date = timezone.now().date()
-                risk_unaccept(None, finding, post_comments=False)  # comments will be posted at end
+                    finding.save(dedupe_option=False)  # resave if changed after risk_unaccept
+
                 reactivated_findings.append(finding)
             else:
                 logger.debug("%i:%s already active, no changes made.", finding.id, finding)

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -22,23 +22,15 @@ def expire_now(risk_acceptance):
     reactivated_findings = []
     if risk_acceptance.reactivate_expired:
         for finding in risk_acceptance.accepted_findings.all():
-            if not finding.active:
-                logger.debug("%i:%s: unaccepting a.k.a reactivating finding.", finding.id, finding)
-                finding.active = True
-                finding.risk_accepted = False
-                # Update any endpoint statuses on each of the findings
-                update_endpoint_statuses(finding, accept_risk=False)
-
+            if not finding.active: # not sure why this is important
+                logger.debug("%i:%s: unaccepting/reactivating finding.", finding.id, finding)
                 if risk_acceptance.restart_sla_expired:
                     finding.sla_start_date = timezone.now().date()
-
-                finding.save(dedupe_option=False)
+                risk_unaccept(None, finding, post_comments=False) #comments will be posted at end
                 reactivated_findings.append(finding)
-                # findings remain in this risk acceptance for reporting / metrics purposes
             else:
                 logger.debug("%i:%s already active, no changes made.", finding.id, finding)
 
-        # best effort JIRA integration, no status changes
         post_jira_comments(risk_acceptance, risk_acceptance.accepted_findings.all(), expiration_message_creator)
 
     risk_acceptance.expiration_date = timezone.now()
@@ -189,7 +181,7 @@ def expiration_handler(*args, **kwargs):
                                 product=risk_acceptance.engagement.product,
                                 url=reverse("view_risk_acceptance", args=(risk_acceptance.engagement.id, risk_acceptance.id)))
 
-            post_jira_comments(risk_acceptance, expiration_warning_message_creator, heads_up_days)
+            post_jira_comments(risk_acceptance, risk_acceptance.accepted_findings.all(), expiration_warning_message_creator, heads_up_days)
 
             risk_acceptance.expiration_date_warned = timezone.now()
             risk_acceptance.save()
@@ -243,20 +235,22 @@ def unaccepted_message_creator(risk_acceptance, heads_up_days=0):
 
 
 def post_jira_comment(finding, message_factory, heads_up_days=0):
-    if not finding or not finding.has_jira_issue:
+    if not finding or (not finding.has_jira_issue and not finding.has_jira_group_issue):
         return
-
     jira_project = jira_helper.get_jira_project(finding)
 
     if jira_project and jira_project.risk_acceptance_expiration_notification:
         jira_instance = jira_helper.get_jira_instance(finding)
-
         if jira_instance:
 
             jira_comment = message_factory(None, heads_up_days)
 
-            logger.debug("Creating JIRA comment for something risk acceptance related")
-            jira_helper.add_simple_jira_comment(jira_instance, finding.jira_issue, jira_comment)
+            jira_issue = None
+            if finding.has_jira_issue:
+                jira_issue = finding.jira_issue
+            elif finding.has_jira_group_issue:
+                jira_issue = finding.finding_group.jira_issue
+            jira_helper.add_simple_jira_comment(jira_instance, jira_issue, jira_comment)
 
 
 def post_jira_comments(risk_acceptance, findings, message_factory, heads_up_days=0):
@@ -270,11 +264,15 @@ def post_jira_comments(risk_acceptance, findings, message_factory, heads_up_days
 
         if jira_instance:
             jira_comment = message_factory(risk_acceptance, heads_up_days)
-
             for finding in findings:
+                jira_issue = None
                 if finding.has_jira_issue:
-                    logger.debug("Creating JIRA comment for something risk acceptance related")
-                    jira_helper.add_simple_jira_comment(jira_instance, finding.jira_issue, jira_comment)
+                    jira_issue = finding.jira_issue
+                elif finding.has_jira_group_issue:
+                    jira_issue = finding.finding_group.jira_issue
+
+                if jira_issue:
+                    jira_helper.add_simple_jira_comment(jira_instance, jira_issue, jira_comment)
 
 
 def get_expired_risk_acceptances_to_handle():
@@ -319,7 +317,7 @@ def simple_risk_accept(user: Dojo_User, finding: Finding, perform_save=True) -> 
         ))
 
 
-def risk_unaccept(user: Dojo_User, finding: Finding, perform_save=True) -> None:
+def risk_unaccept(user: Dojo_User, finding: Finding, perform_save=True, post_comments=True) -> None:
     logger.debug("unaccepting finding %i:%s if it is currently risk accepted", finding.id, finding)
     if finding.risk_accepted:
         logger.debug("unaccepting finding %i:%s", finding.id, finding)
@@ -336,7 +334,12 @@ def risk_unaccept(user: Dojo_User, finding: Finding, perform_save=True) -> None:
 
         # post_jira_comment might reload from database so see unaccepted finding. but the comment
         # only contains some text so that's ok
-        post_jira_comment(finding, unaccepted_message_creator)
+        if post_comments:
+            post_jira_comment(finding, unaccepted_message_creator)
+
+        # Update the JIRA obect for this finding
+        update_risk_acceptance_jira(finding)
+
         # Add a note to reflect that the finding was removed from the risk acceptance
         if user is not None:
             finding.notes.add(Notes.objects.create(
@@ -362,3 +365,24 @@ def update_endpoint_statuses(finding: Finding, *, accept_risk: bool) -> None:
             status.risk_accepted = False
         status.last_modified = timezone.now()
         status.save()
+
+
+def update_risk_acceptance_jira(finding):
+    # Manage the jira status changes
+    push_to_jira = False
+    # Determine if the finding is in a group. if so, not push to jira yet
+    finding_in_group = finding.has_finding_group
+    # Check if there is a jira issue that needs to be updated
+    jira_issue_exists = finding.has_jira_issue or (finding.finding_group and finding.finding_group.has_jira_issue)
+    # Only push if the finding is not in a group
+    if jira_issue_exists:
+        # Determine if any automatic sync should occur
+        push_to_jira = jira_helper.is_push_all_issues(finding) \
+            or jira_helper.get_jira_instance(finding).finding_jira_sync
+    # Save the finding
+    finding.save(push_to_jira=(push_to_jira and not finding_in_group))
+
+    # we only push the group after saving the finding to make sure
+    # the updated data of the finding is pushed as part of the group
+    if push_to_jira and finding_in_group:
+        jira_helper.push_to_jira(finding.finding_group)

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -22,11 +22,11 @@ def expire_now(risk_acceptance):
     reactivated_findings = []
     if risk_acceptance.reactivate_expired:
         for finding in risk_acceptance.accepted_findings.all():
-            if not finding.active: # not sure why this is important
+            if not finding.active:  # not sure why this is important
                 logger.debug("%i:%s: unaccepting/reactivating finding.", finding.id, finding)
                 if risk_acceptance.restart_sla_expired:
                     finding.sla_start_date = timezone.now().date()
-                risk_unaccept(None, finding, post_comments=False) #comments will be posted at end
+                risk_unaccept(None, finding, post_comments=False)  # comments will be posted at end
                 reactivated_findings.append(finding)
             else:
                 logger.debug("%i:%s already active, no changes made.", finding.id, finding)

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -24,6 +24,10 @@ def expire_now(risk_acceptance):
         for finding in risk_acceptance.accepted_findings.all():
             if not finding.active:  # not sure why this is important
                 logger.debug("%i:%s: unaccepting/reactivating finding.", finding.id, finding)
+
+                # Update any endpoint statuses on each of the findings
+                update_endpoint_statuses(finding, accept_risk=False)
+
                 if risk_acceptance.restart_sla_expired:
                     finding.sla_start_date = timezone.now().date()
                 risk_unaccept(None, finding, post_comments=False)  # comments will be posted at end

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -26,7 +26,7 @@ def expire_now(risk_acceptance):
                 logger.debug("%i:%s: unaccepting/reactivating finding.", finding.id, finding)
 
                 # Update any endpoint statuses on each of the findings
-                update_endpoint_statuses(finding, accept_risk=False)
+                # update_endpoint_statuses(finding, accept_risk=False)
 
                 if risk_acceptance.restart_sla_expired:
                     finding.sla_start_date = timezone.now().date()

--- a/unittests/test_jira_import_and_pushing_api.py
+++ b/unittests/test_jira_import_and_pushing_api.py
@@ -2,12 +2,14 @@
 import logging
 
 from crum import impersonate
+from django.urls import reverse
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 from vcr import VCR
 
+import dojo.risk_acceptance.helper as ra_helper
 from dojo.jira_link import helper as jira_helper
-from dojo.models import Finding, Finding_Group, JIRA_Instance, User
+from dojo.models import Finding, Finding_Group, JIRA_Instance, Risk_Acceptance, User
 
 from .dojo_test_case import DojoVCRAPITestCase, get_unit_tests_path, toggle_system_setting_boolean
 
@@ -68,6 +70,7 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         self.scans_path = "/scans/"
         self.zap_sample5_filename = self.scans_path + "zap/5_zap_sample_one.xml"
         self.npm_groups_sample_filename = self.scans_path + "npm_audit/many_vuln_with_groups.json"
+        self.client.force_login(self.get_test_admin())
 
     def test_import_no_push_to_jira(self):
         import0 = self.import_scan_with_params(self.zap_sample5_filename, verified=True)
@@ -280,6 +283,65 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
         # duplicates shouldn't be sent to JIRA
         self.assert_jira_issue_count_in_test(test_id1, 0)
         self.assert_jira_group_issue_count_in_test(test_id, 0)
+
+    def add_risk_acceptance(self, eid, data_risk_accceptance, fid=None):
+        args = (eid, fid) if fid else (eid,)
+        response = self.client.post(reverse("add_risk_acceptance", args=args), data_risk_accceptance)
+        self.assertEqual(302, response.status_code, response.content[:1000])
+        return response
+
+    def test_import_grouped_reopen_expired_sla(self):
+        # steps
+        # import scan, make sure they are in grouped JIRA
+        # risk acceptance all the grouped findings, make sure they are closed in JIRA
+        # expire risk acceptance on all grouped findings, make sure they are open in JIRA
+        import0 = self.import_scan_with_params(self.npm_groups_sample_filename, scan_type="NPM Audit Scan", group_by="component_name+component_version", push_to_jira=True, verified=True)
+        test_id = import0["test"]
+        self.assert_jira_issue_count_in_test(test_id, 0)
+        self.assert_jira_group_issue_count_in_test(test_id, 3)
+        findings = self.get_test_findings_api(test_id)
+        finding_id = findings["results"][0]["id"]
+
+        ra_data = {
+            "name": "Accept: Unit test",
+            "accepted_findings": [],
+            "recommendation": "A",
+            "recommendation_details": "recommendation 1",
+            "decision": "A",
+            "decision_details": "it has been decided!",
+            "accepted_by": "pointy haired boss",
+            "owner": 1,
+            "expiration_date": "2024-12-31",
+            "reactivate_expired": True,
+            }
+
+        for finding in findings["results"]:
+            ra_data["accepted_findings"].append(finding["id"])
+
+        pre_jira_status = self.get_jira_issue_status(finding_id)
+
+        response = self.add_risk_acceptance(1, data_risk_accceptance=ra_data)
+        self.assertEqual("/engagement/1", response.url)
+
+        # We do this to update the JIRA
+        for finding in ra_data["accepted_findings"]:
+            self.patch_finding_api(finding, {"push_to_jira": True})
+
+        post_jira_status = self.get_jira_issue_status(finding_id)
+        self.assertNotEqual(pre_jira_status, post_jira_status)
+
+        pre_jira_status = post_jira_status
+        ra = Risk_Acceptance.objects.last()
+        ra_helper.expire_now(ra)
+        # We do this to update the JIRA
+        for finding in ra_data["accepted_findings"]:
+            self.patch_finding_api(finding, {"push_to_jira": True})
+
+        post_jira_status = self.get_jira_issue_status(finding_id)
+        self.assertNotEqual(pre_jira_status, post_jira_status)
+
+        # by asserting full cassette is played we know all calls to JIRA have been made as expected
+        self.assert_cassette_played()
 
     def test_import_with_groups_twice_push_to_jira(self):
         import0 = self.import_scan_with_params(self.npm_groups_sample_filename, scan_type="NPM Audit Scan", group_by="component_name+component_version", push_to_jira=True, verified=True)
@@ -662,3 +724,4 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
     def assert_epic_issue_count(self, engagement, count):
         jira_issues = self.get_epic_issues(engagement)
         self.assertEqual(count, len(jira_issues))
+

--- a/unittests/test_jira_import_and_pushing_api.py
+++ b/unittests/test_jira_import_and_pushing_api.py
@@ -724,4 +724,3 @@ class JIRAImportAndPushTestApi(DojoVCRAPITestCase):
     def assert_epic_issue_count(self, engagement, count):
         jira_issues = self.get_epic_issues(engagement)
         self.assertEqual(count, len(jira_issues))
-

--- a/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_grouped_reopen_expired_sla.yaml
+++ b/unittests/vcr/jira/JIRAImportAndPushTestApi.test_import_grouped_reopen_expired_sla.yaml
@@ -1,0 +1,7455 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0te3bqbtN26vMkEp+gU2r0oImlyi9U0KU06GGP/3QQH26P6drnn
+        O/cc7oHUwuF20ISTD+97x2czhQ1Kr+ynTYTXwrlWmMSgJxOiWtdrsf8HX+KwayUqdF9r1P0Kjcfh
+        r0dW1jR6RCPxd84dDq61JsAUgCaQwLTcXD+X66fqrG7Grg4T4a8RmsAE3kIm9truu9Cy2vcxbaXt
+        qIKpHlutfiyEBwNbLE7LG+EjyIBlU8qmdFlRxlPKaZoAwBUEOPhd+AMOVdtdsilUtOA0C3iSL86s
+        7O5MYwMIWQ5ZyuYiresiL5Y0X1KVs1RKVqCaU4GNENm8vgjwOibct4OILwz6qP2DlSKuD0SfJoLm
+        fVuS42WxF2uicvtYkeM3AAAA//8DAIJe/usgAgAA
+    headers:
+      Atl-Request-Id:
+      - cd2d7f48-ee2c-4df1-807a-3163dc0e224b
+      Atl-Traceid:
+      - cd2d7f48ee2c4df1807a3163dc0e224b
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:31 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=214,atl-edge-internal;dur=37,atl-edge-upstream;dur=176,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - d50a969d2e184c047378565e1391d27c
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 92e4fee3-8af8-4343-85a2-906308cde605
+      Atl-Traceid:
+      - 92e4fee38af8434385a2906308cde605
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:32 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=312,atl-edge-internal;dur=17,atl-edge-upstream;dur=292,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 4e0b52fac382010988109639367a2804
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
+      group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/358]
+      in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+      | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+      | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/233]
+      | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+      | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+      0.6.0)|http://localhost:8080/finding/233]\n*Defect Dojo link:* http://localhost:8080/finding/233
+      (233)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
+      Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]\n*Defect
+      Dojo link:* http://localhost:8080/finding/232 (232)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3361'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue
+  response:
+    body:
+      string: '{"id":"15997","key":"NTEST-1585","self":"https://defectdojo.atlassian.net/rest/api/2/issue/15997"}'
+    headers:
+      Atl-Request-Id:
+      - df4ed9e1-993f-4c3c-b656-46250a07daec
+      Atl-Traceid:
+      - df4ed9e1993f4c3cb65646250a07daec
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:32 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=677,atl-edge-internal;dur=22,atl-edge-upstream;dur=659,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 03d5482c097ff2a04fe6e3893b2eb52a
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1585
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSY7MmU7HdZTEreu6spI8OB4PTK5IxCTAAKCO2v7v3eUh
+        xYcytTuN/UBce2D32w+rGwdWJZeJEzkaZAIakrcC8sT0JC/A9EycQcF7qgTNrVDS9CARtgDLe3HG
+        ZQq5SnsL0Ab3IJlCqcGAtO3ZuDJWFXNSeBn4fuC7Gr5WYOxsXcKp5rEVMTg9R5D9YLS//xonBvI5
+        TjNrSxN5XgJziG2iviiX25wbI7h0JVgPLVmPl8ILPWFMBV6n4BrWKH8ym5zN+sFoPMKl2gXjRDeO
+        Qd8qE3MLqdLr5g4JzlAi9MNhPwj7A38WjKNgGA1CdxwEP6HfPjlJRiw6Xqt5oZMk76E+P9xcu50k
+        YGItSgocrh4wU/A877FEGCtkbFkpIAam5myp9LVL0rGSH3T+TC8qKShdPL/kC2659hYCll7t1tbB
+        divwB8H4FyP+hp8LTHtVoFWCBZqccXNNuaquLI2iOc8N9JxG8AjvVcv2nEwgcHScrY9hAeirf9dz
+        rEBklYgSJ5IV3tF5AJOB322UWn3BG70w4K10He46gV24afINSLa3+iCFtajAOBvbhNTf67NGze2S
+        a8KrEUWZC3Q4eXBzzEeNsuF4NRw/093vZKa7ySYvQ5+AHg5X4fD/tdJkv8YiGgz2VsHejzC46iwO
+        wtUg/BEWW4Df3T2GY7ALp2G3MRerjw0HYvbPLx6fHHQneZpqSJFvHhUBXkDlVVP+T5sb7drY27Xx
+        esdGuHNjvGtj/7GfDW02q0RK9QvhRP0Ap9ziw9EQ7vMLt6HzLYF7jTpNZVkPD1VFgQuIlD/RgpCp
+        E1ldwV3L06RNi7gJ582jNfIMj5pMVXnyRpgy5+u2lHEZ3bIfETNU3m00NOBliT+eeiSG+2H3SDwM
+        24bKHm7sAlW4AVWphdLCrl8YxE7cq1+af/9WiIKnYDySMJ0SgQuZSDPXLNItW77HlY5WQ+dx4YQb
+        1Of8CogYnygN4pMnAxHswmgwpohk3ExKER8Lef2Wdt5ASf2LjLs81tld1nubFankBNsXfpXDFLhp
+        sKHbkXN6/OHd0cnl8dHh5ORscjmZTv+c4v2wTg2GBA/MMmCn+AJIy8guE4Ypma8ZsonISSmziv0m
+        NGenGgqkE1YZRK37FKsEWFCOfyt8v0wGkdO8ipg9DP+2qu6xBSYiFZLnDw+13Vcb3hrpOXrXzimz
+        qYTN6aqkst2F5NGe3yG5aZReCL5GePPy3u9tnofHLd5+5fE1tpsd5Drlja3DtqP7Tw53bWFTM2gk
+        7BoFCUuqbpUrfdJ4c5VX0E818sa2KVLsjWqSrYoSG2Jpnwb9aBctjDa08L2M3w/nZ/nt/wFLtapK
+        ahTfCpkgMRqGtcKuACQrK5NBUqP0aHpA3ytgQi7IAMEsYfhTgOFrBklEyrLQZe9I3Wf5qv6+itj5
+        Rq2QEZMYLyu4VTry3ZE7uKWgY8xzFfM8U8ZGY3/se/NG5rL2zRuMxhcozc7PIK6Io9h7texbtUMY
+        H+2kwkc7vGAeOw+MZX9VXFvQbCJTrMwC47xDFDYHvKCWPjn9gx1UyAHsLOZyhxS1gN6+f9FE9PaW
+        nWHzWvuJ48OPk/rzqfl0iaZJ2wPQcCYs0gGJ1sDCESpixJjslp2jjn6IFNDHLjkMai8IqHKRuBL7
+        fTdVC29R5RKha5FavPvnL0jFwPc3cvES3EJYDa7SqYf1zQnzAptZ4gUPj7qZLXKS2+YLJ3XGSFmI
+        f1NIq5xjTP8BAAD//+xZbW/aMBD+K9akVoBICkkIharqqFjVTms1rdo+dF8wsYFsIYkSoPuwH7/n
+        HCe8lJSOqlUnTa2A2D77fL57zvfkF9Vwah99Gfo8IFe6lckCpRozWOWmmKHODoPZySmmcc1GtcSW
+        +uSPLNum9XtIvwtZJ1Op+zPbZhcX+2zZnSfbRY9XdnGebhdnp11e3CZWmU0QcLnTdWvKPtTGav25
+        ZH1EKho/AsWY1akzAHmLraNA/jdpmgUMqGfbfLXTxhb6CnkBij8iRjkJWu+UYxV8VLft/9Hdsxoi
+        Eu3f8WXsFRxYEv6kpnheeK4fQe02micw5oUfSMCnzAx+OJ6dcM+T8Uz9XLrfimB/CfM1wHGhRgT8
+        18Bp+tERFws/RaqQlG/byAAjMjrcKL8Y0JEOlisMGK4wjPRHaa4vLYl2B60duYMo3CHV7sBnM2Tg
+        tM7uJ743YbhLj8cA4TkAkMUca4VjxhmKGg+CuBZ5CR+RHoOe2qjxiYfjOeB4wCaSC0guOHKome2W
+        fVsqdA28D+Rqclnvz2ut7qpLYshnVSaIvB/d47y7uT4DRk4gjkY4uQr37u6DIczv0gf5Fx5pWylm
+        iefDwPf0oV37KpXqM/uqbltkYX0YmTIMMBOgI9Gbh9zVNObejGRuIuarB4bEt/CFFGvu9AUxhSso
+        lv4bp9CicUR5k3y8wsXUD6usUv09hQ/Pom7ht1tB48UBw9oTMCwCDOuZgLFX1ngAGPvmrdXzfW3A
+        cP8DxisAhvNvAYZbiO4AjIeMR6so+jcL3rKap+mUdRSEFxVDswS+pHgeYm42hjoFPbXR0SgjzRpl
+        vEOj4B1y85QNLOPKGoUyKgAmVH7oYny1nt+s6tL5dMqpgH33aIVFJic2Kkr2LHWJkziDxxKHdiVO
+        200AYuPA7kn32B26DjcaI6ttOCPeMjqddsMQ7kjI9mjoSJvK4kISy2ay3SdKSvKbnhAUNaQzT6JA
+        vF9RGVUzLfAok64ORZoovNUwksnZXHtkC2soBXfbx1zavCNG3Okce0Pudjyn2TwTp2oW7PXAusB/
+        JmdMeaiLRMPImlJznhr3MJlhmVR9mlnEkk2NmPOUTAp5lRN4kOLn5bnhmHFI5MQmK//2Nd6k9d++
+        xpuvBd66xkAskbHMmj26VM7PzgMe/pRhOvFjFVpUCGZEdgZ6d1FIoz/MkyiWR3eAI48oVx2D9G4K
+        vUWk0zL6jdx23skpw2BnhY7+AwAA//9ClYAPR6NLwMv5ImglMVocDcKER6g4AgAAAP//GowuHi2O
+        aO1i+hVH6KUGvK0HbwoBnZ4OyYLVoDl3KNsAaGF+SSJ0xQC6KTgbdTiLMZytPSPsBSWuyScDXM1b
+        UKmAVcIAV/PWGJcOY3j7MTWvLLMoPw/SgIQIpZRCl6tAuESFXn4uxIRqGBNaO5BRWiOttNGHmauj
+        lJtYEZRaXJoDMhjJbvDcTFGJYwnEHWX5JdSbEoYYBjcUaFdGYnFYPnhqCzaPC5qUBk0YgayEOwTV
+        tUYozoVqAAdPbW0tAAAA//8DAANknFkdJQAA
+    headers:
+      Atl-Request-Id:
+      - f30865ec-4d2d-4762-bd6c-018be1d37964
+      Atl-Traceid:
+      - f30865ec4d2d4762bd6c018be1d37964
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:33 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=259,atl-edge-internal;dur=14,atl-edge-upstream;dur=246,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 074e7b783fa14fe46e209d9cfe89afd6
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSY7MmU7HdZTEreu6spI8OB4PTK5IxCTAAKBkNc5/7y4v
+        xYcytTtN8iDi2AO73367/uLATcll4kSOBpmAhuS1gDwxA8kLMAMTZ1DwgSpBcyuUNANIhC3A8kGc
+        cZlCrtLBCrTBM0jmUGowIG17N66MVcWSFF4Gvh/4robPFRi72JRwqnlsRQzOwBFkP5js77/EhYF8
+        icvM2tJEnpfAEmKbqE/K5TbnxgguXQnWQ0vW46XwQk8YU4HXKbiGDcqfLGZni2EwmU5wq3bBONEX
+        x6BvlYm5hVTpTfOGBFcoEfrheBiEw5G/CKZRMI5GoTsNgp/Qb5+cJCMWHa/VPNNJkvdQnx/2z24X
+        CZhYi5ICh7sHzBQ8zwcsEcYKGVtWCoiBqSVbK33tknSs5DudP9GLSgpKF88v+Ypbrr2VgLVXu7V1
+        sD0K/FEw/cWIv+HnAtNeFWiVYIEmF9xcU66qK0tf0ZLnBgZOI3iE76plB04mEDg6zjbHsAL01f86
+        cKxAZJWIEieSFb7RuQeTkd8dlFp9whc9M+CtdB3uOoFduGnxDUi2r3onhbWowDi9bULq7/Vdo5Z2
+        zTXh1YiizAU6nNx7OeajRtl4ejOePtHd72Sme0mfl7FPQA/HN+H4/7XSZL/GIhoM9m6CvR9h8Kaz
+        OApvRuGPsNgC/OvXh3AMduE07A6W4uZ9w4GY/fOLhzdH3U2ephpS5JsHRYAPUHnVlP/j5ia7DvZ2
+        HbzccRDuPJjuOth/6GdDm80ukVLdIZxoGLRcSSnRIm6e9OXBHhUKRttkqsqTV8KUOd+05YTba26x
+        9TSU/fTSbxrCtgV4jTpNhV1/HqqKQl+7+oE2hEydyOqKbKNS+x4xQ+XdRkMDPpb447EmMd4PuyZx
+        P2w9ld0/2AWqsAdVqYXSwm6eGYJO3Ks7zb/vFaLgKRiPJEynROBGJtLMNat0y5Zvcaej1dB5WDhh
+        j/qcXwER4yOlQXzyaCCCXRgNphSRjJtZKeJjIa9f08krKGl+kXGHoRpZ6/qs35FKznB84Vc5zIGb
+        Bpe6/XJOj9+9OTq5PD46nJ2czS5n8/mfc3wf1qnBkOCFRQbsFDuAtIzsMmGYkvmGIZuInJQyq9hv
+        QnN2qqFAOmGVQcy5j7FKgAXl+LfC98tkFDlNV8TsYfi3VXWHLTARqZA8v3+pnb7a8NbIz9G7dk2Z
+        TSX0t6uSynYXkid7fofkZlB6Jvga4b7z3p1tnobHLd5+5fE1jpsd5Drlja3DdqL7Tw53Y2FTM2gk
+        7AYFCWuqbpUrfdJ4c5VXMEw1ctZ2KFLslWqSrYoSB2JpHwf9pKeF7yX2vlBPGXfD+VF++/+ApVpV
+        JQ2Kr4VMkNYMw1phVwCSlZXJIKlRejQ/oN8rYEKuyDLBLGH4pwDDbgZJRMqy0GVvSN1H+aL+fRGx
+        816tkBGTGC8ruFU68t2JO7qloGPMcxXzPFPGRlN/6nvLRuay9s0bTaYXKM3OzyCuiKPYW7UeWrVD
+        GJt2UmHTDi+Yx84DY9lfFdcWNJvJFCuzwDjvEIX+ghfU0ienf7CDCjmAncVc7pCiEdDb9y+aiN7e
+        sjMcXms/8fvw/az++dD8dImmRTsD0OdCWKQDEq2BhV+oiBFjslt2jjqGIVLAEKfkMKi9IKDKVeJK
+        nPfdVK28VZVLhK5FavHu3r8gFSPf7+XiNbiFsBpcpVMP65sT5gUOs8QLHl51M1vkJLfNFy7qjJGy
+        EP/NIa1yjjH9BwAA///sWW1v2jAQ/ivWpFaASApJCIWq6qhY1U5rNa3aPnRfMLGBbCGJEqD7sB+/
+        5xwnvJSUjqpVJ02tgNg++3y+e8735BfVcGoffRn6PCBXupXJAqUaM1jlppihzg6D2ckppnHNRrXE
+        lvrkjyzbpvV7SP0LWSdTqfsz22YXF/ts2Z0n20WPV3Zxnm4XZ6ddXtwmVplNEHC503Vryj7Uxmr9
+        uWR9RCoaPwLFmNWpMwB5i62jQP43aZoFDKhn23y108YW+gp5AYo/IkY5CVrvlGMVfFS37f/R3bMa
+        IhLt3/Fl7BUcWBL+pKZ4XniuH0HtNponMOaFH0jAp8wMfjienXDPk/FM/Vy634pgfwnzNcBxoUYE
+        /NfAafrRERcLP0UOkZRv28gAIzI63Ci/GNCRDpYrDBiuMIz0R2muLy2JdgetHbmDKNwh1e7AZzNk
+        4LTO7ie+N2G4x4/HAOE5AJDFHGuFY8YZihoPgrgWeQkfkR6Dntqo8YmH4zngeMAmkgtILjhyqJnt
+        ln1bKnQNvA/kanJZ789rre6qS2LIZ3XJF3k/usd5d3N9BoycQByNcHIV7t3dB0OY36UP8i880rZS
+        zBLPh4Hv6UO79lUq1Wf2Vd22yML6MDJlGGAmQEeiNw+5q2nMvRnJ3ETMVw8MiW/hCynW3OkLYgpX
+        UCz9N06hReOI8ib5eIWLqR9WWaX6ewofnkXdwm+3gsaLA4a1J2BYBBjWMwFjr6zxADD2zVur5/va
+        gOH+B4xXAAzn3wIMtxDdARgPGY9WUfRvFrxlVEjTWS2GZglcRpExRA5tDi2jwBplHU7BW21KFLxD
+        boWygWU8RKOMK2sUa6oAmFD5oYvx1Xp+s9xL59MppwL23aMVFpmc2Kgo2bPUJU7iDB5LDNiVOG03
+        AYiNA7sn3WN36DrcaIystuGMeMvodNoNQ7gjIdujoSNtKosLSSybyXafKCnJb3pCUNSQzjyJAvF+
+        RWVUzbTAo0y6Oi1povBWw0gmZ3PtkS2soRTcbR9zafOOGHGnc+wNudvxnGbzTJyqWbDXA+sC/5mc
+        MeWhLhINI2tKzXlq3MNkhmVS9WlmEUs2NWLOUzIp5FVO4EGKn5fnhmPGIZETm6z829d4k9Z/+xpv
+        vhZ46xoDykTGcGv26FI5PzsPePhThunEj1VoUSGY0dAZGt5FIY3+ME+iWB7dAac8olx1DNK7KfQW
+        kU7L6Ddy23knpwyDnRU6+g8AAAD//0KVgA9HF0HrgtFSZxCmL7JLHQAAAAD//xpAF4+WOrR2Mf1K
+        HfRSA1cj0ATe1oM3hYB+SofkzWrQnDuUbQB0SX5JInTFALopuFp7BriKMQMj7OUhrsknA5wewNka
+        hPsMXQeuZqIxTgl4+zE1ryyzKD8P0oCECKWUQperQLjEhF5Zfgn1JlIhhsENBdqUkVgclg+eUoLN
+        3QLzAcTJ1TAmtDoi2wHgpT36MHN1lHITK4JSi0tzQAYjeRY8GVRU4lgC8ThoUho0YQTyOlwcVbMR
+        im6oBrBra2trAQAAAP//AwC//yv3HSUAAA==
+    headers:
+      Atl-Request-Id:
+      - d80393f0-c8d6-4dbb-b06c-68814984b3ef
+      Atl-Traceid:
+      - d80393f0c8d64dbbb06c68814984b3ef
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:33 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=299,atl-edge-internal;dur=14,atl-edge-upstream;dur=286,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 1da1d0b1a01cc131cc1a1d6f87430d82
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQX0vDMBTFv0teXbv8abc2bzLBKTqFdi+KSJrcYjVNSpMOxth3N8Ghe1TfLvf8
+        zj2He0CNcLAdNeLozfvB8flcQQvSK/tuU+G1cK4TJjXg0Qypzg1a7P/BVzDuOgkK3Mca9LAC42H8
+        65GVNa2ewEj4nXMHo+usCTDBmKQ4xUm1uXys1g/1j7qZ+iZMiD9HaIZn+CVkwqDtvg8t6/0Q01ba
+        TiqYmqnT6suCeDDQ5fK0vBI+ghTTLCE0IWVNKGeEE5ZijC9wgIPfhT/AWHf9OctwTQpOMs5YWtLy
+        m5X9jWltAHGW44zRhWBNU+RFSfKSqJwyKWkBakEEtEJki+YswOuYcNuNIr4w6JP2d1aKuD4gfZoQ
+        mNdthY7nxZ6sicr1fY2OnwAAAP//AwAr8WPzIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - b7cdaa61-5afe-4562-aefd-97a5684e5692
+      Atl-Traceid:
+      - b7cdaa615afe4562aefd97a5684e5692
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:33 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=184,atl-edge-internal;dur=32,atl-edge-upstream;dur=155,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 89433fd5d072dee7df29a3909871d4bf
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 37e95857-514d-4576-baa6-a78e6ad0c798
+      Atl-Traceid:
+      - 37e95857514d4576baa6a78e6ad0c798
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:34 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=303,atl-edge-internal;dur=15,atl-edge-upstream;dur=289,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 21c72ac11ff6eb2264d42be0fa541413
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
+      Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/359] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236] | Active,
+      Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/234] | Active,
+      Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236]\n*Defect
+      Dojo link:* http://localhost:8080/finding/236 (236)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+      &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
+      5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
+      6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
+      &lt; 7.1.2)|http://localhost:8080/finding/234]\n*Defect Dojo link:* http://localhost:8080/finding/234
+      (234)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '7143'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue
+  response:
+    body:
+      string: '{"id":"15998","key":"NTEST-1586","self":"https://defectdojo.atlassian.net/rest/api/2/issue/15998"}'
+    headers:
+      Atl-Request-Id:
+      - b4134387-e6da-4096-89be-5e60cf114bed
+      Atl-Traceid:
+      - b4134387e6da409689be5e60cf114bed
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:35 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=662,atl-edge-internal;dur=12,atl-edge-upstream;dur=651,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 6972c7f69c901e2b0ee8ed2e31176648
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1586
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJl45InOl0XEdJnLquKyvJg+PxQOSKREwCLADqaJz/3l1S
+        lGI7Smt3GnvGxLUHdr/9sP7kwLrkMnEiR4NMQEPyUkCemI7kBZiOiTMoeEeVoLkVSpoOJMIWYHkn
+        zrhMIVdpZwna4B4kUyg1GJB2ezaujFXFghReB74f+K6GPyswdrYp4Vzz2IoYnI4jyH4wGI9HODGQ
+        L3CaWVuayPMSWEBsE/VRudzm3BjBpSvBemjJerwUXugJYyrwWgU3sEH5s9nkYtYNBqMhLtUuGCf6
+        5Bj0rTIxt5AqvWnukOAMJUI/7HeDsNvzZ8EoCvpRb+D6o+BH9NsnJ8mIRcdrNU90kuQ91OeHu2tv
+        JwmYWIuSAoerR8wUPM87LBHGChlbVgqIgakFWyl945J0rORbnT/Si0oKShfPr/mSW669pYCVV7u1
+        d3C7Ffi9YPSzEX/BTwWmvSrQKsECTc64uaFcVXNLo2jBcwMdpxE8wXvVsh0nEwgcHWebU1gC+up/
+        7jhWILJKRIkTyQrv6NyDSc8/tBG0G6VWH/GqT8zEVrrOQ53ZNg80+QI9++u+lcJaVGCcnW2C8K/1
+        WaMWdsU1AdmIoswFOpzcCwkmqoZff7Tujx7p7jdS1t5kl7C+/xzdCPvrsP//WmlgUYMUDQbDdTD8
+        HgbXrcVeuO6F38PiFvmfPz+EY3gIp712YyHW7xpyxOxfXiEa0lRDinzzj0UwaDfwAiqvGl74+tHh
+        oY3nBzbCgxujQxvjh+40tNmsEinVL4QTdQOccosPR0O4j6/Phs73BO416jRVXz08VhUFLiBSfk8L
+        QqZOZHUFmCVUat9hYqkGG+dqfaRfi7iJ46cHa+QrCptMVXnyQpgy55ttDVPmNeBliSYePhJ99/n+
+        kbgftkNUFu6o7P7GDlSlFkoLu3liEFtxr35p/v1bIQqegvFIwrRKBC5kIs1cs0z3pPgaV1r2DJ2H
+        9RHuyiDncyD+owq43xMcAm9wCKPBiCKScTMpRXwq5M1L2nkBJfUvMm6zVudyVe/tVqSSE2xf+DyH
+        KXDTIEFvR8756dtXJ2fXpyfHk7OLyfVkOv19ivfDOjUYEjwwy4CdI9FLy8guE4YpmW8YkobISSmz
+        ir0RmrNzDQWyBqsMotb9GnkEWFCOfyt8v0zmkdO8ipg9DP++qu6wBSYiFZLn9w9tu69teGtc5+hd
+        SziY2VTC7nRVUtkeQvJoOGyR3DRKTwRfI7x7YO/2No/D4x5vv/D4BtvNFnKt8sbW8baj+08Ot21h
+        UzNoJGz7AQkrqm6VK33WeDPPK+imGlli3xQp9kI1yVZFiQ2xtF8H/eAQLQx2tPCtjN8N5wf55e8R
+        S7WqSmoUXwqZIDEahrXC5gCSlZXJIKlRejI9ou8cmJBLMkAwSxj+K8Dw0YIkImVZ6LJXpO6DfFZ/
+        n0XscqdWyIiVaTRwA9e/pWBjrHMV8zxTxkYjf+R7i+bsde2T1xuMr1CKXV5AXBE3sddq1bXqgDC+
+        yUmFb3J4xTx2GRjL/qi4tqDZRKZYkQXG94Ao7A54QS19dv4bO6qw9tlFzOUBKerwvLF/1UTy9pZd
+        YNNa+4nj43eT+vO++bQJpsn2iafhTFikARKtAYUjVMSIKdktu0Qd3RBLvxsM/VFYe0EAlcvEldjn
+        u6laessqlwhZi5Ti3T1/RSrG/Z1YvAK3EFaDq3TqYVlzgrrAVpXowBv33cwWOUmVKf6p80QqQvyZ
+        QqEs4DUSYJM1poNkWJf9cJ7+DQAA///sWN9v2zYQ/lcOCBDImkPPsmxjDvwQJH3YsBbD0u5lHmBF
+        ZmJtsuToR5qi6/++70iKomKrRZM9Jgkc+Y5HHr873n3UkE7T6pwCMR6LgOj0rjpf0kT8CGOlmIiZ
+        CKlRhK0iFFMxb+TTVj4VmKuRz1o5P05bOXtn5GMxa+VBKw/c8ZNWPhGTVh628rDdwLxdlx8duV2X
+        H4NBT26YTB4FkxkjegHS8CCHHHpF9+lYnOffGWcz/v+K82uMnx3jsC/GKIRNUVj4Kt4sI/+qlnSF
+        CgrhL+guFPw0JDTYKXWrc/O7HQtbntX3iXg9ly+M2Qx1279SvR5t+O+cmAUhHt+0Iw8fg2OR/Wpc
+        yUcvgPxP/Dt7xnHFgjj3aoKXtYVuavnXeV3EEumVSp8b9Bn66C4pJeO6v3MGXrU0wke7t8si90rT
+        oEWSj6LNQ1KCiuAOMA0CMIxbhhjHoSGezDXW+7s1gdTBv4wiKnQax5zG0qYx70EW0U2Sck+ttlFF
+        eYyFSvq4BTupQK+NIaN2E5WS8oLucU/7RLgrx3wKS8weF9EtOwA6Vu8yYvYl1EEDQS8kgaFT9TFv
+        TGIqY5lFuMkwZcFSSbwlEAGw9zT5R4K/32KVCG7v92kSq1eXhho1DqcS+ODI8gXAHaW3Bp/qrIxu
+        USqY75+VNQ+Bf+V9apYzyJS0i2Cc5GAGjvOlWGXB4ewwyoB0yc7APVx5C7BFzGvRYbZmfYgMUoWs
+        6iJDbuOprNOK0XV8wLijTggG8OQEV5cc8cTfZZ7Fcl+tsvV6vcr4OljRZ7rEzsB6vtCS+F1uUkjv
+        9OQxmCO19P9BMzbWI5cE7mzMPFaqJ2E2x5LGgOFa0vr6za9vLt/TmC6u6fS+zqvzFX705CNfS3AI
+        j6n90Qrn8gfeapmnUuC24CH7Y9zghMweBn+xN6DQMMlGI229Vg5opxSAHvwYkieLYsgIDmjJJ4c+
+        Y2azJ8y1Yce/DAw49IdNFHoL0op8IT5qrrx5D7TolHEwxZ5CDk1fKbdGB8Xcag7KuaN5UtAdzZOS
+        7mieFHVH86SsW81BYXc03dIOnH5TL3g2DUgLM9KAZFDBfA5cjJHBhBdy4WKMDChG1cDFGFlQHE3T
+        8hpUOioGyaLS0TBIFpWOhkGyqHQ0DJJFxdFokCwqHY0GyUkm4LVFJnFKnmnCtzgs9HxXWfAHuhO+
+        XcR8DpCY9Q2Ov+kBbxN18zMtwLdXmUA8iscFfVBvC7gAmWLfhAQVM4WmEK7RpM9IR+uoTdhno8N4
+        1GbaZ6MDfNRm1mejI2JtyKN33IFUd7IdTiXBUEd8qMquDjG3migtc9rrBBbEPMIuOu9bVIX064ua
+        hECXOljAxO7n3T6KK47bu5wS9YWQAg/JRm7aNo+Bv4MUFRLVvPyePm9M9zlfuZmmeNFml2QD8gb/
+        7kBDqnxhqcdRPvvKZZ0D7Ba8b3PZ8JlcNmQuG76My/4HAAD//6JKW5bcri9yuqV1W9ZwtC1bAAAA
+        AP//7JrZasMwEEV/pRTyKNeL4qUQ0gRa0l/I21iSm5J4wQv9/WosW8Rq1JY+GWrIQ4g09mRi3Vy4
+        Z/Gyi5ddvKxF1ifebCLsE292Le2Llx3ntXjZxcvOw8t6uvQHL/s1v1/rCNuMb20JnkdtCxrowGiv
+        rYGde2oBqQNjK9WwhbHg6muYC7YU3dUp+jge20Yb+eHqZiZptJlJQtsCO2HiphLPpstzwDj2/mZe
+        iKNGpqKs/xjYojvZAmNIgrzyTeRJJ+uugp0I4zANKRA38yNCM1iTJIlcwsOMiyhLqQgw3NWV8raq
+        9vGXlQKflx3nspcGe4a6vPCnq5ZZiZzc99hX/2MI561W27BmRI+CLOB+KjiEUQwigIRnQJOYpRAm
+        jHrelm/6q8jvuvJf5EvVkRyKIfIkRH3UOF1DPuTIiO9gluootcSZkgqgwZHK+t7Ny3Mp3x72hDpV
+        gRG7iZDNv2OTQZt/xybDNveOpVJxRUYNDMShf/jv9hcozqJoTu9Vf7QwNlM4lhK7Y1ng7ueuLivx
+        cJQyxBAcGs4ggpRyVZ90vM3Ald6mJ6hNe6kNqqI2Uo9qfa+HP4f/K0efAAAA//8axAlvtDiih4tH
+        iyNcxRF6qQFv48GbRECnp0OyYDVogTiUbQC0ML8kEbruHd0UnI05nMUYzlaeEfaCEtcSSgNczVpQ
+        qYBVwgBXs9YYlw5jeLsxNa8ssyg/D9I2hAillEI3XUC4RIVefi7EhGoYE1o7kFFaI+0X0YeZq6OU
+        m1gRBBllQrEbvMKwqMSxBOKOMmDnhtxlkRgLmyGGwQ0F2pWRWByWD16gCVt7DFpaDVr2CLIS7hBU
+        1xqhOBeqARw8tbW1AAAAAP//AwCOce734zMAAA==
+    headers:
+      Atl-Request-Id:
+      - 280ca78e-37a4-4a69-8e40-d91793d25780
+      Atl-Traceid:
+      - 280ca78e37a44a698e40d91793d25780
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:35 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=312,atl-edge-internal;dur=35,atl-edge-upstream;dur=274,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - e4fe957377af661e38d0343b353d8285
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xX6VPbRhT/V3b0qZPaunxE1kynQ4mT0FJKjUk+EIZZS8/SBmlX3V35aOB/71td
+        DhhnCp0GZtBe7/69gy8WbArKYyu0JPAYJMRvGWSx6nGag+qpKIWc9kQBkmomuOpBzHQOmvailPIE
+        MpH0ViAV3kE8g0KCAq6bt1GptMiXhuGN57qea0v4qwSl59sCziWNNIvA6lnMyPdGk0mAGwXZErep
+        1oUKHSeGJUQ6Fp+FTXVGlWKU2xy0g5K0Qwvm+A5TqgSnZXALW6Q/m08v5n1vFIzxqFJBWeEXS6Fu
+        pYqohkTIbW1DjDuk8F1/2Pf8/sCde0HoDcPByHYD70fU2zVKGiEaFa/YvFBJQ+8gP9fvzG42MahI
+        ssI4Dk+PiMpplvVIzJRmPNKkYBABEUuyFvLWNtSR4Jcye6YWJWcmXDS7oSuqqXRWDNZOpdZOwebK
+        cwde8LNif8NPOYa9zFGqgQWKnFN1a2JVLrRZhUuaKehZNeEJ2lXR9qyUIXBklG5PYQWoq3vfszRD
+        ZBWIEivkJdpoPYLJwG0vCik+o0UvdHhDXbm7CmDrbrP5CiQ7qy450xoZKKuTbZD6W/VWiaVeU2nw
+        qlheZAwVjh9ZjvGoUDYMNsPgmep+IzKtJV1chu5rVMMfbvzh/yuljn6FRRTojTfe+HsI3LQSB/5m
+        4H8PiQ3A7+/34egdwqnfXizZ5kNdAzH6V9f7LwftS5okEhKsN3tJgAaIrKzT/2lxo0MX40MXrw9c
+        +AcvgkMXk30967JZn5qiVHUIK+x7Ta00IZEsqk36sndmEgW9rVJRZvEbpoqMbpt0wuM11dh66pL9
+        /NSvG8KuBTg1O2kSu1oei9K4vlL1ozlgPLFCLUsjG5nqD4gZk96NNySgsaZ+7DeJof161yQeu60r
+        ZY8vDoHK70BVSCYk09sXuqAld6pO8+97BctpAsoxFKplwvAgZUlqq1Wyq5bv8aQtq761nzh+h/qM
+        LsAUxidSw9STJx3hHcKoFxiPpFRNCxadMn771ty8gcLMLzxqMVQha13ddSdc8CmOL3SRwQyoqnEp
+        m5V1fnr57uTs5vTkeHp2Mb2ZzmZ/zNA+zFOFLsEH8xTIOXYAromRS5gigmdbgtWEZYYp0YL8yiQl
+        5xJyLCekVIg5+6mq4mFCWe4dc90iXoRW3RUxeuj+XVY9qBYYiIRxmj1+1ExfjXsr5GeoXbM3kU04
+        dK/LwqTtISQH43GL5HpQeiH4auKu8z6cbZ6Hxx3efqHRLY6bLeRa5rWs42ai+08Kt2NhnTMoxG8H
+        BQ5rk90iE/Ks1maRldBPJNas3VAkyBtRB1vkBQ7EXD8N+lFXFr4V2MdEXcl46M5P/OvfI5JIURZm
+        UHzLeIxlTRHMFbIA4KQoVQpxhdKT2ZH5LoAwvjKSDcxigv8KEOxmEIeGWerb5J1h94m/qr6vQnLV
+        sWU8JEUSjmzPdu+Ms9HXmYholgqlw8ANXGdZv72pdHIGo8k1UpGrC4hKU5vIe7Hua3GAGJt1XGKz
+        9q+JQ648pcmfJZUaJJnyBDMyR/8eIIXugeNV1Gfnv5OjEnOfXESUH6Ayo58zca9rT97dkQscWis9
+        cX38YVp9PtafNsBm0/R+s5wzjWXAkFaAwhUyIqZSkjtyhTz6PqZ+3xu7gV9pYQDKV7HNcc63E7Fy
+        VmXGEbIaS4rz8P21YTEZdmTRGuycaQm2kImDaU0N1BnOsKYcOJOhneo8M1RFgn+qOBkWPv7MIBca
+        0IwYyHSD4TA0pE9+OE/+AQAA///sWN9v2zYQ/lcOCBDImkPPsmxjDvwQJH3YsBbD0u5lHmBFZmJt
+        suToR5qi6/++70iKomKrRZM9Jgkc+Y5HHr873n3UkE7T6pwCMR6LgOj0rjpf0kT8CGOlmIiZCKlR
+        hK0iFFMxb+TTVj4VmKuRz1o5P05bOXtn5GMxa+VBKw/c8ZNWPhGTVh628rDdwLxdlx8duV2XH4NB
+        T26YTB4FkxkjegEK8yCHHHp1D6BjcZ5/Z5zN+P8rzq8xfnaMw74YoxA2RWHhq3izjPyrWtIVKiiE
+        v6C7UPDTkNBgp9Stzs3vdixseVbfJ+L1XL4wZjPUbf9K9Xq04b9zYhaEeHzTjjx8DI5F9qtxJR+9
+        API/8e/sGccVC+Lcqwle1ha6qeVf53URS6RXKn1u0Gfoo7uklIzr/s4ZeNXSCB/t3i6L3CtNgxZJ
+        Poo2D0kJjoI7wDQIwDBuGWIch4Z4MtdY7+/WBFIH/zKKqNBpHHMaS5vGvAdZRDdJyj212kYV5TEW
+        KunjFuykAr02hozaTVRKygu6x63xE+GuHPMpLDF7XES37ADoWL3LiNmXUAcNBL2QBIZO1ce8MYmp
+        jGUW4SbDlAVLJfGWQATA3tPkHwn+fotVIri936dJrF5dGmrUOJxK4IMjyxcAd5TeGnyqszK6Ralg
+        vn9W1jwE/pX3qVnOIFPSLoJxkoMZOM6XYpUFh7PDKAPSJTsD93BhLcAIMa9Fh9ma9SEySBWyqosM
+        uY2nsk4rRtfxAeOOOiEYwJMTXF1yxBN/l3kWy321ytbr9Srj62BFn+kSOwPr+UJL4ne5SSG905PH
+        YI7U0v8HzdhYj1wSuLMx81ipnoTZHEsaA4ZrSevrN7++uXxPY7q4ptP7Oq/OV/jRk498LcEhPKb2
+        Ryucyx94q2WeSoHbgofsj3GDEzJ7GPzF3oBCwyQbjbT1WjmgnVIAevBjSJ4siiEjOKAlnxz6jJnN
+        njDXhh3/MjDg0B82UegtSCvyhfioufLmBdGiU8bBFHsKOTR9pdwaHRRzqzko547mSUF3NE9KuqN5
+        UtQdzZOybjUHhd3RdEs7cPpNvZ7ZNCAtzEgDkkEF8zlwMUYGE17IhYsxMqAYVQMXY2RBcTRNy2tQ
+        6agYJItKR8MgWVQ6GgbJotLRMEgWFUejQbKodDQaJCeZgNcWmcQpeaYJ3+Kw0PNdZcEf6E74dhHz
+        OUBi1jc4/qYHvE3Uzc+0AN9eZQLxKB4X9EG9LeACZIp9ExJUzBSaQrhGkz4jHa2jNmGfjQ7jUZtp
+        n40O8FGbWZ+Njoi1IY/ecQdS3cl2OJUEQx3xoSq7OsTcaqK0zGmvE1gQ8wi76LxvURXSry9qEgJd
+        6mABE7ufd/sorjhu73JK1BdCCjwkG7lp2zwG/g5SVEhU8/J7+rwx3ed85Waa4kWbXZINyBv8uwMN
+        qfKFpR5H+ewrl3UOsFvwvs1lw2dy2ZC5bPgyLvsfAAAA//+iSluW3K4vcrqldVvWcLQtWwAAAAD/
+        /+yay26DMBBFf6WqlKUpDwdCpShNpFbpL2Q32KapEh7iof5+PZhYxInbqisWllgg8OBhsIcr3eO0
+        rNOyTsta2vqVNrtq7FfabNranZa91MtpWadl56FlAx36i5a99e+X2sI27VubsR/QqbXXNcBOA1qA
+        qIM51AZ0+LYbVFMYZoR20S9VsA20ueq+jfzw9ZzQdcCOaKqN1vLUnTbNy7YvCkA79vGuX4ilRqai
+        av5p2KI62QBjyHG883USSCXrL6KtiFdxFlMgfh4mhOawJGma+ITHORdJnlERobmrI+W0Kvb5j5EC
+        18uWc5lLizlDU535yyRlViEn9zMPNnwl4X00ahjGXJikKI94mAkOcbICEUHKc6DpimUQp4wGwYav
+        h6fId12Eb/JQcaSAcrQ8CVGXWq9vyZcsGQk99FI91S2xpqQGaLGkMn5Q83JfytP9jlCvLtFiN9my
+        +Wdswmnzz9iE2+aesWxhXHFaIwOxHxb/w+4M5UmU7fGzHrYW2mYKplJd8FCVOPq1b6paPB1kf2II
+        Do17EAlLeVfvdJxm5Erv0xPU1nupDaqiGqpqxn+A6zo36+sbAAD//xr49DVa6tDDxaOlDq5SB73U
+        wNX4M4G38eBNIKCf0iF5sxq0chzKNgC6JL8kEbruHd0UXK08A1zFmIER9vIQ1xJKA5wewNkKhPsM
+        XQeu5qExTgl4uzE1ryyzKD8P0nCECKWUQjddQLjEhF4ZsFNB7nJEjOXAEMPghgJtykgsDssHL4yE
+        rUAG5gOIk6thTGh1RLYDwBtU9GHm6ijlJlYEQYa1UDwLXtJYVOJYAvE4aGk1aNkjyOtwcVTNRii6
+        oRrArq2trQUAAAD//wMAO5wx+uMzAAA=
+    headers:
+      Atl-Request-Id:
+      - 4ff5f7ff-8d18-4bbf-85bb-508cd0066144
+      Atl-Traceid:
+      - 4ff5f7ff8d184bbf85bb508cd0066144
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:36 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=333,atl-edge-internal;dur=13,atl-edge-upstream;dur=321,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 8b7531b317452184ec57e0570a191a71
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQX0vDMBTFv0te3br8abs2bzLBKTqFdi+KSJrcYjVNSpMOxth3N8Ghe1TfLvf8
+        zj2He0CNcLAdNeLozfvB8cVCQQvSK/tuE+G1cK4TJjHg0Qypzg1a7P/BVzDuOgkK3Mca9LAC42H8
+        65GVNa2ewEj4nXMHo+usCTDBmCQ4wfNqc/lYrR/qH3Uz9U2YEH+O0AzP8EvIhEHbfR9a1vshpq20
+        nVQwNVOn1ZcF8WCgy+VpeSV8BCmm6ZzQOSlrQjkjnLAEY3yBAxz8LvwBxrrrz1mGa1JwknKWJ6zM
+        vlnZ35jWBhCnGU4ZzQVrmiIrSpKVRGWUSUkLUDkR0AqR5s1ZgNcx4bYbRXxh0Cft76wUcX1A+jQh
+        MK/bCh3Piz1ZE5Xr+xodPwEAAP//AwChsT7JIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 27fe2f1b-9f83-4045-9322-bc366f157577
+      Atl-Traceid:
+      - 27fe2f1b9f8340459322bc366f157577
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:36 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=158,atl-edge-internal;dur=14,atl-edge-upstream;dur=145,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 353d6b4edab9302c92df895fa2d603ed
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 2dbf8a5e-2f13-43f7-9e80-bdc5ba5213e0
+      Atl-Traceid:
+      - 2dbf8a5e2f1343f79e80bdc5ba5213e0
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:36 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=305,atl-edge-internal;dur=19,atl-edge-upstream;dur=287,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - a3ecf719596af998b017df96c3a71903
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
+      of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/360] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
+      Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/235]
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/235]\n*Defect
+      Dojo link:* http://localhost:8080/finding/235 (235)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+      File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+      versions of `fresh` are vulnerable to regular expression denial of service when
+      parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
+      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n", "priority": {"name": "High"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1974'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue
+  response:
+    body:
+      string: '{"id":"15999","key":"NTEST-1587","self":"https://defectdojo.atlassian.net/rest/api/2/issue/15999"}'
+    headers:
+      Atl-Request-Id:
+      - 40223e0e-b863-4edc-adf6-50bb7ae7846f
+      Atl-Traceid:
+      - 40223e0eb8634edcadf650bb7ae7846f
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:37 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=681,atl-edge-internal;dur=17,atl-edge-upstream;dur=668,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - ccdc5d5cea4d44b84753189f473cdb30
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1587
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbMmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3SVF
+        KT6Y1u40owfi2gO7335YfXZgVXKZOJGjQSagIXktIE9MT/ICTM/EGRS8p0rQ3AolTQ8SYQuwvBdn
+        XKaQq7S3AG1wD5IplBoMSLs5G1fGqmJOCq8D3w98V8OfFRg7W5dwrnlsRQxOzxFkPxgdHBzgxEA+
+        x2lmbWkiz0tgDrFN1CflcptzYwSXrgTroSXr8VJ4oSeMqcBrFdzCGuXPZpOLWT8YjfdxqXbBONFn
+        x6BvlYm5hVTpdXOHBGcoEfrhsB+E/YE/C8ZRMIwG++5oMPoB/fbJSTJi0fFazQudJHkP9fnh9tqb
+        SQIm1qKkwOHqITMFz/MeS4SxQsaWlQJiYGrOlkrfuiQdK/lO58/0opKC0sXza77glmtvIWDp1W7t
+        HNxsBf4gGP9kxF/wY4Fprwq0SrBAkzNubilX1Y2lUTTnuYGe0wie4L1q2Z6TCQSOjrP1KSwAffW/
+        9BwrEFklosSJZIV3dB7AZOB3bQTtRqnVJ7zqCzOxka7zUGe2zQNNvkLP7rrvpLAWFRhna5sg/Gt9
+        1qi5XXJNQDaiKHOBDicPQoKJquE3HK+G42e6+42UtTfZJmzoE9zD4Soc/r9WGljUIEWDwd4q2Pse
+        BletxUG4GoTfw+IG+V++PIZj2IXTQbsxF6v3DTli9i+vEA1pqiFFvvnHIhi1G3gBlVcNLzx9dK9r
+        Y79jI+zcGHdtHDx2p6HNZpVIqX4hnKgf4JRbfDgawn1+fTZ0viNwr1Gnqfrq4ZGqKHABkfIHWhAy
+        dSKrK8AsoVL7HhNLNdg4V+sj/VrETRw/P1ojX1HYZKrKk2NhypyvNzVMmdeAlyWaeOqRCMNB+0g8
+        DFsXlYVbKnu4sQVVqYXSwq5fGMRW3Ktfmn//VoiCp2A8kjCtEoELmUgz1yzSHSm+xZWWPUPncX2E
+        2zLI+Q0Q/1EFPOwJusAbdGE0GFNEMm4mpYhPhbx9TTvHUFL/IuM2a3Uul/XedkUqOcH2hd/kMAVu
+        GiTozcg5P3335uTs+vTkaHJ2MbmeTKe/T/F+WKcGQ4IHZhmwcyR6aRnZZcIwJfM1Q9IQOSllVrFf
+        hObsXEOBrMEqg6h1nyKPAAvK8e+E75fJp8hpXkXMHoZ/V1X32AITkQrJ84eHNt3XJrw1rnP0riUc
+        zGwqYXu6KqlsO5E83m+R3DRKLwRfI7x9YO/3Ns/D4w5vP/P4FtvNFnKt8sbW0aaj+08Ot21hUzNo
+        JGz7AQlLqm6VK33WeHOTV9BPNbLErilS7Fg1yVZFiQ2xtE+DftRFC6MtLXwr4/fD+VF+/TtkqVZV
+        SY3iayETJEbDsFbYDYBkZWUySGqUnkwP6XsDTMgFGSCYJQz/CjB8tCCJSFkWuuwNqfsoX9XfVxG7
+        3KoVMmJzjGEW+e7A9e8o3hjuXMU8z5Sx0dgf+968OX5du+UN9vwrFGSXFxBXRE/srVr2reoQxmc5
+        qfBZDq+Yxy4DY9kfFdcWNJvIFIuywBB3iML2gBfU0mfnv7HDCsufXcRcdkhRk+cd+FdNMO/u2AX2
+        rbWfOD56P6k/H5pPm2OabF55Gs6ERSYg0RpTOEJFjMiS3bFL1NEPkdz6wV4QHNReEEblInEltvpu
+        qhbeosolotYiq3j3z1+RiqHfxJrk4iW4hbAaXKVTD0ubE9wFtqtECR4edTNb5CRXpwq/dbJIzxTS
+        KucYyhX9a6vdPwYp/gYAAP//7FnbTttAEP2VFVJREsXGsZ0rQjQoRVCJqipqH+gLG++auHXiyHHC
+        Q/n4nllvlsRkaUvVKg8IlMvOXsYzs2fOTHhKwXMt8xWKM+aw2jktbLLDtDjG4rbr1y3G064+8oM2
+        HThEYl3JJtlGUWL2QDZtrC06aCij0BhrjJaSjRCBGHyP28n8fpMBoNpsO7rXf5OWa8JbfQ/cf/w8
+        UHykcARX/FvGCGGh6y/XsRpe6rue+tlnZg0EGca/4s15kb9xJEJHbfF3Ebdt+MZ1tsxhxvMklQAD
+        WZr68K44VuG1MXH0CFINgIk5NgN66bvvJtkRF6tkAaADw2j7HeBXTEZGsKzTGjnvVm1+y5B7GamK
+        mlJn21z7XCtCPhfG5wvt8/sJYR/HfrM7BtIdQY60HeU8ppMoSQOT5svCheW/PO5/BfBJpQa5bdGa
+        1Q82wggzPiqiKtZiSGGZEyPe2AAzJ1iNQYSkupKDqjGbGwMLkBuLIF9Jh9JXEj2dWEpjvqKEu+El
+        wrABvVBw4eswirDfAAlinCaR9uBVorKCduBnRRzI5toz5VOxLGcpBLlrPH85nfOooDUfMpaoLwxA
+        vkqEFFux9AkXCmwKR/9JhOil84zyAAV4jYtpMquzWv1higAusgGC9ikXbxs6WqVitmzcCm0CU5xR
+        mi5yEBNVgVAFUZkamsKpIvDMHlWBjRF7hhGvzWObaKviPKPMFrOs8gteFDyaUOos2ctiOZ1yolYH
+        ttxP1qYSKctfyL/oDp7yKKLC7lKcdFsAQu9NMJSdXmfcCbnjxX7XCWPedvr9rueITixkNx6HMiCu
+        Zlbi2HLt4DdXSgqZoRB0n0hnnmepeLuhMqgcHfBsF0f5Q7pgg2oarVl3EoI4EP5YCt7p9rgMeF/E
+        POz3ojHv9KOw1ToVJ2oXPOsb/xz/5TpnymeavjhOObRwlwvnHiZzfJd4kVteVrKpM+d8QSbFepUL
+        UO7g48WZE7rzGTHmakdo/zWutpT2X+NqS2rfNQZYibLRoUuaCxX87Czls+9ytpgkc3W1iMWV3ZUS
+        727AejH73TLP5vLoBkgUUR9A30Hqi0Jqbjodo9vEu4uh0Aa/oa1HEtoab6GB+Fznh1c42sPAe4Wj
+        /6HxKxzZ4KiKGobmGVYE1e/KK/iDfu/Rnz0cmBVc/4xV3cXK56wwZiV6/m6gtHVEPRuzJVTYKfBs
+        zDboHfwEAAD//8IhAW86puaVZRbl50GahxChlFLoHCqES1To5edCTKiGMaG1AxmlNdL0rz7MXB2l
+        3MSKoNTi0hyQwUh2gwcMi0ocSyDuKMsvod48BcQwuKFAuzISi8PyweOtsKkE0EwJaBQTZCXcIaiu
+        NUJxLlQDOHhqa2sBAAAA//8DAHg6ZrGyHwAA
+    headers:
+      Atl-Request-Id:
+      - 4f077939-7f23-46e5-83d9-69da48a7ed15
+      Atl-Traceid:
+      - 4f0779397f2346e583d969da48a7ed15
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:37 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=281,atl-edge-internal;dur=13,atl-edge-upstream;dur=268,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - e5c85f349a5c18f5462bc73d1dc1807b
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15999
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbMmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3SVF
+        KT6Y1u40owfi2gO7335YfXZgVXKZOJGjQSagIXktIE9MT/ICTM/EGRS8p0rQ3AolTQ8SYQuwvBdn
+        XKaQq7S3AG1wD5IplBoMSLs5G1fGqmJOCq8D3w98V8OfFRg7W5dwrnlsRQxOzxFkPxgdHBzgxEA+
+        x2lmbWkiz0tgDrFN1CflcptzYwSXrgTroSXr8VJ4oSeMqcBrFdzCGuXPZpOLWT8YjfdxqXbBONFn
+        x6BvlYm5hVTpdXOHBGcoEfrhsB+E/YE/C8ZRMIwG++5oMPoB/fbJSTJi0fFazQudJHkP9fnh9tqb
+        SQIm1qKkwOHqITMFz/MeS4SxQsaWlQJiYGrOlkrfuiQdK/lO58/0opKC0sXza77glmtvIWDp1W7t
+        HNxsBf4gGP9kxF/wY4Fprwq0SrBAkzNubilX1Y2lUTTnuYGe0wie4L1q2Z6TCQSOjrP1KSwAffW/
+        9BwrEFklosSJZIV3dB7AZOB3bQTtRqnVJ7zqCzOxka7zUGe2zQNNvkLP7rrvpLAWFRhna5sg/Gt9
+        1qi5XXJNQDaiKHOBDicPQoKJquE3HK+G42e6+42UtTfZJmzoE9zD4Soc/r9WGljUIEWDwd4q2Pse
+        BletxUG4GoTfw+IG+V++PIZj2IXTQbsxF6v3DTli9i+vEA1pqiFFvvnHIhi1G3gBlVcNLzx9dK9r
+        Y79jI+zcGHdtHDx2p6HNZpVIqX4hnKgf4JRbfDgawn1+fTZ0viNwr1Gnqfrq4ZGqKHABkfIHWhAy
+        dSKrK8AsoVL7HhNLNdg4V+sj/VrETRw/P1ojX1HYZKrKk2NhypyvNzVMmdeAlyWaeOqRCMNB+0g8
+        DFsXlYVbKnu4sQVVqYXSwq5fGMRW3Ktfmn//VoiCp2A8kjCtEoELmUgz1yzSHSm+xZWWPUPncX2E
+        2zLI+Q0Q/1EFPOwJusAbdGE0GFNEMm4mpYhPhbx9TTvHUFL/IuM2a3Uul/XedkUqOcH2hd/kMAVu
+        GiTozcg5P3335uTs+vTkaHJ2MbmeTKe/T/F+WKcGQ4IHZhmwcyR6aRnZZcIwJfM1Q9IQOSllVrFf
+        hObsXEOBrMEqg6h1nyKPAAvK8e+E75fJp8hpXkXMHoZ/V1X32AITkQrJ84eHNt3XJrw1rnP0riUc
+        zGwqYXu6KqlsO5E83m+R3DRKLwRfI7x9YO/3Ns/D4w5vP/P4FtvNFnKt8sbW0aaj+08Ot21hUzNo
+        JGz7AQlLqm6VK33WeHOTV9BPNbLErilS7Fg1yVZFiQ2xtE+DftRFC6MtLXwr4/fD+VF+/TtkqVZV
+        SY3iayETJEbDsFbYDYBkZWUySGqUnkwP6XsDTMgFGSCYJQz/CjB8tCCJSFkWuuwNqfsoX9XfVxG7
+        3KoVMmJzjGEW+e7A9e8o3hjuXMU8z5Sx0dgf+968OX5du+UN9vwrFGSXFxBXRE/srVr2reoQxmc5
+        qfBZDq+Yxy4DY9kfFdcWNJvIFIuywBB3iML2gBfU0mfnv7HDCsufXcRcdkhRk+cd+FdNMO/u2AX2
+        rbWfOD56P6k/H5pPm2OabF55Gs6ERSYg0RpTOEJFjMiS3bFL1NEPkdz6wV4QHNReEEblInEltvpu
+        qhbeosolotYiq3j3z1+RiqHfxJrk4iW4hbAaXKVTD0ubE9wFtqtECR4edTNb5CRXpwq/dbJIzxTS
+        KucYyhX9a6vdPwYp/gYAAP//7FnbTttAEP2VFVJREsXGsZ0rQjQoRVCJqipqH+gLG++auHXiyHHC
+        Q/n4nllvlsRkaUvVKg8IlItnZy8zs2fOTHhKwXMt8xWKM+aw2jkpNtlhWhxDue36dYvxtKuP/KBN
+        Cw6RWFeySbZRlJg9kE0ba4sOGsoo9Iw1RkvJRohAPHyP28n8fpMBoNpsO7rXf5OWa8JbfQ/cf3we
+        bHykcARX/FvGCGGx11/qsRpe6rtO/eyZWQNBhudf8ea8yN9YEqGjpvi7iNs2fOM6W+Yw43mSSoCB
+        LE19eFccq/DaGDh6BKkGwMQsmwG99N13k+yIi1WyANCBYbT9DvArJiMjWNZpjZx3qya/Zci9jLaK
+        mlJn21z7XG+EfC6Mzxfa5/cTwj6O+WZ3DKQ7ghxpO8p5TCtRkgYmzZeFC8t/eZz/CuCTSg1y26I1
+        qx9shBFGfFREVazFkMIyJ0a8MQFGTqCNhwhJdSUHVWM2Nx4sQG4sgnwlHUpfSfR0YCmN+YoS7oaX
+        CMMG9ELBha/DKMJ8AySIcZpE2oNXicoK2oGfFXEgm2vPlKdiWc5SCHLXeP5yOudRQTofMpaoLwxA
+        vkqEFFux9AkXCmwKS/9JhGjVeUZ5gAK8xsU0mdVZrf4wRQAX2QBB+5SLtw0drVIxWzZuhZvZuMjB
+        P1ShQYVCdagp1yqC0BROFYFn0/BsjNgzjHhtHttAWxXnmc1sMcsqv+BFwaMJpc6SvSyW0yknanVg
+        y/1kbSqRsvyF/Ivu4CmPIirsLsVJtwUg9N4EQ9npdcadkDte7HedMOZtp9/veo7oxEJ243EoA+Jq
+        RhPLlrqD39SUFDJDIeg+0Z55nqXi7caWQeVogWe7OMof0gUbVMNIZ91JCOJA+GMpeKfb4zLgfRHz
+        sN+LxrzTj8JW61ScqFlw1jf+Of5LPWfKZ5q+OE75aOEuF849TOb4LvEit7ysZFNnzvmCTAp9lQtQ
+        7uDjxZkTuvMZMeZqR2j/d1xtKe3/jqstqX3fMVBMlI0OXdJcqOBnZymffZezxSSZq6tFLK7srpRA
+        eAPWi9Hvlnk2l0c3QKKI+gD6DlJfFFJz02kZ3SbeXQyFNvgNbT2S0NZ4Cw3E5zo/vMLRHgbeKxz9
+        jx2/wpENjqqoYWieYUXY+l15BX/Q7z36s4cFs4Lrn7Gqs1j5nBXGrETP3w2Uto6oZ2O2hAo7BZ45
+        ckUQ9A5+AgAA///CIQFvOqbmlWUW5edBmocQoZRS6BwqhEtU6OXnQkyohjGhtQMZpTXS9K8+zFwd
+        pdzEiqDU4tIckMFIdoMHDItKHEsg7ijLL6HePAXEMLihQLsyEovD8sHjrbCpBNBMCWgUE2Ql3CGo
+        rjVCcS5UAzh4amtrAQAAAP//AwDNg8Y6sh8AAA==
+    headers:
+      Atl-Request-Id:
+      - fbf1c9e1-3b13-411d-9b12-05594b9d0a7f
+      Atl-Traceid:
+      - fbf1c9e13b13411d9b1205594b9d0a7f
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:38 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=254,atl-edge-internal;dur=14,atl-edge-upstream;dur=240,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 5ee8648a6ba691541d5e1c66d605d835
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event test_added has occurred.", "title": "Test created
+      for Security How-to: 1st Quarter Engagement: NPM Audit Scan", "user": null,
+      "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      90, "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/"}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '844'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.41.0
+      X-DefectDojo-Event:
+      - test_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"844\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.41.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"test_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.7:54808\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event test_added has occurred.\\\", \\\"title\\\": \\\"Test created for
+        Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\", \\\"user\\\":
+        null, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/tests/90/\\\", \\\"product_type\\\": {\\\"name\\\":
+        \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 90, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\"}}\",\n  \"files\":
+        {},\n  \"form\": {},\n  \"json\": {\n    \"description\": \"Event test_added
+        has occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\":
+        \"1st Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"product\":
+        {\n      \"id\": 2,\n      \"name\": \"Security How-to\",\n      \"url_api\":
+        \"http://localhost:8080/api/v2/products/2/\",\n      \"url_ui\": \"http://localhost:8080/product/2\"\n
+        \   },\n    \"product_type\": {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n
+        \     \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n      \"url_ui\":
+        \"http://localhost:8080/product/type/2\"\n    },\n    \"test\": {\n      \"id\":
+        90,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/90\"\n    },\n    \"title\":
+        \"Test created for Security How-to: 1st Quarter Engagement: NPM Audit Scan\",\n
+        \   \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n    \"url_ui\":
+        \"http://localhost:8080/test/90\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:38 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "Event scan_added has occurred.", "title": "Created/Updated
+      5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan", "user":
+      null, "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/",
+      "product_type": {"name": "ebooks", "id": 2, "url_ui": "http://localhost:8080/product/type/2",
+      "url_api": "http://localhost:8080/api/v2/product_types/2/"}, "product": {"name":
+      "Security How-to", "id": 2, "url_ui": "http://localhost:8080/product/2", "url_api":
+      "http://localhost:8080/api/v2/products/2/"}, "engagement": {"name": "1st Quarter
+      Engagement", "id": 1, "url_ui": "http://localhost:8080/engagement/1", "url_api":
+      "http://localhost:8080/api/v2/engagements/1/"}, "test": {"title": null, "id":
+      90, "url_ui": "http://localhost:8080/test/90", "url_api": "http://localhost:8080/api/v2/tests/90/"},
+      "finding_count": 5, "findings": {"new": [{"id": 232, "title": "Regular Expression
+      Denial of Service - (Negotiator, &lt;= 0.6.0)", "severity": "High", "url_ui":
+      "http://localhost:8080/finding/232", "url_api": "http://localhost:8080/api/v2/findings/232/"},
+      {"id": 233, "title": "2222Regular Expression Denial of Service - (Negotiator,
+      &lt;= 0.6.0)", "severity": "High", "url_ui": "http://localhost:8080/finding/233",
+      "url_api": "http://localhost:8080/api/v2/findings/233/"}, {"id": 234, "title":
+      "Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
+      4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
+      6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
+      6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/234", "url_api": "http://localhost:8080/api/v2/findings/234/"},
+      {"id": 235, "title": "Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)",
+      "severity": "High", "url_ui": "http://localhost:8080/finding/235", "url_api":
+      "http://localhost:8080/api/v2/findings/235/"}, {"id": 236, "title": "2222Remote
+      Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0
+      &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0
+      &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0
+      &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)", "severity":
+      "High", "url_ui": "http://localhost:8080/finding/236", "url_api": "http://localhost:8080/api/v2/findings/236/"}],
+      "reactivated": [], "mitigated": [], "untouched": []}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Auth:
+      - Token xxx
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2502'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - DefectDojo-2.41.0
+      X-DefectDojo-Event:
+      - scan_added
+      X-DefectDojo-Instance:
+      - http://localhost:8080
+    method: POST
+    uri: http://webhook.endpoint:8080/post
+  response:
+    body:
+      string: "{\n  \"args\": {},\n  \"headers\": {\n    \"Accept\": [\n      \"application/json\"\n
+        \   ],\n    \"Accept-Encoding\": [\n      \"gzip, deflate\"\n    ],\n    \"Auth\":
+        [\n      \"Token xxx\"\n    ],\n    \"Connection\": [\n      \"keep-alive\"\n
+        \   ],\n    \"Content-Length\": [\n      \"2502\"\n    ],\n    \"Content-Type\":
+        [\n      \"application/json\"\n    ],\n    \"Host\": [\n      \"webhook.endpoint:8080\"\n
+        \   ],\n    \"User-Agent\": [\n      \"DefectDojo-2.41.0\"\n    ],\n    \"X-Defectdojo-Event\":
+        [\n      \"scan_added\"\n    ],\n    \"X-Defectdojo-Instance\": [\n      \"http://localhost:8080\"\n
+        \   ]\n  },\n  \"method\": \"POST\",\n  \"origin\": \"172.18.0.7:54810\",\n
+        \ \"url\": \"http://webhook.endpoint:8080/post\",\n  \"data\": \"{\\\"description\\\":
+        \\\"Event scan_added has occurred.\\\", \\\"title\\\": \\\"Created/Updated
+        5 findings for Security How-to: 1st Quarter Engagement: NPM Audit Scan\\\",
+        \\\"user\\\": null, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\", \\\"product_type\\\":
+        {\\\"name\\\": \\\"ebooks\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/type/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/product_types/2/\\\"}, \\\"product\\\":
+        {\\\"name\\\": \\\"Security How-to\\\", \\\"id\\\": 2, \\\"url_ui\\\": \\\"http://localhost:8080/product/2\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/products/2/\\\"}, \\\"engagement\\\":
+        {\\\"name\\\": \\\"1st Quarter Engagement\\\", \\\"id\\\": 1, \\\"url_ui\\\":
+        \\\"http://localhost:8080/engagement/1\\\", \\\"url_api\\\": \\\"http://localhost:8080/api/v2/engagements/1/\\\"},
+        \\\"test\\\": {\\\"title\\\": null, \\\"id\\\": 90, \\\"url_ui\\\": \\\"http://localhost:8080/test/90\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/tests/90/\\\"}, \\\"finding_count\\\":
+        5, \\\"findings\\\": {\\\"new\\\": [{\\\"id\\\": 232, \\\"title\\\": \\\"Regular
+        Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\", \\\"severity\\\":
+        \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/232\\\", \\\"url_api\\\":
+        \\\"http://localhost:8080/api/v2/findings/232/\\\"}, {\\\"id\\\": 233, \\\"title\\\":
+        \\\"2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\\\",
+        \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/233\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/233/\\\"}, {\\\"id\\\":
+        234, \\\"title\\\": \\\"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
+        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
+        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
+        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
+        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/234\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/234/\\\"}, {\\\"id\\\":
+        235, \\\"title\\\": \\\"Regular Expression Denial of Service - (Fresh, &lt;
+        0.5.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/235\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/235/\\\"}, {\\\"id\\\":
+        236, \\\"title\\\": \\\"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;=
+        3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;=
+        6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;=
+        6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;=
+        7.1.0 &lt; 7.1.2)\\\", \\\"severity\\\": \\\"High\\\", \\\"url_ui\\\": \\\"http://localhost:8080/finding/236\\\",
+        \\\"url_api\\\": \\\"http://localhost:8080/api/v2/findings/236/\\\"}], \\\"reactivated\\\":
+        [], \\\"mitigated\\\": [], \\\"untouched\\\": []}}\",\n  \"files\": {},\n
+        \ \"form\": {},\n  \"json\": {\n    \"description\": \"Event scan_added has
+        occurred.\",\n    \"engagement\": {\n      \"id\": 1,\n      \"name\": \"1st
+        Quarter Engagement\",\n      \"url_api\": \"http://localhost:8080/api/v2/engagements/1/\",\n
+        \     \"url_ui\": \"http://localhost:8080/engagement/1\"\n    },\n    \"finding_count\":
+        5,\n    \"findings\": {\n      \"mitigated\": [],\n      \"new\": [\n        {\n
+        \         \"id\": 232,\n          \"severity\": \"High\",\n          \"title\":
+        \"Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)\",\n          \"url_api\":
+        \"http://localhost:8080/api/v2/findings/232/\",\n          \"url_ui\": \"http://localhost:8080/finding/232\"\n
+        \       },\n        {\n          \"id\": 233,\n          \"severity\": \"High\",\n
+        \         \"title\": \"2222Regular Expression Denial of Service - (Negotiator,
+        &lt;= 0.6.0)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/233/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/233\"\n        },\n
+        \       {\n          \"id\": 234,\n          \"severity\": \"High\",\n          \"title\":
+        \"Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;=
+        4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;=
+        6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;=
+        6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
+        \         \"url_api\": \"http://localhost:8080/api/v2/findings/234/\",\n          \"url_ui\":
+        \"http://localhost:8080/finding/234\"\n        },\n        {\n          \"id\":
+        235,\n          \"severity\": \"High\",\n          \"title\": \"Regular Expression
+        Denial of Service - (Fresh, &lt; 0.5.2)\",\n          \"url_api\": \"http://localhost:8080/api/v2/findings/235/\",\n
+        \         \"url_ui\": \"http://localhost:8080/finding/235\"\n        },\n
+        \       {\n          \"id\": 236,\n          \"severity\": \"High\",\n          \"title\":
+        \"2222Remote Code Execution - (Pg, &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||
+        \ &gt;= 4.0.0 &lt; 4.5.7 || &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5
+        || &gt;= 6.1.0 &lt; 6.1.6 || &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3
+        || &gt;= 6.4.0 &lt; 6.4.2 || &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2)\",\n
+        \         \"url_api\": \"http://localhost:8080/api/v2/findings/236/\",\n          \"url_ui\":
+        \"http://localhost:8080/finding/236\"\n        }\n      ],\n      \"reactivated\":
+        [],\n      \"untouched\": []\n    },\n    \"product\": {\n      \"id\": 2,\n
+        \     \"name\": \"Security How-to\",\n      \"url_api\": \"http://localhost:8080/api/v2/products/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/2\"\n    },\n    \"product_type\":
+        {\n      \"id\": 2,\n      \"name\": \"ebooks\",\n      \"url_api\": \"http://localhost:8080/api/v2/product_types/2/\",\n
+        \     \"url_ui\": \"http://localhost:8080/product/type/2\"\n    },\n    \"test\":
+        {\n      \"id\": 90,\n      \"title\": null,\n      \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n
+        \     \"url_ui\": \"http://localhost:8080/test/90\"\n    },\n    \"title\":
+        \"Created/Updated 5 findings for Security How-to: 1st Quarter Engagement:
+        NPM Audit Scan\",\n    \"url_api\": \"http://localhost:8080/api/v2/tests/90/\",\n
+        \   \"url_ui\": \"http://localhost:8080/test/90\",\n    \"user\": null\n  }\n}\n"
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Origin:
+      - '*'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:38 GMT
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQX0vDMBTFv0te3br8abs2bzLBKTqFdi+KSJrcYjVNSpMOxth3N8Ghe1TfLvf8
+        zj2He0CNcLAdNeLozfvB8cVCQQvSK/tuE+G1cK4TJjHg0Qypzg1a7P/BVzDuOgkK3Mca9LAC42H8
+        65GVNa2ewEj4nXMHo+usCTDBmCQ4wfNqc/lYrR/qH3Uz9U2YEH+O0AzP8EvIhEHbfR9a1vshpq20
+        nVQwNVOn1ZcF8WCgy+VpeSV8BCmm6ZzQOSlrQjkjnLAEY3yBAxz8LvwBxrrrz1mGa1JwknJWJMsy
+        /2Zlf2NaG0CcZjhlNBesaYqsKElWEpVRJiUtQOVEQCtEmjdnAV7HhNtuFPGFQZ+0v7NSxPUB6dOE
+        wLxuK3Q8L/ZkTVSu72t0/AQAAP//AwDwqwPDIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 8ca3d81a-84bf-42ac-85e8-3af90a8d8ecd
+      Atl-Traceid:
+      - 8ca3d81a84bf42ac85e83af90a8d8ecd
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:38 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=151,atl-edge-internal;dur=14,atl-edge-upstream;dur=138,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 97cb89a8d2b2fe30fa6c9c0b672e7f90
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSY7MmU7HdZTEreu6suw8OB4PTK5IxCTAAqCOxvnv3SVF
+        KT6Y1u409gNx7YHdbz+sPjuwKrlMnMjRIBPQkLwVkCemJ3kBpmfiDAreUyVoboWSpgeJsAVY3osz
+        LlPIVdpbgDa4B8kUSg0GpN2cjStjVTEnhdeB7we+q+HPCoydrUs41Ty2Igan5wiyH4z291/jxEA+
+        x2lmbWkiz0tgDrFN1CflcptzYwSXrgTroSXr8VJ4oSeMqcBrFdzCGuVPZpOzWT8YjUe4VLtgnOiz
+        Y9C3ysTcQqr0urlDgjOUCP1w2A/C/sCfBeMoGEaD0B0HwQ/ot09OkhGLjtdqXugkyXuozw+3195M
+        EjCxFiUFDlcPmCl4nvdYIowVMrasFBADU3O2VPrWJelYyXOdP9OLSgpKF8+v+YJbrr2FgKVXu7Vz
+        cLMV+INg/JMRf8GPBaa9KtAqwQJNzri5pVxVN5ZG0ZznBnpOI3iE96ple04mEDg6ztbHsAD01f/S
+        c6xAZJWIEieSFd7ReQCTgd+1EbQbpVaf8KovzMRGus5Dndk2DzT5Cj27655LYS0qMM7WNkH41/qs
+        UXO75JqAbERR5gIdTh6EBBNVw284Xg3Hz3T3Gylrb7JN2NCnCgiHq3D4/1ppYFGDFA0Ge6tg73sY
+        XLUWB+FqEH4Pixvkf/nyGI5hF04H7cZcrC4acsTsX14hGtJUQ4p8849FMGo38AIqrxpeeProXtfG
+        646NsHNj3LWx/9idhjabVSKl+oVwon6AU27x4WgI9/n12dD5jsC9Rp2m6quHh6qiwAVEyh9oQcjU
+        iayuALOESu0FJpZqsHGu1kf6tYibOH5+tEa+orDJVJUnb4Qpc77e1DBlXgNelmjiqUdiuB+2j8TD
+        sHVRWbilsocbW1CVWigt7PqFQWzFvfql+fdvhSh4CsYjCdMqEbiQiTRzzSLdkeJ7XGnZM3Qe10e4
+        LYOc3wDxH1XAw56gC7xBF0aDMUUk42ZSivhYyNu3tPMGSupfZNxmrc7lst7brkglJ9i+8JscpsBN
+        gwS9GTmnx+fvjk6uj48OJydnk+vJdPr7FO+HdWowJHhglgE7RaKXlpFdJgxTMl8zJA2Rk1JmFftF
+        aM5ONRTIGqwyiFr3KfIIsKAc/074fpkMIqd5FTF7GP5dVd1jC0xEKiTPHx7adF+b8Na4ztG7lnAw
+        s6mE7emqpLLtQvJoz2+R3DRKLwRfI7x9YO/3Ns/D4w5vP/P4FtvNFnKt8sbW4aaj+08Ot21hUzNo
+        JGz7AQlLqm6VK33SeHOTV9BPNbLErilS7I1qkq2KEhtiaZ8G/aiLFkZbWvhWxu+H86P8+v+ApVpV
+        JTWKb4VMkBgNw1phNwCSlZXJIKlRejQ9oO8NMCEXZIBgljD8KcDw0YIkImVZ6LJ3pO6jfFV/X0Xs
+        cqtWyIhJjJcV3Cod+e7IHdxR0DHmuYp5niljo7E/9r15I3Nd++YNRuMrlGaXZxBXxFHsvVr2reoQ
+        xrc5qfBtDq+Yxy4DY9kfFdcWNJvIFCuzwDh3iML2gBfU0ienv7GDCjmAncVcdkhRp+ft+1dNRO/u
+        2Bk2r7WfOD68mNSfD82nTTRNNk89DWfCIh2QaA0sHKEiRozJ7tgl6uiHSAF97JLDoPaCgCoXiSux
+        33dTtfAWVS4Ruhapxbt//opUDHx/KxcvwS2E1eAqnXpY35wwL7BnJV7w8Kib2SInuV2+cFJnjJSF
+        +DeFtMo5xvRvAAAA///sWW1v2jAQ/ivWpFaASApJCIWq6qhY1U5rNa3aPnRfMLED2UISJYTuw378
+        nnNMeCmUjqpVJ00gILbPPp/vnvM9/KIaTu2jL6OAh+RKtzKdoVRjBqvclDPU2WE4PTnFNK7ZqG6x
+        pT75I8u2af0eku1M1slU6prMNtnFxT5bdufJdtHjlV2cp9vF2WmXF7eJtc0mCLi503Vryj7Uxmr9
+        XLI+IhWNH4FizOrUGYC8xVZRYP4aN80SBtSzbb7aaWMLfYW8AMUfMaOcBK13yrEKPqqb9v/o7lkN
+        EYn27/gy9goOLAl/UlM8LzxXj6B2G+cpjHkRhBLwKQuDH46mJ9zzZDJVPxfutyTYX8B8DXBcqhED
+        /zVwmkF8xMUsyJAqJOXbNjKAT0aHG80vBnSkg8UKA4YrDCP9UZrrS0uq3UFrR+4gSnfItDvw6RQZ
+        OKuz+3HgjRluzqMRQDgHALKEY61oxDhDUeNBENciL+U+6THoqY0an3g0ygHHAzaWXEByxpFDzWK3
+        7NtCoWvgfSiXk8tq/7yk6i67JIZ8VmWCmPejezTvbq7OgJFjiKMRTq7Cvbv7YAjzu/RB/oVH2laG
+        WZJ8GAaePrTrQKVSfWZf1W2LLKwPo1CGAWZCdKR685C7miTcm5LMTcwC9cCQ+GaBkGLFnb4gpnAF
+        xdJ/4xRaNIkpb5KPV7iYBFGVVaq/J/Dhadwt/XYjaLw4YFh7AoZFgGE9EzD2yhoPAGPfvLV8vq8N
+        GO5/wHgFwHD+LcBwS9EdgPGQ8WiVRf96wbut5mk6yzXPNIXLKDqH6Jj1oSUpttbhlPTUWkdjm0Rj
+        G+/QKHmHuXm2DdzGlTVKZVbq9/UqTkXHmGqTokbM8smEUwH77tEKi0xObFSc7lnqEidxBo8lDu1K
+        nLabAMTGgd2T7rE7dB1uNHyrbTg+bxmdTrthCNcXsu0PHWlTWVxKYtlCtvtESUl+0xOCooZ05mkc
+        ivdLKqNqpgUeJczVoUgThbcaRjJz0tb2bWENpeBu+5hLm3eEz53OsTfkbsdzms0zcapmwV4PrAu8
+        CzljwiNdJBpG0ZSZeWbcw2SGZVL1aRYRSzY1Es4zMinkVU7gYYafl+eGYyYRkRPr5Pvb13idvX/7
+        Gq+z/29dY0CZKDhlzR5dKudn5yGPfsooGweJCi0qBAsiu0DDuzii0R/yNE7k0R3gyCPKVccg/QWF
+        3jLSaRn9j9xm3snZhsHOEh39BwAA//9ClcA1x2ECL+eLoJXEaHE0CBMeoeIIAAAA//8ajC4eLY5o
+        7WL6FUfopQa8rQdvGgGdng7JgtWgqXUo2wBoYX5JInTFALopOBt1OIsxnK09I+wFJa7JJwNczVtQ
+        qYBVwgDuZTQJY1w6jOHtx9S8ssyi/DxIGxEilFIKXa4C4RIVevm5EBOqYUxo7UBGaY200kYfZq6O
+        Um5iRVBqcWkOyGAku8FzM0UljiUQd5Tll1BvShhiGNxQoF0ZicVh+eCpLdisLWhSGjRhBLIS7hBU
+        1xqhOBeqARw8tbW1AAAAAP//AwBczEFZHSUAAA==
+    headers:
+      Atl-Request-Id:
+      - 4192167c-e4b7-49e6-9e55-ba26460df8cb
+      Atl-Traceid:
+      - 4192167ce4b749e69e55ba26460df8cb
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:39 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=275,atl-edge-internal;dur=13,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 91bf791ffbfaf4ae86600c8cbd9258e9
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbubpN3avMkEp+gU2r0oImlzi9U0KU06GGP/3RSH7lF9u9zz
+        nXsO90Aq6XA7aCLIm/e9E/O5wgZrr+y7jaXX0rlWmtigJzOiWtdruf8HX+Cwa2tU6D7WqPsVGo/D
+        X4+srGn0iKbG3zl3OLjWmgBTABpDDFGxuXws1g/lj7oZuypMRDxP0Axm8BIysdd234WW5b6f0lba
+        jiqYqrHV6stCRDCw5fK0vJJ+AhmwJKIsonlJmeBUUB4DwAUEOPhd+AMOZdudsxxKmgmaCJ7HS+Df
+        bN3dmMYGEJIUEs4WkldVlmY5TXOqUsbrmmWoFlRiI2WyqM4CvJ4SbttBTi8M+qj9na3ltD4QfZoI
+        mtdtQY7nxZ6smZTr+5IcPwEAAP//AwDhjs6NIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 44e53aec-25aa-4ae2-bcd4-fe76445d7374
+      Atl-Traceid:
+      - 44e53aec25aa4ae2bcd4fe76445d7374
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:39 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=163,atl-edge-internal;dur=19,atl-edge-upstream;dur=144,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - afa02db93ac1ccbed0c06cfcaac2bbab
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xX23LbNhD9FQwfU4k3SY7MmU7HdZTEreu6spI8OB4PTK5IxBTAAKAujfPv3SVF
+        KpbNTO1OYz8Qt71g9+zB6osD64LLxIkcDTIBDclrAXliepIvwPRMnMGC91QBmluhpOlBIuwCLO/F
+        GZcp5CrtLUEb3INkCoUGA9Juz8alsWoxJ4XXge8HvqvhcwnGzjYFnGseWxGD03ME2Q9Gh4cvcWIg
+        n+M0s7YwkeclMIfYJuqTcrnNuTGCS1eC9dCS9XghvNATxpTgNQpuYYPyZ7PJxawfjMYjXKpcME70
+        xTHoW2libiFVelPfIcEZSoR+OOwHYX/gz4JxFAyjQeiOg+An9NsnJ8mIRccrNc90kuQ91OeH7bW3
+        kwRMrEVBgcPVI2YWPM97LBHGChlbVgiIgak5Wyl965J0rOQ7nT/Ri1IKShfPr/mSW669pYCVV7m1
+        c3C7FfiDYPyLEX/DzwtMe7lAqwQLNDnj5pZyVd5YGkVznhvoObXgCd6rku05mUDg6DjbnMIS0Ff/
+        a8+xApFVIEqcSJZ4R2cPJgO/2Si0+oQ3embAt9JVuKsENuGmyTcg2d3qnRTWogLjtLYJqb9XZ42a
+        2xXXhFcjFkUu0OFk7+aYjwplw/F6OH6iu9/JTHOTNi9Dn4AeDtfh8P+1Ume/wiIaDA7WwcGPMLhu
+        LA7C9SD8ERa3AP/69SEcgy6chl0bg2ZjLtbva3JEWFxeIUzSVEOKfPOgCPACKi/r8n9c66hr46Br
+        42XHRti5Me7aOHzoZ02b9SqRUvVCOFE/wCm3+HDUhPv0wq3pfEfgXq1OU1lWw2NVUuACIuUPtCBk
+        6kRWl4DpQ6X2PWacirN2rtJH+rWI6wB/ebBGvqKwyVSZJ6+EKXK+2RY3QUIDXpb447FHYngYNo/E
+        fthaKtvf6AJV2IKq0EJpYTfPDGIj7lUvzb9/K8SCp2A8kjCNEoELmUgz1yzTHVu+xZWGVkPnYeGE
+        bRnk/AaIGKkC9nuCLvAGXRgNxhSRjJtJIeJTIW9f084rKKh/kXGTtSqXq2qvXZFKTrB94Tc5TIGb
+        Ggl6O3LOT9+9OTm7Pj05npxdTK4n0+mfU7wf1qnBkOCBWQbsHF8AaRnZZcIwJfMNQzYROSllVrHf
+        hObsXMMC6YSVBlHrPsYqARaU498J3y+SQeTUryJmD8O/q6p7bIGJSIXk+f6hbfe1DW+F6xy9awgH
+        M5tKaE+XBZVtF5JHB36D5LpReib4auH25b3f2zwNjzu8/crjW2w3G8g1ymtbx9uO7j853LSFdc2g
+        kbBpFCSsqLpVrvRZ7c1NXkI/1cgSu6ZIsVeqTrZaFNgQS/s46EctLXwvsftCLWXcD+dH+e3/EUu1
+        KgtqFF8LmSAxGoa1wm4AJCtKk0FSofRkekTfG2BCLskywSxh+FOA4aMFSUTKstBlb0jdR/mi+r6I
+        2GWrVsiISYyXFdwqHfnuyB3cUdAx5rmKeZ4pY6OxP/a9eS1zXfnmDUbjK5RmlxcQl8RR7K1a9a3q
+        EMZHOynx0Q6vmMcuA2PZXyXXFjSbyBQrc4Fx7hCF9oAXVNJn53+woxI5gF3EXHZIUQvoHfpXdUTv
+        7tgFNq+Vnzg+fj+pPh/qT5NommyfehrOhEU6INEKWDhCRYwYk92xS9TRD5EC+tglh0HlBQFVLhNX
+        Yr/vpmrpLctcInQtUot3//wVqRj4fisXr8BdCKvBVTr1sL45YV5gM0u84OFRN7OLnOR2+cJJlTFS
+        FuLfFNIy5xjTfwAAAP//7Fltb9owEP4r1qRWgEgKSQiFquqoWNVOazWt2j50XzCxgWwhifJC92E/
+        fs85L7yUlI6qVSdNrYDYPvt8vnvO9+QX1XBqH0Ppu9wjV7qV0QKlGtNY7aacockOveTkFNPYeqte
+        Ycv85I8M06T1B0i2C9kkU6n7M9tmFxv77Ji9J9slH6/sYj3dLtZOu7y4TYwqmyDgCqfrN5R9qI01
+        hqlkQ0QqGj8CxZjRazIAeYeto0DxN2vrJQyoZ1N/tdPGFoYKeQGKPwJGOQla75RjNXzUt+3/0d2z
+        BiIS7d/xpe0VHFgS/qSmeF54rh9B4zZIIxjzwvUk4FNmBj+cJifccWSYqJ9L91sRHC5hvgE4LtUI
+        gP85cOpucMTFwo2RQyTl2y4ywISMDjcqLgZ0pKPlCiOGKwwj/VGa55eWKHeHXDtyB1G6Q5y7A08S
+        ZOC4ye5nrjNjuDlPpwDhFADIQo61/CnjDEWNA0Fci5yIT0iP0UBtVPvE/WkKOB6xmeQCkguOHKpn
+        u2XflgpdA+89uZpc1vuLkqq/6pIY8lmVCaLoR/e06G6vz4CRM4ijEU6uwr2/+2AI8/v0Qf6FR9pW
+        jFnCdOy5Tn5o165KpfmZfVW3LbJwfhiZMgww46EjyjcPuat5yJ2EZG4C5qoHhsS3cIUUa+70BTGF
+        KyiW/hunyEXDgPIm+XiNi7nr11mt/nsOH06Cfum3W0HjxQHD2BMwDAIM45mAsVfWeAAY++at1fN9
+        bcCw/wPGKwCG9W8Bhl2K7gCMh4xHpyz6NwveKiqkbVV1lIQXVUlJBF9SPA/xNBtDW1XcmFXyVpsS
+        VbxDq+QdCvNUDaziylrlmmv1+2Z5p6JjRrVJViPG6XzOqYB992iFRSYnNiqI9ix1iZM4g8cSh3Yl
+        TrttAGLrwBxI+9ge2xbXWhOjq1kT3tF6vW5LE/ZEyO5kbEmTyuJSEstmsv0nSkrym4EQFDWkM48C
+        T7xfURlVMy3wKJOuDkXqKLzVMJIp2FxzYgpjLAW3u8dcmrwnJtzqHTtjbvccq90+E6dqFuz1wLjA
+        fyanzbmfF4maljXFehpr9zCZZuhUfepZxJJNtZDzmEwKeZUTuBfj5+W5ZumhT+TEJiv/9jXepPXf
+        vsabrwXeusZALJFxyjl7dKmcn5173P8p/Xjmhiq0qBDMiOwM9O4Cn0Z/SKMglEd3gCOHKNc8Bund
+        FHrLSKdl8jdy23knqwqDrRU6+g8AAAD//0KVwDXHYQIv54uglcRocTQIEx6h4ggAAAD//xqMLh4t
+        jmjtYvoVR+ilBrytB28aAZ2eDsmC1aA5dyjbAGhhfkkidMUAuim4WnsGuIoxAyPs5SHORiCuVqwJ
+        rlkpA1ytWFBxgVXCGKcEvP2YmleWWZSfB2kjQoRSSqHLVSBcokIvPxdiQjWMCa0dyCitkVba6MPM
+        1VHKTawISi0uzQEZjGQ3eG6mqMSxBOKOsvwS6k0JQwyDGwq0KyOxOCwfPLUFm7UFTUqDJoxAVsId
+        gupaIxTnQjWAg6e2thYAAAD//wMA9dwEEB0lAAA=
+    headers:
+      Atl-Request-Id:
+      - cdbffae6-fb4f-4e0c-a5bb-0aa041adcf20
+      Atl-Traceid:
+      - cdbffae6fb4f4e0ca5bb0aa041adcf20
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:40 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=269,atl-edge-internal;dur=14,atl-edge-upstream;dur=255,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 6f204f3e534fde1214913f0c22d929e0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 9d9b0250-1902-48a3-afa0-a9c29f65059e
+      Atl-Traceid:
+      - 9d9b0250190248a3afa0a9c29f65059e
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:40 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=326,atl-edge-internal;dur=20,atl-edge-upstream;dur=288,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - df682c09b2ac5779442bcc3c869a3826
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
+      group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/358]
+      in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+      | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+      | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/233]
+      | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+      | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]
+      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Jan.
+      29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
+      of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/233]\n*Defect
+      Dojo link:* http://localhost:8080/finding/233 (233)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
+      Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]\n*Defect
+      Dojo link:* http://localhost:8080/finding/232 (232)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3379'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 719e079e-76f2-41d0-8213-a326e15369b6
+      Atl-Traceid:
+      - 719e079e76f241d08213a326e15369b6
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:41 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=524,atl-edge-internal;dur=15,atl-edge-upstream;dur=510,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 553c26703689b1379605fa8a65b6e6ce
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSYnMmU7HdZTEreu6spI8OB4PTK5IxCTAAKCOxv7v3eUh
+        xbaUqd1p7Afi2gO7335YfXVgVXKZOJGjQSagIXkjIE9MT/ICTM/EGRS8p0rQ3AolTQ8SYQuwvBdn
+        XKaQq7S3AG1wD5IplBoMSNuejStjVTEnhVeB7we+q+FLBcbO1iWcaR5bEYPTcwTZD0YHB69wYiCf
+        4zSztjSR5yUwh9gm6rNyuc25MYJLV4L10JL1eCm80BPGVOB1Cm5gjfKns8n5rB+MxiNcql0wTvTV
+        MehbZWJuIVV63dwhwRlKhH447Adhf+DPgnEUDKNB6I6D4Cf02ycnyYhFx2s1z3SS5D3U54eba7eT
+        BEysRUmBw9VDZgqe5z2WCGOFjC0rBcTA1Jwtlb5xSTpW8r3On+hFJQWli+dXfMEt195CwNKr3do6
+        2G4F/iAY/2LE3/BzgWmvCrRKsECTM25uKFfVtaVRNOe5gZ7TCB7jvWrZnpMJBI6Os/UJLAB99e96
+        jhWIrBJR4kSywjs6D2Ay8LuNUqvPeKNnBryVrsNdJ7ALN02+Acn2Vu+lsBYVGGdjm5D6e33WqLld
+        ck14NaIoc4EOJw9ujvmoUTYcr4bjJ7r7ncx0N9nkZegT0MPhKhz+v1aa7NdYRIPBy1Xw8kcYXHUW
+        B+FqEP4Iiy3A7+4ewzHYh9Ow25iL1YeGAzH7F5ePTw66kzxNNaTIN4+KAC+g8qop/93mRvs2Xu7b
+        eLVnI9y7Md63cfDYz4Y2m1UipfqFcKJ+gFNu8eFoCPfphdvQ+ZbAvUadprKsh0eqosAFRMofaUHI
+        1ImsruCu5WnSpkXchPProzXyDI+aTFV58lqYMufrtpRxGd2yHxAzVN5tNDTgZYk/dj0Sw4OweyQe
+        hm1DZQ839oEq3ICq1EJpYdfPDGIn7tUvzb9/K0TBUzAeSZhOicCFTKSZaxbpli3f4UpHq6HzuHDC
+        Depzfg1EjDtKg/hkZyCCfRgNxhSRjJtJKeITIW/e0M5rKKl/kXGXxzq7y3pvsyKVnGD7wq9zmAI3
+        DTZ0O3LOTt6/PT69Ojk+mpyeT64m0+mfU7wf1qnBkOCBWQbsDF8AaRnZZcIwJfM1QzYROSllVrHf
+        hObsTEOBdMIqg6h1d7FKgAXl+LfC98tkEDnNq4jZw/Bvq+oeW2AiUiF5/vBQ23214a2RnqN37Zwy
+        m0rYnK5KKtudSB767njod0huGqVngq8R3ry893ubp+Fxi7dfeXyD7WYHuU55Y+uo7ej+k8NdW9jU
+        DBoJu0ZBwpKqW+VKnzbeXOcV9FONvLFtihR7rZpkq6LEhlja3aAf7aOF0YYWvpfx++H8JL/9P2Sp
+        VlVJjeIbIRMkRsOwVtg1gGRlZTJIapQeTw/pew1MyAUZIJglDH8KMHzNIIlIWRa67C2p+yRf1N8X
+        EbvYqBUyYhLjZQW3Ske+O3IHtxR0jHmuYp5nytho7I99b97IXNW+eYPR+BKl2cU5xBVxFHunln2r
+        9gjjo51U+GiHl8xjF4Gx7K+KawuaTWSKlVlgnPeIwuaAF9TSp2d/sMMKOYCdx1zukaIW0DvwL5uI
+        3t6yc2xeaz9xfPRhUn8+Np8u0TRpewAazoRFOiDRGlg4QkWMGJPdsgvU0Q+RAvrYJYdB7QUBVS4S
+        V2K/76Zq4S2qXCJ0LVKLd//8JakY+P5GLl6CWwirwVU69bC+OWFeYDNLvODhUTezRU5y23zhpM4Y
+        KQvxbwpplXOM6T8AAAD//+xZbU/bMBD+KxbSUFs1IU3SlBYhBuoQTANNoO0D+1I3dtuMNImSpuzD
+        fvyec9z0hRa6IhCTJlDb2D77fH7uOd/lF+Vwah9dGQU8JCjdynSKVI0ZrHJdzlBn++Hk6BjTeKZV
+        3WBLffIHtuPQ+pcRJX1TWSdjqRt0nd0E2T079X2ZEALXGcrDxptOe2tD6fHKUO72hnKfNdSrG8ne
+        2khwyRksOzVlMGpjtW4uWRe+jMbP4Dlmt+sMVN9kyzwx+xs1zJIo1LNjvhkesIWu4mbQ5s+YUdSC
+        1s/KsQo+quv2/+TuWQ0+i/Yf+DJ2ch8sCYCpKV7mwMtHULuN8xTGPA9CCYKVhcH3h5Mjrs5b/Zzj
+        cUGwOw8ENRB2qUaMCKGp1QziAy6mQYZgIikitxAjBmR0wGh2daAj7c1X6DFcchjpj+RdX2tSDQet
+        HcFBlHDINBz4ZIIYndXZwyjwRwy37eEQNJ2DIlnCsVY0ZJwh7fEhiIuTn/IB6dErgG184dEwB2H3
+        2EhyAckpR5Q1i92y73OFrhARQrkYfpb7Z9lYZxGSGPJVJRJi1o/u4ay7sTwDRo4gjkaAXPl/5/mD
+        oajQoQ/CFx5pWxlmSfJ+GPj60K4CFWz1mX1T9zGysD6MQhkG3gnRkerNQ+5ynIAWSOY6ZoF6YAiN
+        00BIsQSnG/gULqlY+m9AoUWTmCIrYbzCxTiIqqxS/T0Ghidxp8TtWtJ4dcKwdyQMmwjDfiFh7BRG
+        HhHGroFs8XzfmjC8/4TxBoTh/luE4ZWizxDG45pIsywLrKbEm7KihrupoyyJUbo0SYElVQmi2s7K
+        ULcsYK10WJvKatamyoRVViZm5tk0cFM1zSqVUQ4wogRFp+uLGf9q3pfl4zGnFHfvyRyMTE71qjjd
+        MRmmqsUJEEtVtktx3GqAEK0Pzqn0Dr2+53LDGtgtwx3wptFutyxDeAMhW4O+Kx1KnEtJLFvIdraU
+        lISbUyHIa0hnnsah+LigMvJqWuDJWrs6FGkiNVfDSGZW73UGjrD7UnCvdcilw9tiwN32od/nXtt3
+        G40TcaxmwV4/2Of4L+SMMY90GmkYRVNm5pnxAJMZtkn5qVl4LNnUSDjPyKSQVzGBhxl+XpwZrplE
+        VL5Yrdu/f41XC//vX+PVFwfvXWMwlijq0Lq+dKHAz85CHt3LKBsFiXItyguLUndBendxRKM/5Wmc
+        yIM70JFPRVntg/T2Cr2lp9My+p3d+sqUa+39AQAA///CXmSZ4BqwNoEPWKNLwMv5ImglMVocDbqE
+        BwAAAP//Gi2O6OPi0eIIV3GEXmrA23rwphDQ6emQLFgNmpWHsg2AFuaXJELXFKCbgrNRh7MYw9na
+        M8JeUOKanjLA1bwFlQpYJQxwNW+NcekwhrcfU/PKMovy8yANSIhQSil0QQuES1To5edCTKiGMaG1
+        AxmlNdJaHH2YuTpKuYkVQanFpTkgg5HsBs/eFJU4lkDcUZZfQr1JY4hhcEOBdmUkFoflgye/YDO9
+        oGlr0JQSyEq4Q1Bda4TiXKgGcPDU1tYCAAAA//8DAAx1jO0/JQAA
+    headers:
+      Atl-Request-Id:
+      - a1b01d83-32e0-4f6a-acfc-62f38e8c3ac1
+      Atl-Traceid:
+      - a1b01d8332e04f6aacfc62f38e8c3ac1
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:41 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=256,atl-edge-internal;dur=13,atl-edge-upstream;dur=243,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 3d9fdc9adc5ef8cd9d146d7d0021e730
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": 41}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1585/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - f6090579-d3a1-47e4-845b-0daa1da060ec
+      Atl-Traceid:
+      - f6090579d3a147e4845b0daa1da060ec
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:42 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=521,atl-edge-internal;dur=13,atl-edge-upstream;dur=509,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 1e16775b2750e8a744328dac2de8cdba
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0te3bqbtN26vMkEp+gU2r0oImlyi9U0KU06GGP/3QSH7lF9u9zz
+        nXsO90Bq4XA7aMLJm/e947OZwgalV/bdJsJr4VwrTGLQkwlRreu12P+DL3HYtRIVuo816n6FxuPw
+        1yMraxo9opH4O+cOB9daE2AKQBNIYFpuLh/L9UP1o27Grg4T4c8RmsAEXkIm9truu9Cy2vcxbaXt
+        qIKpHlutviyEBwNbLE7LK+EjyIBlU8qmdFlRxlPKaZoAwAUEOPhd+AMOVdudsylUtOA04xlLcka/
+        WdndmMYGELIcspTNRVrXRV4sab6kKmeplKxANacCGyGyeX0W4HVMuG0HEV8Y9FH7OytFXB+IPk0E
+        zeu2JMfzYk/WROX6viLHTwAAAP//AwAo3mwLIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - b5ac5806-ed9a-4df2-a37d-172a4104c151
+      Atl-Traceid:
+      - b5ac5806ed9a4df2a37d172a4104c151
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:42 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=156,atl-edge-internal;dur=16,atl-edge-upstream;dur=140,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 25cd54cc2c69e8f9e6fd4dede99112f0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+SyDxTKfDQLijpZSGAB84JiPsja3DkXySHJIe/Peu/BYI
+        MS10esMMtiXti3affXbz3YJlRnlkBZYEHoGE6JhBGqkOp3NQHRUmMKcdkYGkmgmuOhAxPQdNO2FC
+        eQypiDsLkAr3IBpDJkEB19XZMFdazGdG4dR1HNfpSviWg9KTVQbnkoaahWB1LGbsu/3hcB8/FKQz
+        /Ey0zlRg2xHMINSR+Cq6VKdUKUZ5l4O20ZK2acZsz2ZK5WDXCu5hhfJnk9HFZNftD/q4VLigrOC7
+        pdC3XIVUQyzkqrxDhF8o4Tleb9f1dn1n4g4Ctxf03O7+nvcT+u0YJ40RjY4Xaj7opJG3UZ/jNdeu
+        PiJQoWSZCRyuHhA1p2naIRFTmvFQk4xBCETMyIOQ910jHQp+KdN3epFzZtJF0yldUE2lvWDwYBdu
+        rR2stlzHdwe/KPYX/DzHtOdztGpggSYnVN2bXOV32rwFM5oq6Fil4Aneq5DtWAlD4MgwWZ3CAtBX
+        56ljaYbIyhAlVsBzvKO1ARPfqTcyKb7ijT4Y8Eq6CHeRwDrc5uMZSNa3uuRMa1SgrMa2QepvxVkl
+        ZvqBSoNXxeZZytDhaOPmmI8CZb3Bsjd4p7tvZKa+SZOXnmOA7vWWXu//tVJmv8AiGnT3lu7ejzC4
+        rC363tL3foTFCuBPT6/h6Lbh1Gvb8OuNGVteleSIsLi5RZjEsYQY+eYfi6Bfb+DNRJqXvPChOlgr
+        2F4KL5nnGumFJFSROwBOQoFIBw0REZzohClSsIThn6pmjpD4rS1R22u72H7Lhte6MWjbGL6O0Vtc
+        7g9rLjccWjQ0K9h18ZNq7HNlf3h/fMvus+43dqlOGhYpXg9FbvLsmh5ybRYYj61AyxyeqrZitEkW
+        1kneXDOe4VGViDyNjpjKUrqqmAeX0S19hRA3bFTFSQKGweT4VRx8r9sbNj1tM6AN825utNWA19RA
+        JpmQTK8+GMRa3C4a479vbWxOY1C2kVC1EoYLCYuTrlrEa6B+xpUa+t4WxHp+XRPTnWBn6hb/h94+
+        fj7umAOO92zDRC+ld2D43hT25qjTBn+3DeXuwEQOC2+UsfCU8ftjs3MEmRnLeFjnu0DBQ7HXrHDB
+        RziV0bsUxkBViSFZvVnnp5efTs6mpyeHo7OL0XQ0Hv8xRueRfhSGDg9MEiDn2Ni4JsYuVjgWe7oi
+        SJIsNUqJFuRXJik5lzBHliS5QnR3t5GliyVpOY/McbLID6yy2WOWMU2mLsubvyBBTFjMOE03D1VD
+        ZRXeoiJS9K7mUURAzKE5nWem8Lci/uUUV85/HwRpKdzMby+J83243SDQjWGwNHRYTan/ydt61LX9
+        yohfDz9RaTgUqZBnpS+YF+AbrhVZxjaA71xvR3u/jTf6DW+8leqXcfzCn/8dkFiKPDOD7zHjETKn
+        WnenLFcJtiYDz5PxgXneAWF8YQwYfEUEf9oQbMIQBUZZ4nXJJ6PuC98pnjsBuWnUMh4QjrHSjGoh
+        A6fb7/qPJuAY71SENE2E0sHAGTj2rJSZFr7Zfn9wi9Lk5gLC3JAY+SwedrVoEcYhJMpxCPFuiU1u
+        XKXJnzmVGiQZ8RhLco5xbhGF5oDtFtJn57+TgxyLn1yElLdImZHWHjq3ZUQfH8kFDuOFn/h+eDUq
+        HtflQ8z/BgAA///sWW1P2zAQ/ivWJFBbNWmapCktQoypQmMaaIJtX9CkurGbRqRJlZeyD/z4Pee8
+        9AVKuyIQk1aqksQ++3z3+DnfJXc03RRHF7r87qfgARJVoMIVBmJEqeyB3WIMzcTe13DqN9tKCwJp
+        OBd6iPxF96J5a54FIWCbglNaq/1/0RCWYVRy7r3Up34aSz2KvRY2Nie8+zicEyG00FWfpNOA5Bb+
+        wo3yGA1m4nMtvSzgsOlvyknVOgYy9HlAULqR8RypJ9NY7aoaockOg/T4BMM4ulHfYMvC8y3Tsmj+
+        i5CS2LlskrFURtBk135yx85cV84IgU8ZysHCO1ZvZ0MV/ZWh7N0NZW811KsbydzZSNiSJSz7DWUw
+        esYag0yyAfYyHn4BxzGz12Tg+A5b5Ynyb9LWK6JQ95b+ZnjAEgaKl9kAxMwoXEHrrXKshp/6U+t/
+        dvWsgT2L57f4p+21fTAlAKaGeNkGXnVB4ybKYhjz3A8kCFbmBj/00mOu/K0uF3hcEhwsAkEDhF2p
+        ESFCFNSq+1GLi7mfIJhICsVdxIgxGR0wKs8M5NLhYoYhw+mGkf4yLs8zcQGHQjuCg6jgkBRw4GnK
+        3bukye4nvjthOI57Hmg6A0WyGcdcocc4QxrnQhAnJjfmY9JjmANb+8pDLwNhD9lEcgHJOQ+QPOWr
+        ZT8XCl0iIgRyOfystpdJZH8ZkujyTWUaomxHs1c2t1dHQM8JxPEQIFf7v7/dMRQV+vRD+MItLSvB
+        KLNsFPhu4bRLXwXbwmc/1EGMLFw4I1eGgXcCNMTF4iF3MZ2BFkjmKmK+umEIjXNfSLECp2vsKZxO
+        MfXfgKIQnUUUWQnjNS6mflhntfrDFBhOo36F2ydJ49UJw9yTMEwiDPOFhLFXGHlEGPsGsmX/vjVh
+        OP8J4w0Iw/63CMOpRLcQxuOiSaeq9q3nwpuyora9nBWlMSCjKkJU41nvWpUB1xrsqva11mBskjA2
+        lSSMqiRRmmdTx02FOKNSZiW1X8/z1O6YUPaSZ5FJNp1ySm8/PJuDkcmpoBXFeybCVK44BWKpDHch
+        TrptEKJxYJ1J58gZOTbXjLHZ1ewx72i9XtfQhDMWsjse2dKiZLySxLS5bH9HSUm4OROCdg3pzOMo
+        EB+XVEZeTRM8++5AOUXqXpx3I5myfm2NLWGOpOBO94hLi/fEmNu9I3fEnZ5rt9un4kSNgrUemOf4
+        5nLalIdFGqlp+aNEzxLtHibTTJ3yUz3fsWRTbcZ5QiaFvIoJPEhw+fmTZuuzkAps6+8h3r/G6y8y
+        3r/G6y9CXk/jPwAAAP//oo6LgUVZCmSgGjq05AFO/ApOOYl52al5xRmZBeCsBeoXQsbCIaVhFGjI
+        yUrJtbQovyBVPwpYHCWDRm2heRA0GweUhed0kDXQOUjsI1MmuMpgE1wj2ia4ZnVM4OV8EbSSGAbF
+        EQAAAP//Gi2OBoOLR4sjWruYfsUReqkBb+vBm0ZAp6dDsmA1aJUBlG0AtDC/JBG6RgLdFJyNOpzF
+        GM7WnhH2ghLXvJQBruYtqFTAKmEA9zKahDEuHcbw9mNqXllmUX4epI0IEUophS7QgXCJCr38XIgJ
+        1TAmtHYgo7RGWlukDzNXRyk3sSIotbg0B2Qwkt3gmZuiEscSiDvK8kuoN6sMMQxuKNCujMTisHzw
+        rBdsKhg0r52TD+pKIDkE1bVGKM6FagAHT21tLQAAAP//AwAFNZ+HDyYAAA==
+    headers:
+      Atl-Request-Id:
+      - 66411ef1-53f3-4b01-b82a-391c6f594660
+      Atl-Traceid:
+      - 66411ef153f34b01b82a391c6f594660
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:42 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=303,atl-edge-internal;dur=14,atl-edge-upstream;dur=289,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 0409d2da8377b9cd3d5c40555da28354
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 41ded392-d26b-47ee-ba8a-80754af6e1b5
+      Atl-Traceid:
+      - 41ded392d26b47eeba8a80754af6e1b5
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:43 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=298,atl-edge-internal;dur=13,atl-edge-upstream;dur=286,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 10525d059506a4ca8e129cd0d74cc199
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
+      group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/358]
+      in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+      | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+      | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/233]
+      | Inactive, Verified, Risk Accepted |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+      | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]
+      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Jan.
+      29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Regular Expression Denial
+      of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/233]\n*Defect
+      Dojo link:* http://localhost:8080/finding/233 (233)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
+      Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]\n*Defect
+      Dojo link:* http://localhost:8080/finding/232 (232)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3379'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 9a5ace92-2904-49c8-93f0-9edbfc562563
+      Atl-Traceid:
+      - 9a5ace92290449c893f09edbfc562563
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:43 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=263,atl-edge-internal;dur=12,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 126927b3cdee0003fae54352fbaf97a1
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+SyDxTKfDQO6OllIaAnzgmIywN7YOW3IlOSQ9+O9d+Q0I
+        MVPo9IYZbEvaF+0+++zmuwWrnPLICiwJPAIJ0ScGaaR6nGageipMIKM9kYOkmgmuehAxnYGmvTCh
+        PIZUxL0lSIV7EE0hl6CA6/psWCgtsoVROHcdx3X6Ev4qQOnZOoczSUPNQrB6FjP23eF4vI8fCtIF
+        fiZa5yqw7QgWEOpIfBN9qlOqFKO8z0HbaEnbNGe2ZzOlCrAbBXewRvnT2eR8tusOR0NcKl1QVvDd
+        UuhboUKqIRZyXd0hwi+U8BxvsOt6u74zc0eBOwgGbn9/z/sJ/XaMk8aIRsdLNR900sjbqM/x2mvX
+        HxGoULLcBA5XD4jKaJr2SMSUZjzUJGcQAhELci/kXd9Ih4JfyPSdXhScmXTRdE6XVFNpLxnc26Vb
+        Tw7WW67ju6NfFPsbfs4w7UWGVg0s0OSMqjuTq+JWm7dgQVMFPasSPMZ7lbI9K2EIHBkm6xNYAvrq
+        PPYszRBZOaLECniBd7Q2YOI7zUYuxTe80QcDXkuX4S4T2ITbfDwDydOtLjjTGhUoq7VtkPpbeVaJ
+        hb6n0uBVsSxPGTocbdwc81GibDBaDUbvdPeNzDQ3afMycAzQvcHKG/y/Vqrsl1hEg+7eyt37EQZX
+        jUXfW/nej7BYA/zx8TUc3S6cel0bfrOxYKvLihwRFtc3CJM4lhAj37wqAryASIuq/D8E9ycF2xH/
+        kmCukEVIQhW5BeAkFAho0BARwYlOmCIlGRiaqUvjCPnd2hKcYVcM9ro29js2vM6NUdfG+HXw3uJy
+        f9xwueHQsqFZwa6Ln1Rjn6v6w/sDX3Wfp35jV+qkYZHy9VAUJs+u6SFXZoHx2Aq0LOCxbitGm2Rh
+        k/3NNeMZHlWJKNLoiKk8peuaeXAZ3dKXCHHDRnWcJGAYTPJfxcH3+oNx29M2A9oy7+ZGVw14bQ3k
+        kgnJ9PqDQWzE7bIx/vvWxjIag7KNhGqUMFxIWJz01TJ+QvAXXGlqwtsCZc9vimW+E+zM3fL/2NvH
+        z4cdc8Dxnm2Y6KX0Fgzfm8LeHHW64O92odwdmchhRU5yFp4wfvfJ7BxBbsYyHjb5LlFwX+61K1zw
+        CU5l9DaFKVBVYUjWb9bZycXn49P5yfHh5PR8Mp9Mp39M0XmkH4WhwwOzBMgZNjauibGLpY8skK4J
+        kiRLjVKiBfmVSUrOJGTIkqRQiO7+NrJ0sSQt54E5Th75gVU1e8wypsnUZXXzFySICYsZp+nmoXqo
+        rMNbVkSK3jU8igiIObSni9wU/lbEv5ziqvnvgyCthNv57SWjvg+3G8y6MQxWhg7rKfU/eduMurZf
+        G/Gb4SeqDIciFfK08gXzAnzDtTLL2B/wnevtaB+2vPFWRjeFWk55Gcev/PnfAYmlKHIz+H5iPELm
+        VE9tKy9Ugj3LwPN4emCet0AYXxrLBl8RwZ82BJswRIFRlnh98tmo+8p3yudOQK5btYwHhGOsNKNa
+        yMDpD/v+gwk4xjsVIU0ToXQwckaOvahk5qVvtj8c3aA0uT6HsDAkRr6I+10tOoRxCIkKHEK8G2KT
+        a1dp8mdBpQZJJjzGkswwzh2i0B6w3VL69Ox3clBg8ZPzkPIOKTPS2mPnporowwM5x2G89BPfDy8n
+        5eOqeojsHwAAAP//7FltT9swEP4r1iRQWzVpmqQpLUKMqUJjGmiCbV/QpLqxm0akSZWXsg/8+D3n
+        vPQFSrsiEJNWqpLEPvt89/g53yV3NN0URxe6/O6n4AESVaDCFQZiRKnsgd1iDM3E3tdw6jfbSgsC
+        aTgXeoj8RfeieWueBSFgm4JTWqv9f9EQlmFUcu691Kd+Gks9ir0WNjYnvPs4nBMhtNBVn6TTgOQW
+        /sKN8hgNZuJzLb0s4LDpb8pJ1ToGMvR5QFC6kfEcqSfTWO2qGqHJDoP0+ATDOLpR32DLwvMt07Jo
+        /ouQkti5bJKxVEbQZNd+csfOXFfOCIFPGcrBwjtWb2dDFf2VoezdDWVvNdSrG8nc2UjYkiUs+w1l
+        MHrGGoNMsgH2Mh5+Accxs9dk4PgOW+WJ8m/S1iuiUPeW/mZ4wBIGipfZAMTMKFxB661yrIaf+lPr
+        f3b1rIE9i+e3+KfttX0wJQCmhnjZBl51QeMmymIY89wPJAhW5gY/9NJjrvytLhd4XBIcLAJBA4Rd
+        qREhQhTUqvtRi4u5nyDKSArFXcSIMRkdMCrPDOTS4WKGIcPphpH+Mi7PM3EBh0I7goOo4JAUcOBp
+        yt27pMnuJ747YTiOex5oOgNFshnHXKHHOEMa50IQJyY35mPSY5gDW/vKQy8DYQ/ZRHIByTkPkFXl
+        q2U/FwpdIiIEcjn8rLaXSWR/GZLo8k1lGqJsR7NXNrdXR0DPCcTxECBX+7+/3TEUFfr0Q/jCLS0r
+        wSizbBT4buG0S18F28JnP9RBjCxcOCNXhoF3AjTExeIhdzGdgRZI5ipivrphCI1zX0ixAqdr7Cmc
+        TjH134CiEJ1FFFkJ4zUupn5YZ7X6wxQYTqN+hdsnSePVCcPckzBMIgzzhYSxVxh5RBj7BrJl/741
+        YTj/CeMNCMP+twjDqUS3EMbjokmnqvat58Kbqilte1NDVU2jPCqNgSVVKqLiz1pXY1Phza6KYusS
+        m0oSRlWSKM2zqeOmQpxRzbmS2q8ngGp3TCh7ybPIJJtOOaW3H57NwcjkVNCK4j0TYSpXnAKxVIa7
+        ECfdNgjROLDOpHPkjByba8bY7Gr2mHe0Xq9raMIZC9kdj2xpUTJeSWLaXLa/o6Qk3JwJQbuGdOZx
+        FIiPSyojr6YJnn13oJwidS/Ou5FMWb+2xpYwR1Jwp3vEpcV7Yszt3pE74k7PtdvtU3GiRsFaD8xz
+        fHM5bcrDIo3UtPxRomeJdg+TaaZO+ame71iyqTbjPCGTQl7FBB4kuPz8SbP1WUgFtvX3EO9f4/UX
+        Ge9f4/UXIa+n8R8AAAD//6KOi4ElVgpkoBo6tOQBTvwKTjmJedmpecUZmQXgrAXqF0LGwiGFXhRo
+        yMlKybW0KL8gVT8KWBwlg0ZtoXkQNBsHlIXndJA10DlI7CNTJrjKYBNcI9omuGZ1TODlfBG0khgG
+        xREAAAD//xotjgaDi0eLI1q7mH7FEXqpAW/rwZtGQKenQ7JgNWiVAZRtALQwvyQRukYC3RRcrT0D
+        XMWYgRH28hBnIxBXK9YE14SVAa5WLKi4wCphjFMC3n5MzSvLLMrPg7QRIUIppdAFOhAuUaGXnwsx
+        oRrGhNYOZJTWSGuL9GHm6ijlJlYEpRaX5oAMRrIbPHNTVOJYAnFHWX4J9WaVIYbBDQXalZFYHJYP
+        nvWCTQWD5rVz8kE9BiSHoLrWCMW5UA3g4KmtrQUAAAD//wMAzRuEcA8mAAA=
+    headers:
+      Atl-Request-Id:
+      - 6da0074d-7215-4b0a-bcfc-62252d20dc75
+      Atl-Traceid:
+      - 6da0074d72154b0abcfc62252d20dc75
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:44 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=244,atl-edge-internal;dur=13,atl-edge-upstream;dur=231,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 12478648e1d68887c9a00708877ca4c8
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbskTbsubzLBKTqFdi+KSJrcYjVNSpMOxth/N8Ghe1TfLvd8
+        557DPaBGONiOGnH05v3g+HyuoAXplX23qfBaONcJkxrwaIZU5wYt9v/gKxh3nQQF7mMNeliB8TD+
+        9cjKmlZPYCT8zrmD0XXWBJhgTFKc4qTaXD5W64f6R91MfRMmxJ8jNMMz/BIyYdB234eW9X6IaStt
+        JxVMzdRp9WVBPBjoYnFaXgkfQYopSwhNyLImlGeEkyzFGF/gAAe/C3+Ase76czbDNSk5YZyxNCfF
+        Nyv7G9PaAGKWY5bRQmRNU+blkuRLonKaSUlLUAUR0ArBiuYswOuYcNuNIr4w6JP2d1aKuD4gfZoQ
+        mNdthY7nxZ6sicr1fY2OnwAAAP//AwA1PnHcIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 0c64ba81-a893-428d-a03a-8da3f30eb7f1
+      Atl-Traceid:
+      - 0c64ba81a893428da03a8da3f30eb7f1
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:44 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=161,atl-edge-internal;dur=13,atl-edge-upstream;dur=148,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 239a1b811565e786b52148c893e582e2
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJl45InOl0XEdJnLquKyvJg+PxQOSKREwCLADqaJz/3l1S
+        lGI7Smt3GnvGxLUHdr/9sP7kwLrkMnEiR4NMQEPyUkCemI7kBZiOiTMoeEeVoLkVSpoOJMIWYHkn
+        zrhMIVdpZwna4B4kUyg1GJB2ezaujFXFghReB74f+K6GPyswdrYp4Vzz2IoYnI4jyH4wGI9HODGQ
+        L3CaWVuayPMSWEBsE/VRudzm3BjBpSvBemjJerwUXugJYyrwWgU3sEH5s9nkYtYNBqMhLtUuGCf6
+        5Bj0rTIxt5AqvWnukOAMJUI/7HeDsNvzZ8EoCvpRb+D6o+BH9NsnJ8mIRcdrNU90kuQ91OeHu2tv
+        JwmYWIuSAoerR8wUPM87LBHGChlbVgqIgakFWyl945J0rORbnT/Si0oKShfPr/mSW669pYCVV7u1
+        d3C7Ffi9YPSzEX/BTwWmvSrQKsECTc64uaFcVXNLo2jBcwMdpxE8wXvVsh0nEwgcHWebU1gC+up/
+        7jhWILJKRIkTyQrv6NyDSc8/tBG0G6VWH/GqT8zEVrrOQ53ZNg80+QI9++u+lcJaVGCcnW2C8K/1
+        WaMWdsU1AdmIoswFOpzcCwkmqoZff7Tujx7p7jdS1t5kl7C+/xzdCPvrsP//WmlgUYMUDQbDdTD8
+        HgbXrcVeuO6F38PiFvmfPz+EY3gIp712YyHW7xpyxOxfXiEa0lRDinzzj0UwaDfwAiqvGl74+tHh
+        oY3nBzbCgxujQxvjh+40tNmsEinVL4QTdQOccosPR0O4j6/Phs73BO416jRVXz08VhUFLiBSfk8L
+        QqZOZHUFmCVUat9hYqkGG+dqfaRfi7iJ46cHa+QrCptMVXnyQpgy55ttDVPmNeBliSYePhJ99/n+
+        kbgftkNUFu6o7P7GDlSlFkoLu3liEFtxr35p/v1bIQqegvFIwrRKBC5kIs1cs0z3pPgaV1r2DJ2H
+        9RHuyiDncyD+owq43xMcAm9wCKPBiCKScTMpRXwq5M1L2nkBJfUvMm6zVudyVe/tVqSSE2xf+DyH
+        KXDTIEFvR8756dtXJ2fXpyfHk7OLyfVkOv19ivfDOjUYEjwwy4CdI9FLy8guE4YpmW8YkobISSmz
+        ir0RmrNzDQWyBqsMotb9GnkEWFCOfyt8v0zmkdO8ipg9DP++qu6wBSYiFZLn9w9tu69teGtc5+hd
+        SziY2VTC7nRVUtkeQvJoOGyR3DRKTwRfI7x7YO/2No/D4x5vv/D4BtvNFnKt8sbW8baj+08Ot21h
+        UzNoJGz7AQkrqm6VK33WeDPPK+imGlli3xQp9kI1yVZFiQ2xtF8H/eAQLQx2tPCtjN8N5wf55e8R
+        S7WqSmoUXwqZIDEahrXC5gCSlZXJIKlRejI9ou8cmJBLMkAwSxj+K8Dw0YIkImVZ6LJXpO6DfFZ/
+        n0XscqdWyIiVaTRwA9e/pWBjrHMV8zxTxkYjf+R7i+bsde2T1xuMr1CKXV5AXBE3sddq1bXqgDC+
+        yUmFb3J4xTx2GRjL/qi4tqDZRKZYkQXG94Ao7A54QS19dv4bO6qw9tlFzOUBKerwvLF/1UTy9pZd
+        YNNa+4nj43eT+vO++bQJpsn2iafhTFikARKtAYUjVMSIKdktu0Qd3RBLvxsM/VFYe0EAlcvEldjn
+        u6laessqlwhZi5Ti3T1/RSrG/Z1YvAK3EFaDq3TqYVlzgrrAVpXowBv33cwWOUmVKf6p80QqQvyZ
+        QqEs4DUSYJM1poNkWJf9cJ7+DQAA///sWN9v2zYQ/lcOCBDImkPPsmxjDvwQJH3YsBbD0u5lHmBF
+        ZmJtsuToR5qi6/++70iKomKrRZM9Jgkc+Y5HHr873n3UkE7T6pwCMR6LgOj0rjpf0kT8CGOlmIiZ
+        CKlRhK0iFFMxb+TTVj4VmKuRz1o5P05bOXtn5GMxa+VBKw/c8ZNWPhGTVh628rDdwLxdlx8duV2X
+        H4NBT26YTB4FkxkjegHS8CCHHHpF9+lYnOffGWcz/v+K82uMnx3jsC/GKIRNUVj4Kt4sI/+qlnSF
+        CgrhL+guFPw0JDTYKXWrc/O7HQtbntX3iXg9ly+M2Qx1279SvR5t+O+cmAUhHt+0Iw8fg2OR/Wpc
+        yUcvgPxP/Dt7xnHFgjj3aoKXtYVuavnXeV3EEumVSp8b9Bn66C4pJeO6v3MGXrU0wke7t8si90rT
+        oEWSj6LNQ1KCiuAOMA0CMIxbhhjHoSGezDXW+7s1gdTBv4wiKnQax5zG0qYx70EW0U2Sck+ttlFF
+        eYyFSvq4BTupQK+NIaN2E5WS8oLucU/7RLgrx3wKS8weF9EtOwA6Vu8yYvYl1EEDQS8kgaFT9TFv
+        TGIqY5lFuMkwZcFSSbwlEAGw9zT5R4K/32KVCG7v92kSq1eXhho1DqcS+ODI8gXAHaW3Bp/qrIxu
+        USqY75+VNQ+Bf+V9apYzyJS0i2Cc5GAGjvOlWGXB4ewwyoB0yc7APVx5C7BFzGvRYbZmfYgMUoWs
+        6iJDbuOprNOK0XV8wLijTggG8OQEV5cc8cTfZZ7Fcl+tsvV6vcr4OljRZ7rEzsB6vtCS+F1uUkjv
+        9OQxmCO19P9BMzbWI5cE7mzMPFaqJ2E2x5LGgOFa0vr6za9vLt/TmC6u6fS+zqvzFX705CNfS3AI
+        j6n90Qrn8gfeapmnUuC24CH7Y9zghMweBn+xN6DQMMlGI229Vg5opxSAHvwYkieLYsgIDmjJJ4c+
+        Y2azJ8y1Yce/DAw49IdNFHoL0op8IT5qrrx5D7TolHEwxZ5CDk1fKbdGB8Xcag7KuaN5UtAdzZOS
+        7mieFHVH86SsW81BYXc03dIOnH5TL3g2DUgLM9KAZFDBfA5cjJHBhBdy4WKMDChG1cDFGFlQHE3T
+        8hpUOioGyaLS0TBIFpWOhkGyqHQ0DJJFxdFokCwqHY0GyUkm4LVFJnFKnmnCtzgs9HxXWfAHuhO+
+        XcR8DpCY9Q2Ov+kBbxN18zMtwLdXmUA8iscFfVBvC7gAmWLfhAQVM4WmEK7RpM9IR+uoTdhno8N4
+        1GbaZ6MDfNRm1mejI2JtyKN33IFUd7IdTiXBUEd8qMquDjG3migtc9rrBBbEPMIuOu9bVIX064ua
+        hECXOljAxO7n3T6KK47bu5wS9YWQAg/JRm7aNo+Bv4MUFRLVvPyePm9M9zlfuZmmeNFml2QD8gb/
+        7kBDqnxhqcdRPvvKZZ0D7Ba8b3PZ8JlcNmQuG76My/4HAAD//6JKW5bcri9yuqV1W9ZwtC1bAAAA
+        AP//7Jpda8IwFIb/yhh4mS5tY2sH4hQ23F/w7jRJ59B+0A/295fT1GAzs41dFVbwQkyOPR6bty+8
+        z+xlZy87e1mHrI+82UjYR97sWtpnL3uZ1+xlZy87DS/rm9IfvOzX/H5pImw7vnUleD67TvDaGvip
+        hxMQLrC3GsTDWmAGtrAWqKuCulJ0alL0y3hcG13kBzXNjNJoO5OEtgV+xMRNJ55Nl+eAcez9zbwQ
+        R41MRVn/MbBFd7IBzpEEeRXr2FdOli7CrYxWURoxIDQLYsIyWJIkiSkRUSZknKVMhhjumkp1WV37
+        +MtKiffLVgjVS4M9Q12exdNVy7xETu577Kv/M6T3VuttWHNBj8IsFEEqBUTxCmQIiciAJSueQpRw
+        5vsbse6/Rf3WRfCiXrqO5FAMkSch+qPG6xryoUZGAg+zVE+rJc6UVAANjlTV925enUv1dr8jzKsK
+        jNhthGz6HdsM2vQ7thm2qXesJExoMmpgIPb9zX+3O0NxkkVzfK/6o4WxmcaxtAoeygJ3P3d1WcmH
+        g5IhjuDQcAYRpFSr5qTjZQau9DY9wVzay1xQFXOReszoez08HP6vHH0CAAD//xrECW+0OKKHi0eL
+        I1zFEXqpAW/jwZtEQKenQ7JgNWiBOJRtALQwvyQRuu4d3RScjTmcxRjOVp4R9oIS1xJKA1zNWlCp
+        gFXCAO5lNAljXDqM4e3G1LyyzKL8PEjbECKUUgrddAHhEhV6+bkQE6phTGjtQEZpjbRfRB9mro5S
+        bmJFEGSUCcVu8ArDohLHEog7yoCdG3KXRWIsbIYYBjcUaFdGYnFYPniBJmztMWhpNWjZI8hKuENQ
+        XWuE4lyoBnDw1NbWAgAAAP//AwCO49xa4zMAAA==
+    headers:
+      Atl-Request-Id:
+      - 57c4eab3-8435-4db0-aa35-378e5e3e7129
+      Atl-Traceid:
+      - 57c4eab384354db0aa35378e5e3e7129
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:44 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=266,atl-edge-internal;dur=17,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 30e772099d6fb3d4cb4805201ef115fb
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 84de3dfd-f2a0-456e-b62b-b838547ab5a1
+      Atl-Traceid:
+      - 84de3dfdf2a0456eb62bb838547ab5a1
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:45 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=239,atl-edge-internal;dur=14,atl-edge-upstream;dur=225,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 305e27bba95c34e5249ed4a944255b0a
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
+      Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/359] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236] | Inactive,
+      Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/234] | Inactive,
+      Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025
+      \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Remote Code Execution - (Pg,
+      &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
+      5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
+      6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
+      &lt; 7.1.2)|http://localhost:8080/finding/236]\n*Defect Dojo link:* http://localhost:8080/finding/236
+      (236)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+      &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
+      5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
+      6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
+      &lt; 7.1.2)|http://localhost:8080/finding/234]\n*Defect Dojo link:* http://localhost:8080/finding/234
+      (234)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '7161'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 6dec3db8-17f2-43bf-9896-8ad397bd7f53
+      Atl-Traceid:
+      - 6dec3db817f243bf98968ad397bd7f53
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:45 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=464,atl-edge-internal;dur=14,atl-edge-upstream;dur=451,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 840d2e4cf8388149bfc2996debaeb132
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWW/bRhD+Kws+FanES5IjESgK11ESt67rykry4BjGihxRG5O77O5SR+P8986Q
+        IhVbVlC7aGzA3Gvubw5/dmBdcJk4kaNBJqAheS0gS0xH8hxMx8QLyHlHFaC5FUqaDiTC5mB5J15w
+        mUKm0s4StME7SCZQaDAg7fZtXBqr8jkxvAl8P/BdDX+VYOx0U8CF5rEVMTgdR5D8YDAaDXFjIJvj
+        dmFtYSLPS2AOsU3UJ+Vym3FjBJeuBOuhJOvxQnihJ4wpwWsY3MIG6c+n48tpNxgMj/CoUsE40WfH
+        oG6libmFVOlNbUOCO6QI/bDfDcJuz58GwyjoR72B6w+DH1Fvn5QkIRYVr9g8U0mi95CfH7ZmbzcJ
+        mFiLghyHp8fM5DzLOiwRxgoZW1YIiIGpOVspfesSdazkO509UYtSCgoXz274kluuvaWAlVeptVNw
+        exX4vWD4sxF/w085hr3MUSrBAkVOubmlWJUzS6tozjMDHacmPEW7KtqOsxAIHB0vNmewBNTV/9Jx
+        rEBkFYgSJ5Il2ug8gEnPby4KrT6hRc90+Ja6cncVwMbdtPkKJDur3klhLTIwTiubkPpb9daouV1x
+        TXg1Ii8ygQonDyzHeFQo6w/X/eET1f1GZBpL2rj0/ZeoRthfh/3/V0od/QqLKDA4WgdH30PgupHY
+        C9e98HtI3AL8y5d9OAaHcBo2F3Oxfl/XQIz+1fX+y17zkqephhTrzV4SoAEqK+v0f1zc4NDF0aGL
+        lwcuwoMXw0MXo30967JZn1JRqjqEE3WDba2kkGgR1yZ93jujREFvm4Uqs+SVMEXGN9t0wmOMrX2P
+        caMU24rgFptRXcSfXgzqFrFrCl7NTlOqV8sTVVIwKuU/0IGQqRNZXZI2sQY0lurHfpPouy93TeKh
+        29pS9vDiEKjCFlSFFkoLu3mmwQ25V3Waf98rRM5TMB5RmIaJwIOFSBeuWaa7avkWT5qyGjr7iRO2
+        qM/4DKgwPpIaVE8edURwCKPBkDyy4GZciPhMyNvXdPMKCppfZNxgqELWqrprT6SSYxxf+CyDCXBT
+        41JvV87F2bs3p+c3Z6cn4/PL8c14MvljgvZhnhp0CT6YLoBdYAeQlpFcJgxTMtswrCYiI6bMKvar
+        0JxdaMixnLDSIMLcx6pKgAnl+HfC94tkFjl1V8Tooft3WXWvWmAgUiF59vDRdvraurfCeYbabfcU
+        2VRC+7osKG0fRXJ/4A6CXoPkelB6Jvhq4rbz3p9tnobHHd5+4fEtjpsN5BrmtayT7UT3nxRuxsI6
+        Z1BI2AwKElaU3SpT+rzWZpaV0E011qzdUKTYK1UHW+UFDsTSPg76QVsWvhXYh0Rtybjvzo/y699j
+        lmpVFjQovhYywSJmGOYKmwFIVpRmAUmF0tPJMX1nwIRckmSCWcLwXwGG3QySiJgtQpe9IXYf5Yvq
+        +yJiVy1bISNWpNHADVz/jpyNvs5UzLOFMjYa+kPfm9dvbyqdvN5gdI1U7OoS4pJqE3urVl2rDhBj
+        s05KbNbhNfPYVWAs+7Pk2oJmY5liRubo3wOk0D7wgor6/OJ3dlxi7rPLmMsDVDT6eSP/uvbk3R27
+        xKG10hPXJ+/H1edD/WkCTJtt76flVFgsA0RaAQpXyIhRpWR37Ap5dENM/W5w5A/DSgsCqFwmrsQ5
+        303V0luWmUTIWiwp3v3318Ri1G/J4hW4ubAaXKVTD9OaE9QFzrBUDrxR313YPCOqIsU/VZyIRYg/
+        E8iVBTQjATZeYziIhnXZDxfpPwAAAP//7FhRb9tGDP4rBAIEsuacZ1m2MQd+KJI+dFiLodn2Mg+w
+        Il9irbKk6KQ0Rdf/vo+n0+kU2+ma7jFJ4MjkUUd95JEfNaTTtDqnQIzHIiA6va3OlzQRP8JYKyZi
+        JkJqFWGnCMVUzFv5tJNPBe7VymednC+nnZy9M/KxmHXyoJMH7vpJJ5+ISScPO3nYPcC825cvHbnd
+        ly+DwZHcMJk8CiYzRvRNxsPrvRxy8PUkMKT3ifpAr+JYFnySDgV+/o2BN+v/r8C/BP3ZQQ//c9BR
+        KtuysfB1ArCM/Mta0iVqLIQ/o/9Q8NOQ0IKn1K/f7e92LGwB198n4uXkfmcQZ6js/qVmA2jUf+fE
+        PAnx+KodefgYHIrsk3ElH90C8j/x7+wZ5xcbohDoG3xf4+inln+V12UskV6p9LmFn6HT7hIlGdfi
+        1ll42RENH4TAbovcU6aFiyQfRZv7RIHFYEqYBgE4yA1DjOPQUlNmI+vidk2gffAvo4jKJo1jTmNp
+        05ifQZbRdZJy1622UUV5jI0UfdyCv1Qg4MaQUbuOlKS8pDvMlZ8I03TMh1Lh7nEZ3bADIGz1LiPm
+        Z0IfNFD4UhI4PFUf89YkJhXLLMKsw6QGWyXxlkAVwO/T5IMEw7/BLhHcLoo0ifXLTUOeWodTCXxw
+        ZHlEcFc1jwaf6kxFN6gcPBGcqZqXwD91l5rtDDKKdhGMkxzcwXFeiVUW7N8dRhmQVuwM3MMAW4Iz
+        4r4WHeZz1ofIIFXKqi4z5DauVJ1WjK7jA9YddEIwgCcnGG5yxBN/F3nGdW+VrdfrVcYDY0Wf6QJP
+        Bl70hZbEb3uTUnqnJw/BHKnV/B+0a+Nm5ZLAro2Zx0p9JczDsaQ1YLiWtL56/cvri99oTK+u6PSu
+        zqvzFX6am4/8RoJDeEjtj1Y4lz/wo6o8lQLzhIfsjzHjCZndD/5ib0CyYZKNRo31WjvQOKUB9ODH
+        kDxZlkNGcEBLPjn0GXc2z4R7bdjxLwMDDv1hE4XegtYiX4iPmitvXyEtemUcXPJIIYfmWCm3RnvF
+        3Gr2yrmjeVTQHc2jku5oHhV1R/OorFvNXmF3NP3SDpx+1a9rNi1IC7PSgGRQwf0cuBgjgwlv5MLF
+        GBlQjKqFizGyoDiatuW1qPRUDJJFpadhkCwqPQ2DZFHpaRgki4qjaUCyqPQ0DUhOMgGvLTKJU/Ks
+        YYCL/ULP08yCP9Cd8I1pjIJRUV/j+Jse8DbRs6FpAb4ddgLxIB4W9Lt+n8AFyBT7NiSomCk0pXCN
+        JseMmmgdtAmP2TRhPGgzPWbTBPigzeyYTRMRa0MeveMOpLuT7XA6CYZNxIe67DYh5lYTpSqnoklg
+        Qcwj7KbzY5vqkD69qUkIdKm9DUzs3uwKMFaO27ucEv2FkAL3yUZuujaPhe9BikqJaq6+pc8b0yLn
+        oZxpihdtdkk2IG/wzw40pMoXlnoc5LMvXNY5wG7B+zqXDZ/JZUPmsuFTXPZfAAAA//+iU1uW3L4w
+        crqldVvWcNi3ZQEAAAD//+yaXWuDMBSG/8oY9DLOj1TroHQtbHR/oXfHJK6j9QM/2N9fjkmDZM02
+        eiVU8EJMjjkezfGF95m17KxlZy07a9lxvWYtO2vZ+9KygQn9Q8v+dPiXxuS2DV6X9R9Q14ABPNAV
+        7Bpgp4FBQErCmuq7WBBqOA07wvjslyq4Jrp8d9/FhvhmTeg6YEe03bT5PPavbXuz7YsC0LB9vOoo
+        YqmRuqiaGy1dVCcbYAy5jne+TgKpZP1FtBXxKs5iCsTPw4TQHJYkTROf8DjnIskzKiK0f02kXFbF
+        Pv8zUuD3suVc5tJiztBUZ/4ySplVSNL9TowNb0l4H42ahjEXainKIx5mgkOcrEBEkPIcaLpiGcQp
+        o0Gw4evhLvJZF+GbPFQcKaDUpigh6lLr9S35kiUjoYduq6e6JdaU1AAtllTGD2pe7kt5ut8R6tUl
+        mvA2fTb9jG18bfoZ2/jb1DOWnYorkktTEvvh43/YnaE8ibI9ftbD1kIXTcFVqtkdqhJnv/ZNVYun
+        g+xPDNEivQeRwZSjZqfjMpo8vc5XUFfvpS7sihrsqtH/gLvrOt8AAAD//xoK6Wu01KGHi0dLHVyl
+        DnqpgavxZwJv48GbQEA/pUPyZjVobTmUbQB0SX5JInRlPLopuFp5BriKMQMj7OUhrkWWBjg9gLMV
+        iKv1CipHsEoY45SAtxtT88oyi/LzIA1HiFBKKXRbBoRLTOiVATsV5C5YxFgeDDEMbijQpozE4rB8
+        8NJJ2BplYD6AOLkaxoRWR2Q7ALyFRR9mro5SbmJFEGRYC8Wz4EWPRSWOJRCPgxZfgxZGgrwOF0fV
+        bISiG6oB7Nra2loAAAAA//8DAO+eS8MFNAAA
+    headers:
+      Atl-Request-Id:
+      - 8272cc14-c522-4abb-8f48-7108c7f8579e
+      Atl-Traceid:
+      - 8272cc14c5224abb8f487108c7f8579e
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:46 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=270,atl-edge-internal;dur=16,atl-edge-upstream;dur=254,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 494e39b2e1dd88f221ef7edde39a9b62
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": 41}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1586/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 530481fc-667c-47b6-a5fd-5a62650cc955
+      Atl-Traceid:
+      - 530481fc667c47b6a5fd5a62650cc955
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:46 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=453,atl-edge-internal;dur=13,atl-edge-upstream;dur=441,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 16632a6015865094d4ed20a01bfbf0a0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbskbdcubzLBKTqFdi+KSJrcYjRNSpMOxth/N8Ghe1TfLvd8
+        557DPaCWO9iOGjH05v3g2HwuoQPhpX23KfeaO6e4SQ14NENSuUHz/T/4GsadEiDBfaxBDyswHsa/
+        HllZ0+kJjIDfOXcwOmVNgAnGJMUpTurN5WO9fmh+1M3Ut2FC7DlCMzzDLyETBm33fWjZ7IeYttJ2
+        ksHUTkrLLwtiwUDL8rS84j6CFNM8ITQhy4ZQlhFGshRjfIEDHPwu/AHGRvXnbIYbUjGSs7xMKS2/
+        WdHfmM4GEOcFzjO64FnbVkW1JMWSyIJmQtAK5IJw6DjPF+1ZgNcx4VaNPL4w6JP2d1bwuD4gfZoQ
+        mNdtjY7nxZ6sicr1fYOOnwAAAP//AwDS3jB9IAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 6f18b881-f23d-402d-b09e-e316f2b32c97
+      Atl-Traceid:
+      - 6f18b881f23d402db09ee316f2b32c97
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:47 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=158,atl-edge-internal;dur=19,atl-edge-upstream;dur=141,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 6505b5ac6aa402714432ba8139056e39
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15999
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSbbMmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxvnv3SVF
+        KT6Y1u40owfi2gO7335YfXZgVXKZOJGjQSagIXktIE9MT/ICTM/EGRS8p0rQ3AolTQ8SYQuwvBdn
+        XKaQq7S3AG1wD5IplBoMSLs5G1fGqmJOCq8D3w98V8OfFRg7W5dwrnlsRQxOzxFkPxgdHBzgxEA+
+        x2lmbWkiz0tgDrFN1CflcptzYwSXrgTroSXr8VJ4oSeMqcBrFdzCGuXPZpOLWT8YjfdxqXbBONFn
+        x6BvlYm5hVTpdXOHBGcoEfrhsB+E/YE/C8ZRMIwG++5oMPoB/fbJSTJi0fFazQudJHkP9fnh9tqb
+        SQIm1qKkwOHqITMFz/MeS4SxQsaWlQJiYGrOlkrfuiQdK/lO58/0opKC0sXza77glmtvIWDp1W7t
+        HNxsBf4gGP9kxF/wY4Fprwq0SrBAkzNubilX1Y2lUTTnuYGe0wie4L1q2Z6TCQSOjrP1KSwAffW/
+        9BwrEFklosSJZIV3dB7AZOB3bQTtRqnVJ7zqCzOxka7zUGe2zQNNvkLP7rrvpLAWFRhna5sg/Gt9
+        1qi5XXJNQDaiKHOBDicPQoKJquE3HK+G42e6+42UtTfZJmzoE9zD4Soc/r9WGljUIEWDwd4q2Pse
+        BletxUG4GoTfw+IG+V++PIZj2IXTQbsxF6v3DTli9i+vEA1pqiFFvvnHIhi1G3gBlVcNLzx9dK9r
+        Y79jI+zcGHdtHDx2p6HNZpVIqX4hnKgf4JRbfDgawn1+fTZ0viNwr1Gnqfrq4ZGqKHABkfIHWhAy
+        dSKrK8AsoVL7HhNLNdg4V+sj/VrETRw/P1ojX1HYZKrKk2NhypyvNzVMmdeAlyWaeOqRCMNB+0g8
+        DFsXlYVbKnu4sQVVqYXSwq5fGMRW3Ktfmn//VoiCp2A8kjCtEoELmUgz1yzSHSm+xZWWPUPncX2E
+        2zLI+Q0Q/1EFPOwJusAbdGE0GFNEMm4mpYhPhbx9TTvHUFL/IuM2a3Uul/XedkUqOcH2hd/kMAVu
+        GiTozcg5P3335uTs+vTkaHJ2MbmeTKe/T/F+WKcGQ4IHZhmwcyR6aRnZZcIwJfM1Q9IQOSllVrFf
+        hObsXEOBrMEqg6h1nyKPAAvK8e+E75fJp8hpXkXMHoZ/V1X32AITkQrJ84eHNt3XJrw1rnP0riUc
+        zGwqYXu6KqlsO5E83m+R3DRKLwRfI7x9YO/3Ns/D4w5vP/P4FtvNFnKt8sbW0aaj+08Ot21hUzNo
+        JGz7AQlLqm6VK33WeHOTV9BPNbLErilS7Fg1yVZFiQ2xtE+DftRFC6MtLXwr4/fD+VF+/TtkqVZV
+        SY3iayETJEbDsFbYDYBkZWUySGqUnkwP6XsDTMgFGSCYJQz/CjB8tCCJSFkWuuwNqfsoX9XfVxG7
+        3KoVMmJzjGEW+e7A9e8o3hjuXMU8z5Sx0dgf+968OX5du+UN9vwrFGSXFxBXRE/srVr2reoQxmc5
+        qfBZDq+Yxy4DY9kfFdcWNJvIFIuywBB3iML2gBfU0mfnv7HDCsufXcRcdkhRk+cd+FdNMO/u2AX2
+        rbWfOD56P6k/H5pPm2OabF55Gs6ERSYg0RpTOEJFjMiS3bFL1NEPkdz6wV4QHNReEEblInEltvpu
+        qhbeosolotYiq3j3z1+RiqHfxJrk4iW4hbAaXKVTD0ubE9wFtqtECR4edTNb5CRXpwq/dbJIzxTS
+        KucYyhX9a6vdPwYp/gYAAP//7FnbTttAEP2VFVJREsXGsZ0rQjQoRVCJqipqH+gLG++auHXiyHHC
+        Q/n4nllvlsRkaUvVKg8IlItnZy8zs2fOTHhKwXMt8xWKM+aw2jkpNtlhWhxDue36dYvxtKuP/KBN
+        Cw6RWFeySbZRlJg9kE0ba4sOGsoo9Iw1RkvJRohAPHyP28n8fpMBoNpsO7rXf5OWa8JbfQ/cf3we
+        bHykcARX/FvGCGGx11/qsRpe6rtO/eyZWQNBhudf8ea8yN9YEqGjpvi7iNs2fOM6W+Yw43mSSoCB
+        LE19eFccq/DaGDh6BKkGwMQsmwG99N13k+yIi1WyANCBYbT9DvArJiMjWNZpjZx3qya/Zci9jLaK
+        mlJn21z7XG+EfC6Mzxfa5/cTwj6O+WZ3DKQ7ghxpO8p5TCtRkgYmzZeFC8t/eZz/CuCTSg1y26I1
+        qx9shBFGfFREVazFkMIyJ0a8MQFGTqCNhwhJdSUHVWM2Nx4sQG4sgnwlHUpfSfR0YCmN+YoS7oaX
+        CMMG9ELBha/DKMJ8AySIcZpE2oNXicoK2oGfFXEgm2vPlKdiWc5SCHLXeP5yOudRQTofMpaoLwxA
+        vkqEFFux9AkXCmwKS/9JhGjVeUZ5gAK8xsU0mdVZrf4wRQAX2QBB+5SLtw0drVIxWzZuhZvZuMjB
+        P1ShQYVCdagp1yqC0BROFYFn0/BsjNgzjHhtHttAWxXnmc1sMcsqv+BFwaMJpc6SvSyW0yknanVg
+        y/1kbSqRsvyF/Ivu4CmPIirsLsVJtwUg9N4EQ9npdcadkDte7HedMOZtp9/veo7oxEJ243EoA+Jq
+        RhPLlrqD39SUFDJDIeg+0Z55nqXi7caWQeVogWe7OMof0gUbVMNIZ91JCOJA+GMpeKfb4zLgfRHz
+        sN+LxrzTj8JW61ScqFlw1jf+Of5LPWfKZ5q+OE75aOEuF849TOb4LvEit7ysZFNnzvmCTAp9lQtQ
+        7uDjxZkTuvMZMeZqR2j/d1xtKe3/jqstqX3fMVBMlI0OXdJcqOBnZymffZezxSSZq6tFLK7srpRA
+        eAPWi9Hvlnk2l0c3QKKI+gD6DlJfFFJz02kZ3SbeXQyFNvgNbT2S0NZ4Cw3E5zo/vMLRHgbeKxz9
+        jx2/wpENjqqoYWieYUXY+l15BX/Q7z36s4cFs4Lrn7Gqs1j5nBXGrETP3w2Uto6oZ2O2hAo7BZ45
+        ckUQ9A5+AgAA///CIQFvOqbmlWUW5edBmocQoZRS6BwqhEtU6OXnQkyohjGhtQMZpTXS9K8+zFwd
+        pdzEiqDU4tIckMFIdoMHDItKHEsg7ijLL6HePAXEMLihQLsyEovD8sHjrbCpBNBMCWgUE2Ql3CGo
+        rjVCcS5UAzh4amtrAQAAAP//AwDNg8Y6sh8AAA==
+    headers:
+      Atl-Request-Id:
+      - 904e4ef1-3592-4a5a-8181-33462edf9e17
+      Atl-Traceid:
+      - 904e4ef135924a5a818133462edf9e17
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:47 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=274,atl-edge-internal;dur=23,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - cae621907ca553677f1a76ab38220c39
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 4bb43564-4423-41b8-9466-145193f67b9e
+      Atl-Traceid:
+      - 4bb43564442341b89466145193f67b9e
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:47 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=277,atl-edge-internal;dur=14,atl-edge-upstream;dur=264,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - a924d760ab797f32fa5a1afaeaaf2806
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
+      of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/360] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
+      Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/235]
+      | Inactive, Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Jan.
+      29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial
+      of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/235]\n*Defect
+      Dojo link:* http://localhost:8080/finding/235 (235)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+      File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+      versions of `fresh` are vulnerable to regular expression denial of service when
+      parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
+      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1975'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15999
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - f33d4c94-aa5f-46ae-aa8e-b1c59ca37fed
+      Atl-Traceid:
+      - f33d4c94aa5f46aeaa8eb1c59ca37fed
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:48 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=448,atl-edge-internal;dur=19,atl-edge-upstream;dur=420,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 354f60827b4f96e929f2c076f4199e91
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15999
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSY7MmU7HtZXEreu6spI8OB4PTK5IxCTAAqCOxv7v3eUh
+        xYfS2p1m9EBce2D32w+rLw6sSi4TJ3I0yAQ0JG8E5InpSV6A6Zk4g4L3VAmaW6Gk6UEibAGW9+KM
+        yxRylfYWoA3uQTKFUoMBaduzcWWsKuak8Crw/cB3NfxZgbGzdQlnmsdWxOD0HEH2g9H+/j5ODORz
+        nGbWlibyvATmENtEfVYutzk3RnDpSrAeWrIeL4UXesKYCrxOwQ2sUf50Njmf9YPR+DUu1S4YJ/ri
+        GPStMjG3kCq9bu6Q4AwlQj8c9oOwP/BnwTgKhtHgtTsajH5Av31ykoxYdLxW80InSd5DfX64uXY7
+        ScDEWpQUOFw9YKbged5jiTBWyNiyUkAMTM3ZUukbl6RjJd/r/JleVFJQunh+xRfccu0tBCy92q2t
+        g+1W4A+C8U9G/AU/Fpj2qkCrBAs0OePmhnJVXVsaRXOeG+g5jeAx3quW7TmZQODoOFufwALQV/+u
+        51iByCoRJU4kK7yj8wAmA7/bKLX6jDd6YcBb6TrcdQK7cNPkK5Bsb/VeCmtRgXE2tgmpv9ZnjZrb
+        JdeEVyOKMhfocPLg5piPGmXD8Wo4fqa738hMd5NNXoY+oTocrsLh/2ulyX6NRTQY7K2Cve9hcNVZ
+        HISrQfg9LLYAv7t7DMdgF07DXRuDbmMuVh8ackRYXFwiTNJUQ4p8849FMOo28GYqrxpeePro3q6N
+        1zs2wp0b410b+4/daWizWSVSql8IJ+oHOOUWH46GcJ9fuA2dbwnca9RpKst6eKgqClxApPyRFoRM
+        ncjqCu5aniZtWsRN1L48WiPP8KjJVJUnR8KUOV+3pYzL6Jb9gJih8m6joQEvS/zx1CMRhoPukXgY
+        tg2VPdzYBapwA6pSC6WFXb8wiJ24V780//6tEAVPwXgkYTolAhcykWauWaRbtnyHKx2ths7jwgk3
+        ZZDzayBipAp42BPsAm+wC6PBmCKScTMpRXwi5M0b2jmCkvoXGXd5rLO7rPc2K1LJCbYv/DqHKXDT
+        YEO3I+fs5P3b49Ork+PDyen55Goynf4+xfthnRoMCR6YZcDO8AWQlpFdJgxTMl8zZBORk1JmFftF
+        aM7ONBRIJ6wyiFr3KVYJsKAc/1b4fpl8jpzmVcTsYfi3VXWPLTARqZA8f3io7b7a8NZIz9G7jnAw
+        s6mEzemqpLJ9EsnDsRvuhR2Sm0bpheBrhDcv7/3e5nl43OLtZx7fYLvZQa5T3tg6bDu6/+Rw1xY2
+        NYNGwq5RkLCk6la50qeNN9d5Bf1UI29smyLFjlSTbFWU2BBL+zToR7toYbShhW9l/H44P8mvfwcs
+        1aoqqVF8I2SCxGgY1gq7BpCsrEwGSY3S4+kBfa+BCbkgAwSzhOFfAYaPFiQRKctCl70ldZ/kq/r7
+        KmIXG7VCRmyOMcwi3x24/i3FG8Odq5jnmTI2Gvtj35s3x69qt7zBnn+JguziHOKK6Im9U8u+VTuE
+        8b1OKnyvw0vmsYvAWPZHxbUFzSYyxaIsMMQ7RGFzwAtq6dOz39hBheXPzmMud0hR9+ft+5dNMG9v
+        2Tn2rbWfOD78MKk/H5tPl2OatK88DWfCIhOQaI0pHKEiRmTJbtkF6uiHSG79YC8I9msvCKNykbgS
+        W303VQtvUeUSUWuRVbz75y9JxdBvYk1y8RLcQlgNrtKph6XNCe4C+1iiBA+PupktcpKrU4XfOlmk
+        ZwpplXMM5Yr+tdXuH4EUfwMAAP//7FnbTttAEP2VVSVQEsXGcZyEBCEKoggqUVWg9oG+sPGuiYsT
+        W7YTHsrH98x6syQmS1uqVnlAoFx29jKemT1zZsITCp5rmS9QnDGHNc5oYZvtJuUBFvdcv2kxnnb1
+        nt/t0YEXMyrwFrJN1lFsuc2u4uKeHYehzCjaHsnIraWJRy1lJRpjrdO5ZKcISQx+xHVl/rDNgFg9
+        th7uy79JxzXxrr533X/8gFD8VAEL7vz3lBHkQtdfrmMNvDQ3PfWLz8xaiDqMf8Ob86oAwJGIJbXF
+        34XguuFb1+k8hxnP4kQCHWRl6t278kDF28rE0yfUagFdzLEp4EyDgRune1ws4gLIB8rR8/sAtIiM
+        jGBZ5jly3q3a/JYhGTNSFUWmTr+59rlWhHwujM8L7fOHCYEhx36zOwYWHkKOPB7mPKKTKGsDpLJ5
+        6cLyX5/2vwQaJVKj3rpoSfNHK2GEGZ8VcxVLMaSwzKERr2yAmROsxiBCUt3RUd2Y7ZWBAmzHIsgX
+        0qF8FofPJ1bSiC8oA694iUBtRC8UXPhKV7SAOtl8nMSh9uBlrNKEduAXxSTI5toz1VOxNGcJBLlr
+        PH8xzYAEtOZTymL1hQHZF7GQYi2WrnChQK9w9J9EiF6apZQYKMAbXEzjWZM1mo9TBHCZjhC0z8l5
+        z/DTOjezpedOYBOYao3ydpmDqaiShIqM2tTAVFI1gWf2qAtsFNkzFHlpHttEW1nnGWXWqGadcPCy
+        5OGEcmlFZ4r5dMqJa72zkQGyNtVMaf5KQkZ38IiHIVV6F+Jw0AEQejvdY9nf74/7AXe8yB84QcR7
+        znA48BzRj4QcRONAdom8mZU4tlo7+s2VkkLmWAi6T6Qzz9NEvF9RGdyODnix36P8IV3QQzWN1ix7
+        Dt2oK/yxFLw/2Oeyy4ci4sFwPxzz/jAMOp0jcah2wbPu+Gf4r9Y5Uz7TfMZxqqHCnRfOA0zm+C4R
+        Jbe6rGRTJ+O8IJNivcoFqH/w8fzECdxsRhS63jvafo3rzaft17jevNp2jQFWouqF6BrnXAU/O0n4
+        7F7OikmcqatFpK5qt1R4dwMajNkf5nmayb0bIFFIjQF9B6mDCqm56XSM7htvro4CG/wGtqZJYOvE
+        BQbic50f3uBoCwPvDY7+h8ZvcGSDozpqGJpnWBFUv6uu4A/6ZUh/9nBgWnL9u1Z9Fyufs8KYlej5
+        m4HS1iL1bMyWUGGjwHtitj8BAAD//0KVMMalwxjedEzNK8ssys+DNA8hQiml0ElVCJeo0MvPhZhQ
+        DWNCawcySmuk+WB9mLk6SrmJFUGpxaU5IIOR7AaPIBaVOJZA3FGWX0K9iQuIYXBDgXZlJBaH5YMH
+        YGGzDaCpE9CwJshKuENQXWuE4lyoBnDw1NbWAgAAAP//AwA8odpCwx8AAA==
+    headers:
+      Atl-Request-Id:
+      - e0531eeb-9979-46ca-a2d6-bb4db28c1f59
+      Atl-Traceid:
+      - e0531eeb997946caa2d6bb4db28c1f59
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:48 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=291,atl-edge-internal;dur=15,atl-edge-upstream;dur=277,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 29144bfb620aff50a0811e16df8a70ef
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": 41}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1587/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 89bd7774-427a-4461-b2fc-f7326466b937
+      Atl-Traceid:
+      - 89bd7774427a4461b2fcf7326466b937
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:49 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=513,atl-edge-internal;dur=14,atl-edge-upstream;dur=499,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 1fe414e6e121d9bdb366059b1c6d0675
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbskbbc2bzLBKTqFdi+KSJrcYjRNSpMOxth/N8HB9qi+Xe75
+        zj2He0Atd7AdNWLow/vBsflcQgfCS/tpU+41d05xkxrwaIakcoPm+3/wNYw7JUCC+1qDHlZgPIx/
+        PbKyptMTGAG/c+5gdMqaABOMSYpTnNSb6+d6/dSc1c3Ut2FC7DVCMzzDbyETBm33fWjZ7IeYttJ2
+        ksHUTkrLHwtiwUCXy9PyhvsIUkzzhNCEVA2hLCOMZCnG+AoHOPhd+AOMjeov2Qw3pGQkZ3mVVssz
+        K/o709kA4rzAeUYXPGvbsigrUlREFjQTgpYgF4RDx3m+aC8CvI4J92rk8YVBn7R/sILH9QHp04TA
+        vG9rdLws9mJNVG4fG3T8BgAA//8DAF8wrQMgAgAA
+    headers:
+      Atl-Request-Id:
+      - db1a6ced-5634-4988-bdf9-3c4a6d3f56f2
+      Atl-Traceid:
+      - db1a6ced56344988bdf93c4a6d3f56f2
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:50 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=139,atl-edge-internal;dur=15,atl-edge-upstream;dur=125,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 177f4088db778be657711f625dbd342d
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/TEP8loTgmU6HgXBHSykNAT5wTEaxN7YOR/JJckh68N+7smMH
+        QkwLnd4wg21J+6LdZ5/dfLdgmVEeWYElgUcgITphkEaqzekcVFuFCcxpW2QgqWaCqzZETM9B03aY
+        UB5DKuL2AqTCPYhGkElQwPX6bJgrLeYzo3DiOo7rdCR8y0Hp8SqDC0lDzUKw2hYz9t3ewcEAPxSk
+        M/xMtM5UYNsRzCDUkfgqOlSnVClGeYeDttGStmnGbM9mSuVgVwruYYXy5+Ph5XjP7Q36uFS4oKzg
+        u6XQt1yFVEMs5Kq8Q4RfKOE5XnfP9fZ8Z+wOArcbdPudbnfwE/rtGCeNEY2OF2o+6KSRt1Gf49XX
+        Xn9EoELJMhM4XD0kak7TtE0ipjTjoSYZgxCImJEHIe87RjoU/Eqm7/Qi58yki6YTuqCaSnvB4MEu
+        3No4uN5yHd8d/KLYX/DzHNOez9GqgQWaHFN1b3KVT7V5C2Y0VdC2SsFTvFch27YShsCRYbI6gwWg
+        r85T29IMkZUhSqyA53hHawsmvtO04VYbmRRf8aofzMRaushDkdkqD+bjGXo2173iTGtUoKzatoHw
+        b8VZJWb6gUoDZMXmWcrQ4WgrJJioAn7dwbI7eKe7b6SsukmdsK6zj2543aXX/X+tlLAoQIoG3f7S
+        7f8Ig8vKou8tfe9HWFwj/+npNRy9Jpz61caMLa9LcsTs394hGuJYQox8849F0Ks28AIizUte+BDc
+        Nwp2I/4l89wgvZCEKjIF4CQUCGjQEBHBiU6YIgVLGP5Zl8YxEr+1Izj9povtN2x4jRuDpo2D1zF6
+        i8v9mssNhxYNzQr2XPykGvtc2R/eH9+y+2z6jV2qk4YsitcjkZs8u6aH3JgFxmMr0DIHjBsq1deI
+        Q0MZ5WUKfUa/ZGGV9u014ysKq0TkaXTMVJbS1ZpyTC4kYBhMjl/Fwe929gduFYftgDYxr1cz7/ZG
+        XQOZZEIyvfpgECtxu2iM/761sTmNQdlGQlVKGC4kLE46ahFvgPoZVyroezsQ6/lVTUxaQWvilv/d
+        fr8/aT22zAnHe7ZjwpfSKRheN5W9Pes04d9tgrk7MKHDyhtmLDxj/P7E7BxDZuYyHlbpLZL+UOzV
+        K1zwIY5ldJrCCKgqISPXb9bF2dWn0/PJ2enR8PxyOBmORn+M0HnkH4WxwwPjBMgFNjCuibGLJY7V
+        nq4IkiFLjVKiBfmVSUouJMyRDUmuEN6dXaToYk1aziNznCyaBlbZ7THNmCdTmOXNX7AgZixmnKbb
+        h9ZT5Tq8RQGk6F1FpAiBmEN9Os9M5e+EfDHG7VeQLwfAD6K0FK4HuJfM+T7gbjHo1jRYGjpaj6n/
+        ydtq1rX9tRG/GnKi0nAoUiHPS18wL8C3XCuyjH0A37nejfZeE3H0auJ4K9Uv4/iFP/87JLEUeWYm
+        3xPGI6ROtWlPWa4S7E0GnqejQ/OcAmF8YQwYfEUEf9sQ7MIQBUZZ4nXIJ6PuC28Vz1ZAbmu1jAck
+        i4Nex+04jybQGOdUhDRNhNLBwBk49qw8Oyl8sv3ewR1KkdtLCHPDXuSzeNjTokEYh4woxyHDuyM2
+        uXWVJn/mVGqQZMhjLMU5xrdBFOoDtltIn1/8Tg5zLHpyGVLeIGVGVvvAuSsj+fhILnEKL/zE96Pr
+        YfG4KR9VgsnfAAAA///sWN9v2zYQ/lcOCBDInk3V8q/FgR+KOA8d1qJIur3UBazIjC1UlhRRcjK0
+        /d/3HUVRUmx3a7unoU5gS3c88vTd8e6jcGM4C1++C3PsfzbVyYQrTERcS+kzvcccfQ97vj+YvPjV
+        015wcsb7tYhxcBGbZO/uiyhGuuaoJW57/Aee4mJkzYJHKXZhnkmRZBsX+9nnNA/BvbkOuBcjsc13
+        EVulG3zpOPEUHj43cpfkEo+xlnT9hHCwDfXJebvp0XmUX5InBgPhEZ1v8ss5DcULGGvFUKBAUKUY
+        1YqRGItpJR/X8rHAXJV8Usv5clzL2TsjH4hJLfdqudccP6zlQzGs5aNaPqofYFqvy5cNuV2XL73O
+        idwwmex6wwkj+irm0/he9jj4+gTTo5tQfaSXQSBT3knHAj/9xsCb8f9V4H8G/buDPvrXQUeprMrG
+        rKsTgGXUXRSSFqixEP6G3kPeRY/Qe8fUrt/V33YgbAHX90Pxc+f+YBAnqOzdhWYCtAAVICZIiMc/
+        2pGDr86xyH41rtRFt4D8PX7637F/sSAKgZ7gxxpHO7W6t0mRBRLpFckut/A+Ou0uVJJxTTeNgYua
+        aHRBCOyyyD1lWrgIE9df70MFsoJzxNjzwEHuGWJsh4qTMhtZpZsVzscx/IvJp6xM44DTWNo05meQ
+        mX8XRtx1862fUxJgIUWPW8knalkZMmp3vpKUZPSAs95fpFIZ8KZUmD3I/Ht2AFyt2MXE9EzojQbu
+        nkkCeaf8MalMAlKBjH2chpjUYKkw2BKoAoh9FH6UoPb3WMWH22kahYF+W2vIU+VwJIEPtiyfDZqj
+        ykeDT0Ws/HtUDj4K9FXBQ+CfeojMcgYZRTsfxmEC7tBwXoll7B3ODqMYSCt2Bu7h2JyBT2Jeiw7z
+        OeuDb5DKZF5kMXIbV6qIcka34QPGHXVCMIBnZzjVJIgn/q+SmOveMl6tVsuYj5Q5faIrPBl40Rea
+        E7++DjPpnJ89eVOkVvnbqcYG5cg5xfLRmDms1FfCPBxLKgOGa06r2+vfr6/e0YBe3tL5Q5Hkl0t8
+        ysndbinBJjym7rpL7Mtf+FFVEkkRJRsH2R/gcCdkvO98YG9AsmESu25pvdIOlE5pAB340SNHZlmP
+        EezQnHcOfcLM5pkw15od/9Ix4NCfNlHoNWgt8oV4qzXl1auvWauMg0ueKOTQnCrl1uigmFvNQTlv
+        aJ4V9IbmWUlvaJ4V9YbmWVm3moPC3tC0SztweqtfEq0rkGZmpAHJoIL5GnAxRgYTXqgJF2NkQDGq
+        Ci7GyILS0FQtr0KlpWKQLCotDYNkUWlpGCSLSkvDIFlUGpoSJItKS1OC1Egm4LVFJnFK9ksGODss
+        9HyamfEXuhPumMYoGKXFHba/6QGvQ302NC2gaw87nngSTzP6Q79I4AJkin0VElTMCJpMNI2Gp4zK
+        aB21GZ2yKcN41GZ8yqYM8FGbySmbMiLWhhx6wx1Idyfb4XQS9MqI93TZLUPMrcaPVEJpmcCCmEfY
+        RaenFtUh/fqiJiHQpQ4WMLF7tUvBWDlubxIK9Q0hBfbhWq7rNo+BNyBFmUQ1V9/S541pmvChnGmK
+        4693Ydwhp/N5BxqSJzNLPY7y2f8Dl/0bAAD//0KI07Uta0JmW9YE1JY1GQRtWXL7wsjpltZtWUP0
+        tiwAAAD//+ya32qDMBTGX2UUehkXNdVaKF0LG90r9O6YxHW0VfEPe/3lGBu6rNlGr8oIeCEmxxyP
+        5vjB9/Na1mtZr2W9lvVa1mtZr2X/jZYNTegvWvY7AzAz8Irt7Lo8vpBdenxdA/wwAA4IKNhTDdVi
+        DTCDclgD1BVBXQY7NQb7uTyuiS6uhJpkvhjVtmsJXQd8j56c9kTb/nQCNGsnVx1FLDVyGVVzo52L
+        6mQFnCNN8iqWaaiULJ3Ga5nMkzxhQGgRpYQVMCNZllIikkLItMiZjNFSNpFqWR27+GOkxO9lLYTK
+        pcWcoamO4ukiZV4hGvgz6Ta8DBm8NXoaxpxpq7iIRZRLAUk6BxlDJgpg2ZznkGScheFKLIe7qGed
+        Ri/q0HHkBOVoihKiL7VB35IPVTISBei2BrpbYk1JDdBiSVX8oObVvlSn2w1hQV0iJ2JTc/efsY3d
+        3X/GNrZ37xmrFiY0XTUCEtvh43/YHKE8yLLdv9fD1kIXTSNdugvuEJxYTJ77pqrl4061IY7w0bgH
+        kR1Vo2an4zIjSnudr2Cu3stcYBZzwYnM9Pdm/DmM7egTAAD//xotjgZTwhstjujh4tHiCFdxhF5q
+        wNt48CYR0OnpkCxYDVoTD2UbAC3ML0mELvVHNwVnYw5nMYazlWeEvaDEtbrSAFezFlQqYJUwgHsZ
+        TcIYlw5jeLsxNa8ssyg/D9I2hAillEL3mUC4RIVefi7EhGoYE1o7kFFaI22R0YeZq6OUm1gRBBll
+        QrEbvP6wqMSxBOKOMmDnhtwVkxiLoyGGwQ0F2pWRWByWD167CVu/DFqenZMP6kIgOQTVtUYozoVq
+        AAdPbW0tAAAA//8DAJUrt8bWNAAA
+    headers:
+      Atl-Request-Id:
+      - b27d138d-f7ed-4536-adf8-1396efe38db2
+      Atl-Traceid:
+      - b27d138df7ed4536adf81396efe38db2
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:50 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=286,atl-edge-internal;dur=11,atl-edge-upstream;dur=275,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - bfb0f0ea272e55a771394a4293d86614
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 143dae7a-752d-4675-b944-d0c11d98120d
+      Atl-Traceid:
+      - 143dae7a752d4675b944d0c11d98120d
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:50 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=327,atl-edge-internal;dur=12,atl-edge-upstream;dur=315,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 410a178f5c013a18def67fb7d4945df1
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
+      Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/359] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236] | Inactive,
+      Verified, Risk Accepted |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/234] | Inactive,
+      Verified, Risk Accepted |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025
+      \n\n\n\n\n\n\n\n\n\n\nh1. Findings\n\nh3. [2222Remote Code Execution - (Pg,
+      &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
+      5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
+      6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
+      &lt; 7.1.2)|http://localhost:8080/finding/236]\n*Defect Dojo link:* http://localhost:8080/finding/236
+      (236)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+      &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
+      5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
+      6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
+      &lt; 7.1.2)|http://localhost:8080/finding/234]\n*Defect Dojo link:* http://localhost:8080/finding/234
+      (234)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '7161'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 53b61aa9-36e3-4e04-8824-e88e50b2631c
+      Atl-Traceid:
+      - 53b61aa936e34e048824e88e50b2631c
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:51 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=272,atl-edge-internal;dur=14,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 5b3f7d6fe31945a5272ad8727cb08129
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+yQvGM50OA7k7WkppCPCBYzKKvbF1OJIrySHpwX/vym+B
+        EDOFTm+YwbakfdHus89uvluwyiiPrMCSwCOQEH1ikEaqw+kCVEeFCSxoR2QgqWaCqw5ETC9A006Y
+        UB5DKuLOEqTCPYjGkElQwHV1NsyVFou5UTh1Hcd1uhL+ykHpyTqDC0lDzUKwOhYz9t3B4aGPHwrS
+        OX4mWmcqsO0I5hDqSHwTXapTqhSjvMtB22hJ2zRjtmczpXKwawX3sEb588nocrLvDvwhLhUuKCv4
+        bin0LVch1RALuS7vEOEXSniO1993vf2eM3H9wO0H/WG33/d/Qr8d46QxotHxQs0HnTTyNupzvOba
+        1UcEKpQsM4HD1SOiFjRNOyRiSjMeapIxCIGIOXkQ8r5rpEPBr2T6Ti9yzky6aDqlS6qptJcMHuzC
+        rY2D1Zbr9Fz/F8X+hp8XmPZ8gVYNLNDkhKp7k6t8ps1bMKepgo5VCp7ivQrZjpUwBI4Mk/UZLAF9
+        dZ46lmaIrAxRYgU8xztaWzDpOfVGJsU3vNEHA15JF+EuEliH23w8A8nmVlecaY0KlNXYNkj9rTir
+        xFw/UGnwqtgiSxk6HG3dHPNRoKzvr/r+O919IzP1TZq89J0DdMPrr7z+/2ulzH6BRTToDlfu8EcY
+        XNUWe96q5/0IixXAn55ew9Ftw6nXttGrN+ZsdV2SI8Li9g5hEscSYuSbV0WAFxBpXpb/h+C+UbAb
+        8S8J5gZZhCRUkRkAJ6FAQIOGiAhOdMIUKcjA0ExVGifI79aO4AzaYjBs2zho2fBaN/y2jcPXwXuL
+        y3sNlxsOLRqaFey7+Ek19rmyP7w/8GX32fQbu1QnDYsUr8ciN3l2TQ+5MQuMx1agZQ4YUFSqrxGg
+        hkvKyxT6jH7JwhoP22vGVxRWicjT6ISpLKXriotMkiRgGEzyX8Wh1+8e+G4dh+2ANsy7vdFWA15T
+        A5lkQjK9/mAQa3G7aIz/vrWxBY1B2UZC1UoYLiQsTrpqGW8Q/AVX6prwdkDZ69XFMt0L9qZu+d8d
+        DofTvcc9c8Lxnu2Y8KV0BobwTWVvzzpt+HfbYO76JnRYkqOMhWeM338yOyeQmbmMh3V6i6Q/FHvN
+        Chd8hGMZnaUwBqpKyMjqzbo4u/p8ej49Oz0enV+OpqPx+I8xOo/8ozB2eGCSALnAzsY1MXax9pEG
+        0jVBlmSpUUq0IL8yScmFhAXSJMkVwru7iy1drEnLeWSOk0WzwCq7PaYZ82QKs7z5CxbEjMWM03T7
+        UDVVVuEtCiBF72oiRQjEHJrTeWYqfyfkizHuoIZ8OQB+EKWlcDPAvaTU9wF3i1q3psHS0HE1pv4n
+        b+tZ1+5VRnr19BOVhkORCnle+oJ5Ab7lWpFlbBD4zvVutA8a4ngro9tCDam8jONX/vzviMRS5JmZ
+        fD8xHiF1qk3fynKVYNMy8DwdH5nnDAjjS2PZ4Csi+NuGYBeGKDDKEq9LPht1X/le8dwLyG2jlvGA
+        ZHEw6Lpd59EEGuOcipCmiVA68B3fsefl2Wnhk90bHN6hFLm9hDA37EW+iId9LVqEcfqIcpw+vDti
+        k1tXafJnTqUGSUY8xlJcYHxbRKE5YLuF9PnF7+Qox6InlyHlLVJmlrUPnbsyko+P5BKn8MJPfD++
+        HhWPm/JRJ5j8AwAA///sWN9v2zYQ/lcOCBDInk3V8q/FgR+KOA8d1qJIur3UBazIjC1UlhRRcjK0
+        /d/3HUVRUmx3a7unoU5gS3c88vTd8e6jcGM4C1++C3PsfzbVyYQrTERcS+kzvcccfQ97vj+YvPjV
+        015wcsb7tYhxcBGbZO/uiyhGuuaoJW57/Aee4mJkzYJHKXZhnkmRZBsX+9nnNA9ByrkOuBcjsc13
+        EVulG3zpOPEUHj43cpfkEo+xlnT9hHCwDfXJebvp0XmUX5InBgPhEZ1v8ss5DcULGGvFUKBAUKUY
+        1YqRGItpJR/X8rHAXJV8Usv5clzL2TsjH4hJLfdqudccP6zlQzGs5aNaPqofYFqvy5cNuV2XL73O
+        idwwmex6wwkj+irm0/he9jj4+mjTo5tQfaSXQSBT3knHAj/9xsCb8f9V4H8G/buDPvrXQUeprMrG
+        rKsTgGXUXRSSFqixEP6G3kPeRY/Qe8fUrt/V33YgbAHX90Pxc+f+YBAnqOzdhWYCtAAVICZIiMc/
+        2pGDr86xyH41rtRFt4D8PX7637F/sSAKgZ7gxxpHO7W6t0mRBRLpFckut/A+Ou0uVJJxTTeNgYua
+        aHRBCOyyyD1lWrgIE9df70MFFoNzxNjzwEHuGWJsh4qTMhtZpZsVDs4x/IvJp6xM44DTWNo05meQ
+        mX8XRtx1862fUxJgIUWPW8lHbVkZMmp3vpKUZPSAs95fpFIZ8KZUmD3I/Ht2AFyt2MXE9EzojQbu
+        nkkCeaf8MalMAlKBjH2chpjUYKkw2BKoAoh9FH6UoPb3WMWH22kahYF+W2vIU+VwJIEPtiyfDZqj
+        ykeDT0Ws/HtUDj4K9FXBQ+CfeojMcgYZRTsfxmEC7tBwXoll7B3ODqMYSCt2Bu7h2JyBM2Jeiw7z
+        OeuDb5DKZF5kMXIbV6qIcka34QPGHXVCMIBnZzjVJIgn/q+SmOveMl6tVsuYj5Q5faIrPBl40Rea
+        E7++DjPpnJ89eVOkVvnbqcYG5cg5xfLRmDms1FfCPBxLKgOGa06r2+vfr6/e0YBe3tL5Q5Hkl0t8
+        ysndbinBJjym7rpL7Mtf+FFVEkkRJRsH2R/gcCdkvO98YG9AsmESu25pvdIOlE5pAB340SNHZlmP
+        EezQnHcOfcLM5pkw15od/9Ix4NCfNlHoNWgt8oV4qzXl1auvWauMg0ueKOTQnCrl1uigmFvNQTlv
+        aJ4V9IbmWUlvaJ4V9YbmWVm3moPC3tC0SztweqtfEq0rkGZmpAHJoIL5GnAxRgYTXqgJF2NkQDGq
+        Ci7GyILS0FQtr0KlpWKQLCotDYNkUWlpGCSLSkvDIFlUGpoSJItKS1OC1Egm4LVFJnFK9ksGODss
+        9HyamfEXuhPumMYoGKXFHba/6QGvQ302NC2gaw87nngSTzP6Q79I4AJkin0VElTMCJpMNI2Gp4zK
+        aB21GZ2yKcN41GZ8yqYM8FGbySmbMiLWhhx6wx1Idyfb4XQS9MqI93TZLUPMrcaPVEJpmcCCmEfY
+        RaenFtUh/fqiJiHQpQ4WMLF7tUvBWDlubxIK9Q0hBfbhWq7rNo+BNyBFmUQ1V9/S541pmvChnGmK
+        4693Ydwhp/N5BxqSJzNLPY7y2f8Dl/0bAAD//0KI07Uta0JmW9YE1JY1GQRtWXL7wsjpltZtWUP0
+        tiwAAAD//+yayWrDMBCGX6UEcpTrRfESCGkCLekr5DaW5KYkXvBCX78ayxGtGrWlJ1MEPhhLY43H
+        1viH/3Na1mlZp2WdlnVa1mlZp2X/jZYNdOgPWvYrA7DS8Irp7NrggIDaBjQcgq5g3wI7j+QDkgvG
+        VN/GkVDNeJgRNoPd1wb7tTy2iTauxNdrfjKqTTsT+h7YCT055Yl2Q1kCmrWLm44ilhq5jLr9o52L
+        6mQLjCFN8sw3SSCVrL+MdiJO4zymQPwiTAgtYEWyLPEJjwsukiKnIkJLWUfKZVXs+peRAr+XHecy
+        lw5zhra+8IcPKbMa0cDvEbjxZQjvpVXTMOaKYUVFxMNccIiTFEQEGS+AZinLIc4YDYIt34x3kc+6
+        DJ/koeJICdVkihKiLnXe0JE3WTISeui2eqpbYk1JA9BhSWX8qOblvpSnhz2hXlMhJ2LidPPP2OTx
+        5p+xyfPNPWPZqbiiqyZA4jB+/Hf7C1RnUXWn12bcWuiiKaRLNbsjghPrxePQ1o24P8o2xBA+mvYg
+        QqVyVO90XGZCaW/zFdTWe6kNzKI2OJHq/t5OP4epHb0DAAD//xotjgZTwhstjujh4tHiCFdxhF5q
+        wNt48CYR0OnpkCxYDVosD2UbAC3ML0mELvVHNwVXK88AVzFmYIS9PMTZ+MPVejXBtezSAFfrFVRc
+        YJUwxikBbzem5pVlFuXnQdqGEKGUUug+EwiXqNDLz4WYUA1jQmsHMkprpC0y+jBzdZRyEyuCIKNM
+        KHaD1x8WlTiWQNxRBuzckLtiEmNxNMQwuKFAuzISi8PywWs3YeuXQcuzc/JBPQUkh6C61gjFuVAN
+        4OCpra0FAAAA//8DAOG+Je3WNAAA
+    headers:
+      Atl-Request-Id:
+      - afa796d5-550a-41f4-bea7-3ff7deb8eb60
+      Atl-Traceid:
+      - afa796d5550a41f4bea73ff7deb8eb60
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:51 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=263,atl-edge-internal;dur=15,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 9370ba7908b6e2fe64781d82ceba632b
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbskbbc2bzLBKTqFdi+KSJrcYjRNSpMOxth/N8Ghe1TfLvd8
+        557DPaCWO9iOGjH05v3g2HwuoQPhpX23KfeaO6e4SQ14NENSuUHz/T/4GsadEiDBfaxBDyswHsa/
+        HllZ0+kJjIDfOXcwOmVNgAnGJMUpTurN5WO9fmh+1M3Ut2FC7DlCMzzDLyETBm33fWjZ7IeYttJ2
+        ksHUTkrLLwtiwUCXy9PyivsIUkzzhNCEVA2hLCOMZCnG+AIHOPhd+AOMjerP2Qw3pGQkZwVJl1X1
+        zYr+xnQ2gDgvcJ7RBc/atizKihQVkQXNhKAlyAXh0HGeL9qzAK9jwq0aeXxh0Cft76zgcX1A+jQh
+        MK/bGh3Piz1ZE5Xr+wYdPwEAAP//AwBv7vEDIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - b90295c3-ea3e-4c26-8ac3-4dfdf70ff9d3
+      Atl-Traceid:
+      - b90295c3ea3e4c268ac34dfdf70ff9d3
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:51 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=158,atl-edge-internal;dur=12,atl-edge-upstream;dur=146,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 86633b8006fb86ae66349ba4d25a438c
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+SyDxTKfDQO6OllIaAnzgmIywN7YOW3IlOS89+O9d+S0Q
+        EqbQ6Q0z2Ja0L9p99tnNdwuWOeWRFVgSeAQSok8M0kh1OM1AdVSYQEY7IgdJNRNcdSBiOgNNO2FC
+        eQypiDtzkAr3IBpDLkEB1/XZsFBaZDOjcOo6jut0JfxVgNKTVQ4XkoaahWB1LGbsu/3h8BA/FKQz
+        /Ey0zlVg2xHMINSR+Ca6VKdUKUZ5l4O20ZK2ac5sz2ZKFWA3Ch5ghfLnk9HlZN/tD/q4VLqgrOC7
+        pdC3QoVUQyzkqrpDhF8o4Tleb9/19n1n4g4Ctxf03O7hgfcT+u0YJ40RjY6Xaj7opJG3UZ/jtdeu
+        PyJQoWS5CRyuHhGV0TTtkIgpzXioSc4gBCJmZCHkQ9dIh4JfyfSdXhScmXTRdErnVFNpzxks7NKt
+        tYP1luv47uAXxf6GnzNMe5GhVQMLNDmh6sHkqrjX5i2Y0VRBx6oET/FepWzHShgCR4bJ6gzmgL46
+        Tx1LM0RWjiixAl7gHa0NmPhOs5FL8Q1v9MGA19JluMsENuE2H89Asr7VFWdaowJltbYNUn8rzyox
+        0wsqDV4Vy/KUocPRxs0xHyXKeoNlb/BOd9/ITHOTNi89xwDd6y293v9rpcp+iUU06B4s3YMfYXDZ
+        WPS9pe/9CIs1wJ+eXsPR3YVTr9mYseV1xYGY/du71yf95iSNYwkx8s2rIsALiLSoyv9DcF8r2I74
+        lwRzgyxCEqrIPQAnoUBAg4aICE50whQpycDQTF0aJ8jv1pbg9HcF52DXxuGODW/nxmDXxvB18N7i
+        cn/YcLnh0LKhWcG+W1O7CaVkYZOBzTVT13h/lYgijU6YylO6qqsflxdUY6esOsz7U1f1r3XHsit1
+        0vBQ+XosCoOU0tUbs8B4bAVaFsY2KtXXCHHDRnWcJGAYTPJfxcH3ur1h29M2A9oy7+bGrhrw2hrI
+        JROS6dUHQ9CI22Vj/PetjWU0BmUbCdUoYbiQsDjpqnm8RvAXXGlqwtsCZc9vimW6F+xN3fL/0DvE
+        z8c9c8Dxnm2Y6KX0Hgzfb6l4Q5NbA+buQrk7MJHDihzlLDxj/OGT2TmB3IxlPGywViJwUe61K1zw
+        EU5l9D6FMVBV4VfWb9bF2dXn0/Pp2enx6PxyNB2Nx3+M0XmkH4WhwwOTBMgFNjauibGLpY8skK4I
+        kiRLjVKiBfmVSUouJGTIkqRQiM3uNrJ0sSQt55E5Th75gVU1e8wypsnU5RYSxITFjNN081A9VNbh
+        LSskRe/qb4OAmEN7ushN4W9F/Msprpr/PgjSSrid314y6vtwu8GsG8NgZei4nlL/k7fNqGv7tRG/
+        GX6iynAoUiHPK18wL8A3XCuzjP0B37nejvZ+yxtvZXRTqOWUl3H8yp//HZFYiiI3g+8nxiPkPbVu
+        W3mhEuxZBp6n4yPzvAfC+NxYNviKCP60IdidIQqMssTrks9G3Ve+Vz73AnLbqmU8IBxjpRnVQgZO
+        t9/1H03AMd6pCGmaCKWDgTNw7FklMy19s/3+4A6lye0lhIUhMfJFLPa12CGMQ0hU4BDi3RGb3LpK
+        kz8LKjVIMuIxlmSGcd4hCu0B2y2lzy9+J0cFFj+5DCnfIWVGWnvo3FURfXwklziMl37i+/H1qHzc
+        VA+R/QMAAP//7FltT9swEP4r1iRQWzVpmqQpLUKMqUJjGmiCbV/QpLqxm0akSZWXsg/8+D3nvPQF
+        SrsiEJNWqpLEPvt89/g53yV3NN0UZxq6/O6n4AESVaDCFQZiRKnsgd1iDM3E3tdw6jfbSgsCaTgX
+        eoj8RfeieWueBSFgm4JTWqv9f9EQlmFUcu691Kd+Gks9ir0WNjYnvPs4nBMhtNBVn6TTgOQW/sKN
+        8hgNZuJzLb0s4LDpb8pJ1ToGMvR5QFC6kfEcqSfTWO2qGqHJDoP0+ATDOLpR32DLwvMt07Jo/ouQ
+        kti5bJKxVEbQZNd+csfOXFfOCIFPGcrBwjtWb2dDFf2VoezdDWVvNdSrG8nc2UjYkiUs+w1lMHrG
+        GoNMsgH2Mh5+Accxs9dk4PgOW+WJ8m/S1iuiUPeW/mZ4wBIGipfZAMTMKFxB661yrIaf+lPrf3b1
+        rIE9i+e3+KfttX0wJQCmhnjZBl51QeMmymIY89wPJAhW5gY/9NJjrvytLhd4XBIcLAJBA4RdqREh
+        QhTUqvtRi4u5nyDKSArFXcSIMRkdMCrPDOTS4WKGIcPphpH+Mi7PM3EBh0I7goOo4JAUcOBpyt27
+        pMnuJ747YUgFPA80nYEi2YxjrtBjnCGNcyGIE5Mb8zHpMcyBrX3loZeBsIdsIrmA5JwHyKry1bKf
+        C4UuERECuRx+VtvL7LK/DEl0+abyBFG2o9krm9urI6DnBOJ4CJCr/d/f7hiKCn36IXzhlpaVYJRZ
+        Ngp8t3Dapa+CbeGzH+ogRhYunJErw8A7ARriYvGQu5jOQAskcxUxX90whMa5L6RYgdM19hROp5j6
+        b0BRiM4iiqyE8RoXUz+ss1r9YQoMp1G/wu2TpPHqhGHuSRgmEYb5QsLYK4w8Iox9A9myf9+aMJz/
+        hPEGhGH/W4ThVKJbCONx0aRTFffWc+FN1ZS2vZwupTEgo+o5VF9a77qpvmZsarCroti6RFWSKK2w
+        qeOmEoWxqRBnVHOqDTChBKXI05dT/fWEMMmmU07p7YdnczAyORW0onjPRJjKFadALBXRLsRJtw1C
+        NA6sM+kcOSPH5poxNruaPeYdrdfrGppwxkJ2xyNbWpSMV5KYNpft7ygpCTdnQtCuIZ15HAXi45LK
+        yKtpgmffHShvSd2L824kU9avrbElzJEU3OkecWnxnhhzu3fkjrjTc+12+1ScqFGw1gPzHN9cTpvy
+        sEgjNS1/lOhZot3DZJqpU36q5zuWbKrNOE/IpJBXMYEHCS4/f9JsfRZSgW39PcT713j9Rcb713j9
+        RcjrafwHAAD//6KOi4FFWQpkkBw6tOQBTvwKTjmJedmpecUZmQXgrAXqF0JGsiGlYRRoyMlKybW0
+        KL8gVT8KWE4lg0ZtoXkQNBsHlIXndJA10DlI7CNTJrjKYBNcI9om8BHtImhdMJxLHQAAAAD//xot
+        dejo4tFSh9Yupl+pg15q4GoEmsDbevCmENBP6ZC8WQ1aZQBlGwBdkl+SCF0jgW4KrtaeAa5izMAI
+        e3mIa17KAKcHcLYG4T5D14GrmWiMUwLefkzNK8ssys+DNCAhQiml0AU6EC4xoVeWX0K9uViIYXBD
+        gTZlJBaH5YNnm2DTv8B8AHFyNYwJrY7IdgB4MZM+zFwdpdzEiqDU4tIckMFIngVPFRWVOJZAPA6a
+        187JB3UlkMRRNRuh6IZqALu2trYWAAAA//8DAE4+G1IPJgAA
+    headers:
+      Atl-Request-Id:
+      - b836cecf-34f7-450c-80e7-ce1253b69e07
+      Atl-Traceid:
+      - b836cecf34f7450c80e7ce1253b69e07
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:52 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=276,atl-edge-internal;dur=14,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - d49ffac1d9854ea198ea904f36c9b299
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQX0vDMBTFv0teXbsk/bMubzLBKTqFdi+KSJrcYjRNSpMOxth3N8Ghe1TfLvf8
+        zj2He0Atd7AdNWLozfvBsflcQgfCS/tuU+41d05xkxrwaIakcoPm+3/wNYw7JUCC+1iDHlZgPIx/
+        PbKyptMTGAG/c+5gdMqaABOMSYpTnNSby8d6/dD8qJupb8OE2HOEZniGX0ImDNru+9Cy2Q8xbaXt
+        JIOpnZSWXxbEgoEuFqflFfcRpJjmCaEJWTaEsowwkqUY4wsc4OB34Q8wNqo/ZzPckIqRnBU0rary
+        mxX9jelsAHFe4DyjJc/atiqqJSmWRBY0E4JWIEvCoeM8L9uzAK9jwq0aeXxh0Cft76zgcX1A+jQh
+        MK/bGh3Piz1ZE5Xr+wYdPwEAAP//AwCH7Ko5IAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 859638ec-ebe7-429a-b93c-96412e0f731b
+      Atl-Traceid:
+      - 859638ecebe7429ab93c96412e0f731b
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:52 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=159,atl-edge-internal;dur=17,atl-edge-upstream;dur=143,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - a8214d3d9be735c9964d7305b09f5bce
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+SyDxTKfDQLijpZSGAB84JiPsja3DkXySHJIe/Peu/BYI
+        MS10esMMtizti3affXbz3YJlRnlkBZYEHoGE6JhBGqkOp3NQHRUmMKcdkYGkmgmuOhAxPQdNO2FC
+        eQypiDsLkAr3IBpDJkEB19XZMFdazGdG4dR1HNfpSviWg9KTVQbnkoaahWB1LGbsu/3hcB8XCtIZ
+        LhOtMxXYdgQzCHUkvoou1SlVilHe5aBttKRtmjHbs5lSOdi1gntYofzZZHQx2XX7gz5+KlxQVvDd
+        UuhbrkKqIRZyVd4hwhVKeI7X23W9Xd+ZuIPA7QU9t7u/5/2EfjvGSWNEo+OFmg86aeRt1Od4zbWr
+        RQQqlCwzgcOvB0TNaZp2SMSUZjzUJGMQAhEz8iDkfddIh4JfyvSdXuScmXTRdEoXVFNpLxg82IVb
+        awerLdfx3cEviv0FP88x7fkcrRpYoMkJVfcmV/mdNm/BjKYKOlYpeIL3KmQ7VsIQODJMVqewAPTV
+        eepYmiGyMkSJFfAc72htwMR32jbceiOT4ite9YOZqKSLPBSZrfNgFs/Qs77uJWdaowJlNbYNhH8r
+        ziox0w9UGiArNs9Shg5HGyHBRBXw6w2WvcE73X0jZfVNmoT1HFMBXm/p9f5fKyUsCpCiQXdv6e79
+        CIPL2qLvLX3vR1iskP/09BqOXhtO/XpjxpZXJTli9m9uEQ1xLCFGvvnHIujXG3gBkeYlL3wI7msF
+        2xH/knmukV5IQhW5A+AkFAho0BARwYlOmCIFSxj+qUrjCInf2hKcvbaL7bdseK0bg7aN4esYvcXl
+        /rDmcsOhRUOzgl0Xl1Rjnyv7w/vjW3afdb+xS3XSkEXxeihyk2fX9JBr84Hx2Aq0zAHjhkr1FeLQ
+        UEZ5mUKf0S9ZWKd985vxFYVVIvI0OmIqS+mqohyTCwkYBpPjV3HwvW5v2PS0zYC2Ma/XMO/mRlMD
+        mWRCMr36YBBrcbtojP++tbE5jUHZRkLVShh+SFicdNUiXgP1M36poe9tQazn1zUx3Ql2pm7xf+jt
+        4/JxxxxwvGcbJnopvQND66awN0edNvi7bSh3ByZyWHijjIWnjN8fm50jyMxYxsM6u0XOH4q95gsX
+        fIRTGb1LYQxUlYiR1Zt1fnr56eRsenpyODq7GE1H4/EfY3Qe6Udh6PDAJAFyjv2La2LsYoVjsacr
+        glzIUqOUaEF+ZZKScwlzJEOSK0R3dxsnuliSlvPIHCeL/MAqmz1mGdNk6rK8+QsSxITFjNN081A1
+        VFbhLfCfonc1jyICYg7N6Twzhb8V8S+nuHL++yBIS+FmfntJnO/D7QaBbgyDpaHDakr9T97Wo67t
+        V0b8esaJSsOhSIU8K33BvADfcK3IMrYBfOd6O9r7bbzRb3jjrVS/jOMX/vzvgMRS5JkZfI8Zj5A5
+        1bo7ZblKsDUZeJ6MD8zzDgjjC2PA4Csi+NOGYBOGKDDKEq9LPhl1X/hO8dwJyE2jlvGAcIyVZlQL
+        GTjdftd/NAHHeKcipGkilA4GzsCxZ6XMtPDN9vuDW5QmNxcQ5obEyGfxsKtFizDOGlGOs4Z3S2xy
+        4ypN/syp1CDJiMdYknOMc4soNAdst5A+O/+dHORY/OQipLxFykyu9tC5LSP6+EgucBgv/MT3w6tR
+        8bguH2L+NwAAAP//7FltT9swEP4r1iRQWzVpmqQpLUKMqUJjGmiCbV/QpLqxm0akSZWXsg/8+D3n
+        vPQFSrsiEJNWqpLEPvt89/g53yV3NN0URxe6/O6n4AESVaDCFQZiRKnsgd1iDM3E3tdw6jfbSgsC
+        aTgXeoj8RfeieWueBSFgm4JTWqv9f9EQlmFUcu691Kd+Gks9ir0WNjYnvPs4gxMhtNBVn6TTgOQW
+        /sKN8hgNZuJzLb0s4LDpb8pJ1ToGMvR5QFC6kfEcqSfTWO2qGqHJDoP0+ATDOLpR32DLwvMt07Jo
+        /ouQkti5bJKx1MG/ya795I6dua6cEQKfMpSDhXes3s6GKvorQ9m7G8reaqhXN5K5s5GwJUtY9hvK
+        YPSMNQaZZAPsZTz8Ao5jZq/JwPEdtsoT5d+krVdEoe4t/c3wgCUMFC+zAYiZUbiC1lvlWA0/9afW
+        /+zqWQN7Fs9v8U/ba/tgSgBMDfGyDbzqgsZNlMUw5rkfSBCszA1+6KXHXPlbXS7wuCQ4WASCBgi7
+        UiNChCioVfejFhdzP0EwkRSKu4gRYzI6YFSeGcilw8UMQ4bTDSP9ZVyeZ+ICDoV2BAdRwSEp4MDT
+        lLt3SZPdT3x3wnD49jzQdAaKZDOOuUKPcYY0zoUgTkxuzMekxzAHtvaVh14Gwh6yieQCknMeIHnK
+        V8t+LhS6REQI5HL4WW0vk8j+MiTR5ZvKNETZjmavbG6vjoCeE4jjIUCu9n9/u2MoKvTph/CFW1pW
+        glFm2Sjw3cJpl74KtoXPfqiDGFm4cEauDAPvBGiIi8VD7mI6Ay2QzFXEfHXDEBrnvpBiBU7X2FM4
+        nWLqvwFFITqLKLISxmtcTP2wzmr1hykwnEb9CrdPksarE4a5J2GYRBjmCwljrzDyiDD2DWTL/n1r
+        wnD+E8YbEIb9bxGGU4luIYzHRZNOVe1bz4U3ZUVtezkrSmNARlWEqKKz3rUqA6412FXta63B2CRh
+        bCpJGFVJojTPpo6bCnFGpcxKar+e56ndMaHsJc8ik2w65ZTefng2ByOTU0ErivdMhKlccQrEUhnu
+        Qpx02yBE48A6k86RM3Jsrhljs6vZY97Rer2uoQlnLGR3PLKlRcl4JYlpc9n+jpKScHMmBO0a0pnH
+        USA+LqmMvJomePYVgXKK1L0470YyZZnaGlvCHEnBne4RlxbviTG3e0fuiDs91263T8WJGgVrPTDP
+        8c3ltCkPizRS0/JHiZ4l2j1Mppk65ad6vmPJptqM84RMCnkVE3iQ4PLzJ83WZyEV2NZfN7x/jdff
+        V7x/jdffd7yexn8AAAD//6KOi4FFWQpkWBo6tOQBTvwKTjmJedmpecUZmQXgrAXqF0LGwiGlYRRo
+        yMlKybW0KL8gVT8KWBwlg0ZtoXkQNOkGlIXndJA10DlI7CNTJrjKYBNcI9omuGZ1TODlfBG0khgG
+        xREAAAD//xotjgaDi0eLI1q7mH7FEXqpAW/rwZtGQKenQ7JgNWgxAZRtALQwvyQRukYC3RScjTqc
+        xRjO1p4R9oIS17yUAa7mLahUwCphAPcymoQxLh3G8PZjal5ZZlF+HqSNCBFKKYUu0IFwiQq9/FyI
+        CdUwJrR2IKO0RlpbpA8zV0cpN7EiKLW4NAdkMJLd4JmbohLHEog7yvJLqDerDDEMbijQrozE4rB8
+        8KwXbOIXNK+dkw/qSiA5BNW1RijOhWoAB09tbS0AAAD//wMA0WGa4A8mAAA=
+    headers:
+      Atl-Request-Id:
+      - 509645bc-9119-41d6-9b33-7cda72f7d2a9
+      Atl-Traceid:
+      - 509645bc911941d69b337cda72f7d2a9
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:53 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=265,atl-edge-internal;dur=14,atl-edge-upstream;dur=251,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 6af4618e20b19382e45f65b7434a6957
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 7800cada-8b84-41a6-acfb-7f0a37e24eaa
+      Atl-Traceid:
+      - 7800cada8b8441a6acfb7f0a37e24eaa
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:53 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=308,atl-edge-internal;dur=14,atl-edge-upstream;dur=295,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - c8d6e631bbceda794429b54813eee14d
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
+      group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/358]
+      in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+      | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+      | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/233]
+      | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+      | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+      0.6.0)|http://localhost:8080/finding/233]\n*Defect Dojo link:* http://localhost:8080/finding/233
+      (233)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
+      Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]\n*Defect
+      Dojo link:* http://localhost:8080/finding/232 (232)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3345'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - d46b99a3-bbf8-4438-b860-211da1a1cae9
+      Atl-Traceid:
+      - d46b99a3bbf84438b860211da1a1cae9
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:54 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=471,atl-edge-internal;dur=15,atl-edge-upstream;dur=458,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - e016388aa5fe6ad3d4565996fa563690
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/pCF+SyDxTKfDQO6OllIaAnzgmIywN7YOW3IlOS89+O9d+S0Q
+        EqbQ6Q0z2Ja0L9p99tnNdwuWOeWRFVgSeAQSok8M0kh1OM1AdVSYQEY7IgdJNRNcdSBiOgNNO2FC
+        eQypiDtzkAr3IBpDLkEB1/XZsFBaZDOjcOo6jut0JfxVgNKTVQ4XkoaahWB1LGbsu/3h8BA/FKQz
+        /Ey0zlVg2xHMINSR+Ca6VKdUKUZ5l4O20ZK2ac5sz2ZKFWA3Ch5ghfLnk9HlZN/tD/q4VLqgrOC7
+        pdC3QoVUQyzkqrpDhF8o4Tleb9/19n1n4g4Ctxf03O7hgfcT+u0YJ40RjY6Xaj7opJG3UZ/jtdeu
+        PyJQoWS5CRyuHhGV0TTtkIgpzXioSc4gBCJmZCHkQ9dIh4JfyfSdXhScmXTRdErnVFNpzxks7NKt
+        tYP1luv47uAXxf6GnzNMe5GhVQMLNDmh6sHkqrjX5i2Y0VRBx6oET/FepWzHShgCR4bJ6gzmgL46
+        Tx1LM0RWjiixAl7gHa0NmPhOs5FL8Q1v9MGA19JluMsENuE2H89Asr7VFWdaowJltbYNUn8rzyox
+        0wsqDV4Vy/KUocPRxs0xHyXKeoNlb/BOd9/ITHOTNi89xwDd6y293v9rpcp+iUU06B4s3YMfYXDZ
+        WPS9pe/9CIs1wJ+eXsPR3YVTr9mYseV1xYGY/du71yf95iSNYwkx8s2rIsALiLSoyv9DcF8r2I74
+        lwRzgyxCEqrIPQAnoUBAg4aICE50whQpycDQTF0aJ8jv1pbg9HcF52DXxuGODW/nxmDXxvB18N7i
+        cn/YcLnh0LKhWcG+W1O7CaVkYZOBzTVT13h/lYgijU6YylO6qqsflxdUY6esOsz7U1f1r3XHsit1
+        0vBQ+XosCoOU0tUbs8B4bAVaFsY2KtXXCHHDRnWcJGAYTPJfxcH3ur1h29M2A9oy7+bGrhrw2hrI
+        JROS6dUHQ9CI22Vj/PetjWU0BmUbCdUoYbiQsDjpqnm8RvAXXGlqwtsCZc9vimW6F+xN3fL/0DvE
+        z8c9c8Dxnm2Y6KX0Hgzfb6l4Q5NbA+buQrk7MJHDihzlLDxj/OGT2TmB3IxlPGywViJwUe61K1zw
+        EU5l9D6FMVBV4VfWb9bF2dXn0/Pp2enx6PxyNB2Nx3+M0XmkH4WhwwOTBMgFNjauibGLpY8skK4I
+        kiRLjVKiBfmVSUouJGTIkqRQiM3uNrJ0sSQt55E5Th75gVU1e8wypsnU5RYSxITFjNN081A9VNbh
+        LSskRe/qb4OAmEN7ushN4W9FfN/vDgdug/hq/vsgSCvhdn57yajvw+0Gs24Mg5Wh43pK/U/eNqOu
+        7ddG/Gb4iSrDoUiFPK98wbwA33CtzDL2B3znejva+y1vvJXRTaGWU17G8St//ndEYimK3Ay+nxiP
+        kPfUum3lhUqwZxl4no6PzPMeCONzY9ngKyL404Zgd4YoMMoSr0s+G3Vf+V753AvIbauW8YBwjJVm
+        VAsZON1+1380Acd4pyKkaSKUDgbOwLFnlcy09M32+4M7lCa3lxAWhsTIF7HY12KHMA4hUYFDiHdH
+        bHLrKk3+LKjUIMmIx1iSGcZ5hyi0B2y3lD6/+J0cFVj85DKkfIeUGWntoXNXRfTxkVziMF76ie/H
+        16PycVM9RPYPAAAA///sWW1v2jAQ/ivWpFaASAhJCIWq6phQtU5rNbXbvlSTMLEJ0UKC8kL3oT9+
+        zzkvvLSUjqpdJ40imsQ++3z33GPfJXc03RRnGrr86qfgARJVoMIVBmJEqeyO3WAMzUTsazj1m22l
+        BYE0XAg9RP6ie9GitciCELBNwSmt9f4/aAjLMCo591bqMz+NpR7FXguBzQnvPg7nRAgtdNWn6Swg
+        uaW/cKM8RoOZ+FxJLws4bPqLclK1jqEMfR4QlK5lvEDqyTRWu6xGaLLDID0+wTCObtS32LLwfMu0
+        LJp/gLPBQjbJVCofYA/ZxcE6O1bvyXYp+iu72E+3i73TLi9uE3ObTRBwJej6DWUfesYaw0yyISIV
+        Dz+BwZjZazIweIets0D5N23rFQ2oe0t/NW9jCUPFumwI2mW0GUHrnXKshp/6Q+t/dPWsgYjE8xv8
+        0/YKDkwJPKkhnhee6y5oXEdZDGOe+YEEfcrc4IdeesxdV85TdbmE34rgcEnzDdBxpUYE/i+IU/ej
+        FhcLP8EeImmj7WIHmJDRAaPyREAuHS1nGDGcXRjpL+PytBIXcCi0IziICg5JAQeeptz9mTTZ7dR3
+        pwwHfc8DCWcgQDbnmCv0GGdI0lwI4jzkxnxCeowGaqHaZx56Geh4xKaSC0gueICcKV8t+75U6AJ8
+        H8jVzWW9vcwd+6uQRJcvKgsQZTuavbK5vT4Cek4hjocAuQr3/m7HEOf36YfwhVtaVoJR5tk48N3C
+        aRe+2koLn31TxyyycOGMXBkGmgnQEBeLh9z5bM7dlGQuI+arG4aNb+ELKdbgdIWYwtkTU/8JKArR
+        eUT7JmG8xsXMD+usVr+bAcNp1K9w+yBpvDhhmHsShkmEYT6TMPbaNe4Rxr771qp/X5swnP+E8QqE
+        Yf9bhOFUojsI435JpFOV7jYz3W21kra9raGqlVGWlMbAkirjUFlpo6uxraxmVyWvTYmq4FBaYVvH
+        bQUIY1uZzajmVAEwpfSjyMJXE/nNdC/JZjNOyeu7RzMsMjmVq6J4zzSXihGnQCyVyM7FSbcNQjQO
+        rIF0jpyxY3PNmJhdzZ7wjtbrdQ1NOBMhu5OxLS1KtStJTJvL9p8oKQk3AyEoakhnHkeBeL+iMrJm
+        muDRNwPKW1L34rwbyZTVaWtiCXMsBXe6R1xavCcm3O4duWPu9Fy73T4VJ2oUrPXAPMM3l9NmPCyS
+        RE3LHyV6lmi3MJlm6pR96nnEkk21OecJmRTyak/gQYLLjx80W5+HVD7bfMvw9jXefE3x9jXefM3x
+        NzX+DQAA//8ixsXAEisFMgQOHTjyACd+BaecxLzs1LzijMwCcNYCdQQh49SQQi8KNKBkpeRaWpRf
+        kKofBSynkkFjstA8CJprA8rCczrIGugMI/ZxJxNcZbAJrvFqE/h4dRG0LhjZpQ4AAAD//xqk6Wu0
+        1KGHi0dLHVylDnqpgasRaAJv68GbQkA/pUPyZjVoDQGUbQB0SX5JInQFBLopuFp7BriKMQMj7OUh
+        rlknA5wewNkaxNWKBZUjWCWMcUrA24+peWWZRfl5kAYkRCilFLr8BsIlJvTK8kuoN9MKMQxuKNCm
+        jMTisHzwXBJscheYDyBOroYxodUR2Q4AL1XSh5mro5SbWBGUWlyaAzIYybPgiaCiEscSiMdBs9Y5
+        +aAeA5I4qmYjFN1QDWDX1tbWAgAAAP//AwDmCyHg7SUAAA==
+    headers:
+      Atl-Request-Id:
+      - bd66e6f8-d2a0-4745-a337-3af3fa125545
+      Atl-Traceid:
+      - bd66e6f8d2a04745a3373af3fa125545
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:54 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=258,atl-edge-internal;dur=14,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 9597c0970c71067def43aaf9ad919e94
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": 11}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1585/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 9f27b226-49e9-445f-99c6-5e3487e6804a
+      Atl-Traceid:
+      - 9f27b22649e9445f99c65e3487e6804a
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:55 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=498,atl-edge-internal;dur=16,atl-edge-upstream;dur=482,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - f84385ede737e08075dbf1a5b0df65b7
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbskbbY2bzLBKTqFdi+KSJrcYjVNSpMOxth/N8Ghe1TfLvd8
+        557DPaBGONiOGnH05v3g+HyuoAXplX23qfBaONcJkxrwaIZU5wYt9v/gKxh3nQQF7mMNeliB8TD+
+        9cjKmlZPYCT8zrmD0XXWBJhgTFKc4qTaXD5W64f6R91MfRMmxJ8jNMMz/BIyYdB234eW9X6IaStt
+        JxVMzdRp9WVBPBjocnlaXgkfQYppnhCakLImlGeEkyzFGF/gAAe/C3+Ase76czbDNSk4yTljKSvz
+        b1b2N6a1AcQ5w3lGFyJrmoIVJWElUYxmUtIC1IIIaIXIF81ZgNcx4bYbRXxh0Cft76wUcX1A+jQh
+        MK/bCh3Piz1ZE5Xr+xodPwEAAP//AwADSunvIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 8b345ef0-42e6-47f0-9d5c-68eb00ace4a6
+      Atl-Traceid:
+      - 8b345ef042e647f09d5c68eb00ace4a6
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:55 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=163,atl-edge-internal;dur=14,atl-edge-upstream;dur=150,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 7d83d163030dc6473420a33a0499404e
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+phIvSYnMmU7HtZXEreu6suI8OB4PTK5IxCTAAqCOxv7v3SVF
+        Kj6U1u409gNx7YHdbz+svjiwKrlMnMjRIBPQkLwVkCemJ3kBpmfiDAreUyVoboWSpgeJsAVY3osz
+        LlPIVdpbgDa4B8kUSg0GpN2cjStjVTEnhVeB7we+q+HPCoydrUs41Ty2Igan5wiyH4z29t7gxEA+
+        x2lmbWkiz0tgDrFN1GflcptzYwSXrgTroSXr8VJ4oSeMqcBrFdzAGuVPZpOzWT8YjUe4VLtgnOiL
+        Y9C3ysTcQqr0urlDgjOUCP1w2A/C/sCfBeMoGEajoTse7f2AfvvkJBmx6Hit5oVOkryH+vywu/Zm
+        koCJtSgpcLi6z0zB87zHEmGskLFlpYAYmJqzpdI3LknHSn7Q+TO9qKSgdPH8ii+45dpbCFh6tVtb
+        BzdbgT8Ixj8Z8Rf8WGDaqwKtEizQ5IybG8pVdW1pFM15bqDnNIJHeK9atudkAoGj42x9DAtAX/27
+        nmMFIqtElDiRrPCOzgOYDPx2o9TqM97ohQHfSNfhrhPYhpsmX4Fke6sPUliLCozT2Sak/lqfNWpu
+        l1wTXo0oylygw8mDm2M+apQNx6vh+JnufiMz7U26vAx9Ano4XIXD/9dKk/0ai2gweL0KXn8Pg6vW
+        4iBcDcLvYXED8Lu7x3AMduE03LUxaDfmYnXekCPC4uISYZKmGlLkm38sglG7gTdTedXwwtNHX+/a
+        eLNjI9y5Md61sffYnYY2m1UipfqFcKJ+gFNu8eFoCPf5hdvQ+ZbAvUadprKshweqosAFRMofaUHI
+        1ImsruBuw9OkTYu4idqXR2vkGR41mary5FCYMufrTSnjMrplzxEzVN6baGjAyxJ/PHokBqE73Avb
+        R+Jh2Doqe7ixC1RhB6pSC6WFXb8wiK24V780//6tEAVPwXgkYVolAhcykWauWaRbtnyPKy2ths7j
+        wgm7Msj5NRAxUgU87Al2gTfYhdFgTBHJuJmUIj4W8uYt7RxCSf2LjNs81tld1nvdilRygu0Lv85h
+        Ctw02NCbkXN6/OHd0cnV8dHB5ORscjWZTn+f4v2wTg2GBA/MMmCn+AJIy8guE4Ypma8ZsonISSmz
+        iv0iNGenGgqkE1YZRK37FKsEWFCOfyt8v0wGkdO8ipg9DP+2qu6xBSYiFZLnDw9tuq9NeGuk5+hd
+        SziY2VRCd7oqqWyfRHLd7oxbJDeN0gvB1wh3L+/93uZ5eNzi7Wce32C72UKuVd7YOth0dP/J4bYt
+        bGoGjYRtoyBhSdWtcqVPGm+u8wr6qUbe2DZFih2qJtmqKLEhlvZp0I920cKoo4VvZfx+OD/Jr//3
+        WapVVVKj+FbIBInRMKwVdg0gWVmZDJIapUfTffpeAxNyQQYIZgnDnwIMHy1IIlKWhS57R+o+yVf1
+        91XELjq1QkZMYrys4FbpyHdH7uCWgo4xz1XM80wZG439se/NG5mr2jdvMBpfojS7OIO4Io5i79Wy
+        b9UOYXy0kwof7fCSeewiMJb9UXFtQbOJTLEyC4zzDlHoDnhBLX1y+hvbr5AD2FnM5Q4pagG9Pf+y
+        iejtLTvD5rX2E8cH55P687H5tImmyeapp+FMWKQDEq2BhSNUxIgx2S27QB39ECmgj11yGNReEFDl
+        InEl9vtuqhbeosolQtcitXj3z1+SioHvd3LxEtxCWA2u0qmH9c0J8wKbWeIFD4+6mS1yktvmCyd1
+        xkhZiH9TSKucY0z/BgAA///sWW1v2jAQ/ivWpFaASApJCIWq6qhY1U5rNa3aPnRfMLED2UISJYTu
+        w378nnNMeCmUjqpVJ02tgNg++3y+e87P5RdxOLWPvowCHpIr3cp0BqrGDFa5KWeos8NwenKKaVyz
+        Ud1iS33yR5Zt0/o9pN+ZrJOp1P2ZbbKLi3227M6T7aLHK7s4T7eLs9MuL24Ta5tNEHBzp+vWlH2o
+        jdX6uWR9RCoaPwLFmNWpMwB5i62iwPxv3DRLGFDPtvlqp40t9BXyAhR/xIxyErTeKccq+Khu2v+j
+        u2c1RCTav+PL2Cs4sCT8SU3xvPBcPYLabZynMOZFEErApywMfjiannDPk8lU/Vy435JgfwHzNcBx
+        qUYM/NfAaQbxERezIEOqkJRv28gAPhkdbjS/GNCRDhYrDBiuMIz0BzXXl5ZUu4PWjtxBlO6QaXfg
+        0ykycFZn9+PAGzPcpUcjgHAOAGQJx1rRiHEGUuNBENciL+U+6THoqY0an3g0ygHHAzaWXEByxpFD
+        zWK37NtCoWvgfSiXk8tq/5xSdZddEkM+K5og5v3oHs27m6szYOQY4miEk6tw7+4+GML8Ln2Qf+GR
+        tpVhliQfhoGnD+06UKlUn9lXddsiC+vDKJRhgJkQHanePOSuJgn3piRzE7NAPTAkvlkgpFhxpy+I
+        KVxBsfTfOIUWTWLKm+TjFS4mQVRllervCXx4GndLv90IGi8OGNaegGERYFjPBIy9ssYDwNg3by2f
+        72sDhvsfMF4BMJx/CzDcUnQHYDyseLRK0r9OeLdxnqazzHmmKVxGlXOoQLM+tCyKrXU4ZXlqraOx
+        TaKxre7QKOsOc/NsG7itVtYolVnh7+ssTkXHmLhJwRGzfDLhRGDfPcqwyORUjYrTPaku1STO4LFU
+        Q7sSp+0mALFxYPeke+wOXYcbDd9qG47PW0an024YwvWFbPtDR9pEi0tJLFvIdp8oKclvekJQ1JDO
+        PI1D8X5JZbBmWuDRSro6FGmCeKthJDOv5tq+LayhFNxtH3Np847wudM59obc7XhOs3kmTtUs2OuB
+        dYH/Qs6Y8EiTRMMomjIzz4x7mMywTGKfZhGxZFMj4Twjk0Je5QQeZvh5eW44ZhJRcWK9Kv/2NV4v
+        6799jddfC7x1jQFloqgy6+rRpXJ+dh7y6KeMsnGQqNAiIlgUsgs0vIsjGv0hT+NEHt0BjjwqueoY
+        pHdT6C0jnZbRb+Q2152cbRjsLJWj/wAAAP//QpXANcdhAi/ni6CVxGhxNAgTHqHiCAAAAP//Gowu
+        Hi2OaO1i+hVH6KUGvK0HbxoBnZ4OyYLVoDl3KNsAaGF+SSJ0xQC6KTgbdTiLMZytPSPsBSWuyScD
+        XM1bUKmAVcIA7mU0CWNcOozh7cfUvLLMovw8SBsRIpRSCl2uAuESFXr5uRATqmFMaO1ARmmNtNJG
+        H2aujlJuYkVQanFpDshgJLvBczNFJY4lEHeU5ZdQb0oYYhjcUKBdGYnFYfngqS3YPC5oUho0YQSy
+        Eu4QVNcaoTgXqgEcPLW1tQAAAAD//wMAVHvxwh0lAAA=
+    headers:
+      Atl-Request-Id:
+      - aea023ac-06d7-49b4-890b-653cdbeb32b9
+      Atl-Traceid:
+      - aea023ac06d749b4890b653cdbeb32b9
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:55 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=255,atl-edge-internal;dur=12,atl-edge-upstream;dur=242,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - db1eece1cc2b9f411bcf055e75cf83f4
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 93b3d9cd-2d71-4f2e-8b20-58184433dd50
+      Atl-Traceid:
+      - 93b3d9cd2d714f2e8b2058184433dd50
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:56 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=386,atl-edge-internal;dur=12,atl-edge-upstream;dur=375,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 55d2f7911669f23faf0f11a821b7d65e
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: negotiator:0.5.3", "description": "\n\n\n\n\n\n\nA
+      group of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2.
+      Group\n*Group*: [Findings in: negotiator:0.5.3|http://localhost:8080/finding_group/358]
+      in [Security How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]
+      | [300|https://cwe.mitre.org/data/definitions/300.html] | negotiator | 0.5.3
+      | [2222Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/233]
+      | Active, Verified |\n| High | [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | negotiator | 0.5.3
+      | [Regular Expression Denial of Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [2222Regular Expression Denial of Service - (Negotiator, &lt;=
+      0.6.0)|http://localhost:8080/finding/233]\n*Defect Dojo link:* http://localhost:8080/finding/233
+      (233)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-300|https://cwe.mitre.org/data/definitions/300.html]
+      \n*CVE:* [CVE-2019-10321|https://nvd.nist.gov/vuln/detail/CVE-2019-10321]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/107\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-300\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/107\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Regular Expression Denial of
+      Service - (Negotiator, &lt;= 0.6.0)|http://localhost:8080/finding/232]\n*Defect
+      Dojo link:* http://localhost:8080/finding/232 (232)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2016-10539|https://nvd.nist.gov/vuln/detail/CVE-2016-10539]\n\n\n\n\n\n\n*Source
+      File*: express&gt;accepts&gt;negotiator\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/106\nAffected
+      versions of `negotiator` are vulnerable to regular expression denial of service
+      attacks, which trigger upon parsing a specially crafted `Accept-Language` header
+      value.\n\n\n Vulnerable Module: negotiator\n Vulnerable Versions: &lt;= 0.6.0\n
+      Patched Version: &gt;= 0.6.1\n Vulnerable Paths: \n  - 0.5.3:express&gt;accepts&gt;negotiator\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.6.1 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/106\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3345'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 28c6e248-3f13-40af-b7ab-9f469694aa89
+      Atl-Traceid:
+      - 28c6e2483f1340afb7ab9f469694aa89
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:56 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=323,atl-edge-internal;dur=13,atl-edge-upstream;dur=311,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 4e13f736d484b357a2ffdd263327e487
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xX23LbNhD9FQwfU4k3SYnMmU7HdZTEreu6spI8OB4PTK5IxCTAAKAutfPv3SVF
+        KrasTO1OYz8Qt71g9+zB6taBVcll4kSOBpmAhuSNgDwxPckLMD0TZ1DwnipBcyuUND1IhC3A8l6c
+        cZlCrtLeArTBPUimUGowIO3mbFwZq4o5KbwKfD/wXQ1fKjB2ti7hTPPYihicniPIfjA6OHiFEwP5
+        HKeZtaWJPC+BOcQ2UZ+Vy23OjRFcuhKsh5asx0vhhZ4wpgKvVXADa5Q/nU3OZ/1gNB7hUu2CcaJb
+        x6BvlYm5hVTpdXOHBGcoEfrhsB+E/YE/C8ZRMIxGQ3c8OvgJ/fbJSTJi0fFazTOdJHkP9flhd+3N
+        JAETa1FS4HD1kJmC53mPJcJYIWPLSgExMDVnS6VvXJKOlXyv8yd6UUlB6eL5FV9wy7W3ELD0are2
+        Dm62An8QjH8x4m/4ucC0VwVaJVigyRk3N5Sr6trSKJrz3EDPaQSP8V61bM/JBAJHx9n6BBaAvvpf
+        e44ViKwSUeJEssI7Og9gMvDbjVKrz3ijZwZ8I12Hu05gG26afAOS7a3eS2EtKjBOZ5uQ+nt91qi5
+        XXJNeDWiKHOBDicPbo75qFE2HK+G4ye6+53MtDfp8jL0CejhcBUO/18rTfZrLKLB4OUqePkjDK5a
+        i4NwNQh/hMUNwL9+3YVjsA+nYbsxF6sPDQdi9i8ud08O2pM8TTWkyDc7RYAXUHnVlP/j5kb7Nl7u
+        23i1ZyPcuzHet3Gw62dDm80qkVL9QjhRP8Apt/hwNIT79MJt6HxL4F6jTlNZ1sMjVVHgAiLlj7Qg
+        ZOpEVleA6UOl9gNmnIqzca7WR/q1iJsA3+6ska8obDJV5clrYcqcrzfFTZDQgJcl/th5JAahOzwI
+        20fiYdg6Knu4sQ9UYQeqUgulhV0/M4ituFe/NP/+rRAFT8F4JGFaJQIXMpFmrlmkW7Z8hystrYbO
+        buGEHepzfg1EjI+UBvHJo4EI9mE0GFNEMm4mpYhPhLx5QzuvoaT+RcZt1upcLuu9bkUqOcH2hV/n
+        MAVuGiTozcg5O3n/9vj06uT4aHJ6PrmaTKd/TvF+WKcGQ4IHZhmwM3wBpGVklwnDlMzXDNlE5KSU
+        WcV+E5qzMw0F0gmrDKLWfYxVAiwox78Tvl8mg8hpXkXMHoZ/W1X32AITkQrJ84eHNt3XJrw1rnP0
+        bjOnzKYSutNVSWX7KJLrdmfcIrlplJ4Jvka4e3nv9zZPw+MWb7/y+AbbzRZyrfLG1tGmo/tPDrdt
+        YVMzaCRsGwUJS6pulSt92nhznVfQTzWyxLYpUuy1apKtihIbYmkfB/1oHy2MOlr4Xsbvh/OT/Pb/
+        kKVaVSU1im+ETJAYDcNaYdcAkpWVySCpUXo8PaTvNTAhF2SAYJYw/CnA8DWDJCJlWeiyt6Tuk3xR
+        f19E7KJTK2TEJMbLCm6Vjnx35A7uKOgY81zFPM+UsdHYH/vevJG5qn3zBqPxJUqzi3OIK+Io9k4t
+        +1btEcZHO6nw0Q4vmccuAmPZXxXXFjSbyBQrs8A47xGF7oAX1NKnZ3+wwwo5gJ3HXO6RohbQO/Av
+        m4je3bFzbF5rP3F89GFSfz42nzbRNNn0ADScCYt0QKI1sHCEihgxJrtjF6ijHyIF9LFLDoPaCwKq
+        XCSuxH7fTdXCW1S5ROhapBbv/vlLUjHw/U4uXoJbCKvBVTr1sL45YV5gM0u84OFRN7NFTnLbfOGk
+        zhgpC/FvCmmVc4zpPwAAAP//7Fltb9owEP4r1qRWgEgKSQiFquqoWNVOazWt2j50XzCxgWwhiRKg
+        +7Afv+ccJ7yUlI6qVSdNrYDYPvt8vnvO9+QX1XBqH30Z+jwgV7qVyQKlGjNY5aaYoc4Og9nJKaZx
+        zUa1xJb65I8s26b1e0i2C1knU6n7M9tmFxf7bNmdJ9tFj1d2cZ5uF2enXV7cJlaZTRBwudN1a8o+
+        1MZq/blkfUQqGj8CxZjVqTMAeYuto0D+N2maBQyoZ9t8tdPGFvoKeQGKPyJGOQla75RjFXxUt+3/
+        0d2zGiIS7d/xZewVHFgS/qSmeF54rh9B7TaaJzDmhR9IwKfMDH44np1wz5PxTP1cut+KYH8J8zXA
+        caFGBPzXwGn60REXCz9FqpCUb9vIACMyOtwovxjQkQ6WKwwYrjCM9Edpri8tiXYHrR25gyjcIdXu
+        wGczZOC0zu4nvjdhuDmPxwDhOQCQxRxrhWPGGYoaD4K4FnkJH5Eeg57aqPGJh+M54HjAJpILSC44
+        cqiZ7ZZ9Wyp0DbwP5GpyWe/Pa63uqktiyGdVJoi8H93jvLu5PgNGTiCORji5Cvfu7oMhzO/SB/kX
+        HmlbKWaJ58PA9/ShXfsqleoz+6puW2RhfRiZMgwwE6Aj0ZuH3NU05t6MZG4i5qsHhsS38IUUa+70
+        BTGFKyiW/hun0KJxRHmTfLzCxdQPq6xS/T2FD8+ibuG3W0HjxQHD2hMwLAIM65mAsVfWeAAY++at
+        1fN9bcBw/wPGKwCG828BhluI7gCMh4xHqyj6Nwvespqn6ZR1FIQXFUOzBL6keB7iaTaGOgU9tdHR
+        KCPNGmW8Q6PgHXLzlA0s48oahTIqACZUfuhifLWe36zq0vl0yqmAffdohUUmJzYqSvYsdYmTOIPH
+        Eod2JU7bTQBi48DuSffYHboONxojq204I94yOp12wxDuSMj2aOhIm8riQhLLZrLdJ0pK8pueEBQ1
+        pDNPokC8X1EZVTMt8CiTrg5Fmii81TCSydlce2QLaygFd9vHXNq8I0bc6Rx7Q+52PKfZPBOnahbs
+        9cC6wH8mZ0x5qItEw8iaUnOeGvcwmWGZVH2aWcSSTY2Y85RMCnmVE3iQ4uflueGYcUjkxCYr//Y1
+        3qT1377Gm68F3rrGQCyRccqaPbpUzs/OAx7+lGE68WMVWlQIZkR2Bnp3UUijP8yTKJZHd4AjjyhX
+        HYP0bgq9RaTTMvqN3HbeySnDYGeFjv4DAAD//0KVgA9Ho0vAy/kiaCUxWhwNwoRHqDgCAAAA//8a
+        jC4eLY5o7WL6FUfopQa8rQdvCgGdng7JgtWgOXco2wBoYX5JInTFALopOBt1OIsxnK09I+wFJa7J
+        JwNczVtQqYBVwgBX89YYlw5jePsxNa8ssyg/D9KAhAillEKXq0C4RIVefi7EhGoYE1o7kFFaI620
+        0YeZq6OUm1gRlFpcmgMyGMlu8NxMUYljCcQdZfkl1JsShhgGNxRoV0ZicVg+eGoLNmsLmpQGTRiB
+        rIQ7BNW1RijOhWoAB09tbS0AAAD//wMAdXxLEh0lAAA=
+    headers:
+      Atl-Request-Id:
+      - ee0f82f7-41e4-41a4-ae99-b421e8f83bf4
+      Atl-Traceid:
+      - ee0f82f741e441a4ae99b421e8f83bf4
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:57 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=257,atl-edge-internal;dur=13,atl-edge-upstream;dur=245,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - c206692c490f1fdc2c81b322e5bfcecf
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQX0vDMBTFv0te3bok/bM2bzLBKTqFdi+KSJrcYjRNSpMOxth3N8Ghe1TfLvf8
+        zj2He0Atd7AdNWLozfvBscVCQgfCS/tuE+41d05xkxjwaIakcoPm+3/wNYw7JUCC+1iDHlZgPIx/
+        PbKyptMTGAG/c+5gdMqaABOMSYITPK83l4/1+qH5UTdT34YJsecIzfAMv4RMGLTd96Flsx9i2krb
+        SQZTOyktvyyIBQNdLk/LK+4jSDHN5oTOSdUQylLCSJpgjC9wgIPfhT/A2Kj+nE1xQ0pGMpYvk6Ko
+        vlnR35jOBhBnOc5SWvC0bcu8rEheEZnTVAhagiwIh47zrGjPAryOCbdq5PGFQZ+0v7OCx/UB6dOE
+        wLxua3Q8L/ZkTVSu7xt0/AQAAP//AwBdjruEIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 3e8a0de9-90c7-40e9-8da7-04be8cc15354
+      Atl-Traceid:
+      - 3e8a0de990c740e98da704be8cc15354
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:57 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=150,atl-edge-internal;dur=14,atl-edge-upstream;dur=126,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 9605e501face6f5b1f7c2da48691f1b0
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/TEP8loTgmU6HgXBHSykNAT5wTEaxN7YOR/JJckh68N+7smMH
+        QkwLnd4wg21J+6LdZ5/dfLdgmVEeWYElgUcgITphkEaqzekcVFuFCcxpW2QgqWaCqzZETM9B03aY
+        UB5DKuL2AqTCPYhGkElQwPX6bJgrLeYzo3DiOo7rdCR8y0Hp8SqDC0lDzUKw2hYz9t3ewcEAPxSk
+        M/xMtM5UYNsRzCDUkfgqOlSnVClGeYeDttGStmnGbM9mSuVgVwruYYXy5+Ph5XjP7Q36uFS4oKzg
+        u6XQt1yFVEMs5Kq8Q4RfKOE5XnfP9fZ8Z+wOArcbdPudbnfwE/rtGCeNEY2OF2o+6KSRt1Gf49XX
+        Xn9EoELJMhM4XD0kak7TtE0ipjTjoSYZgxCImJEHIe87RjoU/Eqm7/Qi58yki6YTuqCaSnvB4MEu
+        3No4uN5yHd8d/KLYX/DzHNOez9GqgQWaHFN1b3KVT7V5C2Y0VdC2SsFTvFch27YShsCRYbI6gwWg
+        r85T29IMkZUhSqyA53hHawsmvtO04VYbmRRf8aofzMRaushDkdkqD+bjGXo2173iTGtUoKzatoHw
+        b8VZJWb6gUoDZMXmWcrQ4WgrJJioAn7dwbI7eKe7b6SsukmdsK6zj2543aXX/X+tlLAoQIoG3f7S
+        7f8Ig8vKou8tfe9HWFwj/+npNRy9Jpz61caMLa9LcsTs394hGuJYQox8849F0Ks28AIizUte+BDc
+        Nwp2I/4l89wgvZCEKjIF4CQUCGjQEBHBiU6YIgVLGP5Zl8YxEr+1Izj9povtN2x4jRuDpo2D1zF6
+        i8v9mssNhxYNzQr2XPykGvtc2R/eH9+y+2z6jV2qk4YsitcjkZs8u6aH3JgFxmMr0DIHjBsq1deI
+        Q0MZ5WUKfUa/ZGGV9u014ysKq0TkaXTMVJbS1ZpyTC4kYBhMjl/Fwe929gduFYftgDYxr1cz7/ZG
+        XQOZZEIyvfpgECtxu2iM/761sTmNQdlGQlVKGC4kLE46ahFvgPoZVyroezsQ6/lVTUxaQWvilv/d
+        fr8/aT22zAnHe7ZjwpfSKRheN5W9Pes04d9tgrk7MKHDyhtmLDxj/P7E7BxDZuYyHlbpLZL+UOzV
+        K1zwIY5ldJrCCKgqISPXb9bF2dWn0/PJ2enR8PxyOBmORn+M0HnkH4WxwwPjBMgFNjCuibGLJY7V
+        nq4IkiFLjVKiBfmVSUouJMyRDUmuEN6dXaToYk1aziNznCyaBlbZ7THNmCdTmOXNX7AgZixmnKbb
+        h9ZT5Tq8RQGk6F1FpAiBmEN9Os9M5e+EfDHG7VeQLwfAD6K0FK4HuJfM+T7gbjHo1jRYGjpaj6n/
+        ydtq1rX9tRG/GnKi0nAoUiHPS18wL8C3XCuyjH0A37nejfZeE3H0auJ4K9Uv4/iFP/87JLEUeWYm
+        3xPGI6ROtWlPWa4S7E0GnqejQ/OcAmF8YQwYfEUEf9sQ7MIQBUZZ4nXIJ6PuC28Vz1ZAbmu1jAck
+        i4Nex+04jybQGOdUhDRNhNLBwBk49qw8Oyl8sv3ewR1KkdtLCHPDXuSzeNjTokEYh4woxyHDuyM2
+        uXWVJn/mVGqQZMhjLMU5xrdBFOoDtltIn1/8Tg5zLHpyGVLeIGVGVvvAuSsj+fhILnEKL/zE96Pr
+        YfG4KR9VgsnfAAAA///sWN9v2zYQ/lcOCBDInk3V8q/FgR+KOA8d1qJIur3UBazIjC1UlhRRcjK0
+        /d/3HUVRUmx3a7unoU5gS3c88vTd8e6jcGM4C1++C3PsfzbVyYQrTERcS+kzvcccfQ97vj+YvPjV
+        015wcsb7tYhxcBGbZO/uiyhGuuaoJW57/Aee4mJkzYJHKXZhnkmRZBsX+9nnNA/BvbkOuBcjsc13
+        EVulG3zpOPEUHj43cpfkEo+xlnT9hHCwDfXJebvp0XmUX5InBgPhEZ1v8ss5DcULGGvFUKBAUKUY
+        1YqRGItpJR/X8rHAXJV8Usv5clzL2TsjH4hJLfdqudccP6zlQzGs5aNaPqofYFqvy5cNuV2XL73O
+        idwwmex6wwkj+irm0/he9jj4+gTTo5tQfaSXQSBT3knHAj/9xsCb8f9V4H8G/buDPvrXQUeprMrG
+        rKsTgGXUXRSSFqixEP6G3kPeRY/Qe8fUrt/V33YgbAHX90Pxc+f+YBAnqOzdhWYCtAAVICZIiMc/
+        2pGDr86xyH41rtRFt4D8PX7637F/sSAKgZ7gxxpHO7W6t0mRBRLpFckut/A+Ou0uVJJxTTeNgYua
+        aHRBCOyyyD1lWrgIE9df70MFsoJzxNjzwEHuGWJsh4qTMhtZpZsVzscx/IvJp6xM44DTWNo05meQ
+        mX8XRtx1862fUxJgIUWPW8knalkZMmp3vpKUZPSAs95fpFIZ8KZUmD3I/Ht2AFyt2MXE9EzojQbu
+        nkkCeaf8MalMAlKBjH2chpjUYKkw2BKoAoh9FH6UoPb3WMWH22kahYF+W2vIU+VwJIEPtiyfDZqj
+        ykeDT0Ws/HtUDj4K9FXBQ+CfeojMcgYZRTsfxmEC7tBwXoll7B3ODqMYSCt2Bu7h2JyBT2Jeiw7z
+        OeuDb5DKZF5kMXIbV6qIcka34QPGHXVCMIBnZzjVJIgn/q+SmOveMl6tVsuYj5Q5faIrPBl40Rea
+        E7++DjPpnJ89eVOkVvnbqcYG5cg5xfLRmDms1FfCPBxLKgOGa06r2+vfr6/e0YBe3tL5Q5Hkl0t8
+        ysndbinBJjym7rpL7Mtf+FFVEkkRJRsH2R/gcCdkvO98YG9AsmESu25pvdIOlE5pAB340SNHZlmP
+        EezQnHcOfcLM5pkw15od/9Ix4NCfNlHoNWgt8oV4qzXl1auvWauMg0ueKOTQnCrl1uigmFvNQTlv
+        aJ4V9IbmWUlvaJ4V9YbmWVm3moPC3tC0SztweqtfEq0rkGZmpAHJoIL5GnAxRgYTXqgJF2NkQDGq
+        Ci7GyILS0FQtr0KlpWKQLCotDYNkUWlpGCSLSkvDIFlUGpoSJItKS1OC1Egm4LVFJnFK9ksGODss
+        9HyamfEXuhPumMYoGKXFHba/6QGvQ302NC2gaw87nngSTzP6Q79I4AJkin0VElTMCJpMNI2Gp4zK
+        aB21GZ2yKcN41GZ8yqYM8FGbySmbMiLWhhx6wx1Idyfb4XQS9MqI93TZLUPMrcaPVEJpmcCCmEfY
+        RaenFtUh/fqiJiHQpQ4WMLF7tUvBWDlubxIK9Q0hBfbhWq7rNo+BNyBFmUQ1V9/S541pmvChnGmK
+        4693Ydwhp/N5BxqSJzNLPY7y2f8Dl/0bAAD//0KI07Uta0JmW9YE1JY1GQRtWXL7wsjpltZtWUP0
+        tiwAAAD//+ya32qDMBTGX2UUehkXNdVaKF0LG90r9O6YxHW0VfEPe/3lGBu6rNlGr8oIeCEmxxyP
+        5vjB9/Na1mtZr2W9lvVa1mtZr2X/jZYNTegvWvY7AzAz8Irt7Lo8vpBdenxdA/wwAA4IKNhTDdVi
+        DTCDclgD1BVBXQY7NQb7uTyuiS6uhJpkvhjVtmsJXQd8j56c9kTb/nQCNGsnVx1FLDVyGVVzo52L
+        6mQFnCNN8iqWaaiULJ3Ga5nMkzxhQGgRpYQVMCNZllIikkLItMiZjNFSNpFqWR27+GOkxO9lLYTK
+        pcWcoamO4ukiZV4hGvgz6Ta8DBm8NXoaxpxpq7iIRZRLAUk6BxlDJgpg2ZznkGScheFKLIe7qGed
+        Ri/q0HHkBOVoihKiL7VB35IPVTISBei2BrpbYk1JDdBiSVX8oObVvlSn2w1hQV0iJ2JTc/efsY3d
+        3X/GNrZ37xmrFiY0XTUCEtvh43/YHKE8yLLdv9fD1kIXTSNdugvuEJxYTJ77pqrl4061IY7w0bgH
+        kR1Vo2an4zIjSnudr2Cu3stcYBZzwYnM9Pdm/DmM7egTAAD//xotjgZTwhstjujh4tHiCFdxhF5q
+        wNt48CYR0OnpkCxYDVoTD2UbAC3ML0mELvVHNwVnYw5nMYazlWeEvaDEtbrSAFezFlQqYJUwgHsZ
+        TcIYlw5jeLsxNa8ssyg/D9I2hAillEL3mUC4RIVefi7EhGoYE1o7kFFaI22R0YeZq6OUm1gRBBll
+        QrEbvP6wqMSxBOKOMmDnhtwVkxiLoyGGwQ0F2pWRWByWD167CVu/DFqenZMP6kIgOQTVtUYozoVq
+        AAdPbW0tAAAA//8DAJUrt8bWNAAA
+    headers:
+      Atl-Request-Id:
+      - 223d084c-51be-4326-a31f-146c1e56d80b
+      Atl-Traceid:
+      - 223d084c51be4326a31f146c1e56d80b
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:58 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=276,atl-edge-internal;dur=14,atl-edge-upstream;dur=262,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 32c867dd78416ce946b467eed9771617
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - be450fa0-0eeb-45db-958a-03f109475237
+      Atl-Traceid:
+      - be450fa00eeb45db958a03f109475237
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:58 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=324,atl-edge-internal;dur=14,atl-edge-upstream;dur=311,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - fbbcd21ccba276b7623197277afd8f11
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
+      Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/359] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236] | Active,
+      Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/234] | Active,
+      Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236]\n*Defect
+      Dojo link:* http://localhost:8080/finding/236 (236)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+      &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
+      5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
+      6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
+      &lt; 7.1.2)|http://localhost:8080/finding/234]\n*Defect Dojo link:* http://localhost:8080/finding/234
+      (234)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '7127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - dfd58689-708c-4c7a-8d83-19364b77ba67
+      Atl-Traceid:
+      - dfd58689708c4c7a8d8319364b77ba67
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:59 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=492,atl-edge-internal;dur=12,atl-edge-upstream;dur=480,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - f40cb7de7bfd57e0ba1cb075229c002e
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/TEP8kheMZzodBsIdLaU0BPjAMRnF3tg6HMknySHpwX/vyi8J
+        hJgWOr1hBtuS9kW7zz67+W7BMqM8sgJLAo9AQnTCII1Um9M5qLYKE5jTtshAUs0EV22ImJ6Dpu0w
+        oTyGVMTtBUiFexCNIJOggOvqbJgrLeYzo3DiOo7rdCR8y0Hp8SqDC0lDzUKw2hYz9t3+wYGPHwrS
+        GX4mWmcqsO0IZhDqSHwVHapTqhSjvMNB22hJ2zRjtmczpXKwawX3sEL58/Hwcrzn9v0BLhUuKCv4
+        bin0LVch1RALuSrvEOEXSniO19tzvb2uM3b9wO0FvUGn1/N/Qr8d46QxotHxQs0HnTTyNupzvPW1
+        q48IVChZZgKHq4dEzWmatknElGY81CRjEAIRM/Ig5H3HSIeCX8n0nV7knJl00XRCF1RTaS8YPNiF
+        WxsHqy3X6br+L4r9BT/PMe35HK0aWKDJMVX3Jlf5VJu3YEZTBW2rFDzFexWybSthCBwZJqszWAD6
+        6jy1Lc0QWRmixAp4jne0tmDSdeqNTIqveKMPBrySLsJdJLAOt/l4BpLNra440xoVKGtt2yD1t+Ks
+        EjP9QKXBq2LzLGXocLR1c8xHgbKev+z573T3jczUN1nnpefsoxteb+n1/l8rZfYLLKJBd7B0Bz/C
+        4LK22PWWXe9HWKwA/vT0Go5uE069po1uvTFjy+uSHBEWt3cIkziWECPf/GMR9OsNvJlI85IXPlQH
+        GwW7S+El89wgvZCEKjIF4CQUiHTQEBHBiU6YIgVLGP6pauYYid/aEbVB08X2Gza8xg2/aePgdYze
+        4vLumssNhxYNzQr2XPykGvtc2R/eH9+y+2z6jV2qk4ZFitcjkZs8u6aH3JgFxmMr0DKHp6qtGG2S
+        hXWSt9eMZ3hUJSJPo2OmspSuKubBZXRLXyPEDRtVcZKAYTA5fhWHbq+z77t1HLYDumbe7Y2mGvDW
+        NZBJJiTTqw8GsRa3i8b471sbm9MYlG0kVK2E4ULC4qSjFvEGqJ9xpYa+twOxXreuiUkraE3c8r87
+        GAwmrceWOeF4z3ZM+FI6BUP4prK3Z50m/LtNMHd9EzqsvGHGwjPG70/MzjFkZi7jYZ3wAgYPxd56
+        hQs+xLGMTlMYAVUliGT1Zl2cXX06PZ+cnR4Nzy+Hk+Fo9McInUf+URg7PDBOgFxgZ+OaGLtY4ljt
+        6YogS7LUKCVakF+ZpORCwhxpkuQK4d3ZxZYu1qTlPDLHyaJpYJXdHtOMeTKFWd78BQtixmLGabp9
+        qJoqq/AWJZGidzWRIgRiDuvTeWYqfyfk+35nf+DVkC8HwA+itBReD3AvmfN9wN1i0K1psDR0VI2p
+        /8nbeta1u5WRbj39RKXhUKRCnpe+YF6Ab7lWZBn7AL5zvRvt/Sbi6K+J461Uv4zjF/7875DEUuSZ
+        mXxPGI+QOtWmPWW5SrA3GXiejg7NcwqE8YUxYPAVEfxtQ7ALQxQYZYnXIZ+Mui+8VTxbAbldq2U8
+        IFkc9Dtux3k0gcY4pyKkaSKUDnzHd+xZeXZS+GR3+wd3KEVuLyHMDXuRz+JhT4sGYZw+ohynD++O
+        2OTWVZr8mVOpQZIhj7EU5xjfBlFYH7DdQvr84ndymGPRk8uQ8gYpM8vaB85dGcnHR3KJU3jhJ74f
+        XQ+Lx035qBNM/gYAAP//7FjbbttGEP2VAQwYFCstI+oWy9CDYfmhRRMEcZqXKIBoai0R5UXmRXaQ
+        5N97ZrlckpaYIknfGtmQyJmd3eGZ2ZmzxI3mLHz5Lsix/9lUJROuMBFxLaUv9AFzDFzs+cFw+uKl
+        q7zg5IwPGxHj4CK2ycE5FGGMdM1RS5z2+I88xcXYmPmPUkRBnkqRpFsH+9njNA9AyrkOOBdjscuj
+        kK32W3ypOPEULj5vZZTkEo+xkXTzhHCwDQ3IerPt03mYX5IrhkPhEp1v88sFjcQLGCvFSIAbUKUY
+        14qxmIhZJZ/U8onAXJV8Wsv5clLL2TstH4ppLXdrudscP6rlIzGq5eNaPq4fYFavy5cNuVmXL91e
+        R27oTHbc0ZQRvQLROMg+h14dbOhUnGffGWc9/r+K868Y/3CMx10xRiGsisLcVvFmGdnLQtISFRTC
+        P9BZyL3oEzrrhNrVufrbDYUpz+p+JH7ty5+M2RR1216qPk9LNHpi+oN4/KsdWfjqnYrsN+NKNnoB
+        5B/wM/iB7YoFse/VBD/XFtqpZd8mRepLpFcobW7QA/TRKMgk47rfNgYuaxpho92bZZF7mW7QIkgc
+        b3MIMlARnBImrguGcc8QYztUjJO5xnq/XeP0G8O/mDxKyzT2OY2lSWN+Bpl6d0HIPTXfeTklPhbK
+        6HEn+bwsK0NG7c7LJCUpPeBs94lw+Pd5F2aY3U+9e3YATKyIYmLyJdRGAzNPJYGaU/6YVCY+Zb6M
+        PZx1mLJgqcDfEYgAaHsY/C1B3O+xige39/sw8NW7WE2NKodDCXywZZn5N0eVjwafijjz7lEqmOgP
+        soKHwL/sIdTLaWQyijwYBwmYQcP5TKxi93h2GMVAOmNn4B4OxSnYIuY16DBbMz54GqlU5kUaI7dx
+        lRVhzug2fMC4k04IBvDsDGeWBPHE/3US+3Kfr+L1er2K+cCY02e6xpOB9XylBfHL6SCV1vnZkztD
+        apW/vWqsX45cUCwftZnFSnUl9MOxpDJguBa0vr358+b6HQ3p6pbOH4okv1zhU07u2KUEm/CU2nZW
+        2Je/8aNmSShFmGwtZL+Po5uQ8aH3kb0BhYZJ7Dil9Vo5UDqlALTgR58smaZ9RrBHC9459Bkz62fC
+        XBt2/GtPg0PvTaLQK5BW5AvxVmvKqxdb81YZB1PsKOTQdJVyY3RUzI3mqJw3NM8KekPzrKQ3NM+K
+        ekPzrKwbzVFhb2japR04vVGvgDYVSHM9UoOkUcF8DbgYI40JL9SEizHSoGhVBRdjZEBpaKqWV6HS
+        UjFIBpWWhkEyqLQ0DJJBpaVhkAwqDU0JkkGlpSlBaiQT8NohkzglByXhmx8Xej6rzPkL3Ql3Vz7v
+        AyRmcYftr3vAq0Cd/HQLsM1RxhVP4mlOf6nXBFyAdLGvQoKKGUKTiqbRqMuojNZJm3GXTRnGkzaT
+        LpsywCdtpl02ZUSMDVn0mjuQ6k6mw6kk6JcR76uyW4aYW40XZgntywQWxDzCLDrrWlSF9NuL6oRA
+        lzpaQMfu92jv+TnH7XVCgbohpMAh2MhN3eYx8C1IUSpRzbPv6fPadJ/wkZtpiuVtoiDukdX7EoGG
+        5MncUI+TfPb/wWX/AQAA//+iSVvWhMy2rAmoLWsyCNqy5HZ9kdMtrduyhqS3ZQEAAAD//+ya326C
+        MBTGX2Ux8bKsQAUxMU6TLe4VvDu0ZS7Kn4Bmr78eio12djO74qIJF4T20MOBHr7k+3kt67Ws17Je
+        y95os+vW7rXspV5ey3otOw4tG5rQP7TsT4d/ZtAU27d1OXghu3bwTi3wQ48vIJBgTzXMijXADKhh
+        DVBXBHXZ59TY55fyuCa6qBFqkrmxoW1PEk4n4Ht03LTj2Z3LEtCKndz1C7HUSF3U7T/NWlQnK+Ac
+        WZF3sUxDpWTpNF7LZJ7kCQNCiyglrIAZybKUEpEUQqZFzmSMhrGJVMvq2MWDkRK/l7UQKpcOc4a2
+        PoqXq5R5jeDf74Bb/zJk8NHqaRhzgaziIhZRLgUk6RxkDJkogGVznkOScRaGK7Hs76KedRq9qUPH
+        kRKqwfIkRF/qgnNHvlTJSBSglxrobok1JQ1AhyVV8b2aV/tSnW43hAVNhRSIDcuNP2Obtht/xjat
+        N/aMVQsTmqYa8Idt//E/bY5QHWTV7T+bfmuhbaaBLd0Fd4hFLCav57Zu5PNOtSGOaNGwBxEZVaNm
+        p+MyAyh7n55grt7LXNgVc6GHzPT3dvg5PNyOvgEAAP//Gi2O6JfwRosjerh4tDjCVRyhlxrwNh68
+        SQR0ejokC1aDlsJD2QZAC/NLEqEL+dFNwdmYw1mM4WzlGWEvKHGtnTTA1awFlQpYJQzgXkaTMMal
+        wxjebkzNK8ssys+DtA0hQiml0F0kEC5RoZefCzGhGsaE1g5klNZIG2D0YebqKOUmVgRBRplQ7Aav
+        LiwqcSyBuKMM2Lkhdz0kxtJniGFwQ4F2ZSQWh+WDV2bC1iuDFl/n5IO6EEgOQXWtEYpzoRrAwVNb
+        WwsAAAD//wMAzWom3LQ0AAA=
+    headers:
+      Atl-Request-Id:
+      - 9c9bae35-b5aa-4b3e-9b14-87b4ee36ee1a
+      Atl-Traceid:
+      - 9c9bae35b5aa4b3e9b1487b4ee36ee1a
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:59 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=308,atl-edge-internal;dur=13,atl-edge-upstream;dur=296,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 22c45948487604bfa7d071f4832d1232
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": 11}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1586/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 22d84caf-4a46-4fbe-9c10-e81082a40025
+      Atl-Traceid:
+      - 22d84caf4a464fbe9c10e81082a40025
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:14:59 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=478,atl-edge-internal;dur=13,atl-edge-upstream;dur=466,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 967e81429bbf103363f138980212d647
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0teXbubpO26vMkEp+gU2r0oImlzi9U0KU06GGP/3RSH7lF9u9zz
+        nXsO90Aq6XA7aCLIm/e9E/O5wgZrr+y7jaXX0rlWmtigJzOiWtdruf8HX+Cwa2tU6D7WqPsVGo/D
+        X4+srGn0iKbG3zl3OLjWmgBTABpDDFGxuXws1g/lj7oZuypMRDxP0Axm8BIysdd234WW5b6f0lba
+        jiqYqrHV6stCRDCwxeK0vJJ+AhmwJKIsosuSMsGpoDwGgAsIcPC78AccyrY7ZzmUNBc0FQAx59k3
+        W3c3prEBhCSFhLNM8qrK03xJ0yVVKeN1zXJUGZXYSJlk1VmA11PCbTvI6YVBH7W/s7Wc1geiTxNB
+        87otyPG82JM1k3J9X5LjJwAAAP//AwCoblEmIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 9facadc4-fc8c-4439-b64f-6cadf7039b8c
+      Atl-Traceid:
+      - 9facadc4fc8c4439b64f6cadf7039b8c
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:00 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=146,atl-edge-internal;dur=13,atl-edge-upstream;dur=132,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - dbec04d655bf23136bdf7b1561dc0bbb
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15999
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXbVPjNhD+Kxp/zIX4LYHEM50OA+GOllIaAnzgmIywN7bAkXySHJIe/Pdb+SWB
+        ENNCpzfMYFvSvmj32Wc33y1YZJRHVmBJ4BFIiI4YpJFqczoD1VZhAjPaFhlIqpngqg0R0zPQtB0m
+        lMeQirg9B6lwD6IRZBIUcF2dDXOlxWxqFE5cx3GdjoRvOSg9XmZwJmmoWQhW22LGvtsbDAb4oSCd
+        4meidaYC245gCqGOxJ3oUJ1SpRjlHQ7aRkvaphmzPZsplYNdK7iHJcqfjofn4x2319/DpcIFZQXf
+        LYW+5SqkGmIhl+UdIvxCCc/xujuut+M7Y7cfuN2gO+h4fe8T+u0YJ40RjY4Xaj7opJG3UZ/jra5d
+        fUSgQskyEzhc3SdqRtO0TSKmNOOhJhmDEIiYkgch7ztGOhT8Qqbv9CLnzKSLphM6p5pKe87gwS7c
+        WjtYbbmO7/Z/Vexv+GWGac9naNXAAk2Oqbo3ucpvtXkLpjRV0LZKwWO8VyHbthKGwJFhsjyBOaCv
+        zlPb0gyRlSFKrIDneEdrAya+U29kUtzhjT4Y8Eq6CHeRwDrc5uMZSNa3uuBMa1SgrJVtg9Tfi7NK
+        TPUDlQavis2ylKHD0cbNMR8Fyrr9Rbf/TnffyEx9k1Veuo5BtdddeN3/10qZ/QKLaNDdXbi7P8Pg
+        orboewvf+xkWK4A/Pb2Go9uEU69pw683pmxxWZIjwuL6BmESxxJi5Jt/LIJevYE3E2le8sKH6mCt
+        YHspvGSeK6QXklBFbgE4CQUiHTRERHCiE6ZIwRKGf6qaOUTit7ZEbbfpYnsNG17jRr9pY/A6Rm9x
+        ea9fc7nh0KKhWcGOi59UY58r+8P741t2n3W/sUt10rBI8XogcpNn1/SQK7PAeGwFWubwVLUVo02y
+        sE7y5prxDI+qRORpdMhUltJlxTy4jG7pS4S4YaMqThIwDCbHr+Lg73U8z6/jsBnQFfNubjTVgLeq
+        gUwyIZlefjCItbhdNMZ/39rYjMagbCOhaiUMFxIWJx01j9dA/YIrNfS9LYj1/LomJq2gNXHL/57T
+        G0xajy1zwvGe7ZjwpfQWDOGbyt6cdZrw7zbB3O2b0GHlDTMWnjB+f2R2DiEzcxkP64QXMHgo9lYr
+        XPAhjmX0NoURUFWCSFZv1tnJxefj08nJ8cHw9Hw4GY5Gf47QeeQfhbHDA+MEyBl2Nq6JsYsljtWe
+        LgmyJEuNUqIF+Y1JSs4kzJAmSa4Q3p1tbOliTVrOI3OcLLoLrLLbY5oxT6Ywy5u/YEHMWMw4TTcP
+        VVNlFd6iJFL0riZShEDMYXU6z0zlb4X8yzGuHAA/iNJSeDXAvWTO9wF3g0E3psHS0EE1pv4nb+tZ
+        1/YrI349/USl4VCkQp6WvmBegG+4VmQZ+wC+c70d7b0m4uitiOOtVL+M41f+/G+fxFLkmZl8jxiP
+        kDrVuj1luUqwNxl4Ho/2zfMWCONzY8DgKyL424ZgF4YoMMoSr0M+G3Vfeat4tgJyvVLLeECmGL8k
+        cDp+x3k0scZQpyKkaSKUDvpO37Gn5fFJ4Zbt7zo3KEiuzyHMDYGRL+JhR4sGYRxAohwHEO+G2OTa
+        VZr8lVOpQZIhj7EaZxjiBlFYHbDdQvr07A+yn2Pdk/OQ8gYpM87aA+emDObjIznHQbzwE98PLofF
+        46p8lDn+AQAA///sWW1P2zAQ/isWEqitmrRN05YWIQbqEEximmDbB9Ak3NhpI9IkyhuTxo/fc44b
+        2kDYxrSpHxBVm+R89uXu8XN3BiyAG1220OVnLwUFkKrCE64wESM6ZQ/sBnMYFljN6A17vbGygvAZ
+        5MIM0LuY8zDv5JkfALEp6KSzOf4bTWF3C1+TnnMvzaWXxtIM43kHe5oT1D0U5sQFHQw1F+nSJz0V
+        KvyqYNE8l3Ke+Ryu/E5tqDJ/KgOP+wSeKxnn6DaZwRqnpNhme356AOWBaTVrnKdD3bH6A1rwPKCO
+        NZdt8o4q/9vs0kvu2LHjyIjQ9kBObq1cPGkpL9Ez1ppmkk0BSTz8gK3KrHGbgaoGbBPuq79Fzyzx
+        ru775j9+QRg+VaTCpmAVRlwLW3+pxxr4aj731i++M2sBdXh+gx/jVQDAksCSmuLvILjp+NZVmMVw
+        46nnS7CDLFy9N08PFN7WBk4fWasFdimXDUFnmgxML+xwkXsJmA9FycAagtBccjLAskpwFLxbNfkt
+        QxZmZCq6Zp13Yx1zbQjFXJQxT3TM7xdEhhzzBXOGtsKBHAnciblLK1G6BklFWWrC818f578AG/lS
+        s96maNW3TNZghBGfVG0rVmJI4ZnDUrw2AUYuoI2HgKTao5OqM9trDxKUOTWCOJcG5TLPeTqwkLo8
+        p9S7FiUitQl9EbhwS1s0gTlRNvM9R0fwwlNpQgfwiyohyOc6MsVbsTBmPgSxWUb+fBmBCUjnY8g8
+        dcPA7LknpNjA0iU2FOoqLP0nCNGqUUiJgQDe4GLpBU3WaD4sAeA0nAC0T8v3Qdl3VouyuvTcs+sE
+        ZftJeTuNuXOnmhZqQypD7bILqwi65RxVQV1t3C1r45V76gbWtYTd0piNGrNacPA05c6CcmlRziTZ
+        csmpztqpKwbI29RVhfErizHag0fccagXPBeHI3QWVne3fyyH+8PZ0OZG17VGhu3ygTEej7qGGLpC
+        jtyZLftUEJaaWLbQnfympiTIHAtB+4ls5nHoi3drJqO2owVePMBS8ZDmPC6Gkc7qEKXv9oU1k4IP
+        R/tc9vlYuNwe7zszPhw7dq93JA7VLHjXXesUn0LPWPJA1zOGUTxKzCwx7uEywzKpUDKLzUo+NSLO
+        E3Ip9FUuQOODy7MTwzajgLq86mHY9ltcPU3bfourp3HbbjHIShSnJbq9OVPgZyc+D+5kkCy8SG0t
+        KuqKA5mC766p7ZnsvM/iMJKdazCRQ0cHeg/SkTCk5U6nZfRB+PPdkV1Hv3bdsYpdd7RolxQf6/zw
+        RkdbCLw3OvofFr/RUR0dVVmjLPPKqgimz4st+IP+1aWvu1jwJwAAAP//yi9JhE7UoZuCsz2HsxjD
+        2dAzwl5Q4hobNcDVsgWVClglDHC1bI1x6TCGNx1T88oyi/LzIM1DiFBKKXSWGMIlKvTycyEmVMOY
+        0NqBjNIaaYJbH2aujlJuYkVQanFpDshgJLvBo4dFJY4lEHeU5ZfgntoAAAAA//8iyl6kqQ2IYXBD
+        gXZlJBaH5YNHXmHzEaDJlZx8UGcBySGorjVCcS5UAzh4amtrAQAAAP//AwCc83VzlCAAAA==
+    headers:
+      Atl-Request-Id:
+      - e3bb06ac-c4f0-4fcf-82a2-81911bd2d467
+      Atl-Traceid:
+      - e3bb06acc4f04fcf82a281911bd2d467
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:00 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=419,atl-edge-internal;dur=16,atl-edge-upstream;dur=406,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 1782fefd462c82d65f3aa2654e8f4e04
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - d8240609-d239-4c20-a7e8-3138a2ec5faf
+      Atl-Traceid:
+      - d8240609d2394c20a7e83138a2ec5faf
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:01 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=317,atl-edge-internal;dur=20,atl-edge-upstream;dur=296,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 1179b936ce0f4566888dc0db568844fe
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: fresh:0.3.0", "description": "\n\n\n\n\n\n\nA group
+      of Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: fresh:0.3.0|http://localhost:8080/finding_group/360] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]
+      | [400|https://cwe.mitre.org/data/definitions/400.html] | fresh | 0.3.0 | [Regular
+      Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/235]
+      | Active, Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [Regular Expression Denial of Service - (Fresh, &lt; 0.5.2)|http://localhost:8080/finding/235]\n*Defect
+      Dojo link:* http://localhost:8080/finding/235 (235)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-400|https://cwe.mitre.org/data/definitions/400.html]
+      \n*CVE:* [CVE-2017-16119|https://nvd.nist.gov/vuln/detail/CVE-2017-16119]\n\n\n\n\n\n\n*Source
+      File*: express&gt;fresh\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/526\nAffected
+      versions of `fresh` are vulnerable to regular expression denial of service when
+      parsing specially crafted user input.\n Vulnerable Module: fresh\n Vulnerable
+      Versions: &lt; 0.5.2\n Patched Version: &gt;= 0.5.2\n Vulnerable Paths: \n  -
+      0.3.0:express&gt;fresh,express&gt;send&gt;fresh,express&gt;serve-static&gt;send&gt;fresh,serve-favicon&gt;fresh\n
+      CWE: CWE-400\n Access: public\n\n\n*Mitigation*:\nUpdate to version 0.5.2 or
+      later.\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/526\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1958'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15999
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 0d094af9-5a37-4ed0-925a-c545e2c309b4
+      Atl-Traceid:
+      - 0d094af95a374ed0925ac545e2c309b4
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:01 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=467,atl-edge-internal;dur=13,atl-edge-upstream;dur=454,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 016d6a20a9f48a227b662b139546e027
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15999
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXW1PrNhD+Kxo/0hDfkpB4ptNhIJxDSykNAR44TEbYG1vgSK4k59ID/70r3wIh
+        YQqdnmEG25L2ot1vv918t2CZUR5ZgSWBRyAhOmGQRqrF6QxUS4UJzGhLZCCpZoKrFkRMz0DTVphQ
+        HkMq4tYcpMI9iEaQSVDAdXU2zJUWs6lROHEdx3XaEv7KQenxKoMLSUPNQrBaFjP23e5gMMAPBekU
+        PxOtMxXYdgRTCHUkHkSb6pQqxShvc9A2WtI2zZjt2UypHOxawSOsUP58PLwc77vd/gEuFS4oK/hu
+        KfQtVyHVEAu5Ku8Q4RdKeI7X2Xe9fd8Zu/3A7QSdQdvrez+h345x0hjR6Hih5pNOGnkb9Tlec+3q
+        IwIVSpaZwOHqIVEzmqYtEjGlGQ81yRiEQMSULIR8bBvpUPArmX7Qi5wzky6aTuicairtOYOFXbi1
+        drDach3f7f+i2N/w8wzTns/QqoEFmhxT9Whyld9r8xZMaaqgZZWCp3ivQrZlJQyBI8NkdQZzQF+d
+        55alGSIrQ5RYAc/xjtYGTHyn3sikeMAbfTLglXQR7iKBdbjNxwuQrG91xZnWqEBZjW2D1N+Ks0pM
+        9YJKg1fFZlnK0OFo4+aYjwJlnf6y0/+gu+9kpr5Jk5eOY1DtdZZe5/+1Uma/wCIadHtLt/cjDC5r
+        i7639L0fYbEC+PPzWzi6u3Dq1RtTtrwuORCzf3v39qRfn6RxLCFGvnlTBHgBkeZl+X8K7msF2xH/
+        mmBukEVIQhW5B+AkFAho0BARwYlOmCIFGRiaqUrjGPnd2hKc7q7g9HZtHOzY8HZu9HdtDN4G7z0u
+        7/ZrLjccWjQ0K9h3K2o3oZQsrDOwuWbqGu+vEpGn0TFTWUpXVfXj8oJq7JRlh/l46sr+te5YdqlO
+        Gh4qXo9EbpBSuHpjFhiPrUDL3NhGpfoaIW7YqIqTBAyDSf6bOPgHbc/z6zhsBrRh3s2NXTXgNTWQ
+        SSYk06tPhqAWt4vG+O9bG5vRGJRtJFSthOFCwuKkrebxGsFfcaWuCW8LlD2/LpbJXrA3ccv/ntMd
+        TPae9swJx3uxY8KX0nswhL+l5A1Pbo2Yuwvmbt+EDktymLHwjPHHE7NzDJmZy3hYg62A4KLYa1a4
+        4EMcy+h9CiOgqgSwrN6si7OrL6fnk7PTo+H55XAyHI3+GKHzyD8KY4cHxgmQC+xsXBNjF2sfaSBd
+        EWRJlhqlRAvyK5OUXEiYIU2SXCE429vY0sWatJwn5jhZ9BBYZbfHNGOeTGFuYUHMWMw4TTcPVVNl
+        Fd6iRFL0rvo2EIg5NKfzzFT+Fsh3A8dt93pODflyAPwkSkvhZoB7TakfA+4GtW5Mg6Who2pM/U/e
+        1rOu7VdG/Hr6iUrDoUiFPC99wbwA33CtyDI2CHznejvauw1xvJfRTaGGVF7H8Rt/+XdIYinyzEy+
+        J4xHSHxq3beyXCXYtAw8T0eH5nkPhPG5sWzwFRH8bUOwPUMUGGWJ1yZfjLpvfK947gXktlHLeECm
+        GL8kcNp+23kyscZQpyKkaSKUDvpO37Gn5fFJ4Zbt95w7FCS3lxDmhsDIV7HY12KHMA4gUY4DiHdH
+        bHLrKk3+zKnUIMmQx1iNMwzxDlFoDthuIX1+8Ts5zLHuyWVI+Q4pM87aA+euDObTE7nEQbzwE9+P
+        rofF46Z8lDn+BwAA///sWWFP2zAQ/SsWEqhUTZqmaUqLECvqEEximmDbB9Ak3NhpI9KkSpMwafz4
+        vXPc0AbCNqZN/YBAbWL77PPd+d07FyiAF81n6PFzkAICSFTFE54wESM4ZQ/sBnMYNlDN6LidzkBp
+        QfEZ5cKMULuY0zhv51kYIWJTwEl7c/w3msKxCluTnHcvzXmQJtKMk2kbZ5pTqAcg5oQFbQw1Z+k8
+        JDnlKnwrZ9E8l3KahRym/E5lqFJ/LKOAhxQ8VzLJUW0ygzVOSbDF9sL0EMI9096vMZ52ddvu9mjB
+        EYhALltkG0X+2QPZtLmy6LCpjEJtrDnOJBsjAtH4ASeT2YMWAzL12GZ0r/5mHbMMb/XeNf/xfqD4
+        WGEIGwNEGEErdP2lHGvgY/+5Xb+4Z9ZEkKH9Bl/Gq/yNJRE6aoq/i7hNwzev4iyBGU+DUAIMZGHq
+        vWl6qMJrbeD4EaSaAJNy2Rjopc++GcRtLvJgCQQEB+nZLvDLJyMjWFb5jJx3qya/ZUi6jFRFkazT
+        bKJ9rhUhn4vS50vt8/sZYR/HfNGUoYrw0I987SXcp5UoOwOTFllqwvJfH+e/APiEUoPcZteqfhmu
+        hRFGfFJEVKy60QvLHJXdaxNg5AzSaERIqiM5rBqztdawBKup6UhyaVDqCrynA4ten+eUade8RBg2
+        pA8KLryOPA/zDZEgJmHgaQ9eBCoraAd+UYyBbK49U+yKxQkL0ZGYpefP5wvupSTzMWaBemEA8jwQ
+        UmzE0iUOFGgUlv6TCNGii5jyAAV4g4t5EO2zxv7DHAGcxkME7VO23iuryioHq6PxHaeuoyzjKH+n
+        CffuVIVBFU9lqFVX8TllNVaVKKnwygp1A+uosVVXAVrlmjxNuTej7Kj54TrFrBKRZTafc6JVO3W5
+        n6xNRVScvJJ70Rk85p5Hhdu5OOqjkLCt3e5IugfuxHW4Yfl233B83jMGg75lCNcXsu9PHNkl/ldK
+        YtlCdvibkpJCZiQEnSfSmSdxKN6tqQwqRwu8eF+lHCXNaVIMI5nVnUnX7wp7IgV3+wdcdvlA+NwZ
+        HHgT7g48p9M5FkdqFux11z7FfyFnzHmk6YthFE1LM1sa9zCZYZvEi8zisJJNjQXnSzIp5FUuQJ2D
+        x7MTwzEXERV11buv7de4enm2/RpXL9+2XWOAlSguZnQ1c6aCn52EPLqT0XIWLNTRIhZX3J4UeHdN
+        Vc5w532WxAvZvgZEeXRToM8g3QCjtzzptIy+936+GHLq4Nepu0VxyluURKeBN9TZwvh6Q53/ofEb
+        6tShThU16vifU9K8kgVhT9PibP6gX7b0swVN4pTr3+X0LD8BAAD//4KbgquhZ4CrGDMwwl4e4hoK
+        NcDpAZwNQVwNWFA5glXCGKcEvOmYmleWWZSfB2k7QoRSSqGTwhAuMaFXll9CvfF/iGFwQ4E2ZSQW
+        h+WDBzhhUw7AfABxcjWMCa2OSHEAAAAA///CnEDXh5mro5SbWBGUWlyaAzIYybPg0cmiEscSiMdB
+        cyk5+aDOApI4qmYjFN1QDWDX1tbWAgAAAP//AwA5onNdgyAAAA==
+    headers:
+      Atl-Request-Id:
+      - 09d9194d-83fc-49bd-b86a-272d3bd346b9
+      Atl-Traceid:
+      - 09d9194d83fc49bdb86a272d3bd346b9
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:02 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=277,atl-edge-internal;dur=15,atl-edge-upstream;dur=263,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 77c1891a23b947928007987fdef95e91
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": 11}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: POST
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/NTEST-1587/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - afa21323-e450-49b7-9876-8ebe8559accd
+      Atl-Traceid:
+      - afa21323e45049b798768ebe8559accd
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - text/html;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:02 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=541,atl-edge-internal;dur=30,atl-edge-upstream;dur=509,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - e4f12081485b44eea834b37eb209f502
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0te3bqbpN26vMkEp+gU2r0oImlzi9U0KU06GGP/3QSH7lF9u9zz
+        nXsO90Aq6XA7aCLIm/e9E7OZwgZrr+y7TaTX0rlWmsSgJxOiWtdruf8HX+Cwa2tU6D7WqPsVGo/D
+        X4+srGn0iKbG3zl3OLjWmgBTAJpAAtNic/lYrB/KH3UzdlWYiHiO0AQm8BIysdd234WW5b6PaStt
+        RxVM1dhq9WUhIhjYYnFaXkkfQQYsnVI2pcuSMsGpoDwBgAsIcPC78AccyrY7ZzmUNBc0E8ATzug3
+        W3c3prEBhDSDlLO55FWVZ/mSZkuqMsbrmuWo5lRiI2U6r84CvI4Jt+0g4wuDPmp/Z2sZ1weiTxNB
+        87otyPG82JM1Ubm+L8nxEwAA//8DANXQk2ggAgAA
+    headers:
+      Atl-Request-Id:
+      - 43a75407-0257-45eb-849a-c81aa051c26a
+      Atl-Traceid:
+      - 43a75407025745eb849ac81aa051c26a
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:03 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=145,atl-edge-internal;dur=18,atl-edge-upstream;dur=125,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 30e02a574c7ae193b8c160f07c01cdc9
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJlyRb4kyn4zpK4tR1XVlJHhyPByJXJGISYAFQR+P89+6S
+        ohQfSmt3GnvGxLUHdr/9sP7swKrkMnEiR4NMQEPySkCemI7kBZiOiTMoeEeVoLkVSpoOJMIWYHkn
+        zrhMIVdpZwHa4B4kEyg1GJB2czaujFXFnBReB74f+K6GPyswdrou4Vzz2IoYnI4jyH4wGI2GODGQ
+        z3GaWVuayPMSmENsE/VJudzm3BjBpSvBemjJerwUXugJYyrwWgU3sEb5s+n4YtoNBsMDXKpdME70
+        2THoW2VibiFVet3cIcEZSoR+2O8GYbfnT4NhFPSjwcg9GIx+RL99cpKMWHS8VvNMJ0neQ31+uL32
+        ZpKAibUoKXC4esRMwfO8wxJhrJCxZaWAGJias6XSNy5Jx0q+0/kTvaikoHTx/JovuOXaWwhYerVb
+        Owc3W4HfC4Y/G/EX/FRg2qsCrRIs0OSUmxvKVTWzNIrmPDfQcRrBE7xXLdtxMoHA0XG2PoUFoK/+
+        l45jBSKrRJQ4kazwjs49mPT8fRtBu1Fq9Qmv+sxMbKTrPNSZbfNAk6/Qs7vuOymsRQXG2domCP9a
+        nzVqbpdcE5CNKMpcoMPJvZBgomr49Yer/vCJ7n4jZe1Ntgnr+4foRthfhf3/10oDixqkaDA4WAUH
+        38PgqrXYC1e98HtY3CD/y5eHcAz34bTXbszF6n1Djpj9yytEQ5pqSJFv/rEIBu0GXkDlVcMLjx89
+        2LdxuGcj3Lsx3LcxeuhOQ5vNKpFS/UI4UTfAKbf4cDSE+/T6bOh8R+Beo05T9dXDY1VR4AIi5Q+0
+        IGTqRFZXgFlCpfY9JpZqsHGu1kf6tYibOH5+sEa+orDJVJUnL4Upc77e1DBlXgNelmjiwSPR67uH
+        w6B9JO6HbR+VhVsqu7+xBVWphdLCrp8ZxFbcq1+af/9WiIKnYDySMK0SgQuZSDPXLNIdKb7BlZY9
+        Q+dhfYTbMsj5DIj/qALu9wT7wBvsw2gwpIhk3IxLEZ8KefOKdl5CSf2LjNus1blc1nvbFankGNsX
+        PsthAtw0SNCbkXN++u71ydn16cnx+OxifD2eTH6f4P2wTg2GBA9MM2DnSPTSMrLLhGFK5muGpCFy
+        UsqsYm+F5uxcQ4GswSqDqHUfI48AC8rxb4Xvl8kscppXEbOH4d9V1R22wESkQvL8/qFN97UJb43r
+        HL1rCQczm0rYnq5KKttHkXy33WkapWeCrxHePrB3e5un4XGHt194fIPtZgu5Vnlj63jT0f0nh9u2
+        sKkZNBK2/YCEJVW3ypU+a7yZ5RV0U40ssWuKFHupmmSrosSGWNrHQT/YRwuDLS18K+N3w/lRfv17
+        xFKtqpIaxVdCJkiMhmGtsBmAZGVlMkhqlJ5Mjug7AybkggwQzBKG/wowfLQgiUhZFrrsNan7KF/U
+        3xcRu9yqFTJiZRoN3MD1bynYGOtcxTzPlLHR0B/63rw5e1375PUGoyuUYpcXEFfETeyNWnat2iOM
+        b3JS4ZscXjGPXQbGsj8qri1oNpYpVmSB8d0jCtsDXlBLn53/xo4qrH12EXO5R4o6PG/kXzWRvL1l
+        F9i01n7i+Pj9uP58aD5tgmmyeeJpOBUWaYBEa0DhCBUxYkp2yy5RRzfE0u8GB/4wrL0ggMpF4krs
+        891ULbxFlUuErEVK8e6evyIVo/5WLF6CWwirwVU69bCsOUFdYKtKdOCN+m5mi5ykyhT/1HkiFSH+
+        TKBQFvAaCbDxCtNBMqzLfjhP/wYAAP//7Fjfb9s2EP5XDggQyJpDz7JsYw78ECR92LAWw9LuZR5g
+        RWZibbLk6Eeaouv/vu9IiqJiq0WTPSYJHPmORx6/O9591JBO0+qcAjEei4Do9K46X9JE/AhjpZiI
+        mQipUYStIhRTMW/k01Y+FZirkc9aOT9OWzl7Z+RjMWvlQSsP3PGTVj4Rk1YetvKw3cC8XZcfHbld
+        lx+DQU9umEweBZMZI3oB0vAghxx6RffpWJzn3xlnM/7/ivNrjJ8d47AvxiiETVFY+CreLCP/qpZ0
+        hQoK4S/oLhT8NCQ02Cl1q3Pzux0LW57V94l4PZcvjNkMddu/Ur0ebfjvnJgFIR7ftCMPH4Njkf1q
+        XMlHL4D8T/w7e8ZxxYI492qCl7WFbmr513ldxBLplUqfG/QZ+uguKSXjur9zBl61NMJHu7fLIvdK
+        06BFko+izUNSgorgDjANAjCMW4YYx6Ehnsw11vu7NYHUwb+MIip0GsecxtKmMe9BFtFNknJPrbZR
+        RXmMhUr6uAU7qUCvjSGjdhOVkvKC7nFP+0S4K8d8CkvMHhfRLTsAOlbvMmL2JdRBA0EvJIGhU/Ux
+        b0xiKmOZRbjJMGXBUkm8JRABsPc0+UeCv99ilQhu7/dpEqtXl4YaNQ6nEvjgyPIFwB2ltwaf6qyM
+        blEqmO+flTUPgX/lfWqWM8iUtItgnORgBo7zpVhlweHsMMqAdMnOwD1ceQuwRcxr0WG2Zn2IDFKF
+        rOoiQ27jqazTitF1fMC4o04IBvDkBFeXHPHE32WexXJfrbL1er3K+DpY0We6xM7Aer7QkvhdblJI
+        7/TkMZgjtfT/QTM21iOXBO5szDxWqidhNseSxoDhWtL6+s2vby7f05gurun0vs6r8xV+9OQjX0tw
+        CI+p/dEK5/IH3mqZp1LgtuAh+2Pc4ITMHgZ/sTeg0DDJRiNtvVYOaKcUgB78GJIni2LICA5oySeH
+        PmNmsyfMtWHHvwwMOPSHTRR6C9KKfCE+aq68eQ+06JRxMMWeQg5NXym3RgfF3GoOyrmjeVLQHc2T
+        ku5onhR1R/OkrFvNQWF3NN3SDpx+Uy94Ng1ICzPSgGRQwXwOXIyRwYQXcuFijAwoRtXAxRhZUBxN
+        0/IaVDoqBsmi0tEwSBaVjoZBsqh0NAySRcXRaJAsKh2NBslJJuC1RSZxSp5pwrc4LPR8V1nwB7oT
+        vl3EfA6QmPUNjr/pAW8TdfMzLcC3V5lAPIrHBX1Qbwu4AJli34QEFTOFphCu0aTPSEfrqE3YZ6PD
+        eNRm2mejA3zUZtZnoyNibcijd9yBVHeyHU4lwVBHfKjKrg4xt5ooLXPa6wQWxDzCLjrvW1SF9OuL
+        moRAlzpYwMTu590+iiuO27ucEvWFkAIPyUZu2jaPgb+DFBUS1bz8nj5vTPc5X7mZpnjRZpdkA/IG
+        /+5AQ6p8YanHUT77ymWdA+wWvG9z2fCZXDZkLhu+jMv+BwAA//+iSluW3K4vcrqldVvWcLQtWwAA
+        AAD//+yaXWvCMBSG/8oYeJkubWNrB+IUNtxf8O40SefQftAP9veX09RgM7ONXRVW8EJMjj0em7cv
+        vM/sZWcvO3tZh6yPvNlI2Efe7FraZy97mdfsZWcvOw0v65vSH7zs1/x+aSJsO751JXg+u07w2hr4
+        qYcTEC6wtxrEw1pgBrawFqirgrpSdGpS9Mt4XBtd5Ac1zYzSaDuThLYFfsTETSeeTZfngHHs/c28
+        EEeNTEVZ/zGwRXeyAc6RBHkV69hXTpYuwq2MVlEaMSA0C2LCMliSJIkpEVEmZJylTIYY7ppKdVld
+        +/jLSon3y1YI1UuDPUNdnsXTVcu8RE7ue+yr/zOk91brbVhzQY/CLBRBKgVE8QpkCInIgCUrnkKU
+        cOb7G7Huv0X91kXwol66juRQDJEnIfqjxusa8qFGRgIPs1RPqyXOlFQADY5U1fduXp1L9Xa/I8yr
+        CozYbYRs+h3bDNr0O7YZtql3rCRMaDJqYCD2/c1/tztDcZJFc3yv+qOFsZnGsbQKHsoCdz93dVnJ
+        h4OSIY7g0HAGEaRUq+ak42UGrvQ2PcFc2stcUBVzkXrM6Hs9PBz+rxx9AgAA//8axAlvtDiih4tH
+        iyNcxRF6qQFv48GbRECnp0OyYDVogTiUbQC0ML8kEbruHd0UnI05nMUYzlaeEfaCEtcSSgNczVpQ
+        qYBVwgDuZTQJY1w6jOHtxtS8ssyi/DxI2xAilFIK3XQB4RIVevm5EBOqYUxo7UBGaY20X0QfZq6O
+        Um5iRRBklAnFbvAKw6ISxxKIO8qAnRtyl0ViLGyGGAY3FGhXRmJxWD54gSZs7TFoaTVo2SPISrhD
+        UF1rhOJcqAZw8NTW1gIAAAD//wMAcqtTseMzAAA=
+    headers:
+      Atl-Request-Id:
+      - 7c5290ce-9243-43ba-b12c-ced579f7aa1a
+      Atl-Traceid:
+      - 7c5290ce924343bab12cced579f7aa1a
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:03 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=342,atl-edge-internal;dur=14,atl-edge-upstream;dur=329,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 70bafd5179c9cafed92ba87ba8a661ae
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/createmeta?projectKeys=NTEST&issuetypeNames=Task&expand=projects.issuetypes.fields
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xW32/TMBD+V6o8V0vbVWOqhBBiIE2gCWndXtCETHJZb3PsYDttyrT/nXPixO5a
+        RjpgvCxP9vl+fOf77uK7CKqCiTSaRYWSN5AYHQ39cvblziug1iWYdQFWRQPPSLYwptCzOE4hI4NU
+        3sgDZjjTGpk4EGBiBdrErMB4Ejuv8XhEH7lA67Td3MKadmfz9+dz2gmWA20vBBpDDmxAtmSGqQvF
+        CdVdND2upsd7xi8FLkFpxr82vuIlwiq2CXXQ3MF4NB29opiTaTWZ/tsobzT+gNc6Z5xTwPFRNT56
+        joBVG/FwUh1OniNiDimWeXQ/DHlk+fUEJnUeai5NQi7ZTQo6UVgYlIKkbwd1rsNBitqgSMygQEhg
+        ILPBSqrbA2udSEHM2hPFI9fgAXYXcTg+3riIjuRzpm9pVwqjmNCcGUjPNk50+c3Y1SxjXMMwWiAo
+        ppLF+hMsgUCPhr5HMwSe2nZxC2oVXeY5U2u7VPC9RAWkaFRJnnSygJzZE4uVzLVRKK5tzLU2kFuJ
+        s77v8J47SduzrQYBY/oEMlZyc8l4CR1gWRBgWw1bcKq3ia5CGvRC5rUDcF7o4Z1a2WDeaDYIQ9te
+        GK9o3HAuV5DWSi88fYSNjeEp5VXb7qDnva12wRQIs1lq52F3rTmKOlxba+fAF/pzI2iL7M57Vrhj
+        YSLzQgqyrHvl99iYUsxyHQkVmXj7EGvg1ON954Ut5kCvL26WpjYS2HgKcrmEaAdbbWYb7OqT2nbz
+        hy58IieBtM0k1OybSlsC98/oNQZa3ZAYThQwo1Ny1Oj2ewDbvtQnjYA/e/Q4azvNPjbDVmZmRUy3
+        F4B5wZHmvC/pyxvpbwb8f2+kemJmWF2Sh4aUffr34Wiy8Zt+7Hol9On75QNWA6fsZ1Oouk/jDN2I
+        enw4FQqlQvPgVfKrzDrtjbZ3srDvO7W28TvBVgLNgNnGvwPwExu/iR2PbUn6/7gxZ9egY2uhWydI
+        ggVeL8j7TwAAAP//vJfBboMwDIZfpeqht8K6tpdJqNph0iax087VBNQCNgqMkHU99N0XxwmE0mms
+        QTvWjZMvtnF+O+wTW7S68SMZ8QTZV0Qw7GClRhkHtk+qMW+tMZfjYNL31gV91rJHoi6tUVfjoIqK
+        7HL6xUFDrqwh16NB9krUlzaNup6etihNzC/RDv0/SwH1Imd1sZfT1at4xherYR0syLEJkfNUCj+n
+        PH6lzIkrgDwpStGHnLe0Cu7iZA5lGs2V/iUXktfitLbZPYhFE58WKTXZQ7vQ9n7s29iVsyAE0g4D
+        bnT22vTVo9qtRfbJoHnV/6Lf8rpAdZxBDQPT2FTCwrlxaSOX8Viktt58cKiO3uDLX1LUgjmo6yBK
+        9oOHlvN4GP5GTAxrG5d7cynFpuM97B50g6goj+14jUV0ZT4Nf4PfsBp5Fb9hN5GTd5vezgY2KVZz
+        tCsK/h2qTcQrnPSUyH/aeTOWFIcXHuKASkOhh4+7aWZkUa4SVOhpL+dZNruqXJowI3Ccg2xjvweZ
+        M6g65aC9jWLQpqYUWoNdFPFwl3YLwgxcBjimb5Qc9eQY8tdoUOdAwbo9fQMAAP//AwBWYTYNTBYA
+        AA==
+    headers:
+      Atl-Request-Id:
+      - 1e551436-4886-47d4-8108-6bd2eefc1407
+      Atl-Traceid:
+      - 1e551436488647d481086bd2eefc1407
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:04 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=314,atl-edge-internal;dur=14,atl-edge-upstream;dur=300,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      Warning:
+      - 'The issue create meta endpoint has been deprecated. (Deprecation start date:
+        June 03, 2024)'
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 2a0d7628c56183e89902369ee1cd2ae6
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"project": {"key": "NTEST"}, "issuetype": {"name": "Task"},
+      "summary": "Findings in: pg:5.1.0", "description": "\n\n\n\n\n\n\nA group of
+      Findings has been pushed to JIRA to be investigated and fixed:\n\nh2. Group\n*Group*:
+      [Findings in: pg:5.1.0|http://localhost:8080/finding_group/359] in [Security
+      How-to|http://localhost:8080/product/2] / [1st Quarter Engagement|http://localhost:8080/engagement/1]
+      / [NPM Audit Scan|http://localhost:8080/test/90]\n\n\n|| Severity || CVE ||
+      CWE || Component || Version || Title || Status ||\n| High | [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [2222Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236] | Active,
+      Verified |\n| High | [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]
+      | [94|https://cwe.mitre.org/data/definitions/94.html] | pg | 5.1.0 | [Remote
+      Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt;
+      4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;=
+      6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0
+      &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/234] | Active,
+      Verified |\n\n*Severity:* High\n\n *Due Date:* Jan. 29, 2025 \n\n\n\n\n\n\n\n\n\n\nh1.
+      Findings\n\nh3. [2222Remote Code Execution - (Pg, &lt; 2.11.2  &gt;= 3.0.0 &lt;
+      3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt; 5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;=
+      6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;= 6.3.0 &lt; 6.3.3  &gt;= 6.4.0
+      &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0 &lt; 7.1.2)|http://localhost:8080/finding/236]\n*Defect
+      Dojo link:* http://localhost:8080/finding/236 (236)\n*Severity:* High\n *Due
+      Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2019-16082|https://nvd.nist.gov/vuln/detail/CVE-2019-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/522\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/522\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n\n\n\nh1. Findings\n\nh3. [Remote Code Execution - (Pg,
+      &lt; 2.11.2  &gt;= 3.0.0 &lt; 3.6.4   &gt;= 4.0.0 &lt; 4.5.7  &gt;= 5.0.0 &lt;
+      5.2.1  &gt;= 6.0.0 &lt; 6.0.5  &gt;= 6.1.0 &lt; 6.1.6  &gt;= 6.2.0 &lt; 6.2.5  &gt;=
+      6.3.0 &lt; 6.3.3  &gt;= 6.4.0 &lt; 6.4.2  &gt;= 7.0.0 &lt; 7.0.2  &gt;= 7.1.0
+      &lt; 7.1.2)|http://localhost:8080/finding/234]\n*Defect Dojo link:* http://localhost:8080/finding/234
+      (234)\n*Severity:* High\n *Due Date:* Jan. 29, 2025 \n *CWE:* [CWE-94|https://cwe.mitre.org/data/definitions/94.html]
+      \n*CVE:* [CVE-2017-16082|https://nvd.nist.gov/vuln/detail/CVE-2017-16082]\n\n\n\n\n\n\n*Source
+      File*: pg-promise&gt;pg\n\n\n\n\n*Description*:\nhttps://nodesecurity.io/advisories/521\nAffected
+      versions of `pg` contain a remote code execution vulnerability that occurs when
+      the remote database or query specifies a crafted column name. \n\nThere are
+      two specific scenarios in which it is likely for an application to be vulnerable:\n1.
+      The application executes unsafe, user-supplied sql which contains malicious
+      column names.\n2. The application connects to an untrusted database and executes
+      a query returning results which contain a malicious column name.\n\n## Proof
+      of Concept\n```\nconst { Client } = require(&#x27;pg&#x27;)\nconst client =
+      new Client()\nclient.connect()\n\nconst sql = `SELECT 1 AS &quot;\\\\&#x27;/*&quot;,
+      2 AS &quot;\\\\&#x27;*/\\n + console.log(process.env)] = null;\\n//&quot;`\n\nclient.query(sql,
+      (err, res) =&gt; {\n  client.end()\n})\n```\n Vulnerable Module: pg\n Vulnerable
+      Versions: &lt; 2.11.2 || &gt;= 3.0.0 &lt; 3.6.4 ||  &gt;= 4.0.0 &lt; 4.5.7 ||
+      &gt;= 5.0.0 &lt; 5.2.1 || &gt;= 6.0.0 &lt; 6.0.5 || &gt;= 6.1.0 &lt; 6.1.6 ||
+      &gt;= 6.2.0 &lt; 6.2.5 || &gt;= 6.3.0 &lt; 6.3.3 || &gt;= 6.4.0 &lt; 6.4.2 ||
+      &gt;= 7.0.0 &lt; 7.0.2 || &gt;= 7.1.0 &lt; 7.1.2\n Patched Version: &gt;= 2.11.2
+      &lt; 3.0.0|| &gt;= 3.6.4 &lt; 4.0.0 ||  &gt;= 4.5.7 &lt; 5.0.0 || &gt;= 5.2.1
+      &lt; 6.0.0 || &gt;= 6.0.5  &lt; 6.1.0 || &gt;= 6.1.6 &lt; 6.2.0 || &gt;= 6.2.5
+      &lt; 6.3.0 || &gt;= 6.3.3 &lt; 6.4.0 || &gt;= 6.4.2 &lt; 7.0.0 || &gt;= 7.0.2
+      &lt; 7.1.0 || &gt;= 7.1.2\n Vulnerable Paths: \n  - 5.1.0:pg-promise&gt;pg\n
+      CWE: CWE-94\n Access: public\n\n\n*Mitigation*:\n* Version 2.x.x: Update to
+      version 2.11.2 or later.\n* Version 3.x.x: Update to version 3.6.4 or later.\n*
+      Version 4.x.x: Update to version 4.5.7 or later.\n* Version 5.x.x: Update to
+      version 5.2.1 or later.\n* Version 6.x.x: Update to version 6.4.2 or later.
+      ( Note that versions 6.1.6, 6.2.5, and 6.3.3 are also patched. )\n* Version
+      7.x.x: Update to version 7.1.2 or later. ( Note that version 7.0.2 is also patched.
+      )\n\n\n\n*Impact*:\nNo impact provided\n\n\n\n\n\n*References*:\nhttps://nodesecurity.io/advisories/521\n\n\n*Reporter:*
+      [(admin) ()|mailto:]\n"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '7127'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: PUT
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: ''
+    headers:
+      Atl-Request-Id:
+      - 9195dc78-a564-44a2-a7d3-be168b63097c
+      Atl-Traceid:
+      - 9195dc78a56444a2a7d3be168b63097c
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:04 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=312,atl-edge-internal;dur=14,atl-edge-upstream;dur=298,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - 34967c5080f6478311766ee710252c25
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15998
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xXWXPbNhD+Kxg+dVKJlyRb4kyn4zpK4tR1XVlJHhyPByJXJGISYAFQR+P89+6S
+        ohQfSmt3GnvGxLUHdr/9sP7swKrkMnEiR4NMQEPySkCemI7kBZiOiTMoeEeVoLkVSpoOJMIWYHkn
+        zrhMIVdpZwHa4B4kEyg1GJB2czaujFXFnBReB74f+K6GPyswdrou4Vzz2IoYnI4jyH4wGI2GODGQ
+        z3GaWVuayPMSmENsE/VJudzm3BjBpSvBemjJerwUXugJYyrwWgU3sEb5s+n4YtoNBsMDXKpdME70
+        2THoW2VibiFVet3cIcEZSoR+2O8GYbfnT4NhFPSjwcg9GIx+RL99cpKMWHS8VvNMJ0neQ31+uL32
+        ZpKAibUoKXC4esRMwfO8wxJhrJCxZaWAGJias6XSNy5Jx0q+0/kTvaikoHTx/JovuOXaWwhYerVb
+        Owc3W4HfC4Y/G/EX/FRg2qsCrRIs0OSUmxvKVTWzNIrmPDfQcRrBE7xXLdtxMoHA0XG2PoUFoK/+
+        l45jBSKrRJQ4kazwjs49mPT8fRtBu1Fq9Qmv+sxMbKTrPNSZbfNAk6/Qs7vuOymsRQXG2domCP9a
+        nzVqbpdcE5CNKMpcoMPJvZBgomr49Yer/vCJ7n4jZe1Ntgnr+4foRthfhf3/10oDixqkaDA4WAUH
+        38PgqrXYC1e98HtY3CD/y5eHcAz34bTXbszF6n1Djpj9yytEQ5pqSJFv/rEIBu0GXkDlVcMLjx89
+        2LdxuGcj3Lsx3LcxeuhOQ5vNKpFS/UI4UTfAKbf4cDSE+/T6bOh8R+Beo05T9dXDY1VR4AIi5Q+0
+        IGTqRFZXgFlCpfY9JpZqsHGu1kf6tYibOH5+sEa+orDJVJUnL4Upc77e1DBlXgNelmjiwSPR67uH
+        w6B9JO6HbR+VhVsqu7+xBVWphdLCrp8ZxFbcq1+af/9WiIKnYDySMK0SgQuZSDPXLNIdKb7BlZY9
+        Q+dhfYTbMsj5DIj/qALu9wT7wBvsw2gwpIhk3IxLEZ8KefOKdl5CSf2LjNus1blc1nvbFankGNsX
+        PsthAtw0SNCbkXN++u71ydn16cnx+OxifD2eTH6f4P2wTg2GBA9MM2DnSPTSMrLLhGFK5muGpCFy
+        UsqsYm+F5uxcQ4GswSqDqHUfI48AC8rxb4Xvl8kscppXEbOH4d9V1R22wESkQvL8/qFN97UJb43r
+        HL1rCQczm0rYnq5KKttHkXy33WkapWeCrxHePrB3e5un4XGHt194fIPtZgu5Vnlj63jT0f0nh9u2
+        sKkZNBK2/YCEJVW3ypU+a7yZ5RV0U40ssWuKFHupmmSrosSGWNrHQT/YRwuDLS18K+N3w/lRfv17
+        xFKtqpIaxVdCJkiMhmGtsBmAZGVlMkhqlJ5Mjug7AybkggwQzBKG/wowfLQgiUhZFrrsNan7KF/U
+        3xcRu9yqFTJiZRoN3MD1bynYGOtcxTzPlLHR0B/63rw5e1375PUGoyuUYpcXEFfETeyNWnat2iOM
+        b3JS4ZscXjGPXQbGsj8qri1oNpYpVmSB8d0jCtsDXlBLn53/xo4qrH12EXO5R4o6PG/kXzWRvL1l
+        F9i01n7i+Pj9uP58aD5tgmmyeeJpOBUWaYBEa0DhCBUxYkp2yy5RRzfE0u8GB/4wrL0ggMpF4krs
+        891ULbxFlUuErEVK8e6evyIVo/5WLF6CWwirwVU69bCsOUFdYKtKdOCN+m5mi5ykyhT/1HkiFSH+
+        TKBQFvAaCbDxCtNBMqzLfjhP/wYAAP//7Fjfb9s2EP5XDggQyJpDz7JsYw78ECR92LAWw9LuZR5g
+        RWZibbLk6Eeaouv/vu9IiqJiq0WTPSYJHPmORx6/O9591JBO0+qcAjEei4Do9K46X9JE/AhjpZiI
+        mQipUYStIhRTMW/k01Y+FZirkc9aOT9OWzl7Z+RjMWvlQSsP3PGTVj4Rk1YetvKw3cC8XZcfHbld
+        lx+DQU9umEweBZMZI3oB0vAghxx6RffpWJzn3xlnM/7/ivNrjJ8d47AvxiiETVFY+CreLCP/qpZ0
+        hQoK4S/oLhT8NCQ02Cl1q3Pzux0LW57V94l4PZcvjNkMddu/Ur0ebfjvnJgFIR7ftCMPH4Njkf1q
+        XMlHL4D8T/w7e8ZxxYI492qCl7WFbmr513ldxBLplUqfG/QZ+uguKSXjur9zBl61NMJHu7fLIvdK
+        06BFko+izUNSgorgDjANAjCMW4YYx6Ehnsw11vu7NYHUwb+MIip0GsecxtKmMe9BFtFNknJPrbZR
+        RXmMhUr6uAU7qUCvjSGjdhOVkvKC7nFP+0S4K8d8CkvMHhfRLTsAOlbvMmL2JdRBA0EvJIGhU/Ux
+        b0xiKmOZRbjJMGXBUkm8JRABsPc0+UeCv99ilQhu7/dpEqtXl4YaNQ6nEvjgyPIFwB2ltwaf6qyM
+        blEqmO+flTUPgX/lfWqWM8iUtItgnORgBo7zpVhlweHsMMqAdMnOwD1ceQuwRcxr0WG2Zn2IDFKF
+        rOoiQ27jqazTitF1fMC4o04IBvDkBFeXHPHE32WexXJfrbL1er3K+DpY0We6xM7Aer7QkvhdblJI
+        7/TkMZgjtfT/QTM21iOXBO5szDxWqidhNseSxoDhWtL6+s2vby7f05gurun0vs6r8xV+9OQjX0tw
+        CI+p/dEK5/IH3mqZp1LgtuAh+2Pc4ITMHgZ/sTeg0DDJRiNtvVYOaKcUgB78GJIni2LICA5oySeH
+        PmNmsyfMtWHHvwwMOPSHTRR6C9KKfCE+aq68eQ+06JRxMMWeQg5NXym3RgfF3GoOyrmjeVLQHc2T
+        ku5onhR1R/OkrFvNQWF3NN3SDpx+Uy94Ng1ICzPSgGRQwXwOXIyRwYQXcuFijAwoRtXAxRhZUBxN
+        0/IaVDoqBsmi0tEwSBaVjoZBsqh0NAySRcXRaJAsKh2NBslJJuC1RSZxSp5pwrc4LPR8V1nwB7oT
+        vl3EfA6QmPUNjr/pAW8TdfMzLcC3V5lAPIrHBX1Qbwu4AJli34QEFTOFphCu0aTPSEfrqE3YZ6PD
+        eNRm2mejA3zUZtZnoyNibcijd9yBVHeyHU4lwVBHfKjKrg4xt5ooLXPa6wQWxDzCLjrvW1SF9OuL
+        moRAlzpYwMTu590+iiuO27ucEvWFkAIPyUZu2jaPgb+DFBUS1bz8nj5vTPc5X7mZpnjRZpdkA/IG
+        /+5AQ6p8YanHUT77ymWdA+wWvG9z2fCZXDZkLhu+jMv+BwAA//+iSluW3K4vcrqldVvWcLQtWwAA
+        AAD//+yaXWvCMBSG/8oYeJkubWNrB+IUNtxf8O40SefQftAP9veX09RgM7ONXRVW8EJMjj0em7cv
+        vM/sZWcvO3tZh6yPvNlI2Efe7FraZy97mdfsZWcvOw0v65vSH7zs1/x+aSJsO751JXg+u07w2hr4
+        qYcTEC6wtxrEw1pgBrawFqirgrpSdGpS9Mt4XBtd5Ac1zYzSaDuThLYFfsTETSeeTZfngHHs/c28
+        EEeNTEVZ/zGwRXeyAc6RBHkV69hXTpYuwq2MVlEaMSA0C2LCMliSJIkpEVEmZJylTIYY7ppKdVld
+        +/jLSon3y1YI1UuDPUNdnsXTVcu8RE7ue+yr/zOk91brbVhzQY/CLBRBKgVE8QpkCInIgCUrnkKU
+        cOb7G7Huv0X91kXwol66juRQDJEnIfqjxusa8qFGRgIPs1RPqyXOlFQADY5U1fduXp1L9Xa/I8yr
+        CozYbYRs+h3bDNr0O7YZtql3rCRMaDJqYCD2/c1/tztDcZJFc3yv+qOFsZnGsbQKHsoCdz93dVnJ
+        h4OSIY7g0HAGEaRUq+ak42UGrvQ2PcFc2stcUBVzkXrM6Hs9PBz+rxx9AgAA//8axAlvtDiih4tH
+        iyNcxRF6qQFv48GbRECnp0OyYDVogTiUbQC0ML8kEbruHd0UnI05nMUYzlaeEfaCEtcSSgNczVpQ
+        qYBVwgDuZTQJY1w6jOHtxtS8ssyi/DxI2xAilFIK3XQB4RIVevm5EBOqYUxo7UBGaY20X0QfZq6O
+        Um5iRRBklAnFbvAKw6ISxxKIO8qAnRtyl0ViLGyGGAY3FGhXRmJxWD54gSZs7TFoaTVo2SPISrhD
+        UF1rhOJcqAZw8NTW1gIAAAD//wMAcqtTseMzAAA=
+    headers:
+      Atl-Request-Id:
+      - 4f5bdfea-42a3-4be0-9958-5507e2b83a54
+      Atl-Traceid:
+      - 4f5bdfea42a34be099585507e2b83a54
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:04 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=249,atl-edge-internal;dur=13,atl-edge-upstream;dur=237,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - bd669784884d8bc95d065cdbe76fcd3f
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/serverInfo
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA5yQUUvDMBSF/0te3bqbtN26vMkEp+gU2r0oImlzi9E0KU06GGP/3QSH7lF9u9zz
+        nXsO90Bq4XA7aMLJm/e947OZxBYbL+27TYTXwjklTGLQkwmRyvVa7P/BlzjsVIMS3ccadb9C43H4
+        65GVNa0e0TT4O+cOB6esCTAFoAkkMC03l4/l+qH6UTdjV4eJ8OcITWACLyETe233XWhZ7fuYttJ2
+        lMFUj0rLLwvhwcAWi9PySvgIMmDZlLIpXVaU8ZRymiYAcAEBDn4X/oBDpbpzNoWKFpzmHPKELeg3
+        23Q3prUBhCyHLGVzkdZ1kRdLmi+pzFnaNKxAOacCWyGyeX0W4HVMuFWDiC8M+qj9nW1EXB+IPk0E
+        zeu2JMfzYk/WROX6viLHTwAAAP//AwDqWLxcIAIAAA==
+    headers:
+      Atl-Request-Id:
+      - 0fac98cf-6777-4ab0-b8b4-5613ae9d242a
+      Atl-Traceid:
+      - 0fac98cf67774ab0b8b45613ae9d242a
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:05 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=161,atl-edge-internal;dur=15,atl-edge-upstream;dur=147,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - f05613a4d6c2b0fbec800b3b8eb167ea
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+    method: GET
+    uri: https://defectdojo.atlassian.net/rest/api/2/issue/15997
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xX23LbNhD9FQwfU4k3SYnMmU7HdZTEreu6spI8OB4PTK5IxCTAAKAujf3v3SVF
+        KpatTO1OYz8Qt71g9+zB6qsDq5LLxIkcDTIBDckbAXliepIXYHomzqDgPVWC5lYoaXqQCFuA5b04
+        4zKFXKW9BWiDe5BModRgQNrN2bgyVhVzUngV+H7guxq+VGDsbF3CmeaxFTE4PUeQ/WB0cPAKJwby
+        OU4za0sTeV4Cc4htoj4rl9ucGyO4dCVYDy1Zj5fCCz1hTAVeq+AG1ih/Opucz/rBaDzCpdoF40Rf
+        HYO+VSbmFlKl180dEpyhROiHw34Q9gf+LBhHwTAaDd3x6OAn9NsnJ8mIRcdrNc90kuQ91OeH3bU3
+        kwRMrEVJgcPVQ2YKnuc9lghjhYwtKwXEwNScLZW+cUk6VvK9zp/oRSUFpYvnV3zBLdfeQsDSq93a
+        OrjZCvxBMP7FiL/h5wLTXhVolWCBJmfc3FCuqmtLo2jOcwM9pxE8xnvVsj0nEwgcHWfrE1gA+urf
+        9RwrEFklosSJZIV3dHZgMvDbjVKrz3ijZwZ8I12Hu05gG26afAOS7a3eS2EtKjBOZ5uQ+nt91qi5
+        XXJNeDWiKHOBDic7N8d81CgbjlfD8RPd/U5m2pt0eRn6BPRwuAqH/6+VJvs1FtFg8HIVvPwRBlet
+        xUG4GoQ/wuIG4Hd3D+EY7MNpuG9j0G7MxepDQ44Ii4tLhEmaakiRbx4UAV5A5VVT/o9rHe3beLlv
+        49WejXDvxnjfxsFDPxvabFaJlOoXwon6AU65xYejIdynF25D51sC9xp1msqyHh6pigIXECl/pAUh
+        UyeyuoK7DU+TNi3iJpxfH6yRZ3jUZKrKk9fClDlfb0oZl9Et+wExQ+W9iYYGvCzxx4NHYhC6w4Ow
+        fSR2w9ZR2e7GPlCFHahKLZQWdv3MILbiXv3S/Pu3QhQ8BeORhGmVCFzIRJq5ZpFu2fIdrrS0GjoP
+        CyfsyiDn10DESBWw2xPsA2+wD6PBmCKScTMpRXwi5M0b2nkNJfUvMm7zWGd3We91K1LJCbYv/DqH
+        KXDTYENvRs7Zyfu3x6dXJ8dHk9PzydVkOv1zivfDOjUYEjwwy4Cd4QsgLSO7TBimZL5myCYiJ6XM
+        Kvab0JydaSiQTlhlELXuY6wSYEE5/q3w/TIZRE7zKmL2MPzbqrrHFpiIVEie7x7adF+b8NZIz9G7
+        lnAws6mE7nRVUtk+iuS63Rm3SG4apWeCrxHuXt77vc3T8LjF2688vsF2s4Vcq7yxdbTp6P6Tw21b
+        2NQMGgnbRkHCkqpb5UqfNt5c5xX0U428sW2KFHutmmSrosSGWNrHQT/qaOF7id0V6ijjfjg/yW//
+        D1mqVVVSo/hGyASJ0TCsFXYNIFlZmQySGqXH00P6XgMTckGWCWYJw58CDB8tSCJSloUue0vqPskX
+        9fdFxC46tUJGTGK8rOBW6ch3R+7gloKOMc9VzPNMGRuN/bHvzRuZq9o3bzAaX6I0uziHuCKOYu/U
+        sm/VHmF8tJMKH+3wknnsIjCW/VVxbUGziUyxMguM8x5R6A54QS19evYHO6yQA9h5zOUeKWoBvQP/
+        sono7S07x+a19hPHRx8m9edj82kTTZPNU0/DmbBIByRaAwtHqIgRY7JbdoE6+iFSQB+75DCovSCg
+        ykXiSuz33VQtvEWVS4SuRWrx7p+/JBUD3+/k4iW4hbAaXKVTD+ubE+YFNrPECx4edTNb5CS3zRdO
+        6oyRshD/ppBWOceY/gMAAP//7Fltb9owEP4r1qRWgEgKSQiFquqoWNVOazWt2j50XzCxgWwhifJC
+        92E/fs85L7yUlI6qVSdNrYDYPvt8vnvO9+QX1XBqH0Ppu9wjV7qV0QKlGtNY7aacockOveTkFNPY
+        eqteYcv85I8M06T1B0i/C9kkU6n7M9tmFxv77Ji9J9slH6/sYj3dLtZOu7y4TYwqmyDgCqfrN5R9
+        qI01hqlkQ0QqGj8CxZjRazIAeYeto0DxN2vrJQyoZ1N/tdPGFoYKeQGKPwJGOQla75RjNXzUt+3/
+        0d2zBiIS7d/xpe0VHFgS/qSmeF54rh9B4zZIIxjzwvUk4FNmBj+cJifccWSYqJ9L91sRHC5hvgE4
+        LtUIgP85cOpucMTFwo2RQyTl2y4ywISMDjcqLgZ0pKPlCiOGKwwj/VGa55eWKHeHXDtyB1G6Q5y7
+        A08SZOC4ye5nrjNjuEtPpwDhFADIQo61/CnjDEWNA0Fci5yIT0iP0UBtVPvE/WkKOB6xmeQCkguO
+        HKpnu2XflgpdA+89uZpc1vuLkqq/6pIY8lmVCaLoR/e06G6vz4CRM4ijEU6uwr2/+2AI8/v0Qf6F
+        R9pWjFnCdOy5Tn5o165KpfmZfVW3LbJwfhiZMgww46EjyjcPuat5yJ2EZG4C5qoHhsS3cIUUa+70
+        BTGFKyiW/hunyEXDgPIm+XiNi7nr11mt/nsOH06Cfum3W0HjxQHD2BMwDAIM45mAsVfWeAAY++at
+        1fN9bcCw/wPGKwCG9W8Bhl2K7gCMh4xHpyz6NwveKiqkbVV1lIQXVUlJBF9SPA8xNxtDW1XcmFXy
+        VpsSVbxDq+QdCvNUDaziylrlmmv1+2Z5p6JjRrVJViPG6XzOqYB992iFRSYnNiqI9ix1iZM4g8cS
+        h3YlTrttAGLrwBxI+9ge2xbXWhOjq1kT3tF6vW5LE/ZEyO5kbEmTyuJSEstmsv0nSkrym4EQFDWk
+        M48CT7xfURlVMy3wKJOuDkXqKLzVMJIp2FxzYgpjLAW3u8dcmrwnJtzqHTtjbvccq90+E6dqFuz1
+        wLjAfyanzbmfF4maljXFehpr9zCZZuhUfepZxJJNtZDzmEwKeZUTuBfj5+W5ZumhT+TEJiv/9jXe
+        pPXfvsabrwXeusZALJGxzDl7dKmcn5173P8p/Xjmhiq0qBDMiOwM9O4Cn0Z/SKMglEd3gCOHKNc8
+        BundFHrLSKdl8jdy23knqwqDrRU6+g8AAAD//0KVwDXHYQIv54uglcRocTQIEx6h4ggAAAD//xqM
+        Lh4tjmjtYvoVR+ilBrytB28aAZ2eDsmC1aA5dyjbAGhhfkkidMUAuim4WnsGuIoxAyPs5SHORiCu
+        VqwJrlkpA1ytWFBxgVXCGKcEvP2YmleWWZSfB2kjQoRSSqHLVSBcokIvPxdiQjWMCa0dyCitkVba
+        6MPM1VHKTawISi0uzQEZjGQ3eG6mqMSxBOKOsvwS6k0JQwyDGwq0KyOxOCwfPLUFm8cFTUqDJoxA
+        VsIdgupaIxTnQjWAg6e2thYAAAD//wMAg8TTWx0lAAA=
+    headers:
+      Atl-Request-Id:
+      - 47bab63f-8363-4986-99f3-2c56e76b311f
+      Atl-Traceid:
+      - 47bab63f8363498699f32c56e76b311f
+      Cache-Control:
+      - no-cache, no-store, no-transform
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Mon, 30 Dec 2024 17:15:05 GMT
+      Nel:
+      - '{"failure_fraction": 0.001, "include_subdomains": true, "max_age": 600, "report_to":
+        "endpoint-1"}'
+      Report-To:
+      - '{"endpoints": [{"url": "https://dz8aopenkvv6s.cloudfront.net"}], "group":
+        "endpoint-1", "include_subdomains": true, "max_age": 600}'
+      Server:
+      - AtlassianEdge
+      Server-Timing:
+      - atl-edge;dur=293,atl-edge-internal;dur=21,atl-edge-upstream;dur=260,atl-edge-pop;desc="aws-us-east-1"
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+      Timing-Allow-Origin:
+      - '*'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Aaccountid:
+      - 712020%3Ae686b64a-0f27-4fa5-9970-d6fde7fb4e32
+      X-Arequestid:
+      - c0c183c5c1167c93821c635531594731
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
[sc-9132]

When a risk exception expires, and reopens all of the associated findings, those changes should be reflected in jira.

