### PR TITLE
Simplify the use of custom NGINX SSL certificates with Docker Compose

### DIFF
--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -143,8 +143,11 @@ RUN env DD_SECRET_KEY='.' python3 manage.py collectstatic --noinput && true
 FROM nginx:1.27.3-alpine@sha256:41523187cf7d7a2f2677a80609d9caa14388bf5c1fbca9c410ba3de602aaaab4
 ARG uid=1001
 ARG appuser=defectdojo
+ARG NGINX_CRT_PATH=""
+ARG NGINX_KEY_PATH=""
 COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf nginx/nginx_TLS.conf /etc/nginx/
+COPY ${NGINX_CRT_PATH:} ${NGINX_KEY_PATH:} /etc/nginx/ssl/
 COPY docker/entrypoint-nginx.sh /
 RUN \
   apk add --no-cache openssl && \

--- a/Dockerfile.nginx-alpine
+++ b/Dockerfile.nginx-alpine
@@ -147,7 +147,7 @@ ARG NGINX_CRT_PATH=""
 ARG NGINX_KEY_PATH=""
 COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf nginx/nginx_TLS.conf /etc/nginx/
-COPY ${NGINX_CRT_PATH:} ${NGINX_KEY_PATH:} /etc/nginx/ssl/
+COPY ${NGINX_CRT_PATH} ${NGINX_KEY_PATH} /etc/nginx/ssl/
 COPY docker/entrypoint-nginx.sh /
 RUN \
   apk add --no-cache openssl && \

--- a/Dockerfile.nginx-debian
+++ b/Dockerfile.nginx-debian
@@ -76,8 +76,11 @@ RUN env DD_SECRET_KEY='.' python3 manage.py collectstatic --noinput && true
 FROM nginx:1.27.3-alpine@sha256:41523187cf7d7a2f2677a80609d9caa14388bf5c1fbca9c410ba3de602aaaab4
 ARG uid=1001
 ARG appuser=defectdojo
+ARG NGINX_CRT_PATH=""
+ARG NGINX_KEY_PATH=""
 COPY --from=collectstatic /app/static/ /usr/share/nginx/html/static/
 COPY wsgi_params nginx/nginx.conf nginx/nginx_TLS.conf /etc/nginx/
+COPY ${NGINX_CRT_PATH} ${NGINX_KEY_PATH} /etc/nginx/ssl/
 COPY docker/entrypoint-nginx.sh /
 RUN \
   apk add --no-cache openssl && \

--- a/docker-compose.override.https.yml
+++ b/docker-compose.override.https.yml
@@ -1,6 +1,11 @@
 ---
 services:
   nginx:
+    build:
+      context: .
+      args:
+        NGINX_CRT_PATH: ''
+        NGINX_KEY_PATH: ''
     environment:
       USE_TLS: 'true'
       GENERATE_TLS_CERTIFICATE: 'true'
@@ -10,6 +15,6 @@ services:
         protocol: tcp
         mode: host
   uwsgi:
-    environment:
-      DD_SESSION_COOKIE_SECURE: 'True'
-      DD_CSRF_COOKIE_SECURE: 'True'
+      environment:
+        DD_SESSION_COOKIE_SECURE: 'True'
+        DD_CSRF_COOKIE_SECURE: 'True'

--- a/readme-docs/DOCKER.md
+++ b/readme-docs/DOCKER.md
@@ -214,14 +214,24 @@ To secure the application by https, follow those steps
 *  Generate a private key without password
 *  Generate a CSR (Certificate Signing Request)
 *  Have the CSR signed by a certificate authority
-*  Place the private key and the certificate under the nginx folder
-*  copy your secrets into ../nginx/nginx_TLS.conf:
+*  Place the private key and the certificate under the `nginx/` folder
+*  copy your secrets into `../nginx/nginx_TLS.conf`:
 ```
         server_name                 your.servername.com;
         ssl_certificate             /etc/nginx/ssl/nginx.crt
         ssl_certificate_key        /etc/nginx/ssl/nginx.key;
 ```
-*set the GENERATE_TLS_CERTIFICATE != True in the docker-compose.override.https.yml 
+* set in the `docker-compose.override.https.yml`
+```
+GENERATE_TLS_CERTIFICATE: 'false'
+```
+* set in the `docker-compose.override.https.yml`
+```
+ NGINX_CRT_PATH: 'nginx/nginx.crt'
+ NGINX_KEY_PATH: 'nginx/nginx.key'
+```
+*or leave both empty if GENERATE_TLS_CERTIFICATE = true
+
 * Protect your private key from other users:
 ```
 chmod 400 nginx/*.key


### PR DESCRIPTION
Instead of manually copying custom user certificates into the image for SSL usage, the arguments `NGINX_CRT_PATH` and `NGINX_KEY_PATH` have been added to simplify the process. These arguments enable automatic handling of certificates when `GENERATE_TLS_CERTIFICATE` is set to false. Providing the paths to the certificate and key through these arguments simplifies the setup, or they can be left empty to use the default certificate generation.