### PR TITLE
including test for Finding in xml parser

### DIFF
--- a/dojo/tools/openvas/xml_parser.py
+++ b/dojo/tools/openvas/xml_parser.py
@@ -38,6 +38,7 @@ class OpenVASXMLParser:
 
             finding = Finding(
                 title=str(title),
+                test=test,
                 description="\n".join(description),
                 severity=severity,
                 dynamic_finding=True,


### PR DESCRIPTION
We are facing difficulties saving a finding to later perform the disambiguation of findings into problems, which will summarize a group of findings into a single problem. There are already several parsers from other tools that pass the variable test as a parameter to the Finding class. I believe there should be no issues with doing something like this.
More information here #11432 