### PR TITLE
Add Ordering to Test_Import API Endpoint

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -60,6 +60,7 @@ from dojo.filters import (
     ApiTestFilter,
     ReportFindingFilter,
     ReportFindingFilterWithoutObjectLookups,
+    TestImportAPIFilter,
 )
 from dojo.finding.queries import (
     get_authorized_findings,
@@ -2259,17 +2260,9 @@ class TestImportViewSet(
     serializer_class = serializers.TestImportSerializer
     queryset = Test_Import.objects.none()
     filter_backends = (DjangoFilterBackend,)
-    filterset_fields = [
-        "test",
-        "findings_affected",
-        "version",
-        "branch_tag",
-        "build_id",
-        "commit_hash",
-        "test_import_finding_action__action",
-        "test_import_finding_action__finding",
-        "test_import_finding_action__created",
-    ]
+
+    filterset_class = TestImportAPIFilter
+
     permission_classes = (
         IsAuthenticated,
         permissions.UserHasTestImportPermission,

--- a/dojo/filters.py
+++ b/dojo/filters.py
@@ -3212,6 +3212,7 @@ class GroupFilter(DojoFilter):
         exclude = ["users"]
 
 
+# This class is used exclusively by Findings
 class TestImportFilter(DojoFilter):
     version = CharFilter(field_name="version", lookup_expr="icontains")
     version_exact = CharFilter(field_name="version", lookup_expr="iexact", label="Version Exact")
@@ -3238,6 +3239,7 @@ class TestImportFilter(DojoFilter):
         fields = []
 
 
+# This class is used exclusively by Findings
 class TestImportFindingActionFilter(DojoFilter):
     action = MultipleChoiceFilter(choices=IMPORT_ACTIONS)
     o = OrderingFilter(
@@ -3250,6 +3252,35 @@ class TestImportFindingActionFilter(DojoFilter):
     class Meta:
         model = Test_Import_Finding_Action
         fields = []
+
+
+# Used within the TestImport API
+class TestImportAPIFilter(DojoFilter):
+    o = OrderingFilter(
+        # tuple-mapping retains order
+        fields=(
+            ("id", "id"),
+            ("created", "created"),
+            ("modified", "modified"),
+            ("version", "version"),
+            ("branch_tag", "branch_tag"),
+            ("build_id", "build_id"),
+            ("commit_hash", "commit_hash"),
+
+        ),
+    )
+
+    class Meta:
+        model = Test_Import
+        fields = ["test",
+        "findings_affected",
+        "version",
+        "branch_tag",
+        "build_id",
+        "commit_hash",
+        "test_import_finding_action__action",
+        "test_import_finding_action__finding",
+        "test_import_finding_action__created"]
 
 
 class LogEntryFilter(DojoFilter):


### PR DESCRIPTION
Added the ability to order the Test_Imports from the API via id, created, modified, version, branch_tag, build_id, and commit_hash (similar to that ability in findings).

[sc-9470]
