### PR TITLE
Fix Webhook notification test

### DIFF
--- a/dojo/notifications/views.py
+++ b/dojo/notifications/views.py
@@ -11,7 +11,7 @@ from django.views import View
 
 from dojo.forms import DeleteNotificationsWebhookForm, NotificationsForm, NotificationsWebhookForm
 from dojo.models import Notification_Webhooks, Notifications
-from dojo.notifications.helper import NotificationManagerHelpers
+from dojo.notifications.helper import NotificationManagerHelpers, WebhookNotificationManger
 from dojo.utils import add_breadcrumb, get_enabled_notifications_list, get_system_setting
 
 logger = logging.getLogger(__name__)
@@ -58,11 +58,7 @@ class SystemNotificationsView(View):
     def process_form(self, request: HttpRequest, context: dict):
         if context["form"].is_valid():
             context["form"].save()
-            messages.add_message(
-                request,
-                messages.SUCCESS,
-                _("Settings saved."),
-                extra_tags="alert-success")
+            messages.add_message(request, messages.SUCCESS, _("Settings saved."), extra_tags="alert-success")
             return request, True
         return request, False
 
@@ -135,9 +131,8 @@ class TemplateNotificationsView(SystemNotificationsView):
 
 
 class NotificationWebhooksView(View):
-
-    def get_webhook_manager_instance(self) -> type[NotificationManagerHelpers]:
-        return Notification_Webhooks()
+    def get_webhook_manager_instance(self) -> NotificationManagerHelpers:
+        return WebhookNotificationManger()
 
     def check_webhooks_enabled(self):
         if not get_system_setting("enable_webhooks_notifications"):
@@ -219,7 +214,7 @@ class AddNotificationWebhooksView(NotificationWebhooksView):
         form = context["form"]
         if form.is_valid():
             try:
-                self.get_webhook_manager_instance().test_webhooks_notification(form.instance)
+                self.get_webhook_manager_instance()._test_webhooks_notification(form.instance)
             except requests.exceptions.RequestException as e:
                 messages.add_message(
                     request,
@@ -299,22 +294,23 @@ class EditNotificationWebhooksView(NotificationWebhooksView):
             nwh.note = "Deactivate from UI"
             nwh.save()
             messages.add_message(
-                                    request,
-                                    messages.SUCCESS,
-                                    _("Notification Webhook deactivated successfully."),
-                                    extra_tags="alert-success",
-                                )
+                request,
+                messages.SUCCESS,
+                _("Notification Webhook deactivated successfully."),
+                extra_tags="alert-success",
+            )
             return request, True
 
         if form.is_valid():
             try:
-                self.get_webhook_manager_instance().test_webhooks_notification(form.instance)
+                self.get_webhook_manager_instance()._test_webhooks_notification(form.instance)
             except requests.exceptions.RequestException as e:
                 messages.add_message(
                     request,
                     messages.ERROR,
                     _("Test of endpoint was not successful: %(error)s") % {"error": str(e)},
-                    extra_tags="alert-danger")
+                    extra_tags="alert-danger",
+                )
                 return request, False
             else:
                 # correct definition reset defaults


### PR DESCRIPTION
**Description**

Adding a Webhook notification was producing this error:

![image](https://github.com/user-attachments/assets/9579ddbe-166e-4966-9e3f-78ff9135fe9c)

It appears that the `get_webhook_manager_instance` method was intended to return a `WebhookNotificationManger` but maybe there was a typo. With this fix, the test "ping" runs successfully again.

![Screenshot 2025-01-23 at 13 01 04](https://github.com/user-attachments/assets/6bb33630-abd1-4acd-a7ca-26de57599c53)
![Screenshot 2025-01-23 at 13 00 07](https://github.com/user-attachments/assets/0b74e379-a686-4998-95b4-b09d50261963)

Ruff also auto-fixed some code styling in this file...
