### PR TITLE
RustyHog: improve description and file_path

### DIFF
--- a/docs/content/en/open_source/upgrading/2.42.md
+++ b/docs/content/en/open_source/upgrading/2.42.md
@@ -4,4 +4,16 @@ toc_hide: true
 weight: -20241202
 description: No special instructions.
 ---
-There are no special instructions for upgrading to 2.42.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.42.0) for the contents of the release.
+
+**Hash Code changes**
+The Rusty Hog parser has been [updated](https://github.com/DefectDojo/django-DefectDojo/pull/11433) to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code please execute the following command:
+
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Horusec Scan" --hash_code_only`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Qualys Hacker Guardian Scan --hash_code_only"`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Red Hat Satellite --hash_code_only"`
+
+This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
+See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.
+
+Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.42.0) for the contents of the release.
+

--- a/docs/content/en/open_source/upgrading/2.42.md
+++ b/docs/content/en/open_source/upgrading/2.42.md
@@ -6,7 +6,7 @@ description: No special instructions.
 ---
 
 **Hash Code changes**
-The Rusty Hog parser has been [updated](https://github.com/DefectDojo/django-DefectDojo/pull/11433) to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code please execute the following command:
+A few parsers have been updated to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code please execute the following command:
 
     `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Horusec Scan" --hash_code_only`
     `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Qualys Hacker Guardian Scan --hash_code_only"`

--- a/docs/content/en/open_source/upgrading/2.43.md
+++ b/docs/content/en/open_source/upgrading/2.43.md
@@ -7,4 +7,16 @@ description: Disclaimer field renamed/split.
 
 [Pull request #10902](https://github.com/DefectDojo/django-DefectDojo/pull/10902) introduced different kinds of disclaimers within the DefectDojo instance. The original content of the disclaimer was copied to all new fields where it had been used until now (so this change does not require any action on the user's side). However, if users were managing the original disclaimer via API (endpoint `/api/v2/system_settings/1/`, field `disclaimer`), be aware that the fields are now called `disclaimer_notifications` and `disclaimer_reports` (plus there is one additional, previously unused field called `disclaimer_notes`).
 
-But there are no other special instructions for upgrading to 2.43.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.43.0) for the contents of the release.
+**Hash Code changes**
+The Rusty Hog parser has been [updated](https://github.com/DefectDojo/django-DefectDojo/pull/11433) to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code and deduplicate existing Rusty Hog findings, please execute the following command:
+
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Rusty Hog Scan)" --hash_code_only`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Choctaw Hog)" --hash_code_only`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Duroc Hog)" --hash_code_only`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Gottingen Hog)" --hash_code_only`
+    `docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser "Essex Hog Scan (Essex Hog)" --hash_code_only`
+
+This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
+See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.
+
+Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.43.0) for the contents of the release.

--- a/dojo/tools/rusty_hog/parser.py
+++ b/dojo/tools/rusty_hog/parser.py
@@ -76,12 +76,17 @@ class RustyhogParser:
         found_secret_string = ""
         cwe = 200
         for vulnerability in vulnerabilities:
+            description = ""
+            if vulnerability.get("reason") is not None:
+                description += "\n**Reason:** {}".format(
+                    vulnerability.get("reason"),
+                )
             if scanner == "Rusty Hog":
                 break
             if scanner == "Choctaw Hog":
                 """Choctaw Hog"""
-                found_secret_string = vulnerability.get("stringsFound")
-                description = f"**This string was found:** {found_secret_string}"
+                found_secret_string = str(vulnerability.get("stringsFound") or "")
+                description += f"**This string was found:** {found_secret_string}"
                 if vulnerability.get("commit") is not None:
                     description += "\n**Commit message:** {}".format(
                         vulnerability.get("commit"),
@@ -116,8 +121,8 @@ class RustyhogParser:
                     )
             elif scanner == "Duroc Hog":
                 """Duroc Hog"""
-                found_secret_string = vulnerability.get("stringsFound")
-                description = f"**This string was found:** {found_secret_string}"
+                found_secret_string = str(vulnerability.get("stringsFound") or "")
+                description += f"**This string was found:** {found_secret_string}"
                 if vulnerability.get("path") is not None:
                     description += "\n**Path of Issue:** {}".format(
                         vulnerability.get("path"),
@@ -132,8 +137,8 @@ class RustyhogParser:
                     )
             elif scanner == "Gottingen Hog":
                 """Gottingen Hog"""
-                found_secret_string = vulnerability.get("stringsFound")
-                description = f"**This string was found:** {found_secret_string}"
+                found_secret_string = str(vulnerability.get("stringsFound") or "")
+                description += f"**This string was found:** {found_secret_string}"
                 if vulnerability.get("issue_id") is not None:
                     description += "\n**JIRA Issue ID:** {}".format(
                         vulnerability.get("issue_id"),
@@ -147,8 +152,8 @@ class RustyhogParser:
                         vulnerability.get("url"), vulnerability.get("url"),
                     )
             elif scanner == "Essex Hog":
-                found_secret_string = vulnerability.get("stringsFound")
-                description = f"**This string was found:** {found_secret_string}"
+                found_secret_string = str(vulnerability.get("stringsFound") or "")
+                description += f"**This string was found:** {found_secret_string}"
                 if vulnerability.get("page_id") is not None:
                     description += "\n**Confluence URL:** [{}]({})".format(
                         vulnerability.get("url"), vulnerability.get("url"),
@@ -179,10 +184,15 @@ class RustyhogParser:
                     vulnerability.get("issue_id"),
                     vulnerability.get("location"),
                 )
+                if not file_path:
+                    file_path = vulnerability.get("url")
             elif scanner == "Essex Hog":
                 title = "{} found in Confluence Page ID {}".format(
                     vulnerability.get("reason"), vulnerability.get("page_id"),
                 )
+                if not file_path:
+                    file_path = vulnerability.get("url")
+
             # create the finding object
             finding = Finding(
                 title=title,

--- a/unittests/tools/test_rusty_hog_parser.py
+++ b/unittests/tools/test_rusty_hog_parser.py
@@ -110,6 +110,9 @@ class TestRustyhogParser(DojoTestCase):
             parser = RustyhogParser()
             findings = parser.get_items(testfile, "Essex Hog", Test())
             self.assertEqual(3, len(findings))
+            self.assertEqual("https://confluence.com/pages/viewpage.action?pageId=12345", findings[0].file_path)
+            self.assertEqual("['-----BEGIN EC PRIVATE KEY-----']", findings[0].payload)
+            self.assertEqual("**Reason:** SSH (EC) private key", findings[0].description[:32])
 
     def test_parse_file_with_multiple_vuln_has_multiple_finding_essexhog_content(self):
         with open("unittests/scans/rusty_hog/essexhog_many_vulns.json", encoding="utf-8") as testfile:


### PR DESCRIPTION
**Description**
Improvements to Rusy Hog parser:
- For Confluence and JIRA scans, set `file_path` to contain URL of scanned page;
- Ensure `found_secret_string` is actually a `String` and not a `list`;
- Add `Reason` to `description`;

**Test results**
Unit tests updated.

**Documentation**
No updates needed

**Checklist**
- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.