### PR TITLE
Added accessibility for the pagination snippet

### DIFF
--- a/dojo/templates/dojo/paging_snippet.html
+++ b/dojo/templates/dojo/paging_snippet.html
@@ -10,15 +10,15 @@
     {% endblocktrans %}
 </div>
 
-<nav class="pull-right">
+<nav class="pull-right" aria-label="Pagination navigation">
     <ul class="pagination pagination-sm">
             {% if page.has_other_pages %}
                 {% for num in page|paginate:5 %}
                     <li {% if num.is_current %}class="active"{% endif %}>
                         {% if num.page_number %}
-                            <a href="?{% url_replace request page_param num.page_number %}"> {{ num.display }}</a>
+                            <a href="?{% url_replace request page_param num.page_number %}" aria-label="{% trans 'Page' %} {{ num.display }}"> {{ num.display }}</a>
                         {% else %}
-                            <a>{{ num.display }}</a>
+                            <a href="#" role="presentation" aria-disabled="true" tabindex="-1">{{ num.display }}</a>
                         {% endif %}
                     </li>
                 {% endfor %}
@@ -28,21 +28,21 @@
                     <!-- Split button -->
                     &nbsp;
                     <div class="btn-group">
-                        <button type="button" class="btn-sm btn-secondary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <button data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="{% trans 'Page size selector' %}" id="pageSizeDropdown" class="btn-sm btn-secondary dropdown-toggle" type="button">
                             {% trans "Page Size" %}
                             <span class="caret"></span>
                             <span class="sr-only">{% trans "Toggle Dropdown" %}</span>
                         </button>
-                        <ul class="dropdown-menu">
-                            <li><a href="?{% url_replace request page_size_param 25 %}">25</a></li>
-                            <li><a href="?{% url_replace request page_size_param 50 %}">50</a></li>
-                            <li><a href="?{% url_replace request page_size_param 75 %}">75</a></li>
-                            <li><a href="?{% url_replace request page_size_param 100 %}">100</a></li>
-                            <li><a href="?{% url_replace request page_size_param 150 %}">150</a></li>
+                        <ul class="dropdown-menu" role="menu" aria-labelledby="pageSizeDropdown">
+                            <li role="presentation"><a href="?{% url_replace request page_size_param 25 %}" aria-label="{% trans '25 items per page' %}" role="menuitem">25</a></li>
+                            <li role="presentation"><a href="?{% url_replace request page_size_param 50 %}" aria-label="{% trans '50 items per page' %}" role="menuitem">50</a></li>
+                            <li role="presentation"><a href="?{% url_replace request page_size_param 75 %}" aria-label="{% trans '75 items per page' %}" role="menuitem" >75</a></li>
+                            <li role="presentation"><a href="?{% url_replace request page_size_param 100 %}" aria-label="{% trans '100 items per page' %}" role="menuitem">100</a></li>
+                            <li role="presentation"><a href="?{% url_replace request page_size_param 150 %}" aria-label="{% trans '150 items per page' %}" role="menuitem">150</a></li>
                             {% if page.paginator.count > 500 %}
-                                <li><a href="?{% url_replace request page_size_param 500 %}">500</a></li>
+                                <li role="presentation"><a href="?{% url_replace request page_size_param 500 %}" aria-label="{% trans '500 items per page' %}" role="menuitem" >500</a></li>
                             {% endif %}
-                            <li><a href="?{% url_replace request page_size_param page.paginator.count %}">{% trans "All" %}</a></li>
+                            <li role="presentation"><a href="?{% url_replace request page_size_param page.paginator.count %}" aria-label="{% trans 'All items per page' %}" role="menuitem">{% trans "All" %}</a></li>
                         </ul>
                     </div>
                 </li>

--- a/dojo/templates/dojo/paging_snippet.html
+++ b/dojo/templates/dojo/paging_snippet.html
@@ -18,7 +18,7 @@
                         {% if num.page_number %}
                             <a href="?{% url_replace request page_param num.page_number %}" aria-label="{% trans 'Page' %} {{ num.display }}"> {{ num.display }}</a>
                         {% else %}
-                            <a href="#" role="presentation" aria-disabled="true" tabindex="-1">{{ num.display }}</a>
+                            <a role="presentation" aria-disabled="true" tabindex="-1">{{ num.display }}</a>
                         {% endif %}
                     </li>
                 {% endfor %}
@@ -42,7 +42,7 @@
                             {% if page.paginator.count > 500 %}
                                 <li role="presentation"><a href="?{% url_replace request page_size_param 500 %}" aria-label="{% trans '500 items per page' %}" role="menuitem" >500</a></li>
                             {% endif %}
-                            <li role="presentation"><a href="?{% url_replace request page_size_param page.paginator.count %}" aria-label="{% trans 'All items per page' %}" role="menuitem">{% trans "All" %}</a></li>
+                            <li role="presentation"><a href="?{% url_replace request page_size_param page.paginator.count %}" aria-label="{% trans 'All items on one page' %}" role="menuitem">{% trans "All" %}</a></li>
                         </ul>
                     </div>
                 </li>


### PR DESCRIPTION
Fixes #11590

The respective nav section is recognised under the aria-label "Pagination navigation". 

The current page has assigned value `aria-disabled true` with `tabindex -1` for better navigation. Instead of "1", "2", "3"... screen reader says "Page 1" / "Page 2" etc...  When using page size dropdown button, user will hear "xyz items per page" instead of just a number.

`<li>` elements are assigned presentation role and their nested `<a>` elements are assigned to menuitem role for more intuitive orientation with keyboard. 

![Screenshot 2025-01-17 at 16 41 13](https://github.com/user-attachments/assets/ebb55867-bffb-41f8-817d-41ff643ab49b)
