### PR TITLE
Import History: Make the absence of action more clear

### DIFF
--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -274,6 +274,8 @@
                                             {% for action in finding_action_list %}
                                                 {{ action.list|length }} {{ action.grouper }}
                                                 {% if not forloop.last %},{% endif %}
+                                            {% empty %}
+                                                There were no findings created, closed, or modified
                                             {% endfor %}
                                         </a>
                                     </td>


### PR DESCRIPTION
In the event an empty report is submitted, and there are no findings to be closed, the test_import_finding_action_set will be empty. When viewing import history objects, there is no indication as to what occurred. 

<img width="1408" alt="image" src="https://github.com/user-attachments/assets/0bcf07df-be79-49b7-b1ad-90e1533c8dbc" />

[sc-9738]