### PR TITLE
fix(dockerfile): rename django stage in alpine

### DIFF
--- a/Dockerfile.django-alpine
+++ b/Dockerfile.django-alpine
@@ -31,7 +31,7 @@ COPY requirements.txt ./
 # https://github.com/unbit/uwsgi/issues/1318#issuecomment-542238096
 RUN CPUCOUNT=1 pip3 wheel --wheel-dir=/tmp/wheels -r ./requirements.txt
 
-FROM base AS django-alpine
+FROM base AS django
 WORKDIR /app
 ARG uid=1001
 ARG gid=1337
@@ -135,5 +135,5 @@ ENV \
   DD_UWSGI_NUM_OF_THREADS="2"
 ENTRYPOINT ["/entrypoint-uwsgi.sh"]
 
-FROM django-alpine AS django-unittests
+FROM django AS django-unittests
 COPY unittests/ ./unittests/


### PR DESCRIPTION
Until know, it wasn't possible to build `alpine` locally and run it:
```bash
$ export DEFECT_DOJO_OS=alpine
$ ./dc-build.sh       
Checking docker compose version
Supported docker compose version
Building docker compose
[+] Building 0.1s (1/1) FINISHED                                                                  docker:default
 => [uwsgi internal] load build definition from Dockerfile.django-alpine                                    0.0s
 => => transferring dockerfile: 4.34kB                                                                      0.0s
failed to solve: target stage "django" could not be found
```

The same naming convention for both images is needed.