### PR TITLE
Add imageTags to AWS SecurityHub and Inspector2 parsers

### DIFF
--- a/dojo/tools/aws_inspector2/parser.py
+++ b/dojo/tools/aws_inspector2/parser.py
@@ -221,6 +221,7 @@ class AWSInspector2Parser:
                             f"Hash: {ecr_image_details.get('imageHash', 'N/A')}",
                             f"Author: {ecr_image_details.get('author', 'N/A')}",
                             f"Pushed at: {ecr_image_details.get('pushedAt', 'N/A')}",
+                            f"Image tags: {','.join(ecr_image_details.get('imageTags', []))}",
                             "---",
                         ),
                     )

--- a/dojo/tools/awssecurityhub/compliance.py
+++ b/dojo/tools/awssecurityhub/compliance.py
@@ -52,6 +52,7 @@ class Compliance:
                         f"Registry: {details.get('RegistryId')}",
                         f"Repository: {details.get('RepositoryName')}",
                         f"Image digest: {details.get('ImageDigest')}",
+                        f"Image tags: {','.join(details.get('ImageTags', []))}",
                     ))
                 title_suffix = f" - Image: {arn.split('/', 1)[1]}"  # repo-name/sha256:digest
             else:  # generic implementation

--- a/dojo/tools/awssecurityhub/guardduty.py
+++ b/dojo/tools/awssecurityhub/guardduty.py
@@ -53,6 +53,7 @@ class GuardDuty:
                         f"Registry: {details.get('RegistryId')}",
                         f"Repository: {details.get('RepositoryName')}",
                         f"Image digest: {details.get('ImageDigest')}",
+                        f"Image tags: {','.join(details.get('ImageTags', []))}",
                     ))
                 title_suffix = f" - Image: {arn.split('/', 1)[1]}"  # repo-name/sha256:digest
             else:  # generic implementation

--- a/dojo/tools/awssecurityhub/inspector.py
+++ b/dojo/tools/awssecurityhub/inspector.py
@@ -64,6 +64,7 @@ class Inspector:
                         f"Registry: {details.get('RegistryId')}",
                         f"Repository: {details.get('RepositoryName')}",
                         f"Image digest: {details.get('ImageDigest')}",
+                        f"Image tags: {','.join(details.get('ImageTags', []))}",
                     ))
                 title_suffix = f" - Image: {arn.split('/', 1)[1]}"  # repo-name/sha256:digest
             else:  # generic implementation


### PR DESCRIPTION
In the impact section of both parsers, the ImageTags (and imageTags respectively) portion was not being captured. This now captures the imageTags as a comma-separated string for the Impact section of the Finding.

[sc-9381]