### PR TITLE
Prefetching multiple endpoints should return all prefetch models

### DIFF
--- a/dojo/api_v2/prefetch/mixins.py
+++ b/dojo/api_v2/prefetch/mixins.py
@@ -6,7 +6,9 @@ from .prefetcher import _Prefetcher
 
 class PrefetchListMixin(ListModelMixin):
     def list(self, request, *args, **kwargs):
-        prefetch_params = request.GET.getlist("prefetch")
+        prefetch_params = request.GET.get("prefetch", "")
+        prefetch_params = prefetch_params.split(",") if "," in prefetch_params else request.GET.getlist("prefetch")
+
         prefetcher = _Prefetcher()
 
         # Apply the same operations as the standard list method defined in the
@@ -30,7 +32,9 @@ class PrefetchListMixin(ListModelMixin):
 
 class PrefetchRetrieveMixin(RetrieveModelMixin):
     def retrieve(self, request, *args, **kwargs):
-        prefetch_params = request.GET.getlist("prefetch")
+        prefetch_params = request.GET.get("prefetch", "")
+        prefetch_params = prefetch_params.split(",") if "," in prefetch_params else request.GET.getlist("prefetch")
+
         prefetcher = _Prefetcher()
 
         entry = self.get_object()

--- a/dojo/api_v2/prefetch/mixins.py
+++ b/dojo/api_v2/prefetch/mixins.py
@@ -6,7 +6,7 @@ from .prefetcher import _Prefetcher
 
 class PrefetchListMixin(ListModelMixin):
     def list(self, request, *args, **kwargs):
-        prefetch_params = request.GET.get("prefetch", "").split(",")
+        prefetch_params = request.GET.getlist("prefetch")
         prefetcher = _Prefetcher()
 
         # Apply the same operations as the standard list method defined in the
@@ -30,7 +30,7 @@ class PrefetchListMixin(ListModelMixin):
 
 class PrefetchRetrieveMixin(RetrieveModelMixin):
     def retrieve(self, request, *args, **kwargs):
-        prefetch_params = request.GET.get("prefetch", "").split(",")
+        prefetch_params = request.GET.getlist("prefetch")
         prefetcher = _Prefetcher()
 
         entry = self.get_object()


### PR DESCRIPTION
When attempting a prefetch with multiple parameters, the response would only return one of the prefetch parameters. 

[sc-6144]