### PR TITLE
feat(db-checker): Extension of "db reachable"

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -85,7 +85,7 @@ jobs:
                ./helm/defectdojo \
                --set django.ingress.enabled=true \
                --set imagePullPolicy=Never \
-               --set initializer.keepSeconds="x" \
+               --set initializer.keepSeconds="-1" \
                ${{ env[matrix.databases] }} \
                ${{ env[matrix.brokers] }} \
                --set createSecret=true \

--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -85,6 +85,7 @@ jobs:
                ./helm/defectdojo \
                --set django.ingress.enabled=true \
                --set imagePullPolicy=Never \
+               --set initializer.keepSeconds="x" \
                ${{ env[matrix.databases] }} \
                ${{ env[matrix.brokers] }} \
                --set createSecret=true \

--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e  # needed to handle "exit" correctly
+
 . /reach_database.sh
 
 umask 0002
@@ -7,7 +9,7 @@ umask 0002
 id
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null || true)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo "$FILES" | tr -s '[:blank:]' ', ')

--- a/docker/entrypoint-celery-beat.sh
+++ b/docker/entrypoint-celery-beat.sh
@@ -2,6 +2,7 @@
 
 set -e  # needed to handle "exit" correctly
 
+. /secret-file-loader.sh
 . /reach_database.sh
 
 umask 0002

--- a/docker/entrypoint-celery-worker.sh
+++ b/docker/entrypoint-celery-worker.sh
@@ -3,11 +3,13 @@ umask 0002
 
 id
 
+set -e  # needed to handle "exit" correctly
+
 . /secret-file-loader.sh
 . /reach_database.sh
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null || true)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo "$FILES" | tr -s '[:blank:]' ', ')

--- a/docker/entrypoint-initializer.sh
+++ b/docker/entrypoint-initializer.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e  # needed to handle "exit" correctly
+
 . /secret-file-loader.sh
 . /reach_database.sh
 
@@ -40,7 +42,7 @@ fi
 }
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null || true)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo "$FILES" | tr -s '[:blank:]' ', ')
@@ -127,7 +129,7 @@ echo "Migrating"
 python3 manage.py migrate
 
 echo "Admin user: ${DD_ADMIN_USER}"
-ADMIN_EXISTS=$(echo "SELECT * from auth_user;" | python manage.py dbshell | grep "${DD_ADMIN_USER}")
+ADMIN_EXISTS=$(echo "SELECT * from auth_user;" | python manage.py dbshell | grep "${DD_ADMIN_USER}" || true)
 # Abort if the admin user already exists, instead of giving a new fake password that won't work
 if [ -n "$ADMIN_EXISTS" ]
 then

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e  # needed to handle "exit" correctly
+
 . /secret-file-loader.sh
 
 echo "Testing DefectDojo Service"

--- a/docker/entrypoint-nginx.sh
+++ b/docker/entrypoint-nginx.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e  # needed to handle "exit" correctly
+
 umask 0002
 if [ "${GENERATE_TLS_CERTIFICATE}" = true ]; then
   openssl req  \

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -3,9 +3,8 @@
 # - Fail if migrations are not created
 # - Exit container after running tests to allow exit code to propagate as test result
 # set -x
-# set -e
+set -e
 # set -v
-
 
 . /secret-file-loader.sh
 . /reach_database.sh

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e  # needed to handle "exit" correctly
+
 . /secret-file-loader.sh
 
 

--- a/docker/entrypoint-uwsgi-dev.sh
+++ b/docker/entrypoint-uwsgi-dev.sh
@@ -3,7 +3,10 @@
 set -e  # needed to handle "exit" correctly
 
 . /secret-file-loader.sh
+. /reach_database.sh
 
+wait_for_database_to_be_reachable
+echo
 
 cd /app || exit
 

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -3,6 +3,7 @@
 set -e  # needed to handle "exit" correctly
 
 . /secret-file-loader.sh
+. /reach_database.sh
 
 # Allow for bind-mount multiple settings.py overrides
 FILES=$(ls /app/docker/extra_settings/* 2>/dev/null || true)
@@ -16,6 +17,9 @@ if [ "$NUM_FILES" -gt 0 ]; then
     cp /app/docker/extra_settings/* /app/dojo/settings/
     rm -f /app/dojo/settings/README.md
 fi
+
+wait_for_database_to_be_reachable
+echo
 
 umask 0002
 

--- a/docker/entrypoint-uwsgi.sh
+++ b/docker/entrypoint-uwsgi.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+set -e  # needed to handle "exit" correctly
+
 . /secret-file-loader.sh
 
 # Allow for bind-mount multiple settings.py overrides
-FILES=$(ls /app/docker/extra_settings/* 2>/dev/null)
+FILES=$(ls /app/docker/extra_settings/* 2>/dev/null || true)
 NUM_FILES=$(echo "$FILES" | wc -w)
 if [ "$NUM_FILES" -gt 0 ]; then
     COMMA_LIST=$(echo "$FILES" | tr -s '[:blank:]' ', ')

--- a/docker/reach_database.sh
+++ b/docker/reach_database.sh
@@ -6,11 +6,22 @@ wait_for_database_to_be_reachable() {
     DD_DATABASE_READINESS_TIMEOUT=${DD_DATABASE_READINESS_TIMEOUT:-30}
     until echo "select 1;" | python3 manage.py dbshell > /dev/null
     do 
-    echo -n "."
-    failure_count=$((failure_count + 1)) 
-    sleep 1
-    if [ $DD_DATABASE_READINESS_TIMEOUT = $failure_count ]; then
-        exit 1
-    fi
+        echo -n "."
+        failure_count=$((failure_count + 1)) 
+        sleep 1
+        if [ $DD_DATABASE_READINESS_TIMEOUT = $failure_count ]; then
+            exit 1
+        fi
     done
+    cat <<EOD | python manage.py shell
+from django.db import connections
+connections['default'].cursor()
+EOD
+    DB_TEST=$?
+    if [[ $DB_TEST -ne 0 ]]; then
+        echo "Simple database test failed with $DB_TEST"
+    else
+        echo "Simple database test was successful"
+    fi
+    return $DB_TEST 
 }

--- a/docker/unit-tests.sh
+++ b/docker/unit-tests.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e  # needed to handle "exit" correctly
 # Run available unittests with a simple setup
 cd /app || exit
 python manage.py makemigrations dojo


### PR DESCRIPTION
Reopen #10497

Extend `wait_for_database_to_be_reachable`. Not only for simple operation but check that DB is compatible.

Added based on https://github.com/DefectDojo/django-DefectDojo/issues/10490

This PR also contains changes from #11650 because they are needed for proper testing of this functionality.