### PR TITLE
View Alerts: Sanitize and mark safe

### DIFF
--- a/dojo/templates/dojo/alerts.html
+++ b/dojo/templates/dojo/alerts.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% load i18n %}
 {% load static %}
+{% load display_tags %}
 {% block content %}
     {{ block.super }}
     <div class="row">
@@ -28,7 +29,7 @@
                                 <td class="text-center"><i class="fa-solid fa-{{ alert.icon }} fa-fw"></i></td>
                                 <td class="text-center">{{ alert.source }}</td>
                                 <td>{%if alert.url %}<a href="{{ alert.url }}">{% endif %}{{ alert.title }}{% if alert.url %}</a>{% endif %}</td>
-                                <td>{{ alert.description|linebreaks }}</td>
+                                <td>{{ alert.description|markdown_render|linebreaks }}</td>
                                 <td>{{ alert.created }}</td>
                                 <td class="centered">
                                         <input type="checkbox" name="alert_select" value="{{ alert.id }}"


### PR DESCRIPTION
Alerts are being HTML escaped in places where they should not be. Rather on relying on the default HTML escaping, we should use the markdown bleaching templatetag to allow for more options in object titles. Here is a before and after of an innocuous alert vs a dangerous one (no xss triggered here). 

Before: 
<img width="1177" alt="Screenshot 2025-01-17 at 2 23 43 PM" src="https://github.com/user-attachments/assets/2f0992c3-49bc-40af-89e3-ef5c1f2f2959" />

After:
<img width="1177" alt="Screenshot 2025-01-17 at 2 23 56 PM" src="https://github.com/user-attachments/assets/7dbe5d3e-3b4b-46ca-8090-2a91d5df99db" />

[sc-9944]
