### PR TITLE
update changelog, add changelog link to navbar

### DIFF
--- a/docs/config/_default/menus/menus.en.toml
+++ b/docs/config/_default/menus/menus.en.toml
@@ -3,6 +3,11 @@
   url = "/en/about_defectdojo/about_docs/"
   weight = 10
 
+  [[main]]
+  name = "Changelog"
+  url = "/en/changelog/changelog/"
+  weight = 11
+
 [[social]]
   name = "X"
   pre = '<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-brand-x" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M4 4l11.733 16h4.267l-11.733 -16z"></path><path d="M4 20l6.768 -6.768m2.46 -2.46l6.772 -6.772"></path></svg>'

--- a/docs/content/en/changelog/changelog.md
+++ b/docs/content/en/changelog/changelog.md
@@ -7,6 +7,16 @@ Here are the release notes for **DefectDojo Pro (Cloud Version)**. These release
 
 For Open Source release notes, please see the [Releases page on GitHub](https://github.com/DefectDojo/django-DefectDojo/releases), or alternatively consult the Open Source [upgrade notes](../../open_source/upgrading/upgrading_guide).
 
+## Dec 24, 2024: v2.41.3
+
+- **(API)** Added `/request_response_pairs` endpoint.
+- **(Beta UI)** When sorting by Severity, Findings will now be ordered by **severity level** rather than alphabetically.
+- **(Beta UI)** On the Findings table, the Endpoint Hosts column has been replaced with a numerical count of affected Endpoints.
+- **(Beta UI)** On the Findings table, the Vulnerability ID field can now be filtered with "starts_with", "ends_with" filters.
+- **(Beta UI)** Added Edit Test Type form: you can now edit the properties of a custom Test Type to determine if it is Active or Inactive, or a Static Scan or Dynamic Scan Test.
+- **(Beta UI)** Same Tool Deduplication Settings / Test Type field is now searchable.
+- **(Tools)** Qualys HackerGuardian now uses hashcode against "title", "severity", "description" for deduplication.
+- **(Tools)** Horusec scan now uses hashcode against "title", "description", "file_path", and "line" for deduplication.
 
 ## Dec 16, 2024: v2.41.2
 


### PR DESCRIPTION
Adds Pro release notes for 2.41.3, and adds a 'Changelog' link to the documentation navbar to locate the changelog more easily.