### PR TITLE
fix(doc): Fix order for upgrade notes

### DIFF
--- a/docs/content/en/open_source/upgrading/2.42.md
+++ b/docs/content/en/open_source/upgrading/2.42.md
@@ -1,7 +1,7 @@
 ---
 title: 'Upgrading to DefectDojo Version 2.42.x'
 toc_hide: true
-weight: -20241104
+weight: -20241202
 description: No special instructions.
 ---
 There are no special instructions for upgrading to 2.42.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/2.42.0) for the contents of the release.


### PR DESCRIPTION
Fix the order of notes

Before change: 
![image](https://github.com/user-attachments/assets/f4036d01-00a5-45c5-ad42-23591e43d406)
