### PR TITLE
Add EPSS score and percentile to generic csv parser

### DIFF
--- a/docs/content/en/connecting_your_tools/parsers/generic_findings_import.md
+++ b/docs/content/en/connecting_your_tools/parsers/generic_findings_import.md
@@ -12,7 +12,7 @@ These attributes are supported for CSV:
 - Title: Title of the finding
 - CweId: Cwe identifier, must be an integer value.
 - epss_score: The probability of exploitation in the next 30 days, must be a float value between 0 and 1.0.
-- epss_percentile: The proportion of all scored vulnerabilities with the same or a lower EPSS score, must be a float value.
+- epss_percentile: The proportion of all scored vulnerabilities with the same or a lower EPSS score, must be a float value between 0 and 1.0.
 - Url: Url associated with the finding.
 - Severity: Severity of the finding. Must be one of Info, Low, Medium, High, or Critical.
 - Description: Description of the finding. Can be multiple lines if enclosed in double quotes.

--- a/docs/content/en/connecting_your_tools/parsers/generic_findings_import.md
+++ b/docs/content/en/connecting_your_tools/parsers/generic_findings_import.md
@@ -11,6 +11,8 @@ These attributes are supported for CSV:
 - Date: Date of the finding in mm/dd/yyyy format.
 - Title: Title of the finding
 - CweId: Cwe identifier, must be an integer value.
+- epss_score: The probability of exploitation in the next 30 days, must be a float value between 0 and 1.0.
+- epss_percentile: The proportion of all scored vulnerabilities with the same or a lower EPSS score, must be a float value.
 - Url: Url associated with the finding.
 - Severity: Severity of the finding. Must be one of Info, Low, Medium, High, or Critical.
 - Description: Description of the finding. Can be multiple lines if enclosed in double quotes.

--- a/dojo/tools/generic/csv_parser.py
+++ b/dojo/tools/generic/csv_parser.py
@@ -66,6 +66,12 @@ class GenericCSVParser:
             if "CweId" in row:
                 finding.cwe = int(row["CweId"])
 
+            if "epss_score" in row:
+                finding.epss_score = float(row["epss_score"])
+
+            if "epss_percentile" in row:
+                finding.epss_percentile = float(row["epss_percentile"])
+
             if "CVSSV3" in row:
                 cvss_objects = cvss_parser.parse_cvss_from_text(row["CVSSV3"])
                 if len(cvss_objects) > 0:

--- a/unittests/scans/generic/generic_csv_with_epss.csv
+++ b/unittests/scans/generic/generic_csv_with_epss.csv
@@ -1,0 +1,2 @@
+Date,Title,CweId,epss_score,epss_percentile, Url,Severity,Description,Mitigation,Impact,References,Active,Verified,FalsePositive,Duplicate
+01/30/2018,"Server leaks inodes via ETags, header found with file /, fields: 0xW/109b 0xpqG8TolgxCnpM/7cGOOI0GRS+rc ",0,.00042,.23474,https://192.168.1.1/,Low,"Server leaks inodes via ETags, header found with file /, fields: 0xW/109b 0xpqG8TolgxCnpM/7cGOOI0GRS+rc ",,,,False,False,False,False

--- a/unittests/tools/test_generic_parser.py
+++ b/unittests/tools/test_generic_parser.py
@@ -649,3 +649,12 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             with self.assertRaisesMessage(ValueError,
                     "Not allowed fields are present: ['invalid_field', 'last_status_update']"):
                 parser.get_findings(file, Test())
+
+    def test_parse_csv_with_epss(self):
+        with open("unittests/scans/generic/generic_csv_with_epss.csv", encoding="utf-8") as file:
+            parser = GenericParser()
+            findings = parser.get_findings(file, self.test)
+            self.assertEqual(1, len(findings))
+            finding = findings[0]
+            self.assertEqual(.00042, finding.epss_score)
+            self.assertEqual(.23474, finding.epss_percentile)


### PR DESCRIPTION
epss_score and epss_percentile have been added to the generic parser for csv files
test created to validate that the new headers are read in correctly
documentation on generic parser updated to include the new fields

[sc-9384]