### PR TITLE
Jira Template: Do not HTML encode before shipping to jira

### DIFF
--- a/dojo/templates/issue-trackers/jira_full/jira-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-description.tpl
@@ -72,26 +72,26 @@
 {% endif %}
 
 *Description*:
-{{ finding.description }}
+{{ finding.description|safe }}
 
 {% if finding.mitigation %}
 *Mitigation*:
-{{ finding.mitigation }}
+{{ finding.mitigation|safe }}
 {% endif %}
 
-{% if finding.impact %}
+{% if finding.impact|safe %}
 *Impact*:
 {{ finding.impact }}
 {% endif %}
 
 {% if finding.steps_to_reproduce %}
 *Steps to reproduce*:
-{{ finding.steps_to_reproduce }}
+{{ finding.steps_to_reproduce|safe }}
 {% endif %}
 
 {% if finding.references %}
 *References*:
-{{ finding.references }}
+{{ finding.references|safe }}
 {% endif %}
 
 *Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]

--- a/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
+++ b/dojo/templates/issue-trackers/jira_full/jira-finding-group-description.tpl
@@ -66,26 +66,26 @@ h3. [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]
 {% endif %}
 
 *Description*:
-{{ finding.description }}
+{{ finding.description|safe }}
 
 {% if finding.mitigation %}
 *Mitigation*:
-{{ finding.mitigation }}
+{{ finding.mitigation|safe }}
 {% endif %}
 
 {% if finding.impact %}
 *Impact*:
-{{ finding.impact }}
+{{ finding.impact|safe }}
 {% endif %}
 
 {% if finding.steps_to_reproduce %}
 *Steps to reproduce*:
-{{ finding.steps_to_reproduce }}
+{{ finding.steps_to_reproduce|safe }}
 {% endif %}
 
 {% if finding.references %}
 *References*:
-{{ finding.references }}
+{{ finding.references|safe }}
 {% endif %}
 
 *Reporter:* [{{ finding.reporter|full_name}} ({{ finding.reporter.email }})|mailto:{{ finding.reporter.email }}]


### PR DESCRIPTION
In cases when a finding has `"` (very prevalent with JSON blobs) the final body submitted to jira looks something like this:
```
{
    &quot;findings&quot;: [
        {
            &quot;title&quot;: &quot;test title3&quot;,
            &quot;description&quot;: &quot;Some very long description with\n\n some UTF-8 chars à qu&#x27;il est beau&quot;,
            &quot;severity&quot;: &quot;Medium&quot;
        }
    ]
}
```
The reason for this is because of the HTML escaping from the `render_to_string` is tampering with the contents of the finding. To mitigate this, applying the `safe` template tag to mark the contents of the finding as "not to be touched" allows for the contents to be shipped to jira without issue. This `safe` template tag can be a scary thing as it may welcome some malicious opportunities if used irresponsibly, but as we are shipping the contents straight to jira, we are offloading the final contents to jira.

[sc-9870]