### PR TITLE
Make links in the login page visually obvious

### DIFF
--- a/dojo/static/dojo/css/dojo.css
+++ b/dojo/static/dojo/css/dojo.css
@@ -446,6 +446,11 @@ form ul {
     padding-left: 0px
 }
 
+form ul li a#reset-password,
+form ul li a#forgot-username {
+    color: rgb(51, 122, 183)
+}
+
 form ul#id_accepted_findings {
     list-style: none;
     margin-left: 0;

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -34,10 +34,10 @@
                         <div class="col-sm-4">
                             <ul style="list-style-type: none">
                                 {% if FORGOT_PASSWORD %}
-                                    <li><a id="reset-password" style="color: rgb(51, 122, 183)" href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a></li>
+                                    <li><a id="reset-password" href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a></li>
                                 {% endif %}
                                 {% if FORGOT_USERNAME %}
-                                    <li><a id="forgot-username" style="color: rgb(51, 122, 183)" href="{% url 'forgot_username' %}">{% trans "I forgot my username" %}</a></li>
+                                    <li><a id="forgot-username" href="{% url 'forgot_username' %}">{% trans "I forgot my username" %}</a></li>
                                 {% endif %}
                             </ul>
                         </div>

--- a/dojo/templates/dojo/login.html
+++ b/dojo/templates/dojo/login.html
@@ -34,10 +34,10 @@
                         <div class="col-sm-4">
                             <ul style="list-style-type: none">
                                 {% if FORGOT_PASSWORD %}
-                                    <li><a id="reset-password" href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a></li>
+                                    <li><a id="reset-password" style="color: rgb(51, 122, 183)" href="{% url 'password_reset' %}">{% trans "I forgot my password" %}</a></li>
                                 {% endif %}
                                 {% if FORGOT_USERNAME %}
-                                    <li><a id="forgot-username" href="{% url 'forgot_username' %}">{% trans "I forgot my username" %}</a></li>
+                                    <li><a id="forgot-username" style="color: rgb(51, 122, 183)" href="{% url 'forgot_username' %}">{% trans "I forgot my username" %}</a></li>
                                 {% endif %}
                             </ul>
                         </div>


### PR DESCRIPTION
**Page / Screen Title**
Defect Dojo login
**Page URL / Screen ID**
https://demo.defectdojo.org
**Error Title**
Creating links that are not visually evident without color vision
**Error Severity**
Serious
**Status**
Fail
**Accessibility Issue**
[Description of issue] "I forgot my password" and "I forgot my username" are links without underline and its not visually evident without color vision.

[Impact on users] Users may not know that they are links and can be misleading.

[Pattern] Within the login page.

[Sample of code] `<a id="reset-password" href="/password_reset/">I forgot my password</a>`

**Remediation**
[Recommendation] 
Please remove styles on the hyperlinks so that it is visually easy to know that its an hyperlink. 
 
 
[Additional Resources] 
https://www.w3.org/WAI/WCAG21/Techniques/failures/F73
https://www.w3.org/WAI/WCAG21/Techniques/general/G182
