### PR TITLE
Remove makemigrations from scripts

### DIFF
--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -16,7 +16,7 @@ initialize_data()
     python3 manage.py initialize_permissions
 }
 
-create_announcement_banner() 
+create_announcement_banner()
 {
 # Load the announcement banner
 if [ -z "$DD_CREATE_CLOUD_BANNER" ]; then
@@ -103,8 +103,26 @@ then
   exit 47
 fi
 
-echo "Making migrations"
-python3 manage.py makemigrations dojo
+
+python3 manage.py makemigrations --no-input --check --dry-run --verbosity 3 || {
+    cat <<-EOF
+
+********************************************************************************
+
+You made changes to the models without creating a DB migration for them.
+
+**NEVER** change existing migrations, create a new one.
+
+If you're not familiar with migrations in Django, please read the
+great documentation thoroughly:
+https://docs.djangoproject.com/en/5.0/topics/migrations/
+
+********************************************************************************
+
+EOF
+    exit 1
+}
+
 echo "Migrating"
 python3 manage.py migrate
 
@@ -139,7 +157,7 @@ fi
 if [ -z "${ADMIN_EXISTS}" ]
 then
   . /entrypoint-first-boot.sh
-    
+
   create_announcement_banner
   initialize_data
 fi

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -18,7 +18,25 @@ unset DD_CELERY_BROKER_URL
 
 wait_for_database_to_be_reachable
 
-python3 manage.py makemigrations dojo
+python3 manage.py makemigrations --no-input --check --dry-run --verbosity 3 || {
+    cat <<-EOF
+
+********************************************************************************
+
+You made changes to the models without creating a DB migration for them.
+
+**NEVER** change existing migrations, create a new one.
+
+If you're not familiar with migrations in Django, please read the
+great documentation thoroughly:
+https://docs.djangoproject.com/en/5.0/topics/migrations/
+
+********************************************************************************
+
+EOF
+    exit 1
+}
+
 python3 manage.py migrate
 
 # do the check with Django stack
@@ -56,10 +74,10 @@ echo "------------------------------------------------------------"
 
 # Removing parallel and shuffle for now to maintain stability
 python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
-    exit 1; 
+    exit 1;
 }
 python3 manage.py test unittests -v 3 --keepdb --no-input --tag="non-parallel" || {
-    exit 1; 
+    exit 1;
 }
 
 # you can select a single file to "test" unit tests

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -64,7 +64,7 @@ You made changes to the models without creating a DB migration for them.
 
 If you're not familiar with migrations in Django, please read the
 great documentation thoroughly:
-https://docs.djangoproject.com/en/1.11/topics/migrations/
+https://docs.djangoproject.com/en/5.0/topics/migrations/
 
 ********************************************************************************
 
@@ -82,8 +82,8 @@ echo "------------------------------------------------------------"
 
 # Removing parallel and shuffle for now to maintain stability
 python3 manage.py test unittests -v 3 --keepdb --no-input --exclude-tag="non-parallel" || {
-    exit 1; 
+    exit 1;
 }
 python3 manage.py test unittests -v 3 --keepdb --no-input --tag="non-parallel" || {
-    exit 1; 
+    exit 1;
 }

--- a/docker/unit-tests.sh
+++ b/docker/unit-tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Run available unittests with a simple setup
+cd /app || exit
+python manage.py makemigrations dojo
+python manage.py migrate
+python manage.py test unittests -v 2

--- a/docker/unit-tests.sh
+++ b/docker/unit-tests.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Run available unittests with a simple setup
-cd /app || exit
-python manage.py makemigrations dojo
-python manage.py migrate
-python manage.py test unittests -v 2

--- a/readme-docs/CONTRIBUTING.md
+++ b/readme-docs/CONTRIBUTING.md
@@ -65,6 +65,12 @@ For changes that require additional settings, you can now use local_settings.py 
 ## Python3 Version
 For compatibility reasons, the code in dev branch should be python3.11 compliant.
 
+## Database migrations
+When changes are made to the database model, a database migration is needed. This migration can be generated using something like
+`docker compose exec uwsgi bash -c "python manage.py makemigrations"`.
+This will result in a new file in the `dojo/db_migrations` folder that can be committed to `git`
+When making downstream database model changes in your fork of Defect Dojo please be aware of the risks of getting out of sync with our upstream migrations.
+It requiers proper knowledge of [Django Migrations](https://docs.djangoproject.com/en/5.0/topics/migrations/) to reconcile the migrations before you can upgrade to a newer version of Defect Dojo.
 
 ## Submitting Pull Requests
 


### PR DESCRIPTION
**Description**
Historically the `initializer` and other scripts automatically made new migration files for any changes made to the database model. This is practical for (first time) users making modifications to the Defect Dojo codebase.

But when these migrations end up in production or even staging environments, it may prevent these user from ever being able to upgrade to new upstream releases.

It's possible to merge custom migration with upstream migrations and keep upgrading to newer upstream Defect Dojo releases. But this requires a bit of Django knowledge, which users might not realize until they're stuck in production with an out of sync data model.

This PR (suggests to) remove(s) the `makemigrations` step and instead warns the users if the datamodel was changed without proper/versioned migrations. This makes users aware of the risks and make a more conscious decision about having custom migrations which could diverge from official Defect Dojo releases.

The PR also adds a bit of documentation to explain how to generate new migrations. 

**Test results**
It just works ;-)

**Documentation**

Please update any documentation when needed in the [documentation folder](https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs))

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is flake8 compliant.
- [x] Your code is python 3.11 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [x] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.

**Extra information**

Possibly we could go one step further and let the defect dojo startup script fail if there are changes detected in the datamodel that have no migrations.