### PR TITLE
Kubescape: Reduce the size of steps to reproduce

### DIFF
--- a/dojo/tools/kubescape/parser.py
+++ b/dojo/tools/kubescape/parser.py
@@ -98,8 +98,6 @@ class KubescapeParser:
 
                         steps_to_reproduce = "The following rules have failed :" + "\n"
                         steps_to_reproduce += "\t**Rules:** " + str(json.dumps(control["rules"], indent=4)) + "\n"
-                        steps_to_reproduce += "Resource object may contain evidence:" + "\n"
-                        steps_to_reproduce += "\t**Resource object:** " + str(json.dumps(resource["object"], indent=4))
 
                         find = Finding(
                             title=textwrap.shorten(title, 150),


### PR DESCRIPTION
- This is a change on the kubescape parser
- It removes the resource objects (a whole manifest) from "steps to reproduce" as it is often so long (thousands of lines) that conflicts with the default Jira configurations of maximum accepted length of fields, resulting on the failing to create a Jira ticket via the Defect Dojo integration
- Note that also, there is arguably little value on storing this very large objects on the database (for duplicate and original findings)
- Potentially, the Jira integration should validate that, but that isn't possibly the case