### PR TITLE
Accessibility calendar switch buttons

### DIFF
--- a/dojo/locale/en/LC_MESSAGES/django.po
+++ b/dojo/locale/en/LC_MESSAGES/django.po
@@ -4964,3 +4964,23 @@ msgstr ""
 #: dojo/utils.py
 msgid "Home"
 msgstr ""
+
+#: dojo/templates/dojo/calendar.html
+msgid "previous month"
+msgstr ""
+
+#: dojo/templates/dojo/calendar.html
+msgid "next month"
+msgstr ""
+
+#: dojo/templates/dojo/calendar.html
+msgid "month preview"
+msgstr ""
+
+#: dojo/templates/dojo/calendar.html
+msgid "week preview"
+msgstr ""
+
+#: dojo/templates/dojo/calendar.html
+msgid "day preview"
+msgstr ""

--- a/dojo/locale/en/LC_MESSAGES/django.po
+++ b/dojo/locale/en/LC_MESSAGES/django.po
@@ -4966,21 +4966,21 @@ msgid "Home"
 msgstr ""
 
 #: dojo/templates/dojo/calendar.html
-msgid "previous month"
+msgid "Previous month"
 msgstr ""
 
 #: dojo/templates/dojo/calendar.html
-msgid "next month"
+msgid "Next month"
 msgstr ""
 
 #: dojo/templates/dojo/calendar.html
-msgid "month preview"
+msgid "Month preview"
 msgstr ""
 
 #: dojo/templates/dojo/calendar.html
-msgid "week preview"
+msgid "Week preview"
 msgstr ""
 
 #: dojo/templates/dojo/calendar.html
-msgid "day preview"
+msgid "Day preview"
 msgstr ""

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -75,7 +75,15 @@
                             },
                         {%  endfor %}
                     {% endif %}
-                ]
+                ],
+                viewRender: function(view, element) {
+                // Updating aria-label attributes calendar switches after the view is rendered
+                $('.fc-prev-button').attr('aria-label', 'previous month');
+                $('.fc-next-button').attr('aria-label', 'next month');
+                $('.fc-month-button').attr('aria-label', 'month preview');
+                $('.fc-basicWeek-button').attr('aria-label', 'week preview');
+                $('.fc-basicDay-button').attr('aria-label', 'day preview');
+            }
             });
         });
     </script>

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -79,11 +79,11 @@
                 ],
                 viewRender: function(view, element) {
                 // Updating aria-label attributes calendar switches after the view is rendered
-                $('.fc-prev-button').attr('aria-label', '{% trans "previous month" %}');
-                $('.fc-next-button').attr('aria-label', '{% trans "next month" %}');
-                $('.fc-month-button').attr('aria-label', '{% trans "month preview" %}');
-                $('.fc-basicWeek-button').attr('aria-label', '{% trans "week preview" %}');
-                $('.fc-basicDay-button').attr('aria-label', '{% trans "day preview" %}');
+                $('.fc-prev-button').attr('aria-label', '{% trans "Previous month" %}');
+                $('.fc-next-button').attr('aria-label', '{% trans "Next month" %}');
+                $('.fc-month-button').attr('aria-label', '{% trans "Month preview" %}');
+                $('.fc-basicWeek-button').attr('aria-label', '{% trans "Week preview" %}');
+                $('.fc-basicDay-button').attr('aria-label', '{% trans "Day preview" %}');
             }
             });
         });

--- a/dojo/templates/dojo/calendar.html
+++ b/dojo/templates/dojo/calendar.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load static %}
+{% load i18n %}
 
 {% block content %}
     {{ block.super }}
@@ -78,11 +79,11 @@
                 ],
                 viewRender: function(view, element) {
                 // Updating aria-label attributes calendar switches after the view is rendered
-                $('.fc-prev-button').attr('aria-label', 'previous month');
-                $('.fc-next-button').attr('aria-label', 'next month');
-                $('.fc-month-button').attr('aria-label', 'month preview');
-                $('.fc-basicWeek-button').attr('aria-label', 'week preview');
-                $('.fc-basicDay-button').attr('aria-label', 'day preview');
+                $('.fc-prev-button').attr('aria-label', '{% trans "previous month" %}');
+                $('.fc-next-button').attr('aria-label', '{% trans "next month" %}');
+                $('.fc-month-button').attr('aria-label', '{% trans "month preview" %}');
+                $('.fc-basicWeek-button').attr('aria-label', '{% trans "week preview" %}');
+                $('.fc-basicDay-button').attr('aria-label', '{% trans "day preview" %}');
             }
             });
         });


### PR DESCRIPTION
Fixes #11660 

**Description**
As calendar is from a standalone library, the aria-labels were included using their built-in [viewRender hook ](https://fullcalendar.io/docs/v3/viewRender)

This is a tiny enhancement that is not visible from outside but improves the accessibility of DefectDojo.

Before:
<img width="565" alt="Screenshot 2025-01-27 at 12 14 04" src="https://github.com/user-attachments/assets/93c4f4bb-8c0f-4251-9847-b16674369454" />


After:
<img width="1242" alt="Screenshot 2025-01-27 at 10 30 22" src="https://github.com/user-attachments/assets/1a9d29b3-1b35-4d9f-96a0-1de1391a9543" />
<img width="1227" alt="Screenshot 2025-01-27 at 10 28 57" src="https://github.com/user-attachments/assets/8e71cef8-e29f-4f56-9463-29178eaae14b" />
<img width="1204" alt="Screenshot 2025-01-27 at 10 29 12" src="https://github.com/user-attachments/assets/1c06d6c9-5b6c-4d47-8b94-483b70ccec42" />
