### PR TITLE
Allow None Option for Active/Verified on Import/Reimport to Mirror UI Options

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2087,10 +2087,10 @@ class CommonImportScanSerializer(serializers.Serializer):
         help_text="Minimum severity level to be imported",
     )
     active = serializers.BooleanField(
-        help_text="Override the active setting from the tool.", required=False,
+        help_text="Force findings to be active/inactive or default to the original tool (None)", required=False,
     )
     verified = serializers.BooleanField(
-        help_text="Override the verified setting from the tool.", required=False,
+        help_text="Force findings to be verified/not verified or default to the original tool (None)", required=False,
     )
 
     # TODO: why do we allow only existing endpoints?

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2087,10 +2087,10 @@ class CommonImportScanSerializer(serializers.Serializer):
         help_text="Minimum severity level to be imported",
     )
     active = serializers.BooleanField(
-        help_text="Override the active setting from the tool.",
+        help_text="Override the active setting from the tool.", required=False,
     )
     verified = serializers.BooleanField(
-        help_text="Override the verified setting from the tool.",
+        help_text="Override the verified setting from the tool.", required=False,
     )
 
     # TODO: why do we allow only existing endpoints?


### PR DESCRIPTION
The help on the Active/Verified options for the Import and Reimport Scan APIs is misleading. The help says 'Override the active setting from the tool' and 'Override the verified setting from the tool' which suggests that True means 'Yes, do that', and False would mean 'No, don't override the tool'. However, viewed that way, there is no way to set the Active/Verified, just a way to say 'override' it with "something". The UI allows for a third option: "None" which means do NOT override the tool instead of Override the Tool with This Setting. This PR allows the API to also have a 'None' option and updates the help text to match what is given in the UI.

fixes #11235 

[sc-9259]