### PR TITLE
Match all unchanged findings on reimport

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -204,11 +204,11 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             deduplicationLogger.debug(f"found {len(matched_findings)} findings matching with current new finding")
             # Determine how to proceed based on whether matches were found or not
             if matched_findings:
-                existing_finding = matched_findings[0]
-                finding, force_continue = self.process_matched_finding(
-                    unsaved_finding,
-                    existing_finding,
-                )
+                for existing_finding in matched_findings:
+                    finding, force_continue = self.process_matched_finding(
+                        unsaved_finding,
+                        existing_finding,
+                    )
                 # Determine if we should skip the rest of the loop
                 if force_continue:
                     continue

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -209,19 +209,23 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                         unsaved_finding,
                         existing_finding,
                     )
-                # Determine if we should skip the rest of the loop
-                if force_continue:
-                    continue
-                # Update endpoints on the existing finding with those on the new finding
-                if finding.dynamic_finding:
-                    logger.debug(
-                        "Re-import found an existing dynamic finding for this new "
-                        "finding. Checking the status of endpoints",
-                    )
-                    self.endpoint_manager.update_endpoint_status(
-                        existing_finding,
-                        unsaved_finding,
-                        self.user,
+                    # Determine if we should skip the rest of the loop
+                    if force_continue:
+                        continue
+
+                    last_existing_finding = existing_finding
+
+                if last_existing_finding is not None:
+                    # Update endpoints on the existing finding with those on the new finding
+                    if finding.dynamic_finding:
+                        logger.debug(
+                            "Re-import found an existing dynamic finding for this new "
+                            "finding. Checking the status of endpoints",
+                        )
+                        self.endpoint_manager.update_endpoint_status(
+                            last_existing_finding,
+                            unsaved_finding,
+                            self.user,
                     )
             else:
                 finding = self.process_finding_that_was_not_matched(unsaved_finding)


### PR DESCRIPTION
This is a proposed fix of https://github.com/DefectDojo/django-DefectDojo/issues/3958
Currently when reimporting, only the first matching vulnerability is added to the list of unchanged items. So if there are 2 or more vulnerabilities with the same hash, only the first one will be considered unchanged. Rest of them will get mitigated. With this change all the matching vulnerabilities will be considered unchanged.

I tested several scenarios:
1. Report with duplicated vulns A and B was added and then reimported without changes: no findings were mitigated
2. After first reimport, other one was sent with only vulnerability A in the report: no findings were affected
3. Then the report without any of those findings was sent with reimport: all the findings got mitigated
4. After that I sent again report with finding A and all the duplicates were reactivated

I think this is how it should work, but I may miss some edge case.
About the dynamic finding - I wrote it to update only from the last one, I'm not sure what is it updating exactly but I suspect it shouldn't be called 2 times, the last one is enough.