### PR TITLE
Fixing openvas parser and including script_id for openvas and nmap

### DIFF
--- a/dojo/tools/nmap/parser.py
+++ b/dojo/tools/nmap/parser.py
@@ -96,6 +96,7 @@ class NmapParser:
                             "**Extra Info:** {}\n".format(port_element.find("service").attrib["extrainfo"])
                         )
                     description += service_info
+                script_id = None
                 if script := port_element.find("script"):
                     if script_id := script.attrib.get("id"):
                         description += f"**Script ID:** {script_id}\n"
@@ -126,6 +127,7 @@ class NmapParser:
                         severity=severity,
                         mitigation="N/A",
                         impact="No impact provided",
+                        vuln_id_from_tool=script_id,
                     )
                     find.unsaved_endpoints = []
                     dupes[dupe_key] = find

--- a/dojo/tools/openvas/xml_parser.py
+++ b/dojo/tools/openvas/xml_parser.py
@@ -16,6 +16,7 @@ class OpenVASXMLParser:
         report = root.find("report")
         results = report.find("results")
         for result in results:
+            script_id = None
             for finding in result:
                 if finding.tag == "name":
                     title = finding.text
@@ -27,7 +28,8 @@ class OpenVASXMLParser:
                     title = title + "_" + finding.text
                     description.append(f"**Port**: {finding.text}")
                 if finding.tag == "nvt":
-                    description.append(f"**NVT**: {finding.text}")
+                    script_id = finding.get("oid")
+                    description.append(f"**NVT**: {script_id}")
                 if finding.tag == "severity":
                     severity = self.convert_cvss_score(finding.text)
                     description.append(f"**Severity**: {finding.text}")
@@ -38,10 +40,12 @@ class OpenVASXMLParser:
 
             finding = Finding(
                 title=str(title),
+                test=test,
                 description="\n".join(description),
                 severity=severity,
                 dynamic_finding=True,
                 static_finding=False,
+                vuln_id_from_tool=script_id,
             )
             findings.append(finding)
         return findings

--- a/dojo/tools/openvas/xml_parser.py
+++ b/dojo/tools/openvas/xml_parser.py
@@ -28,8 +28,9 @@ class OpenVASXMLParser:
                     title = title + "_" + finding.text
                     description.append(f"**Port**: {finding.text}")
                 if finding.tag == "nvt":
-                    script_id = finding.get("oid")
-                    description.append(f"**NVT**: {script_id}")
+                    script_id = finding.get("oid") or finding.text
+                    text = f"{script_id}\n{finding.text}" if finding.get("oid") and finding.text else script_id
+                    description.append(f"**NVT**: {text}")
                 if finding.tag == "severity":
                     severity = self.convert_cvss_score(finding.text)
                     description.append(f"**Severity**: {finding.text}")
@@ -40,7 +41,6 @@ class OpenVASXMLParser:
 
             finding = Finding(
                 title=str(title),
-                test=test,
                 description="\n".join(description),
                 severity=severity,
                 dynamic_finding=True,

--- a/dojo/tools/openvas/xml_parser.py
+++ b/dojo/tools/openvas/xml_parser.py
@@ -28,9 +28,8 @@ class OpenVASXMLParser:
                     title = title + "_" + finding.text
                     description.append(f"**Port**: {finding.text}")
                 if finding.tag == "nvt":
+                    description.append(f"**NVT**: {finding.text}")
                     script_id = finding.get("oid") or finding.text
-                    text = f"{script_id}\n{finding.text}" if finding.get("oid") and finding.text else script_id
-                    description.append(f"**NVT**: {text}")
                 if finding.tag == "severity":
                     severity = self.convert_cvss_score(finding.text)
                     description.append(f"**Severity**: {finding.text}")


### PR DESCRIPTION
i'm including the script_id from tool to consider in the parser of `nmap` and `openvas` fixing a problem of get the id from openvas parser who get the id by the param of the tag.